### PR TITLE
[Kiali-501] Out Cluster Configuration for dev environments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -282,6 +282,14 @@ server:
 prometheus_service_url: VALUE
 ----
 
+|`IN_CLUSTER`
+|The annotation used by Istio in a Deployment template.If in_cluster: false you need to set environments: `KUBERNETES_SERVICE_HOST`, `KUBERNETES_SERVICE_PORT` (Local development mode : oc proxy --port KUBERNETES_SERVICE_PORT )
+|Default: true
+[source,yaml]
+----
+in_cluster: (true\|false)
+----
+
 |`ISTIO_SIDECAR_ANNOTATION`
 |The annotation used by Istio in a Deployment template.
 [source,yaml]

--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,10 @@ server:
 
 prometheus_service_url: http://prometheus-istio-system.127.0.0.1.nip.io
 
+# Uncomment in_cluster to set a different value.
+# Default is true (which matches Kiali default configuration to run inside a pod running on kubernetes)
+# in_cluster: true
+
 # Uncomment istio_identity_domain to set a different value. This value must match the Istio configuration.
 # Default is "svc.cluster.local" (which matches Istio's default)
 # istio_identity_domain: svc.cluster.local

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ const (
 	EnvIdentityPrivateKeyFile = "IDENTITY_PRIVATE_KEY_FILE"
 
 	EnvPrometheusServiceURL   = "PROMETHEUS_SERVICE_URL"
+	EnvInCluster              = "IN_CLUSTER"
 	EnvIstioIdentityDomain    = "ISTIO_IDENTITY_DOMAIN"
 	EnvIstioSidecarAnnotation = "ISTIO_SIDECAR_ANNOTATION"
 
@@ -80,6 +81,7 @@ type Config struct {
 	Identity               security.Identity `yaml:",omitempty"`
 	Server                 Server            `yaml:",omitempty"`
 	PrometheusServiceURL   string            `yaml:"prometheus_service_url,omitempty"`
+	InCluster              bool              `yaml:"in_cluster,omitempty"`
 	IstioIdentityDomain    string            `yaml:"istio_identity_domain,omitempty"`
 	IstioSidecarAnnotation string            `yaml:"istio_sidecar_annotation,omitempty"`
 	Grafana                GrafanaConfig     `yaml:"grafana,omitempty"`
@@ -103,6 +105,8 @@ func NewConfig() (c *Config) {
 	c.Server.StaticContentRootDirectory = strings.TrimSpace(getDefaultString(EnvServerStaticContentRootDirectory, "/static-files"))
 	c.Server.CORSAllowAll = getDefaultBool(EnvServerCORSAllowAll, false)
 	c.PrometheusServiceURL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, "http://prometheus:9090"))
+
+	c.InCluster = getDefaultBool(EnvInCluster, true)
 	c.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))
 	c.IstioSidecarAnnotation = strings.TrimSpace(getDefaultString(EnvIstioSidecarAnnotation, "sidecar.istio.io/status"))
 


### PR DESCRIPTION
With this small changes we can configure de backend to be outside the cluster.
I think that we can add this to the method InCluster, Only we need to check if config.InCluster is false to 
get the environments instead of default values for the token and the CA file.

[KIALI-501](https://issues.jboss.org/browse/KIALI-501)

What do you think? I think this is useful to debug the backend
```
export KUBERNETES_SERVICE_HOST="127.0.0.1"
export KUBERNETES_SERVICE_PORT=8443
export KUBERNETES_TOKEN_PATH="/home/alberto/source/go/"
export KUBERNETES_CA_PATH="/var/lib/origin/openshift.local.config/master/"
```

cc @lucasponce 