### PR TITLE
KIALI-1144 Add swagger documentation to validations endpoints

### DIFF
--- a/config/token.go
+++ b/config/token.go
@@ -18,19 +18,6 @@ type TokenClaim struct {
 	jwt.StandardClaims
 }
 
-// HTTP status code 200 and tokenGenerated model in data
-// swagger:response tokenGenerated
-type swaggTokenGeneratedResp struct {
-	// in:body
-	Body struct {
-		// HTTP status code
-		// default: 200
-		Code int `json:"code"`
-		// StatusInfo model
-		Data TokenGenerated `json:"data"`
-	}
-}
-
 // TokenGenerated tokenGenerated
 //
 // This is used for returning the token

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/services/models"
+	"github.com/kiali/kiali/status"
+)
+
+/////////////////////
+// SWAGGER PARAMETERS
+/////////////////////
+
+// A Namespace provide a scope for names.
+// This type used to describe a set of objects.
+//
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations
+type NamespaceParam struct {
+	// The id of the namespace.
+	//
+	// in: path
+	// required: true
+	Name string `json:"namespace"`
+}
+
+// Service identify the a service object
+//
+// swagger:parameters serviceValidations
+type ServiceParam struct {
+	// The name of the service
+	//
+	// in: path
+	// required: true
+	Name string `json:"service"`
+}
+
+// Istio Object Type:
+//
+// swagger:parameters objectValidations
+type ObjectType struct {
+	// The type of the istio object
+	//
+	// in: path
+	// required: true
+	// pattern: ^(gateways|virtualservices|destinationrules|serviceentries|rules|quotaspecs|quotaspecbindings)$
+	Name string `json:"object_type"`
+}
+
+// Istio Object name
+//
+// swagger:parameters objectValidations
+type ObjectName struct {
+	// The name of the istio object
+	//
+	// in: path
+	// required: true
+	Name string `json:"object"`
+}
+
+/////////////////////
+// SWAGGER RESPONSES
+/////////////////////
+
+// A GenericError is the default error message that is generated.
+//
+// swagger:response genericError
+type GenericError struct {
+	// in: body
+	Body struct {
+		// HTTP status code
+		// example: 400
+		// default: 400
+		Code    int32 `json:"code"`
+		Message error `json:"message"`
+	} `json:"body"`
+}
+
+// A NotFoundError is the error message that is generated when server could not find what was requested.
+//
+// swagger:response notFoundError
+type NotFoundError struct {
+	// in: body
+	Body struct {
+		// HTTP status code
+		// example: 404
+		// default: 404
+		Code    int32 `json:"code"`
+		Message error `json:"message"`
+	} `json:"body"`
+}
+
+// A Internal is the error message that means something has gone wrong
+//
+// swagger:response internalError
+type InternalError struct {
+	// in: body
+	Body struct {
+		// HTTP status code
+		// example: 500
+		// default: 500
+		Code    int32 `json:"code"`
+		Message error `json:"message"`
+	} `json:"body"`
+}
+
+// HTTP status code 200 and statusInfo model in data
+// swagger:response statusInfo
+type swaggStatusInfoResp struct {
+	// in:body
+	Body status.StatusInfo
+}
+
+// HTTP status code 200 and tokenGenerated model in data
+// swagger:response tokenGenerated
+type swaggTokenGeneratedResp struct {
+	// in:body
+	Body config.TokenGenerated
+}
+
+// HTTP status code 200 and IstioConfigList model in data
+// swagger:response istioConfigList
+type IstioConfigResponse struct {
+	// in:body
+	Body models.IstioConfigList
+}
+
+// Listing all istio validations for object in the namespace
+// swagger:response namespaceValidationsResponse
+type NamespaceValidationResponse struct {
+	// in:body
+	Body NamespaceValidations
+}
+
+// Listing all istio validations for object in the namespace
+// swagger:response typeValidationsResponse
+type ServiceValidationResponse struct {
+	// in:body
+	Body TypedIstioValidations
+}
+
+//////////////////
+// SWAGGER MODELS
+//////////////////
+
+// List of validations grouped by namespace
+// swagger:model
+type NamespaceValidations map[string]TypedIstioValidations
+
+// List of validations grouped by object type
+// swagger:model
+type TypedIstioValidations map[string]NameIstioValidation
+
+// List of validations grouped by object name
+// swagger:model
+type NameIstioValidation map[string]models.IstioValidation

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -20,48 +20,6 @@ type Routes struct {
 	Routes []Route
 }
 
-// A GenericError is the default error message that is generated.
-//
-// swagger:response genericError
-type GenericError struct {
-	// in: body
-	Body struct {
-		// HTTP status code
-		// example: 400
-		// default: 400
-		Code    int32 `json:"code"`
-		Message error `json:"message"`
-	} `json:"body"`
-}
-
-// A NotFoundError is the error message that is generated when server could not find what was requested.
-//
-// swagger:response notFoundError
-type NotFoundError struct {
-	// in: body
-	Body struct {
-		// HTTP status code
-		// example: 404
-		// default: 404
-		Code    int32 `json:"code"`
-		Message error `json:"message"`
-	} `json:"body"`
-}
-
-// A Internal is the error message that means something has gone wrong
-//
-// swagger:response internalError
-type InternalError struct {
-	// in: body
-	Body struct {
-		// HTTP status code
-		// example: 500
-		// default: 500
-		Code    int32 `json:"code"`
-		Message error `json:"message"`
-	} `json:"body"`
-}
-
 // NewRoutes creates and returns all the API routes
 func NewRoutes() (r *Routes) {
 	r = new(Routes)
@@ -173,6 +131,24 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigDetails,
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/istio/{object_type}/{object}/istio_validations validations objectValidations
+		// ---
+		// Endpoint to get the list of istio object validations for a service
+		//
+		//     Consumes:
+		//     - application/json
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      default: genericError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: typeValidationsResponse
+		//
 		{
 			"IstioConfigValidation",
 			"GET",
@@ -226,6 +202,24 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceHealth,
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/services/{service}/istio_validations validations serviceValidations
+		// ---
+		// Endpoint to get the list of istio object validations for a service
+		//
+		//     Consumes:
+		//     - application/json
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      default: genericError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: typeValidationsResponse
+		//
 		{
 			"ServiceValidations",
 			"GET",
@@ -247,6 +241,24 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceHealth,
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/istio_validations validations namespaceValidations
+		// ---
+		// Endpoint to get the list of istio object validations for a namespace
+		//
+		//     Consumes:
+		//     - application/json
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      default: genericError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: namespaceValidationsResponse
+		//
 		{
 			"NamespaceValidations",
 			"GET",

--- a/services/models/istio_config.go
+++ b/services/models/istio_config.go
@@ -1,18 +1,5 @@
 package models
 
-// HTTP status code 200 and IstioConfigList model in data
-// swagger:response istioConfigList
-type swaggIstioConfigList struct {
-	// in:body
-	Body struct {
-		// HTTP status code
-		// default: 200
-		Code int `json:"code"`
-		// IstioConfigList model
-		Data IstioConfigList `json:"data"`
-	}
-}
-
 // IstioConfigList istioConfigList
 //
 // This type is used for returning a response of IstioConfigList

--- a/services/models/istio_validation.go
+++ b/services/models/istio_validation.go
@@ -17,18 +17,43 @@ type IstioValidationKey struct {
 type IstioValidations map[IstioValidationKey]*IstioValidation
 
 // IstioValidation represents a list of checks associated to an Istio object.
+// swagger:model
 type IstioValidation struct {
-	Name       string        `json:"name"`       // Name of the object itself
-	ObjectType string        `json:"objectType"` // Type of the object
-	Valid      bool          `json:"valid"`      // Represents validity of the object: in case of warning, validity remainds as true
-	Checks     []*IstioCheck `json:"checks"`     // Array of checks
+	// Name of the object itself
+	// required: true
+	// example: reviews
+	Name string `json:"name"`
+
+	// Type of the object
+	// required: true
+	// example: virtualservice
+	ObjectType string `json:"objectType"`
+
+	// Represents validity of the object: in case of warning, validity remains as true
+	// required: true
+	// example: false
+	Valid bool `json:"valid"`
+
+	// Array of checks. It might be empty.
+	Checks []*IstioCheck `json:"checks"`
 }
 
 // IstioCheck represents an individual check.
+// swagger:model
 type IstioCheck struct {
-	Message  string `json:"message"`  // Description of the check
-	Severity string `json:"severity"` // Indicates the level of importance: error or warning
-	Path     string `json:"path"`     // String that describes where in the yaml file is the check located
+	// Description of the check
+	// required: true
+	// example: Weight sum should be 100
+	Message string `json:"message"`
+
+	// Indicates the level of importance: error or warning
+	// required: true
+	// example: error
+	Severity string `json:"severity"`
+
+	// String that describes where in the yaml file is the check located
+	// example: spec/http[0]/route
+	Path string `json:"path"`
 }
 
 var ObjectTypeSingular = map[string]string{

--- a/services/models/namespace.go
+++ b/services/models/namespace.go
@@ -6,18 +6,6 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 )
 
-// A Namespace provide a scope for names.
-// This type used to describe a set of objects.
-//
-// swagger:parameters istioConfigList
-type NamespaceParam struct {
-	// The id of the namespace.
-	//
-	// in: path
-	// required: true
-	Name string `json:"namespace"`
-}
-
 // A Namespace provide a scope for names
 // This type is used to describe a set of objects.
 //

--- a/status/status.go
+++ b/status/status.go
@@ -10,20 +10,6 @@ const (
 	StateRunning   = "running"
 )
 
-// HTTP status code 200 and statusInfo model in data
-// swagger:response statusInfo
-type swaggStatusInfoResp struct {
-	// in:body
-	Body struct {
-		// HTTP status code
-		// example: 200
-		// default: 200
-		Code int `json:"code"`
-		// StatusInfo model
-		Data StatusInfo `json:"data"`
-	}
-}
-
 // StatusInfo statusInfo
 //
 // This is used for returning a response of Kiali Status

--- a/swagger.json
+++ b/swagger.json
@@ -87,6 +87,160 @@
         }
       }
     },
+    "/namespaces/{namespace}/istio/{object_type}/{object}/istio_validations": {
+      "get": {
+        "description": "Endpoint to get the list of istio object validations for a service",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "validations"
+        ],
+        "operationId": "objectValidations",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "pattern": "^(gateways|virtualservices|destinationrules|serviceentries|rules|quotaspecs|quotaspecbindings)$",
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The type of the istio object",
+            "name": "object_type",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name of the istio object",
+            "name": "object",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/typeValidationsResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/istio_validations": {
+      "get": {
+        "description": "Endpoint to get the list of istio object validations for a namespace",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "validations"
+        ],
+        "operationId": "namespaceValidations",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/namespaceValidationsResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/services/{service}/istio_validations": {
+      "get": {
+        "description": "Endpoint to get the list of istio object validations for a service",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "validations"
+        ],
+        "operationId": "serviceValidations",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name of the service",
+            "name": "service",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/typeValidationsResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
     "/status": {
       "get": {
         "description": "Endpoint to get the status of Kiali",
@@ -190,6 +344,35 @@
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
+    "IstioCheck": {
+      "type": "object",
+      "title": "IstioCheck represents an individual check.",
+      "required": [
+        "message",
+        "severity"
+      ],
+      "properties": {
+        "message": {
+          "description": "Description of the check",
+          "type": "string",
+          "x-go-name": "Message",
+          "example": "Weight sum should be 100"
+        },
+        "path": {
+          "description": "String that describes where in the yaml file is the check located",
+          "type": "string",
+          "x-go-name": "Path",
+          "example": "spec/http[0]/route"
+        },
+        "severity": {
+          "description": "Indicates the level of importance: error or warning",
+          "type": "string",
+          "x-go-name": "Severity",
+          "example": "error"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
     "IstioConfigList": {
       "description": "This type is used for returning a response of IstioConfigList",
       "type": "object",
@@ -198,9 +381,6 @@
         "namespace"
       ],
       "properties": {
-        "destinationPolicies": {
-          "$ref": "#/definitions/destinationPolicies"
-        },
         "destinationRules": {
           "$ref": "#/definitions/destinationRules"
         },
@@ -210,8 +390,11 @@
         "namespace": {
           "$ref": "#/definitions/namespace"
         },
-        "routeRules": {
-          "$ref": "#/definitions/routeRules"
+        "quotaSpecBindings": {
+          "$ref": "#/definitions/QuotaSpecBindings"
+        },
+        "quotaSpecs": {
+          "$ref": "#/definitions/QuotaSpecs"
         },
         "rules": {
           "$ref": "#/definitions/istioRules"
@@ -222,6 +405,122 @@
         "virtualServices": {
           "$ref": "#/definitions/virtualServices"
         }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "IstioValidation": {
+      "type": "object",
+      "title": "IstioValidation represents a list of checks associated to an Istio object.",
+      "required": [
+        "name",
+        "objectType",
+        "valid"
+      ],
+      "properties": {
+        "checks": {
+          "description": "Array of checks. It might be empty.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IstioCheck"
+          },
+          "x-go-name": "Checks"
+        },
+        "name": {
+          "description": "Name of the object itself",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "reviews"
+        },
+        "objectType": {
+          "description": "Type of the object",
+          "type": "string",
+          "x-go-name": "ObjectType",
+          "example": "virtualservice"
+        },
+        "valid": {
+          "description": "Represents validity of the object: in case of warning, validity remains as true",
+          "type": "boolean",
+          "x-go-name": "Valid",
+          "example": false
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "NameIstioValidation": {
+      "description": "List of validations grouped by object name",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/IstioValidation"
+      },
+      "x-go-package": "github.com/kiali/kiali"
+    },
+    "NamespaceValidations": {
+      "description": "List of validations grouped by namespace",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/TypedIstioValidations"
+      },
+      "x-go-package": "github.com/kiali/kiali"
+    },
+    "QuotaSpec": {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "x-go-name": "CreatedAt"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "resourceVersion": {
+          "type": "string",
+          "x-go-name": "ResourceVersion"
+        },
+        "rules": {
+          "type": "object",
+          "x-go-name": "Rules"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "QuotaSpecBinding": {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "x-go-name": "CreatedAt"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "quotaSpecs": {
+          "type": "object",
+          "x-go-name": "QuotaSpecs"
+        },
+        "resourceVersion": {
+          "type": "string",
+          "x-go-name": "ResourceVersion"
+        },
+        "services": {
+          "type": "object",
+          "x-go-name": "Services"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "QuotaSpecBindings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/QuotaSpecBinding"
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "QuotaSpecs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/QuotaSpec"
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
@@ -335,61 +634,13 @@
       },
       "x-go-package": "github.com/kiali/kiali/config"
     },
-    "destinationPolicies": {
-      "description": "This type is used for returning an array of DestinationPolicies",
-      "type": "array",
-      "title": "DestinationPolicies destinationPolicies",
-      "items": {
-        "$ref": "#/definitions/destinationPolicy"
-      },
-      "x-go-name": "DestinationPolicies",
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
-    "destinationPolicy": {
-      "description": "This type is used for returning a DestinationPolicy",
+    "TypedIstioValidations": {
+      "description": "List of validations grouped by object type",
       "type": "object",
-      "title": "DestinationPolicy destinationPolicy",
-      "required": [
-        "name",
-        "createdAt",
-        "resourceVersion"
-      ],
-      "properties": {
-        "circuitBreaker": {
-          "type": "object",
-          "x-go-name": "CircuitBreaker"
-        },
-        "createdAt": {
-          "description": "The creation date of the destinationPolicy",
-          "type": "string",
-          "pattern": "\\w[\\w-]+",
-          "x-go-name": "CreatedAt"
-        },
-        "destination": {
-          "type": "object",
-          "x-go-name": "Destination"
-        },
-        "loadbalancing": {
-          "type": "object",
-          "x-go-name": "LoadBalancing"
-        },
-        "name": {
-          "description": "The name of the destinationPolicy",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "resourceVersion": {
-          "description": "The resource version of the destinationPolicy",
-          "type": "string",
-          "x-go-name": "ResourceVersion"
-        },
-        "source": {
-          "type": "object",
-          "x-go-name": "Source"
-        }
+      "additionalProperties": {
+        "$ref": "#/definitions/NameIstioValidation"
       },
-      "x-go-name": "DestinationPolicy",
-      "x-go-package": "github.com/kiali/kiali/services/models"
+      "x-go-package": "github.com/kiali/kiali"
     },
     "destinationRule": {
       "description": "This is used for returning a DestinationRule",
@@ -519,107 +770,6 @@
       "x-go-name": "Namespace",
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
-    "routeRule": {
-      "description": "This type is used for returning a RouteRule",
-      "type": "object",
-      "title": "RouteRule routeRule",
-      "required": [
-        "name",
-        "createdAt",
-        "resourceVersion"
-      ],
-      "properties": {
-        "appendHeaders": {
-          "type": "object",
-          "x-go-name": "AppendHeaders"
-        },
-        "corsPolicy": {
-          "type": "object",
-          "x-go-name": "CorsPolicy"
-        },
-        "createdAt": {
-          "description": "The created time",
-          "type": "string",
-          "x-go-name": "CreatedAt",
-          "example": "2018-06-20T07:39:52Z"
-        },
-        "destination": {
-          "type": "object",
-          "x-go-name": "Destination"
-        },
-        "httpFault": {
-          "type": "object",
-          "x-go-name": "HttpFault"
-        },
-        "httpReqRetries": {
-          "type": "object",
-          "x-go-name": "HttpReqRetries"
-        },
-        "httpReqTimeout": {
-          "type": "object",
-          "x-go-name": "HttpReqTimeout"
-        },
-        "l4Fault": {
-          "type": "object",
-          "x-go-name": "L4Fault"
-        },
-        "match": {
-          "type": "object",
-          "x-go-name": "Match"
-        },
-        "mirror": {
-          "type": "object",
-          "x-go-name": "Mirror"
-        },
-        "name": {
-          "description": "The name of the routeRule",
-          "type": "string",
-          "x-go-name": "Name",
-          "example": "details-default"
-        },
-        "precedence": {
-          "type": "object",
-          "x-go-name": "Precedence"
-        },
-        "redirect": {
-          "type": "object",
-          "x-go-name": "Redirect"
-        },
-        "resourceVersion": {
-          "type": "string",
-          "x-go-name": "ResourceVersion",
-          "example": "1507"
-        },
-        "rewrite": {
-          "type": "object",
-          "x-go-name": "Rewrite"
-        },
-        "route": {
-          "type": "object",
-          "x-go-name": "Route"
-        },
-        "routeWarning": {
-          "type": "string",
-          "x-go-name": "RouteWarning"
-        },
-        "websocketUpgrade": {
-          "type": "object",
-          "x-go-name": "WebsocketUpgrade"
-        }
-      },
-      "x-go-name": "RouteRule",
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
-    "routeRules": {
-      "description": "This type is used for returning an array of RouteRule",
-      "type": "array",
-      "title": "RouteRules routeRules",
-      "items": {
-        "$ref": "#/definitions/routeRule"
-      },
-      "x-go-name": "RouteRules",
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
     "virtualService": {
       "description": "This type is used for returning a VirtualService",
       "type": "object",
@@ -720,19 +870,13 @@
     "istioConfigList": {
       "description": "HTTP status code 200 and IstioConfigList model in data",
       "schema": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "description": "HTTP status code",
-            "type": "integer",
-            "format": "int64",
-            "default": 200,
-            "x-go-name": "Code"
-          },
-          "data": {
-            "$ref": "#/definitions/IstioConfigList"
-          }
-        }
+        "$ref": "#/definitions/IstioConfigList"
+      }
+    },
+    "namespaceValidationsResponse": {
+      "description": "Listing all istio validations for object in the namespace",
+      "schema": {
+        "$ref": "#/definitions/NamespaceValidations"
       }
     },
     "notFoundError": {
@@ -758,38 +902,19 @@
     "statusInfo": {
       "description": "HTTP status code 200 and statusInfo model in data",
       "schema": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "description": "HTTP status code",
-            "type": "integer",
-            "format": "int64",
-            "default": 200,
-            "x-go-name": "Code",
-            "example": 200
-          },
-          "data": {
-            "$ref": "#/definitions/StatusInfo"
-          }
-        }
+        "$ref": "#/definitions/StatusInfo"
       }
     },
     "tokenGenerated": {
       "description": "HTTP status code 200 and tokenGenerated model in data",
       "schema": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "description": "HTTP status code",
-            "type": "integer",
-            "format": "int64",
-            "default": 200,
-            "x-go-name": "Code"
-          },
-          "data": {
-            "$ref": "#/definitions/TokenGenerated"
-          }
-        }
+        "$ref": "#/definitions/TokenGenerated"
+      }
+    },
+    "typeValidationsResponse": {
+      "description": "Listing all istio validations for object in the namespace",
+      "schema": {
+        "$ref": "#/definitions/TypedIstioValidations"
       }
     }
   }


### PR DESCRIPTION
In my process to add documentation to Validation endpoints:
* /api/namespaces/{namespace}/services/{service}/istio_validations
* /api/namespaces/{namespace}/istio_validations

I detect two issues:
1. GoSwagger doesn't allow us to document structs like `map[keyObject]valueObject`
2. Each API endpoint needs a different response (not letting us reuse a single response with different data object in the response body)

#### GoSwagger doesn't allow us to document structs like map[keyObject]valueObject

In [services/models/istio_validations.go#L17](https://github.com/kiali/kiali/blob/master/services/models/istio_validation.go#L17) we have the type:
```golang
// IstioValidations represents a set of IstioValidation grouped by IstioValidationKey.
type IstioValidations map[IstioValidationKey]*IstioValidation
```

Which is what we add in the response body for [service validations handler](https://github.com/kiali/kiali/blob/master/handlers/services.go#L103).

Check the GoSwagger warning [here](https://goswagger.io/faq/faq_spec.html#maps-as-swagger-parameters).

The workaround for that is to create three new structs that represents the same concept. Find them at the end of `doc.go`: 
```golang
type NamespaceValidations map[string]TypedIstioValidations
type TypedIstioValidations map[string]NameIstioValidation
type NameIstioValidation map[string]models.IstioValidation
```
These types are only used for documentation purposes. Changes into the actual implementation should might imply a change in this structure.

#### Each API endpoint needs a different response

In order to show the output of each route our API has, swagger needs a response struct (with a body field). Swagger doesn't allow us to create a generic response that can respond to different struct depending to the route (actually, this is how our server works: only one response method that convert any input struct to JSON).

Therefore, we need to create a different type for each API route. Plus, this type will be only for documentation purposes, because this will have no effect in any KIALI request.
Here an example:

```golang
// HTTP status code 200 and statusInfo model in data
// swagger:response statusInfo
type swaggStatusInfoResp struct {
	// in:body
	Body status.StatusInfo
}
```

My proposal is to have an specific file where we add this only-for-documentation code in order not to mix production code with documentation one.


#### Modifications output

![screenshot of api documentation](https://user-images.githubusercontent.com/613814/43319124-e361675c-91a3-11e8-8ccf-db3af4b372ad.jpg)
![screenshot of api documentation 1](https://user-images.githubusercontent.com/613814/43319130-e5fd23d4-91a3-11e8-858b-069d5db3450b.jpg)
![screenshot of api documentation 3](https://user-images.githubusercontent.com/613814/43319133-e8aa45d0-91a3-11e8-83f1-378cb74e5b3a.jpg)
