### PR TITLE
KIALI-545 introduce appenders to graph generation

### DIFF
--- a/graph/appender/appender.go
+++ b/graph/appender/appender.go
@@ -1,0 +1,16 @@
+package appender
+
+import "github.com/kiali/kiali/graph/tree"
+
+// Appender is implemented by any code offering to append a service graph with
+// supplemental information.  On error the appender should panic and it will be
+// handled as an error response.
+type Appender interface {
+	AppendGraph(trees *[]tree.ServiceNode, namespaceName string)
+}
+
+func checkError(err error) {
+	if err != nil {
+		panic(err.Error)
+	}
+}

--- a/graph/appender/circuit_breaker.go
+++ b/graph/appender/circuit_breaker.go
@@ -1,0 +1,49 @@
+package appender
+
+import (
+	"strings"
+
+	"github.com/kiali/kiali/graph/tree"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/services/models"
+)
+
+type CircuitBreakerAppender struct{}
+
+func (a CircuitBreakerAppender) AppendGraph(trees *[]tree.ServiceNode, namespaceName string) {
+	istioClient, err := kubernetes.NewClient()
+	checkError(err)
+
+	for _, tree := range *trees {
+		applyCircuitBreakers(&tree, namespaceName, istioClient)
+	}
+}
+
+func applyCircuitBreakers(n *tree.ServiceNode, namespaceName string, istioClient *kubernetes.IstioClient) {
+	// determine if there is a circuit breaker on this node
+	istioDetails, err := istioClient.GetIstioDetails(namespaceName, strings.Split(n.Name, ".")[0])
+	if err == nil {
+		if istioDetails.DestinationPolicies != nil {
+			dps := make(models.DestinationPolicies, 0)
+			dps.Parse(istioDetails.DestinationPolicies)
+			for _, dp := range dps {
+				if dp.CircuitBreaker != nil {
+					if d, ok := dp.Destination.(map[string]interface{}); ok {
+						if d["labels"].(map[string]interface{})["version"] == n.Version {
+							n.Metadata["hasCircuitBreaker"] = "true"
+							break // no need to keep going, we know it has at least one CB policy
+						}
+					}
+				}
+			}
+		}
+	} else {
+		log.Warningf("Cannot determine if service [%v:%v] has circuit breakers: %v", namespaceName, n.Name, err)
+		n.Metadata["hasCircuitBreaker"] = "unknown"
+	}
+
+	for _, child := range n.Children {
+		applyCircuitBreakers(child, namespaceName, istioClient)
+	}
+}

--- a/graph/appender/unused_service.go
+++ b/graph/appender/unused_service.go
@@ -1,4 +1,4 @@
-package handlers
+package appender
 
 import (
 	"fmt"
@@ -7,8 +7,22 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph/tree"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 )
+
+type UnusedServiceAppender struct {
+}
+
+func (a UnusedServiceAppender) AppendGraph(trees *[]tree.ServiceNode, namespaceName string) {
+	istioClient, err := kubernetes.NewClient()
+	checkError(err)
+
+	deployments, err := istioClient.GetDeployments(namespaceName)
+	checkError(err)
+
+	addUnusedNodes(trees, namespaceName, deployments)
+}
 
 func addUnusedNodes(trees *[]tree.ServiceNode, namespaceName string, deployments *v1beta1.DeploymentList) {
 	staticNodeList := buildStaticNodeList(namespaceName, deployments)

--- a/graph/appender/unused_service_test.go
+++ b/graph/appender/unused_service_test.go
@@ -1,4 +1,4 @@
-package handlers
+package appender
 
 import (
 	"testing"

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
 )
@@ -198,19 +197,19 @@ func TestNamespaceGraph(t *testing.T) {
 	mockQuery(api, q7, &v7)
 	mockQuery(api, q8, &v8)
 
-	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client, ic *kubernetes.IstioClient)
+	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/graphs", http.HandlerFunc(
+	mr.HandleFunc("/api/namespaces/{namespace}/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client, nil)
+			fut(w, r, client)
 		}))
 
 	ts := httptest.NewServer(mr)
 	defer ts.Close()
 
 	fut = graphNamespace
-	url := ts.URL + "/api/namespaces/istio-system/graphs?queryTime=1523364075"
+	url := ts.URL + "/api/namespaces/istio-system/graph?appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -322,7 +321,7 @@ func TestServiceGraph(t *testing.T) {
 	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/services/{service}/graphs", http.HandlerFunc(
+	mr.HandleFunc("/api/namespaces/{namespace}/services/{service}/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			fut(w, r, client)
 		}))
@@ -331,7 +330,7 @@ func TestServiceGraph(t *testing.T) {
 	defer ts.Close()
 
 	fut = graphService
-	url := ts.URL + "/api/namespaces/istio-system/services/reviews/graphs?queryTime=1523364075"
+	url := ts.URL + "/api/namespaces/istio-system/services/reviews/graph?appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -99,8 +99,9 @@ func NewRoutes() (r *Routes) {
 			// vendor:         cytoscape (default) | vizceral
 			// metric:         Prometheus metric name used to generate the dependency graph (default=istio_request_count)
 			// groupByVersion: visually group versions of the same service (cytoscape only, default true)
-			// offset:         Duration indicating desired query offset (default 0m)
-			// interval:       Duration indicating desired query period (default 10m)
+			// queryTime:      Unix timestamp in seconds is query range end time (default now)
+			// duration:       Duration indicating desired query period (default 10m)
+			// appenders:      comma-separated list of desired appenders (default all)
 
 			"GraphNamespace",
 			"GET",
@@ -112,8 +113,9 @@ func NewRoutes() (r *Routes) {
 			// vendor:         cytoscape (default)
 			// metric:         Prometheus metric name used to generate the dependency graph (default=istio_request_count)
 			// groupByVersion: visually group versions of the same service (cytoscape only, default true)
-			// offset:         Duration indicating desired query offset (default 0m)
-			// interval:       Duration indicating desired query period (default 10m)
+			// queryTime:      Unix timestamp in seconds is query range end time (default now)
+			// duration:       Duration indicating desired query period (default 10m)
+			// appenders:      comma-separated list of desired appenders (default all)
 
 			"GraphService",
 			"GET",


### PR DESCRIPTION
This refactors things to further detach unused service and circuit breaker
additions fron the base graph generation.  It sets things up to more
easily allow potential include/exclude options on requests.