### PR TITLE
R&D: Provide synthetic routing rules from looking at the detected downstream

### DIFF
--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -220,6 +220,20 @@ func graphService(w http.ResponseWriter, r *http.Request, client *prometheus.Cli
 	generateGraph(&trees, w, o)
 }
 
+// Helper to get a service graph for other internal callers
+func TreesService(ns string, svcName string) (trees []tree.ServiceNode) {
+	client, err := prometheus.NewClient()
+	checkError(err)
+
+	o:= options.Options{Duration:time.Hour,
+						Service:svcName,
+						Metric: "istio_request_count",
+						QueryTime: time.Now().Unix(),
+						Namespace:ns}
+
+	return buildNamespaceTrees(o,client)
+}
+
 // buildServiceTrees returns trees routed at source services for versions of the service of interest
 func buildServiceTrees(o options.Options, client *prometheus.Client) (trees []tree.ServiceNode) {
 	// Query for root nodes. Root nodes for the service graph represent


### PR DESCRIPTION
This is some R&D work to provide routing rules in case there is no explicit routing rule defined for a service where we have detected that it has some downstream it is talking to.

There is a corresponding PR on the UI side: https://github.com/kiali/kiali-ui/pull/248