### PR TITLE
KIALI-941 Update DestinationRule Host on model and checker

### DIFF
--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -199,7 +199,7 @@ func (in *IstioClient) GetDestinationRules(namespace string, serviceName string)
 	for _, destinationRule := range destinationRuleList.Items {
 		appendDestinationRule := serviceName == ""
 		if host, ok := destinationRule.Spec["host"]; ok {
-			if dHost, ok := host.(string); ok && matchService(dHost, serviceName, namespace) {
+			if dHost, ok := host.(string); ok && CheckHostnameService(dHost, serviceName, namespace) {
 				appendDestinationRule = true
 			}
 		}
@@ -286,7 +286,7 @@ func GetDestinationRulesSubsets(destinationRules []IstioObject, serviceName, ver
 	foundSubsets := make([]string, 0)
 	for _, destinationRule := range destinationRules {
 		if dHost, ok := destinationRule.GetSpec()["host"]; ok {
-			if host, ok := dHost.(string); ok && matchService(host, serviceName, destinationRule.GetObjectMeta().Namespace) {
+			if host, ok := dHost.(string); ok && CheckHostnameService(host, serviceName, destinationRule.GetObjectMeta().Namespace) {
 				if subsets, ok := destinationRule.GetSpec()["subsets"]; ok {
 					if dSubsets, ok := subsets.([]interface{}); ok {
 						for _, subset := range dSubsets {
@@ -319,7 +319,7 @@ func CheckDestinationRuleCircuitBreaker(destinationRule IstioObject, namespace s
 	}
 	cfg := config.Get()
 	if dHost, ok := destinationRule.GetSpec()["host"]; ok {
-		if host, ok := dHost.(string); ok && matchService(host, serviceName, namespace) {
+		if host, ok := dHost.(string); ok && CheckHostnameService(host, serviceName, namespace) {
 			if trafficPolicy, ok := destinationRule.GetSpec()["trafficPolicy"]; ok && checkTrafficPolicy(trafficPolicy) {
 				return true
 			}
@@ -460,11 +460,11 @@ func FilterByHost(spec map[string]interface{}, hostName string) bool {
 	return false
 }
 
-// Match returns true when the hostname specifies the service passed by param.
+// CheckHostnameService returns true when the hostname specifies the service passed by param.
 // It accepts the following hostname formats:
 // reviews, reviews.bookinfo.svc, reviews.bookinfo.svc.cluster.local,
 // *.bookinfo.svc, *.bookinfo.svc.cluster.local
-func matchService(hostname, service, namespace string) bool {
+func CheckHostnameService(hostname, service, namespace string) bool {
 	domainParts := strings.Split(hostname, ".")
 	match := false
 

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -412,33 +412,33 @@ func TestCheckDestinationRulemTLS(t *testing.T) {
 }
 
 func TestShortHostname(t *testing.T) {
-	assert.True(t, matchService("reviews", "reviews", "bookinfo"))
-	assert.False(t, matchService("reviews", "ratings", "bookinfo"))
+	assert.True(t, CheckHostnameService("reviews", "reviews", "bookinfo"))
+	assert.False(t, CheckHostnameService("reviews", "ratings", "bookinfo"))
 }
 
 func TestFQDNHostname(t *testing.T) {
-	assert.True(t, matchService("reviews.bookinfo.svc", "reviews", "bookinfo"))
-	assert.True(t, matchService("reviews.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.True(t, CheckHostnameService("reviews.bookinfo.svc", "reviews", "bookinfo"))
+	assert.True(t, CheckHostnameService("reviews.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
 
-	assert.False(t, matchService("reviews.foo.svc", "reviews", "bookinfo"))
-	assert.False(t, matchService("reviews.foo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.False(t, CheckHostnameService("reviews.foo.svc", "reviews", "bookinfo"))
+	assert.False(t, CheckHostnameService("reviews.foo.svc.cluster.local", "reviews", "bookinfo"))
 
-	assert.False(t, matchService("ratings.bookinfo.svc", "reviews", "bookinfo"))
-	assert.False(t, matchService("ratings.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.False(t, CheckHostnameService("ratings.bookinfo.svc", "reviews", "bookinfo"))
+	assert.False(t, CheckHostnameService("ratings.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
 
-	assert.False(t, matchService("ratings.foo.svc", "reviews", "bookinfo"))
-	assert.False(t, matchService("ratings.foo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.False(t, CheckHostnameService("ratings.foo.svc", "reviews", "bookinfo"))
+	assert.False(t, CheckHostnameService("ratings.foo.svc.cluster.local", "reviews", "bookinfo"))
 }
 
 func TestWildcardHostname(t *testing.T) {
-	assert.True(t, matchService("*.bookinfo.svc", "reviews", "bookinfo"))
-	assert.True(t, matchService("*.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.True(t, CheckHostnameService("*.bookinfo.svc", "reviews", "bookinfo"))
+	assert.True(t, CheckHostnameService("*.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
 
-	assert.True(t, matchService("*.bookinfo.svc", "ratings", "bookinfo"))
-	assert.True(t, matchService("*.bookinfo.svc.cluster.local", "ratings", "bookinfo"))
+	assert.True(t, CheckHostnameService("*.bookinfo.svc", "ratings", "bookinfo"))
+	assert.True(t, CheckHostnameService("*.bookinfo.svc.cluster.local", "ratings", "bookinfo"))
 
-	assert.False(t, matchService("*.foo.svc", "ratings", "bookinfo"))
-	assert.False(t, matchService("*.foo.svc.cluster.local", "ratings", "bookinfo"))
-	assert.False(t, matchService("*.foo.svc", "reviews", "bookinfo"))
-	assert.False(t, matchService("*.foo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.False(t, CheckHostnameService("*.foo.svc", "ratings", "bookinfo"))
+	assert.False(t, CheckHostnameService("*.foo.svc.cluster.local", "ratings", "bookinfo"))
+	assert.False(t, CheckHostnameService("*.foo.svc", "reviews", "bookinfo"))
+	assert.False(t, CheckHostnameService("*.foo.svc.cluster.local", "reviews", "bookinfo"))
 }

--- a/services/business/checkers/destination_rules/no_host_checker_test.go
+++ b/services/business/checkers/destination_rules/no_host_checker_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-func TestValidName(t *testing.T) {
+func TestValidHost(t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := NoNameChecker{
+	validations, valid := NoHostChecker{
 		Namespace:       "test-namespace",
 		ServiceNames:    []string{"reviews", "other"},
 		DestinationRule: fakeNameDestinationRule(),
@@ -19,11 +19,11 @@ func TestValidName(t *testing.T) {
 	assert.Empty(validations)
 }
 
-func TestNoValidName(t *testing.T) {
+func TestNoValidHost(t *testing.T) {
 	assert := assert.New(t)
 
 	// reviews is not part of service names
-	validations, valid := NoNameChecker{
+	validations, valid := NoHostChecker{
 		Namespace:       "test-namespace",
 		ServiceNames:    []string{"details", "other"},
 		DestinationRule: fakeNameDestinationRule(),
@@ -32,14 +32,14 @@ func TestNoValidName(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
-	assert.Equal("Name doesn't have a valid service", validations[0].Message)
-	assert.Equal("spec/name", validations[0].Path)
+	assert.Equal("Host doesn't have a valid service", validations[0].Message)
+	assert.Equal("spec/host", validations[0].Path)
 }
 
 func fakeNameDestinationRule() kubernetes.IstioObject {
 	destinationRule := kubernetes.DestinationRule{
 		Spec: map[string]interface{}{
-			"name": "reviews",
+			"host": "reviews",
 			"subsets": []interface{}{
 				map[string]interface{}{
 					"name": "v1",

--- a/services/business/checkers/no_service_checker.go
+++ b/services/business/checkers/no_service_checker.go
@@ -160,7 +160,7 @@ func runDestinationRulesCheck(destinationRules []kubernetes.IstioObject, namespa
 func runDestinationRuleCheck(destinationRule kubernetes.IstioObject, namespace string, serviceNames []string, drvalidationsc chan models.IstioValidations, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	result, valid := destination_rules.NoNameChecker{
+	result, valid := destination_rules.NoHostChecker{
 		Namespace:       namespace,
 		ServiceNames:    serviceNames,
 		DestinationRule: destinationRule,

--- a/services/business/checkers/no_service_checker_test.go
+++ b/services/business/checkers/no_service_checker_test.go
@@ -59,8 +59,8 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	customerDr := validations[models.IstioValidationKey{"destinationrule", "customer-dr"}]
 	assert.False(customerDr.Valid)
 	assert.Equal(1, len(customerDr.Checks))
-	assert.Equal("spec/name", customerDr.Checks[0].Path)
-	assert.Equal("Name doesn't have a valid service", customerDr.Checks[0].Message)
+	assert.Equal("spec/host", customerDr.Checks[0].Path)
+	assert.Equal("Host doesn't have a valid service", customerDr.Checks[0].Message)
 
 	validations = NoServiceChecker{
 		Namespace:    "test",
@@ -159,7 +159,7 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 				Name: "customer-dr",
 			},
 			Spec: map[string]interface{}{
-				"name": "customer",
+				"host": "customer",
 				"subsets": []interface{}{
 					map[string]interface{}{
 						"name": "v1",

--- a/services/business/istio_validations_test.go
+++ b/services/business/istio_validations_test.go
@@ -382,7 +382,7 @@ func fakeCombinedIstioDetails() *kubernetes.IstioDetails {
 				Name: "customer-dr",
 			},
 			Spec: map[string]interface{}{
-				"name": "customer",
+				"host": "customer",
 				"subsets": []interface{}{
 					map[string]interface{}{
 						"name": "v1",

--- a/services/models/destination_rule.go
+++ b/services/models/destination_rule.go
@@ -9,7 +9,7 @@ type DestinationRule struct {
 	Name            string      `json:"name"`
 	CreatedAt       string      `json:"createdAt"`
 	ResourceVersion string      `json:"resourceVersion"`
-	DestinationName interface{} `json:"destinationName"`
+	Host 			interface{} `json:"host"`
 	TrafficPolicy   interface{} `json:"trafficPolicy"`
 	Subsets         interface{} `json:"subsets"`
 }
@@ -26,7 +26,7 @@ func (dRule *DestinationRule) Parse(destinationRule kubernetes.IstioObject) {
 	dRule.Name = destinationRule.GetObjectMeta().Name
 	dRule.CreatedAt = formatTime(destinationRule.GetObjectMeta().CreationTimestamp.Time)
 	dRule.ResourceVersion = destinationRule.GetObjectMeta().ResourceVersion
-	dRule.DestinationName = destinationRule.GetSpec()["name"]
+	dRule.Host = destinationRule.GetSpec()["host"]
 	dRule.TrafficPolicy = destinationRule.GetSpec()["trafficPolicy"]
 	dRule.Subsets = destinationRule.GetSpec()["subsets"]
 }

--- a/services/models/service_test.go
+++ b/services/models/service_test.go
@@ -230,7 +230,7 @@ func TestServiceDetailParsing(t *testing.T) {
 			Name:            "reviews-destination",
 			CreatedAt:       "2018-03-08T17:47:00+03:00",
 			ResourceVersion: "1234",
-			DestinationName: "reviews",
+			Host: "reviews",
 			Subsets: []interface{}{
 				map[string]interface{}{
 					"name": "v1",
@@ -250,7 +250,7 @@ func TestServiceDetailParsing(t *testing.T) {
 			Name:            "bookinfo-ratings",
 			CreatedAt:       "2018-03-08T17:47:00+03:00",
 			ResourceVersion: "1234",
-			DestinationName: "ratings",
+			Host: "ratings",
 			TrafficPolicy: map[string]interface{}{
 				"loadBalancer": map[string]interface{}{
 					"simple": "LEAST_CONN",
@@ -581,7 +581,7 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 			ResourceVersion:   "1234",
 		},
 		Spec: map[string]interface{}{
-			"name": "reviews",
+			"host": "reviews",
 			"subsets": []interface{}{
 				map[string]interface{}{
 					"name": "v1",
@@ -605,7 +605,7 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 			ResourceVersion:   "1234",
 		},
 		Spec: map[string]interface{}{
-			"name": "ratings",
+			"host": "ratings",
 			"trafficPolicy": map[string]interface{}{
 				"loadBalancer": map[string]interface{}{
 					"simple": "LEAST_CONN",


### PR DESCRIPTION
This updates the DestinationRule name -> host in model and checkers.
There is also a missing PR for the UI side.