### PR TITLE
KIALI-913 Fix auth PopUp when access to url different to /api

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -84,7 +84,7 @@ func (h *serverAuthProxyHandler) handler(w http.ResponseWriter, r *http.Request)
 			log.Warning("Error token %+v", err)
 			statusCode = http.StatusUnauthorized
 		}
-	} else if h.credentials.Username != "" || h.credentials.Password != "" {
+	} else if (h.credentials.Username != "" || h.credentials.Password != "") && strings.HasPrefix(r.URL.Path, "/api") {
 		u, p, ok := r.BasicAuth()
 		if !ok || h.credentials.Username != u || h.credentials.Password != p {
 			statusCode = http.StatusUnauthorized

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -75,7 +75,6 @@ func TestSecureComm(t *testing.T) {
 	conf.Server.Credentials.Password = authorizedPassword
 
 	serverURL := fmt.Sprintf("https://%v", testServerHostPort)
-	consoleURL := serverURL + "/"
 	apiURL := serverURL + "/api"
 
 	config.Set(conf)
@@ -123,29 +122,17 @@ func TestSecureComm(t *testing.T) {
 
 	// TEST WITH AN AUTHORIZED USER
 
-	if _, err = getRequestResults(t, httpClient, consoleURL, basicCredentials); err != nil {
-		t.Fatalf("Failed: Basic Auth Console URL: %v", err)
-	}
-
 	if _, err = getRequestResults(t, httpClient, apiURL, basicCredentials); err != nil {
 		t.Fatalf("Failed: Basic Auth API URL: %v", err)
 	}
 
 	// TEST WITH AN INVALID USER
 
-	if _, err = getRequestResults(t, httpClient, consoleURL, badBasicCredentials); err == nil {
-		t.Fatalf("Failed: Basic Auth Console URL should have failed")
-	}
-
 	if _, err = getRequestResults(t, httpClient, apiURL, badBasicCredentials); err == nil {
 		t.Fatalf("Failed: Basic Auth API URL should have failed")
 	}
 
 	// TEST WITH NO USER
-
-	if _, err = getRequestResults(t, httpClient, consoleURL, noCredentials); err == nil {
-		t.Fatalf("Failed: Basic Auth Console URL should have failed with no credentials: %v", err)
-	}
 
 	if _, err = getRequestResults(t, httpClient, apiURL, noCredentials); err == nil {
 		t.Fatalf("Failed: Basic Auth API URL should have failed with with no credentials")


### PR DESCRIPTION

Jira: [KIALI-913](https://issues.jboss.org/browse/KIALI-913)

When the request come from Kiali-UI there is a header called X-Auth-Type-Kiali-UI to avoid the response with header Basic realm=\"Kiali\" and avoid the auth popup.

When the user go to the same url / or /console this not happens so we need to filter this kind of requests.

Removed tests authentication when request is /console, this has no sense when the authentication is against Kiali-UI