### PR TITLE
KIALI-982 Support generic wildcard in host validation

### DIFF
--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -60,7 +60,7 @@ func TestFilterByHost(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	assert.False(t, FilterByHost(nil, ""))
+	assert.False(t, FilterByHost(nil, "", ""))
 
 	spec := map[string]interface{}{
 		"hosts": []interface{}{
@@ -68,8 +68,8 @@ func TestFilterByHost(t *testing.T) {
 		},
 	}
 
-	assert.True(t, FilterByHost(spec, "host1"))
-	assert.False(t, FilterByHost(spec, "host2"))
+	assert.True(t, FilterByHost(spec, "host1", "test"))
+	assert.False(t, FilterByHost(spec, "host2", "test"))
 
 	spec = map[string]interface{}{
 		"hosts": []interface{}{
@@ -78,9 +78,9 @@ func TestFilterByHost(t *testing.T) {
 		},
 	}
 
-	assert.True(t, FilterByHost(spec, "host1"))
-	assert.True(t, FilterByHost(spec, "host2"))
-	assert.False(t, FilterByHost(spec, "host3"))
+	assert.True(t, FilterByHost(spec, "host1", "test"))
+	assert.True(t, FilterByHost(spec, "host2", "test"))
+	assert.False(t, FilterByHost(spec, "host3", "test"))
 }
 
 func TestCheckRouteRule(t *testing.T) {
@@ -428,6 +428,7 @@ func TestCheckDestinationRulemTLS(t *testing.T) {
 func TestShortHostname(t *testing.T) {
 	assert.True(t, CheckHostnameService("reviews", "reviews", "bookinfo"))
 	assert.False(t, CheckHostnameService("reviews", "ratings", "bookinfo"))
+	assert.True(t, CheckHostnameService("*", "reviews", "bookinfo"))
 }
 
 func TestFQDNHostname(t *testing.T) {

--- a/services/business/checkers/virtual_services/no_host_checker.go
+++ b/services/business/checkers/virtual_services/no_host_checker.go
@@ -16,7 +16,7 @@ func (virtualService NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
 	for _, serviceName := range virtualService.ServiceNames {
-		if valid = kubernetes.FilterByHost(virtualService.VirtualService.GetSpec(), serviceName); valid {
+		if valid = kubernetes.FilterByHost(virtualService.VirtualService.GetSpec(), serviceName, virtualService.Namespace); valid {
 			break
 		}
 	}


### PR DESCRIPTION
- Unify checker function used

This PR unifies checker function for hostname and supports single wildcard.

There are other use cases that are not yet covered but I will prepare a following PR to separate from this one.