### PR TITLE
KIALI-1121 VirtualServices are filtered by host from routes

### DIFF
--- a/services/business/checkers/destination_rules/no_host_checker.go
+++ b/services/business/checkers/destination_rules/no_host_checker.go
@@ -17,7 +17,7 @@ func (destinationRule NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 
 	for _, serviceName := range destinationRule.ServiceNames {
 		if host, ok := destinationRule.DestinationRule.GetSpec()["host"]; ok {
-			if dHost, ok := host.(string); ok && kubernetes.CheckHostnameService(dHost, serviceName, destinationRule.Namespace) {
+			if dHost, ok := host.(string); ok && kubernetes.FilterByHost(dHost, serviceName, destinationRule.Namespace) {
 				valid = true
 				break
 			}

--- a/services/business/checkers/destination_rules/no_host_checker_test.go
+++ b/services/business/checkers/destination_rules/no_host_checker_test.go
@@ -1,9 +1,12 @@
 package destination_rules
 
 import (
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 )
 
 func TestValidHost(t *testing.T) {
@@ -20,6 +23,9 @@ func TestValidHost(t *testing.T) {
 }
 
 func TestNoValidHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
 	assert := assert.New(t)
 
 	// reviews is not part of service names

--- a/services/business/checkers/virtual_services/no_host_checker_test.go
+++ b/services/business/checkers/virtual_services/no_host_checker_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -23,19 +24,55 @@ func TestValidHost(t *testing.T) {
 }
 
 func TestNoValidHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
 	assert := assert.New(t)
+
+	virtualService := fakeVirtualService()
 
 	validations, valid := NoHostChecker{
 		Namespace:      "test-namespace",
 		ServiceNames:   []string{"details", "other"},
-		VirtualService: fakeVirtualService(),
+		VirtualService: virtualService,
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
-	assert.Equal("Hosts doesn't have a valid service", validations[0].Message)
-	assert.Equal("spec/hosts", validations[0].Path)
+	assert.Equal("Route doesn't have a valid service", validations[0].Message)
+	assert.Equal("spec/http", validations[0].Path)
+	assert.Equal("error", validations[1].Severity)
+	assert.Equal("Route doesn't have a valid service", validations[1].Message)
+	assert.Equal("spec/tcp", validations[1].Path)
+
+	delete(virtualService.GetSpec(), "http")
+
+	validations, valid = NoHostChecker{
+		Namespace:      "test-namespace",
+		ServiceNames:   []string{"details", "other"},
+		VirtualService: virtualService,
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal("error", validations[0].Severity)
+	assert.Equal("Route doesn't have a valid service", validations[0].Message)
+	assert.Equal("spec/tcp", validations[0].Path)
+
+	delete(virtualService.GetSpec(), "tcp")
+
+	validations, valid = NoHostChecker{
+		Namespace:      "test-namespace",
+		ServiceNames:   []string{"details", "other"},
+		VirtualService: virtualService,
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal("error", validations[0].Severity)
+	assert.Equal("VirtualService doesn't define any protocol", validations[0].Message)
+	assert.Equal("", validations[0].Path)
 }
 
 func fakeVirtualService() kubernetes.IstioObject {
@@ -46,6 +83,30 @@ func fakeVirtualService() kubernetes.IstioObject {
 		Spec: map[string]interface{}{
 			"hosts": []interface{}{
 				"reviews",
+			},
+			"http": []interface{}{
+				map[string]interface{}{
+					"route": []interface{}{
+						map[string]interface{}{
+							"destination": map[string]interface{}{
+								"host":   "reviews",
+								"subset": "v1",
+							},
+						},
+					},
+				},
+			},
+			"tcp": []interface{}{
+				map[string]interface{}{
+					"route": []interface{}{
+						map[string]interface{}{
+							"destination": map[string]interface{}{
+								"host":   "reviews",
+								"subset": "v1",
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/services/business/checkers/virtual_services/subset_presence_checker.go
+++ b/services/business/checkers/virtual_services/subset_presence_checker.go
@@ -107,7 +107,7 @@ func (checker SubsetPresenceChecker) getDestinationRule(virtualServiceHost strin
 			namespace = domainParts[1]
 		}
 
-		if kubernetes.CheckHostnameService(virtualServiceHost, serviceName, namespace) {
+		if kubernetes.FilterByHost(virtualServiceHost, serviceName, namespace) {
 			return destinationRule, true
 		}
 	}

--- a/services/business/istio_validations_test.go
+++ b/services/business/istio_validations_test.go
@@ -23,7 +23,6 @@ func TestGetNamespaceValidations(t *testing.T) {
 		[]string{"details", "product", "customer"}, fakePods())
 
 	validations, _ := vs.GetNamespaceValidations("test")
-
 	assert.NotEmpty(validations)
 	assert.True(validations["test"][models.IstioValidationKey{"virtualservice", "product-vs"}].Valid)
 	assert.True(validations["test"][models.IstioValidationKey{"destinationrule", "customer-dr"}].Valid)
@@ -73,11 +72,51 @@ func fakeCombinedIstioDetails() *kubernetes.IstioDetails {
 				"hosts": []interface{}{
 					"product",
 				},
+				"http": []interface{}{
+					map[string]interface{}{
+						"route": []interface{}{
+							map[string]interface{}{
+								"destination": map[string]interface{}{
+									"host":   "product",
+									"subset": "v1",
+								},
+							},
+						},
+					},
+				},
+				"tcp": []interface{}{
+					map[string]interface{}{
+						"route": []interface{}{
+							map[string]interface{}{
+								"destination": map[string]interface{}{
+									"host":   "product",
+									"subset": "v1",
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
 
 	istioDetails.DestinationRules = []kubernetes.IstioObject{
+		&kubernetes.DestinationRule{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "product-dr",
+			},
+			Spec: map[string]interface{}{
+				"host": "product",
+				"subsets": []interface{}{
+					map[string]interface{}{
+						"name": "v1",
+						"labels": map[string]interface{}{
+							"version": "v1",
+						},
+					},
+				},
+			},
+		},
 		&kubernetes.DestinationRule{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: "customer-dr",


### PR DESCRIPTION
Main change for this fix is to filter services by host defined in routes.

VirtualServices "hosts" field can be anything:
https://istio.io/docs/reference/config/istio.networking.v1alpha3/#VirtualService

So, it is not correct to link the services by that field, instead, using the host defined within the routes, it filter correctly from services from the mesh.