### PR TITLE
KIALI-750 Adding mTLS attribute to edges

### DIFF
--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -345,6 +345,28 @@ func CheckDestinationRuleCircuitBreaker(destinationRule IstioObject, namespace s
 	return false
 }
 
+func CheckDestinationRulemTLS(destinationRule IstioObject, namespace string, serviceName string) bool {
+	if destinationRule == nil || destinationRule.GetSpec() == nil {
+		return false
+	}
+	if dName, ok := destinationRule.GetSpec()["name"]; ok && dName == serviceName {
+		if trafficPolicy, ok := destinationRule.GetSpec()["trafficPolicy"]; ok {
+			if dTrafficPolicy, ok := trafficPolicy.(map[string]interface{}); ok {
+				if mtls, ok := dTrafficPolicy["tls"]; ok {
+					if dmTLS, ok := mtls.(map[string]interface{}); ok {
+						if mode, ok := dmTLS["mode"]; ok {
+							if dmode, ok := mode.(string); ok {
+								return dmode == "ISTIO_MUTUAL"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
 // Helper method to check if exist a route with a destination and a subset defined for a httpRoute or tcpRoute in a VirtualService
 func checkSubsetRoute(routes interface{}, serviceName string, subsets []string) bool {
 	if httpTcpRoutes, ok := routes.([]interface{}); ok {

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -393,6 +393,24 @@ func TestCheckDestinationRuleCircuitBreaker(t *testing.T) {
 	assert.False(t, CheckDestinationRuleCircuitBreaker(&destinationRule2, "", "reviews-bad", "v2"))
 }
 
+func TestCheckDestinationRulemTLS(t *testing.T) {
+	assert.False(t, CheckDestinationRulemTLS(nil, "", ""))
+
+	destinationRule1 := MockIstioObject{
+		Spec: map[string]interface{}{
+			"name": "reviews",
+			"trafficPolicy": map[string]interface{}{
+				"tls": map[string]interface{}{
+					"mode": "ISTIO_MUTUAL",
+				},
+			},
+		},
+	}
+
+	assert.True(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews"))
+	assert.False(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews-bad"))
+}
+
 func TestShortHostname(t *testing.T) {
 	assert.True(t, matchService("reviews", "reviews", "bookinfo"))
 	assert.False(t, matchService("reviews", "ratings", "bookinfo"))


### PR DESCRIPTION
This is copy of #254. Feature added here works for Istio 0.8 version. That's why the base of this PR is istio-0.8 branch.

-----------------------------------

The goal of this PR is to add an attribute to those edges that connect two services transmitting under mTLS.

This PR is a first step to add fully coverage of mTLS. Right now, it only support the meshes using Istio without default mTLS enabled. 

![hasenabledmtls](https://user-images.githubusercontent.com/613814/41154783-8ea779da-6b1b-11e8-9acd-8a79952c633b.png)

Please, see more information into https://issues.jboss.org/browse/KIALI-750

This PR should be merged after achieving Istio 0.8.0 migration.