### PR TITLE
KIALI-817 Change shape of nodes on different namespaces

### DIFF
--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -92,9 +92,20 @@ func graphNamespaces(o options.Options, client *prometheus.Client) graph.Traffic
 		mergeTrafficMaps(trafficMap, namespaceTrafficMap)
 	}
 
-	// now that the services are final, make one pass to set the roots (i.e. traffic generators).
-	// A root is defined as a service with only outgoing traffic.
 	for _, s := range trafficMap {
+		// Check if the node is in one of the requested namespaces.
+		found := false
+		for _, namespace := range o.Namespaces {
+			if s.Namespace == namespace {
+				found = true
+				break
+			}
+		}
+
+		s.Metadata["isOutside"] = !found && s.ServiceName != "unknown"
+
+		// now that the services are final, make one pass to set the roots (i.e. traffic generators).
+		// A root is defined as a service with only outgoing traffic.
 		if s.Metadata["rate"].(float64) == 0.0 && s.Metadata["rateOut"].(float64) > 0.0 {
 			s.Metadata["isRoot"] = true
 		}

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -238,8 +238,8 @@ func TestNamespaceGraph(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual, _ := ioutil.ReadAll(resp.Body)
+	ioutil.WriteFile("testdata/test_namespace_graph.expected", actual, 0644)
 	expected, _ := ioutil.ReadFile("testdata/test_namespace_graph.expected")
-	expected = expected[:len(expected)-1] // remove EOF byte
 
 	if !assert.Equal(t, expected, actual) {
 		fmt.Printf("\nActual:\n%v", string(actual))
@@ -309,7 +309,6 @@ func TestMultiNamespaceGraph(t *testing.T) {
 	}
 	actual, _ := ioutil.ReadAll(resp.Body)
 	expected, _ := ioutil.ReadFile("testdata/test_multi_namespace_graph.expected")
-	expected = expected[:len(expected)-1] // remove EOF byte
 
 	if !assert.Equal(t, expected, actual) {
 		fmt.Printf("\nActual:\n%v", string(actual))
@@ -420,8 +419,8 @@ func TestServiceGraph(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual, _ := ioutil.ReadAll(resp.Body)
+	//ioutil.WriteFile("testdata/test_service_graph.expected", actual, 0644)
 	expected, _ := ioutil.ReadFile("testdata/test_service_graph.expected")
-	expected = expected[:len(expected)-1] // remove EOF byte
 
 	if !assert.Equal(t, expected, actual) {
 		fmt.Printf("\nActual:\n%v", string(actual))

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -238,8 +238,8 @@ func TestNamespaceGraph(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual, _ := ioutil.ReadAll(resp.Body)
-	ioutil.WriteFile("testdata/test_namespace_graph.expected", actual, 0644)
 	expected, _ := ioutil.ReadFile("testdata/test_namespace_graph.expected")
+	expected = expected[:len(expected)-1] // remove EOF byte
 
 	if !assert.Equal(t, expected, actual) {
 		fmt.Printf("\nActual:\n%v", string(actual))
@@ -309,6 +309,7 @@ func TestMultiNamespaceGraph(t *testing.T) {
 	}
 	actual, _ := ioutil.ReadAll(resp.Body)
 	expected, _ := ioutil.ReadFile("testdata/test_multi_namespace_graph.expected")
+	expected = expected[:len(expected)-1] // remove EOF byte
 
 	if !assert.Equal(t, expected, actual) {
 		fmt.Printf("\nActual:\n%v", string(actual))
@@ -419,8 +420,8 @@ func TestServiceGraph(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual, _ := ioutil.ReadAll(resp.Body)
-	//ioutil.WriteFile("testdata/test_service_graph.expected", actual, 0644)
 	expected, _ := ioutil.ReadFile("testdata/test_service_graph.expected")
+	expected = expected[:len(expected)-1] // remove EOF byte
 
 	if !assert.Equal(t, expected, actual) {
 		fmt.Printf("\nActual:\n%v", string(actual))

--- a/handlers/testdata/test_multi_namespace_graph.expected
+++ b/handlers/testdata/test_multi_namespace_graph.expected
@@ -6,6 +6,7 @@
         "data": {
           "id": "80c2e74be9c24effcaf63df866f8f02d",
           "service": "customer.tutorial.svc.cluster.local",
+          "namespace": "tutorial",
           "version": "v1",
           "rate": "50.000"
         }
@@ -14,6 +15,7 @@
         "data": {
           "id": "32f13d185b9a6764d67f9f96f8796f6c",
           "service": "productpage.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v1",
           "rate": "50.000"
         }
@@ -22,6 +24,7 @@
         "data": {
           "id": "ba113404e46b8aa41dc0e7cc339073fe",
           "service": "unknown",
+          "namespace": "unknown",
           "version": "unknown",
           "rateOut": "50.000",
           "isRoot": true

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -6,6 +6,7 @@
         "data": {
           "id": "50c81fc80cd32ed8f2c2b5c1e698e9f8",
           "service": "details.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v1",
           "rate": "80.000",
           "rate3XX": "20.000",
@@ -17,15 +18,18 @@
         "data": {
           "id": "a8b6f512ceed0f9209287424b216200c",
           "service": "ingressgateway.istio-system.svc.cluster.local",
+          "namespace": "istio-system",
           "version": "unknown",
           "rateOut": "100.000",
-          "isRoot": true
+          "isRoot": true,
+          "isOutside": true
         }
       },
       {
         "data": {
           "id": "32f13d185b9a6764d67f9f96f8796f6c",
           "service": "productpage.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v1",
           "rate": "170.000",
           "rateOut": "160.000"
@@ -35,6 +39,7 @@
         "data": {
           "id": "4bd6b4e52f760784b8cf5a9ae38241e2",
           "service": "ratings.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v1",
           "rate": "40.000"
         }
@@ -43,6 +48,7 @@
         "data": {
           "id": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
+          "namespace": "",
           "isGroup": "version"
         }
       },
@@ -51,6 +57,7 @@
           "id": "09db1ec4064c7f4e77c2c65f0c8709ac",
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v1",
           "rate": "20.000"
         }
@@ -60,6 +67,7 @@
           "id": "a30ebe6d7004dc26a24a989e27550aa2",
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v2",
           "rate": "40.000",
           "rateOut": "40.000"
@@ -70,6 +78,7 @@
           "id": "9b88963ddbd1603b0bbca88cfca29781",
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v3",
           "rate": "40.000",
           "rateOut": "40.000"
@@ -79,6 +88,7 @@
         "data": {
           "id": "ba113404e46b8aa41dc0e7cc339073fe",
           "service": "unknown",
+          "namespace": "unknown",
           "version": "unknown",
           "rateOut": "50.000",
           "isRoot": true

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -21,8 +21,8 @@
           "namespace": "istio-system",
           "version": "unknown",
           "rateOut": "100.000",
-          "isRoot": true,
-          "isOutside": true
+          "isOutside": true,
+          "isRoot": true
         }
       },
       {

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -6,6 +6,7 @@
         "data": {
           "id": "32f13d185b9a6764d67f9f96f8796f6c",
           "service": "productpage.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v1",
           "rateOut": "60.000"
         }
@@ -14,6 +15,7 @@
         "data": {
           "id": "4bd6b4e52f760784b8cf5a9ae38241e2",
           "service": "ratings.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v1",
           "rate": "40.000"
         }
@@ -22,6 +24,7 @@
         "data": {
           "id": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
+          "namespace": "",
           "isGroup": "version"
         }
       },
@@ -30,6 +33,7 @@
           "id": "09db1ec4064c7f4e77c2c65f0c8709ac",
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v1",
           "rate": "20.000"
         }
@@ -39,6 +43,7 @@
           "id": "a30ebe6d7004dc26a24a989e27550aa2",
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v2",
           "rate": "40.000",
           "rateOut": "40.000"
@@ -49,6 +54,7 @@
           "id": "9b88963ddbd1603b0bbca88cfca29781",
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
+          "namespace": "bookinfo",
           "version": "v3",
           "rate": "40.000",
           "rateOut": "40.000"


### PR DESCRIPTION
This is a two-part PR, the other one being on the ui repo. The idea here is to
show the services on a different namespace with a different color and shape.

Here's how it looks right now:

![](https://i.imgur.com/fTPEOqz.png)

Things that are missing:

- [X] On the `all` namespaces page, the nodes are still being marked as from other namespaces.
- [ ] Discuss on how to group the namespaces on the `all` page.
- [ ] There are two bugs on some configurations of connections, and both can be
  shown on the image below. I'm not sure exactly what happens on that, what I do
  have in mind right now is that those bugs appear when there's a graph on the
  connection that comes and goes to a different namespace, like this:

![](https://i.imgur.com/LvVWsjE.png)

The configuration on this one is pingpong, which is `a d a e a f`, meaning that
it goes from one namespace to the other and then back.

On the other namespace page, the weird behaviour also happens:

![](https://i.imgur.com/MHhIJbE.png)

That means that ingress traffic that comes from another namespace is not being shown.


---

If you want to test these configurations, you can use this script on the gist: [https://gist.github.com/cfcosta/75620f9e82ee0eb05b68953f33e45949]().

Just run `generate-mesh.sh` to generate the mesh, and `ruby generate_traffic.rb` to add some traffic to those nodes.