### PR TITLE
KIALI-450: Adding backend support for error rates in service list

### DIFF
--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -101,6 +101,12 @@ func (in *Client) GetNamespaceMetrics(query *NamespaceMetricsQuery) Metrics {
 	return getNamespaceMetrics(in.api, query)
 }
 
+// GetNamespaceServicesRequestRates queries Prometheus to fetch request counters
+// for each service, both in and out counters.
+func (in *Client) GetNamespaceServicesRequestCounters(namespace string, ratesInterval string) MetricsVector {
+	return getNamespaceServicesRequestCounters(in.api, namespace, ratesInterval)
+}
+
 // API returns the Prometheus V1 HTTP API for performing calls not supported natively by this client
 func (in *Client) API() v1.API {
 	return in.api


### PR DESCRIPTION
Because of KIALI-388, the service list must show the error rate of the services.
With this PR, the service list endpoint is now fetching the request counters and calculating the error rates.

UI counterpart is in kiali/kiali-ui#208