### PR TITLE
KIALI-460 Service pod status fixed

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -91,6 +91,19 @@ func NewClient() (*IstioClient, error) {
 	return &client, nil
 }
 
+func LabelsMatch(serviceLabels, filterLabels map[string]string) bool {
+	labelMatch := true
+
+	for key, value := range filterLabels {
+		if serviceLabels[key] != value {
+			labelMatch = false
+			break
+		}
+	}
+
+	return labelMatch
+}
+
 func GetLabeledListOptions(labelSelector string) *meta_v1.ListOptions {
 	return &meta_v1.ListOptions{
 		LabelSelector: labelSelector}

--- a/models/service_test.go
+++ b/models/service_test.go
@@ -383,6 +383,7 @@ func fakeServiceList() *kubernetes.ServiceList {
 					Spec: v1.ServiceSpec{
 						ClusterIP: "fromservice",
 						Type:      "ClusterIP",
+						Selector:  map[string]string{"app": "reviews"},
 						Ports: []v1.ServicePort{
 							{
 								Name:     "http",
@@ -402,6 +403,7 @@ func fakeServiceList() *kubernetes.ServiceList {
 					Spec: v1.ServiceSpec{
 						ClusterIP: "fromservice",
 						Type:      "ClusterIP",
+						Selector:  map[string]string{"app": "httpbin"},
 						Ports: []v1.ServicePort{
 							{
 								Name:     "http",


### PR DESCRIPTION
This PR fixes the issue of listing more pods than actually a service has. Check the following example out:
![screenshot from 2018-03-29 13-05-57](https://user-images.githubusercontent.com/613814/38423578-9d8f4958-39ae-11e8-97a0-07a4ee0e1dc0.png)

Deploy filtering it is now made using service.selector and deployment.template.labels. 

Result:
![screenshot from 2018-04-06 15-25-28](https://user-images.githubusercontent.com/613814/38423651-c9a83072-39ae-11e8-93aa-8bcb874b92c6.png)
