### PR TITLE
KIALI-665 SSL Support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -263,12 +263,6 @@ identity:
 ----
 istio_namespace: VALUE
 ----
-
-|`KIALI_SERVICE`
-| The name of the service of Kiali. (Default: kiali)
-[source,yaml]
-----
-kiali_service: VALUE
 ----
 
 |`SERVER_ADDRESS`
@@ -458,6 +452,18 @@ external_services:
     var_workload: VALUE
 ----
 
+|`JAEGER_URL`
+|Optional, URL to the Jaeger Query service. This URL must be accessible directly from the client browser.
+If the URL is not provided, Kiali will start a proxy for Jaeger queries.
+Note that in order to enable proxy when SSL is also activated, you must make sure that Kiali certificate is valid for the main Kiali server and for the Proxy server, which runs on a different port (see proxy options below).
+By default, Jaeger URL is unset, so proxy is enabled.
+[source,yaml]
+----
+external_services:
+  jaeger:
+    url: VALUE
+----
+
 |`JAEGER_SERVICE_NAMESPACE`
 |The Kubernetes namespace that holds the Jaeger service. (default is `istio-system`)
 [source,yaml]
@@ -483,6 +489,24 @@ external_services:
 external_services:
   jaeger:
     service: VALUE
+----
+
+|`JAEGER_PROXY_NODE_PORT`
+|Node port for the Jaeger proxy, if enabled. If changed, make sure it still matches the `kiali-jaeger` service definition. (default is `32439`)
+[source,yaml]
+----
+external_services:
+  jaeger:
+    proxy_node_port: VALUE
+----
+
+|`JAEGER_PROXY_SERVICE_PORT`
+|Service port for the Jaeger proxy, if enabled. If changed, make sure it still matches the `kiali-jaeger` service definition. (default is `20002`)
+[source,yaml]
+----
+external_services:
+  jaeger:
+    proxy_service_port: VALUE
 ----
 
 |`LOGIN_TOKEN_SIGNING_KEY`
@@ -540,6 +564,14 @@ If you git cloned the Kiali UI repository in directory `/my/git/repo` and have b
 ----
 CONSOLE_VERSION=local CONSOLE_LOCAL_DIR=/my/git/repo make docker-build
 ----
+
+=== Disabling SSL
+
+In the provided OpenShift templates, SSL is turned on by default. If you want to turn it off, you should:
+
+* Remove the "tls: termination: reencrypt" option in Kiali route
+* Remove the "identity" block, with certificate paths, in Kiali Config Map.
+* Optionnally you can also remove the annotation "service.alpha.openshift.io/serving-cert-secret-name", and the related volume that is declared and mounted in Kiali Deployment (but if you don't, they will just be ignored).
 
 == Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -42,9 +42,12 @@ const (
 	EnvGrafanaVarService               = "GRAFANA_VAR_SERVICE"
 	EnvGrafanaVarWorkload              = "GRAFANA_VAR_WORKLOAD"
 
+	EnvJaegerURL              = "JAEGER_URL"
 	EnvJaegerServiceNamespace = "JAEGER_SERVICE_NAMESPACE"
 	EnvJaegerService          = "JAEGER_SERVICE"
 	EnvJaegerServicePort      = "JAEGER_SERVICE_PORT"
+	EnvJaegerProxyNodePort    = "JAEGER_PROXY_NODE_PORT"
+	EnvJaegerProxyServicePort = "JAEGER_PROXY_SERVICE_PORT"
 
 	EnvAppLabelName     = "APP_LABEL_NAME"
 	EnvVersionLabelName = "VERSION_LABEL_NAME"
@@ -53,7 +56,6 @@ const (
 	EnvLoginTokenExpirationSeconds = "LOGIN_TOKEN_EXPIRATION_SECONDS"
 	EnvIstioNamespace              = "ISTIO_NAMESPACE"
 
-	EnvKialiService       = "KIALI_SERVICE"
 	IstioVersionSupported = ">= 1.0"
 )
 
@@ -84,9 +86,12 @@ type GrafanaConfig struct {
 
 // JaegerConfig describes configuration used for jaeger links
 type JaegerConfig struct {
+	URL              string `yaml:"url"`
 	ServiceNamespace string `yaml:"service_namespace"`
 	Service          string `yaml:"service"`
 	ServicePort      string `yaml:"service_port"`
+	ProxyNodePort    int    `yaml:"proxy_node_port"`
+	ProxyServicePort int    `yaml:"proxy_service_port"`
 }
 
 // IstioConfig describes configuration used for istio links
@@ -119,7 +124,6 @@ type Config struct {
 	VersionLabelName string            `yaml:"version_label_name,omitempty"`
 	ExternalServices ExternalServices  `yaml:"external_services,omitempty"`
 	LoginToken       LoginToken        `yaml:"login_token,omitempty"`
-	KialiService     string            `yaml:"kiali_service,omitempty"`
 	IstioNamespace   string            `yaml:"istio_namespace,omitempty"`
 }
 
@@ -132,7 +136,6 @@ func NewConfig() (c *Config) {
 	c.InCluster = getDefaultBool(EnvInCluster, true)
 	c.AppLabelName = strings.TrimSpace(getDefaultString(EnvAppLabelName, "app"))
 	c.VersionLabelName = strings.TrimSpace(getDefaultString(EnvVersionLabelName, "version"))
-	c.KialiService = strings.TrimSpace(getDefaultString(EnvKialiService, "kiali"))
 	c.IstioNamespace = strings.TrimSpace(getDefaultString(EnvIstioNamespace, "istio-system"))
 
 	// Server configuration
@@ -160,9 +163,12 @@ func NewConfig() (c *Config) {
 	c.ExternalServices.Grafana.VarWorkload = strings.TrimSpace(getDefaultString(EnvGrafanaVarWorkload, "var-workload"))
 
 	// Jaeger Configuration
+	c.ExternalServices.Jaeger.URL = strings.TrimSpace(getDefaultString(EnvJaegerURL, ""))
 	c.ExternalServices.Jaeger.ServiceNamespace = strings.TrimSpace(getDefaultString(EnvJaegerServiceNamespace, "istio-system"))
 	c.ExternalServices.Jaeger.Service = strings.TrimSpace(getDefaultString(EnvJaegerService, "jaeger-query"))
 	c.ExternalServices.Jaeger.ServicePort = strings.TrimSpace(getDefaultString(EnvJaegerServicePort, "16686"))
+	c.ExternalServices.Jaeger.ProxyNodePort = getDefaultInt(EnvJaegerProxyNodePort, 32439)
+	c.ExternalServices.Jaeger.ProxyServicePort = getDefaultInt(EnvJaegerProxyServicePort, 20002)
 
 	// Istio Configuration
 	c.ExternalServices.Istio.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))

--- a/deploy/openshift/kiali-configmap.yaml
+++ b/deploy/openshift/kiali-configmap.yaml
@@ -10,3 +10,7 @@ data:
     server:
       port: 20001
       static_content_root_directory: /opt/kiali/console
+    identity:
+      cert_file: /kiali-cert/tls.crt
+      private_key_file: /kiali-cert/tls.key
+

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -9,6 +9,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
   name: kiali
   labels:
     app: kiali
@@ -50,6 +52,8 @@ metadata:
     app: kiali
     version: ${VERSION_LABEL}
 spec:
+  tls:
+    termination: reencrypt
   to:
     kind: Service
     targetPort: 20001
@@ -108,10 +112,15 @@ spec:
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
+        - name: kiali-cert
+          mountPath: "/kiali-cert"
       volumes:
       - name: kiali-configuration
         configMap:
           name: kiali
+      - name: kiali-cert
+        secret:
+          secretName: kiali-cert-secret
 ---
 apiVersion: v1
 kind: ClusterRole


### PR DESCRIPTION
- Get Openshift generates certificate
- Mount in  pod volume and configure to use them in kiali config
- Use them also for jaeger proxy
- Route: use reencrypting termination