### PR TITLE
Use host field in DestinationRule

### DIFF
--- a/services/business/checkers/destination_rules/no_name_checker.go
+++ b/services/business/checkers/destination_rules/no_name_checker.go
@@ -16,7 +16,7 @@ func (destinationRule NoNameChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
 	for _, serviceName := range destinationRule.ServiceNames {
-		if name, ok := destinationRule.DestinationRule.GetSpec()["name"]; ok && name == serviceName {
+		if name, ok := destinationRule.DestinationRule.GetSpec()["host"]; ok && name == serviceName {
 			valid = true
 			break
 		}

--- a/services/business/checkers/destination_rules/no_name_checker_test.go
+++ b/services/business/checkers/destination_rules/no_name_checker_test.go
@@ -1,9 +1,10 @@
 package destination_rules
 
 import (
+	"testing"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestValidName(t *testing.T) {
@@ -39,7 +40,7 @@ func TestNoValidName(t *testing.T) {
 func fakeNameDestinationRule() kubernetes.IstioObject {
 	destinationRule := kubernetes.DestinationRule{
 		Spec: map[string]interface{}{
-			"name": "reviews",
+			"host": "reviews",
 			"subsets": []interface{}{
 				map[string]interface{}{
 					"name": "v1",

--- a/services/business/checkers/no_service_checker_test.go
+++ b/services/business/checkers/no_service_checker_test.go
@@ -159,7 +159,7 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 				Name: "customer-dr",
 			},
 			Spec: map[string]interface{}{
-				"name": "customer",
+				"host": "customer",
 				"subsets": []interface{}{
 					map[string]interface{}{
 						"name": "v1",

--- a/services/business/istio_validations_test.go
+++ b/services/business/istio_validations_test.go
@@ -382,7 +382,7 @@ func fakeCombinedIstioDetails() *kubernetes.IstioDetails {
 				Name: "customer-dr",
 			},
 			Spec: map[string]interface{}{
-				"name": "customer",
+				"host": "customer",
 				"subsets": []interface{}{
 					map[string]interface{}{
 						"name": "v1",

--- a/services/models/destination_rule.go
+++ b/services/models/destination_rule.go
@@ -9,7 +9,7 @@ type DestinationRule struct {
 	Name            string      `json:"name"`
 	CreatedAt       string      `json:"createdAt"`
 	ResourceVersion string      `json:"resourceVersion"`
-	DestinationName interface{} `json:"destinationName"`
+	Host            interface{} `json:"host"`
 	TrafficPolicy   interface{} `json:"trafficPolicy"`
 	Subsets         interface{} `json:"subsets"`
 }
@@ -26,7 +26,7 @@ func (dRule *DestinationRule) Parse(destinationRule kubernetes.IstioObject) {
 	dRule.Name = destinationRule.GetObjectMeta().Name
 	dRule.CreatedAt = formatTime(destinationRule.GetObjectMeta().CreationTimestamp.Time)
 	dRule.ResourceVersion = destinationRule.GetObjectMeta().ResourceVersion
-	dRule.DestinationName = destinationRule.GetSpec()["name"]
+	dRule.Host = destinationRule.GetSpec()["host"]
 	dRule.TrafficPolicy = destinationRule.GetSpec()["trafficPolicy"]
 	dRule.Subsets = destinationRule.GetSpec()["subsets"]
 }

--- a/services/models/service_test.go
+++ b/services/models/service_test.go
@@ -230,7 +230,7 @@ func TestServiceDetailParsing(t *testing.T) {
 			Name:            "reviews-destination",
 			CreatedAt:       "2018-03-08T17:47:00+03:00",
 			ResourceVersion: "1234",
-			DestinationName: "reviews",
+			Host:            "reviews",
 			Subsets: []interface{}{
 				map[string]interface{}{
 					"name": "v1",
@@ -250,7 +250,7 @@ func TestServiceDetailParsing(t *testing.T) {
 			Name:            "bookinfo-ratings",
 			CreatedAt:       "2018-03-08T17:47:00+03:00",
 			ResourceVersion: "1234",
-			DestinationName: "ratings",
+			Host:            "ratings",
 			TrafficPolicy: map[string]interface{}{
 				"loadBalancer": map[string]interface{}{
 					"simple": "LEAST_CONN",
@@ -581,7 +581,7 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 			ResourceVersion:   "1234",
 		},
 		Spec: map[string]interface{}{
-			"name": "reviews",
+			"host": "reviews",
 			"subsets": []interface{}{
 				map[string]interface{}{
 					"name": "v1",
@@ -605,7 +605,7 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 			ResourceVersion:   "1234",
 		},
 		Spec: map[string]interface{}{
-			"name": "ratings",
+			"host": "ratings",
 			"trafficPolicy": map[string]interface{}{
 				"loadBalancer": map[string]interface{}{
 					"simple": "LEAST_CONN",


### PR DESCRIPTION
The field ```destinationName``` doesn't exists in DestinationRule, according to the Istio documentation it is called ```host```