### PR TITLE
Allowing show error/warning messages to collection fields e.g. labels

### DIFF
--- a/services/business/checkers/route_rules/route_checker.go
+++ b/services/business/checkers/route_rules/route_checker.go
@@ -42,14 +42,14 @@ func (route RouteChecker) Check() ([]*models.IstioCheck, bool) {
 		if err != nil {
 			valid = false
 			validation := models.BuildCheck("Weight must be a number",
-				"error", "spec/route/weight/"+route["weight"].(string))
+				"error", "spec/route["+strconv.Itoa(i)+"]/weight/"+route["weight"].(string))
 			validations = append(validations, &validation)
 		}
 
 		if weight > 100 || weight < 0 {
 			valid = false
 			validation := models.BuildCheck("Weight should be between 0 and 100",
-				"error", "spec/route/weight/"+strconv.Itoa(weight))
+				"error", "spec/route["+strconv.Itoa(i)+"]/weight/"+strconv.Itoa(weight))
 			validations = append(validations, &validation)
 		}
 

--- a/services/business/checkers/route_rules/route_checker_test.go
+++ b/services/business/checkers/route_rules/route_checker_test.go
@@ -31,7 +31,7 @@ func TestServiceMultipleChecks(t *testing.T) {
 	assert.Len(validations, 2)
 	assert.Equal(validations[0].Message, "Weight should be between 0 and 100")
 	assert.Equal(validations[0].Severity, "error")
-	assert.Equal(validations[0].Path, "spec/route/weight/155")
+	assert.Equal(validations[0].Path, "spec/route[0]/weight/155")
 
 	assert.Equal(validations[1].Message, "Weight sum should be 100")
 	assert.Equal(validations[1].Severity, "error")

--- a/services/business/istio_validations_test.go
+++ b/services/business/istio_validations_test.go
@@ -55,7 +55,7 @@ func TestServiceMultipleChecks(t *testing.T) {
 
 	assert.Equal(checks[0].Message, "Weight should be between 0 and 100")
 	assert.Equal(checks[0].Severity, "error")
-	assert.Equal(checks[0].Path, "spec/route/weight/155")
+	assert.Equal(checks[0].Path, "spec/route[0]/weight/155")
 
 	assert.Equal(checks[1].Message, "Weight sum should be 100")
 	assert.Equal(checks[1].Severity, "error")
@@ -131,7 +131,7 @@ func TestGetNamespaceValidations(t *testing.T) {
 	assert.False(reviewsRr.Valid)
 	assert.Equal(3, len(reviewsRr.Checks))
 
-	assert.Equal("spec/route/weight/155", reviewsRr.Checks[0].Path)
+	assert.Equal("spec/route[0]/weight/155", reviewsRr.Checks[0].Path)
 	assert.Equal("Weight should be between 0 and 100", reviewsRr.Checks[0].Message)
 	assert.Equal("error", reviewsRr.Checks[0].Severity)
 
@@ -160,7 +160,7 @@ func TestGetIstioObjectValidations(t *testing.T) {
 	assert.False(reviewsRr.Valid)
 	assert.Equal(3, len(reviewsRr.Checks))
 
-	assert.Equal("spec/route/weight/155", reviewsRr.Checks[0].Path)
+	assert.Equal("spec/route[0]/weight/155", reviewsRr.Checks[0].Path)
 	assert.Equal("Weight should be between 0 and 100", reviewsRr.Checks[0].Message)
 	assert.Equal("error", reviewsRr.Checks[0].Severity)
 


### PR DESCRIPTION
Minor change for allowing UI to show warnings/errors into weight table.

![array-syntax-validations-2](https://user-images.githubusercontent.com/613814/40789604-16b27f20-64f3-11e8-835f-3fb831fc4ce2.png)

Needs to be merged at same time as [kiali/kiali-ui#389](https://github.com/kiali/kiali-ui/pull/389).