### PR TITLE
KIALI-767 parse annotations and provide container images info

### DIFF
--- a/services/models/pod.go
+++ b/services/models/pod.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"encoding/json"
+
 	"k8s.io/api/core/v1"
 )
 
@@ -9,10 +11,24 @@ type Pods []*Pod
 
 // Pod holds a subset of v1.Pod data that is meaningful in Kiali
 type Pod struct {
-	Name        string            `json:"name"`
-	Annotations map[string]string `json:"annotations"`
-	Labels      map[string]string `json:"labels"`
-	CreatedAt   string            `json:"created_at"`
+	Name                string            `json:"name"`
+	Labels              map[string]string `json:"labels"`
+	CreatedAt           string            `json:"createdAt"`
+	CreatedBy           Reference         `json:"createdBy"`
+	IstioContainers     []*ContainerInfo  `json:"istioContainers"`
+	IstioInitContainers []*ContainerInfo  `json:"istioInitContainers"`
+}
+
+// Reference holds some information on the pod creator
+type Reference struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}
+
+// ContainerInfo holds container name and image
+type ContainerInfo struct {
+	Name  string `json:"name"`
+	Image string `json:"image"`
 }
 
 // Parse extracts desired information from k8s PodList info
@@ -31,7 +47,66 @@ func (pods *Pods) Parse(list *v1.PodList) {
 // Parse extracts desired information from k8s Pod info
 func (pod *Pod) Parse(p *v1.Pod) {
 	pod.Name = p.Name
-	pod.Annotations = p.Annotations
 	pod.Labels = p.Labels
 	pod.CreatedAt = formatTime(p.CreationTimestamp.Time)
+	// Parse some annotations
+	if createdBy, ok := p.Annotations["kubernetes.io/created-by"]; ok {
+		var f interface{}
+		err := json.Unmarshal([]byte(createdBy), &f)
+		if err == nil {
+			switch ff := f.(type) {
+			case map[string]interface{}:
+				if fref, ok := ff["reference"]; ok {
+					switch ref := fref.(type) {
+					case map[string]interface{}:
+						pod.CreatedBy = Reference{
+							Name: ref["name"].(string),
+							Kind: ref["kind"].(string),
+						}
+					}
+				}
+			}
+		}
+	}
+	if istio, ok := p.Annotations["sidecar.istio.io/status"]; ok {
+		var f interface{}
+		err := json.Unmarshal([]byte(istio), &f)
+		if err == nil {
+			switch ff := f.(type) {
+			case map[string]interface{}:
+				if fcontainers, ok := ff["initContainers"]; ok {
+					switch containers := fcontainers.(type) {
+					case []interface{}:
+						for _, name := range containers {
+							pod.IstioInitContainers = append(pod.IstioInitContainers, &ContainerInfo{Name: name.(string)})
+						}
+					}
+				}
+				if fcontainers, ok := ff["containers"]; ok {
+					switch containers := fcontainers.(type) {
+					case []interface{}:
+						for _, name := range containers {
+							pod.IstioContainers = append(pod.IstioContainers, &ContainerInfo{Name: name.(string)})
+						}
+					}
+				}
+			}
+		}
+	}
+	// Lookup images for containers found
+	for _, container := range pod.IstioInitContainers {
+		container.Image = lookupImage(container.Name, p.Spec.InitContainers)
+	}
+	for _, container := range pod.IstioContainers {
+		container.Image = lookupImage(container.Name, p.Spec.Containers)
+	}
+}
+
+func lookupImage(containerName string, containers []v1.Container) string {
+	for _, c := range containers {
+		if c.Name == containerName {
+			return c.Image
+		}
+	}
+	return ""
 }

--- a/services/models/pod_test.go
+++ b/services/models/pod_test.go
@@ -1,0 +1,117 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodFullyParsing(t *testing.T) {
+	assert := assert.New(t)
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	k8sPod := v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:              "details-v1-3618568057-dnkjp",
+			CreationTimestamp: meta_v1.NewTime(t1),
+			Labels:            map[string]string{"apps": "details", "version": "v1"},
+			Annotations: map[string]string{"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"bookinfo\",\"name\":\"details-v1-3618568057\",\"uid\":\"\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"9068\"}}",
+				"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				v1.Container{Name: "details", Image: "whatever"},
+				v1.Container{Name: "istio-proxy", Image: "docker.io/istio/proxy:0.7.1"},
+			},
+			InitContainers: []v1.Container{
+				v1.Container{Name: "istio-init", Image: "docker.io/istio/proxy_init:0.7.1"},
+				v1.Container{Name: "enable-core-dump", Image: "alpine"},
+			},
+		}}
+
+	pod := Pod{}
+	pod.Parse(&k8sPod)
+	assert.Equal("details-v1-3618568057-dnkjp", pod.Name)
+	assert.Equal("2018-03-08T17:44:00+03:00", pod.CreatedAt)
+	assert.Equal(map[string]string{"apps": "details", "version": "v1"}, pod.Labels)
+	assert.Equal(Reference{Name: "details-v1-3618568057", Kind: "ReplicaSet"}, pod.CreatedBy)
+	assert.Len(pod.IstioContainers, 1)
+	assert.Equal("istio-proxy", pod.IstioContainers[0].Name)
+	assert.Equal("docker.io/istio/proxy:0.7.1", pod.IstioContainers[0].Image)
+	assert.Len(pod.IstioInitContainers, 2)
+	assert.Equal("istio-init", pod.IstioInitContainers[0].Name)
+	assert.Equal("docker.io/istio/proxy_init:0.7.1", pod.IstioInitContainers[0].Image)
+	assert.Equal("enable-core-dump", pod.IstioInitContainers[1].Name)
+	assert.Equal("alpine", pod.IstioInitContainers[1].Image)
+}
+
+func TestPodParsingMissingImage(t *testing.T) {
+	assert := assert.New(t)
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	k8sPod := v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:              "details-v1-3618568057-dnkjp",
+			CreationTimestamp: meta_v1.NewTime(t1),
+			Labels:            map[string]string{"apps": "details", "version": "v1"},
+			Annotations: map[string]string{"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"bookinfo\",\"name\":\"details-v1-3618568057\",\"uid\":\"\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"9068\"}}",
+				"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
+	}
+
+	pod := Pod{}
+	pod.Parse(&k8sPod)
+	assert.Equal("details-v1-3618568057-dnkjp", pod.Name)
+	assert.Equal("2018-03-08T17:44:00+03:00", pod.CreatedAt)
+	assert.Equal(map[string]string{"apps": "details", "version": "v1"}, pod.Labels)
+	assert.Equal(Reference{Name: "details-v1-3618568057", Kind: "ReplicaSet"}, pod.CreatedBy)
+	assert.Len(pod.IstioContainers, 1)
+	assert.Equal("istio-proxy", pod.IstioContainers[0].Name)
+	assert.Equal("", pod.IstioContainers[0].Image)
+	assert.Len(pod.IstioInitContainers, 2)
+	assert.Equal("istio-init", pod.IstioInitContainers[0].Name)
+	assert.Equal("", pod.IstioInitContainers[0].Image)
+	assert.Equal("enable-core-dump", pod.IstioInitContainers[1].Name)
+	assert.Equal("", pod.IstioInitContainers[1].Image)
+}
+
+func TestPodParsingMissingAnnotations(t *testing.T) {
+	assert := assert.New(t)
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	k8sPod := v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:              "details-v1-3618568057-dnkjp",
+			CreationTimestamp: meta_v1.NewTime(t1),
+			Labels:            map[string]string{"apps": "details", "version": "v1"},
+		}}
+
+	pod := Pod{}
+	pod.Parse(&k8sPod)
+	assert.Equal("details-v1-3618568057-dnkjp", pod.Name)
+	assert.Equal("2018-03-08T17:44:00+03:00", pod.CreatedAt)
+	assert.Equal(map[string]string{"apps": "details", "version": "v1"}, pod.Labels)
+	assert.Equal(Reference{Name: "", Kind: ""}, pod.CreatedBy)
+	assert.Len(pod.IstioContainers, 0)
+	assert.Len(pod.IstioInitContainers, 0)
+}
+
+func TestPodParsingInvalidAnnotations(t *testing.T) {
+	assert := assert.New(t)
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	k8sPod := v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:              "details-v1-3618568057-dnkjp",
+			CreationTimestamp: meta_v1.NewTime(t1),
+			Labels:            map[string]string{"apps": "details", "version": "v1"},
+			Annotations: map[string]string{"kubernetes.io/created-by": "{whoops! bad json!",
+				"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[{\"badkey\": \"Ooops! Not expected!\"}]}"}},
+	}
+
+	pod := Pod{}
+	pod.Parse(&k8sPod)
+	assert.Equal("details-v1-3618568057-dnkjp", pod.Name)
+	assert.Equal("2018-03-08T17:44:00+03:00", pod.CreatedAt)
+	assert.Equal(map[string]string{"apps": "details", "version": "v1"}, pod.Labels)
+	assert.Equal(Reference{Name: "", Kind: ""}, pod.CreatedBy)
+	assert.Len(pod.IstioContainers, 0)
+	assert.Len(pod.IstioInitContainers, 0)
+}


### PR DESCRIPTION
@lucasponce , following our discussion, this is to provide the container images information.
I've also transposed the annotation parsing from frontend to backend, so that we build our own model that is closer to what we need on the frontend side. It's also good for reducing the amount of data coming from the backend.