### PR TITLE
KIALI-454 Contributing section (readme) - more in style guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -501,6 +501,12 @@ If you git cloned the Kiali UI repository in directory `/my/git/repo` and have b
 CONSOLE_VERSION=local CONSOLE_LOCAL_DIR=/my/git/repo make docker-build
 ----
 
-== Style Code Guide
+== Contributing
 
-See the link:./STYLE_GUIDE.adoc[STYLE CODE GUIDE file].
+All contributions are welcome - Kiali uses the Apache 2 license and does not require any contributor agreement to submit patches. Please link:https://github.com/kiali/kiali/issues[open issues] for any bugs or problems you encounter or to suggest new features. Ask questions on the Kiali IRC channel (_#kiali_ on freenode) or the Google Groups: link:++https://groups.google.com/forum/#!forum/kiali-users++[kiali-users] or link:++https://groups.google.com/forum/#!forum/kiali-dev++[kiali-dev]. Get involved by submitting pull requests on GitHub.
+
+To setup your environment, check instructions in the link:#building[Building] and link:#running[Running] sections.
+
+=== Code Style Guide
+
+See the link:./STYLE_GUIDE.adoc[Backend Style Guide] and the link:https://github.com/kiali/kiali-ui/blob/master/STYLE_GUIDE.adoc[Frontend Style Guide].

--- a/STYLE_GUIDE.adoc
+++ b/STYLE_GUIDE.adoc
@@ -1,8 +1,17 @@
-= Style Code Guide
+= Code Style Guide
 :toc: macro
 :toc-title:
 
 toc::[]
+
+== Backend - Go
+
+The backend is written in link:https://golang.org/[Go]. If you are not familiar with it, you can take link:https://tour.golang.org/welcome/1[a Tour of Go].
+
+In Kiali we use link:https://golang.org/cmd/gofmt/[gofmt] as part of our build process to keep a consistent formatting.
+
+While we haven't automated static code analysers, it is still a good idea to check that new pieces of code are correct with tools such as link:https://github.com/golang/lint[golint] or link:https://golang.org/cmd/vet/[govet].
+
 === Imports
 
 If you need any library you should import them in the following format
@@ -29,3 +38,7 @@ import (
 	"github.com/kiali/kiali/log"
 )
 ----
+
+== Frontend - TypeScript
+
+Check the link:https://github.com/kiali/kiali-ui/blob/master/STYLE_GUIDE.adoc[dedicated guide] in _kiali-ui_.


### PR DESCRIPTION
I took inspiration from origin's contributing section ( https://github.com/openshift/origin#contributing )
Added links to gougle groups (kiali-dev + kiali-users) , bug tracker and other anchored sections.

I didn't mentioned JIRA or Confluence to keep things simple for newcomers. I guess GitHub tracker & docs should be enough for external contributors.

Please review also my English.