### PR TITLE
KIALI-1225 [1.0] graph, update missing-sidecar appender

### DIFF
--- a/graph/appender/sidecars_check.go
+++ b/graph/appender/sidecars_check.go
@@ -3,13 +3,19 @@ package appender
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/services/business/checkers"
 )
 
-type SidecarsCheckAppender struct{}
+type SidecarsCheckAppender struct {
+	GraphType string
+	Versioned bool
+}
 
 // AppendGraph implements Appender
 func (a SidecarsCheckAppender) AppendGraph(trafficMap graph.TrafficMap, _ string) {
@@ -23,26 +29,69 @@ func (a SidecarsCheckAppender) AppendGraph(trafficMap graph.TrafficMap, _ string
 	a.applySidecarsChecks(trafficMap, k8s)
 }
 
-func (a SidecarsCheckAppender) applySidecarsChecks(trafficMap graph.TrafficMap, k8s *kubernetes.IstioClient) {
+func (a *SidecarsCheckAppender) applySidecarsChecks(trafficMap graph.TrafficMap, k8s *kubernetes.IstioClient) {
 	appLabel := config.Get().AppLabelName
 	versionLabel := config.Get().VersionLabelName
 
-	for _, s := range trafficMap {
-		// TODO FIX s.ServiceName, s.Name --> s.App to compile
-		if s.App == graph.UnknownApp {
-			return
+	for _, n := range trafficMap {
+		// dead nodes have no pods
+		if isDead, ok := n.Metadata["isDead"]; ok && isDead.(bool) {
+			continue
 		}
 
-		pods, err := k8s.GetPods(s.Namespace, fmt.Sprintf("%s=%s,%s=%s", appLabel, s.App, versionLabel, s.Version))
+		// get the pods for the node, either by app+version labels, or workload deployment
+		var podLabels string
+		var err error
+		switch a.GraphType {
+		case graph.GraphTypeApp:
+			podLabels = a.getAppLabels(appLabel, n.App, versionLabel, n.Version)
+		case graph.GraphTypeWorkload:
+			podLabels, err = a.getWorkloadLabels(n.Namespace, n.Workload, k8s)
+			if err != nil {
+				continue
+			}
+		case graph.GraphTypeAppPreferred:
+			if n.App != graph.UnknownApp && (!a.Versioned || n.Version != graph.UnknownVersion) {
+				podLabels = a.getAppLabels(appLabel, n.App, versionLabel, n.Version)
+			} else {
+				podLabels, err = a.getWorkloadLabels(n.Namespace, n.Workload, k8s)
+				if err != nil {
+					continue
+				}
+			}
+		}
+
+		pods, err := k8s.GetPods(n.Namespace, podLabels)
 		checkError(err)
 
+		if len(pods.Items) == 0 {
+			log.Warningf("Sidecar check found no pods Checking sidecars node [%s] num pods [%v]", n.ID, len(pods.Items))
+		}
+
+		// check each pod for sidecar, stop and flag at first pod missing sidecar
 		checker := checkers.PodChecker{Pods: pods.Items}
 		validations := checker.Check()
 
-		sidecarsOk := true
 		for _, check := range validations {
-			sidecarsOk = sidecarsOk && check.Valid
+			if !check.Valid {
+				n.Metadata["hasMissingSC"] = true
+				break
+			}
 		}
-		s.Metadata["hasMissingSC"] = !sidecarsOk
 	}
+}
+
+func (a *SidecarsCheckAppender) getAppLabels(appLabel, app, versionLabel, version string) string {
+	if a.Versioned {
+		return fmt.Sprintf("%s=%s,%s=%s", appLabel, app, versionLabel, version)
+	}
+	return fmt.Sprintf("%s=%s", appLabel, app)
+}
+
+func (a *SidecarsCheckAppender) getWorkloadLabels(namespace, workload string, k8s *kubernetes.IstioClient) (string, error) {
+	deployment, err := k8s.GetDeployment(namespace, workload)
+	if err != nil {
+		return "", err
+	}
+	return labels.Set(deployment.Spec.Selector.MatchLabels).String(), nil
 }

--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -105,9 +105,9 @@ func NewConfig(trafficMap graph.TrafficMap, o options.VendorOptions) (result Con
 
 	buildConfig(trafficMap, &nodes, &edges, o)
 
-	// Add compound nodes that group together different versions of the same service
-	if o.GroupBy == options.GroupByVersion {
-		addCompoundNodes(&nodes)
+	// Add compound nodes that group together different versions of the same node
+	if o.GraphType != graph.GraphTypeWorkload && o.Versioned && o.GroupBy == options.GroupByVersion {
+		groupByVersion(&nodes)
 	}
 
 	// sort nodes and edges for better json presentation (and predictable testing)
@@ -340,7 +340,7 @@ func add(current string, val float64) string {
 
 // addCompoundNodes generates additional nodes to group multiple versions of the
 // same service.
-func addCompoundNodes(nodes *[]*NodeWrapper) {
+func groupByVersion(nodes *[]*NodeWrapper) {
 	grouped := make(map[string][]*NodeData)
 
 	for _, nw := range *nodes {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -77,7 +77,7 @@ func Id(namespace, workload, app, version, graphType string, versioned bool) str
 		}
 		return fmt.Sprintf("%v_%v", namespace, app)
 	case GraphTypeAppPreferred:
-		if app != UnknownApp {
+		if app != UnknownApp && (!versioned || version != UnknownVersion) {
 			if versioned {
 				return fmt.Sprintf("%v_%v_%v", namespace, app, version)
 			}

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -179,7 +179,10 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 		//appenders = append(appenders, appender.IstioAppender{})
 	}
 	if csl == AppenderAll || strings.Contains(csl, "sidecars_check") {
-		//appenders = append(appenders, appender.SidecarsCheckAppender{})
+		appenders = append(appenders, appender.SidecarsCheckAppender{
+			GraphType: o.GraphType,
+			Versioned: o.Versioned,
+		})
 	}
 
 	return appenders


### PR DESCRIPTION
- update to 1.0 nodes
- add support for workload nodes
  - restrict appPreferred nodes to requiring app+version labels
- enable appender

also:
- fix issue with group compound nodes, only add for versioned app or appPreferred