### PR TITLE
KIALI-1024 Ensure outsider nodes are terminal nodes

### DIFF
--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -173,6 +173,13 @@ func TestNamespaceGraph(t *testing.T) {
 		"destination_version": "v3",
 		"response_code":       "200",
 		"connection_mtls":     "false"}
+	q1m12 := model.Metric{
+		"source_service":      "reviews.bookinfo.svc.cluster.local",
+		"source_version":      "v3",
+		"destination_service": "pricing.bankapp.svc.cluster.local",
+		"destination_version": "v1",
+		"response_code":       "200",
+		"connection_mtls":     "false"}
 
 	v1 := model.Vector{
 		&model.Sample{
@@ -210,6 +217,9 @@ func TestNamespaceGraph(t *testing.T) {
 			Value:  20},
 		&model.Sample{
 			Metric: q1m11,
+			Value:  20},
+		&model.Sample{
+			Metric: q1m12,
 			Value:  20}}
 
 	client, api, err := setupMocked()

--- a/handlers/testdata/test_multi_namespace_graph.expected
+++ b/handlers/testdata/test_multi_namespace_graph.expected
@@ -7,6 +7,7 @@
           "id": "80c2e74be9c24effcaf63df866f8f02d",
           "service": "customer.tutorial.svc.cluster.local",
           "namespace": "tutorial",
+          "serviceName": "customer",
           "version": "v1",
           "rate": "50.000"
         }
@@ -16,6 +17,7 @@
           "id": "32f13d185b9a6764d67f9f96f8796f6c",
           "service": "productpage.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "productpage",
           "version": "v1",
           "rate": "50.000"
         }
@@ -25,6 +27,7 @@
           "id": "ba113404e46b8aa41dc0e7cc339073fe",
           "service": "unknown",
           "namespace": "unknown",
+          "serviceName": "unknown",
           "version": "unknown",
           "rateOut": "50.000",
           "isRoot": true

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -7,6 +7,7 @@
           "id": "50c81fc80cd32ed8f2c2b5c1e698e9f8",
           "service": "details.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "details",
           "version": "v1",
           "rate": "80.000",
           "rate3XX": "20.000",
@@ -19,10 +20,21 @@
           "id": "a8b6f512ceed0f9209287424b216200c",
           "service": "ingressgateway.istio-system.svc.cluster.local",
           "namespace": "istio-system",
+          "serviceName": "ingressgateway",
           "version": "unknown",
           "rateOut": "100.000",
-          "isOutside": true,
           "isRoot": true
+        }
+      },
+      {
+        "data": {
+          "id": "9e16fca557fb710c354ac3f048b91dee",
+          "service": "pricing.bankapp.svc.cluster.local",
+          "namespace": "bankapp",
+          "serviceName": "pricing",
+          "version": "v1",
+          "rate": "20.000",
+          "isOutside": true
         }
       },
       {
@@ -30,6 +42,7 @@
           "id": "32f13d185b9a6764d67f9f96f8796f6c",
           "service": "productpage.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "productpage",
           "version": "v1",
           "rate": "170.000",
           "rateOut": "160.000"
@@ -40,6 +53,7 @@
           "id": "4bd6b4e52f760784b8cf5a9ae38241e2",
           "service": "ratings.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "ratings",
           "version": "v1",
           "rate": "40.000"
         }
@@ -48,7 +62,8 @@
         "data": {
           "id": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
-          "namespace": "",
+          "namespace": "bookinfo",
+          "serviceName": "reviews",
           "isGroup": "version"
         }
       },
@@ -58,6 +73,7 @@
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "reviews",
           "version": "v1",
           "rate": "20.000"
         }
@@ -68,6 +84,7 @@
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "reviews",
           "version": "v2",
           "rate": "40.000",
           "rateOut": "40.000"
@@ -79,9 +96,10 @@
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "reviews",
           "version": "v3",
           "rate": "40.000",
-          "rateOut": "40.000"
+          "rateOut": "60.000"
         }
       },
       {
@@ -89,6 +107,7 @@
           "id": "ba113404e46b8aa41dc0e7cc339073fe",
           "service": "unknown",
           "namespace": "unknown",
+          "serviceName": "unknown",
           "version": "unknown",
           "rateOut": "50.000",
           "isRoot": true
@@ -151,7 +170,7 @@
           "source": "9b88963ddbd1603b0bbca88cfca29781",
           "target": "4bd6b4e52f760784b8cf5a9ae38241e2",
           "rate": "20.000",
-          "percentRate": "50.000"
+          "percentRate": "33.333"
         }
       },
       {
@@ -160,7 +179,16 @@
           "source": "9b88963ddbd1603b0bbca88cfca29781",
           "target": "9b88963ddbd1603b0bbca88cfca29781",
           "rate": "20.000",
-          "percentRate": "50.000"
+          "percentRate": "33.333"
+        }
+      },
+      {
+        "data": {
+          "id": "27ce10fa0bffd6962c1a49e8a1c7e5d5",
+          "source": "9b88963ddbd1603b0bbca88cfca29781",
+          "target": "9e16fca557fb710c354ac3f048b91dee",
+          "rate": "20.000",
+          "percentRate": "33.333"
         }
       },
       {

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -7,6 +7,7 @@
           "id": "32f13d185b9a6764d67f9f96f8796f6c",
           "service": "productpage.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "productpage",
           "version": "v1",
           "rateOut": "60.000"
         }
@@ -16,6 +17,7 @@
           "id": "4bd6b4e52f760784b8cf5a9ae38241e2",
           "service": "ratings.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "ratings",
           "version": "v1",
           "rate": "40.000"
         }
@@ -24,7 +26,8 @@
         "data": {
           "id": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
-          "namespace": "",
+          "namespace": "bookinfo",
+          "serviceName": "reviews",
           "isGroup": "version"
         }
       },
@@ -34,6 +37,7 @@
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "reviews",
           "version": "v1",
           "rate": "20.000"
         }
@@ -44,6 +48,7 @@
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "reviews",
           "version": "v2",
           "rate": "40.000",
           "rateOut": "40.000"
@@ -55,6 +60,7 @@
           "parent": "091c4c76cb13828352bbe375d51e3b01",
           "service": "reviews.bookinfo.svc.cluster.local",
           "namespace": "bookinfo",
+          "serviceName": "reviews",
           "version": "v3",
           "rate": "40.000",
           "rateOut": "40.000"


### PR DESCRIPTION
- also, fix issue with setting namespace on group node
- add an outsider to the namespace graph test
- also, add serviceName to service json as a convenience, to go with
  namespace.  Clients will no longer need to parse them out of the name.
- also, change 'composite' to 'compound', cy calls them compont nodes.