### PR TITLE
KIALI-855 Move credentials from ConfigMap to Secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ openshift-deploy: openshift-undeploy
 	@if ! which envsubst > /dev/null 2>&1; then echo "You are missing 'envsubst'. Please install it and retry. If on MacOS, you can get this by installing the gettext package"; exit 1; fi
 	@echo Deploying to OpenShift project ${NAMESPACE}
 	cat deploy/openshift/kiali-configmap.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${OC} create -n ${NAMESPACE} -f -
+	cat deploy/openshift/kiali-secrets.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${OC} create -n ${NAMESPACE} -f -
 	cat deploy/openshift/kiali.yaml | IMAGE_NAME=${DOCKER_NAME} IMAGE_VERSION=${DOCKER_VERSION} NAMESPACE=${NAMESPACE} VERSION_LABEL=${VERSION_LABEL} VERBOSE_MODE=${VERBOSE_MODE} envsubst | ${OC} create -n ${NAMESPACE} -f -
 
 openshift-undeploy: .openshift-validate
@@ -193,6 +194,7 @@ k8s-deploy: k8s-undeploy
 	@if ! which envsubst > /dev/null 2>&1; then echo "You are missing 'envsubst'. Please install it and retry. If on MacOS, you can get this by installing the gettext package"; exit 1; fi
 	@echo Deploying to Kubernetes namespace ${NAMESPACE}
 	cat deploy/kubernetes/kiali-configmap.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
+	cat deploy/kubernetes/kiali-secrets.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
 	cat deploy/kubernetes/kiali.yaml | IMAGE_NAME=${DOCKER_NAME} IMAGE_VERSION=${DOCKER_VERSION} NAMESPACE=${NAMESPACE} VERSION_LABEL=${VERSION_LABEL} VERBOSE_MODE=${VERBOSE_MODE} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
 
 k8s-undeploy: .k8s-validate

--- a/config.yaml
+++ b/config.yaml
@@ -3,9 +3,11 @@ server:
   port: 8000
 
   # Uncomment credentials to enable basic authentication for server
-  credentials:
-    username: admin
-    password: admin
+  # If you are deploying Kiali in Kubernetes or Openshift, to enable authentication you should use Secrets
+  # and pass credentials through environment variables.
+  # credentials:
+  #  username: admin
+  #  password: admin
 
   # Uncomment static_content_root_directory to set up a different directory for static front-end content.
   # Default is /static-files

--- a/deploy/kubernetes/kiali-configmap.yaml
+++ b/deploy/kubernetes/kiali-configmap.yaml
@@ -10,6 +10,3 @@ data:
     server:
       port: 20001
       static_content_root_directory: /opt/kiali/console
-      credentials:
-        username: admin
-        password: admin

--- a/deploy/kubernetes/kiali-secrets.yaml
+++ b/deploy/kubernetes/kiali-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kiali
+  labels:
+    app: kiali
+    version: ${VERSION_LABEL}
+type: Opaque
+data:
+  username: YWRtaW4=    # admin
+  password: YWRtaW4=    # admin

--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -75,6 +75,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: SERVER_CREDENTIALS_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: kiali
+              key: username
+        - name: SERVER_CREDENTIALS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: kiali
+              key: password
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"

--- a/deploy/openshift/kiali-configmap.yaml
+++ b/deploy/openshift/kiali-configmap.yaml
@@ -10,6 +10,3 @@ data:
     server:
       port: 20001
       static_content_root_directory: /opt/kiali/console
-      credentials:
-        username: admin
-        password: admin

--- a/deploy/openshift/kiali-secrets.yaml
+++ b/deploy/openshift/kiali-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kiali
+  labels:
+    app: kiali
+    version: ${VERSION_LABEL}
+type: Opaque
+data:
+  username: YWRtaW4=    # admin
+  password: YWRtaW4=    # admin

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -75,6 +75,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: SERVER_CREDENTIALS_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: kiali
+              key: username
+        - name: SERVER_CREDENTIALS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: kiali
+              key: password
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"


### PR DESCRIPTION
Credentials are now passed to Kiali in environment variables.

Tried both in OS and  K8s and everything seems to work ok.