### PR TITLE
KIALI-1155 Remove unused method: CheckDestinationRulemTLS

### DIFF
--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -330,30 +330,6 @@ func CheckDestinationRuleCircuitBreaker(destinationRule IstioObject, namespace s
 	return false
 }
 
-func CheckDestinationRulemTLS(destinationRule IstioObject, namespace string, serviceName string) bool {
-	if destinationRule == nil || destinationRule.GetSpec() == nil {
-		return false
-	}
-	if dHost, ok := destinationRule.GetSpec()["host"]; ok {
-		if host, ok := dHost.(string); ok && FilterByHost(host, serviceName, namespace) {
-			if trafficPolicy, ok := destinationRule.GetSpec()["trafficPolicy"]; ok {
-				if dTrafficPolicy, ok := trafficPolicy.(map[string]interface{}); ok {
-					if mtls, ok := dTrafficPolicy["tls"]; ok {
-						if dmTLS, ok := mtls.(map[string]interface{}); ok {
-							if mode, ok := dmTLS["mode"]; ok {
-								if dmode, ok := mode.(string); ok {
-									return dmode == "ISTIO_MUTUAL"
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
 // Helper method to check if a trafficPolicy has defined a connetionPool or outlierDetection element
 func checkTrafficPolicy(trafficPolicy interface{}) bool {
 	if trafficPolicy == nil {

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -280,41 +280,6 @@ func TestCheckDestinationRuleCircuitBreaker(t *testing.T) {
 	assert.False(t, CheckDestinationRuleCircuitBreaker(&destinationRule2, "", "reviews-bad", "v2"))
 }
 
-func TestCheckDestinationRulemTLS(t *testing.T) {
-	conf := config.NewConfig()
-	config.Set(conf)
-
-	assert.False(t, CheckDestinationRulemTLS(nil, "", ""))
-
-	destinationRule := MockIstioObject{
-		Spec: map[string]interface{}{
-			"host": "reviews",
-			"trafficPolicy": map[string]interface{}{
-				"tls": map[string]interface{}{
-					"mode": "ISTIO_MUTUAL",
-				},
-			},
-		},
-	}
-
-	assert.True(t, CheckDestinationRulemTLS(&destinationRule, "", "reviews"))
-	assert.False(t, CheckDestinationRulemTLS(&destinationRule, "", "reviews-bad"))
-
-	destinationRule = MockIstioObject{
-		Spec: map[string]interface{}{
-			"host": "reviews",
-			"trafficPolicy": map[string]interface{}{
-				"tls": map[string]interface{}{
-					"mode": "DISABLE",
-				},
-			},
-		},
-	}
-
-	assert.False(t, CheckDestinationRulemTLS(&destinationRule, "", "reviews"))
-	assert.False(t, CheckDestinationRulemTLS(&destinationRule, "", "reviews-bad"))
-}
-
 func TestFQDNHostname(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)


### PR DESCRIPTION
Due to a change on the implementation of flag mTLS for service graph, the `CheckDestinationRulemTLS` method got unused.

This PR remove that method.

JIRA: [KIALI-1155](https://issues.jboss.org/browse/KIALI-1155)