### PR TITLE
KIALI-719 Place RouteRule badges on service

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,4 +30,4 @@ products:
 
 # Uncomment service_filter_label_name to set up a different lable name for grouping all resources of a service.
 # Default is "app"
-service_filter_label_name: service
+# service_filter_label_name: service

--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -280,10 +280,20 @@ func addCompositeNodes(nodes *[]*NodeWrapper, nodeIdSequence *int) {
 			}
 
 			// assign each service version node to the composite parent
+			hasRouteRule := false
 			for _, n := range *nodes {
 				if k == n.Data.Service {
 					n.Data.Parent = nodeId
+					// If there is a route rule defined in version node, move it to composite parent
+					if n.Data.HasRouteRule == "true" {
+						n.Data.HasRouteRule = "false"
+						hasRouteRule = true
+					}
 				}
+			}
+
+			if hasRouteRule {
+				nd.HasRouteRule = "true"
 			}
 
 			// add the composite node to the list of nodes

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -83,6 +83,56 @@ func TestFilterByHost(t *testing.T) {
 	assert.False(t, filterByHost(spec, "host3"))
 }
 
+func TestCheckRouteRule(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert.False(t, CheckRouteRule(nil, "", "", ""))
+
+	route1 := MockIstioObject{
+		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name":      "reviews",
+				"namespace": "tutorial",
+			},
+			"precedence": 1,
+			"route": []interface{}{
+				map[string]interface{}{
+					"labels": map[string]interface{}{
+						"version": "v1",
+					},
+				},
+			},
+		},
+	}
+
+	assert.True(t, CheckRouteRule(&route1, "tutorial", "reviews", "v1"))
+	assert.False(t, CheckRouteRule(&route1, "tutorial-bad", "reviews", "v1"))
+	assert.False(t, CheckRouteRule(&route1, "tutorial", "reviews-bad", "v1"))
+	assert.False(t, CheckRouteRule(&route1, "tutorial", "reviews", "v2"))
+
+	route2 := MockIstioObject{
+		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
+			"precedence": 1,
+			"route": []interface{}{
+				map[string]interface{}{
+					"labels": map[string]interface{}{
+						"version": "v1",
+					},
+				},
+			},
+		},
+	}
+
+	assert.True(t, CheckRouteRule(&route2, "tutorial", "reviews", "v1"))
+	assert.True(t, CheckRouteRule(&route2, "tutorial-bad", "reviews", "v1"))
+	assert.False(t, CheckRouteRule(&route2, "tutorial", "reviews-bad", "v1"))
+	assert.False(t, CheckRouteRule(&route2, "tutorial", "reviews", "v2"))
+}
+
 func TestCheckVirtualService(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)


### PR DESCRIPTION
KIALI-718 Fix proper version location on RouteRule objects

Now when RouteRule is defined in any of the versioned services, the badge will be placed on the box.

![image](https://user-images.githubusercontent.com/1662329/39989536-8a3fac92-576a-11e8-9f61-40c7288e3124.png)

KIALI-718 was somehow rejected, but the bug detected there was also affecting, so now CheckRouteRule detects a version in Destination and the DestinationWeight, so, graph will show correctly where the badge is.