### PR TITLE
KIALI-268 - KIALI-270  Show Product Versions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -297,6 +297,20 @@ in_cluster: (true\|false)
 istio_sidecar_annotation: VALUE
 ----
 
+|`ISTIO_SERVICE_NAMESPACE`
+|The Kubernetes namespace that holds the Istio service
+[source,yaml]
+----
+istio_service_namespace: VALUE
+----
+
+|`ISTIO_SERVICE`
+|The Service of Istio to check version. ( Default: istio-pilot)
+[source,yaml]
+----
+istio_service: VALUE
+----
+
 |`SERVICE_FILTER_LABEL_NAME`
 |Label name which all resources of a service are group by. Default is `app`.
 [source,yaml]

--- a/README.adoc
+++ b/README.adoc
@@ -275,40 +275,12 @@ server:
   static_content_root_directory: VALUE
 ----
 
-|`PROMETHEUS_SERVICE_URL`
-|The URL used to access and query the Prometheus Server.
-[source,yaml]
-----
-prometheus_service_url: VALUE
-----
-
 |`IN_CLUSTER`
 |The annotation used by Istio in a Deployment template.If in_cluster: false you need to set environments: `KUBERNETES_SERVICE_HOST`, `KUBERNETES_SERVICE_PORT` (Local development mode : oc proxy --port KUBERNETES_SERVICE_PORT )
 |Default: true
 [source,yaml]
 ----
 in_cluster: (true\|false)
-----
-
-|`ISTIO_SIDECAR_ANNOTATION`
-|The annotation used by Istio in a Deployment template.
-[source,yaml]
-----
-istio_sidecar_annotation: VALUE
-----
-
-|`ISTIO_SERVICE_NAMESPACE`
-|The Kubernetes namespace that holds the Istio service
-[source,yaml]
-----
-istio_service_namespace: VALUE
-----
-
-|`ISTIO_SERVICE`
-|The Service of Istio to check version. ( Default: istio-pilot)
-[source,yaml]
-----
-istio_service: VALUE
 ----
 
 |`SERVICE_FILTER_LABEL_NAME`
@@ -318,84 +290,130 @@ istio_service: VALUE
 service_filter_label_name: VALUE
 ----
 
+|`PROMETHEUS_SERVICE_URL`
+|The URL used to access and query the Prometheus Server.
+[source,yaml]
+----
+products:
+  prometheus_service_url: VALUE
+----
+
+|`ISTIO_SIDECAR_ANNOTATION`
+|The annotation used by Istio in a Deployment template.
+[source,yaml]
+----
+products:
+  istio:
+    istio_sidecar_annotation: VALUE
+----
+
+|`ISTIO_IDENTITY_DOMAIN`
+|The annotation used by Istio how Identity Domain. (Default: svc.cluster.local)
+[source,yaml]
+----
+products:
+  istio:
+    istio_identity_domain: VALUE
+----
+
+|`ISTIO_URL_SERVICE_VERSION`
+|The Service of Istio to check version. ( Default: http://istio-pilot:9093/version)
+[source,yaml]
+----
+products:
+  istio:
+    istio_url_service_version: VALUE
+----
+
+
 |`GRAFANA_DISPLAY_LINK`
 |When true, a link to Grafana will be displayed for more metrics.
 [source,yaml]
 ----
-grafana:
-  display_link: (true\|false)
+products:
+  grafana:
+    display_link: (true\|false)
 ----
 
 |`GRAFANA_URL`
 |The URL to the Grafana server. When not set, the URL may be automatically detected from OpenShift or Kubernetes API.
 [source,yaml]
 ----
-grafana:
-  url: VALUE
+products:
+  grafana:
+    url: VALUE
 ----
 
 |`GRAFANA_SERVICE_NAMESPACE`
 |The Kubernetes namespace that holds the Grafana service. This configuration is ignored if `GRAFANA_URL` is set. Default is `istio-system`.
 [source,yaml]
 ----
-grafana:
-  service_namespace: VALUE
+products:
+  grafana:
+    service_namespace: VALUE
 ----
 
 |`GRAFANA_SERVICE`
 |The OpenShift route name or the Kubernetes service name for Grafana. This configuration is ignored if `GRAFANA_URL` is set. Default is `grafana`.
 [source,yaml]
 ----
-grafana:
-  service: VALUE
+products:
+  grafana:
+    service: VALUE
 ----
 
 |`GRAFANA_DASHBOARD`
 |The name of the Grafana dashboard used as a landing page. Default is `istio-dashboard`.
 [source,yaml]
 ----
-grafana:
-  dashboard: VALUE
+products:
+  grafana:
+    dashboard: VALUE
 ----
 
 |`GRAFANA_VAR_SERVICE_SOURCE`
 |The name of the Grafana variable that controls service sources, as defined in the configured `GRAFANA_DASHBOARD`. Default is `var-source`.
 [source,yaml]
 ----
-grafana:
-  var_service_source: VALUE
+products:
+  grafana:
+    var_service_source: VALUE
 ----
 
 |`GRAFANA_VAR_SERVICE_DEST`
 |The name of the Grafana variable that controls service destinations, as defined in the configured `GRAFANA_DASHBOARD`. Default is `var-http_destination`.
 [source,yaml]
 ----
-grafana:
-  var_service_dest: VALUE
+products:
+  grafana:
+    var_service_dest: VALUE
 ----
 
 |`JAEGER_URL`
 |The URL to the Jaeger server. When not set, the URL may be automatically detected from OpenShift or Kubernetes API.
 [source,yaml]
 ----
-jaeger:
-  url: VALUE
+products:
+  jaeger:
+    url: VALUE
 ----
 
 |`JAEGER_SERVICE_NAMESPACE`
 |The Kubernetes namespace that holds the Jaeger service. This configuration is ignored if `JAEGER_URL` is set. Default is `istio-system`.
 [source,yaml]
 ----
-jaeger:
-  service_namespace: VALUE
+products:
+  jaeger:
+    service_namespace: VALUE
 ----
 
 |`JAEGER_SERVICE`
 |The OpenShift route name or the Kubernetes service name for Jaeger. This configuration is ignored if `JAEGER_URL` is set. Default is `jaeger-query`.
 [source,yaml]
 ----
-jaeger:
-  service: VALUE
+products:
+  jaeger:
+    service: VALUE
 ----
 |===
 

--- a/config.yaml
+++ b/config.yaml
@@ -14,20 +14,19 @@ server:
   # Uncomment cors_allow_all to allow serving front-end from a different host (mainly for development)
   # Default is false
   # cors_allow_all: true
+products:
+  prometheus_service_url: http://prometheus-istio-system.127.0.0.1.nip.io
+  # Uncomment istio_identity_domain to set a different value. This value must match the Istio configuration.
+  # Default is "svc.cluster.local" (which matches Istio's default)
+  # istio_identity_domain: svc.cluster.local
 
-prometheus_service_url: http://prometheus-istio-system.127.0.0.1.nip.io
+  # Uncomment grafana_service_url, used to generate links to Grafana
+  # If unset, the Grafana service URL will be looked up from Kubernetes Grafana service. It may not always be available.
+  # grafana_service_url: http://grafana-istio-system.127.0.0.1.nip.io
 
 # Uncomment in_cluster to set a different value.
 # Default is true (which matches Kiali default configuration to run inside a pod running on kubernetes)
 # in_cluster: true
-
-# Uncomment istio_identity_domain to set a different value. This value must match the Istio configuration.
-# Default is "svc.cluster.local" (which matches Istio's default)
-# istio_identity_domain: svc.cluster.local
-
-# Uncomment grafana_service_url, used to generate links to Grafana
-# If unset, the Grafana service URL will be looked up from Kubernetes Grafana service. It may not always be available.
-# grafana_service_url: http://grafana-istio-system.127.0.0.1.nip.io
 
 # Uncomment service_filter_label_name to set up a different lable name for grouping all resources of a service.
 # Default is "app"

--- a/config/config.go
+++ b/config/config.go
@@ -23,8 +23,7 @@ const (
 	EnvInCluster              = "IN_CLUSTER"
 	EnvIstioIdentityDomain    = "ISTIO_IDENTITY_DOMAIN"
 	EnvIstioSidecarAnnotation = "ISTIO_SIDECAR_ANNOTATION"
-	EnvIstioServiceNamespace  = "ISTIO_SERVICE_NAMESPACE"
-	EnvIstioServiceVersion    = "ISTIO_SERVICE"
+	EnvIstioUrlServiceVersion = "ISTIO_URL_SERVICE_VERSION"
 
 	EnvServerAddress                    = "SERVER_ADDRESS"
 	EnvServerPort                       = "SERVER_PORT"
@@ -81,8 +80,7 @@ type JaegerConfig struct {
 
 // IstioConfig describes configuration used for istio links
 type IstioConfig struct {
-	ServiceNamespace       string `yaml:"service_namespace"`
-	ServiceVersion         string `yaml:"service_version"`
+	UrlServiceVersion      string `yaml:"url_service_version"`
 	IstioIdentityDomain    string `yaml:"istio_identity_domain,omitempty"`
 	IstioSidecarAnnotation string `yaml:"istio_sidecar_annotation,omitempty"`
 }
@@ -144,8 +142,7 @@ func NewConfig() (c *Config) {
 	// Istio Configuration
 	c.Products.Istio.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))
 	c.Products.Istio.IstioSidecarAnnotation = strings.TrimSpace(getDefaultString(EnvIstioSidecarAnnotation, "sidecar.istio.io/status"))
-	c.Products.Istio.ServiceNamespace = strings.TrimSpace(getDefaultString(EnvIstioServiceNamespace, "istio-system"))
-	c.Products.Istio.ServiceVersion = strings.TrimSpace(getDefaultString(EnvIstioServiceVersion, "istio-pilot"))
+	c.Products.Istio.UrlServiceVersion = strings.TrimSpace(getDefaultString(EnvIstioUrlServiceVersion, "http://istio-pilot:9093/version"))
 
 	return
 }

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -29,8 +29,8 @@ func GetGrafanaInfo(w http.ResponseWriter, r *http.Request) {
 
 // getGrafanaInfo returns the Grafana URL and other info, the HTTP status code (int) and eventually an error
 func getGrafanaInfo(osRouteSupplier osRouteSupplier, serviceSupplier serviceSupplier) (*models.GrafanaInfo, int, error) {
-	suffix := config.Get().IstioIdentityDomain
-	grafanaConfig := config.Get().Grafana
+	suffix := config.Get().Products.Istio.IstioIdentityDomain
+	grafanaConfig := config.Get().Products.Grafana
 	if !grafanaConfig.DisplayLink {
 		return nil, http.StatusNoContent, nil
 	}

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestGetGrafanaInfoDisabled(t *testing.T) {
 	conf := config.NewConfig()
-	conf.Grafana.DisplayLink = false
+	conf.Products.Grafana.DisplayLink = false
 	config.Set(conf)
 	info, code, err := getGrafanaInfo(func(_, _ string) (string, error) {
 		return "http://fromopenshift", nil
@@ -64,7 +64,7 @@ func TestGetGrafanaInfoFromService(t *testing.T) {
 
 func TestGetGrafanaInfoFromConfig(t *testing.T) {
 	conf := config.NewConfig()
-	conf.Grafana.URL = "http://fromconfig:3001"
+	conf.Products.Grafana.URL = "http://fromconfig:3001"
 	config.Set(conf)
 	info, code, err := getGrafanaInfo(func(_, _ string) (string, error) {
 		return "http://fromopenshift", nil

--- a/handlers/graph_unused.go
+++ b/handlers/graph_unused.go
@@ -36,7 +36,7 @@ func buildStaticNodeList(namespaceName string, deployments *v1beta1.DeploymentLi
 	nonTrafficList := make([]tree.ServiceNode, 0)
 	appLabel := config.Get().ServiceFilterLabelName
 	versionLabel := config.Get().VersionFilterLabelName
-	identityDomain := config.Get().IstioIdentityDomain
+	identityDomain := config.Get().Products.Istio.IstioIdentityDomain
 	for _, deployment := range deployments.Items {
 		app, ok := deployment.GetObjectMeta().GetLabels()[appLabel]
 		if !ok {

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -24,7 +24,7 @@ func GetJaegerInfo(w http.ResponseWriter, r *http.Request) {
 
 // getJaegerInfo returns the Jaeger URL, the HTTP status code (int) and eventually an error
 func getJaegerInfo(osRouteSupplier osRouteSupplier, serviceSupplier serviceSupplier) (*models.JaegerInfo, int, error) {
-	jaegerConfig := config.Get().Jaeger
+	jaegerConfig := config.Get().Products.Jaeger
 	jaegerInfo := models.JaegerInfo{
 		URL: jaegerConfig.URL}
 	if jaegerInfo.URL != "" {

--- a/handlers/jaeger_test.go
+++ b/handlers/jaeger_test.go
@@ -45,7 +45,7 @@ func TestGetJaegerInfoFromService(t *testing.T) {
 
 func TestGetJaegerInfoFromConfig(t *testing.T) {
 	conf := config.NewConfig()
-	conf.Jaeger.URL = "http://fromconfig:3001"
+	conf.Products.Jaeger.URL = "http://fromconfig:3001"
 	config.Set(conf)
 	info, code, err := getJaegerInfo(func(_, _ string) (string, error) {
 		return "http://fromopenshift", nil

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -35,7 +35,7 @@ func NewClient() (*Client, error) {
 	if config.Get() == nil {
 		return nil, errors.New("config.Get() must be not null")
 	}
-	p8s, err := api.NewClient(api.Config{Address: config.Get().PrometheusServiceURL})
+	p8s, err := api.NewClient(api.Config{Address: config.Get().Products.PrometheusServiceURL})
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (in *Client) Inject(api v1.API) {
 // It returns an error on any problem.
 func (in *Client) GetSourceServices(namespace string, servicename string) (map[string][]string, error) {
 	query := fmt.Sprintf("istio_request_count{destination_service=\"%s.%s.%s\"}",
-		servicename, namespace, config.Get().IstioIdentityDomain)
+		servicename, namespace, config.Get().Products.Istio.IstioIdentityDomain)
 	result, err := in.api.Query(context.Background(), query, time.Now())
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (in *Client) GetSourceServices(namespace string, servicename string) (map[s
 			index := fmt.Sprintf("%s", metric["destination_version"])
 			sourceService := string(metric["source_service"])
 			// sourceService is in the form "service.namespace.istio_identity_domain". We want to keep only "service.namespace".
-			if i := strings.Index(sourceService, "."+config.Get().IstioIdentityDomain); i > 0 {
+			if i := strings.Index(sourceService, "."+config.Get().Products.Istio.IstioIdentityDomain); i > 0 {
 				sourceService = sourceService[:i]
 			}
 			source := fmt.Sprintf("%s/%s", sourceService, metric["source_version"])
@@ -122,5 +122,5 @@ func (in *Client) API() v1.API {
 
 // Address return the configured Prometheus service URL
 func (in *Client) Address() string {
-	return config.Get().PrometheusServiceURL
+	return config.Get().Products.PrometheusServiceURL
 }

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -83,7 +83,7 @@ type Histogram struct {
 
 // Returns <healthy, total, error>
 func getServiceHealth(api v1.API, namespace string, servicename string) (int, int, error) {
-	envoyClustername := strings.Replace(config.Get().IstioIdentityDomain, ".", "_", -1)
+	envoyClustername := strings.Replace(config.Get().Products.Istio.IstioIdentityDomain, ".", "_", -1)
 	queryPart := replaceInvalidCharacters(fmt.Sprintf("%s_%s_%s", servicename, namespace, envoyClustername))
 	now := time.Now()
 
@@ -115,7 +115,7 @@ func getServiceHealth(api v1.API, namespace string, servicename string) (int, in
 }
 
 func getServiceMetrics(api v1.API, q *ServiceMetricsQuery) Metrics {
-	clustername := config.Get().IstioIdentityDomain
+	clustername := config.Get().Products.Istio.IstioIdentityDomain
 	destService := fmt.Sprintf("destination_service=\"%s.%s.%s\"", q.Service, q.Namespace, clustername)
 	srcService := fmt.Sprintf("source_service=\"%s.%s.%s\"", q.Service, q.Namespace, clustername)
 	labelsIn, labelsOut, labelsErrorIn, labelsErrorOut := buildLabelStrings(destService, srcService, q.Version)

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -471,7 +471,7 @@ func mockEmptyHistogram(api *PromAPIMock, baseName string, suffix string) {
 
 func setupExternal() (*prometheus.Client, error) {
 	conf := config.NewConfig()
-	conf.PrometheusServiceURL = "http://prometheus-istio-system.127.0.0.1.nip.io"
+	conf.Products.PrometheusServiceURL = "http://prometheus-istio-system.127.0.0.1.nip.io"
 	config.Set(conf)
 	return prometheus.NewClient()
 }

--- a/services/business/services.go
+++ b/services/business/services.go
@@ -70,7 +70,7 @@ func (in *SvcService) castServiceOverview(s *v1.Service, deployments []v1beta1.D
 func hasIstioSideCar(deployments []v1beta1.Deployment) bool {
 	for _, deployment := range deployments {
 		if deployment.Spec.Template.Annotations != nil {
-			if _, exists := deployment.Spec.Template.Annotations[config.Get().IstioSidecarAnnotation]; exists {
+			if _, exists := deployment.Spec.Template.Annotations[config.Get().Products.Istio.IstioSidecarAnnotation]; exists {
 				return true
 			}
 		}

--- a/status/status.go
+++ b/status/status.go
@@ -10,23 +10,34 @@ const (
 	StateRunning   = "running"
 )
 
-type StatusInfo map[string]string
+type StatusInfo struct {
+	Status   map[string]string `json:"status"`
+	Products []ProductInfo     `json:"products"`
+}
 
 var info StatusInfo
 
+type ProductInfo struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	FullVersion string `json:"full_version"`
+}
+
 func init() {
-	info = StatusInfo(make(map[string]string))
-	info[State] = StateRunning
+	info = StatusInfo{Status: make(map[string]string)}
+	info.Status[State] = StateRunning
 }
 
 // Put adds or replaces status info for the provided name. Any previous setting is returned.
 func Put(name, value string) (previous string, hasPrevious bool) {
-	previous, hasPrevious = info[name]
-	info[name] = value
+	previous, hasPrevious = info.Status[name]
+	info.Status[name] = value
 	return previous, hasPrevious
 }
 
 // Get returns a copy of the current status info.
 func Get() (status StatusInfo) {
+	info.Products = []ProductInfo{}
+	getVersions()
 	return info
 }

--- a/status/status.go
+++ b/status/status.go
@@ -18,9 +18,8 @@ type StatusInfo struct {
 var info StatusInfo
 
 type ProductInfo struct {
-	Name        string `json:"name"`
-	Version     string `json:"version"`
-	FullVersion string `json:"full_version"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 func init() {

--- a/status/versions.go
+++ b/status/versions.go
@@ -1,0 +1,116 @@
+package status
+
+import (
+	"encoding/json"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"io/ioutil"
+	"k8s.io/api/core/v1"
+	kube "k8s.io/client-go/kubernetes"
+	"net/http"
+	"regexp"
+)
+
+type serviceProduct func() (*ProductInfo, error)
+
+func getVersions() {
+	products := []serviceProduct{
+		istioVersion,
+		prometheusVersion,
+		kubernetesVersion,
+	}
+	for _, prod := range products {
+		getVersionProduct(prod)
+	}
+}
+
+func getVersionProduct(serviceProduct serviceProduct) {
+	productInfo, err := serviceProduct()
+	if err == nil {
+		info.Products = append(info.Products, *productInfo)
+	}
+}
+
+func istioVersion() (*ProductInfo, error) {
+	product := ProductInfo{}
+	istioConfig := config.Get().Products.Istio
+	serviceInfo, err := getService(istioConfig.ServiceNamespace, istioConfig.ServiceVersion)
+	if err == nil {
+		resp, err := http.Get("http://" + serviceInfo.ClusterIP + ":9093/version")
+		if err == nil {
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			if err == nil {
+				product.Name = "Istio"
+				product.FullVersion = string(body)
+				re := regexp.MustCompile("[0-9]\\.[0-9]\\.[0-9]")
+				product.Version = re.FindStringSubmatch(string(body))[0]
+				return &product, nil
+			}
+		}
+	}
+	return nil, err
+}
+
+type p8sResponseVersion struct {
+	Version  string `json:"version"`
+	Revision string `json:"revision"`
+}
+
+func prometheusVersion() (*ProductInfo, error) {
+	product := ProductInfo{}
+	prometheusV := new(p8sResponseVersion)
+	prometheusUrl := config.Get().Products.PrometheusServiceURL
+	resp, err := http.Get(prometheusUrl + "/version")
+	if err == nil {
+		defer resp.Body.Close()
+		err = json.NewDecoder(resp.Body).Decode(&prometheusV)
+		if err == nil {
+			product.Name = "Prometheus"
+			product.FullVersion = prometheusV.Revision
+			product.Version = prometheusV.Version
+			return &product, nil
+		}
+	}
+	return nil, err
+}
+
+const (
+	// These constants are tweaks to the k8s client I think once are set up they won't change so no need to put them on the config
+	// Default QPS and Burst are quite low and those are not designed for a backend that should perform several
+	// queries to build an inventory of entities from a k8s backend.
+	// Other k8s clients have increased these values to a similar values.
+	k8sQPS   = 100
+	k8sBurst = 200
+)
+
+func kubernetesVersion() (*ProductInfo, error) {
+	product := ProductInfo{}
+	config, err := kubernetes.ConfigClient()
+	if err == nil {
+		config.QPS = k8sQPS
+		config.Burst = k8sBurst
+		k8s, err := kube.NewForConfig(config)
+		if err == nil {
+			serverVersion, err := k8s.Discovery().ServerVersion()
+			if err == nil {
+				product.Name = "Kubernetes"
+				product.FullVersion = serverVersion.GitCommit
+				product.Version = serverVersion.GitVersion
+				return &product, nil
+			}
+		}
+	}
+	return nil, err
+}
+func getService(namespace string, service string) (*v1.ServiceSpec, error) {
+	client, err := kubernetes.NewClient()
+	if err != nil {
+		return nil, err
+	}
+	details, err := client.GetServiceDetails(namespace, service)
+	if err != nil {
+		return nil, err
+	}
+	return &details.Service.Spec, nil
+}


### PR DESCRIPTION
I don't know if it is a good idea inspect the version of mixer and pilot, they return the version in the endpoint ip:9093/version, It could be possible that in the future they'll have a different version.

[KIALI-268](https://issues.jboss.org/browse/KIALI-268)
[KIALI-270](https://issues.jboss.org/browse/KIALI-270)
What do you think?

![producst2](https://user-images.githubusercontent.com/3019213/38610682-df86f0d2-3d81-11e8-823c-e733c38d7490.png)


- [x] Order Configuration
- [X] Added products versions to status:
   - [X]  Istio
   - [X]  Prometheus
   - [X]   Kubernetes 


