### PR TITLE
Fix error when running tests

### DIFF
--- a/config/token.go
+++ b/config/token.go
@@ -52,7 +52,7 @@ func ValidateToken(tokenString string) error {
 		return err
 	}
 	if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-		return errors.New(fmt.Sprintf("Unexpected signing method: ", token.Header["alg"]))
+		return errors.New(fmt.Sprintf("Unexpected signing method: %s", token.Header["alg"]))
 	}
 	if token.Valid {
 		return nil


### PR DESCRIPTION
When running ```make test``` the following error fails the tests:

```
config/token.go:55: Sprintf call has arguments but no formatting directives
```

This PR adds the missing formatting argument