### PR TITLE
KIALI-879 Calculate IstioDeployed flag from Pods

### DIFF
--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -51,7 +51,13 @@ func TestFilterDeploymentsForService(t *testing.T) {
 						MatchLabels: map[string]string{"foo": "bazz", "version": "v1"}}}},
 		}}
 
-	matches := FilterDeploymentsForService(&service, &pods, &deployments)
+	sPods:= FilterPodsForService(&service, &pods)
+
+	assert.Len(sPods, 2)
+	assert.Equal("reviews-v1", sPods[0].ObjectMeta.Name)
+	assert.Equal("reviews-v2", sPods[1].ObjectMeta.Name)
+
+	matches := FilterDeploymentsForService(&service, sPods, &deployments)
 
 	assert.Len(matches, 2)
 	assert.Equal("reviews-v1", matches[0].ObjectMeta.Name)
@@ -81,7 +87,10 @@ func TestFilterDeploymentsForServiceWithSpecificLabels(t *testing.T) {
 						MatchLabels: map[string]string{"jaeger-infra": "jaeger-pod"}}}},
 		}}
 
-	matches := FilterDeploymentsForService(&service, &pods, &deployments)
+	sPods := FilterPodsForService(&service, &pods)
+	assert.Len(sPods, 1)
+
+	matches := FilterDeploymentsForService(&service, sPods, &deployments)
 	assert.Len(matches, 1)
 }
 
@@ -101,7 +110,10 @@ func TestFilterDeploymentsForServiceWithoutPod(t *testing.T) {
 					Labels: map[string]string{"app": "foo", "hash": "123456"}}},
 		}}
 
-	matches := FilterDeploymentsForService(&service, &pods, &deployments)
+	sPods := FilterPodsForService(&service, &pods)
+	assert.Len(sPods, 0)
+
+	matches := FilterDeploymentsForService(&service, sPods, &deployments)
 	assert.Len(matches, 1)
 }
 

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -51,7 +51,7 @@ func TestFilterDeploymentsForService(t *testing.T) {
 						MatchLabels: map[string]string{"foo": "bazz", "version": "v1"}}}},
 		}}
 
-	sPods:= FilterPodsForService(&service, &pods)
+	sPods := FilterPodsForService(&service, &pods)
 
 	assert.Len(sPods, 2)
 	assert.Equal("reviews-v1", sPods[0].ObjectMeta.Name)

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -173,8 +173,9 @@ func (in *IstioClient) GetServiceDetails(namespace string, serviceName string) (
 	serviceDetails.Pods = filterPodsForEndpoints(serviceDetails.Endpoints, podsResponse.pods)
 
 	// Finally, after we get the pods we can narrow down the deployments list
+	servicePods := FilterPodsForService(service, podsResponse.pods)
 	serviceDetails.Deployments = &v1beta1.DeploymentList{
-		Items: FilterDeploymentsForService(service, podsResponse.pods, deployments)}
+		Items: FilterDeploymentsForService(service, servicePods, deployments)}
 
 	return &serviceDetails, nil
 }

--- a/services/business/services.go
+++ b/services/business/services.go
@@ -77,14 +77,12 @@ func (in *SvcService) castServiceOverview(s *v1.Service, pods []v1.Pod, deployme
 func hasIstioSideCar(pods []v1.Pod) bool {
 	mPods := models.Pods{}
 	mPods.Parse(pods)
-	hasSideCar := true
 	for _, pod := range mPods {
-		if len(pod.IstioContainers) == 0 {
-			hasSideCar = false
-			break
+		if len(pod.IstioContainers) > 0 {
+			return true
 		}
 	}
-	return hasSideCar
+	return false
 }
 
 // processRequestRates aggregates requests rates from metrics fetched from Prometheus, and stores the result in the service list.

--- a/services/business/services.go
+++ b/services/business/services.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"
 
-	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/services/models"
@@ -41,8 +40,9 @@ func (in *SvcService) buildServiceList(namespace models.Namespace, sl *kubernete
 
 	// Convert each k8s service into our model
 	for i, item := range sl.Services.Items {
-		depls := kubernetes.FilterDeploymentsForService(&item, sl.Pods, sl.Deployments)
-		services[i] = in.castServiceOverview(&item, depls)
+		sPods := kubernetes.FilterPodsForService(&item, sl.Pods)
+		depls := kubernetes.FilterDeploymentsForService(&item, sPods, sl.Deployments)
+		services[i] = in.castServiceOverview(&item, sPods, depls)
 	}
 
 	// Fill with collected request rates
@@ -62,8 +62,8 @@ func (in *SvcService) buildServiceList(namespace models.Namespace, sl *kubernete
 	return &models.ServiceList{Namespace: namespace, Services: services}
 }
 
-func (in *SvcService) castServiceOverview(s *v1.Service, deployments []v1beta1.Deployment) models.ServiceOverview {
-	hasSideCar := hasIstioSideCar(deployments)
+func (in *SvcService) castServiceOverview(s *v1.Service, pods []v1.Pod, deployments []v1beta1.Deployment) models.ServiceOverview {
+	hasSideCar := hasIstioSideCar(pods)
 	statuses := castDeploymentsStatuses(deployments)
 	health := models.Health{
 		DeploymentStatuses: statuses,
@@ -74,15 +74,17 @@ func (in *SvcService) castServiceOverview(s *v1.Service, deployments []v1beta1.D
 		Health:       health}
 }
 
-func hasIstioSideCar(deployments []v1beta1.Deployment) bool {
-	for _, deployment := range deployments {
-		if deployment.Spec.Template.Annotations != nil {
-			if _, exists := deployment.Spec.Template.Annotations[config.Get().ExternalServices.Istio.IstioSidecarAnnotation]; exists {
-				return true
-			}
+func hasIstioSideCar(pods []v1.Pod) bool {
+	mPods := models.Pods{}
+	mPods.Parse(pods)
+	hasSideCar := true
+	for _, pod := range mPods {
+		if len(pod.IstioContainers) == 0 {
+			hasSideCar = false
+			break
 		}
 	}
-	return false
+	return hasSideCar
 }
 
 // processRequestRates aggregates requests rates from metrics fetched from Prometheus, and stores the result in the service list.


### PR DESCRIPTION
IstioDeployed flag was calculated from Deployments.
So, in Service List view, we couldn't filter when deployment is different from k8s "Deployment" object.