### PR TITLE
bump up version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL=/bin/bash
 
 # Identifies the current build.
 # These will be embedded in the app and displayed when it starts.
-VERSION ?= 0.1.0.Final-SNAPSHOT
+VERSION ?= 0.2.0.Alpha
 COMMIT_HASH ?= $(shell git rev-parse HEAD)
 
 # Version label is used in the OpenShift/K8S resources to identify

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL=/bin/bash
 
 # Identifies the current build.
 # These will be embedded in the app and displayed when it starts.
-VERSION ?= 0.2.0.Alpha
+VERSION ?= 0.3.0.Alpha-SNAPSHOT
 COMMIT_HASH ?= $(shell git rev-parse HEAD)
 
 # Version label is used in the OpenShift/K8S resources to identify


### PR DESCRIPTION
we released 0.2.0.Alpha - this PR bumps up the version to the next snapshot version