### PR TITLE
KIALI-446 Identify Services with Istio Sidecar

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -282,6 +282,13 @@ server:
 prometheus_service_url: VALUE
 ----
 
+|`ISTIO_SIDECAR_ANNOTATION`
+|The annotation used by Istio in a Deployment template.
+[source,yaml]
+----
+istio_sidecar_annotation: VALUE
+----
+
 |`SERVICE_FILTER_LABEL_NAME`
 |Label name which all resources of a service are group by. Default is `app`.
 [source,yaml]

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 )
 
 // Environment vars can define some default values.
+// NOTE: If you add a new variable, don't forget to update README.adoc
 const (
 	EnvIdentityCertFile       = "IDENTITY_CERT_FILE"
 	EnvIdentityPrivateKeyFile = "IDENTITY_PRIVATE_KEY_FILE"
@@ -80,7 +81,7 @@ type Config struct {
 	Server                 Server            `yaml:",omitempty"`
 	PrometheusServiceURL   string            `yaml:"prometheus_service_url,omitempty"`
 	IstioIdentityDomain    string            `yaml:"istio_identity_domain,omitempty"`
-	IstioSidecarAnnotation string            `yaml:"istio_sidecar,omitempty"`
+	IstioSidecarAnnotation string            `yaml:"istio_sidecar_annotation,omitempty"`
 	Grafana                GrafanaConfig     `yaml:"grafana,omitempty"`
 	Jaeger                 JaegerConfig      `yaml:"jaeger,omitempty"`
 	ServiceFilterLabelName string            `yaml:"service_filter_label_name,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,9 @@ const (
 	EnvIdentityCertFile       = "IDENTITY_CERT_FILE"
 	EnvIdentityPrivateKeyFile = "IDENTITY_PRIVATE_KEY_FILE"
 
-	EnvPrometheusServiceURL = "PROMETHEUS_SERVICE_URL"
-	EnvIstioIdentityDomain  = "ISTIO_IDENTITY_DOMAIN"
+	EnvPrometheusServiceURL   = "PROMETHEUS_SERVICE_URL"
+	EnvIstioIdentityDomain    = "ISTIO_IDENTITY_DOMAIN"
+	EnvIstioSidecarAnnotation = "ISTIO_SIDECAR_ANNOTATION"
 
 	EnvServerAddress                    = "SERVER_ADDRESS"
 	EnvServerPort                       = "SERVER_PORT"
@@ -79,6 +80,7 @@ type Config struct {
 	Server                 Server            `yaml:",omitempty"`
 	PrometheusServiceURL   string            `yaml:"prometheus_service_url,omitempty"`
 	IstioIdentityDomain    string            `yaml:"istio_identity_domain,omitempty"`
+	IstioSidecarAnnotation string            `yaml:"istio_sidecar,omitempty"`
 	Grafana                GrafanaConfig     `yaml:"grafana,omitempty"`
 	Jaeger                 JaegerConfig      `yaml:"jaeger,omitempty"`
 	ServiceFilterLabelName string            `yaml:"service_filter_label_name,omitempty"`
@@ -101,6 +103,7 @@ func NewConfig() (c *Config) {
 	c.Server.CORSAllowAll = getDefaultBool(EnvServerCORSAllowAll, false)
 	c.PrometheusServiceURL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, "http://prometheus:9090"))
 	c.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))
+	c.IstioSidecarAnnotation = strings.TrimSpace(getDefaultString(EnvIstioSidecarAnnotation, "sidecar.istio.io/status"))
 
 	c.Grafana.DisplayLink = getDefaultBool(EnvGrafanaDisplayLink, true)
 	c.Grafana.URL = strings.TrimSpace(getDefaultString(EnvGrafanaURL, ""))

--- a/models/deployment.go
+++ b/models/deployment.go
@@ -10,6 +10,7 @@ import (
 type Deployments []*Deployment
 type Deployment struct {
 	Name                string            `json:"name"`
+	TemplateAnnotations map[string]string `json:"template_annotations"`
 	Labels              map[string]string `json:"labels"`
 	CreatedAt           string            `json:"created_at"`
 	Replicas            int32             `json:"replicas"`
@@ -32,6 +33,7 @@ func (deployments *Deployments) Parse(ds *v1beta1.DeploymentList) {
 
 func (deployment *Deployment) Parse(d *v1beta1.Deployment) {
 	deployment.Name = d.Name
+	deployment.TemplateAnnotations = d.Spec.Template.Annotations
 	deployment.Labels = d.Labels
 	deployment.CreatedAt = d.CreationTimestamp.Time.Format(time.RFC3339)
 	deployment.Replicas = d.Status.Replicas


### PR DESCRIPTION
This is a minor change, but we can use the Deployment details to identify services with and without Istio sidecar deployed.
So, we can show this parameter in the service list / service details and also as part of future work for graph where we may want to identify potential Istio services without traffic.