### PR TITLE
KIALI-750 Fixing enablemTLS flag - now using destination rule with 0.8 syntax

### DIFF
--- a/graph/appender/istio_details.go
+++ b/graph/appender/istio_details.go
@@ -96,12 +96,18 @@ func applymTLS(n *tree.ServiceNode, namespaceName string, istioDetails *kubernet
 		return
 	}
 
-	serviceName := strings.Split(n.Name, ".")[0]
+	splitedHost := strings.Split(n.Name, ".")
+	if len(splitedHost) < 3 {
+		return
+	}
+
+	nodeService := splitedHost[0]
+	nodeNamespace := splitedHost[1]
 
 	hasmTLSenabled := false
 
 	for _, destinationRule := range istioDetails.DestinationRules {
-		if kubernetes.CheckDestinationRulemTLS(destinationRule, namespaceName, serviceName) {
+		if kubernetes.CheckDestinationRulemTLS(destinationRule, nodeNamespace, nodeService) {
 			hasmTLSenabled = true
 		}
 	}

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -349,14 +349,16 @@ func CheckDestinationRulemTLS(destinationRule IstioObject, namespace string, ser
 	if destinationRule == nil || destinationRule.GetSpec() == nil {
 		return false
 	}
-	if dName, ok := destinationRule.GetSpec()["name"]; ok && dName == serviceName {
-		if trafficPolicy, ok := destinationRule.GetSpec()["trafficPolicy"]; ok {
-			if dTrafficPolicy, ok := trafficPolicy.(map[string]interface{}); ok {
-				if mtls, ok := dTrafficPolicy["tls"]; ok {
-					if dmTLS, ok := mtls.(map[string]interface{}); ok {
-						if mode, ok := dmTLS["mode"]; ok {
-							if dmode, ok := mode.(string); ok {
-								return dmode == "ISTIO_MUTUAL"
+	if dHost, ok := destinationRule.GetSpec()["host"]; ok {
+		if host, ok := dHost.(string); ok && matchService(host, serviceName, namespace) {
+			if trafficPolicy, ok := destinationRule.GetSpec()["trafficPolicy"]; ok {
+				if dTrafficPolicy, ok := trafficPolicy.(map[string]interface{}); ok {
+					if mtls, ok := dTrafficPolicy["tls"]; ok {
+						if dmTLS, ok := mtls.(map[string]interface{}); ok {
+							if mode, ok := dmTLS["mode"]; ok {
+								if dmode, ok := mode.(string); ok {
+									return dmode == "ISTIO_MUTUAL"
+								}
 							}
 						}
 					}

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -396,7 +396,7 @@ func TestCheckDestinationRuleCircuitBreaker(t *testing.T) {
 func TestCheckDestinationRulemTLS(t *testing.T) {
 	assert.False(t, CheckDestinationRulemTLS(nil, "", ""))
 
-	destinationRule1 := MockIstioObject{
+	destinationRule := MockIstioObject{
 		Spec: map[string]interface{}{
 			"host": "reviews",
 			"trafficPolicy": map[string]interface{}{
@@ -407,10 +407,10 @@ func TestCheckDestinationRulemTLS(t *testing.T) {
 		},
 	}
 
-	assert.True(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews"))
-	assert.False(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews-bad"))
+	assert.True(t, CheckDestinationRulemTLS(&destinationRule, "", "reviews"))
+	assert.False(t, CheckDestinationRulemTLS(&destinationRule, "", "reviews-bad"))
 
-	destinationRule1 := MockIstioObject{
+	destinationRule = MockIstioObject{
 		Spec: map[string]interface{}{
 			"host": "reviews",
 			"trafficPolicy": map[string]interface{}{
@@ -421,8 +421,8 @@ func TestCheckDestinationRulemTLS(t *testing.T) {
 		},
 	}
 
-	assert.FALSE(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews"))
-	assert.False(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews-bad"))
+	assert.False(t, CheckDestinationRulemTLS(&destinationRule, "", "reviews"))
+	assert.False(t, CheckDestinationRulemTLS(&destinationRule, "", "reviews-bad"))
 }
 
 func TestShortHostname(t *testing.T) {

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -398,7 +398,7 @@ func TestCheckDestinationRulemTLS(t *testing.T) {
 
 	destinationRule1 := MockIstioObject{
 		Spec: map[string]interface{}{
-			"name": "reviews",
+			"host": "reviews",
 			"trafficPolicy": map[string]interface{}{
 				"tls": map[string]interface{}{
 					"mode": "ISTIO_MUTUAL",
@@ -408,6 +408,20 @@ func TestCheckDestinationRulemTLS(t *testing.T) {
 	}
 
 	assert.True(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews"))
+	assert.False(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews-bad"))
+
+	destinationRule1 := MockIstioObject{
+		Spec: map[string]interface{}{
+			"host": "reviews",
+			"trafficPolicy": map[string]interface{}{
+				"tls": map[string]interface{}{
+					"mode": "DISABLE",
+				},
+			},
+		},
+	}
+
+	assert.FALSE(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews"))
 	assert.False(t, CheckDestinationRulemTLS(&destinationRule1, "", "reviews-bad"))
 }
 


### PR DESCRIPTION
This is a quick fix of #269. It didn't include the change to use 0.8 syntax for Destination Rule