### PR TITLE
KIALI-505 Provide Error Rate in health

### DIFF
--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -272,6 +273,8 @@ func TestServiceHealth(t *testing.T) {
 		assert.Equal(t, "ns", args[0])
 		assert.Equal(t, "svc", args[1])
 	}).Return(1, 1, nil)
+
+	prom.On("GetServiceRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(model.Vector{}, model.Vector{}, nil)
 
 	resp, err := http.Get(url)
 	if err != nil {

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -17,7 +17,8 @@ import (
 // ClientInterface for mocks (only mocked function are necessary here)
 type ClientInterface interface {
 	GetServiceHealth(namespace string, servicename string) (int, int, error)
-	GetNamespaceServicesRequestCounters(namespace string, ratesInterval string) MetricsVector
+	GetNamespaceServicesRequestRates(namespace string, ratesInterval string) (model.Vector, model.Vector, error)
+	GetServiceRequestRates(namespace, service string, ratesInterval string) (model.Vector, model.Vector, error)
 	GetSourceServices(namespace string, servicename string) (map[string][]string, error)
 }
 
@@ -109,10 +110,18 @@ func (in *Client) GetNamespaceMetrics(query *NamespaceMetricsQuery) Metrics {
 	return getNamespaceMetrics(in.api, query)
 }
 
-// GetNamespaceServicesRequestCounters queries Prometheus to fetch request counters
-// for each service, both in and out counters.
-func (in *Client) GetNamespaceServicesRequestCounters(namespace string, ratesInterval string) MetricsVector {
-	return getNamespaceServicesRequestCounters(in.api, namespace, ratesInterval)
+// GetNamespaceServicesRequestRates queries Prometheus to fetch request counters rates over a time interval
+// for each service, both in and out.
+// Returns (in, out, error)
+func (in *Client) GetNamespaceServicesRequestRates(namespace string, ratesInterval string) (model.Vector, model.Vector, error) {
+	return getNamespaceServicesRequestRates(in.api, namespace, ratesInterval)
+}
+
+// GetServiceRequestRates queries Prometheus to fetch request counters rates over a time interval
+// for a given service, both in and out.
+// Returns (in, out, error)
+func (in *Client) GetServiceRequestRates(namespace, service string, ratesInterval string) (model.Vector, model.Vector, error) {
+	return getServiceRequestRates(in.api, namespace, service, ratesInterval)
 }
 
 // API returns the Prometheus V1 HTTP API for performing calls not supported natively by this client

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -368,7 +368,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	assert.Equal(t, 0.9, float64(rsSizeIn.Percentile99.Matrix[0].Values[0].Value))
 }
 
-func TestGetNamespaceServicesRequestCounters(t *testing.T) {
+func TestGetNamespaceServicesRequestRates(t *testing.T) {
 	client, api, err := setupMocked()
 	if err != nil {
 		t.Error(err)
@@ -391,12 +391,11 @@ func TestGetNamespaceServicesRequestCounters(t *testing.T) {
 	}
 	mockQuery(api, `rate(istio_request_count{destination_service=~".*\\.istio-system\\..*"}[5m])`, &vectorQ2)
 
-	counters := client.GetNamespaceServicesRequestCounters("istio-system", "5m")
-	assert.NotNil(t, counters)
-	assert.NotNil(t, counters.Vector)
-	assert.Equal(t, 2, counters.Vector.Len())
-	assert.Equal(t, append(vectorQ1, vectorQ2...), counters.Vector)
-
+	in, out, err := client.GetNamespaceServicesRequestRates("istio-system", "5m")
+	assert.Equal(t, 1, in.Len())
+	assert.Equal(t, 1, out.Len())
+	assert.Equal(t, vectorQ1, in)
+	assert.Equal(t, vectorQ2, out)
 }
 
 func mockQuery(api *PromAPIMock, query string, ret *model.Vector) {

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -7,8 +7,6 @@ import (
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
-
-	"github.com/kiali/kiali/prometheus"
 )
 
 // PromAPIMock for mocking Prometheus API
@@ -89,17 +87,22 @@ type PromClientMock struct {
 	mock.Mock
 }
 
-func (o *PromClientMock) GetServiceHealth(namespace string, servicename string) (int, int, error) {
+func (o *PromClientMock) GetServiceHealth(namespace, servicename string) (int, int, error) {
 	args := o.Called(namespace, servicename)
 	return args.Int(0), args.Int(1), args.Error(2)
 }
 
-func (o *PromClientMock) GetNamespaceServicesRequestCounters(namespace string, ratesInterval string) prometheus.MetricsVector {
+func (o *PromClientMock) GetNamespaceServicesRequestRates(namespace, ratesInterval string) (model.Vector, model.Vector, error) {
 	args := o.Called(namespace, ratesInterval)
-	return args.Get(0).(prometheus.MetricsVector)
+	return args.Get(0).(model.Vector), args.Get(1).(model.Vector), args.Error(2)
 }
 
-func (o *PromClientMock) GetSourceServices(namespace string, servicename string) (map[string][]string, error) {
+func (o *PromClientMock) GetServiceRequestRates(namespace, service, ratesInterval string) (model.Vector, model.Vector, error) {
+	args := o.Called(namespace, ratesInterval)
+	return args.Get(0).(model.Vector), args.Get(1).(model.Vector), args.Error(2)
+}
+
+func (o *PromClientMock) GetSourceServices(namespace, servicename string) (map[string][]string, error) {
 	args := o.Called(namespace, servicename)
 	return args.Get(0).(map[string][]string), args.Error(1)
 }

--- a/services/models/health.go
+++ b/services/models/health.go
@@ -4,12 +4,15 @@ package models
 type Health struct {
 	Envoy              EnvoyHealth        `json:"envoy"`
 	DeploymentStatuses []DeploymentStatus `json:"deploymentStatuses"`
+	Requests           RequestHealth      `json:"requests"`
+	DeploymentsFetched bool               `json:"-"`
 }
 
 // EnvoyHealth is the number of healthy versus total membership (ie. replicas) inside envoy cluster (ie. service)
 type EnvoyHealth struct {
-	Healthy int `json:"healthy"`
-	Total   int `json:"total"`
+	Healthy int  `json:"healthy"`
+	Total   int  `json:"total"`
+	Fetched bool `json:"-"`
 }
 
 // DeploymentStatus gives the available / total replicas in a deployment of a pod
@@ -17,4 +20,39 @@ type DeploymentStatus struct {
 	Name              string `json:"name"`
 	Replicas          int32  `json:"replicas"`
 	AvailableReplicas int32  `json:"available"`
+}
+
+// RequestHealth holds several stats about recent request errors
+type RequestHealth struct {
+	RequestCount      float64 `json:"requestCount"`
+	RequestErrorCount float64 `json:"requestErrorCount"`
+	Fetched           bool    `json:"-"`
+}
+
+// FillDeploymentStatusesIfMissing sets DeploymentStatuses if necessary
+func (in *Health) FillDeploymentStatusesIfMissing(supplier func() []DeploymentStatus) {
+	if !in.DeploymentsFetched {
+		in.DeploymentStatuses = supplier()
+		in.DeploymentsFetched = true
+	}
+}
+
+// FillIfMissing sets EnvoyHealth if necessary. Supplier must return (healthy, total)
+func (in *EnvoyHealth) FillIfMissing(supplier func() (int, int)) {
+	if !in.Fetched {
+		h, t := supplier()
+		in.Healthy = h
+		in.Total = t
+		in.Fetched = true
+	}
+}
+
+// FillIfMissing sets RequestHealth if necessary. Supplier must return (errors, total)
+func (in *RequestHealth) FillIfMissing(supplier func() (float64, float64)) {
+	if !in.Fetched {
+		e, t := supplier()
+		in.RequestErrorCount = e
+		in.RequestCount = t
+		in.Fetched = true
+	}
 }

--- a/services/models/service.go
+++ b/services/models/service.go
@@ -3,18 +3,13 @@ package models
 import (
 	"time"
 
-	"github.com/prometheus/common/model"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type ServiceOverview struct {
-	Name              string            `json:"name"`
-	Health            Health            `json:"health"`
-	IstioSidecar      bool              `json:"istio_sidecar"`
-	RequestCount      model.SampleValue `json:"request_count"`
-	RequestErrorCount model.SampleValue `json:"request_error_count"`
-	ErrorRate         model.SampleValue `json:"error_rate"`
+	Name         string `json:"name"`
+	Health       Health `json:"health"`
+	IstioSidecar bool   `json:"istio_sidecar"`
 }
 
 type ServiceList struct {


### PR DESCRIPTION
- Move service error rate fields to health
- Add rateInterval query param to endpoints provding health
- Fix issue while getting error rates: dulicates may appear when fetching for namespace, they must not be added twice to the counters
- Fetch Error Rates per service
- Some rework on Health to make it easier to fill incrementally

UI counterpart: https://github.com/kiali/kiali-ui/pull/265