### PR TITLE
KIALI-976 Proxy solution for Jaeger https

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -257,6 +257,20 @@ identity:
   private_key_file: VALUE
 ----
 
+|`ISTIO_NAMESPACE`
+| The namespace where Istio is installed. (Default: istio-system)
+[source,yaml]
+----
+istio_namespace: VALUE
+----
+
+|`KIALI_SERVICE`
+| The name of the service of Kiali. (Default: kiali)
+[source,yaml]
+----
+kiali_service: VALUE
+----
+
 |`SERVER_ADDRESS`
 |Where the http server is bound to.
 [source,yaml]

--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,9 @@ const (
 
 	EnvTokenSecret       = "TOKEN_SECRET"
 	EnvTokenExpirationAt = "TOKEN_EXPIRATION_AT"
+	EnvIstioNamespace    = "ISTIO_NAMESPACE"
 
+	EnvKialiService       = "KIALI_SERVICE"
 	IstioVersionSupported = ">= 0.8"
 )
 
@@ -111,6 +113,8 @@ type Config struct {
 	VersionFilterLabelName string            `yaml:"version_filter_label_name,omitempty"`
 	ExternalServices       ExternalServices  `yaml:"external_services,omitempty"`
 	Token                  Token             `yaml:"token,omitempty"`
+	KialiService           string            `yaml:"kiali_service,omitempty"`
+	IstioNamespace         string            `yaml:"istio_namespace,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -122,6 +126,8 @@ func NewConfig() (c *Config) {
 	c.InCluster = getDefaultBool(EnvInCluster, true)
 	c.ServiceFilterLabelName = strings.TrimSpace(getDefaultString(EnvServiceFilterLabelName, "app"))
 	c.VersionFilterLabelName = strings.TrimSpace(getDefaultString(EnvVersionFilterLabelName, "version"))
+	c.KialiService = strings.TrimSpace(getDefaultString(EnvKialiService, "kiali"))
+	c.IstioNamespace = strings.TrimSpace(getDefaultString(EnvIstioNamespace, "istio-system"))
 
 	// Server configuration
 	c.Server.Address = strings.TrimSpace(getDefaultString(EnvServerAddress, ""))

--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -23,6 +23,24 @@ spec:
     app: kiali
     version: ${VERSION_LABEL}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kiali
+  labels:
+    app: kiali
+    version: ${VERSION_LABEL}
+spec:
+  type: NodePort
+  ports:
+  - name: jaeger
+    protocol: TCP
+    nodePort: 32439
+    port: 20002
+  selector:
+    app: kiali
+    version: ${VERSION_LABEL}
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -24,6 +24,25 @@ spec:
     version: ${VERSION_LABEL}
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  name: kiali-jaeger
+  labels:
+    app: kiali
+    version: ${VERSION_LABEL}
+spec:
+  type: NodePort
+  ports:
+  - name: jaeger
+    nodePort: 32439
+    port: 20002
+    protocol: TCP
+    targetPort: 20002
+  selector:
+    app: kiali
+    version: ${VERSION_LABEL}
+---
+apiVersion: v1
 kind: Route
 metadata:
   name: kiali
@@ -33,6 +52,7 @@ metadata:
 spec:
   to:
     kind: Service
+    targetPort: 20001
     name: kiali
 ---
 apiVersion: extensions/v1beta1

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/handlers"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/routing"
 )
@@ -52,6 +53,13 @@ func (s *Server) Start() {
 		}
 		log.Warning(err)
 	}()
+	/** Proxy solution Jaeger*/
+	go func() {
+		server20002 := http.NewServeMux()
+		server20002.HandleFunc("/", handlers.ProxyJaeger)
+		log.Error(http.ListenAndServe(":20002", server20002))
+	}()
+	/** End Proxy solution Jaeger*/
 }
 
 // Stop the HTTP server


### PR DESCRIPTION
This is the most clean thing than I found. We don't need any change in the UI and I commented the new things to remove them in future.

The problem was that after get the content of jaeger site the browser need to get the static build files of jaeger, trying to get /static/js/<files> and /static/css/<files> , so the browser try to get this files in : 

http://kiali-istio-system.127.0.0.1.nip.io/static/js

when should go to http://kiali-istio-system.127.0.0.1.nip.io/api/jaeger/static/js, or we do scrapping of the content that could be a nightmare o this solution.

A port service for the proxy opened in port 20002 in the container and expose 32439, and the api/jaeger result will be the same until we fix the certificates.

![proxy](https://user-images.githubusercontent.com/3019213/42375081-b4daea50-811a-11e8-8fbc-aa8b6c93e86d.png)

