### PR TITLE
Kiali 556 - Add configuration checks for Istio Objects

### DIFF
--- a/handlers/services.go
+++ b/handlers/services.go
@@ -91,6 +91,27 @@ func ServiceHealth(w http.ResponseWriter, r *http.Request) {
 	RespondWithJSON(w, http.StatusOK, health)
 }
 
+// ServiceIstioValidations is the API handler to get istio validations of a single service
+func ServiceIstioValidations(w http.ResponseWriter, r *http.Request) {
+	// Get business layer
+	business, err := business.Get()
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+		return
+	}
+
+	vars := mux.Vars(r)
+	namespace := vars["namespace"]
+	service := vars["service"]
+
+	istioValidations, err := business.Validations.GetServiceValidations(namespace, service)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Error checking istio object consistency: "+err.Error())
+		return
+	}
+	RespondWithJSON(w, http.StatusOK, istioValidations)
+}
+
 // ServiceDetails is the API handler to fetch full details of an specific service
 func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 	// Get business layer

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -89,6 +89,12 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceHealth,
 		},
 		{
+			"ServiceValidations",
+			"GET",
+			"/api/namespaces/{namespace}/services/{service}/istio_validations",
+			handlers.ServiceIstioValidations,
+		},
+		{
 			"NamespaceMetrics",
 			"GET",
 			"/api/namespaces/{namespace}/metrics",

--- a/services/business/checkers/route_rule_checker.go
+++ b/services/business/checkers/route_rule_checker.go
@@ -1,0 +1,82 @@
+package checkers
+
+import (
+	"sync"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/business/checkers/route_rules"
+	"github.com/kiali/kiali/services/models"
+)
+
+const objectType = "routerule"
+
+type Checker interface {
+	Check() ([]*models.IstioCheck, bool)
+}
+
+type RouteRuleChecker struct {
+	RouteRules []kubernetes.IstioObject
+}
+
+func (in RouteRuleChecker) Check() *models.IstioValidations {
+	objectValidations := models.IstioValidations{}
+
+	objectValidations = objectValidations.MergeValidations(in.runIndividualChecks())
+	objectValidations = objectValidations.MergeValidations(in.runGroupChecks())
+
+	return &objectValidations
+}
+
+func (in RouteRuleChecker) runIndividualChecks() *models.IstioValidations {
+	validations := models.IstioValidations{}
+	var wg sync.WaitGroup
+
+	wg.Add(len(in.RouteRules))
+
+	for _, routeRule := range in.RouteRules {
+		go runChecks(routeRule, &validations, &wg)
+	}
+
+	wg.Wait()
+
+	return &validations
+}
+
+func (in *RouteRuleChecker) runGroupChecks() *models.IstioValidations {
+	return &models.IstioValidations{}
+}
+
+func enabledCheckersFor(object kubernetes.IstioObject) []Checker {
+	return []Checker{
+		route_rules.RouteChecker{object},
+		route_rules.PrecedenceChecker{object},
+	}
+}
+
+func runChecks(routeRule kubernetes.IstioObject, validationsPointer *models.IstioValidations, wg *sync.WaitGroup) {
+	defer (*wg).Done()
+	var checkersWg sync.WaitGroup
+
+	ruleName := routeRule.GetObjectMeta().Name
+	validation := &models.IstioValidation{Name: ruleName, ObjectType: objectType, Valid: true}
+	validations := *validationsPointer
+	validations[ruleName] = validation
+
+	checkers := enabledCheckersFor(routeRule)
+	checkersWg.Add(len(checkers))
+
+	for _, checker := range checkers {
+		go runChecker(checker, ruleName, validationsPointer, &checkersWg)
+	}
+
+	checkersWg.Wait()
+}
+
+func runChecker(checker Checker, objectName string, validationsPointer *models.IstioValidations, wg *sync.WaitGroup) {
+	defer (*wg).Done()
+	validations := *validationsPointer
+
+	checks, validChecker := checker.Check()
+	validations[objectName].Checks = append(validations[objectName].Checks, checks...)
+	validations[objectName].Valid = validations[objectName].Valid && validChecker
+}

--- a/services/business/checkers/route_rule_checker_test.go
+++ b/services/business/checkers/route_rule_checker_test.go
@@ -1,0 +1,204 @@
+package checkers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/models"
+)
+
+func prepareTest(istioObject kubernetes.IstioObject) *models.IstioValidations {
+	istioObjects := []kubernetes.IstioObject{istioObject}
+
+	routeRuleChecker := RouteRuleChecker{istioObjects}
+	return routeRuleChecker.Check()
+}
+
+func TestWellRouteRuleValidation(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations := *(prepareTest(fakeIstioObjects()))
+
+	// Well configured object
+	validObject := validations["reviews-well"]
+	assert.Equal(validObject.Name, "reviews-well")
+	assert.Equal(validObject.ObjectType, "routerule")
+	assert.Equal(validObject.Valid, true)
+	assert.NotEmpty(validObject)
+	assert.Len(validObject.Checks, 0)
+}
+
+func TestMultipleCheck(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations := *(prepareTest(fakeMultipleChecks()))
+
+	// route rule with multiple problems
+	invalidObject := validations["reviews-multiple"]
+	assert.NotEmpty(invalidObject)
+	assert.Equal(invalidObject.Name, "reviews-multiple")
+	assert.Equal(invalidObject.ObjectType, "routerule")
+	assert.Equal(invalidObject.Valid, false)
+	assert.Len(invalidObject.Checks, 2)
+}
+
+func TestCorrectPrecedence(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations := *(prepareTest(fakeCorrectPrecedence()))
+
+	// wrong weight'ed route rule
+	invalidObject := validations["reviews-precedence"]
+	assert.NotEmpty(invalidObject)
+	assert.Equal(invalidObject.Name, "reviews-precedence")
+	assert.Equal(invalidObject.ObjectType, "routerule")
+	assert.Equal(invalidObject.Valid, true)
+	assert.Empty(invalidObject.Checks)
+}
+
+func TestNegativePrecedence(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations := *(prepareTest(fakeNegative()))
+
+	// Negative precedence
+	invalidObject := validations["reviews-negative"]
+	assert.NotEmpty(invalidObject)
+	assert.Equal(invalidObject.Name, "reviews-negative")
+	assert.Equal(invalidObject.ObjectType, "routerule")
+	assert.Equal(invalidObject.Valid, false)
+	assert.Len(invalidObject.Checks, 1)
+}
+
+func TestMixedCheckerRoule(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations := *(prepareTest(fakeMixedChecker()))
+
+	// Precedence is incorrect
+	invalidObject := validations["reviews-mixed"]
+	assert.NotEmpty(invalidObject)
+	assert.Equal(invalidObject.Name, "reviews-mixed")
+	assert.Equal(invalidObject.ObjectType, "routerule")
+	assert.Equal(invalidObject.Valid, false)
+	assert.Len(invalidObject.Checks, 3)
+}
+
+func fakeIstioObjects() kubernetes.IstioObject {
+	validRouteRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-well",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(55),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return validRouteRule
+}
+
+func fakeMultipleChecks() kubernetes.IstioObject {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-multiple",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(155),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return routeRule
+}
+
+func fakeCorrectPrecedence() kubernetes.IstioObject {
+	validRouteRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-precedence",
+		},
+		Spec: map[string]interface{}{
+			"precedence": uint64(1),
+		},
+	}).DeepCopyIstioObject()
+
+	return validRouteRule
+}
+
+func fakeNegative() kubernetes.IstioObject {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-negative",
+		},
+		Spec: map[string]interface{}{
+			"precedence": int64(-1),
+		},
+	}).DeepCopyIstioObject()
+
+	return routeRule
+}
+
+func fakeMixedChecker() kubernetes.IstioObject {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-mixed",
+		},
+		Spec: map[string]interface{}{
+			"precedence": int64(-1),
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(155),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return routeRule
+}

--- a/services/business/checkers/route_rules/precedence_checker.go
+++ b/services/business/checkers/route_rules/precedence_checker.go
@@ -1,0 +1,37 @@
+package route_rules
+
+import (
+	"strconv"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/models"
+	"github.com/kiali/kiali/util/intutil"
+)
+
+type PrecedenceChecker struct{ kubernetes.IstioObject }
+
+func (route PrecedenceChecker) Check() ([]*models.IstioCheck, bool) {
+	valid := true
+	validations := make([]*models.IstioCheck, 0)
+
+	if route.GetSpec()["precedence"] == nil {
+		return validations, valid
+	}
+
+	precedence, err := intutil.Convert(route.GetSpec()["precedence"])
+	if err != nil {
+		valid = false
+		validation := models.BuildCheck("Precedence must be a number",
+			"error", "spec/precedence/"+route.GetSpec()["precedence"].(string))
+		validations = append(validations, &validation)
+	}
+
+	if precedence < 0 {
+		valid = false
+		validation := models.BuildCheck("Precedence should be greater than or equal to 0",
+			"error", "spec/precedence/"+strconv.Itoa(int(precedence)))
+		validations = append(validations, &validation)
+	}
+
+	return validations, valid
+}

--- a/services/business/checkers/route_rules/precedence_checker_test.go
+++ b/services/business/checkers/route_rules/precedence_checker_test.go
@@ -1,0 +1,89 @@
+package route_rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+func TestCheckerWell(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations, valid := PrecedenceChecker{fakeCorrectPrecedence()}.Check()
+
+	// Well configured object
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+func TestCheckerString(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := PrecedenceChecker{fakeString()}.Check()
+
+	// wrong weight'ed route rule
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(validations[0].Message, "Precedence must be a number")
+	assert.Equal(validations[0].Severity, "error")
+	assert.Equal(validations[0].Path, "spec/precedence/abc")
+}
+
+func TestCheckerNegative(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations, valid := PrecedenceChecker{fakeNegative()}.Check()
+
+	// wrong weight'ed route rule
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(validations[0].Message, "Precedence should be greater than or equal to 0")
+	assert.Equal(validations[0].Severity, "error")
+	assert.Equal(validations[0].Path, "spec/precedence/-1")
+}
+
+func fakeCorrectPrecedence() kubernetes.IstioObject {
+	validRouteRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-well",
+		},
+		Spec: map[string]interface{}{
+			"precedence": uint64(1),
+		},
+	}).DeepCopyIstioObject()
+
+	return validRouteRule
+}
+
+func fakeString() kubernetes.IstioObject {
+	validRouteRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-string",
+		},
+		Spec: map[string]interface{}{
+			"precedence": "abc",
+		},
+	}).DeepCopyIstioObject()
+
+	return validRouteRule
+}
+
+func fakeNegative() kubernetes.IstioObject {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-negative",
+		},
+		Spec: map[string]interface{}{
+			"precedence": int64(-1),
+		},
+	}).DeepCopyIstioObject()
+
+	return routeRule
+}

--- a/services/business/checkers/route_rules/route_checker.go
+++ b/services/business/checkers/route_rules/route_checker.go
@@ -1,0 +1,66 @@
+package route_rules
+
+import (
+	"reflect"
+	"strconv"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/models"
+	"github.com/kiali/kiali/util/intutil"
+)
+
+type RouteChecker struct{ kubernetes.IstioObject }
+
+func (route RouteChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	var weightSum int
+	var weightCount int
+	var valid bool = true
+
+	slice := reflect.ValueOf(route.GetSpec()["route"])
+	if slice.Kind() != reflect.Slice {
+		return validations, valid
+	}
+
+	for i := 0; i < slice.Len(); i++ {
+		var weight int
+
+		route := slice.Index(i).Interface().(map[string]interface{})
+		if route["weight"] == nil {
+			continue
+		}
+
+		weightCount = weightCount + 1
+		weight, err := intutil.Convert(route["weight"])
+		if err != nil {
+			valid = false
+			validation := models.BuildCheck("Weight must be a number",
+				"error", "spec/precedence/"+route["weight"].(string))
+			validations = append(validations, &validation)
+		}
+
+		if weight > 100 || weight < 0 {
+			valid = false
+			validation := models.BuildCheck("Weight should be between 0 and 100",
+				"error", "spec/route/weight/"+strconv.Itoa(weight))
+			validations = append(validations, &validation)
+		}
+
+		weightSum = weightSum + weight
+	}
+
+	if weightCount > 0 && weightSum != 100 {
+		valid = false
+		validation := models.BuildCheck("Weight sum should be 100", "error", "")
+		validations = append(validations, &validation)
+	}
+
+	if weightCount > 0 && weightCount != slice.Len() {
+		valid = false
+		validation := models.BuildCheck("All routes should have weight", "error", "")
+		validations = append(validations, &validation)
+	}
+
+	return validations, valid
+}

--- a/services/business/checkers/route_rules/route_checker_test.go
+++ b/services/business/checkers/route_rules/route_checker_test.go
@@ -1,0 +1,182 @@
+package route_rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+func TestServiceWellRouteRuleValidation(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations, valid := RouteChecker{fakeIstioObjects()}.Check()
+
+	// Well configured object
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestServiceMultipleChecks(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := RouteChecker{fakeMultipleChecks()}.Check()
+
+	// wrong weight'ed route rule
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 2)
+	assert.Equal(validations[0].Message, "Weight should be between 0 and 100")
+	assert.Equal(validations[0].Severity, "error")
+	assert.Equal(validations[0].Path, "spec/route/weight/155")
+
+	assert.Equal(validations[1].Message, "Weight sum should be 100")
+	assert.Equal(validations[1].Severity, "error")
+	assert.Equal(validations[1].Path, "")
+
+}
+
+func TestServiceOver100RouteRule(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations, valid := RouteChecker{fakeOver100RouteRule()}.Check()
+
+	// wrong weight'ed route rule
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(validations[0].Message, "Weight sum should be 100")
+	assert.Equal(validations[0].Severity, "error")
+	assert.Equal(validations[0].Path, "")
+}
+
+func TestServiceUnder100RouteRule(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	validations, valid := RouteChecker{fakeUnder100RouteRule()}.Check()
+
+	// wrong weight'ed route rule
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(validations[0].Message, "Weight sum should be 100")
+	assert.Equal(validations[0].Severity, "error")
+	assert.Equal(validations[0].Path, "")
+}
+
+func fakeIstioObjects() kubernetes.IstioObject {
+	validRouteRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-well",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(55),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return validRouteRule
+}
+
+func fakeUnder100RouteRule() kubernetes.IstioObject {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-100-minus",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return routeRule
+}
+
+func fakeOver100RouteRule() kubernetes.IstioObject {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-100-plus",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(55),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(55),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return routeRule
+}
+
+func fakeMultipleChecks() kubernetes.IstioObject {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-multiple",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(155),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return routeRule
+}

--- a/services/business/istio_validations.go
+++ b/services/business/istio_validations.go
@@ -1,0 +1,51 @@
+package business
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/business/checkers"
+	"github.com/kiali/kiali/services/models"
+)
+
+type IstioValidationsService struct {
+	k8s kubernetes.IstioClientInterface
+}
+
+type ObjectChecker interface {
+	Check() *models.IstioValidations
+}
+
+func (in *IstioValidationsService) GetServiceValidations(namespace, service string) (models.IstioValidations, error) {
+	// Get all the Istio objects from a namespace and service
+	istioDetails, err := in.k8s.GetIstioDetails(namespace, service)
+	if err != nil {
+		return nil, err
+	}
+
+	objectCheckers := enabledCheckersFor(istioDetails)
+	objectCheckersCount := len(objectCheckers)
+
+	objectValidations := models.IstioValidations{}
+	validationsChannel := make(chan *models.IstioValidations, objectCheckersCount)
+
+	// Run checks for each IstioObject type
+	for _, objectChecker := range objectCheckers {
+		go func() {
+			validationsChannel <- objectChecker.Check()
+			close(validationsChannel)
+		}()
+	}
+
+	// Receive validations and merge them into one object
+	for validation := range validationsChannel {
+		objectValidations.MergeValidations(validation)
+	}
+
+	// Get groupal validations for same kind istio objects
+	return objectValidations, nil
+}
+
+func enabledCheckersFor(istioDetails *kubernetes.IstioDetails) []ObjectChecker {
+	return []ObjectChecker{
+		checkers.RouteRuleChecker{istioDetails.RouteRules},
+	}
+}

--- a/services/business/istio_validations_test.go
+++ b/services/business/istio_validations_test.go
@@ -1,0 +1,229 @@
+package business
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+)
+
+func TestServiceWellRouteRuleValidation(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	vs := mockValidationService(fakeIstioObjects())
+	validations, _ := vs.GetServiceValidations("bookinfo", "reviews")
+
+	// Well configured object
+	validObject := validations["reviews-well"]
+	assert.NotEmpty(validObject)
+	assert.Equal(validObject.Name, "reviews-well")
+	assert.Equal(validObject.ObjectType, "routerule")
+	assert.Equal(validObject.Valid, true)
+
+	// Assert checks
+	assert.Len(validObject.Checks, 0)
+}
+
+func TestServiceMultipleChecks(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	vs := mockValidationService(fakeMultipleChecks())
+	validations, _ := vs.GetServiceValidations("bookinfo", "reviews")
+
+	// wrong weight'ed route rule
+	invalidObject := validations["reviews-multiple"]
+	assert.NotEmpty(invalidObject)
+	assert.Equal(invalidObject.Name, "reviews-multiple")
+	assert.Equal(invalidObject.ObjectType, "routerule")
+	assert.Equal(invalidObject.Valid, false)
+
+	checks := invalidObject.Checks
+	assert.Len(checks, 2)
+
+	assert.Equal(checks[0].Message, "Weight should be between 0 and 100")
+	assert.Equal(checks[0].Severity, "error")
+	assert.Equal(checks[0].Path, "spec/route/weight/155")
+
+	assert.Equal(checks[1].Message, "Weight sum should be 100")
+	assert.Equal(checks[1].Severity, "error")
+	assert.Equal(checks[1].Path, "")
+
+}
+
+func TestServiceOver100RouteRule(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	vs := mockValidationService(fakeOver100RouteRule())
+	validations, _ := vs.GetServiceValidations("bookinfo", "reviews")
+
+	// wrong weight'ed route rule
+	invalidObject := validations["reviews-100-plus"]
+	assert.NotEmpty(invalidObject)
+
+	assert.Equal(invalidObject.Name, "reviews-100-plus")
+	assert.Equal(invalidObject.ObjectType, "routerule")
+	assert.Equal(invalidObject.Valid, false)
+
+	checks := invalidObject.Checks
+	assert.Len(checks, 1)
+
+	assert.Equal(checks[0].Message, "Weight sum should be 100")
+	assert.Equal(checks[0].Severity, "error")
+	assert.Equal(checks[0].Path, "")
+}
+
+func TestServiceUnder100RouteRule(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	vs := mockValidationService(fakeUnder100RouteRule())
+	validations, _ := vs.GetServiceValidations("bookinfo", "reviews")
+
+	// wrong weight'ed route rule
+	invalidObject := validations["reviews-100-minus"]
+	assert.NotEmpty(invalidObject)
+
+	assert.Equal(invalidObject.Name, "reviews-100-minus")
+	assert.Equal(invalidObject.ObjectType, "routerule")
+	assert.Equal(invalidObject.Valid, false)
+
+	checks := invalidObject.Checks
+	assert.Len(checks, 1)
+	assert.Equal(checks[0].Message, "Weight sum should be 100")
+	assert.Equal(checks[0].Severity, "error")
+	assert.Equal(checks[0].Path, "")
+}
+
+func fakeIstioObjects() *kubernetes.IstioDetails {
+	validRouteRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-well",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(55),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	var istioDetails = &kubernetes.IstioDetails{}
+	istioDetails.RouteRules = []kubernetes.IstioObject{validRouteRule}
+	return istioDetails
+}
+
+func fakeUnder100RouteRule() *kubernetes.IstioDetails {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-100-minus",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	var istioDetails = &kubernetes.IstioDetails{}
+	istioDetails.RouteRules = []kubernetes.IstioObject{routeRule}
+	return istioDetails
+}
+
+func fakeOver100RouteRule() *kubernetes.IstioDetails {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-100-plus",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(55),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(55),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	var istioDetails = &kubernetes.IstioDetails{}
+	istioDetails.RouteRules = []kubernetes.IstioObject{routeRule}
+	return istioDetails
+}
+
+func fakeMultipleChecks() *kubernetes.IstioDetails {
+	routeRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews-multiple",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(155),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version":   "v1",
+						"namespace": "bookinfo",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	var istioDetails = &kubernetes.IstioDetails{}
+	istioDetails.RouteRules = []kubernetes.IstioObject{routeRule}
+	return istioDetails
+}
+
+func mockValidationService(istioObjects *kubernetes.IstioDetails) IstioValidationsService {
+	k8s := new(kubetest.K8SClientMock)
+	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(istioObjects, nil)
+
+	return IstioValidationsService{k8s: k8s}
+}

--- a/services/business/layer.go
+++ b/services/business/layer.go
@@ -7,8 +7,9 @@ import (
 
 // Layer is a container for fast access to inner services
 type Layer struct {
-	Svc    SvcService
-	Health HealthService
+	Svc         SvcService
+	Health      HealthService
+	Validations IstioValidationsService
 }
 
 // Global business.Layer; currently only used for tests to inject mocks,
@@ -32,6 +33,7 @@ func Get() (*Layer, error) {
 	temporaryLayer := &Layer{}
 	temporaryLayer.Health = HealthService{prom: prom, k8s: k8s}
 	temporaryLayer.Svc = SvcService{prom: prom, k8s: k8s, health: &temporaryLayer.Health}
+	temporaryLayer.Validations = IstioValidationsService{k8s: k8s}
 	return temporaryLayer, nil
 }
 
@@ -40,5 +42,6 @@ func SetWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	layer = &Layer{}
 	layer.Health = HealthService{prom: prom, k8s: k8s}
 	layer.Svc = SvcService{prom: prom, k8s: k8s, health: &layer.Health}
+	layer.Validations = IstioValidationsService{k8s: k8s}
 	return layer
 }

--- a/services/models/istio_validation.go
+++ b/services/models/istio_validation.go
@@ -1,0 +1,32 @@
+package models
+
+type IstioValidations map[string]*IstioValidation
+type IstioValidation struct {
+	Name       string        `json:"name"`
+	ObjectType string        `json:"object_type"`
+	Valid      bool          `json:"valid"`
+	Checks     []*IstioCheck `json:"checks"`
+}
+
+type IstioCheck struct {
+	Message  string `json:"message"`
+	Severity string `json:"severity"`
+	Path     string `json:"path"`
+}
+
+func BuildCheck(message, severity, path string) IstioCheck {
+	return IstioCheck{message, severity, path}
+}
+
+func (in IstioValidations) MergeValidations(validations *IstioValidations) IstioValidations {
+	for name, validation := range *validations {
+		if in[name] != nil {
+			in[name].Checks = append(in[name].Checks, validation.Checks...)
+			in[name].Valid = validation.Valid && in[name].Valid
+		} else {
+			in[name] = validation
+		}
+	}
+
+	return in
+}

--- a/services/models/route_rule.go
+++ b/services/models/route_rule.go
@@ -24,6 +24,7 @@ type RouteRule struct {
 	Mirror           interface{} `json:"mirror"`
 	CorsPolicy       interface{} `json:"corsPolicy"`
 	AppendHeaders    interface{} `json:"appendHeaders"`
+	RouteWarning     string      `json:"routeWarning"`
 }
 
 func (rules *RouteRules) Parse(routeRules []kubernetes.IstioObject) {

--- a/util/intutil/convert.go
+++ b/util/intutil/convert.go
@@ -1,0 +1,20 @@
+package intutil
+
+import "errors"
+
+func Convert(subject interface{}) (int, error) {
+	var result int
+
+	switch subject.(type) {
+	case uint64:
+		result = int(subject.(uint64))
+	case int64:
+		result = int(subject.(int64))
+	case int:
+		result = subject.(int)
+	default:
+		return 0, errors.New("It is not a numeric input")
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
# Goal
This provides to KIALI a system prepared to run checks for all desired Istio Objects (route rules, destination policies, virtual services and destination rules).

Right now, in this PR, route rule weight and precedence validations are added. However, this system allow us to add as many validations as wanted (following SOLID principles).

PR related to [KIALI-556](https://issues.jboss.org/browse/KIALI-556) (and parcially documented in [KIALI-555](https://issues.jboss.org/browse/KIALI-555)).

## Output

![endpoint-both-valid-invalid](https://user-images.githubusercontent.com/613814/39537113-e4aa7e0e-4e38-11e8-9d1d-4f693aaf79c0.png)

### IstioValidation
For each IstioObject, we have an IstioValidation which aggregate all checks run for it.

An IstioValidation has:
- name: name of the istio object
- object_type: routerule, destinationpolicy,...
- valid: bool - true means that there are at least one check that returns an error (warnings are counted as valid)
- checks: array of IstioCheck - each check is a notification (i.e.: error, warning, improvement) for that istio object.

### IstioCheck
An IstioCheck is a configuration error, warning or improvement that one of the checkers has detected in a given Istio Object. (e.g. routing traffic to non-existant service).

An IstioCheck has:
- message: descriptive message of the error found.
- severity: type of message (error, warning, improvement)
- path: key that shows where exactly the error is found in the yaml.

#### Path
Given the following yaml, with an error on precedence value:

```yaml
apiVersion: config.istio.io/v1alpha2
kind: RouteRule
metadata:
  name: reviews-default
spec:
  destination:
    name: reviews
  precedence: -2
  route:
  - labels:
      version: v2
    weight: 55
  - labels:
      version: v3
    weight: 45
```

Path give a precise method to point where the error is. For the previous example, path value would be `spec/precedence/-2` (precedence has to be a positive number).

## Architecture

### ObjectChecker
An Object checker is a component responsible of running all the checks registered for an specific Istio Object.
For example, the RouteRuleChecker runs checks for weight validations within route balancing (sum of weights must be 100) and for precedence statement (checking that is always a positive number).

Check an ObjectChecker out [here](https://github.com/kiali/kiali/pull/180/files#diff-14de00b9c8bae60d021a351f4d1070fb).

### Checker
A Checker is a specific validation run for a Istio Object. One checker is responsible of checking one specific aspect of that Istio object. For example, check precedence validity (number and positive).

Check a Checker object out [here](https://github.com/kiali/kiali/pull/180/files#diff-bc9f505892e59eb9a6171329d40c8c32)

There will be one Object checker file for each Istio Object.

### Service
On top of it, we have a service/business object responsible of connecting the request handler with this validation system.
Service is called [IstioValidationService](https://github.com/kiali/kiali/pull/180/files#diff-e5fee97773f0c6b94aa993b34ca6d286).


Best practices guides followed:
- https://talks.golang.org/2014/go4gophers.slide
- https://talks.golang.org/2013/bestpractices.slide