### PR TITLE
Kiali 893 DestinatioRule is using host field

### DIFF
--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -196,7 +196,7 @@ func (in *IstioClient) GetDestinationRules(namespace string, serviceName string)
 	destinationRules := make([]IstioObject, 0)
 	for _, destinationRule := range destinationRuleList.Items {
 		appendDestinationRule := serviceName == ""
-		if name, ok := destinationRule.Spec["name"]; ok {
+		if name, ok := destinationRule.Spec["host"]; ok {
 			if name == serviceName {
 				appendDestinationRule = true
 			}
@@ -283,7 +283,7 @@ func GetDestinationRulesSubsets(destinationRules []IstioObject, serviceName, ver
 	cfg := config.Get()
 	foundSubsets := make([]string, 0)
 	for _, destinationRule := range destinationRules {
-		if dName, ok := destinationRule.GetSpec()["name"]; ok && dName == serviceName {
+		if dName, ok := destinationRule.GetSpec()["host"]; ok && dName == serviceName {
 			if subsets, ok := destinationRule.GetSpec()["subsets"]; ok {
 				if dSubsets, ok := subsets.([]interface{}); ok {
 					for _, subset := range dSubsets {
@@ -314,7 +314,7 @@ func CheckDestinationRuleCircuitBreaker(destinationRule IstioObject, namespace s
 		return false
 	}
 	cfg := config.Get()
-	if dName, ok := destinationRule.GetSpec()["name"]; ok && dName == serviceName {
+	if dName, ok := destinationRule.GetSpec()["host"]; ok && dName == serviceName {
 		if trafficPolicy, ok := destinationRule.GetSpec()["trafficPolicy"]; ok && checkTrafficPolicy(trafficPolicy) {
 			return true
 		}

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -2,8 +2,10 @@ package kubernetes
 
 import (
 	"fmt"
-	"github.com/kiali/kiali/config"
+	"strings"
 	"sync"
+
+	"github.com/kiali/kiali/config"
 )
 
 // GetIstioDetails returns Istio details for a given namespace,
@@ -196,8 +198,8 @@ func (in *IstioClient) GetDestinationRules(namespace string, serviceName string)
 	destinationRules := make([]IstioObject, 0)
 	for _, destinationRule := range destinationRuleList.Items {
 		appendDestinationRule := serviceName == ""
-		if name, ok := destinationRule.Spec["host"]; ok {
-			if name == serviceName {
+		if host, ok := destinationRule.Spec["host"]; ok {
+			if dHost, ok := host.(string); ok && matchService(dHost, serviceName, namespace) {
 				appendDestinationRule = true
 			}
 		}
@@ -283,16 +285,18 @@ func GetDestinationRulesSubsets(destinationRules []IstioObject, serviceName, ver
 	cfg := config.Get()
 	foundSubsets := make([]string, 0)
 	for _, destinationRule := range destinationRules {
-		if dName, ok := destinationRule.GetSpec()["host"]; ok && dName == serviceName {
-			if subsets, ok := destinationRule.GetSpec()["subsets"]; ok {
-				if dSubsets, ok := subsets.([]interface{}); ok {
-					for _, subset := range dSubsets {
-						if innerSubset, ok := subset.(map[string]interface{}); ok {
-							subsetName := innerSubset["name"]
-							if labels, ok := innerSubset["labels"]; ok {
-								if dLabels, ok := labels.(map[string]interface{}); ok {
-									if versionValue, ok := dLabels[cfg.VersionFilterLabelName]; ok && versionValue == version {
-										foundSubsets = append(foundSubsets, subsetName.(string))
+		if dHost, ok := destinationRule.GetSpec()["host"]; ok {
+			if host, ok := dHost.(string); ok && matchService(host, serviceName, destinationRule.GetObjectMeta().Namespace) {
+				if subsets, ok := destinationRule.GetSpec()["subsets"]; ok {
+					if dSubsets, ok := subsets.([]interface{}); ok {
+						for _, subset := range dSubsets {
+							if innerSubset, ok := subset.(map[string]interface{}); ok {
+								subsetName := innerSubset["name"]
+								if labels, ok := innerSubset["labels"]; ok {
+									if dLabels, ok := labels.(map[string]interface{}); ok {
+										if versionValue, ok := dLabels[cfg.VersionFilterLabelName]; ok && versionValue == version {
+											foundSubsets = append(foundSubsets, subsetName.(string))
+										}
 									}
 								}
 							}
@@ -314,19 +318,21 @@ func CheckDestinationRuleCircuitBreaker(destinationRule IstioObject, namespace s
 		return false
 	}
 	cfg := config.Get()
-	if dName, ok := destinationRule.GetSpec()["host"]; ok && dName == serviceName {
-		if trafficPolicy, ok := destinationRule.GetSpec()["trafficPolicy"]; ok && checkTrafficPolicy(trafficPolicy) {
-			return true
-		}
-		if subsets, ok := destinationRule.GetSpec()["subsets"]; ok {
-			if dSubsets, ok := subsets.([]interface{}); ok {
-				for _, subset := range dSubsets {
-					if innerSubset, ok := subset.(map[string]interface{}); ok {
-						if trafficPolicy, ok := innerSubset["trafficPolicy"]; ok && checkTrafficPolicy(trafficPolicy) {
-							if labels, ok := innerSubset["labels"]; ok {
-								if dLabels, ok := labels.(map[string]interface{}); ok && version != "" {
-									if versionValue, ok := dLabels[cfg.VersionFilterLabelName]; ok && versionValue == version {
-										return true
+	if dHost, ok := destinationRule.GetSpec()["host"]; ok {
+		if host, ok := dHost.(string); ok && matchService(host, serviceName, namespace) {
+			if trafficPolicy, ok := destinationRule.GetSpec()["trafficPolicy"]; ok && checkTrafficPolicy(trafficPolicy) {
+				return true
+			}
+			if subsets, ok := destinationRule.GetSpec()["subsets"]; ok {
+				if dSubsets, ok := subsets.([]interface{}); ok {
+					for _, subset := range dSubsets {
+						if innerSubset, ok := subset.(map[string]interface{}); ok {
+							if trafficPolicy, ok := innerSubset["trafficPolicy"]; ok && checkTrafficPolicy(trafficPolicy) {
+								if labels, ok := innerSubset["labels"]; ok {
+									if dLabels, ok := labels.(map[string]interface{}); ok && version != "" {
+										if versionValue, ok := dLabels[cfg.VersionFilterLabelName]; ok && versionValue == version {
+											return true
+										}
 									}
 								}
 							}
@@ -430,4 +436,27 @@ func FilterByHost(spec map[string]interface{}, hostName string) bool {
 		}
 	}
 	return false
+}
+
+// Match returns true when the hostname specifies the service passed by param.
+// It accepts the following hostname formats:
+// reviews, reviews.bookinfo.svc, reviews.bookinfo.svc.cluster.local,
+// *.bookinfo.svc, *.bookinfo.svc.cluster.local
+func matchService(hostname, service, namespace string) bool {
+	domainParts := strings.Split(hostname, ".")
+	match := false
+
+	if len(domainParts) > 2 {
+		// hostname is a FQDN/Wildcard (e.g. reviews.bookinfo.svc, *.bookinfo.svc)
+		match = domainParts[1] == namespace && domainParts[2] == "svc"
+
+		if match && domainParts[0] != "*" {
+			match = domainParts[0] == service
+		}
+	} else {
+		// hostname is a service name (e.g. reviews)
+		match = hostname == service
+	}
+
+	return match
 }

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -392,3 +392,35 @@ func TestCheckDestinationRuleCircuitBreaker(t *testing.T) {
 	assert.True(t, CheckDestinationRuleCircuitBreaker(&destinationRule2, "", "reviews", "v2"))
 	assert.False(t, CheckDestinationRuleCircuitBreaker(&destinationRule2, "", "reviews-bad", "v2"))
 }
+
+func TestShortHostname(t *testing.T) {
+	assert.True(t, matchService("reviews", "reviews", "bookinfo"))
+	assert.False(t, matchService("reviews", "ratings", "bookinfo"))
+}
+
+func TestFQDNHostname(t *testing.T) {
+	assert.True(t, matchService("reviews.bookinfo.svc", "reviews", "bookinfo"))
+	assert.True(t, matchService("reviews.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
+
+	assert.False(t, matchService("reviews.foo.svc", "reviews", "bookinfo"))
+	assert.False(t, matchService("reviews.foo.svc.cluster.local", "reviews", "bookinfo"))
+
+	assert.False(t, matchService("ratings.bookinfo.svc", "reviews", "bookinfo"))
+	assert.False(t, matchService("ratings.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
+
+	assert.False(t, matchService("ratings.foo.svc", "reviews", "bookinfo"))
+	assert.False(t, matchService("ratings.foo.svc.cluster.local", "reviews", "bookinfo"))
+}
+
+func TestWildcardHostname(t *testing.T) {
+	assert.True(t, matchService("*.bookinfo.svc", "reviews", "bookinfo"))
+	assert.True(t, matchService("*.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
+
+	assert.True(t, matchService("*.bookinfo.svc", "ratings", "bookinfo"))
+	assert.True(t, matchService("*.bookinfo.svc.cluster.local", "ratings", "bookinfo"))
+
+	assert.False(t, matchService("*.foo.svc", "ratings", "bookinfo"))
+	assert.False(t, matchService("*.foo.svc.cluster.local", "ratings", "bookinfo"))
+	assert.False(t, matchService("*.foo.svc", "reviews", "bookinfo"))
+	assert.False(t, matchService("*.foo.svc.cluster.local", "reviews", "bookinfo"))
+}

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -268,7 +268,7 @@ func TestGetDestinationRulesSubsets(t *testing.T) {
 
 	destinationRule1 := MockIstioObject{
 		Spec: map[string]interface{}{
-			"name": "reviews",
+			"host": "reviews",
 			"subsets": []interface{}{
 				map[string]interface{}{
 					"name": "v1",
@@ -287,7 +287,7 @@ func TestGetDestinationRulesSubsets(t *testing.T) {
 	}
 	destinationRule2 := MockIstioObject{
 		Spec: map[string]interface{}{
-			"name": "reviews",
+			"host": "reviews",
 			"trafficPolicy": map[string]interface{}{
 				"loadBalancer": map[string]interface{}{
 					"simple": "LEAST_CONN",
@@ -322,7 +322,7 @@ func TestCheckDestinationRuleCircuitBreaker(t *testing.T) {
 
 	destinationRule1 := MockIstioObject{
 		Spec: map[string]interface{}{
-			"name": "reviews",
+			"host": "reviews",
 			"trafficPolicy": map[string]interface{}{
 				"connectionPool": map[string]interface{}{
 					"http": map[string]interface{}{
@@ -358,7 +358,7 @@ func TestCheckDestinationRuleCircuitBreaker(t *testing.T) {
 
 	destinationRule2 := MockIstioObject{
 		Spec: map[string]interface{}{
-			"name": "reviews",
+			"host": "reviews",
 			"subsets": []interface{}{
 				map[string]interface{}{
 					"name": "v1",


### PR DESCRIPTION
Due to a change of Destination Rule specification in Istio 0.8,  those resources are bound to a hostname instead of a service name.

In this PR all API calls that fetch Destination Rules are adapted to this change.