### PR TITLE
[minor] Fix swift sunshine to kiali in basic auth dialog

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -91,7 +91,7 @@ func (h *serverAuthProxyHandler) handler(w http.ResponseWriter, r *http.Request)
 	case http.StatusOK:
 		h.trueHandler.ServeHTTP(w, r)
 	case http.StatusUnauthorized:
-		w.Header().Set("WWW-Authenticate", "Basic realm=\"Swift-Sunshine\"")
+		w.Header().Set("WWW-Authenticate", "Basic realm=\"Kiali\"")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 	default:
 		http.Error(w, http.StatusText(statusCode), statusCode)


### PR DESCRIPTION
the highlighted part said "swift sunshine" before the fix
![afterfix](https://user-images.githubusercontent.com/6277245/38199132-28e4ff3a-3698-11e8-819e-da06631cd2c4.png)
