### PR TITLE
Fixing kiali cluster role to list new istio resources

### DIFF
--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -156,6 +156,8 @@ rules:
   resources:
   - virtualservices
   - destinationrules
+  - serviceentries
+  - gateways
   verbs:
   - get
   - list

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -162,6 +162,8 @@ rules:
   resources:
   - virtualservices
   - destinationrules
+  - serviceentries
+  - gateways
   verbs:
   - get
   - list


### PR DESCRIPTION
Fixing issue of not able to show the *Istio Config* tab for istio 0.8.0  as permissions for gateways and virtualservices were missing in *kiali* cluster role

Ref: https://issues.jboss.org/browse/KIALI-1046