### PR TITLE
Route Rule weight validation path fixed

### DIFF
--- a/services/business/checkers/route_rules/route_checker.go
+++ b/services/business/checkers/route_rules/route_checker.go
@@ -36,7 +36,7 @@ func (route RouteChecker) Check() ([]*models.IstioCheck, bool) {
 		if err != nil {
 			valid = false
 			validation := models.BuildCheck("Weight must be a number",
-				"error", "spec/precedence/"+route["weight"].(string))
+				"error", "spec/route/weight/"+route["weight"].(string))
 			validations = append(validations, &validation)
 		}
 


### PR DESCRIPTION
Quick fix. A path to any weight field in a route rule configuration is under `spec/route/weight` not under `spec/precedence`.
