### PR TITLE
Kiali 812 - Check if route rule versions labels has pods running

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -39,6 +39,7 @@ type IstioClientInterface interface {
 	GetServices(namespaceName string) (*ServiceList, error)
 	GetServiceDetails(namespace string, serviceName string) (*ServiceDetails, error)
 	GetPods(namespace string, labelsSet labels.Set) (*v1.PodList, error)
+	GetNamespacePods(namespace string) (*v1.PodList, error)
 	GetServicePods(namespace string, serviceName string, serviceVersion string) (*v1.PodList, error)
 	GetIstioDetails(namespace string, serviceName string) (*IstioDetails, error)
 	GetRouteRules(namespace string, serviceName string) ([]IstioObject, error)

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -105,6 +105,12 @@ func (in *IstioClient) GetPods(namespace string, labelsSet labels.Set) (*v1.PodL
 	return in.k8s.CoreV1().Pods(namespace).List(meta_v1.ListOptions{LabelSelector: formatted})
 }
 
+// GetPods returns the pods definitions for a given namespace
+// It returns an error on any problem.
+func (in *IstioClient) GetNamespacePods(namespace string) (*v1.PodList, error) {
+	return in.k8s.CoreV1().Pods(namespace).List(emptyListOptions)
+}
+
 // GetServiceDetails returns full details for a given service, consisting on service description, endpoints and pods.
 // A service is defined by the namespace and the service name.
 // It returns an error on any problem.
@@ -211,7 +217,7 @@ func (in *IstioClient) getServiceList(namespace string, servicesChan chan servic
 }
 
 func (in *IstioClient) getPodsList(namespace string, podsChan chan podsResponse) {
-	pods, err := in.k8s.CoreV1().Pods(namespace).List(emptyListOptions)
+	pods, err := in.GetNamespacePods(namespace)
 	podsChan <- podsResponse{pods: pods, err: err}
 }
 

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -105,7 +105,7 @@ func (in *IstioClient) GetPods(namespace string, labelsSet labels.Set) (*v1.PodL
 	return in.k8s.CoreV1().Pods(namespace).List(meta_v1.ListOptions{LabelSelector: formatted})
 }
 
-// GetPods returns the pods definitions for a given namespace
+// GetNamespacePods returns the pods definitions for a given namespace
 // It returns an error on any problem.
 func (in *IstioClient) GetNamespacePods(namespace string) (*v1.PodList, error) {
 	return in.k8s.CoreV1().Pods(namespace).List(emptyListOptions)

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -32,6 +32,11 @@ func (o *K8SClientMock) GetPods(namespace string, labelsSet labels.Set) (*v1.Pod
 	return args.Get(0).(*v1.PodList), args.Error(1)
 }
 
+func (o *K8SClientMock) GetNamespacePods(namespace string) (*v1.PodList, error) {
+	args := o.Called(namespace)
+	return args.Get(0).(*v1.PodList), args.Error(1)
+}
+
 func (o *K8SClientMock) GetServiceDetails(namespace string, serviceName string) (*kubernetes.ServiceDetails, error) {
 	args := o.Called(namespace, serviceName)
 	return args.Get(0).(*kubernetes.ServiceDetails), args.Error(1)

--- a/services/business/checkers/route_rule_checker.go
+++ b/services/business/checkers/route_rule_checker.go
@@ -1,10 +1,11 @@
 package checkers
 
 import (
+	"k8s.io/api/core/v1"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/services/business/checkers/route_rules"
 	"github.com/kiali/kiali/services/models"
-	"k8s.io/api/core/v1"
 )
 
 const objectType = "routerule"

--- a/services/business/checkers/route_rule_checker_test.go
+++ b/services/business/checkers/route_rule_checker_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/kubernetes"
@@ -13,7 +14,7 @@ import (
 func prepareTest(istioObject kubernetes.IstioObject) models.IstioValidations {
 	istioObjects := []kubernetes.IstioObject{istioObject}
 
-	routeRuleChecker := RouteRuleChecker{istioObjects}
+	routeRuleChecker := RouteRuleChecker{"bookinfo", fakePods(), istioObjects}
 	return routeRuleChecker.Check()
 }
 
@@ -102,7 +103,7 @@ func TestMultipleIstioObjects(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
-	routeRuleChecker := RouteRuleChecker{fakeMultipleIstioObjects()}
+	routeRuleChecker := RouteRuleChecker{"bookinfo", fakePods(), fakeMultipleIstioObjects()}
 	validations := routeRuleChecker.Check()
 	assert.NotEmpty(validations)
 
@@ -132,16 +133,14 @@ func fakeIstioObjects() kubernetes.IstioObject {
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(55),
-					"labels": map[string]string{
-						"version":   "v1",
-						"namespace": "bookinfo",
+					"labels": map[string]interface{}{
+						"version": "v1",
 					},
 				},
 				map[string]interface{}{
 					"weight": uint64(45),
-					"labels": map[string]string{
-						"version":   "v1",
-						"namespace": "bookinfo",
+					"labels": map[string]interface{}{
+						"version": "v1",
 					},
 				},
 			},
@@ -160,16 +159,14 @@ func fakeMultipleChecks() kubernetes.IstioObject {
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(155),
-					"labels": map[string]string{
-						"version":   "v1",
-						"namespace": "bookinfo",
+					"labels": map[string]interface{}{
+						"version": "v1",
 					},
 				},
 				map[string]interface{}{
 					"weight": uint64(45),
-					"labels": map[string]string{
-						"version":   "v1",
-						"namespace": "bookinfo",
+					"labels": map[string]interface{}{
+						"version": "v1",
 					},
 				},
 			},
@@ -215,16 +212,14 @@ func fakeMixedChecker() kubernetes.IstioObject {
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(155),
-					"labels": map[string]string{
-						"version":   "v1",
-						"namespace": "bookinfo",
+					"labels": map[string]interface{}{
+						"version": "v1",
 					},
 				},
 				map[string]interface{}{
 					"weight": uint64(45),
-					"labels": map[string]string{
-						"version":   "v1",
-						"namespace": "bookinfo",
+					"labels": map[string]interface{}{
+						"version": "v1",
 					},
 				},
 			},
@@ -236,4 +231,25 @@ func fakeMixedChecker() kubernetes.IstioObject {
 
 func fakeMultipleIstioObjects() []kubernetes.IstioObject {
 	return []kubernetes.IstioObject{fakeMixedChecker(), fakeNegative()}
+}
+
+func fakePods() []v1.Pod {
+	return []v1.Pod{
+		v1.Pod{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "reviews-12345-hello",
+				Labels: map[string]string{
+					"version": "v2",
+				},
+			},
+		},
+		v1.Pod{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "reviews-54321-hello",
+				Labels: map[string]string{
+					"version": "v1",
+				},
+			},
+		},
+	}
 }

--- a/services/business/checkers/route_rule_checker_test.go
+++ b/services/business/checkers/route_rule_checker_test.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/services/models"
 )
@@ -20,6 +21,8 @@ func prepareTest(istioObject kubernetes.IstioObject) models.IstioValidations {
 
 func TestWellRouteRuleValidation(t *testing.T) {
 	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
 
 	// Setup mocks
 	validations := prepareTest(fakeIstioObjects())
@@ -130,6 +133,9 @@ func fakeIstioObjects() kubernetes.IstioObject {
 			Name: "reviews-well",
 		},
 		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(55),
@@ -156,6 +162,9 @@ func fakeMultipleChecks() kubernetes.IstioObject {
 			Name: "reviews-multiple",
 		},
 		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(155),
@@ -182,6 +191,9 @@ func fakeCorrectPrecedence() kubernetes.IstioObject {
 			Name: "reviews-precedence",
 		},
 		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
 			"precedence": uint64(1),
 		},
 	}).DeepCopyIstioObject()
@@ -195,6 +207,9 @@ func fakeNegative() kubernetes.IstioObject {
 			Name: "reviews-negative",
 		},
 		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
 			"precedence": int64(-1),
 		},
 	}).DeepCopyIstioObject()
@@ -208,6 +223,9 @@ func fakeMixedChecker() kubernetes.IstioObject {
 			Name: "reviews-mixed",
 		},
 		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
 			"precedence": int64(-1),
 			"route": []map[string]interface{}{
 				map[string]interface{}{
@@ -239,6 +257,7 @@ func fakePods() []v1.Pod {
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: "reviews-12345-hello",
 				Labels: map[string]string{
+					"app":     "reviews",
 					"version": "v2",
 				},
 			},
@@ -247,6 +266,7 @@ func fakePods() []v1.Pod {
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: "reviews-54321-hello",
 				Labels: map[string]string{
+					"app":     "reviews",
 					"version": "v1",
 				},
 			},

--- a/services/business/checkers/route_rules/version_presence_checker.go
+++ b/services/business/checkers/route_rules/version_presence_checker.go
@@ -1,0 +1,58 @@
+package route_rules
+
+import (
+	"reflect"
+	"strconv"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/models"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type VersionPresenceChecker struct {
+	Namespace string
+	PodList   []v1.Pod
+	RouteRule kubernetes.IstioObject
+}
+
+func (checker VersionPresenceChecker) Check() ([]*models.IstioCheck, bool) {
+	valid := true
+	validations := make([]*models.IstioCheck, 0)
+
+	slice := reflect.ValueOf(checker.RouteRule.GetSpec()["route"])
+	if slice.Kind() != reflect.Slice {
+		return validations, valid
+	}
+
+	for i := 0; i < slice.Len(); i++ {
+		route := slice.Index(i).Interface().(map[string]interface{})
+		if route["labels"] == nil {
+			continue
+		}
+
+		routeSelector := labels.Set(route["labels"].(map[string]string)).AsSelector()
+		if !checker.hasMatchingPod(routeSelector) {
+			valid = false
+			validation := models.BuildCheck("No pods found for the selector", "warning",
+				"spec/route["+strconv.Itoa(i)+"]/labels")
+			validations = append(validations, &validation)
+		}
+
+	}
+
+	return validations, valid
+}
+
+func (checker VersionPresenceChecker) hasMatchingPod(selector labels.Selector) bool {
+	podFound := false
+
+	for _, pod := range checker.PodList {
+		podFound = podFound || selector.Matches(labels.Set(pod.ObjectMeta.Labels))
+		if podFound {
+			break
+		}
+	}
+
+	return podFound
+}

--- a/services/business/checkers/route_rules/version_presence_checker.go
+++ b/services/business/checkers/route_rules/version_presence_checker.go
@@ -31,7 +31,7 @@ func (checker VersionPresenceChecker) Check() ([]*models.IstioCheck, bool) {
 			continue
 		}
 
-		routeSelector := labels.Set(route["labels"].(map[string]string)).AsSelector()
+		routeSelector := getSelector(route["labels"])
 		if !checker.hasMatchingPod(routeSelector) {
 			valid = false
 			validation := models.BuildCheck("No pods found for the selector", "warning",
@@ -55,4 +55,13 @@ func (checker VersionPresenceChecker) hasMatchingPod(selector labels.Selector) b
 	}
 
 	return podFound
+}
+
+func getSelector(rawLabels interface{}) labels.Selector {
+	routeLabels := map[string]string{}
+	for key, value := range rawLabels.(map[string]interface{}) {
+		routeLabels[key] = value.(string)
+	}
+
+	return labels.Set(routeLabels).AsSelector()
 }

--- a/services/business/checkers/route_rules/version_presence_checker_test.go
+++ b/services/business/checkers/route_rules/version_presence_checker_test.go
@@ -45,13 +45,13 @@ func fakeCorrectVersions() kubernetes.IstioObject {
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(55),
-					"labels": map[string]string{
+					"labels": map[string]interface{}{
 						"version": "v1",
 					},
 				},
 				map[string]interface{}{
 					"weight": uint64(45),
-					"labels": map[string]string{
+					"labels": map[string]interface{}{
 						"version": "v2",
 					},
 				},
@@ -93,13 +93,13 @@ func fakeNoPodsVersion() kubernetes.IstioObject {
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(55),
-					"labels": map[string]string{
+					"labels": map[string]interface{}{
 						"version": "not-v1",
 					},
 				},
 				map[string]interface{}{
 					"weight": uint64(45),
-					"labels": map[string]string{
+					"labels": map[string]interface{}{
 						"version": "not-v2",
 					},
 				},

--- a/services/business/checkers/route_rules/version_presence_checker_test.go
+++ b/services/business/checkers/route_rules/version_presence_checker_test.go
@@ -1,0 +1,111 @@
+package route_rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+func TestCheckerWithPodsMatching(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	podList := []v1.Pod{
+		fakePodsForLabels(map[string]string{"app": "reviews", "version": "v1"}),
+		fakePodsForLabels(map[string]string{"app": "reviews", "version": "v2"}),
+	}
+
+	validations, valid := VersionPresenceChecker{"bookinfo", podList, fakeCorrectVersions()}.Check()
+
+	// Well configured object
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+func fakePodsForLabels(labels labels.Set) v1.Pod {
+	return v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:   "reviews-12345-hello",
+			Labels: labels,
+		},
+	}
+}
+
+func fakeCorrectVersions() kubernetes.IstioObject {
+	validRouteRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(55),
+					"labels": map[string]string{
+						"version": "v1",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version": "v2",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return validRouteRule
+}
+
+func TestNoMatchingPods(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	podList := []v1.Pod{
+		fakePodsForLabels(map[string]string{"version": "v1"}),
+		fakePodsForLabels(map[string]string{"version": "v2"}),
+	}
+	validations, valid := VersionPresenceChecker{"bookinfo", podList, fakeNoPodsVersion()}.Check()
+
+	// There are no pods no deployments
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 2)
+	assert.Equal(validations[0].Message, "No pods found for the selector")
+	assert.Equal(validations[0].Severity, "warning")
+	assert.Equal(validations[0].Path, "spec/route[0]/labels")
+	assert.Equal(validations[1].Message, "No pods found for the selector")
+	assert.Equal(validations[1].Severity, "warning")
+	assert.Equal(validations[1].Path, "spec/route[1]/labels")
+}
+
+func fakeNoPodsVersion() kubernetes.IstioObject {
+	validRouteRule := (&kubernetes.RouteRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "reviews",
+		},
+		Spec: map[string]interface{}{
+			"route": []map[string]interface{}{
+				map[string]interface{}{
+					"weight": uint64(55),
+					"labels": map[string]string{
+						"version": "not-v1",
+					},
+				},
+				map[string]interface{}{
+					"weight": uint64(45),
+					"labels": map[string]string{
+						"version": "not-v2",
+					},
+				},
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return validRouteRule
+}

--- a/services/business/istio_validations.go
+++ b/services/business/istio_validations.go
@@ -31,7 +31,7 @@ func (in *IstioValidationsService) GetServiceValidations(namespace, service stri
 	}
 
 	objectCheckers := []ObjectChecker{
-		checkers.RouteRuleChecker{istioDetails.RouteRules},
+		checkers.RouteRuleChecker{namespace, pods.Items, istioDetails.RouteRules},
 		&checkers.PodChecker{Pods: pods.Items},
 	}
 
@@ -51,8 +51,14 @@ func (in *IstioValidationsService) GetNamespaceValidations(namespace string) (mo
 		return nil, err
 	}
 
+	pods, err := in.k8s.GetNamespacePods(namespace)
+	if err != nil {
+		log.Warningf("Cannot get pods for namespace %v.", namespace)
+		return nil, err
+	}
+
 	objectCheckers := []ObjectChecker{
-		checkers.RouteRuleChecker{istioDetails.RouteRules},
+		checkers.RouteRuleChecker{Namespace: namespace, PodList: pods.Items, RouteRules: istioDetails.RouteRules},
 		checkers.NoServiceChecker{IstioDetails: istioDetails, ServiceList: serviceList},
 	}
 

--- a/services/business/istio_validations_test.go
+++ b/services/business/istio_validations_test.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/services/models"
-	"k8s.io/api/core/v1"
 )
 
 func TestServiceWellRouteRuleValidation(t *testing.T) {
 	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
 
 	// Setup mocks
 	vs := mockValidationService(fakeIstioObjects(), fakePods())
@@ -139,6 +142,9 @@ func fakeIstioObjects() *kubernetes.IstioDetails {
 			Name: "reviews-well",
 		},
 		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(55),
@@ -167,6 +173,9 @@ func fakeUnder100RouteRule() *kubernetes.IstioDetails {
 			Name: "reviews-100-minus",
 		},
 		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(45),
@@ -195,6 +204,9 @@ func fakeOver100RouteRule() *kubernetes.IstioDetails {
 			Name: "reviews-100-plus",
 		},
 		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(55),
@@ -223,6 +235,9 @@ func fakeMultipleChecks() *kubernetes.IstioDetails {
 			Name: "reviews-multiple",
 		},
 		Spec: map[string]interface{}{
+			"destination": map[string]interface{}{
+				"name": "reviews",
+			},
 			"route": []map[string]interface{}{
 				map[string]interface{}{
 					"weight": uint64(155),
@@ -372,6 +387,7 @@ func fakePods() *v1.PodList {
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "reviews-12345-hello",
 					Labels: map[string]string{
+						"app":     "reviews",
 						"version": "v2",
 					},
 				},
@@ -380,6 +396,7 @@ func fakePods() *v1.PodList {
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "reviews-54321-hello",
 					Labels: map[string]string{
+						"app":     "reviews",
 						"version": "v1",
 					},
 				},


### PR DESCRIPTION
Given a route rule routing traffic to v1 and v2, add a new validation if v1 or v2 doesn't have any pod running.