### PR TITLE
KIALI-750 Adding mTLS attribute to edges

### DIFF
--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -62,7 +62,8 @@ type EdgeData struct {
 	PercentErr  string `json:"percentErr,omitempty"`
 	PercentRate string `json:"percentRate,omitempty"` // percent of total parent requests
 	Latency     string `json:"latency,omitempty"`
-	IsUnused    string `json:"isUnused,omitempty"` // true | false
+	IsUnused    string `json:"isUnused,omitempty"`    // true | false
+	EnabledmTLS string `json:"enabledmTLS,omitempty"` // true | false
 }
 
 type NodeWrapper struct {
@@ -206,6 +207,7 @@ func walk(sn *tree.ServiceNode, ndParent *NodeData, nodes *[]*NodeWrapper, edges
 			Target: nd.Id,
 		}
 		addTelemetry(&ed, sn, nd, o)
+		addTLS(&ed, sn, o)
 		// TODO: Add in the response code breakdowns and/or other metric info
 		ew := EdgeWrapper{
 			Data: &ed,
@@ -269,6 +271,31 @@ func addTelemetry(ed *EdgeData, sn *tree.ServiceNode, nd *NodeData, o options.Ve
 		if val, ok := sn.Metadata["isUnused"]; ok {
 			ed.IsUnused = val.(string)
 		}
+	}
+}
+
+func addTLS(ed *EdgeData, sn *tree.ServiceNode, o options.VendorOptions) {
+	if sn.Parent == nil {
+		return
+	}
+
+	nmTLS, ok := sn.Metadata["hasmTLS"].(bool)
+	if !ok {
+		nmTLS = false
+	}
+
+	nMissingSideCars, ok := sn.Metadata["hasMissingSidecars"].(bool)
+	if !ok {
+		nMissingSideCars = true
+	}
+
+	pnMissingSideCars, ok := sn.Parent.Metadata["hasMissingSidecars"].(bool)
+	if !ok {
+		pnMissingSideCars = true
+	}
+
+	if nmTLS && !nMissingSideCars && !pnMissingSideCars {
+		ed.EnabledmTLS = "true"
 	}
 }
 

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -339,6 +339,28 @@ func CheckDestinationRuleCircuitBreaker(destinationRule IstioObject, namespace s
 	return false
 }
 
+func CheckDestinationRulemTLS(destinationRule IstioObject, namespace string, serviceName string) bool {
+	if destinationRule == nil || destinationRule.GetSpec() == nil {
+		return false
+	}
+	if dName, ok := destinationRule.GetSpec()["name"]; ok && dName == serviceName {
+		if trafficPolicy, ok := destinationRule.GetSpec()["trafficPolicy"]; ok {
+			if dTrafficPolicy, ok := trafficPolicy.(map[string]interface{}); ok {
+				if mtls, ok := dTrafficPolicy["tls"]; ok {
+					if dmTLS, ok := mtls.(map[string]interface{}); ok {
+						if mode, ok := dmTLS["mode"]; ok {
+							if dmode, ok := mode.(string); ok {
+								return dmode == "ISTIO_MUTUAL"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
 // Helper method to check if exist a route with a destination and a subset defined for a httpRoute or tcpRoute in a VirtualService
 func checkSubsetRoute(routes interface{}, serviceName string, subsets []string) bool {
 	if httpTcpRoutes, ok := routes.([]interface{}); ok {

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -392,3 +392,21 @@ func TestCheckDestinationRuleCircuitBreaker(t *testing.T) {
 	assert.True(t, CheckDestinationRuleCircuitBreaker(&destinationRule2, "", "reviews", "v2"))
 	assert.False(t, CheckDestinationRuleCircuitBreaker(&destinationRule2, "", "reviews-bad", "v2"))
 }
+
+func TestCheckDestinationRulemTLS(t *testing.T) {
+	assert.False(t, CheckDestinationRulemTLS(nil, "", ""))
+
+	destinationRule1 := MockIstioObject{
+		Spec: map[string]interface{}{
+			"name": "reviews",
+			"trafficPolicy": map[string]interface{}{
+				"tls": map[string]interface{}{
+					"mode": "ISTIO_MUTUAL",
+				},
+			},
+		},
+	}
+
+	assert.True(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews"))
+	assert.False(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews-bad"))
+}


### PR DESCRIPTION
The goal of this PR is to add an attribute to those edges that connect two services transmitting under mTLS.

This PR is a first step to add fully coverage of mTLS. Right now, it only support the meshes using Istio without default mTLS enabled. 

![hasenabledmtls](https://user-images.githubusercontent.com/613814/41154783-8ea779da-6b1b-11e8-9acd-8a79952c633b.png)

Please, see more information into https://issues.jboss.org/browse/KIALI-750

This PR should be merged after achieving Istio 0.8.0 migration.