### PR TITLE
[Kiali_269] Throw warning message when istio version is not supported

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,8 @@ const (
 
 	EnvTokenSecret       = "TOKEN_SECRET"
 	EnvTokenExpirationAt = "TOKEN_EXPIRATION_AT"
+
+	IstioVersionSupported = ">= 0.7.1"
 )
 
 // Global configuration for the application.

--- a/status/status.go
+++ b/status/status.go
@@ -11,8 +11,9 @@ const (
 )
 
 type StatusInfo struct {
-	Status   map[string]string `json:"status"`
-	Products []ProductInfo     `json:"products"`
+	Status          map[string]string `json:"status"`
+	Products        []ProductInfo     `json:"products"`
+	WarningMessages []string          `json:"warningMessages"`
 }
 
 var info StatusInfo
@@ -37,6 +38,7 @@ func Put(name, value string) (previous string, hasPrevious bool) {
 // Get returns a copy of the current status info.
 func Get() (status StatusInfo) {
 	info.Products = []ProductInfo{}
+	info.WarningMessages = []string{}
 	getVersions()
 	return info
 }

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -1,0 +1,89 @@
+package status
+
+import (
+	"testing"
+)
+
+func TestValidateVersion(t *testing.T) {
+	result := validateVersion(">= 0.7.1", "0.7.1")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 0.7.1 is >= 0.7.1")
+	}
+
+	result = validateVersion(">= 0.7.1", "0.8.1")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 0.8.1 is >= 0.7.1")
+	}
+
+	result = validateVersion(">= 0.7.1", "1.3.0")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 1.3.0 is >= 0.7.1")
+	}
+
+	result = validateVersion("== 0.7.1", "1.3.0")
+
+	if result {
+		t.Errorf("validateVersion was incorrect, got true, want false, 1.3.0 is not == 0.7.1")
+	}
+
+	result = validateVersion("> 0.7.1", "1.3.0")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 1.3.0 is > 0.7.1")
+	}
+
+	result = validateVersion(">= 0.7.1", "0.6.3")
+
+	if result {
+		t.Errorf("validateVersion was incorrect, got true, want false, 0.6.3 is not >= 0.7.1")
+	}
+
+	result = validateVersion("> 0.7.1", "0.6.3")
+
+	if result {
+		t.Errorf("validateVersion was incorrect, got true, want false, 0.6.3 is not > 0.7.1")
+	}
+
+	// Alpha / Beta versions
+
+	result = validateVersion("> 0.7.1", "0.8.3-alpha")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 0.8.3-alpha is > 0.7.1")
+	}
+
+	result = validateVersion(">= 0.8.3-alpha", "0.8.3-alpha")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 0.8.3-alpha is >= 0.8.3-alpha")
+	}
+
+	// Longer releases
+
+	result = validateVersion(">= 0.8.3", "0.8.3.1")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 0.8.3.1 is >= 0.8.3")
+	}
+
+	result = validateVersion("> 0.9", "0.9.1.1")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 0.9.1.1 is > 0.9")
+	}
+
+	result = validateVersion("> 0.8.1.1", "0.8.2")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 0.8.2 is > 0.8.1.1")
+	}
+
+	result = validateVersion("> 0.8.1.1", "1")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 1 is > 0.8.1.1")
+	}
+}


### PR DESCRIPTION
[KIALI-269](https://issues.jboss.org/browse/KIALI-269)

The object will be warning_messages

## With a correct version
![correct_version](https://user-images.githubusercontent.com/3019213/40710809-f48654a2-63f9-11e8-9b2c-1fec8aadaccc.png)
## With a version not supported
![version_error](https://user-images.githubusercontent.com/3019213/40710808-f46b6db8-63f9-11e8-86c1-801cf2603590.png)