### PR TITLE
KIALI-1077 Another attempt at correctly handling root and outsider nodes

### DIFF
--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -23,7 +23,7 @@
           "serviceName": "ingressgateway",
           "version": "unknown",
           "rateOut": "100.000",
-          "isRoot": true
+          "isOutside": true
         }
       },
       {


### PR DESCRIPTION
I'm going to generate a PR that does two things:

- remove the no outgoing edge restriction on outsider nodes.
- disallow outsider roots.

That means that only insider traffic generators (and unknown) will get the isRoot=true and the subsequent diamond shape. This will distinguish insider traffic generator services from the rest of the insider services. It will also make all outsider services consistently show as a pentagon and make it easy to know which services support the navigation feature.