### PR TITLE
Keeping validations when multiple route rules are present

### DIFF
--- a/services/business/checkers/route_rule_checker.go
+++ b/services/business/checkers/route_rule_checker.go
@@ -58,7 +58,6 @@ func runChecks(routeRule kubernetes.IstioObject, typeValidations *models.IstioTy
 	var checkersWg sync.WaitGroup
 
 	nameValidations := models.IstioNameValidations{}
-	(*typeValidations)[objectType] = &nameValidations
 
 	ruleName := routeRule.GetObjectMeta().Name
 	validation := &models.IstioValidation{Name: ruleName, ObjectType: objectType, Valid: true}
@@ -72,6 +71,11 @@ func runChecks(routeRule kubernetes.IstioObject, typeValidations *models.IstioTy
 	}
 
 	checkersWg.Wait()
+	if (*typeValidations)[objectType] != nil {
+		(*typeValidations)[objectType].MergeNameValidations(&nameValidations)
+	} else {
+		(*typeValidations)[objectType] = &nameValidations
+	}
 }
 
 func runChecker(checker Checker, objectName string, nameValidations *models.IstioNameValidations, wg *sync.WaitGroup) {

--- a/services/business/checkers/route_rule_checker_test.go
+++ b/services/business/checkers/route_rule_checker_test.go
@@ -112,6 +112,34 @@ func TestMixedCheckerRoule(t *testing.T) {
 	assert.Len(invalidObject.Checks, 3)
 }
 
+func TestMultipleIstioObjects(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	routeRuleChecker := RouteRuleChecker{fakeMultipleIstioObjects()}
+	typeValidations := *(routeRuleChecker.Check())
+	assert.NotEmpty(typeValidations)
+
+	nameValidations := (*typeValidations["routerule"])
+	assert.NotEmpty(nameValidations)
+
+	// Precedence is incorrect
+	invalidObject := nameValidations["reviews-mixed"]
+	assert.NotEmpty(invalidObject)
+	assert.Equal(invalidObject.Name, "reviews-mixed")
+	assert.Equal(invalidObject.ObjectType, "routerule")
+	assert.Equal(invalidObject.Valid, false)
+	assert.Len(invalidObject.Checks, 3)
+
+	// Negative precedence
+	invalidObject = nameValidations["reviews-negative"]
+	assert.NotEmpty(invalidObject)
+	assert.Equal(invalidObject.Name, "reviews-negative")
+	assert.Equal(invalidObject.ObjectType, "routerule")
+	assert.Equal(invalidObject.Valid, false)
+	assert.Len(invalidObject.Checks, 1)
+}
+
 func fakeIstioObjects() kubernetes.IstioObject {
 	validRouteRule := (&kubernetes.RouteRule{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -221,4 +249,8 @@ func fakeMixedChecker() kubernetes.IstioObject {
 	}).DeepCopyIstioObject()
 
 	return routeRule
+}
+
+func fakeMultipleIstioObjects() []kubernetes.IstioObject {
+	return []kubernetes.IstioObject{fakeMixedChecker(), fakeNegative()}
 }


### PR DESCRIPTION
Small but pitty bug. Only showing validations for one single object type, the latest one. All the previous validations were overwritten.
Now it is fixed.