### PR TITLE
[WIP] KIALI-170: Add route for Jaeger-query

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ const (
 	EnvIdentityPrivateKeyFile = "IDENTITY_PRIVATE_KEY_FILE"
 
 	EnvPrometheusServiceURL = "PROMETHEUS_SERVICE_URL"
+	EnvJaegerServiceURL     = "JAEGER_SERVICE_URL"
 	EnvIstioIdentityDomain  = "ISTIO_IDENTITY_DOMAIN"
 
 	EnvServerAddress                    = "SERVER_ADDRESS"
@@ -67,6 +68,7 @@ type Config struct {
 	Identity               security.Identity `yaml:",omitempty"`
 	Server                 Server            `yaml:",omitempty"`
 	PrometheusServiceURL   string            `yaml:"prometheus_service_url,omitempty"`
+	JaegerServiceURL       string            `yaml:"jaeger_service_url,omitempty"`
 	IstioIdentityDomain    string            `yaml:"istio_identity_domain,omitempty"`
 	Grafana                GrafanaConfig     `yaml:"grafana,omitempty"`
 	ServiceFilterLabelName string            `yaml:"service_filter_label_name,omitempty"`
@@ -88,6 +90,7 @@ func NewConfig() (c *Config) {
 	c.Server.StaticContentRootDirectory = strings.TrimSpace(getDefaultString(EnvServerStaticContentRootDirectory, "/static-files"))
 	c.Server.CORSAllowAll = getDefaultBool(EnvServerCORSAllowAll, false)
 	c.PrometheusServiceURL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, "http://prometheus:9090"))
+	c.JaegerServiceURL = strings.TrimSpace(getDefaultString(EnvJaegerServiceURL, "http://jaeger-query"))
 	c.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))
 
 	c.Grafana.DisplayLink = getDefaultBool(EnvGrafanaDisplayLink, true)


### PR DESCRIPTION
This is need it by the frontend for search traces.

[KIALI-170](https://issues.jboss.org/browse/KIALI-170)
Needed by [SWSUI-149](https://github.com/kiali/swsui/pull/149)
We should change the deploy to add the jaeger addon.