### PR TITLE
Fix Errorf formatting to correct type

### DIFF
--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -143,7 +143,7 @@ func (in *IstioClient) GetServiceEntry(namespace string, serviceEntryName string
 
 	serviceEntry, ok := result.(*ServiceEntry)
 	if !ok {
-		return nil, fmt.Errorf("%s/%s doesn't return a ServiceEntry object", namespace, serviceEntry)
+		return nil, fmt.Errorf("%s/%v doesn't return a ServiceEntry object", namespace, serviceEntry)
 	}
 	return serviceEntry.DeepCopyIstioObject(), nil
 }


### PR DESCRIPTION
When trying to compile make test, the compilation fails with:

# github.com/kiali/kiali/kubernetes
kubernetes/istio_details_service.go:146: Errorf format %s has arg serviceEntry of wrong type *kubernetes.ServiceEntry

This is because *kubernetes.ServiceEntry should use %v instead of %s