### PR TITLE
[Bug] Local environment authentication, set username/password to admi…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,9 +3,9 @@ server:
   port: 8000
 
   # Uncomment credentials to enable basic authentication for server
-  # credentials:
-  #   username: u
-  #   password: p
+  credentials:
+    username: admin
+    password: admin
 
   # Uncomment static_content_root_directory to set up a different directory for static front-end content.
   # Default is /static-files


### PR DESCRIPTION
Local environment authentication, set username/password to admin/admin in config.yaml

Actually the UI is running with admin/admin in the condifuration file but the backend is running without authentication if you don't deploy it in openshift with the configmaps.

Discussion in Istio: [Istio #5869](https://github.com/istio/istio/pull/5869#discussion_r191646435)

cc @abonas 