### PR TITLE
KIALI-629 Do not bring unnecessary null values on Istio Objects

### DIFF
--- a/services/models/destination_policy.go
+++ b/services/models/destination_policy.go
@@ -11,10 +11,10 @@ type DestinationPolicy struct {
 	Name            string      `json:"name"`
 	CreatedAt       string      `json:"created_at"`
 	ResourceVersion string      `json:"resource_version"`
-	Source          interface{} `json:"source"`
-	Destination     interface{} `json:"destination"`
-	LoadBalancing   interface{} `json:"loadbalancing"`
-	CircuitBreaker  interface{} `json:"circuitBreaker"`
+	Source          interface{} `json:"source,omitempty"`
+	Destination     interface{} `json:"destination,omitempty"`
+	LoadBalancing   interface{} `json:"loadbalancing,omitempty"`
+	CircuitBreaker  interface{} `json:"circuitBreaker,omitempty"`
 }
 
 func (policies *DestinationPolicies) Parse(destinationPolicies []kubernetes.IstioObject) {

--- a/services/models/destination_rule.go
+++ b/services/models/destination_rule.go
@@ -11,9 +11,9 @@ type DestinationRule struct {
 	Name            string      `json:"name"`
 	CreatedAt       string      `json:"created_at"`
 	ResourceVersion string      `json:"resource_version"`
-	DestinationName interface{} `json:"destination_name"`
-	TrafficPolicy   interface{} `json:"traffic_policy"`
-	Subsets         interface{} `json:"subsets"`
+	DestinationName interface{} `json:"destination_name,omitempty"`
+	TrafficPolicy   interface{} `json:"traffic_policy,omitempty"`
+	Subsets         interface{} `json:"subsets,omitempty"`
 }
 
 func (dRules *DestinationRules) Parse(destinationRules []kubernetes.IstioObject) {

--- a/services/models/istio_rule.go
+++ b/services/models/istio_rule.go
@@ -11,14 +11,14 @@ type IstioRuleList struct {
 
 type IstioRule struct {
 	Name    string      `json:"name"`
-	Match   interface{} `json:"match"`
-	Actions interface{} `json:"actions"`
+	Match   interface{} `json:"match,omitempty"`
+	Actions interface{} `json:"actions,omitempty"`
 }
 
 type IstioRuleDetails struct {
 	Name      string             `json:"name"`
 	Namespace Namespace          `json:"namespace"`
-	Match     interface{}        `json:"match"`
+	Match     interface{}        `json:"match,omitempty"`
 	Actions   []*IstioRuleAction `json:"actions"`
 }
 
@@ -30,13 +30,13 @@ type IstioRuleAction struct {
 type IstioHandler struct {
 	Name    string      `json:"name"`
 	Adapter string      `json:"adapter"`
-	Spec    interface{} `json:"spec"`
+	Spec    interface{} `json:"spec,omitempty"`
 }
 
 type IstioInstance struct {
 	Name     string      `json:"name"`
 	Template string      `json:"template"`
-	Spec     interface{} `json:"spec"`
+	Spec     interface{} `json:"spec,omitempty"`
 }
 
 func GetIstioRulesByNamespace(namespaceName string) ([]IstioRule, error) {

--- a/services/models/route_rule.go
+++ b/services/models/route_rule.go
@@ -11,20 +11,20 @@ type RouteRule struct {
 	Name             string      `json:"name"`
 	CreatedAt        string      `json:"created_at"`
 	ResourceVersion  string      `json:"resource_version"`
-	Destination      interface{} `json:"destination"`
-	Precedence       interface{} `json:"precedence"`
-	Match            interface{} `json:"match"`
-	Route            interface{} `json:"route"`
-	Redirect         interface{} `json:"redirect"`
-	Rewrite          interface{} `json:"rewrite"`
-	WebsocketUpgrade interface{} `json:"websocketUpgrade"`
-	HttpReqTimeout   interface{} `json:"httpReqTimeout"`
-	HttpReqRetries   interface{} `json:"httpReqRetries"`
-	HttpFault        interface{} `json:"httpFault"`
-	L4Fault          interface{} `json:"l4Fault"`
-	Mirror           interface{} `json:"mirror"`
-	CorsPolicy       interface{} `json:"corsPolicy"`
-	AppendHeaders    interface{} `json:"appendHeaders"`
+	Destination      interface{} `json:"destination,omitempty"`
+	Precedence       interface{} `json:"precedence,omitempty"`
+	Match            interface{} `json:"match,omitempty"`
+	Route            interface{} `json:"route,omitempty"`
+	Redirect         interface{} `json:"redirect,omitempty"`
+	Rewrite          interface{} `json:"rewrite,omitempty"`
+	WebsocketUpgrade interface{} `json:"websocketUpgrade,omitempty"`
+	HttpReqTimeout   interface{} `json:"httpReqTimeout,omitempty"`
+	HttpReqRetries   interface{} `json:"httpReqRetries,omitempty"`
+	HttpFault        interface{} `json:"httpFault,omitempty"`
+	L4Fault          interface{} `json:"l4Fault,omitempty"`
+	Mirror           interface{} `json:"mirror,omitempty"`
+	CorsPolicy       interface{} `json:"corsPolicy,omitempty"`
+	AppendHeaders    interface{} `json:"appendHeaders,omitempty"`
 }
 
 func (rules *RouteRules) Parse(routeRules []kubernetes.IstioObject) {

--- a/services/models/virtual_service.go
+++ b/services/models/virtual_service.go
@@ -11,10 +11,10 @@ type VirtualService struct {
 	Name            string      `json:"name"`
 	CreatedAt       string      `json:"created_at"`
 	ResourceVersion string      `json:"resource_version"`
-	Hosts           interface{} `json:"hosts"`
-	Gateways        interface{} `json:"gateways"`
-	Http            interface{} `json:"http"`
-	Tcp             interface{} `json:"tcp"`
+	Hosts           interface{} `json:"hosts,omitempty"`
+	Gateways        interface{} `json:"gateways,omitempty"`
+	Http            interface{} `json:"http,omitempty"`
+	Tcp             interface{} `json:"tcp,omitempty"`
 }
 
 func (vServices *VirtualServices) Parse(virtualServices []kubernetes.IstioObject) {


### PR DESCRIPTION
This is specially useful on ACE yaml scenarios to avoid UI layer to clean null values that are not used.

Before:
![image](https://user-images.githubusercontent.com/1662329/39431203-48508d5e-4c90-11e8-8fd8-b6cdc7eb4d88.png)

After:
![image](https://user-images.githubusercontent.com/1662329/39431219-561e7f18-4c90-11e8-860f-e4aaf8bcee6a.png)

This only applies to objects that are planned to be shown as YAML sources.