### PR TITLE
KIALI-1123 Remove use of goroutines and channels from checkers

### DIFF
--- a/services/business/istio_validations.go
+++ b/services/business/istio_validations.go
@@ -114,20 +114,10 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 
 func runObjectCheckers(objectCheckers []ObjectChecker) models.IstioValidations {
 	objectTypeValidations := models.IstioValidations{}
-	validationsChannels := make([]chan models.IstioValidations, len(objectCheckers))
 
 	// Run checks for each IstioObject type
-	for i, objectChecker := range objectCheckers {
-		validationsChannels[i] = make(chan models.IstioValidations)
-		go func(channel chan models.IstioValidations, checker ObjectChecker) {
-			channel <- checker.Check()
-			close(channel)
-		}(validationsChannels[i], objectChecker)
-	}
-
-	// Receive validations and merge them into one object
-	for _, validation := range validationsChannels {
-		objectTypeValidations.MergeValidations(<-validation)
+	for _, objectChecker := range objectCheckers {
+		objectTypeValidations.MergeValidations(objectChecker.Check())
 	}
 	return objectTypeValidations
 }


### PR DESCRIPTION
Since there's no I/O done by any of the checkers, it is wasteful to spawn new goroutines for them. Processing in a single thread provides better use of CPU caches, reduces stack usage and makes the code more simple.