### PR TITLE
KIALI-922 Fix empty envoy metrics with istio0.8

### DIFF
--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -275,7 +275,7 @@ func TestServiceHealth(t *testing.T) {
 	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
 		assert.Equal(t, "ns", args[0])
 		assert.Equal(t, "svc", args[1])
-	}).Return(1, 1, nil)
+	}).Return(prometheus.EnvoyHealth{}, nil)
 
 	prom.On("GetServiceRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(model.Vector{}, model.Vector{}, nil)
 

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -16,7 +16,7 @@ import (
 
 // ClientInterface for mocks (only mocked function are necessary here)
 type ClientInterface interface {
-	GetServiceHealth(namespace string, servicename string) (int, int, error)
+	GetServiceHealth(namespace string, servicename string) (EnvoyHealth, error)
 	GetNamespaceServicesRequestRates(namespace string, ratesInterval string) (model.Vector, model.Vector, error)
 	GetServiceRequestRates(namespace, service string, ratesInterval string) (model.Vector, model.Vector, error)
 	GetSourceServices(namespace string, servicename string) (map[string][]string, error)
@@ -98,9 +98,9 @@ func (in *Client) GetServiceMetrics(query *ServiceMetricsQuery) Metrics {
 }
 
 // GetServiceHealth returns the Health related to the provided service identified by its namespace and service name.
-// Health tuple is [healthy, total, error] (using Envoy metrics).
-// When the health is unavailable, total number of replicas will be 0.
-func (in *Client) GetServiceHealth(namespace string, servicename string) (int, int, error) {
+// It reads Envoy metrics, inbound and outbound
+// When the health is unavailable, total number of members will be 0.
+func (in *Client) GetServiceHealth(namespace string, servicename string) (EnvoyHealth, error) {
 	return getServiceHealth(in.api, namespace, servicename)
 }
 

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -241,13 +241,17 @@ func TestGetServiceHealth(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockSingle(api, "envoy_cluster_out_productpage_istio_system_svc_cluster_local_http_membership_healthy", 0)
-	mockSingle(api, "envoy_cluster_out_productpage_istio_system_svc_cluster_local_http_membership_total", 1)
-	healthy, total, _ := client.GetServiceHealth("istio-system", "productpage")
+	mockSingle(api, "envoy_cluster_inbound_9080__productpage_istio_system_svc_cluster_local_membership_healthy", 0)
+	mockSingle(api, "envoy_cluster_inbound_9080__productpage_istio_system_svc_cluster_local_membership_total", 1)
+	mockSingle(api, "envoy_cluster_outbound_9080__productpage_istio_system_svc_cluster_local_membership_healthy", 0)
+	mockSingle(api, "envoy_cluster_outbound_9080__productpage_istio_system_svc_cluster_local_membership_total", 1)
+	health, _ := client.GetServiceHealth("istio-system", "productpage")
 
 	// Check health
-	assert.Equal(t, 0, healthy)
-	assert.Equal(t, 1, total)
+	assert.Equal(t, 0, health.Inbound.Healthy)
+	assert.Equal(t, 1, health.Inbound.Total)
+	assert.Equal(t, 0, health.Outbound.Healthy)
+	assert.Equal(t, 1, health.Outbound.Total)
 }
 
 func TestGetServiceMetricsUnavailable(t *testing.T) {
@@ -305,13 +309,16 @@ func TestGetServiceHealthUnavailable(t *testing.T) {
 		return
 	}
 	// Mock everything to return empty data
-	mockQuery(api, "envoy_cluster_out_productpage_istio_system_svc_cluster_local_http_membership_healthy", &model.Vector{})
-	mockQuery(api, "envoy_cluster_out_productpage_istio_system_svc_cluster_local_http_membership_total", &model.Vector{})
-	_, total, err := client.GetServiceHealth("istio-system", "productpage")
+	mockQuery(api, "envoy_cluster_inbound_9080__productpage_istio_system_svc_cluster_local_membership_healthy", &model.Vector{})
+	mockQuery(api, "envoy_cluster_inbound_9080__productpage_istio_system_svc_cluster_local_membership_total", &model.Vector{})
+	mockQuery(api, "envoy_cluster_outbound_9080__productpage_istio_system_svc_cluster_local_membership_healthy", &model.Vector{})
+	mockQuery(api, "envoy_cluster_outbound_9080__productpage_istio_system_svc_cluster_local_membership_total", &model.Vector{})
+	h, err := client.GetServiceHealth("istio-system", "productpage")
 
 	// Check health unavailable
 	assert.Nil(t, err)
-	assert.Equal(t, 0, total)
+	assert.Equal(t, 0, h.Inbound.Total)
+	assert.Equal(t, 0, h.Outbound.Total)
 }
 
 func TestGetNamespaceMetrics(t *testing.T) {

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/kiali/kiali/prometheus"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
@@ -87,9 +88,9 @@ type PromClientMock struct {
 	mock.Mock
 }
 
-func (o *PromClientMock) GetServiceHealth(namespace, servicename string) (int, int, error) {
+func (o *PromClientMock) GetServiceHealth(namespace, servicename string) (prometheus.EnvoyHealth, error) {
 	args := o.Called(namespace, servicename)
-	return args.Int(0), args.Int(1), args.Error(2)
+	return args.Get(0).(prometheus.EnvoyHealth), args.Error(1)
 }
 
 func (o *PromClientMock) GetNamespaceServicesRequestRates(namespace, ratesInterval string) (model.Vector, model.Vector, error) {

--- a/services/business/health.go
+++ b/services/business/health.go
@@ -34,9 +34,9 @@ func (in *HealthService) fillMissingParts(namespace, service, rateInterval strin
 	})
 
 	// Envoy health
-	health.Envoy.FillIfMissing(func() (int, int) {
-		healthy, total, _ := in.prom.GetServiceHealth(namespace, service)
-		return healthy, total
+	health.Envoy.FillIfMissing(func() prometheus.EnvoyHealth {
+		health, _ := in.prom.GetServiceHealth(namespace, service)
+		return health
 	})
 
 	// Request errors

--- a/services/business/services_test.go
+++ b/services/business/services_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
 )
 
@@ -24,7 +25,7 @@ func TestServiceListParsing(t *testing.T) {
 	k8s := new(kubetest.K8SClientMock)
 	prom := new(prometheustest.PromClientMock)
 	k8s.On("GetServices", mock.AnythingOfType("string")).Return(fakeServiceList(), nil)
-	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(1, 1, nil)
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(prometheus.EnvoyHealth{Inbound: prometheus.EnvoyRatio{Healthy: 1, Total: 1}}, nil)
 	prom.On("GetNamespaceServicesRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeRequestCounters())
 	svc := setupServices(k8s, prom)
 
@@ -36,8 +37,8 @@ func TestServiceListParsing(t *testing.T) {
 	httpbinOverview := serviceList.Services[1]
 
 	assert.Equal("reviews", reviewsOverview.Name)
-	assert.Equal(1, reviewsOverview.Health.Envoy.Total)
-	assert.Equal(1, reviewsOverview.Health.Envoy.Healthy)
+	assert.Equal(1, reviewsOverview.Health.Envoy.Inbound.Total)
+	assert.Equal(1, reviewsOverview.Health.Envoy.Inbound.Healthy)
 	assert.Equal(int32(2), reviewsOverview.Health.DeploymentStatuses[0].AvailableReplicas)
 	assert.Equal(int32(3), reviewsOverview.Health.DeploymentStatuses[0].Replicas)
 	assert.Equal(int32(1), reviewsOverview.Health.DeploymentStatuses[1].AvailableReplicas)
@@ -46,8 +47,8 @@ func TestServiceListParsing(t *testing.T) {
 	assert.Equal(float64(1.6), reviewsOverview.Health.Requests.RequestErrorCount)
 
 	assert.Equal("httpbin", httpbinOverview.Name)
-	assert.Equal(1, httpbinOverview.Health.Envoy.Total)
-	assert.Equal(1, httpbinOverview.Health.Envoy.Healthy)
+	assert.Equal(1, httpbinOverview.Health.Envoy.Inbound.Total)
+	assert.Equal(1, httpbinOverview.Health.Envoy.Inbound.Healthy)
 	assert.Equal(int32(1), httpbinOverview.Health.DeploymentStatuses[0].AvailableReplicas)
 	assert.Equal(int32(1), httpbinOverview.Health.DeploymentStatuses[0].Replicas)
 	assert.Equal(float64(20.4), httpbinOverview.Health.Requests.RequestCount)
@@ -63,7 +64,7 @@ func TestSingleServiceHealthParsing(t *testing.T) {
 	k8s.On("GetServiceDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeServiceDetails(), nil)
 	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeIstioDetails(), nil)
 	prom.On("GetSourceServices", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(make(map[string][]string), nil)
-	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(1, 1, nil)
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(prometheus.EnvoyHealth{Inbound: prometheus.EnvoyRatio{Healthy: 1, Total: 1}}, nil)
 	prom.On("GetServiceRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeServiceRequestCounters())
 	svc := setupServices(k8s, prom)
 
@@ -71,8 +72,8 @@ func TestSingleServiceHealthParsing(t *testing.T) {
 
 	assert.Equal("Namespace", service.Namespace.Name)
 	assert.Equal("httpbin", service.Name)
-	assert.Equal(1, service.Health.Envoy.Total)
-	assert.Equal(1, service.Health.Envoy.Healthy)
+	assert.Equal(1, service.Health.Envoy.Inbound.Total)
+	assert.Equal(1, service.Health.Envoy.Inbound.Healthy)
 	assert.Equal(int32(1), service.Health.DeploymentStatuses[0].AvailableReplicas)
 	assert.Equal(int32(1), service.Health.DeploymentStatuses[0].Replicas)
 	assert.Equal(float64(20.4), service.Health.Requests.RequestCount)


### PR DESCRIPTION
- metric queries updated as per new naming scheme
- now inbound and outbound metrics are available; model updated
- remove some goroutines from fine-grained metric-fetching and add some to coarser level => this should optimize waiting time