### PR TITLE
KIALI-985 Fix missing rename field in VirtualService

### DIFF
--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -412,7 +412,7 @@ func checkSubsetRoute(routes interface{}, serviceName string, subsets []string) 
 							if innerRoute, ok := dRoute.(map[string]interface{}); ok {
 								if destination, ok := innerRoute["destination"]; ok {
 									if dDestination, ok := destination.(map[string]interface{}); ok {
-										if dName, ok := dDestination["name"]; ok && dName == serviceName {
+										if dHost, ok := dDestination["host"]; ok && dHost == serviceName {
 											if dSubset, ok := dDestination["subset"]; ok {
 												for _, subsetName := range subsets {
 													if dSubset == subsetName {

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -152,14 +152,14 @@ func TestCheckVirtualService(t *testing.T) {
 					"route": []interface{}{
 						map[string]interface{}{
 							"destination": map[string]interface{}{
-								"name":   "reviews",
+								"host":   "reviews",
 								"subset": "v2",
 							},
 							"weight": 50,
 						},
 						map[string]interface{}{
 							"destination": map[string]interface{}{
-								"name":   "reviews",
+								"host":   "reviews",
 								"subset": "v3",
 							},
 							"weight": 50,
@@ -186,14 +186,14 @@ func TestCheckVirtualService(t *testing.T) {
 					"route": []interface{}{
 						map[string]interface{}{
 							"destination": map[string]interface{}{
-								"name":   "reviews",
+								"host":   "reviews",
 								"subset": "v2",
 							},
 							"weight": 50,
 						},
 						map[string]interface{}{
 							"destination": map[string]interface{}{
-								"name":   "reviews",
+								"host":   "reviews",
 								"subset": "v3",
 							},
 							"weight": 50,


### PR DESCRIPTION
Tested locally, installed bookinfo-ratings-delay.yaml from hack/istio folder
![image](https://user-images.githubusercontent.com/1662329/41610160-c1be9a36-73ec-11e8-8cd4-494cf55e119c.png)
