### PR TITLE
trivial - fix test

### DIFF
--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -76,7 +76,7 @@ func TestCheckVirtualService(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	assert.False(t, CheckVirtualService(nil, "", "", nil))
+	assert.False(t, CheckVirtualServiceSubset(nil, "", "", nil))
 
 	virtualService := MockIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -109,8 +109,8 @@ func TestCheckVirtualService(t *testing.T) {
 		},
 	}
 
-	assert.True(t, CheckVirtualService(&virtualService, "", "reviews", []string{"v1", "v2", "v3"}))
-	assert.False(t, CheckVirtualService(&virtualService, "", "reviews", []string{"v1"}))
+	assert.True(t, CheckVirtualServiceSubset(&virtualService, "", "reviews", []string{"v1", "v2", "v3"}))
+	assert.False(t, CheckVirtualServiceSubset(&virtualService, "", "reviews", []string{"v1"}))
 
 	virtualService = MockIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -143,8 +143,8 @@ func TestCheckVirtualService(t *testing.T) {
 		},
 	}
 
-	assert.True(t, CheckVirtualService(&virtualService, "", "reviews", []string{"v1", "v2", "v3"}))
-	assert.False(t, CheckVirtualService(&virtualService, "", "reviews", []string{"v1"}))
+	assert.True(t, CheckVirtualServiceSubset(&virtualService, "", "reviews", []string{"v1", "v2", "v3"}))
+	assert.False(t, CheckVirtualServiceSubset(&virtualService, "", "reviews", []string{"v1"}))
 }
 
 func TestGetDestinationRulesSubsets(t *testing.T) {


### PR DESCRIPTION
Update test to call renamed method.  We may just want to get rid of this renamed method,
it's no longer used and I'm not sure we ever want to look for a virtual service
based on subset.