### PR TITLE
Use hashes for the edges on the cytoscape graph

### DIFF
--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -216,7 +216,6 @@ func TestNamespaceGraph(t *testing.T) {
 	}
 	actual, _ := ioutil.ReadAll(resp.Body)
 	expected, _ := ioutil.ReadFile("testdata/test_namespace_graph.expected")
-	expected = expected[:len(expected)-1] // remove EOF byte
 
 	if !assert.Equal(t, expected, actual) {
 		fmt.Printf("\nActual:\n%v", string(actual))
@@ -337,7 +336,6 @@ func TestServiceGraph(t *testing.T) {
 	}
 	actual, _ := ioutil.ReadAll(resp.Body)
 	expected, _ := ioutil.ReadFile("testdata/test_service_graph.expected")
-	expected = expected[:len(expected)-1] // remove EOF byte
 
 	if !assert.Equal(t, expected, actual) {
 		fmt.Printf("\nActual:\n%v", string(actual))

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -4,7 +4,7 @@
     "nodes": [
       {
         "data": {
-          "id": "3aa52f02c5df900d0abaca04bb535217",
+          "id": "32fda8753c26d348f348807c6b56705c",
           "service": "details.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "80.000",
@@ -15,7 +15,7 @@
       },
       {
         "data": {
-          "id": "8f9a69b2b147b88f4486beffeb11185f",
+          "id": "dbcb1a8f5bb7328294eebda1e370d3a3",
           "service": "ingress.istio-system.svc.cluster.local",
           "version": "unknown",
           "isRoot": "true"
@@ -23,7 +23,7 @@
       },
       {
         "data": {
-          "id": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "id": "ef10172953f8ad2cd4135d73afe62c63",
           "service": "productpage.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "150.000",
@@ -32,7 +32,7 @@
       },
       {
         "data": {
-          "id": "f66bcc30ac809e472db4dfe6b2091815",
+          "id": "5932332ea8128356e493d44620483e23",
           "service": "ratings.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "40.000"
@@ -40,15 +40,15 @@
       },
       {
         "data": {
-          "id": "0afa1e7244eebc91f2da51f8bc273a2e",
+          "id": "98a1c1cea90d0a4af0f009d6d7a9814e",
           "service": "reviews.istio-system.svc.cluster.local",
           "isGroup": "version"
         }
       },
       {
         "data": {
-          "id": "29dde1c226065e3dca6d36108c72fee3",
-          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
+          "id": "047fedf43d6b41f55d8c7c14a80a22ca",
+          "parent": "98a1c1cea90d0a4af0f009d6d7a9814e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "20.000"
@@ -56,8 +56,8 @@
       },
       {
         "data": {
-          "id": "e116d63b26d2dd0f0450a1ef4c481d4e",
-          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
+          "id": "c7a03b129bb359511003f1d560c092fd",
+          "parent": "98a1c1cea90d0a4af0f009d6d7a9814e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
           "rate": "20.000",
@@ -66,8 +66,8 @@
       },
       {
         "data": {
-          "id": "6e2292bee6d458c624ed9b661fa34675",
-          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
+          "id": "ff0100c5e664424396c2f264bb30da25",
+          "parent": "98a1c1cea90d0a4af0f009d6d7a9814e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",
           "rate": "20.000",
@@ -76,7 +76,7 @@
       },
       {
         "data": {
-          "id": "5582b7c1d1de9a5859ba9353ff1d9cec",
+          "id": "ba113404e46b8aa41dc0e7cc339073fe",
           "service": "unknown",
           "version": "unknown",
           "isRoot": "true"
@@ -86,43 +86,43 @@
     "edges": [
       {
         "data": {
-          "id": "b98a852249b463497ccfe5cfe485f04d",
-          "source": "5582b7c1d1de9a5859ba9353ff1d9cec",
-          "target": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "id": "27abd2c57da5dc459a2695524e33cc8b",
+          "source": "ba113404e46b8aa41dc0e7cc339073fe",
+          "target": "ef10172953f8ad2cd4135d73afe62c63",
           "rate": "50.000"
         }
       },
       {
         "data": {
-          "id": "2857d88250a8f34f155cd791a145e674",
-          "source": "6e2292bee6d458c624ed9b661fa34675",
-          "target": "f66bcc30ac809e472db4dfe6b2091815",
+          "id": "fdbc06677bb0f6130f6ac1072fa92cb3",
+          "source": "c7a03b129bb359511003f1d560c092fd",
+          "target": "5932332ea8128356e493d44620483e23",
           "rate": "20.000",
           "percentRate": "50.000"
         }
       },
       {
         "data": {
-          "id": "96a865cabf7491c1f8dde20739b1c7e2",
-          "source": "8f9a69b2b147b88f4486beffeb11185f",
-          "target": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "id": "e9d7488f52233ea7a5f440ab6fc777e2",
+          "source": "dbcb1a8f5bb7328294eebda1e370d3a3",
+          "target": "ef10172953f8ad2cd4135d73afe62c63",
           "rate": "100.000"
         }
       },
       {
         "data": {
-          "id": "206ef341e7b6c51c170b331f261e2967",
-          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
-          "target": "29dde1c226065e3dca6d36108c72fee3",
+          "id": "875b53697932c163844cd17ce454d962",
+          "source": "ef10172953f8ad2cd4135d73afe62c63",
+          "target": "047fedf43d6b41f55d8c7c14a80a22ca",
           "rate": "20.000",
           "percentRate": "12.500"
         }
       },
       {
         "data": {
-          "id": "0238070d8d93ebed5d65456ccf1a7d0a",
-          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
-          "target": "3aa52f02c5df900d0abaca04bb535217",
+          "id": "ae6a74a628bdd233ddb48bc5b4faa9fb",
+          "source": "ef10172953f8ad2cd4135d73afe62c63",
+          "target": "32fda8753c26d348f348807c6b56705c",
           "rate": "80.000",
           "rate3XX": "20.000",
           "rate4XX": "20.000",
@@ -133,27 +133,27 @@
       },
       {
         "data": {
-          "id": "6cb486d17eef1a3e43b488c826dfdfd4",
-          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
-          "target": "6e2292bee6d458c624ed9b661fa34675",
+          "id": "7071b96e54595edd3e1ce226788facb3",
+          "source": "ef10172953f8ad2cd4135d73afe62c63",
+          "target": "c7a03b129bb359511003f1d560c092fd",
           "rate": "20.000",
           "percentRate": "12.500"
         }
       },
       {
         "data": {
-          "id": "58fcc188cb5101417390f7c83e588a42",
-          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
-          "target": "e116d63b26d2dd0f0450a1ef4c481d4e",
+          "id": "35ef6eb03cb34330034f87a98f62452f",
+          "source": "ef10172953f8ad2cd4135d73afe62c63",
+          "target": "ff0100c5e664424396c2f264bb30da25",
           "rate": "20.000",
           "percentRate": "12.500"
         }
       },
       {
         "data": {
-          "id": "045473b3ef0125b0cf3b3df4d042a469",
-          "source": "e116d63b26d2dd0f0450a1ef4c481d4e",
-          "target": "f66bcc30ac809e472db4dfe6b2091815",
+          "id": "fa39bdc4937943a9e645dffd0117a2f9",
+          "source": "ff0100c5e664424396c2f264bb30da25",
+          "target": "5932332ea8128356e493d44620483e23",
           "rate": "20.000",
           "percentRate": "50.000"
         }

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -4,7 +4,7 @@
     "nodes": [
       {
         "data": {
-          "id": "n2",
+          "id": "3aa52f02c5df900d0abaca04bb535217",
           "service": "details.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "80.000",
@@ -15,7 +15,7 @@
       },
       {
         "data": {
-          "id": "n7",
+          "id": "8f9a69b2b147b88f4486beffeb11185f",
           "service": "ingress.istio-system.svc.cluster.local",
           "version": "unknown",
           "isRoot": "true"
@@ -23,7 +23,7 @@
       },
       {
         "data": {
-          "id": "n1",
+          "id": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
           "service": "productpage.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "150.000",
@@ -32,7 +32,7 @@
       },
       {
         "data": {
-          "id": "n5",
+          "id": "f66bcc30ac809e472db4dfe6b2091815",
           "service": "ratings.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "40.000"
@@ -40,15 +40,15 @@
       },
       {
         "data": {
-          "id": "n8",
+          "id": "0afa1e7244eebc91f2da51f8bc273a2e",
           "service": "reviews.istio-system.svc.cluster.local",
           "isGroup": "version"
         }
       },
       {
         "data": {
-          "id": "n3",
-          "parent": "n8",
+          "id": "29dde1c226065e3dca6d36108c72fee3",
+          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "20.000"
@@ -56,8 +56,8 @@
       },
       {
         "data": {
-          "id": "n4",
-          "parent": "n8",
+          "id": "e116d63b26d2dd0f0450a1ef4c481d4e",
+          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
           "rate": "20.000",
@@ -66,8 +66,8 @@
       },
       {
         "data": {
-          "id": "n6",
-          "parent": "n8",
+          "id": "6e2292bee6d458c624ed9b661fa34675",
+          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",
           "rate": "20.000",
@@ -76,7 +76,7 @@
       },
       {
         "data": {
-          "id": "n0",
+          "id": "5582b7c1d1de9a5859ba9353ff1d9cec",
           "service": "unknown",
           "version": "unknown",
           "isRoot": "true"
@@ -86,17 +86,43 @@
     "edges": [
       {
         "data": {
-          "id": "e0",
-          "source": "n0",
-          "target": "n1",
+          "id": "b98a852249b463497ccfe5cfe485f04d",
+          "source": "5582b7c1d1de9a5859ba9353ff1d9cec",
+          "target": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
           "rate": "50.000"
         }
       },
       {
         "data": {
-          "id": "e1",
-          "source": "n1",
-          "target": "n2",
+          "id": "2857d88250a8f34f155cd791a145e674",
+          "source": "6e2292bee6d458c624ed9b661fa34675",
+          "target": "f66bcc30ac809e472db4dfe6b2091815",
+          "rate": "20.000",
+          "percentRate": "50.000"
+        }
+      },
+      {
+        "data": {
+          "id": "96a865cabf7491c1f8dde20739b1c7e2",
+          "source": "8f9a69b2b147b88f4486beffeb11185f",
+          "target": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "rate": "100.000"
+        }
+      },
+      {
+        "data": {
+          "id": "206ef341e7b6c51c170b331f261e2967",
+          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "target": "29dde1c226065e3dca6d36108c72fee3",
+          "rate": "20.000",
+          "percentRate": "12.500"
+        }
+      },
+      {
+        "data": {
+          "id": "0238070d8d93ebed5d65456ccf1a7d0a",
+          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "target": "3aa52f02c5df900d0abaca04bb535217",
           "rate": "80.000",
           "rate3XX": "20.000",
           "rate4XX": "20.000",
@@ -107,55 +133,29 @@
       },
       {
         "data": {
-          "id": "e2",
-          "source": "n1",
-          "target": "n3",
+          "id": "6cb486d17eef1a3e43b488c826dfdfd4",
+          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "target": "6e2292bee6d458c624ed9b661fa34675",
           "rate": "20.000",
           "percentRate": "12.500"
         }
       },
       {
         "data": {
-          "id": "e3",
-          "source": "n1",
-          "target": "n4",
+          "id": "58fcc188cb5101417390f7c83e588a42",
+          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "target": "e116d63b26d2dd0f0450a1ef4c481d4e",
           "rate": "20.000",
           "percentRate": "12.500"
         }
       },
       {
         "data": {
-          "id": "e5",
-          "source": "n1",
-          "target": "n6",
-          "rate": "20.000",
-          "percentRate": "12.500"
-        }
-      },
-      {
-        "data": {
-          "id": "e4",
-          "source": "n4",
-          "target": "n5",
+          "id": "045473b3ef0125b0cf3b3df4d042a469",
+          "source": "e116d63b26d2dd0f0450a1ef4c481d4e",
+          "target": "f66bcc30ac809e472db4dfe6b2091815",
           "rate": "20.000",
           "percentRate": "50.000"
-        }
-      },
-      {
-        "data": {
-          "id": "e6",
-          "source": "n6",
-          "target": "n5",
-          "rate": "20.000",
-          "percentRate": "50.000"
-        }
-      },
-      {
-        "data": {
-          "id": "e7",
-          "source": "n7",
-          "target": "n1",
-          "rate": "100.000"
         }
       }
     ]

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -4,14 +4,14 @@
     "nodes": [
       {
         "data": {
-          "id": "n0",
+          "id": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
           "service": "productpage.istio-system.svc.cluster.local",
           "version": "v1"
         }
       },
       {
         "data": {
-          "id": "n3",
+          "id": "f66bcc30ac809e472db4dfe6b2091815",
           "service": "ratings.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "40.000"
@@ -19,15 +19,15 @@
       },
       {
         "data": {
-          "id": "n5",
+          "id": "0afa1e7244eebc91f2da51f8bc273a2e",
           "service": "reviews.istio-system.svc.cluster.local",
           "isGroup": "version"
         }
       },
       {
         "data": {
-          "id": "n1",
-          "parent": "n5",
+          "id": "29dde1c226065e3dca6d36108c72fee3",
+          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "20.000"
@@ -35,8 +35,8 @@
       },
       {
         "data": {
-          "id": "n2",
-          "parent": "n5",
+          "id": "e116d63b26d2dd0f0450a1ef4c481d4e",
+          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
           "rate": "20.000",
@@ -45,8 +45,8 @@
       },
       {
         "data": {
-          "id": "n4",
-          "parent": "n5",
+          "id": "6e2292bee6d458c624ed9b661fa34675",
+          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",
           "rate": "20.000",
@@ -57,45 +57,45 @@
     "edges": [
       {
         "data": {
-          "id": "e0",
-          "source": "n0",
-          "target": "n1",
-          "rate": "20.000",
-          "percentRate": "33.333"
-        }
-      },
-      {
-        "data": {
-          "id": "e1",
-          "source": "n0",
-          "target": "n2",
-          "rate": "20.000",
-          "percentRate": "33.333"
-        }
-      },
-      {
-        "data": {
-          "id": "e3",
-          "source": "n0",
-          "target": "n4",
-          "rate": "20.000",
-          "percentRate": "33.333"
-        }
-      },
-      {
-        "data": {
-          "id": "e2",
-          "source": "n2",
-          "target": "n3",
+          "id": "2857d88250a8f34f155cd791a145e674",
+          "source": "6e2292bee6d458c624ed9b661fa34675",
+          "target": "f66bcc30ac809e472db4dfe6b2091815",
           "rate": "20.000",
           "percentRate": "50.000"
         }
       },
       {
         "data": {
-          "id": "e4",
-          "source": "n4",
-          "target": "n3",
+          "id": "206ef341e7b6c51c170b331f261e2967",
+          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "target": "29dde1c226065e3dca6d36108c72fee3",
+          "rate": "20.000",
+          "percentRate": "33.333"
+        }
+      },
+      {
+        "data": {
+          "id": "6cb486d17eef1a3e43b488c826dfdfd4",
+          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "target": "6e2292bee6d458c624ed9b661fa34675",
+          "rate": "20.000",
+          "percentRate": "33.333"
+        }
+      },
+      {
+        "data": {
+          "id": "58fcc188cb5101417390f7c83e588a42",
+          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "target": "e116d63b26d2dd0f0450a1ef4c481d4e",
+          "rate": "20.000",
+          "percentRate": "33.333"
+        }
+      },
+      {
+        "data": {
+          "id": "045473b3ef0125b0cf3b3df4d042a469",
+          "source": "e116d63b26d2dd0f0450a1ef4c481d4e",
+          "target": "f66bcc30ac809e472db4dfe6b2091815",
           "rate": "20.000",
           "percentRate": "50.000"
         }

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -4,14 +4,14 @@
     "nodes": [
       {
         "data": {
-          "id": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
+          "id": "ef10172953f8ad2cd4135d73afe62c63",
           "service": "productpage.istio-system.svc.cluster.local",
           "version": "v1"
         }
       },
       {
         "data": {
-          "id": "f66bcc30ac809e472db4dfe6b2091815",
+          "id": "5932332ea8128356e493d44620483e23",
           "service": "ratings.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "40.000"
@@ -19,15 +19,15 @@
       },
       {
         "data": {
-          "id": "0afa1e7244eebc91f2da51f8bc273a2e",
+          "id": "98a1c1cea90d0a4af0f009d6d7a9814e",
           "service": "reviews.istio-system.svc.cluster.local",
           "isGroup": "version"
         }
       },
       {
         "data": {
-          "id": "29dde1c226065e3dca6d36108c72fee3",
-          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
+          "id": "047fedf43d6b41f55d8c7c14a80a22ca",
+          "parent": "98a1c1cea90d0a4af0f009d6d7a9814e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
           "rate": "20.000"
@@ -35,8 +35,8 @@
       },
       {
         "data": {
-          "id": "e116d63b26d2dd0f0450a1ef4c481d4e",
-          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
+          "id": "c7a03b129bb359511003f1d560c092fd",
+          "parent": "98a1c1cea90d0a4af0f009d6d7a9814e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
           "rate": "20.000",
@@ -45,8 +45,8 @@
       },
       {
         "data": {
-          "id": "6e2292bee6d458c624ed9b661fa34675",
-          "parent": "0afa1e7244eebc91f2da51f8bc273a2e",
+          "id": "ff0100c5e664424396c2f264bb30da25",
+          "parent": "98a1c1cea90d0a4af0f009d6d7a9814e",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",
           "rate": "20.000",
@@ -57,45 +57,45 @@
     "edges": [
       {
         "data": {
-          "id": "2857d88250a8f34f155cd791a145e674",
-          "source": "6e2292bee6d458c624ed9b661fa34675",
-          "target": "f66bcc30ac809e472db4dfe6b2091815",
+          "id": "fdbc06677bb0f6130f6ac1072fa92cb3",
+          "source": "c7a03b129bb359511003f1d560c092fd",
+          "target": "5932332ea8128356e493d44620483e23",
           "rate": "20.000",
           "percentRate": "50.000"
         }
       },
       {
         "data": {
-          "id": "206ef341e7b6c51c170b331f261e2967",
-          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
-          "target": "29dde1c226065e3dca6d36108c72fee3",
+          "id": "875b53697932c163844cd17ce454d962",
+          "source": "ef10172953f8ad2cd4135d73afe62c63",
+          "target": "047fedf43d6b41f55d8c7c14a80a22ca",
           "rate": "20.000",
           "percentRate": "33.333"
         }
       },
       {
         "data": {
-          "id": "6cb486d17eef1a3e43b488c826dfdfd4",
-          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
-          "target": "6e2292bee6d458c624ed9b661fa34675",
+          "id": "7071b96e54595edd3e1ce226788facb3",
+          "source": "ef10172953f8ad2cd4135d73afe62c63",
+          "target": "c7a03b129bb359511003f1d560c092fd",
           "rate": "20.000",
           "percentRate": "33.333"
         }
       },
       {
         "data": {
-          "id": "58fcc188cb5101417390f7c83e588a42",
-          "source": "b86b9cd5c1cfea8b88c4e422f45d1eb9",
-          "target": "e116d63b26d2dd0f0450a1ef4c481d4e",
+          "id": "35ef6eb03cb34330034f87a98f62452f",
+          "source": "ef10172953f8ad2cd4135d73afe62c63",
+          "target": "ff0100c5e664424396c2f264bb30da25",
           "rate": "20.000",
           "percentRate": "33.333"
         }
       },
       {
         "data": {
-          "id": "045473b3ef0125b0cf3b3df4d042a469",
-          "source": "e116d63b26d2dd0f0450a1ef4c481d4e",
-          "target": "f66bcc30ac809e472db4dfe6b2091815",
+          "id": "fa39bdc4937943a9e645dffd0117a2f9",
+          "source": "ff0100c5e664424396c2f264bb30da25",
+          "target": "5932332ea8128356e493d44620483e23",
           "rate": "20.000",
           "percentRate": "50.000"
         }


### PR DESCRIPTION
We're going to support multiple/all namespaces, that ensures that even
if we do many requests to get more nodes on the graph, the edges between
them will not crash.

The graph using hashes:

![](https://i.imgur.com/d7fcT81.png)