### PR TITLE
KIALI-923 Allow authentication by route

### DIFF
--- a/config/authentication.go
+++ b/config/authentication.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/kiali/kiali/log"
+)
+
+func AuthenticationHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		statusCode := http.StatusOK
+		conf := Get()
+		if strings.Contains(r.Header.Get("Authorization"), "Bearer") {
+			err := ValidateToken(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+			if err != nil {
+				log.Warning("Error token %+v", err)
+				statusCode = http.StatusUnauthorized
+			}
+		} else if conf.Server.Credentials.Username != "" || conf.Server.Credentials.Password != "" {
+			u, p, ok := r.BasicAuth()
+			if !ok || conf.Server.Credentials.Username != u || conf.Server.Credentials.Password != p {
+				statusCode = http.StatusUnauthorized
+			}
+		} else {
+			log.Trace("Access to the server endpoint is not secured with credentials - letting request come in")
+		}
+
+		switch statusCode {
+		case http.StatusOK:
+			next.ServeHTTP(w, r)
+		case http.StatusUnauthorized:
+			// If header exists return the value, must be 1 to use the API from Kiali
+			// Otherwise an empty string is returned and WWW-Authenticate will be Basic
+			if r.Header.Get("X-Auth-Type-Kiali-UI") == "1" {
+				w.Header().Set("WWW-Authenticate", "xBasic realm=\"Kiali\"")
+			} else {
+				w.Header().Set("WWW-Authenticate", "Basic realm=\"Kiali\"")
+			}
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		default:
+			http.Error(w, http.StatusText(statusCode), statusCode)
+			log.Errorf("Cannot send response to unauthorized user: %v", statusCode)
+		}
+	})
+}

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestDrawPathProperly(t *testing.T) {
-	router := NewRouter(new(config.Config))
+	conf := new(config.Config)
+	config.Set(conf)
+	router := NewRouter()
 	testRoute(router, "Root", "GET", t)
 }
 

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -8,10 +8,11 @@ import (
 
 // Route describes a single route
 type Route struct {
-	Name        string
-	Method      string
-	Pattern     string
-	HandlerFunc http.HandlerFunc
+	Name          string
+	Method        string
+	Pattern       string
+	HandlerFunc   http.HandlerFunc
+	Authenticated bool
 }
 
 // Routes holds an array of Route
@@ -29,54 +30,63 @@ func NewRoutes() (r *Routes) {
 			"GET",
 			"/api",
 			handlers.Root,
+			false,
 		},
 		{ // Request the token
 			"Status",
 			"GET",
 			"/api/token",
 			handlers.GetToken,
+			true,
 		},
 		{ // another way to get to root, both show status
 			"Status",
 			"GET",
 			"/api/status",
 			handlers.Root,
+			false,
 		},
 		{
 			"IstioConfigList",
 			"GET",
 			"/api/namespaces/{namespace}/istio",
 			handlers.IstioConfigList,
+			true,
 		},
 		{
 			"IstioConfigDetails",
 			"GET",
 			"/api/namespaces/{namespace}/istio/{object_type}/{object}",
 			handlers.IstioConfigDetails,
+			true,
 		},
 		{
 			"IstioConfigValidation",
 			"GET",
 			"/api/namespaces/{namespace}/istio/{object_type}/{object}/istio_validations",
 			handlers.IstioConfigValidations,
+			true,
 		},
 		{
 			"ServiceList",
 			"GET",
 			"/api/namespaces/{namespace}/services",
 			handlers.ServiceList,
+			true,
 		},
 		{
 			"ServiceDetails",
 			"GET",
 			"/api/namespaces/{namespace}/services/{service}",
 			handlers.ServiceDetails,
+			true,
 		},
 		{
 			"NamespaceList",
 			"GET",
 			"/api/namespaces",
 			handlers.NamespaceList,
+			true,
 		},
 		{
 			// Supported query parameters:
@@ -93,30 +103,35 @@ func NewRoutes() (r *Routes) {
 			"GET",
 			"/api/namespaces/{namespace}/services/{service}/metrics",
 			handlers.ServiceMetrics,
+			true,
 		},
 		{
 			"ServiceHealth",
 			"GET",
 			"/api/namespaces/{namespace}/services/{service}/health",
 			handlers.ServiceHealth,
+			true,
 		},
 		{
 			"ServiceValidations",
 			"GET",
 			"/api/namespaces/{namespace}/services/{service}/istio_validations",
 			handlers.ServiceIstioValidations,
+			true,
 		},
 		{
 			"NamespaceMetrics",
 			"GET",
 			"/api/namespaces/{namespace}/metrics",
 			handlers.NamespaceMetrics,
+			true,
 		},
 		{
 			"NamespaceValidations",
 			"GET",
 			"/api/namespaces/{namespace}/istio_validations",
 			handlers.NamespaceIstioValidations,
+			true,
 		},
 		{
 			// Supported query parameters:
@@ -132,6 +147,7 @@ func NewRoutes() (r *Routes) {
 			"GET",
 			"/api/namespaces/{namespace}/graph",
 			handlers.GraphNamespace,
+			true,
 		},
 		{
 			// Supported query parameters:
@@ -145,6 +161,7 @@ func NewRoutes() (r *Routes) {
 			"GET",
 			"/api/namespaces/{namespace}/services/{service}/graph",
 			handlers.GraphService,
+			true,
 		},
 		{
 			// Supported query parameters:
@@ -156,18 +173,21 @@ func NewRoutes() (r *Routes) {
 			"GET",
 			"/api/overview/graph",
 			handlers.GraphOverview,
+			true,
 		},
 		{
 			"GrafanaURL",
 			"GET",
 			"/api/grafana",
 			handlers.GetGrafanaInfo,
+			true,
 		},
 		{
 			"JaegerURL",
 			"GET",
 			"/api/jaeger",
 			handlers.GetJaegerInfo,
+			true,
 		},
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -75,6 +75,7 @@ func TestSecureComm(t *testing.T) {
 	conf.Server.Credentials.Password = authorizedPassword
 
 	serverURL := fmt.Sprintf("https://%v", testServerHostPort)
+	apiURLWithAuthentication := serverURL + "/api/token"
 	apiURL := serverURL + "/api"
 
 	config.Set(conf)
@@ -122,20 +123,32 @@ func TestSecureComm(t *testing.T) {
 
 	// TEST WITH AN AUTHORIZED USER
 
+	if _, err = getRequestResults(t, httpClient, apiURLWithAuthentication, basicCredentials); err != nil {
+		t.Fatalf("Failed: Basic Auth API URL: %v", err)
+	}
+
 	if _, err = getRequestResults(t, httpClient, apiURL, basicCredentials); err != nil {
 		t.Fatalf("Failed: Basic Auth API URL: %v", err)
 	}
 
 	// TEST WITH AN INVALID USER
 
-	if _, err = getRequestResults(t, httpClient, apiURL, badBasicCredentials); err == nil {
+	if _, err = getRequestResults(t, httpClient, apiURLWithAuthentication, badBasicCredentials); err == nil {
 		t.Fatalf("Failed: Basic Auth API URL should have failed")
+	}
+
+	if _, err = getRequestResults(t, httpClient, apiURL, badBasicCredentials); err != nil {
+		t.Fatalf("Failed: Basic Auth API URL shouldn't have failed")
 	}
 
 	// TEST WITH NO USER
 
-	if _, err = getRequestResults(t, httpClient, apiURL, noCredentials); err == nil {
+	if _, err = getRequestResults(t, httpClient, apiURLWithAuthentication, noCredentials); err == nil {
 		t.Fatalf("Failed: Basic Auth API URL should have failed with with no credentials")
+	}
+
+	if _, err = getRequestResults(t, httpClient, apiURL, noCredentials); err != nil {
+		t.Fatalf("Failed: Basic Auth API URL shouldn't have failed with with no credentials")
 	}
 }
 


### PR DESCRIPTION
Jira : [KIALI-923](https://issues.jboss.org/browse/KIALI-923)

- Server file now only have the server methods related
- Authentication moved to configuration
- Allow set authentication required by route

- Disable authentication required in /api and /api/status this routes only show status of kiali and products versions