### PR TITLE
KIALI-1133 [Istio-1.0] Update metrics queries

### DIFF
--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -9,22 +9,6 @@ import (
 	"github.com/kiali/kiali/prometheus"
 )
 
-func extractServiceMetricsQuery(r *http.Request, namespace, service string) (*prometheus.ServiceMetricsQuery, error) {
-	q := prometheus.ServiceMetricsQuery{
-		Namespace: namespace,
-		Service:   service}
-	err := extractMetricsQueryParams(r, &q.MetricsQuery)
-	return &q, err
-}
-
-func extractNamespaceMetricsQuery(r *http.Request, namespace, servicePattern string) (*prometheus.NamespaceMetricsQuery, error) {
-	q := prometheus.NamespaceMetricsQuery{
-		Namespace:      namespace,
-		ServicePattern: servicePattern}
-	err := extractMetricsQueryParams(r, &q.MetricsQuery)
-	return &q, err
-}
-
 func extractMetricsQueryParams(r *http.Request, q *prometheus.MetricsQuery) error {
 	q.FillDefaults()
 	queryParams := r.URL.Query()
@@ -64,9 +48,6 @@ func extractMetricsQueryParams(r *http.Request, q *prometheus.MetricsQuery) erro
 			// Bad request
 			return errors.New("Bad request, cannot parse query parameter 'step'")
 		}
-	}
-	if versions, ok := queryParams["version"]; ok && len(versions) > 0 {
-		q.Version = versions[0]
 	}
 	if filters, ok := queryParams["filters[]"]; ok && len(filters) > 0 {
 		q.Filters = filters

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -79,7 +79,8 @@ func NamespaceIstioValidations(w http.ResponseWriter, r *http.Request) {
 func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promClientSupplier func() (*prometheus.Client, error)) {
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
-	params, err := extractNamespaceMetricsQuery(r, namespace, "")
+	params := prometheus.MetricsQuery{Namespace: namespace}
+	err := extractMetricsQueryParams(r, &params)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
@@ -90,6 +91,6 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promClientSuppl
 		RespondWithError(w, http.StatusServiceUnavailable, "Prometheus client error: "+err.Error())
 		return
 	}
-	metrics := prometheusClient.GetNamespaceMetrics(params)
+	metrics := prometheusClient.GetMetrics(&params)
 	RespondWithJSON(w, http.StatusOK, metrics)
 }

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -39,7 +39,7 @@ func TestNamespaceMetricsDefault(t *testing.T) {
 		query := args[1].(string)
 		assert.IsType(t, v1.Range{}, args[2])
 		r := args[2].(v1.Range)
-		assert.Contains(t, query, ".*\\\\.ns\\\\..*")
+		assert.Contains(t, query, "_namespace=\"ns\"")
 		assert.Contains(t, query, "[1m]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
@@ -100,7 +100,7 @@ func TestNamespaceMetricsWithParams(t *testing.T) {
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
 			assert.Contains(t, query, " by (le,response_code)")
-			assert.Contains(t, query, "istio_request_size")
+			assert.Contains(t, query, "istio_request_bytes")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
 			assert.Contains(t, query, " by (response_code)")

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -92,9 +92,9 @@ func (in *Client) GetSourceServices(namespace string, servicename string) (map[s
 	return routes, nil
 }
 
-// GetServiceMetrics returns the Metrics related to the provided service identified by its namespace and service name.
-func (in *Client) GetServiceMetrics(query *ServiceMetricsQuery) Metrics {
-	return getServiceMetrics(in.api, query)
+// GetMetrics returns the Metrics related to the provided service identified by its namespace and service name.
+func (in *Client) GetMetrics(query *MetricsQuery) Metrics {
+	return getMetrics(in.api, query)
 }
 
 // GetServiceHealth returns the Health related to the provided service identified by its namespace and service name.
@@ -102,12 +102,6 @@ func (in *Client) GetServiceMetrics(query *ServiceMetricsQuery) Metrics {
 // When the health is unavailable, total number of members will be 0.
 func (in *Client) GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyHealth, error) {
 	return getServiceHealth(in.api, namespace, servicename, ports)
-}
-
-// GetNamespaceMetrics returns the Metrics described by the optional service pattern ("" for all), and optional
-// version, for the given namespace. Use GetServiceMetrics if you don't need pattern matching.
-func (in *Client) GetNamespaceMetrics(query *NamespaceMetricsQuery) Metrics {
-	return getNamespaceMetrics(in.api, query)
 }
 
 // GetNamespaceServicesRequestRates queries Prometheus to fetch request counters rates over a time interval

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -92,7 +92,7 @@ func (in *Client) GetSourceServices(namespace string, servicename string) (map[s
 	return routes, nil
 }
 
-// GetMetrics returns the Metrics related to the provided service identified by its namespace and service name.
+// GetMetrics returns the Metrics related to the provided query options.
 func (in *Client) GetMetrics(query *MetricsQuery) Metrics {
 	return getMetrics(in.api, query)
 }

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -161,8 +161,8 @@ func getMetrics(api v1.API, q *MetricsQuery) Metrics {
 }
 
 func buildLabelStrings(q *MetricsQuery) (string, string, string, string) {
-	labelsIn := []string{`reporter="server"`}
-	labelsOut := []string{`reporter="client"`}
+	labelsIn := []string{`reporter="destination"`}
+	labelsOut := []string{`reporter="source"`}
 	if q.Workload != "" {
 		labelsIn = append(labelsIn, fmt.Sprintf(`destination_workload="%s"`, q.Workload))
 		labelsOut = append(labelsOut, fmt.Sprintf(`source_workload="%s"`, q.Workload))
@@ -176,14 +176,14 @@ func buildLabelStrings(q *MetricsQuery) (string, string, string, string) {
 		labelsOut = append(labelsOut, fmt.Sprintf(`source_app=~"%s"`, apps))
 	}
 	if q.Namespace != "" {
-		labelsIn = append(labelsIn, fmt.Sprintf(`destination_namespace="%s"`, q.Namespace))
-		labelsOut = append(labelsOut, fmt.Sprintf(`source_namespace="%s"`, q.Namespace))
+		labelsIn = append(labelsIn, fmt.Sprintf(`destination_workload_namespace="%s"`, q.Namespace))
+		labelsOut = append(labelsOut, fmt.Sprintf(`source_workload_namespace="%s"`, q.Namespace))
 	}
 
 	// when filtering we still keep incoming istio traffic, it's typically ingressgateway. We
 	// only want to filter outgoing traffic to the istio infra services.
 	if !q.IncludeIstio {
-		labelsOut = append(labelsOut, `destination_namespace!="istio-system"`)
+		labelsOut = append(labelsOut, `destination_workload_namespace!="istio-system"`)
 	}
 	fullIn := "{" + strings.Join(labelsIn, ",") + "}"
 	fullOut := "{" + strings.Join(labelsOut, ",") + "}"

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -18,7 +18,7 @@ var (
 	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 )
 
-// MetricsQuery is a common struct for ServiceMetricsQuery and NamespaceMetricsQuery
+// MetricsQuery holds query parameters for a typical metrics query
 type MetricsQuery struct {
 	v1.Range
 	RateInterval string
@@ -161,8 +161,8 @@ func getMetrics(api v1.API, q *MetricsQuery) Metrics {
 }
 
 func buildLabelStrings(q *MetricsQuery) (string, string, string, string) {
-	var labelsIn []string
-	var labelsOut []string
+	labelsIn := []string{`reporter="server"`}
+	labelsOut := []string{`reporter="client"`}
 	if q.Workload != "" {
 		labelsIn = append(labelsIn, fmt.Sprintf(`destination_workload="%s"`, q.Workload))
 		labelsOut = append(labelsOut, fmt.Sprintf(`source_workload="%s"`, q.Workload))

--- a/prometheus/metrics_definitions.go
+++ b/prometheus/metrics_definitions.go
@@ -11,24 +11,24 @@ var (
 	kialiMetrics = []kialiMetric{
 		kialiMetric{
 			name:      "request_count",
-			istioName: "istio_request_count",
+			istioName: "istio_requests_total",
 			isHisto:   false},
 		kialiMetric{
 			name:           "request_error_count",
-			istioName:      "istio_request_count",
+			istioName:      "istio_requests_total",
 			isHisto:        false,
 			useErrorLabels: true},
 		kialiMetric{
 			name:      "request_size",
-			istioName: "istio_request_size",
+			istioName: "istio_request_bytes",
 			isHisto:   true},
 		kialiMetric{
 			name:      "request_duration",
-			istioName: "istio_request_duration",
+			istioName: "istio_request_duration_seconds",
 			isHisto:   true},
 		kialiMetric{
 			name:      "response_size",
-			istioName: "istio_response_size",
+			istioName: "istio_response_bytes",
 			isHisto:   true}}
 )
 

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -100,16 +100,16 @@ func TestGetServiceMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m])), 0.001)", 1.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m])), 0.001)", 2.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 3.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 4.5)
-	mockHistogram(api, "istio_request_bytes", "{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_duration_seconds", "{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
-	mockHistogram(api, "istio_response_bytes", "{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
-	mockHistogram(api, "istio_request_bytes", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
-	mockHistogram(api, "istio_request_duration_seconds", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
-	mockHistogram(api, "istio_response_bytes", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 1.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 2.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 3.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 4.5)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
+	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
+	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
+	mockHistogram(api, "istio_response_bytes", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
 	metrics := client.GetMetrics(&prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		Apps:      []string{"productpage"},
@@ -169,16 +169,16 @@ func TestGetServiceMetricsIncludeIstioFalse(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_namespace=\"bookinfo\",destination_namespace!=\"istio-system\"}[5m])), 0.001)", 1.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m])), 0.001)", 2.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_namespace=\"bookinfo\",destination_namespace!=\"istio-system\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 3.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 4.5)
-	mockHistogram(api, "istio_request_bytes", "{source_app=\"productpage\",source_namespace=\"bookinfo\",destination_namespace!=\"istio-system\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_duration_seconds", "{source_app=\"productpage\",source_namespace=\"bookinfo\",destination_namespace!=\"istio-system\"}[5m]", 0.35, 0.2, 0.3, 0.5)
-	mockHistogram(api, "istio_response_bytes", "{source_app=\"productpage\",source_namespace=\"bookinfo\",destination_namespace!=\"istio-system\"}[5m]", 0.35, 0.2, 0.3, 0.6)
-	mockHistogram(api, "istio_request_bytes", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
-	mockHistogram(api, "istio_request_duration_seconds", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
-	mockHistogram(api, "istio_response_bytes", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\",destination_workload_namespace!=\"istio-system\"}[5m])), 0.001)", 1.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 2.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\",destination_workload_namespace!=\"istio-system\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 3.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 4.5)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\",destination_workload_namespace!=\"istio-system\"}[5m]", 0.35, 0.2, 0.3, 0.4)
+	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\",destination_workload_namespace!=\"istio-system\"}[5m]", 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\",destination_workload_namespace!=\"istio-system\"}[5m]", 0.35, 0.2, 0.3, 0.6)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
+	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
+	mockHistogram(api, "istio_response_bytes", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
 	metrics := client.GetMetrics(&prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		Apps:      []string{"productpage"},
@@ -237,10 +237,10 @@ func TestGetFilteredServiceMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m])), 0.001)", 1.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m])), 0.001)", 2.5)
-	mockHistogram(api, "istio_request_bytes", "{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_bytes", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 1.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 2.5)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
 	metrics := client.GetMetrics(&prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		Apps:      []string{"productpage"},
@@ -274,8 +274,8 @@ func TestGetServiceMetricsInstantRates(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, "round(sum(irate(istio_requests_total{source_app=\"productpage\",source_namespace=\"bookinfo\"}[1m])), 0.001)", 1.5)
-	mockRange(api, "round(sum(irate(istio_requests_total{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[1m])), 0.001)", 2.5)
+	mockRange(api, "round(sum(irate(istio_requests_total{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[1m])), 0.001)", 1.5)
+	mockRange(api, "round(sum(irate(istio_requests_total{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[1m])), 0.001)", 2.5)
 	metrics := client.GetMetrics(&prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		Apps:      []string{"productpage"},
@@ -329,16 +329,16 @@ func TestGetServiceMetricsUnavailable(t *testing.T) {
 		return
 	}
 	// Mock everything to return empty data
-	mockEmptyRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m])), 0.001)")
-	mockEmptyRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m])), 0.001)")
-	mockEmptyRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)")
-	mockEmptyRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)")
-	mockEmptyHistogram(api, "istio_request_bytes", "{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m]")
-	mockEmptyHistogram(api, "istio_request_duration_seconds", "{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m]")
-	mockEmptyHistogram(api, "istio_response_bytes", "{source_app=\"productpage\",source_namespace=\"bookinfo\"}[5m]")
-	mockEmptyHistogram(api, "istio_request_bytes", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]")
-	mockEmptyHistogram(api, "istio_request_duration_seconds", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]")
-	mockEmptyHistogram(api, "istio_response_bytes", "{destination_app=\"productpage\",destination_namespace=\"bookinfo\"}[5m]")
+	mockEmptyRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m])), 0.001)")
+	mockEmptyRange(api, "round(sum(rate(istio_requests_total{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m])), 0.001)")
+	mockEmptyRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)")
+	mockEmptyRange(api, "round(sum(rate(istio_requests_total{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)")
+	mockEmptyHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]")
+	mockEmptyHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]")
+	mockEmptyHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]")
+	mockEmptyHistogram(api, "istio_request_bytes", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]")
+	mockEmptyHistogram(api, "istio_request_duration_seconds", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]")
+	mockEmptyHistogram(api, "istio_response_bytes", "{reporter=\"destination\",destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]")
 	metrics := client.GetMetrics(&prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		Apps:      []string{"productpage"},
@@ -394,16 +394,16 @@ func TestGetNamespaceMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, "round(sum(rate(istio_requests_total{source_namespace=\"bookinfo\"}[5m])), 0.001)", 1.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_namespace=\"bookinfo\"}[5m])), 0.001)", 2.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{source_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 3.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 4.5)
-	mockHistogram(api, "istio_request_bytes", "{source_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_duration_seconds", "{source_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
-	mockHistogram(api, "istio_response_bytes", "{source_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
-	mockHistogram(api, "istio_request_bytes", "{destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
-	mockHistogram(api, "istio_request_duration_seconds", "{destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
-	mockHistogram(api, "istio_response_bytes", "{destination_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 1.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"destination\",destination_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 2.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 3.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"destination\",destination_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 4.5)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
+	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"destination\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
+	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"destination\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
+	mockHistogram(api, "istio_response_bytes", "{reporter=\"destination\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
 	metrics := client.GetMetrics(&prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		Range: v1.Range{

--- a/services/business/services.go
+++ b/services/business/services.go
@@ -83,3 +83,19 @@ func (in *SvcService) GetService(namespace, service, interval string) (*models.S
 	s.SetServiceDetails(serviceDetails, istioDetails, prometheusDetails)
 	return &s, nil
 }
+
+// GetApps returns a list of "app" label values used for the Deployments covered by this service
+func (in *SvcService) GetApps(namespace, service string) ([]string, error) {
+	serviceDetails, err := in.k8s.GetServiceDetails(namespace, service)
+	if err != nil {
+		return nil, fmt.Errorf("GetApps: %s", err.Error())
+	}
+
+	var apps []string
+	for _, depl := range serviceDetails.Deployments.Items {
+		if app, ok := depl.Labels["app"]; ok {
+			apps = append(apps, app)
+		}
+	}
+	return apps, nil
+}


### PR DESCRIPTION
- Update queries to match new names and labels
- Keep our internal names
- For service metrics fetching, search for "app" labels in deployments before actually querying prometheus