### PR TITLE
[KIALI-534] Avoid the javascript prompt when 401 and WWW-Authenticate…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -422,6 +422,22 @@ products:
 
 When developing the http://github.com/kiali/kiali-ui[Kiali UI] you will find it useful to run it outside of the core to make it easier to update the UI code and see the changes without having to recompile. The prefered approach for this is to use a proxy on the UI to mount the core. The process is described https://github.com/kiali/kiali-ui#developing[here].
 
+To connect with the backend and avoid the javascript prompt requesting authentication you need to send the requests with a specific header.
+[source]
+----
+X-Auth-Type-Kiali-UI: 1
+----
+The response will contain the header
+[source]
+----
+WWW-Authenticate: xBasic realm="Kiali"
+----
+Otherwise the header will be
+[source]
+----
+WWW-Authenticate: Basic realm="Kiali"
+----
+
 === Running A Locally Built UI Inside the Core
 
 If you are developing the UI on your local machine but you want to see it deployed and running inside of the core server, you can do so by setting the environment variable CONSOLE_VERSION to the value "local" when building the docker image via the `docker-build` target. By default, your UI's build/ directory is assumed to be in a directory called `kiali-ui` that is a peer directory of the GOPATH root directory for the core server. If it is not, you can set the environment variable CONSOLE_LOCAL_DIR to the value of the path of the root directory for the UI such that `$CONSOLE_LOCAL_DIR/build` contains the generated build files for the UI.

--- a/server/server.go
+++ b/server/server.go
@@ -91,7 +91,13 @@ func (h *serverAuthProxyHandler) handler(w http.ResponseWriter, r *http.Request)
 	case http.StatusOK:
 		h.trueHandler.ServeHTTP(w, r)
 	case http.StatusUnauthorized:
-		w.Header().Set("WWW-Authenticate", "Basic realm=\"Kiali\"")
+		// If header exists return the value, must be 1 to use the API from Kiali
+		// Otherwise an empty string is returned and WWW-Authenticate will be Basic
+		if r.Header.Get("X-Auth-Type-Kiali-UI") == "1" {
+			w.Header().Set("WWW-Authenticate", "xBasic realm=\"Kiali\"")
+		} else {
+			w.Header().Set("WWW-Authenticate", "Basic realm=\"Kiali\"")
+		}
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 	default:
 		http.Error(w, http.StatusText(statusCode), statusCode)


### PR DESCRIPTION
Related with [#314](https://github.com/kiali/kiali-ui/pull/314)
To avoid the javascript prompt it’s not actually the only 401 response which causes the login prompt box; but it’s the combination of 401 response and also the header WWW-Authenticate: Basic.

So I changed the Basic to xBasic.  Another solution is change the status code.

## BEFORE
![before_login](https://user-images.githubusercontent.com/3019213/39625905-fae43738-4f9f-11e8-906f-324b40097c26.gif)

## AFTER
![after_login](https://user-images.githubusercontent.com/3019213/39625912-fda945bc-4f9f-11e8-987c-d74725bf94b4.gif)
