### PR TITLE
KIALI-1170 Fix envoy health hardcoded ports

### DIFF
--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -154,7 +154,7 @@ func TestNamespaceHealth(t *testing.T) {
 		assert.Equal(t, "ns", args[0])
 	}).Return(fakeServiceList(), nil)
 
-	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Run(func(args mock.Arguments) {
 		assert.Equal(t, "ns", args[0])
 		assert.Contains(t, []string{"reviews", "httpbin"}, args[1])
 	}).Return(prometheus.EnvoyHealth{}, nil)

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -272,7 +272,7 @@ func TestServiceHealth(t *testing.T) {
 		assert.Equal(t, "svc", args[1])
 	}).Return((*kubernetes.ServiceDetails)(nil), nil)
 
-	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Run(func(args mock.Arguments) {
 		assert.Equal(t, "ns", args[0])
 		assert.Equal(t, "svc", args[1])
 	}).Return(prometheus.EnvoyHealth{}, nil)

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -16,10 +16,10 @@ import (
 
 // ClientInterface for mocks (only mocked function are necessary here)
 type ClientInterface interface {
-	GetServiceHealth(namespace string, servicename string) (EnvoyHealth, error)
-	GetNamespaceServicesRequestRates(namespace string, ratesInterval string) (model.Vector, model.Vector, error)
-	GetServiceRequestRates(namespace, service string, ratesInterval string) (model.Vector, model.Vector, error)
-	GetSourceServices(namespace string, servicename string) (map[string][]string, error)
+	GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyHealth, error)
+	GetNamespaceServicesRequestRates(namespace, ratesInterval string) (model.Vector, model.Vector, error)
+	GetServiceRequestRates(namespace, service, ratesInterval string) (model.Vector, model.Vector, error)
+	GetSourceServices(namespace, servicename string) (map[string][]string, error)
 }
 
 // Client for Prometheus API.
@@ -100,8 +100,8 @@ func (in *Client) GetServiceMetrics(query *ServiceMetricsQuery) Metrics {
 // GetServiceHealth returns the Health related to the provided service identified by its namespace and service name.
 // It reads Envoy metrics, inbound and outbound
 // When the health is unavailable, total number of members will be 0.
-func (in *Client) GetServiceHealth(namespace string, servicename string) (EnvoyHealth, error) {
-	return getServiceHealth(in.api, namespace, servicename)
+func (in *Client) GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyHealth, error) {
+	return getServiceHealth(in.api, namespace, servicename, ports)
 }
 
 // GetNamespaceMetrics returns the Metrics described by the optional service pattern ("" for all), and optional

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -318,13 +318,17 @@ func TestGetServiceHealth(t *testing.T) {
 	mockSingle(api, "envoy_cluster_inbound_9080__productpage_istio_system_svc_cluster_local_membership_total", 1)
 	mockSingle(api, "envoy_cluster_outbound_9080__productpage_istio_system_svc_cluster_local_membership_healthy", 0)
 	mockSingle(api, "envoy_cluster_outbound_9080__productpage_istio_system_svc_cluster_local_membership_total", 1)
-	health, _ := client.GetServiceHealth("istio-system", "productpage")
+	mockSingle(api, "envoy_cluster_inbound_8080__productpage_istio_system_svc_cluster_local_membership_healthy", 1)
+	mockSingle(api, "envoy_cluster_inbound_8080__productpage_istio_system_svc_cluster_local_membership_total", 2)
+	mockSingle(api, "envoy_cluster_outbound_8080__productpage_istio_system_svc_cluster_local_membership_healthy", 3)
+	mockSingle(api, "envoy_cluster_outbound_8080__productpage_istio_system_svc_cluster_local_membership_total", 4)
+	health, _ := client.GetServiceHealth("istio-system", "productpage", []int32{9080, 8080})
 
 	// Check health
-	assert.Equal(t, 0, health.Inbound.Healthy)
-	assert.Equal(t, 1, health.Inbound.Total)
-	assert.Equal(t, 0, health.Outbound.Healthy)
-	assert.Equal(t, 1, health.Outbound.Total)
+	assert.Equal(t, 1, health.Inbound.Healthy)
+	assert.Equal(t, 3, health.Inbound.Total)
+	assert.Equal(t, 3, health.Outbound.Healthy)
+	assert.Equal(t, 5, health.Outbound.Total)
 }
 
 func TestGetServiceMetricsUnavailable(t *testing.T) {
@@ -387,7 +391,7 @@ func TestGetServiceHealthUnavailable(t *testing.T) {
 	mockQuery(api, "envoy_cluster_inbound_9080__productpage_istio_system_svc_cluster_local_membership_total", &model.Vector{})
 	mockQuery(api, "envoy_cluster_outbound_9080__productpage_istio_system_svc_cluster_local_membership_healthy", &model.Vector{})
 	mockQuery(api, "envoy_cluster_outbound_9080__productpage_istio_system_svc_cluster_local_membership_total", &model.Vector{})
-	h, err := client.GetServiceHealth("istio-system", "productpage")
+	h, err := client.GetServiceHealth("istio-system", "productpage", []int32{9080})
 
 	// Check health unavailable
 	assert.Nil(t, err)

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -88,8 +88,8 @@ type PromClientMock struct {
 	mock.Mock
 }
 
-func (o *PromClientMock) GetServiceHealth(namespace, servicename string) (prometheus.EnvoyHealth, error) {
-	args := o.Called(namespace, servicename)
+func (o *PromClientMock) GetServiceHealth(namespace, servicename string, ports []int32) (prometheus.EnvoyHealth, error) {
+	args := o.Called(namespace, servicename, ports)
 	return args.Get(0).(prometheus.EnvoyHealth), args.Error(1)
 }
 

--- a/services/business/services.go
+++ b/services/business/services.go
@@ -63,6 +63,9 @@ func (in *SvcService) GetService(namespace, service, interval string) (*models.S
 		return nil, fmt.Errorf("Service details: %s", err.Error())
 	}
 
+	health := models.Health{}
+	in.health.fillMissingParts(namespace, service, serviceDetails, interval, &health)
+
 	istioDetails, err := in.k8s.GetIstioDetails(namespace, service)
 	if err != nil {
 		return nil, fmt.Errorf("Istio details: %s", err.Error())
@@ -72,12 +75,6 @@ func (in *SvcService) GetService(namespace, service, interval string) (*models.S
 	if err != nil {
 		return nil, fmt.Errorf("Source services: %s", err.Error())
 	}
-
-	statuses := castDeploymentsStatuses(serviceDetails.Deployments.Items)
-	health := models.Health{
-		DeploymentStatuses: statuses,
-		DeploymentsFetched: true}
-	in.health.fillMissingParts(namespace, service, interval, &health)
 
 	s := models.Service{
 		Namespace: models.Namespace{Name: namespace},

--- a/services/business/services_test.go
+++ b/services/business/services_test.go
@@ -48,7 +48,7 @@ func TestSingleServiceHealthParsing(t *testing.T) {
 	k8s.On("GetServiceDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeServiceDetails(), nil)
 	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeIstioDetails(), nil)
 	prom.On("GetSourceServices", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(make(map[string][]string), nil)
-	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(prometheus.EnvoyHealth{Inbound: prometheus.EnvoyRatio{Healthy: 1, Total: 1}}, nil)
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Return(prometheus.EnvoyHealth{Inbound: prometheus.EnvoyRatio{Healthy: 1, Total: 1}}, nil)
 	prom.On("GetServiceRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeServiceRequestCounters())
 	svc := setupServices(k8s, prom)
 


### PR DESCRIPTION
- service ports are gathered from k8s Service before querying for envoy health. Some refactoring was necessary to make it ok for all three use cases (from service list, service details & graph) and keep an optimized loading workflow.
- updated envoy health query. While we could have a per-port granularity in health, at the moment the simplest is to aggregate all metrics regardless the port.
- tests & mocks updated