### PR TITLE
Kiali 924 replace latency with responseTime

### DIFF
--- a/graph/appender/response_time.go
+++ b/graph/appender/response_time.go
@@ -19,17 +19,17 @@ const (
 	TF              = "2006-01-02 15:04:05" // TF is the TimeFormat for printing timestamp
 )
 
-// LatencyAppender is responsible for adding latency information to the graph. Latency
+// ResponseTimeAppender is responsible for adding responseTime information to the graph. ResponseTime
 // is represented as a percentile value. The default is 95th percentile, which means that
 // 95% of requests executed in no more than the resulting milliseconds.
-type LatencyAppender struct {
+type ResponseTimeAppender struct {
 	Duration  time.Duration
 	Quantile  float64
 	QueryTime int64 // unix time in seconds
 }
 
 // AppendGraph implements Appender
-func (a LatencyAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string) {
+func (a ResponseTimeAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string) {
 	if len(trafficMap) == 0 {
 		return
 	}
@@ -40,15 +40,15 @@ func (a LatencyAppender) AppendGraph(trafficMap graph.TrafficMap, namespace stri
 	a.appendGraph(trafficMap, namespace, client)
 }
 
-func (a LatencyAppender) appendGraph(trafficMap graph.TrafficMap, namespace string, client *prometheus.Client) {
+func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace string, client *prometheus.Client) {
 	quantile := a.Quantile
 	if a.Quantile <= 0.0 || a.Quantile >= 100.0 {
 		log.Warningf("Replacing invalid quantile [%.2f] with default [%.2f]", a.Quantile, DefaultQuantile)
 		quantile = DefaultQuantile
 	}
-	log.Warningf("Generating latency using quantile [%.2f]", quantile)
+	log.Warningf("Generating responseTime using quantile [%.2f]", quantile)
 
-	// query prometheus for the latency info in two queries. The first query gathers latency for
+	// query prometheus for the responseTime info in two queries. The first query gathers responseTime for
 	// requests originating outside of the namespace...
 	namespacePattern := fmt.Sprintf(".*\\\\.%v\\\\..*", namespace)
 	query := fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{source_service!~\"%v\",destination_service=~\"%v\",response_code=\"200\"}[%vs])) by (%s))",
@@ -60,7 +60,7 @@ func (a LatencyAppender) appendGraph(trafficMap graph.TrafficMap, namespace stri
 		"le,source_service,source_version,destination_service,destination_version")
 	outVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
 
-	// The second query gathers latency for requests originating inside of the namespace...
+	// The second query gathers responseTime for requests originating inside of the namespace...
 	query = fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{source_service=~\"%v\",response_code=\"200\"}[%vs])) by (%s))",
 		quantile,
 		"istio_request_duration_bucket",
@@ -69,24 +69,24 @@ func (a LatencyAppender) appendGraph(trafficMap graph.TrafficMap, namespace stri
 		"le,source_service,source_version,destination_service,destination_version")
 	inVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
 
-	// create map to quickly look up latency
-	latencyMap := make(map[string]float64)
-	populateLatencyMap(latencyMap, &outVector)
-	populateLatencyMap(latencyMap, &inVector)
+	// create map to quickly look up responseTime
+	responseTimeMap := make(map[string]float64)
+	populateResponseTimeMap(responseTimeMap, &outVector)
+	populateResponseTimeMap(responseTimeMap, &inVector)
 
-	applyLatency(trafficMap, latencyMap)
+	applyResponseTime(trafficMap, responseTimeMap)
 }
 
-func applyLatency(trafficMap graph.TrafficMap, latencyMap map[string]float64) {
+func applyResponseTime(trafficMap graph.TrafficMap, responseTimeMap map[string]float64) {
 	for _, s := range trafficMap {
 		for _, e := range s.Edges {
 			key := fmt.Sprintf("%s %s %s %s", e.Source.Name, e.Source.Version, e.Dest.Name, e.Dest.Version)
-			e.Metadata["latency"] = latencyMap[key]
+			e.Metadata["responseTime"] = responseTimeMap[key]
 		}
 	}
 }
 
-func populateLatencyMap(latencyMap map[string]float64, vector *model.Vector) {
+func populateResponseTimeMap(responseTimeMap map[string]float64, vector *model.Vector) {
 	for _, s := range *vector {
 		m := s.Metric
 		sourceSvc, sourceSvcOk := m["source_service"]
@@ -100,7 +100,7 @@ func populateLatencyMap(latencyMap map[string]float64, vector *model.Vector) {
 
 		key := fmt.Sprintf("%s %s %s %s", sourceSvc, sourceVer, destSvc, destVer)
 		val := float64(s.Value)
-		latencyMap[key] = val
+		responseTimeMap[key] = val
 	}
 }
 

--- a/graph/appender/response_time_test.go
+++ b/graph/appender/response_time_test.go
@@ -42,7 +42,7 @@ func mockQuery(api *prometheustest.PromAPIMock, query string, ret *model.Vector)
 	).Return(*ret, nil)
 }
 
-func TestLatency(t *testing.T) {
+func TestResponseTime(t *testing.T) {
 	assert := assert.New(t)
 
 	q0 := "round(histogram_quantile(0.95, sum(rate(istio_request_duration_bucket{source_service!~\".*\\\\.bookinfo\\\\..*\",destination_service=~\".*\\\\.bookinfo\\\\..*\",response_code=\"200\"}[60s])) by (le,source_service,source_version,destination_service,destination_version)),0.001)"
@@ -99,16 +99,16 @@ func TestLatency(t *testing.T) {
 	mockQuery(api, q0, &v0)
 	mockQuery(api, q1, &v1)
 
-	trafficMap := latencyTestTraffic()
+	trafficMap := responseTimeTestTraffic()
 	ingressId := graph.Id("ingress.istio-system.svc.cluster.local", graph.UnknownVersion)
 	ingress, ok := trafficMap[ingressId]
 	assert.Equal(true, ok)
 	assert.Equal("ingress.istio-system.svc.cluster.local", ingress.Name)
 	assert.Equal(1, len(ingress.Edges))
-	assert.Equal(nil, ingress.Edges[0].Metadata["latency"])
+	assert.Equal(nil, ingress.Edges[0].Metadata["responseTime"])
 
 	duration, _ := time.ParseDuration("60s")
-	appender := LatencyAppender{
+	appender := ResponseTimeAppender{
 		Duration:  duration,
 		Quantile:  0.95,
 		QueryTime: time.Now().Unix(),
@@ -120,46 +120,46 @@ func TestLatency(t *testing.T) {
 	assert.Equal(true, ok)
 	assert.Equal("ingress.istio-system.svc.cluster.local", ingress.Name)
 	assert.Equal(1, len(ingress.Edges))
-	assert.Equal(10.0, ingress.Edges[0].Metadata["latency"])
+	assert.Equal(10.0, ingress.Edges[0].Metadata["responseTime"])
 
 	productpage := ingress.Edges[0].Dest
 	assert.Equal("productpage.bookinfo.svc.cluster.local", productpage.Name)
 	assert.Equal("v1", productpage.Version)
-	assert.Equal(nil, productpage.Metadata["latency"])
+	assert.Equal(nil, productpage.Metadata["responseTime"])
 	assert.Equal(2, len(productpage.Edges))
-	assert.Equal(20.0, productpage.Edges[0].Metadata["latency"])
-	assert.Equal(20.0, productpage.Edges[1].Metadata["latency"])
+	assert.Equal(20.0, productpage.Edges[0].Metadata["responseTime"])
+	assert.Equal(20.0, productpage.Edges[1].Metadata["responseTime"])
 
 	reviews1 := productpage.Edges[0].Dest
 	assert.Equal("reviews.bookinfo.svc.cluster.local", reviews1.Name)
 	assert.Equal("v1", reviews1.Version)
-	assert.Equal(nil, reviews1.Metadata["latency"])
+	assert.Equal(nil, reviews1.Metadata["responseTime"])
 	assert.Equal(1, len(reviews1.Edges))
-	assert.Equal(30.0, reviews1.Edges[0].Metadata["latency"])
+	assert.Equal(30.0, reviews1.Edges[0].Metadata["responseTime"])
 
 	reviews2 := productpage.Edges[1].Dest
 	assert.Equal("reviews.bookinfo.svc.cluster.local", reviews2.Name)
 	assert.Equal("v2", reviews2.Version)
-	assert.Equal(nil, reviews2.Metadata["latency"])
+	assert.Equal(nil, reviews2.Metadata["responseTime"])
 	assert.Equal(1, len(reviews2.Edges))
-	assert.Equal(30.0, reviews2.Edges[0].Metadata["latency"])
+	assert.Equal(30.0, reviews2.Edges[0].Metadata["responseTime"])
 
 	ratingsPath1 := reviews1.Edges[0].Dest
 	assert.Equal("ratings.bookinfo.svc.cluster.local", ratingsPath1.Name)
 	assert.Equal("v1", ratingsPath1.Version)
-	assert.Equal(nil, ratingsPath1.Metadata["latency"])
+	assert.Equal(nil, ratingsPath1.Metadata["responseTime"])
 	assert.Equal(0, len(ratingsPath1.Edges))
 
 	ratingsPath2 := reviews2.Edges[0].Dest
 	assert.Equal("ratings.bookinfo.svc.cluster.local", ratingsPath2.Name)
 	assert.Equal("v1", ratingsPath2.Version)
-	assert.Equal(nil, ratingsPath2.Metadata["latency"])
+	assert.Equal(nil, ratingsPath2.Metadata["responseTime"])
 	assert.Equal(0, len(ratingsPath2.Edges))
 
 	assert.Equal(ratingsPath1, ratingsPath2)
 }
 
-func latencyTestTraffic() graph.TrafficMap {
+func responseTimeTestTraffic() graph.TrafficMap {
 	ingress := graph.NewServiceNode("ingress.istio-system.svc.cluster.local", graph.UnknownVersion)
 	productpage := graph.NewServiceNode("productpage.bookinfo.svc.cluster.local", "v1")
 	reviewsV1 := graph.NewServiceNode("reviews.bookinfo.svc.cluster.local", "v1")

--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -54,15 +54,15 @@ type EdgeData struct {
 	Target string `json:"target"` // child node ID
 
 	// App Fields (not required by Cytoscape)
-	Rate        string `json:"rate,omitempty"`
-	Rate3xx     string `json:"rate3XX,omitempty"`
-	Rate4xx     string `json:"rate4XX,omitempty"`
-	Rate5xx     string `json:"rate5XX,omitempty"`
-	PercentErr  string `json:"percentErr,omitempty"`
-	PercentRate string `json:"percentRate,omitempty"` // percent of total parent requests
-	Latency     string `json:"latency,omitempty"`
-	IsMTLS      bool   `json:"isMTLS,omitempty"`   // true (mutual TLS connection) | false
-	IsUnused    bool   `json:"isUnused,omitempty"` // true | false
+	Rate         string `json:"rate,omitempty"`
+	Rate3xx      string `json:"rate3XX,omitempty"`
+	Rate4xx      string `json:"rate4XX,omitempty"`
+	Rate5xx      string `json:"rate5XX,omitempty"`
+	PercentErr   string `json:"percentErr,omitempty"`
+	PercentRate  string `json:"percentRate,omitempty"` // percent of total parent requests
+	ResponseTime string `json:"responseTime,omitempty"`
+	IsMTLS       bool   `json:"isMTLS,omitempty"`   // true (mutual TLS connection) | false
+	IsUnused     bool   `json:"isUnused,omitempty"` // true | false
 }
 
 type NodeWrapper struct {
@@ -255,9 +255,9 @@ func addEdgeTelemetry(ed *EdgeData, e *graph.Edge, o options.VendorOptions) {
 			ed.PercentErr = fmt.Sprintf("%.3f", percentErr)
 		}
 
-		if val, ok := e.Metadata["latency"]; ok {
-			latency := val.(float64)
-			ed.Latency = fmt.Sprintf("%.3f", latency)
+		if val, ok := e.Metadata["responseTime"]; ok {
+			responseTime := val.(float64)
+			ed.ResponseTime = fmt.Sprintf("%.3f", responseTime)
 		}
 
 		percentRate := rate / e.Source.Metadata["rateOut"].(float64) * 100.0

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -134,14 +134,14 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 	if csl == AppenderAll || strings.Contains(csl, "dead_service") {
 		appenders = append(appenders, appender.DeadServiceAppender{})
 	}
-	if csl == AppenderAll || strings.Contains(csl, "latency") {
+	if csl == AppenderAll || strings.Contains(csl, "response_time") {
 		quantile := appender.DefaultQuantile
-		if _, ok := params["latencyQuantile"]; ok {
-			if latencyQuantile, err := strconv.ParseFloat(params.Get("latencyQuantile"), 64); err == nil {
-				quantile = latencyQuantile
+		if _, ok := params["responseTimeQuantile"]; ok {
+			if responseTimeQuantile, err := strconv.ParseFloat(params.Get("responseTimeQuantile"), 64); err == nil {
+				quantile = responseTimeQuantile
 			}
 		}
-		a := appender.LatencyAppender{
+		a := appender.ResponseTimeAppender{
 			Duration:  o.Duration,
 			Quantile:  quantile,
 			QueryTime: o.QueryTime,


### PR DESCRIPTION
Latency is not really correct for the data we are showing, it is the complete response time for the request (of which latency is only a part).