### PR TITLE
KIALI-544 Add creation time to route rules and destination policies

### DIFF
--- a/services/models/destination_policy.go
+++ b/services/models/destination_policy.go
@@ -1,12 +1,15 @@
 package models
 
 import (
+	"time"
+
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type DestinationPolicies []DestinationPolicy
 type DestinationPolicy struct {
 	Name           string      `json:"name"`
+	CreatedAt      string      `json:"created_at"`
 	Source         interface{} `json:"source"`
 	Destination    interface{} `json:"destination"`
 	LoadBalancing  interface{} `json:"loadbalancing"`
@@ -23,6 +26,7 @@ func (policies *DestinationPolicies) Parse(destinationPolicies []kubernetes.Isti
 
 func (policy *DestinationPolicy) Parse(destinationPolicy kubernetes.IstioObject) {
 	policy.Name = destinationPolicy.GetObjectMeta().Name
+	policy.CreatedAt = destinationPolicy.GetObjectMeta().CreationTimestamp.Time.Format(time.RFC3339)
 	policy.Source = destinationPolicy.GetSpec()["source"]
 	policy.Destination = destinationPolicy.GetSpec()["destination"]
 	policy.LoadBalancing = destinationPolicy.GetSpec()["loadBalancing"]

--- a/services/models/route_rule.go
+++ b/services/models/route_rule.go
@@ -1,12 +1,15 @@
 package models
 
 import (
+	"time"
+
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type RouteRules []RouteRule
 type RouteRule struct {
 	Name             string      `json:"name"`
+	CreatedAt        string      `json:"created_at"`
 	Destination      interface{} `json:"destination"`
 	Precedence       interface{} `json:"precedence"`
 	Match            interface{} `json:"match"`
@@ -33,6 +36,7 @@ func (rules *RouteRules) Parse(routeRules []kubernetes.IstioObject) {
 
 func (rule *RouteRule) Parse(routeRule kubernetes.IstioObject) {
 	rule.Name = routeRule.GetObjectMeta().Name
+	rule.CreatedAt = routeRule.GetObjectMeta().CreationTimestamp.Time.Format(time.RFC3339)
 	rule.Destination = routeRule.GetSpec()["destination"]
 	rule.Precedence = routeRule.GetSpec()["precedence"]
 	rule.Match = routeRule.GetSpec()["match"]

--- a/services/models/service.go
+++ b/services/models/service.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"time"
+
 	"github.com/prometheus/common/model"
 
 	"github.com/kiali/kiali/kubernetes"
@@ -22,6 +24,7 @@ type ServiceList struct {
 
 type Service struct {
 	Name                string              `json:"name"`
+	CreatedAt           string              `json:"created_at"`
 	Namespace           Namespace           `json:"namespace"`
 	Labels              map[string]string   `json:"labels"`
 	Type                string              `json:"type"`
@@ -46,6 +49,7 @@ func (s *Service) setKubernetesDetails(serviceDetails *kubernetes.ServiceDetails
 		s.Labels = serviceDetails.Service.Labels
 		s.Type = string(serviceDetails.Service.Spec.Type)
 		s.Ip = serviceDetails.Service.Spec.ClusterIP
+		s.CreatedAt = serviceDetails.Service.CreationTimestamp.Time.Format(time.RFC3339)
 		(&s.Ports).Parse(serviceDetails.Service.Spec.Ports)
 	}
 

--- a/services/models/service_test.go
+++ b/services/models/service_test.go
@@ -82,6 +82,7 @@ func TestServiceDetailParsing(t *testing.T) {
 	// Istio Details
 	assert.Equal(service.RouteRules, RouteRules{
 		RouteRule{
+			CreatedAt: "2018-03-08T17:46:00+03:00",
 			Destination: map[string]string{
 				"name":      "reviews",
 				"namespace": "tutorial"},
@@ -97,6 +98,7 @@ func TestServiceDetailParsing(t *testing.T) {
 				},
 			}},
 		RouteRule{
+			CreatedAt: "2018-03-08T17:46:00+03:00",
 			Destination: map[string]string{
 				"name":      "reviews",
 				"namespace": "tutorial"},
@@ -108,6 +110,7 @@ func TestServiceDetailParsing(t *testing.T) {
 
 	assert.Equal(service.DestinationPolicies, DestinationPolicies{
 		DestinationPolicy{
+			CreatedAt: "2018-03-08T17:47:00+03:00",
 			Source: map[string]string{
 				"name": "recommendation"},
 			Destination: map[string]string{
@@ -117,6 +120,7 @@ func TestServiceDetailParsing(t *testing.T) {
 				"name": "RANDOM"},
 		},
 		DestinationPolicy{
+			CreatedAt: "2018-03-08T17:47:00+03:00",
 			Destination: map[string]interface{}{
 				"name":      "reviews",
 				"namespace": "tutorial",
@@ -243,7 +247,12 @@ func fakeServiceDetails() *kubernetes.ServiceDetails {
 }
 
 func fakeIstioDetails() *kubernetes.IstioDetails {
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:46 +0300")
+	t2, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:47 +0300")
+
 	route1 := kubernetes.MockIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			CreationTimestamp: meta_v1.NewTime(t1)},
 		Spec: map[string]interface{}{
 			"destination": map[string]string{
 				"name":      "reviews",
@@ -260,6 +269,8 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 				}}},
 	}
 	route2 := kubernetes.MockIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			CreationTimestamp: meta_v1.NewTime(t1)},
 		Spec: map[string]interface{}{
 			"destination": map[string]string{
 				"name":      "reviews",
@@ -272,6 +283,8 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 	}
 	routes := []kubernetes.IstioObject{&route1, &route2}
 	policy1 := kubernetes.MockIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			CreationTimestamp: meta_v1.NewTime(t2)},
 		Spec: map[string]interface{}{
 			"source": map[string]string{
 				"name": "recommendation",
@@ -286,6 +299,8 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 		},
 	}
 	policy2 := kubernetes.MockIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			CreationTimestamp: meta_v1.NewTime(t2)},
 		Spec: map[string]interface{}{
 			"destination": map[string]interface{}{
 				"name":      "reviews",

--- a/services/models/service_test.go
+++ b/services/models/service_test.go
@@ -24,6 +24,7 @@ func TestServiceDetailParsing(t *testing.T) {
 	// Kubernetes Details
 	assert.Equal(service.Name, "service")
 	assert.Equal(service.Namespace.Name, "namespace")
+	assert.Equal(service.CreatedAt, "2018-03-08T17:44:00+03:00")
 	assert.Equal(service.Type, "ClusterIP")
 	assert.Equal(service.Ip, "fromservice")
 	assert.Equal(service.Labels, map[string]string{"label1": "labelName1", "label2": "labelName2"})
@@ -145,10 +146,14 @@ func TestServiceDetailParsing(t *testing.T) {
 }
 
 func fakeServiceDetails() *kubernetes.ServiceDetails {
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	t2, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:45 +0300")
+
 	service := &v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      "Name",
-			Namespace: "Namespace",
+			Name:              "Name",
+			Namespace:         "Namespace",
+			CreationTimestamp: meta_v1.NewTime(t1),
 			Labels: map[string]string{
 				"label1": "labelName1",
 				"label2": "labelName2"}},
@@ -185,8 +190,6 @@ func fakeServiceDetails() *kubernetes.ServiceDetails {
 					{Name: "http", Protocol: "TCP", Port: 3000},
 				}}}}
 
-	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
-	t2, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:45 +0300")
 	deployments := &v1beta1.DeploymentList{
 		Items: []v1beta1.Deployment{
 			v1beta1.Deployment{


### PR DESCRIPTION
Adding creation time to service, route rules and destination policies. Dates are shown in kubernetes format: [RFC3339](https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L168)

![created-at-service-details-marked](https://user-images.githubusercontent.com/613814/38860553-bc9040de-4230-11e8-9911-18847f7e1f81.png)
