### PR TITLE
Fix data races

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 
 script:
   - if [ ! -z "$(gofmt -l ${GO_FILES})" ]; then echo "These files need to be formatted:" "$(gofmt -l ${GO_FILES})";echo "Diff files:"; gofmt -d ${GO_FILES}; exit 1; fi # Gofmt Linter
-  - make clean build test
+  - make clean build test-race
 
 # Push the docker images to docker hub
 # If a tag build, use the tag as docker version; otherwise, use branch name as docker version (where master==latest)

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ test-debug:
 	@echo Running tests in debug mode, excluding third party tests under vendor
 	go test -v $(shell go list ./... | grep -v -e /vendor/)
 
+test-race:
+	@echo Running tests with race detection, excluding third party tests under vendor
+	go test -race $(shell go list ./... | grep -v -e /vendor/)
+
 run:
 	@echo Running...
 	@${GOPATH}/bin/kiali -v ${VERBOSE_MODE} -config config.yaml

--- a/graph/appender/sidecars_check.go
+++ b/graph/appender/sidecars_check.go
@@ -33,14 +33,11 @@ func (a SidecarsCheckAppender) applySidecarsChecks(n *tree.ServiceNode, k8s *kub
 	checkError(err)
 
 	checker := checkers.PodChecker{Pods: pods.Items}
-	typeValidations := checker.Check()
-	nameValidations := (*typeValidations)["pod"]
+	validations := checker.Check()
 
 	sidecarsOk := true
-	if nameValidations != nil {
-		for _, check := range *nameValidations {
-			sidecarsOk = sidecarsOk && check.Valid
-		}
+	for _, check := range validations {
+		sidecarsOk = sidecarsOk && check.Valid
 	}
 	n.Metadata["hasMissingSidecars"] = !sidecarsOk
 

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,8 +30,7 @@ func TestServiceMetricsDefault(t *testing.T) {
 	url := ts.URL + "/api/namespaces/ns/services/svc/metrics"
 	now := time.Now()
 	delta := 15 * time.Second
-	coveredPath := 0
-	path := make(chan int)
+	var histogramSentinel, gaugeSentinel uint32
 
 	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
 		query := args[1].(string)
@@ -42,25 +41,15 @@ func TestServiceMetricsDefault(t *testing.T) {
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
 			assert.Contains(t, query, " by (le)")
-			path <- 1
+			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
 			assert.NotContains(t, query, " by ")
-			path <- 2
+			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 15*time.Second, r.Step)
 		assert.WithinDuration(t, now, r.End, delta)
 		assert.WithinDuration(t, now.Add(-30*time.Minute), r.Start, delta)
 	})
-
-	// Update coveredPath through a channel to avoid data races.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := range path {
-			coveredPath |= i
-		}
-	}()
 
 	resp, err := http.Get(url)
 	if err != nil {
@@ -71,9 +60,8 @@ func TestServiceMetricsDefault(t *testing.T) {
 	assert.NotEmpty(t, actual)
 	assert.Equal(t, 200, resp.StatusCode, string(actual))
 	// Assert branch coverage
-	close(path)
-	wg.Wait()
-	assert.Equal(t, coveredPath, 3)
+	assert.NotZero(t, histogramSentinel)
+	assert.NotZero(t, gaugeSentinel)
 }
 
 func TestServiceMetricsWithParams(t *testing.T) {
@@ -98,8 +86,7 @@ func TestServiceMetricsWithParams(t *testing.T) {
 
 	queryTime := time.Unix(1523364075, 0)
 	delta := 2 * time.Second
-	coveredPath := 0
-	path := make(chan int)
+	var histogramSentinel, gaugeSentinel uint32
 
 	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
 		query := args[1].(string)
@@ -111,25 +98,15 @@ func TestServiceMetricsWithParams(t *testing.T) {
 			// Histogram specific queries
 			assert.Contains(t, query, " by (le,response_code)")
 			assert.Contains(t, query, "istio_request_size")
-			path <- 1
+			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
 			assert.Contains(t, query, " by (response_code)")
-			path <- 2
+			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 2*time.Second, r.Step)
 		assert.WithinDuration(t, queryTime, r.End, delta)
 		assert.WithinDuration(t, queryTime.Add(-1000*time.Second), r.Start, delta)
 	})
-
-	// Update coveredPath through a channel to avoid data races.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := range path {
-			coveredPath |= i
-		}
-	}()
 
 	httpclient := &http.Client{}
 	resp, err := httpclient.Do(req)
@@ -141,9 +118,8 @@ func TestServiceMetricsWithParams(t *testing.T) {
 	assert.NotEmpty(t, actual)
 	assert.Equal(t, 200, resp.StatusCode, string(actual))
 	// Assert branch coverage
-	close(path)
-	wg.Wait()
-	assert.Equal(t, coveredPath, 3)
+	assert.NotZero(t, histogramSentinel)
+	assert.NotZero(t, gaugeSentinel)
 }
 
 func TestServiceMetricsBadQueryTime(t *testing.T) {

--- a/services/business/istio_config.go
+++ b/services/business/istio_config.go
@@ -144,7 +144,7 @@ func (in *IstioConfigService) GetIstioConfigDetails(namespace string, objectType
 
 		}
 	default:
-		err = fmt.Errorf("Object type not found", objectType)
+		err = fmt.Errorf("Object type not found: %v", objectType)
 	}
 
 	return istioConfigDetail, err

--- a/services/models/istio_validation.go
+++ b/services/models/istio_validation.go
@@ -1,5 +1,9 @@
 package models
 
+import (
+	"encoding/json"
+)
+
 // IstioValidationKey is the key value composed of an Istio ObjectType and Name.
 type IstioValidationKey struct {
 	ObjectType string
@@ -39,4 +43,17 @@ func (iv IstioValidations) MergeValidations(validations IstioValidations) IstioV
 		}
 	}
 	return iv
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (iv IstioValidations) MarshalJSON() ([]byte, error) {
+	out := make(map[string]map[string]*IstioValidation)
+	for k, v := range iv {
+		_, ok := out[k.ObjectType]
+		if !ok {
+			out[k.ObjectType] = make(map[string]*IstioValidation)
+		}
+		out[k.ObjectType][k.Name] = v
+	}
+	return json.Marshal(out)
 }

--- a/services/models/istio_validation_test.go
+++ b/services/models/istio_validation_test.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIstioValidationsMarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	validations := IstioValidations{
+		IstioValidationKey{"routerule", "foo"}: &IstioValidation{
+			Name:       "foo",
+			ObjectType: "routerule",
+			Valid:      true,
+		},
+		IstioValidationKey{"routerule", "bar"}: &IstioValidation{
+			Name:       "bar",
+			ObjectType: "routerule",
+			Valid:      false,
+		},
+	}
+	b, err := json.Marshal(validations)
+	assert.Empty(err)
+	assert.Equal(string(b), `{"routerule":{"bar":{"name":"bar","objectType":"routerule","valid":false,"checks":null},"foo":{"name":"foo","objectType":"routerule","valid":true,"checks":null}}}`)
+}


### PR DESCRIPTION
This PR adds a Makefile target (`make test-race`) to run the tests with [race detection](https://golang.org/doc/articles/race_detector.html) enabled. It also fixes the reported data races. The Travis CI configuration is modified to run `make test-race` as it can surface problems that are hard to debug in live conditions.