### PR TITLE
KIALI-511 Change unused nodes layout strategy

### DIFF
--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -28,6 +28,7 @@ type NodeData struct {
 	// Cytoscape Fields
 	Id     string `json:"id"`               // unique internal node ID (n0, n1...)
 	Text   string `json:"text"`             // display text for the node
+	Style  string `json:"style"`            // line style
 	Parent string `json:"parent,omitempty"` // Compound Node parent ID
 
 	// App Fields (not required by Cytoscape)
@@ -133,12 +134,20 @@ func walk(sn *tree.ServiceNode, nodes *[]*NodeWrapper, edges *[]*EdgeWrapper, pa
 		if tree.UnknownVersion != sn.Version {
 			text = fmt.Sprintf("%v %v", text, sn.Version)
 		}
+		style := "solid"
+		if valRate, ok := sn.Metadata["rate"]; ok {
+			rate, ok := valRate.(float64)
+			if ok && rate < 0 {
+				style = "dotted"
+			}
+		}
 		*nodeIdSequence++
 		nd = &NodeData{
 			Id:      nodeId,
 			Service: name,
 			Version: sn.Version,
 			Text:    text,
+			Style:   style,
 			// LinkPromGraph: sn.Metadata["link_prom_graph"].(string),
 		}
 		nw := NodeWrapper{
@@ -254,6 +263,7 @@ func addCompositeNodes(nodes *[]*NodeWrapper, nodeIdSequence *int) {
 				Id:      nodeId,
 				Service: k,
 				Text:    strings.Split(k, ".")[0],
+				Style:   "solid",
 				GroupBy: "version",
 			}
 			nw := NodeWrapper{

--- a/handlers/graph_unused.go
+++ b/handlers/graph_unused.go
@@ -66,15 +66,9 @@ func buildDefaultTrees(trees *[]tree.ServiceNode, staticNodeList *[]tree.Service
 	if len(*staticNodeList) == 0 {
 		return
 	}
-	// A static picture of services without traffic will not infer the sources,
-	// so we need an ephemeral representation of static services until we have traffic and this can properly fetched
-	// from prometheus
-	rootNode := tree.NewServiceNode(tree.UnknownService, tree.UnknownVersion)
-	rootNode.Children = make([]*tree.ServiceNode, len(*staticNodeList))
 	for i := 0; i < len(*staticNodeList); i++ {
-		rootNode.Children[i] = &(*staticNodeList)[i]
+		*trees = append(*trees, (*staticNodeList)[i])
 	}
-	*trees = append(*trees, rootNode)
 }
 
 func addNodeToTrees(trees *[]tree.ServiceNode, node *tree.ServiceNode) {
@@ -87,9 +81,9 @@ func addNodeToTrees(trees *[]tree.ServiceNode, node *tree.ServiceNode) {
 			break
 		}
 	}
-	// Second, if not founded, we create a unknown root to add them as parent
+	// Second, if not founded, we add them as root tree level
 	if !added {
-		addUnderUnknownTree(trees, node)
+		*trees = append(*trees, *node)
 	}
 }
 
@@ -124,22 +118,4 @@ func findAndAddSibling(tree *tree.ServiceNode, node *tree.ServiceNode) bool {
 		}
 	}
 	return added
-}
-
-func addUnderUnknownTree(trees *[]tree.ServiceNode, node *tree.ServiceNode) {
-	// Find and add as child under unknown
-	added := false
-	for i := 0; i < len(*trees); i++ {
-		if (*trees)[i].Name == tree.UnknownService {
-			(*trees)[i].Children = append((*trees)[i].Children, node)
-			added = true
-		}
-	}
-	// If not added, create a new "unknown" tree
-	if !added {
-		rootNode := tree.NewServiceNode(tree.UnknownService, tree.UnknownVersion)
-		rootNode.Children = make([]*tree.ServiceNode, 1)
-		rootNode.Children[0] = node
-		*trees = append(*trees, rootNode)
-	}
 }

--- a/handlers/graph_unused_test.go
+++ b/handlers/graph_unused_test.go
@@ -22,23 +22,21 @@ func TestNonTrafficScenario(t *testing.T) {
 
 	addUnusedNodes(&trees, "testNamespace", deployments)
 
-	assert.Equal(1, len(trees))
-	assert.Equal(tree.UnknownService, trees[0].Name)
-	assert.Equal(4, len(trees[0].Children))
+	assert.Equal(4, len(trees))
 
-	assert.Equal("customer.testNamespace.svc.cluster.local", trees[0].Children[0].Name)
-	assert.Equal(float64(-1), trees[0].Children[0].Metadata["rate"])
+	assert.Equal("customer.testNamespace.svc.cluster.local", trees[0].Name)
+	assert.Equal(float64(-1), trees[0].Metadata["rate"])
 
-	assert.Equal("preference.testNamespace.svc.cluster.local", trees[0].Children[1].Name)
-	assert.Equal(float64(-1), trees[0].Children[1].Metadata["rate"])
+	assert.Equal("preference.testNamespace.svc.cluster.local", trees[1].Name)
+	assert.Equal(float64(-1), trees[1].Metadata["rate"])
 
-	assert.Equal("recommendation.testNamespace.svc.cluster.local", trees[0].Children[2].Name)
-	assert.Equal("v1", trees[0].Children[2].Version)
-	assert.Equal(float64(-1), trees[0].Children[2].Metadata["rate"])
+	assert.Equal("recommendation.testNamespace.svc.cluster.local", trees[2].Name)
+	assert.Equal("v1", trees[2].Version)
+	assert.Equal(float64(-1), trees[2].Metadata["rate"])
 
-	assert.Equal("recommendation.testNamespace.svc.cluster.local", trees[0].Children[3].Name)
-	assert.Equal("v2", trees[0].Children[3].Version)
-	assert.Equal(float64(-1), trees[0].Children[3].Metadata["rate"])
+	assert.Equal("recommendation.testNamespace.svc.cluster.local", trees[3].Name)
+	assert.Equal("v2", trees[3].Version)
+	assert.Equal(float64(-1), trees[3].Metadata["rate"])
 }
 
 func TestOneNodeTrafficScenario(t *testing.T) {
@@ -51,23 +49,23 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 
 	addUnusedNodes(&trees, "testNamespace", deployments)
 
-	assert.Equal(1, len(trees))
+	assert.Equal(4, len(trees))
 	assert.Equal(tree.UnknownService, trees[0].Name)
-	assert.Equal(4, len(trees[0].Children))
+	assert.Equal(1, len(trees[0].Children))
 
 	assert.Equal("customer.testNamespace.svc.cluster.local", trees[0].Children[0].Name)
 	assert.Equal(float64(0.8), trees[0].Children[0].Metadata["rate"])
 
-	assert.Equal("preference.testNamespace.svc.cluster.local", trees[0].Children[1].Name)
-	assert.Equal(float64(-1), trees[0].Children[1].Metadata["rate"])
+	assert.Equal("preference.testNamespace.svc.cluster.local", trees[1].Name)
+	assert.Equal(float64(-1), trees[1].Metadata["rate"])
 
-	assert.Equal("recommendation.testNamespace.svc.cluster.local", trees[0].Children[2].Name)
-	assert.Equal("v1", trees[0].Children[2].Version)
-	assert.Equal(float64(-1), trees[0].Children[2].Metadata["rate"])
+	assert.Equal("recommendation.testNamespace.svc.cluster.local", trees[2].Name)
+	assert.Equal("v1", trees[2].Version)
+	assert.Equal(float64(-1), trees[2].Metadata["rate"])
 
-	assert.Equal("recommendation.testNamespace.svc.cluster.local", trees[0].Children[3].Name)
-	assert.Equal("v2", trees[0].Children[3].Version)
-	assert.Equal(float64(-1), trees[0].Children[3].Metadata["rate"])
+	assert.Equal("recommendation.testNamespace.svc.cluster.local", trees[3].Name)
+	assert.Equal("v2", trees[3].Version)
+	assert.Equal(float64(-1), trees[3].Metadata["rate"])
 }
 
 func TestVersionWithNoTrafficScenario(t *testing.T) {

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -6,6 +6,7 @@
         "data": {
           "id": "n2",
           "text": "details v1",
+          "style": "solid",
           "service": "details.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "80.000",
@@ -18,6 +19,7 @@
         "data": {
           "id": "n7",
           "text": "ingress",
+          "style": "solid",
           "service": "ingress.istio-system.svc.cluster.local",
           "version": "unknown"
         }
@@ -26,6 +28,7 @@
         "data": {
           "id": "n1",
           "text": "productpage v1 \u003c20.00pm\u003e",
+          "style": "solid",
           "service": "productpage.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "150.000"
@@ -35,6 +38,7 @@
         "data": {
           "id": "n5",
           "text": "ratings v1",
+          "style": "solid",
           "service": "ratings.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "40.000"
@@ -44,6 +48,7 @@
         "data": {
           "id": "n8",
           "text": "reviews",
+          "style": "solid",
           "service": "reviews.istio-system.svc.cluster.local",
           "groupBy": "version"
         }
@@ -52,6 +57,7 @@
         "data": {
           "id": "n3",
           "text": "reviews v1",
+          "style": "solid",
           "parent": "n8",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
@@ -62,6 +68,7 @@
         "data": {
           "id": "n4",
           "text": "reviews v2 \u003c20.00pm\u003e",
+          "style": "solid",
           "parent": "n8",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
@@ -72,6 +79,7 @@
         "data": {
           "id": "n6",
           "text": "reviews v3 \u003c20.00pm\u003e",
+          "style": "solid",
           "parent": "n8",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",
@@ -82,6 +90,7 @@
         "data": {
           "id": "n0",
           "text": "unknown",
+          "style": "solid",
           "service": "unknown",
           "version": "unknown"
         }

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -6,6 +6,7 @@
         "data": {
           "id": "n0",
           "text": "productpage v1",
+          "style": "solid",
           "service": "productpage.istio-system.svc.cluster.local",
           "version": "v1"
         }
@@ -14,6 +15,7 @@
         "data": {
           "id": "n3",
           "text": "ratings v1",
+          "style": "solid",
           "service": "ratings.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "40.000"
@@ -23,6 +25,7 @@
         "data": {
           "id": "n5",
           "text": "reviews",
+          "style": "solid",
           "service": "reviews.istio-system.svc.cluster.local",
           "groupBy": "version"
         }
@@ -31,6 +34,7 @@
         "data": {
           "id": "n1",
           "text": "reviews v1",
+          "style": "solid",
           "parent": "n5",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
@@ -41,6 +45,7 @@
         "data": {
           "id": "n2",
           "text": "reviews v2 \u003c20.00pm\u003e",
+          "style": "solid",
           "parent": "n5",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
@@ -51,6 +56,7 @@
         "data": {
           "id": "n4",
           "text": "reviews v3 \u003c20.00pm\u003e",
+          "style": "solid",
           "parent": "n5",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",


### PR DESCRIPTION
- Place them in the root trees when no info about siblings found.
- Place them grouped with siblings if appropiate.
- Mark nodes with dotted border to easily differentiate them.

Scenarios:

a) No traffic

![image](https://user-images.githubusercontent.com/1662329/38669392-87db6a82-3e46-11e8-9e51-c6870c3adfcc.png)

b) Traffic and a new node appears, and we know where to place them:

![image](https://user-images.githubusercontent.com/1662329/38669419-9daaa6ca-3e46-11e8-818c-a8b9bf33aaff.png)

c) Traffic and new nodes without information:

![image](https://user-images.githubusercontent.com/1662329/38669450-af979a64-3e46-11e8-831a-55b2712ae68f.png)

d) Same as c) but with multiple versions for unused nodes:

![image](https://user-images.githubusercontent.com/1662329/38669477-c8371b1c-3e46-11e8-84a6-b7f8fda20989.png)

This PR changes only the backend, a following PR in the UI code will adapt the dotted style for the new nodes.