### PR TITLE
fix build hack script

### DIFF
--- a/hack/build-openshift.sh
+++ b/hack/build-openshift.sh
@@ -85,8 +85,12 @@ if [ ! -z "${OPENSHIFT_BRANCH_NAME}" ]; then
     echo "Switching to the origin/${OPENSHIFT_BRANCH_NAME} branch"
     git checkout origin/${OPENSHIFT_BRANCH_NAME}
     if [ "$?" != "0" ]; then
-      echo "Cannot build - there is no branch for the version you want: ${OPENSHIFT_BRANCH_NAME}"
-      exit 1
+      echo "${OPENSHIFT_BRANCH_NAME} is not a branch - switching to a tag of the same name"
+      git checkout ${OPENSHIFT_BRANCH_NAME}
+      if [ "$?" != "0" ]; then
+        echo "Cannot build - there is no branch or tag for the version you want: ${OPENSHIFT_BRANCH_NAME}"
+        exit 1
+      fi
     fi
   fi
 else

--- a/hack/build-openshift.sh
+++ b/hack/build-openshift.sh
@@ -101,7 +101,7 @@ fi
 export GOPATH=${OPENSHIFT_GOPATH}
 
 echo Building OpenShift Origin binaries ...
-python2 hack/env make clean build
+hack/env make clean build
 
 echo Building OpenShift Origin images...
 python2 hack/build-local-images.py

--- a/hack/env-openshift.sh
+++ b/hack/env-openshift.sh
@@ -17,7 +17,7 @@ OPENSHIFT_IP_ADDRESS=${OPENSHIFT_IP_ADDRESS:-`echo $(ip -f inet addr | grep 'sta
 
 # If you want to run the last release of OpenShift, use "latest" or "master".
 # If you want to run with a specific version, set it to the branch you want.
-OPENSHIFT_BRANCH_NAME="release-3.7"
+OPENSHIFT_BRANCH_NAME="release-3.9"
 
 # If you want to persist data across restarts of OpenShift, uncomment this
 # line and set the host data directory to the place where you want the data stored.


### PR DESCRIPTION
1. Support building from a tag
2. Not sure why python2 is being passed hack/env - hack/env is a bash script. Removing python2 because this is broken the way it is.
3. Build release-3.9 by default

@jshaughn item 2 above fixes the build error I think you are getting (at least, it is why my build was broken; I think you are probably hitting the same thing). Please review and merge.