### PR TITLE
KIALI-833 Always run appenders, even on empty graph

### DIFF
--- a/graph/appender/dead_service.go
+++ b/graph/appender/dead_service.go
@@ -14,6 +14,10 @@ type DeadServiceAppender struct{}
 
 // AppendGraph implements Appender
 func (a DeadServiceAppender) AppendGraph(trees *[]tree.ServiceNode, _ string) {
+	if len(*trees) == 0 {
+		return
+	}
+
 	istioClient, err := kubernetes.NewClient()
 	checkError(err)
 

--- a/graph/appender/istio_details.go
+++ b/graph/appender/istio_details.go
@@ -11,6 +11,10 @@ type IstioAppender struct{}
 
 // AppendGraph implements Appender
 func (a IstioAppender) AppendGraph(trees *[]tree.ServiceNode, namespaceName string) {
+	if len(*trees) == 0 {
+		return
+	}
+
 	istioClient, err := kubernetes.NewClient()
 	checkError(err)
 

--- a/graph/appender/latency.go
+++ b/graph/appender/latency.go
@@ -30,6 +30,10 @@ type LatencyAppender struct {
 
 // AppendGraph implements Appender
 func (a LatencyAppender) AppendGraph(trees *[]tree.ServiceNode, namespace string) {
+	if len(*trees) == 0 {
+		return
+	}
+
 	client, err := prometheus.NewClient()
 	checkError(err)
 

--- a/graph/appender/sidecars_check.go
+++ b/graph/appender/sidecars_check.go
@@ -12,6 +12,10 @@ type SidecarsCheckAppender struct{}
 
 // AppendGraph implements Appender
 func (a SidecarsCheckAppender) AppendGraph(trees *[]tree.ServiceNode, _ string) {
+	if len(*trees) == 0 {
+		return
+	}
+
 	k8s, err := kubernetes.NewClient()
 	checkError(err)
 

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -87,14 +87,10 @@ func graphNamespaces(o options.Options, client *prometheus.Client) *[]tree.Servi
 		log.Debugf("Build graph for namespace [%s]", namespace)
 		namespaceRoots := buildNamespaceTrees(namespace, o, client)
 
-		if len(*namespaceRoots) > 0 {
-			for _, a := range o.Appenders {
-				a.AppendGraph(namespaceRoots, namespace)
-			}
-			mergeRoots(&roots, namespaceRoots)
-		} else {
-			log.Debugf("No roots found for namespace [%s]", namespace)
+		for _, a := range o.Appenders {
+			a.AppendGraph(namespaceRoots, namespace)
 		}
+		mergeRoots(&roots, namespaceRoots)
 	}
 
 	if len(o.Namespaces) > 0 {


### PR DESCRIPTION
- appenders must now handle an empty tree list.