### PR TITLE
prepare for next release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL=/bin/bash
 
 # Identifies the current build.
 # These will be embedded in the app and displayed when it starts.
-VERSION ?= 0.3.0.Alpha-SNAPSHOT
+VERSION ?= 0.3.1.Alpha-SNAPSHOT
 COMMIT_HASH ?= $(shell git rev-parse HEAD)
 
 # Version label is used in the OpenShift/K8S resources to identify


### PR DESCRIPTION
0.3.0.Alpha has been released, this bumps up the version to the next snapshot