### PR TITLE
Provide a routing rule for fault injection and an installer script

### DIFF
--- a/hack/istio/install-istio-rule.sh
+++ b/hack/istio/install-istio-rule.sh
@@ -1,0 +1,17 @@
+#/bin/sh
+
+if [ $# -eq 1 ]
+then 
+  NAME=`grep name $1 | head -n1 | awk '{print $2}'`
+  NS=`grep namespace $1 | head -n1 | awk '{print $2}'`
+  istioctl get routerule $NAME -n $NS | grep -v "No resources"
+  if [ $? -eq 1 ]
+  then
+    istioctl create -n $NS -f $1
+  else
+    istioctl replace -n $NS -f $1
+  fi
+else
+  echo "Usage: install-istio-rule.sh <rulefile>"
+fi
+

--- a/hack/istio/ratings-delay-abort.yaml
+++ b/hack/istio/ratings-delay-abort.yaml
@@ -1,0 +1,25 @@
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: ratings-delay-abort
+  namespace: bookinfo
+spec:
+  destination:
+    name: ratings
+  match:
+    source:
+      name: reviews
+      labels:
+        version: v2
+  route:
+  - labels:
+      version: v1
+  httpFault:
+    abort:
+      percent: 30
+      httpStatus: 400
+    delay:
+      fixedDelay: 3.000s
+      percent: 30
+  precedence: 2
+


### PR DESCRIPTION
Just some convenience stuff.
We should/could perhaps collect other rules here, so that we can more easily test stuff.
@lucasponce I think you should also have some that you are using for your tests (?)