### PR TITLE
KIALI-769 Refactor IstioValidation to group per type and name

### DIFF
--- a/graph/appender/sidecars_check.go
+++ b/graph/appender/sidecars_check.go
@@ -27,10 +27,11 @@ func (a SidecarsCheckAppender) applySidecarsChecks(n *tree.ServiceNode, namespac
 	checkError(err)
 
 	checker := checkers.PodChecker{Pods: pods.Items}
-	results := checker.Check()
+	typeValidations := checker.Check()
+	nameValidations := (*typeValidations)["pod"]
 
 	sidecarsOk := true
-	for _, check := range *results {
+	for _, check := range *nameValidations {
 		sidecarsOk = sidecarsOk && check.Valid
 	}
 	n.Metadata["hasMissingSidecars"] = !sidecarsOk

--- a/services/business/checkers/pod_checker.go
+++ b/services/business/checkers/pod_checker.go
@@ -12,17 +12,20 @@ type PodChecker struct {
 
 const podsCheckerType = "pod"
 
-func (checker PodChecker) Check() *models.IstioValidations {
+func (checker PodChecker) Check() *models.IstioTypeValidations {
 	// The only available checker test for missing
 	// sidecars in a service. Only individual checks makes sense for now.
 	return checker.runIndividualChecks()
 }
 
-func (checker PodChecker) runIndividualChecks() *models.IstioValidations {
-	validations := models.IstioValidations{}
+func (checker PodChecker) runIndividualChecks() *models.IstioTypeValidations {
+	typeValidations := models.IstioTypeValidations{}
 	if len(checker.Pods) == 0 {
-		return &validations
+		return &typeValidations
 	}
+
+	nameValidations := models.IstioNameValidations{}
+	typeValidations[podsCheckerType] = &nameValidations
 
 	for _, pod := range checker.Pods {
 		validation := models.IstioValidation{
@@ -30,7 +33,7 @@ func (checker PodChecker) runIndividualChecks() *models.IstioValidations {
 			ObjectType: podsCheckerType,
 			Valid:      true,
 		}
-		validations[pod.ObjectMeta.Name] = &validation
+		nameValidations[pod.ObjectMeta.Name] = &validation
 
 		checkers := checker.enabledCheckersFor(&pod)
 
@@ -41,7 +44,7 @@ func (checker PodChecker) runIndividualChecks() *models.IstioValidations {
 		}
 	}
 
-	return &validations
+	return &typeValidations
 }
 
 func (checker *PodChecker) enabledCheckersFor(object *v1.Pod) []Checker {

--- a/services/business/checkers/pod_checker_test.go
+++ b/services/business/checkers/pod_checker_test.go
@@ -23,11 +23,15 @@ func TestSidecarsCheckOneValidPod(t *testing.T) {
 	}
 
 	checker := PodChecker{Pods: fakePodList}
-	result := checker.Check()
+	typeValidations := checker.Check()
 
-	assert.Equal(t, 1, len(*result))
-	assert.True(t, (*result)["myPodWithSidecar"].Valid)
-	assert.Equal(t, 0, len((*result)["myPodWithSidecar"].Checks))
+	assert.Equal(t, 1, len(*typeValidations))
+
+	nameValidations := (*typeValidations)["pod"]
+
+	assert.Equal(t, 1, len(*nameValidations))
+	assert.True(t, (*nameValidations)["myPodWithSidecar"].Valid)
+	assert.Equal(t, 0, len((*nameValidations)["myPodWithSidecar"].Checks))
 }
 
 // Pod with no sidecar, check should be Warning
@@ -37,13 +41,17 @@ func TestSidecarsCheckOneInvalidPod(t *testing.T) {
 	}
 
 	checker := PodChecker{Pods: fakePodList}
-	result := checker.Check()
+	typeValidations := checker.Check()
 
-	assert.Equal(t, 1, len(*result))
-	assert.False(t, (*result)["myPodWithNoSidecar"].Valid)
-	assert.Equal(t, 1, len((*result)["myPodWithNoSidecar"].Checks))
-	assert.Equal(t, "warning", (*result)["myPodWithNoSidecar"].Checks[0].Severity)
-	assert.NotEqual(t, "Ok", (*result)["myPodWithNoSidecar"].Checks[0].Message)
+	assert.Equal(t, 1, len(*typeValidations))
+
+	nameValidations := (*typeValidations)["pod"]
+
+	assert.Equal(t, 1, len(*nameValidations))
+	assert.False(t, (*nameValidations)["myPodWithNoSidecar"].Valid)
+	assert.Equal(t, 1, len((*nameValidations)["myPodWithNoSidecar"].Checks))
+	assert.Equal(t, "warning", (*nameValidations)["myPodWithNoSidecar"].Checks[0].Severity)
+	assert.NotEqual(t, "Ok", (*nameValidations)["myPodWithNoSidecar"].Checks[0].Message)
 }
 
 func buildPodWithSidecar() v1.Pod {

--- a/services/business/checkers/route_rule_checker_test.go
+++ b/services/business/checkers/route_rule_checker_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kiali/kiali/services/models"
 )
 
-func prepareTest(istioObject kubernetes.IstioObject) *models.IstioValidations {
+func prepareTest(istioObject kubernetes.IstioObject) *models.IstioTypeValidations {
 	istioObjects := []kubernetes.IstioObject{istioObject}
 
 	routeRuleChecker := RouteRuleChecker{istioObjects}
@@ -21,10 +21,14 @@ func TestWellRouteRuleValidation(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
-	validations := *(prepareTest(fakeIstioObjects()))
+	typeValidations := *(prepareTest(fakeIstioObjects()))
+	assert.NotEmpty(typeValidations)
+
+	nameValidations := (*typeValidations["routerule"])
+	assert.NotEmpty(nameValidations)
 
 	// Well configured object
-	validObject := validations["reviews-well"]
+	validObject := nameValidations["reviews-well"]
 	assert.Equal(validObject.Name, "reviews-well")
 	assert.Equal(validObject.ObjectType, "routerule")
 	assert.Equal(validObject.Valid, true)
@@ -36,10 +40,14 @@ func TestMultipleCheck(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
-	validations := *(prepareTest(fakeMultipleChecks()))
+	typeValidations := *(prepareTest(fakeMultipleChecks()))
+	assert.NotEmpty(typeValidations)
+
+	nameValidations := (*typeValidations["routerule"])
+	assert.NotEmpty(nameValidations)
 
 	// route rule with multiple problems
-	invalidObject := validations["reviews-multiple"]
+	invalidObject := nameValidations["reviews-multiple"]
 	assert.NotEmpty(invalidObject)
 	assert.Equal(invalidObject.Name, "reviews-multiple")
 	assert.Equal(invalidObject.ObjectType, "routerule")
@@ -51,10 +59,14 @@ func TestCorrectPrecedence(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
-	validations := *(prepareTest(fakeCorrectPrecedence()))
+	typeValidations := *(prepareTest(fakeCorrectPrecedence()))
+	assert.NotEmpty(typeValidations)
+
+	nameValidations := (*typeValidations["routerule"])
+	assert.NotEmpty(nameValidations)
 
 	// wrong weight'ed route rule
-	invalidObject := validations["reviews-precedence"]
+	invalidObject := nameValidations["reviews-precedence"]
 	assert.NotEmpty(invalidObject)
 	assert.Equal(invalidObject.Name, "reviews-precedence")
 	assert.Equal(invalidObject.ObjectType, "routerule")
@@ -66,10 +78,14 @@ func TestNegativePrecedence(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
-	validations := *(prepareTest(fakeNegative()))
+	typeValidations := *(prepareTest(fakeNegative()))
+	assert.NotEmpty(typeValidations)
+
+	nameValidations := (*typeValidations["routerule"])
+	assert.NotEmpty(nameValidations)
 
 	// Negative precedence
-	invalidObject := validations["reviews-negative"]
+	invalidObject := nameValidations["reviews-negative"]
 	assert.NotEmpty(invalidObject)
 	assert.Equal(invalidObject.Name, "reviews-negative")
 	assert.Equal(invalidObject.ObjectType, "routerule")
@@ -81,10 +97,14 @@ func TestMixedCheckerRoule(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
-	validations := *(prepareTest(fakeMixedChecker()))
+	typeValidations := *(prepareTest(fakeMixedChecker()))
+	assert.NotEmpty(typeValidations)
+
+	nameValidations := (*typeValidations["routerule"])
+	assert.NotEmpty(nameValidations)
 
 	// Precedence is incorrect
-	invalidObject := validations["reviews-mixed"]
+	invalidObject := nameValidations["reviews-mixed"]
 	assert.NotEmpty(invalidObject)
 	assert.Equal(invalidObject.Name, "reviews-mixed")
 	assert.Equal(invalidObject.ObjectType, "routerule")

--- a/services/business/istio_validations_test.go
+++ b/services/business/istio_validations_test.go
@@ -20,7 +20,9 @@ func TestServiceWellRouteRuleValidation(t *testing.T) {
 	validations, _ := vs.GetServiceValidations("bookinfo", "reviews")
 
 	// Well configured object
-	validObject := validations["reviews-well"]
+	nameValidations := validations["routerule"]
+	assert.NotEmpty(nameValidations)
+	validObject := (*nameValidations)["reviews-well"]
 	assert.NotEmpty(validObject)
 	assert.Equal(validObject.Name, "reviews-well")
 	assert.Equal(validObject.ObjectType, "routerule")
@@ -38,7 +40,9 @@ func TestServiceMultipleChecks(t *testing.T) {
 	validations, _ := vs.GetServiceValidations("bookinfo", "reviews")
 
 	// wrong weight'ed route rule
-	invalidObject := validations["reviews-multiple"]
+	nameValidations := validations["routerule"]
+	assert.NotEmpty(nameValidations)
+	invalidObject := (*nameValidations)["reviews-multiple"]
 	assert.NotEmpty(invalidObject)
 	assert.Equal(invalidObject.Name, "reviews-multiple")
 	assert.Equal(invalidObject.ObjectType, "routerule")
@@ -65,7 +69,9 @@ func TestServiceOver100RouteRule(t *testing.T) {
 	validations, _ := vs.GetServiceValidations("bookinfo", "reviews")
 
 	// wrong weight'ed route rule
-	invalidObject := validations["reviews-100-plus"]
+	nameValidations := validations["routerule"]
+	assert.NotEmpty(nameValidations)
+	invalidObject := (*nameValidations)["reviews-100-plus"]
 	assert.NotEmpty(invalidObject)
 
 	assert.Equal(invalidObject.Name, "reviews-100-plus")
@@ -88,7 +94,9 @@ func TestServiceUnder100RouteRule(t *testing.T) {
 	validations, _ := vs.GetServiceValidations("bookinfo", "reviews")
 
 	// wrong weight'ed route rule
-	invalidObject := validations["reviews-100-minus"]
+	nameValidations := validations["routerule"]
+	assert.NotEmpty(nameValidations)
+	invalidObject := (*nameValidations)["reviews-100-minus"]
 	assert.NotEmpty(invalidObject)
 
 	assert.Equal(invalidObject.Name, "reviews-100-minus")

--- a/services/models/istio_validation.go
+++ b/services/models/istio_validation.go
@@ -1,6 +1,13 @@
 package models
 
-type IstioValidations map[string]*IstioValidation
+// IstioTypeValidations represents a set of IstioNameValidations grouper per Istio ObjectType.
+// It is possible that different object types have same name, but names per ObjectType are unique.
+type IstioTypeValidations map[string]*IstioNameValidations
+
+// IstioNameValidations represents a set of checks grouped per Istio object.
+// The key of the map represents the name of the Istio object.
+type IstioNameValidations map[string]*IstioValidation
+
 type IstioValidation struct {
 	Name       string        `json:"name"`
 	ObjectType string        `json:"object_type"`
@@ -18,8 +25,20 @@ func BuildCheck(message, severity, path string) IstioCheck {
 	return IstioCheck{message, severity, path}
 }
 
-func (in IstioValidations) MergeValidations(validations *IstioValidations) IstioValidations {
-	for name, validation := range *validations {
+func (in IstioTypeValidations) MergeValidations(typeValidations *IstioTypeValidations) IstioTypeValidations {
+	for objectType, nameValidations := range *typeValidations {
+		if in[objectType] != nil {
+			in[objectType].MergeNameValidations(nameValidations)
+		} else {
+			in[objectType] = nameValidations
+		}
+	}
+
+	return in
+}
+
+func (in IstioNameValidations) MergeNameValidations(nameValidations *IstioNameValidations) IstioNameValidations {
+	for name, validation := range *nameValidations {
 		if in[name] != nil {
 			in[name].Checks = append(in[name].Checks, validation.Checks...)
 			in[name].Valid = validation.Valid && in[name].Valid


### PR DESCRIPTION
Please @xeviknal, review this one.

I needed this change as the IstioValidation model didn't consider that name are not unique betwen different objectTypes.

So, I introduced another map to group first by type, and then by name, as per a single type names are unique.

This blocked me in the progress of KIALI-557.

Don't merge yet, as I need to prepare the changes on the UI for these one but I guess it can be reviewed.