### PR TITLE
KIALI-508 support queryTime param for metrics requests

### DIFF
--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -40,6 +40,14 @@ func extractMetricsQueryParams(r *http.Request, q *prometheus.MetricsQuery) erro
 		}
 		q.RateFunc = rateFuncs[0]
 	}
+	if queryTimes, ok := queryParams["queryTime"]; ok && len(queryTimes) > 0 {
+		if num, err := strconv.ParseInt(queryTimes[0], 10, 64); err == nil {
+			q.QueryTime = time.Unix(num, 0)
+		} else {
+			// Bad request
+			return errors.New("Bad request, cannot parse query parameter 'queryTime'")
+		}
+	}
 	if durations, ok := queryParams["duration"]; ok && len(durations) > 0 {
 		if num, err := strconv.Atoi(durations[0]); err == nil {
 			q.Duration = time.Duration(num) * time.Second

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -22,6 +22,7 @@ var (
 // MetricsQuery is a common struct for ServiceMetricsQuery and NamespaceMetricsQuery
 type MetricsQuery struct {
 	Version      string
+	QueryTime    time.Time
 	Duration     time.Duration
 	Step         time.Duration
 	RateInterval string
@@ -33,6 +34,7 @@ type MetricsQuery struct {
 
 // FillDefaults fills the struct with default parameters
 func (q *MetricsQuery) FillDefaults() {
+	q.QueryTime = time.Now()
 	q.Duration = 30 * time.Minute
 	q.Step = 15 * time.Second
 	q.RateInterval = "1m"
@@ -174,10 +176,9 @@ func joinLabels(labels []string) string {
 }
 
 func fetchAllMetrics(api v1.API, q *MetricsQuery, labelsIn, labelsOut, labelsErrorIn, labelsErrorOut, groupingIn, groupingOut string) Metrics {
-	now := time.Now()
 	bounds := v1.Range{
-		Start: now.Add(-q.Duration),
-		End:   now,
+		Start: q.QueryTime.Add(-q.Duration),
+		End:   q.QueryTime,
 		Step:  q.Step}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Allow the caller to fix the query time instead of always using 'now'