### PR TITLE
KIALI-1068 Warn user when more than virtual service points to one host

### DIFF
--- a/services/business/checkers/checker.go
+++ b/services/business/checkers/checker.go
@@ -5,3 +5,7 @@ import "github.com/kiali/kiali/services/models"
 type Checker interface {
 	Check() ([]*models.IstioCheck, bool)
 }
+
+type GroupChecker interface {
+	Check() models.IstioValidations
+}

--- a/services/business/checkers/virtual_services/single_host_checker.go
+++ b/services/business/checkers/virtual_services/single_host_checker.go
@@ -53,7 +53,7 @@ func multipleVirtualServiceCheck(virtualService kubernetes.IstioObject, validati
 	rrValidation := &models.IstioValidation{
 		Name:       virtualServiceName,
 		ObjectType: "virtualservice",
-		Valid:      false,
+		Valid:      true,
 		Checks: []*models.IstioCheck{
 			&checks,
 		},

--- a/services/business/checkers/virtual_services/single_host_checker.go
+++ b/services/business/checkers/virtual_services/single_host_checker.go
@@ -1,0 +1,152 @@
+package virtual_services
+
+import (
+	"fmt"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/models"
+	"reflect"
+	"strings"
+)
+
+type SingleHostChecker struct {
+	Namespace       string
+	VirtualServices []kubernetes.IstioObject
+}
+
+type Host struct {
+	Service   string
+	Namespace string
+	Cluster   string
+}
+
+func (in SingleHostChecker) Check() ([]*models.IstioCheck, bool) {
+	hostCounter := make(map[string]map[string]map[string]bool)
+	validations := make([]*models.IstioCheck, 0)
+
+	for _, vs := range in.VirtualServices {
+		if host, ok := getHost(vs); ok {
+			if len(hostCounter) > 0 {
+				if isSameHost(hostCounter, host) {
+					return multipleVirtualServiceCheck(), false
+				} else if isNamespaceWildcard(hostCounter, host) {
+					return multipleVirtualServiceCheck(), false
+				} else if isFullWildcard(hostCounter, host) {
+					return multipleVirtualServiceCheck(), false
+				}
+			}
+
+			storeHost(hostCounter, host)
+		}
+	}
+
+	return validations, true
+}
+
+func multipleVirtualServiceCheck() []*models.IstioCheck {
+	validation := models.BuildCheck("More than one Virtual Service for same host",
+		"warning", "spec/hosts")
+	return []*models.IstioCheck{&validation}
+
+}
+
+func storeHost(hostCounter map[string]map[string]map[string]bool, host Host) {
+	if hostCounter[host.Cluster] == nil {
+		hostCounter[host.Cluster] = map[string]map[string]bool{
+			host.Namespace: {
+				host.Service: true,
+			},
+		}
+	} else if hostCounter[host.Cluster][host.Namespace] == nil {
+		hostCounter[host.Cluster][host.Namespace] = map[string]bool{
+			host.Service: true,
+		}
+	} else if hostCounter[host.Cluster][host.Namespace] != nil {
+		hostCounter[host.Cluster][host.Namespace][host.Service] = true
+	} else if hostCounter[host.Cluster][host.Namespace][host.Service] {
+		fmt.Errorf("SHOULDNT HAPPEN")
+
+	}
+}
+
+func isSameHost(hostCounter map[string]map[string]map[string]bool, host Host) bool {
+	return hostCounter[host.Cluster] != nil && hostCounter[host.Cluster][host.Namespace] != nil &&
+		hostCounter[host.Cluster][host.Namespace][host.Service]
+}
+
+func isNamespaceWildcard(hostCounter map[string]map[string]map[string]bool, host Host) bool {
+	if host.Service == "*" && host.Namespace != "*" {
+		return hostCounter[host.Cluster] != nil &&
+			hostCounter[host.Cluster][host.Namespace] != nil &&
+			len(hostCounter[host.Cluster][host.Namespace]) > 0
+	} else if host.Service != "*" {
+		return hostCounter[host.Cluster] != nil &&
+			hostCounter[host.Cluster][host.Namespace] != nil &&
+			hostCounter[host.Cluster][host.Namespace]["*"]
+	}
+
+	return false
+}
+
+func isFullWildcard(hostCounter map[string]map[string]map[string]bool, host Host) bool {
+	if host.Service == "*" && host.Namespace == "*" {
+		return len(hostCounter) > 0
+	}
+
+	return false
+}
+
+func getHost(virtualService kubernetes.IstioObject) (Host, bool) {
+	host := Host{}
+	hosts := virtualService.GetSpec()["hosts"]
+	if hosts == nil {
+		return host, false
+	}
+
+	// Getting a []HTTPRoute
+	slice := reflect.ValueOf(hosts)
+	if slice.Kind() != reflect.Slice {
+		return host, false
+	}
+
+	for hostIdx := 0; hostIdx < slice.Len(); hostIdx++ {
+		if hostIdx > 1 {
+			break
+		}
+
+		hostName, ok := slice.Index(hostIdx).Interface().(string)
+		if !ok {
+			continue
+		}
+
+		host = formatHostForSearch(hostName, virtualService.GetObjectMeta().Namespace)
+	}
+
+	return host, true
+}
+
+// Convert host to Host struct for searching
+// e.g. reviews -> reviews, virtualService.Namespace, svc.cluster.local
+// e.g. reviews.bookinfo.svc.cluster.local -> reviews, bookinfo, svc.cluster.local
+// e.g. *.bookinfo.svc.cluster.local -> *, bookinfo, svc.cluster.local
+// e.g. * -> *, *, *
+func formatHostForSearch(hostName, virtualServiceNamespace string) Host {
+	domainParts := strings.Split(hostName, ".")
+	host := Host{}
+
+	host.Service = domainParts[0]
+	if len(domainParts) > 1 {
+		host.Namespace = domainParts[1]
+
+		if len(domainParts) > 2 {
+			host.Cluster = strings.Join(domainParts[2:], ".")
+		}
+	} else if host.Service != "*" {
+		host.Namespace = virtualServiceNamespace
+		host.Cluster = "svc.cluster.local"
+	} else if host.Service == "*" {
+		host.Namespace = "*"
+		host.Cluster = "*"
+	}
+
+	return host
+}

--- a/services/business/checkers/virtual_services/single_host_checker_test.go
+++ b/services/business/checkers/virtual_services/single_host_checker_test.go
@@ -59,6 +59,7 @@ func TestRepeatingSimpleHost(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
+	presentValidationTest(t, validations, "virtual-1")
 	presentValidationTest(t, validations, "virtual-2")
 }
 
@@ -85,6 +86,7 @@ func TestRepeatingFQDNWildcardHost(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
+	presentValidationTest(t, validations, "virtual-1")
 	presentValidationTest(t, validations, "virtual-2")
 }
 
@@ -98,6 +100,7 @@ func TestIncludedIntoWildCard(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
+	presentValidationTest(t, validations, "virtual-1")
 	presentValidationTest(t, validations, "virtual-2")
 
 	// Same test, with different order of appearance
@@ -123,6 +126,7 @@ func TestShortHostNameIncludedIntoWildCard(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
+	presentValidationTest(t, validations, "virtual-1")
 	presentValidationTest(t, validations, "virtual-2")
 }
 
@@ -137,6 +141,7 @@ func TestMultipleHostsFailing(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
+	presentValidationTest(t, validations, "virtual-1")
 	presentValidationTest(t, validations, "virtual-2")
 }
 

--- a/services/business/checkers/virtual_services/single_host_checker_test.go
+++ b/services/business/checkers/virtual_services/single_host_checker_test.go
@@ -1,0 +1,185 @@
+package virtual_services
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/stretchr/testify/assert"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOneVirtualServicePerHost(t *testing.T) {
+	assert := assert.New(t)
+
+	vss := []kubernetes.IstioObject{
+		buildVirtualService("reviews"),
+		buildVirtualService("ratings"),
+	}
+	validations, valid := SingleHostChecker{
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestOneVirtualServicePerFQDNHost(t *testing.T) {
+	assert := assert.New(t)
+
+	vss := []kubernetes.IstioObject{
+		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("ratings.bookinfo.svc.cluster.local"),
+	}
+	validations, valid := SingleHostChecker{
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestOneVirtualServicePerFQDNWildcardHost(t *testing.T) {
+	assert := assert.New(t)
+
+	vss := []kubernetes.IstioObject{
+		buildVirtualService("*.bookinfo.svc.cluster.local"),
+		buildVirtualService("*.eshop.svc.cluster.local"),
+	}
+	validations, valid := SingleHostChecker{
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestRepeatingSimpleHost(t *testing.T) {
+	assert := assert.New(t)
+
+	vss := []kubernetes.IstioObject{
+		buildVirtualService("reviews"),
+		buildVirtualService("reviews"),
+	}
+	validations, valid := SingleHostChecker{
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal("warning", validations[0].Severity)
+	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
+	assert.Equal("spec/hosts", validations[0].Path)
+}
+
+func TestRepeatingFQDNHost(t *testing.T) {
+	assert := assert.New(t)
+
+	vss := []kubernetes.IstioObject{
+		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
+	}
+	validations, valid := SingleHostChecker{
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal("warning", validations[0].Severity)
+	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
+	assert.Equal("spec/hosts", validations[0].Path)
+}
+
+func TestRepeatingFQDNWildcardHost(t *testing.T) {
+	assert := assert.New(t)
+
+	vss := []kubernetes.IstioObject{
+		buildVirtualService("*.bookinfo.svc.cluster.local"),
+		buildVirtualService("*.bookinfo.svc.cluster.local"),
+	}
+	validations, valid := SingleHostChecker{
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal("warning", validations[0].Severity)
+	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
+	assert.Equal("spec/hosts", validations[0].Path)
+}
+
+func TestIncludedIntoWildCard(t *testing.T) {
+	assert := assert.New(t)
+
+	vss := []kubernetes.IstioObject{
+		buildVirtualService("*.bookinfo.svc.cluster.local"),
+		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
+	}
+	validations, valid := SingleHostChecker{
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal("warning", validations[0].Severity)
+	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
+	assert.Equal("spec/hosts", validations[0].Path)
+
+	// Same test, with different order of appearance
+	vss = []kubernetes.IstioObject{
+		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("*.bookinfo.svc.cluster.local"),
+	}
+	validations, valid = SingleHostChecker{
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal("warning", validations[0].Severity)
+	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
+	assert.Equal("spec/hosts", validations[0].Path)
+}
+
+func TestShortHostNameIncludedIntoWildCard(t *testing.T) {
+	assert := assert.New(t)
+
+	vss := []kubernetes.IstioObject{
+		buildVirtualService("*.bookinfo.svc.cluster.local"),
+		buildVirtualService("reviews"),
+	}
+	validations, valid := SingleHostChecker{
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal("warning", validations[0].Severity)
+	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
+	assert.Equal("spec/hosts", validations[0].Path)
+}
+
+func buildVirtualService(host string) kubernetes.IstioObject {
+	vs := (&kubernetes.VirtualService{
+
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "reviews",
+			Namespace: "bookinfo",
+		},
+		Spec: map[string]interface{}{
+			"hosts": []interface{}{
+				host,
+			},
+		},
+	}).DeepCopyIstioObject()
+
+	return vs
+}

--- a/services/business/checkers/virtual_services/single_host_checker_test.go
+++ b/services/business/checkers/virtual_services/single_host_checker_test.go
@@ -4,174 +4,133 @@ import (
 	"testing"
 
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/models"
 	"github.com/stretchr/testify/assert"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestOneVirtualServicePerHost(t *testing.T) {
-	assert := assert.New(t)
-
 	vss := []kubernetes.IstioObject{
-		buildVirtualService("reviews"),
-		buildVirtualService("ratings"),
+		buildVirtualService("virtual-1", "reviews"),
+		buildVirtualService("virtual-2", "ratings"),
 	}
-	validations, valid := SingleHostChecker{
+	validations := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	assert.True(valid)
-	assert.Empty(validations)
+	noValidationResult(t, validations)
 }
 
 func TestOneVirtualServicePerFQDNHost(t *testing.T) {
-	assert := assert.New(t)
-
 	vss := []kubernetes.IstioObject{
-		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
-		buildVirtualService("ratings.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-1", "reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "ratings.bookinfo.svc.cluster.local"),
 	}
-	validations, valid := SingleHostChecker{
+	validations := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	assert.True(valid)
-	assert.Empty(validations)
+	noValidationResult(t, validations)
 }
 
 func TestOneVirtualServicePerFQDNWildcardHost(t *testing.T) {
-	assert := assert.New(t)
-
 	vss := []kubernetes.IstioObject{
-		buildVirtualService("*.bookinfo.svc.cluster.local"),
-		buildVirtualService("*.eshop.svc.cluster.local"),
+		buildVirtualService("virtual-1", "*.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "*.eshop.svc.cluster.local"),
 	}
-	validations, valid := SingleHostChecker{
+	validations := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	assert.True(valid)
-	assert.Empty(validations)
+	noValidationResult(t, validations)
 }
 
 func TestRepeatingSimpleHost(t *testing.T) {
-	assert := assert.New(t)
-
 	vss := []kubernetes.IstioObject{
-		buildVirtualService("reviews"),
-		buildVirtualService("reviews"),
+		buildVirtualService("virtual-1", "reviews"),
+		buildVirtualService("virtual-2", "reviews"),
 	}
-	validations, valid := SingleHostChecker{
+
+	validations := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal("warning", validations[0].Severity)
-	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
-	assert.Equal("spec/hosts", validations[0].Path)
+	presentValidationTest(t, validations, "virtual-2")
 }
 
 func TestRepeatingFQDNHost(t *testing.T) {
-	assert := assert.New(t)
-
 	vss := []kubernetes.IstioObject{
-		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
-		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-1", "reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "reviews.bookinfo.svc.cluster.local"),
 	}
-	validations, valid := SingleHostChecker{
+	validations := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal("warning", validations[0].Severity)
-	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
-	assert.Equal("spec/hosts", validations[0].Path)
+	presentValidationTest(t, validations, "virtual-2")
 }
 
 func TestRepeatingFQDNWildcardHost(t *testing.T) {
-	assert := assert.New(t)
-
 	vss := []kubernetes.IstioObject{
-		buildVirtualService("*.bookinfo.svc.cluster.local"),
-		buildVirtualService("*.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-1", "*.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "*.bookinfo.svc.cluster.local"),
 	}
-	validations, valid := SingleHostChecker{
+	validations := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal("warning", validations[0].Severity)
-	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
-	assert.Equal("spec/hosts", validations[0].Path)
+	presentValidationTest(t, validations, "virtual-2")
 }
 
 func TestIncludedIntoWildCard(t *testing.T) {
-	assert := assert.New(t)
-
 	vss := []kubernetes.IstioObject{
-		buildVirtualService("*.bookinfo.svc.cluster.local"),
-		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-1", "*.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "reviews.bookinfo.svc.cluster.local"),
 	}
-	validations, valid := SingleHostChecker{
+	validations := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal("warning", validations[0].Severity)
-	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
-	assert.Equal("spec/hosts", validations[0].Path)
+	presentValidationTest(t, validations, "virtual-2")
 
 	// Same test, with different order of appearance
 	vss = []kubernetes.IstioObject{
-		buildVirtualService("reviews.bookinfo.svc.cluster.local"),
-		buildVirtualService("*.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-1", "reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "*.bookinfo.svc.cluster.local"),
 	}
-	validations, valid = SingleHostChecker{
+	validations = SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal("warning", validations[0].Severity)
-	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
-	assert.Equal("spec/hosts", validations[0].Path)
+	presentValidationTest(t, validations, "virtual-2")
 }
 
 func TestShortHostNameIncludedIntoWildCard(t *testing.T) {
-	assert := assert.New(t)
-
 	vss := []kubernetes.IstioObject{
-		buildVirtualService("*.bookinfo.svc.cluster.local"),
-		buildVirtualService("reviews"),
+		buildVirtualService("virtual-1", "*.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "reviews"),
 	}
-	validations, valid := SingleHostChecker{
+	validations := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal("warning", validations[0].Severity)
-	assert.Equal("More than one Virtual Service for same host", validations[0].Message)
-	assert.Equal("spec/hosts", validations[0].Path)
+	presentValidationTest(t, validations, "virtual-2")
 }
 
-func buildVirtualService(host string) kubernetes.IstioObject {
+func buildVirtualService(name, host string) kubernetes.IstioObject {
 	vs := (&kubernetes.VirtualService{
 
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      "reviews",
+			Name:      name,
 			Namespace: "bookinfo",
 		},
 		Spec: map[string]interface{}{
@@ -182,4 +141,27 @@ func buildVirtualService(host string) kubernetes.IstioObject {
 	}).DeepCopyIstioObject()
 
 	return vs
+}
+
+func noValidationResult(t *testing.T, validations models.IstioValidations) {
+	assert := assert.New(t)
+	assert.Empty(validations)
+
+	validation, ok := validations[models.IstioValidationKey{"virtualservice", "reviews"}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
+func presentValidationTest(t *testing.T, validations models.IstioValidations, serviceName string) {
+	assert := assert.New(t)
+	assert.NotEmpty(validations)
+
+	validation, ok := validations[models.IstioValidationKey{"virtualservice", serviceName}]
+	assert.True(ok)
+
+	assert.False(validation.Valid)
+	assert.NotEmpty(validation.Checks)
+	assert.Equal("warning", validation.Checks[0].Severity)
+	assert.Equal("More than one Virtual Service for same host", validation.Checks[0].Message)
+	assert.Equal("spec/hosts", validation.Checks[0].Path)
 }

--- a/services/business/checkers/virtual_services/single_host_checker_test.go
+++ b/services/business/checkers/virtual_services/single_host_checker_test.go
@@ -202,7 +202,7 @@ func presentValidationTest(t *testing.T, validations models.IstioValidations, se
 	validation, ok := validations[models.IstioValidationKey{"virtualservice", serviceName}]
 	assert.True(ok)
 
-	assert.False(validation.Valid)
+	assert.True(validation.Valid)
 	assert.NotEmpty(validation.Checks)
 	assert.Equal("warning", validation.Checks[0].Severity)
 	assert.Equal("More than one Virtual Service for same host", validation.Checks[0].Message)

--- a/services/business/checkers/virtual_services/subset_presence_checker.go
+++ b/services/business/checkers/virtual_services/subset_presence_checker.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/services/models"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 type SubsetPresenceChecker struct {
@@ -134,12 +133,4 @@ func hasSubsetDefined(destinationRule kubernetes.IstioObject, subsetTarget strin
 		}
 	}
 	return false
-}
-
-func ParseLabels(rawLabels map[string]interface{}) labels.Selector {
-	routeLabels := map[string]string{}
-	for key, value := range rawLabels {
-		routeLabels[key] = value.(string)
-	}
-	return labels.Set(routeLabels).AsSelector()
 }

--- a/services/business/istio_validations.go
+++ b/services/business/istio_validations.go
@@ -83,7 +83,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 			if drs, err := in.k8s.GetDestinationRules(namespace, ""); err == nil {
 				istioDetails.VirtualServices = []kubernetes.IstioObject{vs}
 				istioDetails.DestinationRules = drs
-				virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, VirtualService: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}
+				virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}
 				objectCheckers = []ObjectChecker{noServiceChecker, virtualServiceChecker}
 			}
 		}


### PR DESCRIPTION
When two virtual services point to one host, it returns a warning:

First Virtual Service SPEC:
```yaml
spec:
  hosts:
    - reviews
  http:
    - route:
        - destination:
            host: reviews
            subset: v2
          weight: 50
        - destination:
            host: reviews
            subset: v3
          weight: 50
```

Second Virtual Service SPEC:
```yaml
spec:
  hosts:
    - mongo.backup.svc.cluster.local
    - mongo.staging.svc.cluster.local
    - reviews
  http:
    - match:
        - headers:
            cookie:
              regex: ^(.*?;)?(user=jason)(;.*)?$
      retries:
        attempts: 3
        perTryTimeout: 2s
      route:
        - destination:
            host: reviews
            subset: v2
[...]
```
Result of running that validation:

![virtual-service-single-host-validation](https://user-images.githubusercontent.com/613814/42287955-fe2ba72a-7fb8-11e8-8b39-d030eb31f454.png)
