### PR TITLE
be able to download different versions of Istio.

### DIFF
--- a/hack/istio/README.adoc
+++ b/hack/istio/README.adoc
@@ -1,7 +1,7 @@
 == Installing Istio Bookinfo Demo
 
 [NOTE]
-Before attempting to install the https://istio.io/docs/guides/bookinfo.html[Istio Bookinfo Demo] make sure you have a running cluster (either OpenShift or Kubernetes) with  Istio deployed in it. Kiali has provided some link:..[hack scripts] to assist you if you want a quick way to start that up.
+Before attempting to install the https://istio.io/docs/guides/bookinfo.html[Istio Bookinfo Demo] make sure you have a running cluster (either OpenShift or Kubernetes) with Istio deployed in it. Kiali has provided some link:..[hack scripts] to assist you if you want a quick way to start that up.
 
 [NOTE]
 Use of this provided hack script is not required. It is provided only as a convenience. You can decide to install the Bookinfo Demo in whatever way you choose. This script only illustrates one way to do this.
@@ -14,13 +14,21 @@ oc adm policy add-cluster-role-to-user cluster-admin -z default admin
 oc login -u admin -p admin
 ```
 
-Then, simply run the script link:./install-bookinfo-demo.sh[] on a command line with no arguments.
-
-This script actually needs to download a copy of Istio.  If you want to install a specific version of Istio, pass the argument `-v x.y.z` where `x.y.z` is the version you want to install (e.g. `-v 0.8.0`). By default, it will install Istio in the `_output` directory. If you want it to go somewhere else, pass in the `-o` option specifying the parent directory where Istio is to be installed.
+Then simply run the script link:./install-bookinfo-demo.sh[] on a command line.
 
 If you are installing the Bookinfo Demo in Kubernetes, pass in the option `-c kubectl` to indicate the script should use that client tool. The default client tool that will be used is `istiooc`. You can optionally choose to use `-c oc` if you want general OpenShift `oc` client tool to be used. Whatever you pass into the `-c` option must either be a full path to the binary or must be an executable found in your PATH.
 
+This script needs a copy of Istio which contains the Bookinfo Demo files. If you already have Istio downloaded, pass in the `-id` (or `--istio-dir`) option telling the script where your Istio is installed (e.g. `-id /opt/istio-0.8.0`). Note that you do not have to pass this option in if you already downloaded Istio to the default location used by this script or the link:./download-istio.sh[] script (i.e. `../../_output`).
+
+If you do not yet have Istio downloaded, this script will download it using link:./download-istio.sh[] and put Istio under the `../../_output` directory (relative to the script's location - if you git cloned the Kiali source, this is where the output build files also go).
+
+=== download-istio.sh
+
+link:./download-istio.sh[] can be used to download Istio. By default it will store it in `../../_output` but you can tell it to put it anywhere via the `-o` (or `--output`) option (e.g. `-id /opt/istio`).
+
+If you want to download a specific version of Istio, pass the argument `-iv x.y.z` where `x.y.z` is the version you want to install (e.g. `-iv 0.8.0`).
+
 == Uninstalling Istio Bookinfo Demo
 
-All the Bookinfo Demo pods and services are installed in the "bookinfo" namespace. In order to uninstall it, simply delete that namespace via something like `oc delete namespace bookinfo`.
+All the Bookinfo Demo pods and services are installed in the "bookinfo" namespace. In order to uninstall it, simply delete that namespace via something like `kubectl delete namespace bookinfo` or `oc delete project bookinfo`.
 

--- a/hack/istio/download-istio.sh
+++ b/hack/istio/download-istio.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+##############################################################################
+# download-istio.sh
+#
+# This simply confirms you have a specific Istio version installed in a
+# specific output directory and if you do not it will download it.
+#
+# The 'istioctl' client tool will be found in <output-dir>/istio-#/bin
+# where "#" is the Istio version.
+#
+# By default, the version will be the latest version of Istio.
+# By default, the output directory will be ../../_output.
+#
+# You can set the version you want as well as your own output directory.
+# See the --help output for details.
+##############################################################################
+
+# The version used by the getLatestIstio script - if empty, gets the latest version
+ISTIO_VERSION=
+
+# process command line args
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -iv|--istio-version)
+      ISTIO_VERSION="$2"
+      shift;shift
+      ;;
+    -o|--output)
+      OUTPUT_DIR="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -iv|--istio-version <#.#.#>: Version of Istio to download.
+  -o|--output <dir> : Output directory where Istio is (or will be downloaded to if it doesn't exist).
+  -h|--help : This message.
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+# Go to the main output directory
+HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+OUTPUT_DIR="${OUTPUT_DIR:-${HACK_SCRIPT_DIR}/../../_output}"
+mkdir -p "$OUTPUT_DIR"
+cd "$OUTPUT_DIR"
+OUTPUT_DIR="$(pwd)" # remove the .. references
+echo "Output Directory: ${OUTPUT_DIR}"
+
+if [ "x${ISTIO_VERSION}" == "x" ]; then
+   VERSION_WE_WANT=$(curl https://api.github.com/repos/istio/istio/releases/latest 2> /dev/null |\
+         grep  "tag_name" | \
+         sed -e 's/.*://' -e 's/ *"//' -e 's/",//')
+   echo "Will use the latest Istio version: $VERSION_WE_WANT"
+else
+   VERSION_WE_WANT="${ISTIO_VERSION}"
+   echo "Will use a specific Istio version: $VERSION_WE_WANT"
+fi
+
+# See if Istio is downloaded; if not, get it now.
+echo "Will look for Istio here: ${OUTPUT_DIR}/istio-${VERSION_WE_WANT}"
+if [ ! -d "./istio-${VERSION_WE_WANT}" ]; then
+   echo "Cannot find Istio ${VERSION_WE_WANT} - will download it now..."
+   export ISTIO_VERSION
+   curl -L https://git.io/getLatestIstio | sh -
+fi
+
+cd "./istio-${VERSION_WE_WANT}/"
+ISTIO_DIR="$(pwd)"
+echo "Istio is found here: ${ISTIO_DIR}"
+if [[ -x "${ISTIO_DIR}/bin/istioctl" ]]; then
+  echo "istioctl is found here: ${ISTIO_DIR}/bin/istioctl"
+  ISTIOCTL="${ISTIO_DIR}/bin/istioctl"
+  ${ISTIOCTL} version
+else
+  echo "WARNING: istioctl is NOT found at ${ISTIO_DIR}/bin/istioctl"
+  exit 1
+fi


### PR DESCRIPTION
Let the bookinfo demo script use the download script only when necessary.

I am finding these helpful, especially when needing to switch between Istio versions but also knowing that the bookinfo demo is the same across recent versions.