### PR TITLE
KIALI-1115 Individual Virtual Service validates also multiple host constraint

### DIFF
--- a/services/business/istio_validations.go
+++ b/services/business/istio_validations.go
@@ -70,7 +70,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	}
 
 	// Get only the given Istio Object
-	var vs, dr kubernetes.IstioObject
+	var dr kubernetes.IstioObject
+	var vss []kubernetes.IstioObject
 	var objectCheckers []ObjectChecker
 	noServiceChecker := checkers.NoServiceChecker{Namespace: namespace, ServiceList: serviceList}
 	istioDetails := kubernetes.IstioDetails{}
@@ -79,9 +80,9 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	case "gateways":
 		// Validations on Gateways are not yet in place
 	case "virtualservices":
-		if vs, err = in.k8s.GetVirtualService(namespace, object); err == nil {
+		if vss, err = in.k8s.GetVirtualServices(namespace, ""); err == nil {
 			if drs, err := in.k8s.GetDestinationRules(namespace, ""); err == nil {
-				istioDetails.VirtualServices = []kubernetes.IstioObject{vs}
+				istioDetails.VirtualServices = vss
 				istioDetails.DestinationRules = drs
 				virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}
 				objectCheckers = []ObjectChecker{noServiceChecker, virtualServiceChecker}

--- a/services/business/istio_validations.go
+++ b/services/business/istio_validations.go
@@ -109,7 +109,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		return models.IstioValidations{}, err
 	}
 
-	return runObjectCheckers(objectCheckers), nil
+	return runObjectCheckers(objectCheckers).FilterByKey(models.ObjectTypeSingular[objectType], object), nil
 }
 
 func runObjectCheckers(objectCheckers []ObjectChecker) models.IstioValidations {

--- a/services/business/istio_validations_test.go
+++ b/services/business/istio_validations_test.go
@@ -55,7 +55,7 @@ func mockCombinedValidationService(istioObjects *kubernetes.IstioDetails, servic
 	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(istioObjects, nil)
 	k8s.On("GetServices", mock.AnythingOfType("string")).Return(fakeCombinedServices(services), nil)
 	k8s.On("GetNamespacePods", mock.AnythingOfType("string")).Return(podList, nil)
-	k8s.On("GetVirtualService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().VirtualServices[0], nil)
+	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().VirtualServices, nil)
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().DestinationRules, nil)
 
 	return IstioValidationsService{k8s: k8s}

--- a/services/models/istio_validation.go
+++ b/services/models/istio_validation.go
@@ -31,8 +31,29 @@ type IstioCheck struct {
 	Path     string `json:"path"`     // String that describes where in the yaml file is the check located
 }
 
+var ObjectTypeSingular = map[string]string{
+	"gateways":          "gateway",
+	"virtualservices":   "virtualservice",
+	"destinationrules":  "destinationrule",
+	"serviceentries":    "serviceentry",
+	"rules":             "rule",
+	"quotaspecs":        "quotaspec",
+	"quotaspecbindings": "quotaspecbinding",
+}
+
 func BuildCheck(message, severity, path string) IstioCheck {
 	return IstioCheck{Message: message, Severity: severity, Path: path}
+}
+
+func (iv IstioValidations) FilterByKey(objectType, name string) IstioValidations {
+	fiv := IstioValidations{}
+	for k, v := range iv {
+		if k.Name == name && k.ObjectType == objectType {
+			fiv[k] = v
+		}
+	}
+
+	return fiv
 }
 
 func (iv IstioValidations) MergeValidations(validations IstioValidations) IstioValidations {


### PR DESCRIPTION
JIRA: [KIALI-1115](https://issues.jboss.org/browse/KIALI-1115)

In order to validate multiple host constraint, we need to include all virtual services in the computation.
The output now would respond with checks of all virtual services from namespace. Frontend will use only the needed one.