### PR TITLE
KIALI-1215 , istio-1.0, new health endpoints

### DIFF
--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/graph/options"
-	"github.com/kiali/kiali/services/models"
 )
 
 type NodeData struct {
@@ -45,7 +44,6 @@ type NodeData struct {
 	HasCB        bool            `json:"hasCB,omitempty"`        // true (has circuit breaker) | false
 	HasMissingSC bool            `json:"hasMissingSC,omitempty"` // true (has missing sidecar) | false
 	HasVS        bool            `json:"hasVS,omitempty"`        // true (has route rule) | false
-	Health       *models.Health  `json:"health,omitempty"`
 	IsDead       bool            `json:"isDead,omitempty"`    // true (has no pods) | false
 	IsGroup      string          `json:"isGroup,omitempty"`   // set to the grouping type, current values: [ 'version' ]
 	IsOutside    bool            `json:"isOutside,omitempty"` // true | false

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -1,0 +1,204 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/kiali/kiali/services/business"
+)
+
+const defaultHealthRateInterval = "10m"
+
+// NamespaceHealth is the API handler to get app-based health of every services in the given namespace
+func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
+	// Get business layer
+	business, err := business.Get()
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+		return
+	}
+
+	p := namespaceHealthParams{}
+	if ok, err := p.extract(r); !ok {
+		// Bad request
+		RespondWithError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if p.Type == "app" {
+		health, err := business.Health.GetNamespaceAppHealth(p.Namespace, p.RateInterval)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Error while fetching app health: "+err.Error())
+			return
+		}
+		RespondWithJSON(w, http.StatusOK, health)
+	} else {
+		health, err := business.Health.GetNamespaceWorkloadHealth(p.Namespace, p.RateInterval)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Error while fetching workload health: "+err.Error())
+			return
+		}
+		RespondWithJSON(w, http.StatusOK, health)
+	}
+}
+
+// AppHealth is the API handler to get health of a single app
+func AppHealth(w http.ResponseWriter, r *http.Request) {
+	business, err := business.Get()
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+		return
+	}
+
+	p := appHealthParams{}
+	p.extract(r)
+
+	health, err := business.Health.GetAppHealth(p.Namespace, p.App, p.RateInterval)
+	handleHealthResponse(w, health, err)
+}
+
+// WorkloadHealth is the API handler to get health of a single workload
+func WorkloadHealth(w http.ResponseWriter, r *http.Request) {
+	business, err := business.Get()
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+		return
+	}
+
+	p := workloadHealthParams{}
+	p.extract(r)
+
+	health, err := business.Health.GetWorkloadHealth(p.Namespace, p.Workload, p.RateInterval)
+	handleHealthResponse(w, health, err)
+}
+
+// ServiceHealth is the API handler to get health of a single service
+func ServiceHealth(w http.ResponseWriter, r *http.Request) {
+	business, err := business.Get()
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+		return
+	}
+
+	p := serviceHealthParams{}
+	p.extract(r)
+
+	health, err := business.Health.GetServiceHealth(p.Namespace, p.Service, p.RateInterval)
+	handleHealthResponse(w, health, err)
+}
+
+func handleHealthResponse(w http.ResponseWriter, health interface{}, err error) {
+	if err != nil {
+		if errors.IsNotFound(err) {
+			RespondWithError(w, http.StatusNotFound, err.Error())
+		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+			RespondWithError(w, http.StatusInternalServerError, statusError.ErrStatus.Message)
+		} else {
+			RespondWithError(w, http.StatusInternalServerError, err.Error())
+		}
+	} else {
+		RespondWithJSON(w, http.StatusOK, health)
+	}
+}
+
+type baseHealthParams struct {
+	// The namespace scope
+	//
+	// in: path
+	Namespace string `json:"namespace"`
+	// The rate interval used for fetching error rate
+	//
+	// in: query
+	// default: 10m
+	RateInterval string `json:"rateInterval"`
+}
+
+func (p *baseHealthParams) baseExtract(r *http.Request, vars map[string]string) {
+	p.RateInterval = defaultHealthRateInterval
+	queryParams := r.URL.Query()
+	if rateIntervals, ok := queryParams["rateInterval"]; ok && len(rateIntervals) > 0 {
+		p.RateInterval = rateIntervals[0]
+	}
+	p.Namespace = vars["namespace"]
+}
+
+// namespaceHealthParams holds the path and query parameters for NamespaceHealth
+//
+// swagger:parameters namespaceHealth
+type namespaceHealthParams struct {
+	baseHealthParams
+	// The type of health, "app" or "workload".
+	//
+	// in: query
+	// pattern: ^(app|workload)$
+	// default: app
+	Type string `json:"type"`
+}
+
+func (p *namespaceHealthParams) extract(r *http.Request) (bool, string) {
+	vars := mux.Vars(r)
+	p.baseExtract(r, vars)
+	p.Type = "app"
+	queryParams := r.URL.Query()
+	if healthTypes, ok := queryParams["type"]; ok && len(healthTypes) > 0 {
+		if healthTypes[0] != "app" && healthTypes[0] != "workload" {
+			// Bad request
+			return false, "Bad request, query parameter 'type' must be either 'app' or 'workload'"
+		}
+		p.Type = healthTypes[0]
+	}
+	return true, ""
+}
+
+// appHealthParams holds the path and query parameters for AppHealth
+//
+// swagger:parameters appHealth
+type appHealthParams struct {
+	baseHealthParams
+	// The target app
+	//
+	// in: path
+	App string `json:"app"`
+}
+
+func (p *appHealthParams) extract(r *http.Request) {
+	vars := mux.Vars(r)
+	p.baseExtract(r, vars)
+	p.App = vars["app"]
+}
+
+// workloadHealthParams holds the path and query parameters for WorkloadHealth
+//
+// swagger:parameters workloadHealth
+type workloadHealthParams struct {
+	baseHealthParams
+	// The target workload
+	//
+	// in: path
+	Workload string `json:"workload"`
+}
+
+func (p *workloadHealthParams) extract(r *http.Request) {
+	vars := mux.Vars(r)
+	p.baseExtract(r, vars)
+	p.Workload = vars["workload"]
+}
+
+// serviceHealthParams holds the path and query parameters for ServiceHealth
+//
+// swagger:parameters serviceHealth
+type serviceHealthParams struct {
+	baseHealthParams
+	// The target service
+	//
+	// in: path
+	Service string `json:"service"`
+}
+
+func (p *serviceHealthParams) extract(r *http.Request) {
+	vars := mux.Vars(r)
+	p.baseExtract(r, vars)
+	p.Service = vars["service"]
+}

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -1,0 +1,149 @@
+package handlers
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/prometheustest"
+	"github.com/kiali/kiali/services/business"
+)
+
+// TestNamespaceAppHealth is unit test (testing request handling, not the prometheus client behaviour)
+func TestNamespaceAppHealth(t *testing.T) {
+	ts, k8s, prom := setupNamespaceHealthEndpoint(t)
+	defer ts.Close()
+
+	url := ts.URL + "/api/namespaces/ns/health"
+
+	k8s.On("GetNamespaceAppsDetails", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+		assert.Equal(t, "ns", args[0])
+	}).Return(k8s.FakeNamespaceApps(), nil)
+
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Run(func(args mock.Arguments) {
+		assert.Equal(t, "ns", args[0])
+		assert.Contains(t, []string{"reviews", "httpbin"}, args[1])
+	}).Return(prometheus.EnvoyServiceHealth{}, nil)
+
+	prom.On("GetAllRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(model.Vector{}, model.Vector{}, nil)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := ioutil.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	k8s.AssertNumberOfCalls(t, "GetNamespaceAppsDetails", 1)
+	prom.AssertNumberOfCalls(t, "GetServiceHealth", 2)
+	prom.AssertNumberOfCalls(t, "GetAllRequestRates", 1)
+}
+
+func setupNamespaceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
+	k8s := new(kubetest.K8SClientMock)
+	prom := new(prometheustest.PromClientMock)
+	business.SetWithBackends(k8s, prom)
+
+	mr := mux.NewRouter()
+	mr.HandleFunc("/api/namespaces/{namespace}/health", NamespaceHealth)
+
+	ts := httptest.NewServer(mr)
+	return ts, k8s, prom
+}
+
+// TestAppHealth is unit test (testing request handling, not the prometheus client behaviour)
+func TestAppHealth(t *testing.T) {
+	ts, k8s, prom := setupAppHealthEndpoint(t)
+	defer ts.Close()
+
+	url := ts.URL + "/api/namespaces/ns/apps/reviews/health"
+
+	k8s.On("GetAppDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+		assert.Equal(t, "ns", args[0])
+		assert.Equal(t, "reviews", args[1])
+	}).Return(k8s.FakeAppDetails(), nil)
+
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Run(func(args mock.Arguments) {
+		assert.Equal(t, "ns", args[0])
+		assert.Equal(t, "reviews", args[1])
+	}).Return(prometheus.EnvoyServiceHealth{}, nil)
+
+	prom.On("GetAppRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(model.Vector{}, model.Vector{}, nil)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := ioutil.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	k8s.AssertNumberOfCalls(t, "GetAppDetails", 1)
+	prom.AssertNumberOfCalls(t, "GetServiceHealth", 1)
+	prom.AssertNumberOfCalls(t, "GetAppRequestRates", 1)
+}
+
+func setupAppHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
+	k8s := new(kubetest.K8SClientMock)
+	prom := new(prometheustest.PromClientMock)
+	business.SetWithBackends(k8s, prom)
+
+	mr := mux.NewRouter()
+	mr.HandleFunc("/api/namespaces/{namespace}/apps/{app}/health", AppHealth)
+
+	ts := httptest.NewServer(mr)
+	return ts, k8s, prom
+}
+
+// TestServiceHealth is unit test (testing request handling, not the prometheus client behaviour)
+func TestServiceHealth(t *testing.T) {
+	ts, k8s, prom := setupServiceHealthEndpoint(t)
+	defer ts.Close()
+
+	url := ts.URL + "/api/namespaces/ns/services/svc/health"
+
+	k8s.On("GetServiceDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+		assert.Equal(t, "ns", args[0])
+		assert.Equal(t, "svc", args[1])
+	}).Return(k8s.FakeServiceDetails(), nil)
+
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Run(func(args mock.Arguments) {
+		assert.Equal(t, "ns", args[0])
+		assert.Equal(t, "svc", args[1])
+	}).Return(prometheus.EnvoyServiceHealth{}, nil)
+
+	prom.On("GetServiceRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(model.Vector{}, nil)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := ioutil.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	k8s.AssertNumberOfCalls(t, "GetServiceDetails", 1)
+	prom.AssertNumberOfCalls(t, "GetServiceHealth", 1)
+	prom.AssertNumberOfCalls(t, "GetServiceRequestRates", 1)
+}
+
+func setupServiceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
+	k8s := new(kubetest.K8SClientMock)
+	prom := new(prometheustest.PromClientMock)
+	business.SetWithBackends(k8s, prom)
+
+	mr := mux.NewRouter()
+	mr.HandleFunc("/api/namespaces/{namespace}/services/{service}/health", ServiceHealth)
+
+	ts := httptest.NewServer(mr)
+	return ts, k8s, prom
+}

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -33,7 +33,7 @@ func TestNamespaceAppHealth(t *testing.T) {
 		assert.Contains(t, []string{"reviews", "httpbin"}, args[1])
 	}).Return(prometheus.EnvoyServiceHealth{}, nil)
 
-	prom.On("GetAllRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(model.Vector{}, model.Vector{}, nil)
+	prom.On("GetAllRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(model.Vector{}, nil)
 
 	resp, err := http.Get(url)
 	if err != nil {

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -28,33 +28,6 @@ func NamespaceMetrics(w http.ResponseWriter, r *http.Request) {
 	getNamespaceMetrics(w, r, prometheus.NewClient)
 }
 
-// NamespaceHealth is the API handler to get health of every services in the given namespace
-func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
-	// Get business layer
-	business, err := business.Get()
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
-
-	vars := mux.Vars(r)
-	namespace := vars["namespace"]
-
-	// Rate interval is needed to fetch request rates based health
-	rateInterval := defaultHealthRateInterval
-	queryParams := r.URL.Query()
-	if rateIntervals, ok := queryParams["rateInterval"]; ok && len(rateIntervals) > 0 {
-		rateInterval = rateIntervals[0]
-	}
-
-	health, err := business.Health.GetNamespaceHealth(namespace, rateInterval)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Error while fetching health: "+err.Error())
-		return
-	}
-	RespondWithJSON(w, http.StatusOK, health)
-}
-
 // NamespaceIstioValidations is the API handler to get istio validations of a given namespace
 func NamespaceIstioValidations(w http.ResponseWriter, r *http.Request) {
 	// Get business layer

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -11,18 +11,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"k8s.io/api/apps/v1beta1"
-	kube_v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
-	"github.com/kiali/kiali/services/business"
 )
 
 // TestNamespaceMetricsDefault is unit test (testing request handling, not the prometheus client behaviour)
@@ -141,147 +134,4 @@ func setupNamespaceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheust
 
 	ts := httptest.NewServer(mr)
 	return ts, api
-}
-
-// TestNamespaceHealth is unit test (testing request handling, not the prometheus client behaviour)
-func TestNamespaceHealth(t *testing.T) {
-	ts, k8s, prom := setupNamespaceHealthEndpoint(t)
-	defer ts.Close()
-
-	url := ts.URL + "/api/namespaces/ns/health"
-
-	k8s.On("GetFullServices", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
-		assert.Equal(t, "ns", args[0])
-	}).Return(fakeServiceList(), nil)
-
-	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Run(func(args mock.Arguments) {
-		assert.Equal(t, "ns", args[0])
-		assert.Contains(t, []string{"reviews", "httpbin"}, args[1])
-	}).Return(prometheus.EnvoyHealth{}, nil)
-
-	prom.On("GetNamespaceRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(model.Vector{}, model.Vector{}, nil)
-
-	resp, err := http.Get(url)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, _ := ioutil.ReadAll(resp.Body)
-
-	assert.NotEmpty(t, actual)
-	assert.Equal(t, 200, resp.StatusCode, string(actual))
-	k8s.AssertNumberOfCalls(t, "GetFullServices", 1)
-	prom.AssertNumberOfCalls(t, "GetServiceHealth", 2)
-}
-
-func setupNamespaceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
-	k8s := new(kubetest.K8SClientMock)
-	prom := new(prometheustest.PromClientMock)
-	business.SetWithBackends(k8s, prom)
-
-	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/health", NamespaceHealth)
-
-	ts := httptest.NewServer(mr)
-	return ts, k8s, prom
-}
-
-func fakeServiceList() *kubernetes.ServiceList {
-	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
-	t2, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:45 +0300")
-
-	return &kubernetes.ServiceList{
-		Services: &kube_v1.ServiceList{
-			Items: []kube_v1.Service{
-				kube_v1.Service{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:      "reviews",
-						Namespace: "tutorial",
-						Labels: map[string]string{
-							"app":     "reviews",
-							"version": "v1"}},
-					Spec: kube_v1.ServiceSpec{
-						ClusterIP: "fromservice",
-						Type:      "ClusterIP",
-						Selector:  map[string]string{"app": "reviews"},
-						Ports: []kube_v1.ServicePort{
-							{
-								Name:     "http",
-								Protocol: "TCP",
-								Port:     3001},
-							{
-								Name:     "http",
-								Protocol: "TCP",
-								Port:     3000}}}},
-				kube_v1.Service{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:      "httpbin",
-						Namespace: "tutorial",
-						Labels: map[string]string{
-							"app":     "httpbin",
-							"version": "v1"}},
-					Spec: kube_v1.ServiceSpec{
-						ClusterIP: "fromservice",
-						Type:      "ClusterIP",
-						Selector:  map[string]string{"app": "httpbin"},
-						Ports: []kube_v1.ServicePort{
-							{
-								Name:     "http",
-								Protocol: "TCP",
-								Port:     3001},
-							{
-								Name:     "http",
-								Protocol: "TCP",
-								Port:     3000}}}},
-			}},
-		Pods: &kube_v1.PodList{
-			Items: []kube_v1.Pod{
-				kube_v1.Pod{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:   "reviews-v1",
-						Labels: map[string]string{"app": "reviews", "version": "v1"}}},
-				kube_v1.Pod{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:   "reviews-v2",
-						Labels: map[string]string{"app": "reviews", "version": "v2"}}},
-				kube_v1.Pod{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:   "httpbin-v1",
-						Labels: map[string]string{"app": "httpbin", "version": "v1"}}},
-			}},
-		Deployments: &v1beta1.DeploymentList{
-			Items: []v1beta1.Deployment{
-				v1beta1.Deployment{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:              "reviews-v1",
-						CreationTimestamp: meta_v1.NewTime(t1)},
-					Status: v1beta1.DeploymentStatus{
-						Replicas:            3,
-						AvailableReplicas:   2,
-						UnavailableReplicas: 1},
-					Spec: v1beta1.DeploymentSpec{
-						Selector: &meta_v1.LabelSelector{
-							MatchLabels: map[string]string{"app": "reviews", "version": "v1"}}}},
-				v1beta1.Deployment{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:              "reviews-v2",
-						CreationTimestamp: meta_v1.NewTime(t1)},
-					Status: v1beta1.DeploymentStatus{
-						Replicas:            2,
-						AvailableReplicas:   1,
-						UnavailableReplicas: 1},
-					Spec: v1beta1.DeploymentSpec{
-						Selector: &meta_v1.LabelSelector{
-							MatchLabels: map[string]string{"app": "reviews", "version": "v2"}}}},
-				v1beta1.Deployment{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:              "httpbin-v1",
-						CreationTimestamp: meta_v1.NewTime(t2)},
-					Status: v1beta1.DeploymentStatus{
-						Replicas:            1,
-						AvailableReplicas:   1,
-						UnavailableReplicas: 0},
-					Spec: v1beta1.DeploymentSpec{
-						Selector: &meta_v1.LabelSelector{
-							MatchLabels: map[string]string{"app": "httpbin", "version": "v1"}}}},
-			}}}
 }

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -11,8 +11,6 @@ import (
 	"github.com/kiali/kiali/services/business"
 )
 
-const defaultHealthRateInterval = "10m"
-
 // ServiceList is the API handler to fetch the list of services in a given namespace
 func ServiceList(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
@@ -72,30 +70,6 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promClientSupplie
 	}
 	metrics := prometheusClient.GetMetrics(&params)
 	RespondWithJSON(w, http.StatusOK, metrics)
-}
-
-// ServiceHealth is the API handler to get health of a single service
-func ServiceHealth(w http.ResponseWriter, r *http.Request) {
-	// Get business layer
-	business, err := business.Get()
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
-
-	vars := mux.Vars(r)
-	namespace := vars["namespace"]
-	service := vars["service"]
-
-	// Rate interval is needed to fetch request rates based health
-	rateInterval := defaultHealthRateInterval
-	queryParams := r.URL.Query()
-	if rateIntervals, ok := queryParams["rateInterval"]; ok && len(rateIntervals) > 0 {
-		rateInterval = rateIntervals[0]
-	}
-
-	health := business.Health.GetServiceHealth(namespace, service, rateInterval)
-	RespondWithJSON(w, http.StatusOK, health)
 }
 
 // ServiceIstioValidations is the API handler to get istio validations of a single service that returns

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -37,6 +37,8 @@ type IstioClientInterface interface {
 	GetNamespaces() (*v1.NamespaceList, error)
 	GetService(namespace string, serviceName string) (*v1.Service, error)
 	GetFullServices(namespace string) (*ServiceList, error)
+	GetNamespaceAppsDetails(namespace string) (NamespaceApps, error)
+	GetAppDetails(namespace, app string) (AppDetails, error)
 	GetServices(namespace string) (*v1.ServiceList, error)
 	GetServiceDetails(namespace string, serviceName string) (*ServiceDetails, error)
 	GetPods(namespace, labelSelector string) (*v1.PodList, error)
@@ -56,6 +58,7 @@ type IstioClientInterface interface {
 	GetQuotaSpec(namespace string, quotaSpecName string) (IstioObject, error)
 	GetQuotaSpecBindings(namespace string) ([]IstioObject, error)
 	GetQuotaSpecBinding(namespace string, quotaSpecBindingName string) (IstioObject, error)
+	GetDeployments(namespace string) (*v1beta1.DeploymentList, error)
 	GetDeployment(namespace string, deploymentName string) (*v1beta1.Deployment, error)
 }
 

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -2,12 +2,15 @@ package kubernetes
 
 import (
 	"fmt"
+	"sync"
 
 	"k8s.io/api/apps/v1beta1"
 	autoscalingV1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kiali/kiali/config"
 )
 
 type servicesResponse struct {
@@ -85,6 +88,117 @@ func (in *IstioClient) GetFullServices(namespace string) (*ServiceList, error) {
 	}
 
 	return services, err
+}
+
+// GetNamespaceAppsDetails returns a map of apps details (services, deployments and pods) in the given namespace.
+// The map key is the app label.
+// Entities without app label are gathered under empty-string-key
+// It returns an error on any problem.
+func (in *IstioClient) GetNamespaceAppsDetails(namespace string) (NamespaceApps, error) {
+	allEntities := make(NamespaceApps)
+	var err error
+	servicesChan, podsChan, deploymentsChan := make(chan servicesResponse), make(chan podsResponse), make(chan deploymentsResponse)
+	appLabel := config.Get().AppLabelName
+
+	go in.getServiceList(namespace, servicesChan)
+	go in.getPodsList(namespace, podsChan)
+	go in.getDeployments(namespace, deploymentsChan)
+
+	servicesResponse := <-servicesChan
+	podsResponse := <-podsChan
+	deploymentsResponse := <-deploymentsChan
+	for _, service := range servicesResponse.services.Items {
+		app := service.Labels[appLabel]
+		if appEntities, ok := allEntities[app]; ok {
+			appEntities.Services = append(appEntities.Services, service)
+		} else {
+			allEntities[app] = &AppDetails{
+				app:      app,
+				Services: []v1.Service{service},
+			}
+		}
+	}
+	for _, pod := range podsResponse.pods.Items {
+		app := pod.Labels[appLabel]
+		if appEntities, ok := allEntities[app]; ok {
+			appEntities.Pods = append(appEntities.Pods, pod)
+		} else {
+			allEntities[app] = &AppDetails{
+				app:  app,
+				Pods: []v1.Pod{pod},
+			}
+		}
+	}
+	for _, depl := range deploymentsResponse.deployments.Items {
+		app := depl.Labels[appLabel]
+		if appEntities, ok := allEntities[app]; ok {
+			appEntities.Deployments = append(appEntities.Deployments, depl)
+		} else {
+			allEntities[app] = &AppDetails{
+				app:         app,
+				Deployments: []v1beta1.Deployment{depl},
+			}
+		}
+	}
+
+	if servicesResponse.err != nil {
+		err = servicesResponse.err
+	} else if podsResponse.err != nil {
+		err = podsResponse.err
+	} else {
+		err = deploymentsResponse.err
+	}
+
+	return allEntities, err
+}
+
+// GetAppDetails returns the app details (services, deployments and pods) for the input app label.
+// It returns an error on any problem.
+func (in *IstioClient) GetAppDetails(namespace, app string) (AppDetails, error) {
+	var errSvc, errPods, errDepls error
+	var wg sync.WaitGroup
+	var services *v1.ServiceList
+	var pods *v1.PodList
+	var depls *v1beta1.DeploymentList
+	appLabel := config.Get().AppLabelName
+	opts := meta_v1.ListOptions{LabelSelector: appLabel + "=" + app}
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		services, errSvc = in.k8s.CoreV1().Services(namespace).List(opts)
+	}()
+	go func() {
+		defer wg.Done()
+		pods, errPods = in.k8s.CoreV1().Pods(namespace).List(opts)
+	}()
+	go func() {
+		defer wg.Done()
+		depls, errDepls = in.k8s.AppsV1beta1().Deployments(namespace).List(opts)
+	}()
+
+	wg.Wait()
+
+	details := AppDetails{
+		Services:    []v1.Service{},
+		Pods:        []v1.Pod{},
+		Deployments: []v1beta1.Deployment{},
+	}
+	if services != nil {
+		details.Services = services.Items
+	}
+	if pods != nil {
+		details.Pods = pods.Items
+	}
+	if depls != nil {
+		details.Deployments = depls.Items
+	}
+	if errSvc != nil {
+		return details, errSvc
+	} else if errPods != nil {
+		return details, errPods
+	}
+	return details, errDepls
 }
 
 // GetServices returns a list of services for a given namespace.

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -1,9 +1,12 @@
 package kubetest
 
 import (
+	"time"
+
 	"github.com/stretchr/testify/mock"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/kubernetes"
 )
@@ -22,6 +25,11 @@ func (o *K8SClientMock) GetDeployment(namespace string, deploymentName string) (
 	return args.Get(0).(*v1beta1.Deployment), args.Error(1)
 }
 
+func (o *K8SClientMock) GetDeployments(namespace string) (*v1beta1.DeploymentList, error) {
+	args := o.Called(namespace)
+	return args.Get(0).(*v1beta1.DeploymentList), args.Error(1)
+}
+
 func (o *K8SClientMock) GetService(namespace string, serviceName string) (*v1.Service, error) {
 	args := o.Called(namespace, serviceName)
 	return args.Get(0).(*v1.Service), args.Error(1)
@@ -30,6 +38,16 @@ func (o *K8SClientMock) GetService(namespace string, serviceName string) (*v1.Se
 func (o *K8SClientMock) GetFullServices(namespace string) (*kubernetes.ServiceList, error) {
 	args := o.Called(namespace)
 	return args.Get(0).(*kubernetes.ServiceList), args.Error(1)
+}
+
+func (o *K8SClientMock) GetNamespaceAppsDetails(namespace string) (kubernetes.NamespaceApps, error) {
+	args := o.Called(namespace)
+	return args.Get(0).(kubernetes.NamespaceApps), args.Error(1)
+}
+
+func (o *K8SClientMock) GetAppDetails(namespace, app string) (kubernetes.AppDetails, error) {
+	args := o.Called(namespace, app)
+	return args.Get(0).(kubernetes.AppDetails), args.Error(1)
 }
 
 func (o *K8SClientMock) GetServices(namespace string) (*v1.ServiceList, error) {
@@ -130,4 +148,244 @@ func (o *K8SClientMock) GetQuotaSpecBindings(namespace string) ([]kubernetes.Ist
 func (o *K8SClientMock) GetQuotaSpecBinding(namespace string, quotaSpecBindingName string) (kubernetes.IstioObject, error) {
 	args := o.Called(namespace, quotaSpecBindingName)
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
+}
+
+func (o *K8SClientMock) FakeServiceDetails() *kubernetes.ServiceDetails {
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+
+	return &kubernetes.ServiceDetails{
+		Service: &v1.Service{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "httpbin",
+				Namespace: "tutorial",
+				Labels: map[string]string{
+					"app":     "httpbin",
+					"version": "v1"}},
+			Spec: v1.ServiceSpec{
+				ClusterIP: "fromservice",
+				Type:      "ClusterIP",
+				Selector:  map[string]string{"app": "httpbin"},
+				Ports: []v1.ServicePort{
+					{
+						Name:     "http",
+						Protocol: "TCP",
+						Port:     3001},
+					{
+						Name:     "http",
+						Protocol: "TCP",
+						Port:     3000}}}},
+		Deployments: &v1beta1.DeploymentList{
+			Items: []v1beta1.Deployment{
+				v1beta1.Deployment{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "httpbin-v1",
+						CreationTimestamp: meta_v1.NewTime(t1),
+						Labels:            map[string]string{"app": "httpbin", "version": "v1"}},
+					Status: v1beta1.DeploymentStatus{
+						Replicas:            1,
+						AvailableReplicas:   1,
+						UnavailableReplicas: 0}}}}}
+}
+
+func (o *K8SClientMock) FakeServiceList() *kubernetes.ServiceList {
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	t2, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:45 +0300")
+
+	return &kubernetes.ServiceList{
+		Services: &v1.ServiceList{
+			Items: []v1.Service{
+				v1.Service{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:      "reviews",
+						Namespace: "tutorial",
+						Labels: map[string]string{
+							"app":     "reviews",
+							"version": "v1"}},
+					Spec: v1.ServiceSpec{
+						ClusterIP: "fromservice",
+						Type:      "ClusterIP",
+						Selector:  map[string]string{"app": "reviews"},
+						Ports: []v1.ServicePort{
+							{
+								Name:     "http",
+								Protocol: "TCP",
+								Port:     3001},
+							{
+								Name:     "http",
+								Protocol: "TCP",
+								Port:     3000}}}},
+				v1.Service{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:      "httpbin",
+						Namespace: "tutorial",
+						Labels: map[string]string{
+							"app":     "httpbin",
+							"version": "v1"}},
+					Spec: v1.ServiceSpec{
+						ClusterIP: "fromservice",
+						Type:      "ClusterIP",
+						Selector:  map[string]string{"app": "httpbin"},
+						Ports: []v1.ServicePort{
+							{
+								Name:     "http",
+								Protocol: "TCP",
+								Port:     3001},
+							{
+								Name:     "http",
+								Protocol: "TCP",
+								Port:     3000}}}},
+			}},
+		Pods: &v1.PodList{
+			Items: []v1.Pod{
+				v1.Pod{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:   "reviews-v1",
+						Labels: map[string]string{"app": "reviews", "version": "v1"}}},
+				v1.Pod{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:   "reviews-v2",
+						Labels: map[string]string{"app": "reviews", "version": "v2"}}},
+				v1.Pod{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:   "httpbin-v1",
+						Labels: map[string]string{"app": "httpbin", "version": "v1"}}},
+			}},
+		Deployments: &v1beta1.DeploymentList{
+			Items: []v1beta1.Deployment{
+				v1beta1.Deployment{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "reviews-v1",
+						CreationTimestamp: meta_v1.NewTime(t1)},
+					Status: v1beta1.DeploymentStatus{
+						Replicas:            3,
+						AvailableReplicas:   2,
+						UnavailableReplicas: 1},
+					Spec: v1beta1.DeploymentSpec{
+						Selector: &meta_v1.LabelSelector{
+							MatchLabels: map[string]string{"app": "reviews", "version": "v1"}}}},
+				v1beta1.Deployment{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "reviews-v2",
+						CreationTimestamp: meta_v1.NewTime(t1)},
+					Status: v1beta1.DeploymentStatus{
+						Replicas:            2,
+						AvailableReplicas:   1,
+						UnavailableReplicas: 1},
+					Spec: v1beta1.DeploymentSpec{
+						Selector: &meta_v1.LabelSelector{
+							MatchLabels: map[string]string{"app": "reviews", "version": "v2"}}}},
+				v1beta1.Deployment{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "httpbin-v1",
+						CreationTimestamp: meta_v1.NewTime(t2)},
+					Status: v1beta1.DeploymentStatus{
+						Replicas:            1,
+						AvailableReplicas:   1,
+						UnavailableReplicas: 0},
+					Spec: v1beta1.DeploymentSpec{
+						Selector: &meta_v1.LabelSelector{
+							MatchLabels: map[string]string{"app": "httpbin", "version": "v1"}}}},
+			}}}
+}
+
+func (o *K8SClientMock) FakeNamespaceApps() kubernetes.NamespaceApps {
+	ret := make(kubernetes.NamespaceApps)
+	ret["reviews"] = &kubernetes.AppDetails{
+		Services: []v1.Service{
+			v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "reviews",
+					Namespace: "tutorial",
+					Labels: map[string]string{
+						"app":     "reviews",
+						"version": "v1"}},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "fromservice",
+					Type:      "ClusterIP",
+					Selector:  map[string]string{"app": "reviews"},
+					Ports: []v1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     3001},
+						{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     3000}}}}},
+		Pods: []v1.Pod{
+			v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:   "reviews-v1",
+					Labels: map[string]string{"app": "reviews", "version": "v1"}}},
+			v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:   "reviews-v2",
+					Labels: map[string]string{"app": "reviews", "version": "v2"}}}},
+		Deployments: []v1beta1.Deployment{
+			v1beta1.Deployment{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "reviews-v1"},
+				Status: v1beta1.DeploymentStatus{
+					Replicas:            3,
+					AvailableReplicas:   2,
+					UnavailableReplicas: 1},
+				Spec: v1beta1.DeploymentSpec{
+					Selector: &meta_v1.LabelSelector{
+						MatchLabels: map[string]string{"app": "reviews", "version": "v1"}}}},
+			v1beta1.Deployment{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "reviews-v2"},
+				Status: v1beta1.DeploymentStatus{
+					Replicas:            2,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 1},
+				Spec: v1beta1.DeploymentSpec{
+					Selector: &meta_v1.LabelSelector{
+						MatchLabels: map[string]string{"app": "reviews", "version": "v2"}}}}},
+	}
+	ret["httpbin"] = &kubernetes.AppDetails{
+		Services: []v1.Service{
+			v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "httpbin",
+					Namespace: "tutorial",
+					Labels: map[string]string{
+						"app":     "httpbin",
+						"version": "v1"}},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "fromservice",
+					Type:      "ClusterIP",
+					Selector:  map[string]string{"app": "httpbin"},
+					Ports: []v1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     3001},
+						{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     3000}}}}},
+		Pods: []v1.Pod{
+			v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:   "httpbin-v1",
+					Labels: map[string]string{"app": "httpbin", "version": "v1"}}}},
+		Deployments: []v1beta1.Deployment{
+			v1beta1.Deployment{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "httpbin-v1"},
+				Status: v1beta1.DeploymentStatus{
+					Replicas:            1,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 0},
+				Spec: v1beta1.DeploymentSpec{
+					Selector: &meta_v1.LabelSelector{
+						MatchLabels: map[string]string{"app": "httpbin", "version": "v1"}}}}},
+	}
+	return ret
+}
+
+func (o *K8SClientMock) FakeAppDetails() kubernetes.AppDetails {
+	app, _ := o.FakeNamespaceApps()["reviews"]
+	return *app
 }

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -394,11 +394,23 @@ type IstioObjectList interface {
 	GetItems() []IstioObject
 }
 
+// ServiceList holds list of services, pods and deployments
 type ServiceList struct {
 	Services    *v1.ServiceList
 	Pods        *v1.PodList
 	Deployments *v1beta1.DeploymentList
 }
+
+// AppDetails holds Services, Pods and Deployments having the same "app" label
+type AppDetails struct {
+	app         string
+	Services    []v1.Service
+	Pods        []v1.Pod
+	Deployments []v1beta1.Deployment
+}
+
+// NamespaceApps is a map of app_name x AppDetails
+type NamespaceApps = map[string]*AppDetails
 
 // ServiceDetails is a wrapper to group full Service description, Endpoints and Pods.
 // Used to fetch all details in a single operation instead to invoke individual APIs per each group.

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -16,7 +16,7 @@ import (
 // ClientInterface for mocks (only mocked function are necessary here)
 type ClientInterface interface {
 	GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyServiceHealth, error)
-	GetAllRequestRates(namespace, ratesInterval string) (model.Vector, model.Vector, error)
+	GetAllRequestRates(namespace, ratesInterval string) (model.Vector, error)
 	GetServiceRequestRates(namespace, service, ratesInterval string) (model.Vector, error)
 	GetAppRequestRates(namespace, app, ratesInterval string) (model.Vector, model.Vector, error)
 	GetWorkloadRequestRates(namespace, workload, ratesInterval string) (model.Vector, model.Vector, error)
@@ -117,10 +117,9 @@ func (in *Client) GetServiceHealth(namespace, servicename string, ports []int32)
 	return getServiceHealth(in.api, namespace, servicename, ports)
 }
 
-// GetAllRequestRates queries Prometheus to fetch request counters rates over a time interval
-// for each service, both in and out.
-// Returns (in, out, error)
-func (in *Client) GetAllRequestRates(namespace string, ratesInterval string) (model.Vector, model.Vector, error) {
+// GetAllRequestRates queries Prometheus to fetch request counters rates over a time interval within a namespace
+// Returns (rates, error)
+func (in *Client) GetAllRequestRates(namespace string, ratesInterval string) (model.Vector, error) {
 	return getAllRequestRates(in.api, namespace, ratesInterval)
 }
 

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -15,9 +15,11 @@ import (
 
 // ClientInterface for mocks (only mocked function are necessary here)
 type ClientInterface interface {
-	GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyHealth, error)
-	GetNamespaceRequestRates(namespace, ratesInterval string) (model.Vector, model.Vector, error)
-	GetAppsRequestRates(namespace string, apps []string, ratesInterval string) (model.Vector, model.Vector, error)
+	GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyServiceHealth, error)
+	GetAllRequestRates(namespace, ratesInterval string) (model.Vector, model.Vector, error)
+	GetServiceRequestRates(namespace, service, ratesInterval string) (model.Vector, error)
+	GetAppRequestRates(namespace, app, ratesInterval string) (model.Vector, model.Vector, error)
+	GetWorkloadRequestRates(namespace, workload, ratesInterval string) (model.Vector, model.Vector, error)
 	GetSourceWorkloads(namespace, servicename string) (map[string][]Workload, error)
 }
 
@@ -111,22 +113,36 @@ func (in *Client) GetMetrics(query *MetricsQuery) Metrics {
 // GetServiceHealth returns the Health related to the provided service identified by its namespace and service name.
 // It reads Envoy metrics, inbound and outbound
 // When the health is unavailable, total number of members will be 0.
-func (in *Client) GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyHealth, error) {
+func (in *Client) GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyServiceHealth, error) {
 	return getServiceHealth(in.api, namespace, servicename, ports)
 }
 
-// GetNamespaceRequestRates queries Prometheus to fetch request counters rates over a time interval
+// GetAllRequestRates queries Prometheus to fetch request counters rates over a time interval
 // for each service, both in and out.
 // Returns (in, out, error)
-func (in *Client) GetNamespaceRequestRates(namespace string, ratesInterval string) (model.Vector, model.Vector, error) {
-	return getNamespaceRequestRates(in.api, namespace, ratesInterval)
+func (in *Client) GetAllRequestRates(namespace string, ratesInterval string) (model.Vector, model.Vector, error) {
+	return getAllRequestRates(in.api, namespace, ratesInterval)
 }
 
-// GetAppsRequestRates queries Prometheus to fetch request counters rates over a time interval
-// for a given list of apps, both in and out.
+// GetServiceRequestRates queries Prometheus to fetch request counters rates over a time interval
+// for a given service (hence only inbound).
+// Returns (in, error)
+func (in *Client) GetServiceRequestRates(namespace, service, ratesInterval string) (model.Vector, error) {
+	return getServiceRequestRates(in.api, namespace, service, ratesInterval)
+}
+
+// GetAppRequestRates queries Prometheus to fetch request counters rates over a time interval
+// for a given app, both in and out.
 // Returns (in, out, error)
-func (in *Client) GetAppsRequestRates(namespace string, apps []string, ratesInterval string) (model.Vector, model.Vector, error) {
-	return getAppsRequestRates(in.api, namespace, apps, ratesInterval)
+func (in *Client) GetAppRequestRates(namespace, app, ratesInterval string) (model.Vector, model.Vector, error) {
+	return getItemRequestRates(in.api, namespace, app, "app", ratesInterval)
+}
+
+// GetWorkloadRequestRates queries Prometheus to fetch request counters rates over a time interval
+// for a given workload, both in and out.
+// Returns (in, out, error)
+func (in *Client) GetWorkloadRequestRates(namespace, workload, ratesInterval string) (model.Vector, model.Vector, error) {
+	return getItemRequestRates(in.api, namespace, workload, "workload", ratesInterval)
 }
 
 // API returns the Prometheus V1 HTTP API for performing calls not supported natively by this client

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -60,8 +60,8 @@ type Histogram struct {
 	Percentile99 *Metric `json:"percentile99"`
 }
 
-// EnvoyHealth is the number of healthy versus total membership (ie. replicas) inside envoy cluster (ie. service)
-type EnvoyHealth struct {
+// EnvoyServiceHealth is the number of healthy versus total membership (ie. replicas) inside envoy cluster (ie. service)
+type EnvoyServiceHealth struct {
 	Inbound  EnvoyRatio `json:"inbound"`
 	Outbound EnvoyRatio `json:"outbound"`
 }
@@ -72,8 +72,8 @@ type EnvoyRatio struct {
 	Total   int `json:"total"`
 }
 
-func getServiceHealth(api v1.API, namespace, servicename string, ports []int32) (EnvoyHealth, error) {
-	ret := EnvoyHealth{}
+func getServiceHealth(api v1.API, namespace, servicename string, ports []int32) (EnvoyServiceHealth, error) {
+	ret := EnvoyServiceHealth{}
 	if len(ports) == 0 {
 		return ret, nil
 	}
@@ -346,20 +346,17 @@ func replaceInvalidCharacters(metricName string) string {
 	return invalidLabelCharRE.ReplaceAllString(metricName, "_")
 }
 
-func getNamespaceRequestRates(api v1.API, namespace string, ratesInterval string) (model.Vector, model.Vector, error) {
-	reporter := "source"
+func getAllRequestRates(api v1.API, namespace string, ratesInterval string) (model.Vector, model.Vector, error) {
+	outReporter := "source"
 	if config.Get().IstioNamespace == namespace {
-		reporter = "destination"
+		outReporter = "destination"
 	}
-
-	// traffic originating outside the namespace to destinations inside the namespace
-	lblIn := fmt.Sprintf(`reporter="%s",destination_service_namespace="%s",source_workload_namespace!="%s"`, reporter, namespace, namespace)
+	lblIn := fmt.Sprintf(`reporter="destination",destination_workload_namespace="%s"`, namespace)
 	in, err := getRequestRatesForLabel(api, time.Now(), lblIn, ratesInterval)
 	if err != nil {
 		return model.Vector{}, model.Vector{}, err
 	}
-	// traffic originating inside the namespace to destinations inside or outside the namespace
-	lblOut := fmt.Sprintf(`reporter="%s",source_workload_namespace="%s"`, reporter, namespace)
+	lblOut := fmt.Sprintf(`reporter="%s",source_workload_namespace="%s"`, outReporter, namespace)
 	out, err := getRequestRatesForLabel(api, time.Now(), lblOut, ratesInterval)
 	if err != nil {
 		return model.Vector{}, model.Vector{}, err
@@ -367,24 +364,22 @@ func getNamespaceRequestRates(api v1.API, namespace string, ratesInterval string
 	return in, out, nil
 }
 
-func getAppsRequestRates(api v1.API, namespace string, apps []string, ratesInterval string) (model.Vector, model.Vector, error) {
-	lblIn := fmt.Sprintf(`reporter="destination",destination_workload_namespace="%s"`, namespace)
+func getServiceRequestRates(api v1.API, namespace, service, ratesInterval string) (model.Vector, error) {
+	lbl := fmt.Sprintf(`reporter="destination",destination_service_name="%s",destination_service_namespace="%s"`, service, namespace)
+	in, err := getRequestRatesForLabel(api, time.Now(), lbl, ratesInterval)
+	if err != nil {
+		return model.Vector{}, err
+	}
+	return in, nil
+}
+
+func getItemRequestRates(api v1.API, namespace, item, itemLabelSuffix, ratesInterval string) (model.Vector, model.Vector, error) {
+	lblIn := fmt.Sprintf(`reporter="destination",destination_workload_namespace="%s",destination_%s="%s"`, namespace, itemLabelSuffix, item)
 	outReporter := "source"
 	if config.Get().IstioNamespace == namespace {
 		outReporter = "destination"
 	}
-	lblOut := fmt.Sprintf(`reporter="%s",source_workload_namespace="%s"`, outReporter, namespace)
-	if len(apps) == 1 {
-		lblIn += fmt.Sprintf(`,destination_app="%s"`, apps[0])
-		lblOut += fmt.Sprintf(`,source_app="%s"`, apps[0])
-	} else if len(apps) > 1 {
-		strApps := strings.Join(apps, "|")
-		lblIn += fmt.Sprintf(`,destination_app=~"%s"`, strApps)
-		lblOut += fmt.Sprintf(`,source_app=~"%s"`, strApps)
-	} else {
-		// no app => no result
-		return model.Vector{}, model.Vector{}, nil
-	}
+	lblOut := fmt.Sprintf(`reporter="%s",source_workload_namespace="%s",source_%s="%s"`, outReporter, namespace, itemLabelSuffix, item)
 	in, err := getRequestRatesForLabel(api, time.Now(), lblIn, ratesInterval)
 	if err != nil {
 		return model.Vector{}, model.Vector{}, err

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -442,7 +442,7 @@ func TestGetAllRequestRates(t *testing.T) {
 			Metric:    model.Metric{"foo": "bar"},
 		},
 	}
-	mockQuery(api, `rate(istio_requests_total{reporter="destination",destination_workload_namespace="ns"}[5m])`, &vectorQ1)
+	mockQuery(api, `rate(istio_requests_total{reporter="source",destination_service_namespace="ns",source_workload_namespace!="ns"}[5m])`, &vectorQ1)
 
 	vectorQ2 := model.Vector{
 		&model.Sample{
@@ -452,11 +452,10 @@ func TestGetAllRequestRates(t *testing.T) {
 	}
 	mockQuery(api, `rate(istio_requests_total{reporter="source",source_workload_namespace="ns"}[5m])`, &vectorQ2)
 
-	in, out, err := client.GetAllRequestRates("ns", "5m")
-	assert.Equal(t, 1, in.Len())
-	assert.Equal(t, 1, out.Len())
-	assert.Equal(t, vectorQ1, in)
-	assert.Equal(t, vectorQ2, out)
+	rates, err := client.GetAllRequestRates("ns", "5m")
+	assert.Equal(t, 2, rates.Len())
+	assert.Equal(t, vectorQ1[0], rates[0])
+	assert.Equal(t, vectorQ2[0], rates[1])
 }
 
 func TestGetAllRequestRatesIstioSystem(t *testing.T) {
@@ -473,7 +472,7 @@ func TestGetAllRequestRatesIstioSystem(t *testing.T) {
 			Metric:    model.Metric{"foo": "bar"},
 		},
 	}
-	mockQuery(api, `rate(istio_requests_total{reporter="destination",destination_workload_namespace="istio-system"}[5m])`, &vectorQ1)
+	mockQuery(api, `rate(istio_requests_total{reporter="destination",destination_service_namespace="istio-system",source_workload_namespace!="istio-system"}[5m])`, &vectorQ1)
 
 	vectorQ2 := model.Vector{
 		&model.Sample{
@@ -483,11 +482,10 @@ func TestGetAllRequestRatesIstioSystem(t *testing.T) {
 	}
 	mockQuery(api, `rate(istio_requests_total{reporter="destination",source_workload_namespace="istio-system"}[5m])`, &vectorQ2)
 
-	in, out, err := client.GetAllRequestRates("istio-system", "5m")
-	assert.Equal(t, 1, in.Len())
-	assert.Equal(t, 1, out.Len())
-	assert.Equal(t, vectorQ1, in)
-	assert.Equal(t, vectorQ2, out)
+	rates, err := client.GetAllRequestRates("istio-system", "5m")
+	assert.Equal(t, 2, rates.Len())
+	assert.Equal(t, vectorQ1[0], rates[0])
+	assert.Equal(t, vectorQ2[0], rates[1])
 }
 
 func mockQuery(api *PromAPIMock, query string, ret *model.Vector) {

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -93,9 +93,9 @@ func (o *PromClientMock) GetServiceHealth(namespace, servicename string, ports [
 	return args.Get(0).(prometheus.EnvoyServiceHealth), args.Error(1)
 }
 
-func (o *PromClientMock) GetAllRequestRates(namespace, ratesInterval string) (model.Vector, model.Vector, error) {
+func (o *PromClientMock) GetAllRequestRates(namespace, ratesInterval string) (model.Vector, error) {
 	args := o.Called(namespace, ratesInterval)
-	return args.Get(0).(model.Vector), args.Get(1).(model.Vector), args.Error(2)
+	return args.Get(0).(model.Vector), args.Error(1)
 }
 
 func (o *PromClientMock) GetAppRequestRates(namespace, app, ratesInterval string) (model.Vector, model.Vector, error) {

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -88,18 +88,28 @@ type PromClientMock struct {
 	mock.Mock
 }
 
-func (o *PromClientMock) GetServiceHealth(namespace, servicename string, ports []int32) (prometheus.EnvoyHealth, error) {
+func (o *PromClientMock) GetServiceHealth(namespace, servicename string, ports []int32) (prometheus.EnvoyServiceHealth, error) {
 	args := o.Called(namespace, servicename, ports)
-	return args.Get(0).(prometheus.EnvoyHealth), args.Error(1)
+	return args.Get(0).(prometheus.EnvoyServiceHealth), args.Error(1)
 }
 
-func (o *PromClientMock) GetNamespaceRequestRates(namespace, ratesInterval string) (model.Vector, model.Vector, error) {
+func (o *PromClientMock) GetAllRequestRates(namespace, ratesInterval string) (model.Vector, model.Vector, error) {
 	args := o.Called(namespace, ratesInterval)
 	return args.Get(0).(model.Vector), args.Get(1).(model.Vector), args.Error(2)
 }
 
-func (o *PromClientMock) GetAppsRequestRates(namespace string, apps []string, ratesInterval string) (model.Vector, model.Vector, error) {
-	args := o.Called(namespace, apps, ratesInterval)
+func (o *PromClientMock) GetAppRequestRates(namespace, app, ratesInterval string) (model.Vector, model.Vector, error) {
+	args := o.Called(namespace, app, ratesInterval)
+	return args.Get(0).(model.Vector), args.Get(1).(model.Vector), args.Error(2)
+}
+
+func (o *PromClientMock) GetServiceRequestRates(namespace, service, ratesInterval string) (model.Vector, error) {
+	args := o.Called(namespace, service, ratesInterval)
+	return args.Get(0).(model.Vector), args.Error(1)
+}
+
+func (o *PromClientMock) GetWorkloadRequestRates(namespace, workload, ratesInterval string) (model.Vector, model.Vector, error) {
+	args := o.Called(namespace, workload, ratesInterval)
 	return args.Get(0).(model.Vector), args.Get(1).(model.Vector), args.Error(2)
 }
 

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -20,7 +20,7 @@ type Routes struct {
 	Routes []Route
 }
 
-// A GenericError is the default error message that is generated.
+// GenericError: any other kind of error
 //
 // swagger:response genericError
 type GenericError struct {
@@ -34,7 +34,21 @@ type GenericError struct {
 	} `json:"body"`
 }
 
-// A NotFoundError is the error message that is generated when server could not find what was requested.
+// BadRequestError: the client request is incorrect
+//
+// swagger:response badRequestError
+type BadRequestError struct {
+	// in: body
+	Body struct {
+		// HTTP status code
+		// example: 400
+		// default: 400
+		Code    int32 `json:"code"`
+		Message error `json:"message"`
+	} `json:"body"`
+}
+
+// NotFoundError: the requested resource is not found
 //
 // swagger:response notFoundError
 type NotFoundError struct {
@@ -48,7 +62,7 @@ type NotFoundError struct {
 	} `json:"body"`
 }
 
-// A Internal is the error message that means something has gone wrong
+// InternalError: something went wrong server-side
 //
 // swagger:response internalError
 type InternalError struct {
@@ -233,11 +247,67 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadMetrics,
 			true,
 		},
+		// swagger:route GET /api/namespaces/{namespace}/services/{service}/health serviceHealth
+		// ---
+		// Get health associated to the given service
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      200: serviceHealthResponse
+		//      404: notFoundError
+		//      500: internalError
+		//
 		{
 			"ServiceHealth",
 			"GET",
 			"/api/namespaces/{namespace}/services/{service}/health",
 			handlers.ServiceHealth,
+			true,
+		},
+		// swagger:route GET /api/namespaces/{namespace}/apps/{app}/health appHealth
+		// ---
+		// Get health associated to the given app
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      200: appHealthResponse
+		//      404: notFoundError
+		//      500: internalError
+		//
+		{
+			"AppHealth",
+			"GET",
+			"/api/namespaces/{namespace}/app/{app}/health",
+			handlers.AppHealth,
+			true,
+		},
+		// swagger:route GET /api/namespaces/{namespace}/workloads/{workload}/health workloadHealth
+		// ---
+		// Get health associated to the given workload
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      200: workloadHealthResponse
+		//      404: notFoundError
+		//      500: internalError
+		//
+		{
+			"WorkloadHealth",
+			"GET",
+			"/api/namespaces/{namespace}/workloads/{workload}/health",
+			handlers.WorkloadHealth,
 			true,
 		},
 		{
@@ -254,6 +324,20 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceMetrics,
 			true,
 		},
+		// swagger:route GET /api/namespaces/{namespace}/health namespaceHealth
+		// ---
+		// Get health for all objects in the given namespace
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      200: namespaceAppHealthResponse
+		//			400: badRequestError
+		//      500: internalError
+		//
 		{
 			"NamespaceHealth",
 			"GET",

--- a/services/business/health.go
+++ b/services/business/health.go
@@ -1,11 +1,11 @@
 package business
 
 import (
-	"strings"
 	"sync"
 
 	"github.com/prometheus/common/model"
 	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/prometheus"
@@ -18,128 +18,252 @@ type HealthService struct {
 	k8s  kubernetes.IstioClientInterface
 }
 
-// NamespaceHealth is an alias of map of service name x health
-type NamespaceHealth map[string]*models.Health
-
 // GetServiceHealth returns a service health from just Namespace and service (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetServiceHealth(namespace, service, rateInterval string) models.Health {
-	// Fill all parts
-	health := models.Health{}
-	details, _ := in.k8s.GetServiceDetails(namespace, service)
-	in.fillMissingParts(namespace, service, details, rateInterval, &health)
-	return health
-}
-
-// GetNamespaceHealth returns a health for all services in given Namespace (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetNamespaceHealth(namespace, rateInterval string) (NamespaceHealth, error) {
-	serviceList, err := in.k8s.GetFullServices(namespace)
+func (in *HealthService) GetServiceHealth(namespace, service, rateInterval string) (*models.ServiceHealth, error) {
+	details, err := in.k8s.GetServiceDetails(namespace, service)
 	if err != nil {
 		return nil, err
 	}
-	return in.getNamespaceHealth(namespace, serviceList, rateInterval), nil
+	h := in.getServiceHealth(namespace, service, rateInterval, details)
+	return &h, nil
 }
 
-func (in *HealthService) getNamespaceHealth(namespace string, sl *kubernetes.ServiceList, rateInterval string) NamespaceHealth {
-	allHealth := make(NamespaceHealth)
-	serviceDetailsMap := make(map[string]*kubernetes.ServiceDetails)
+func (in *HealthService) getServiceHealth(namespace, service, rateInterval string, details *kubernetes.ServiceDetails) models.ServiceHealth {
+	var envoyHealth prometheus.EnvoyServiceHealth
+	var ports []int32
+	for _, port := range details.Service.Spec.Ports {
+		ports = append(ports, port.Port)
+	}
+	envoyHealth, _ = in.prom.GetServiceHealth(namespace, service, ports)
+	rqHealth := in.getServiceRequestsHealth(namespace, service, rateInterval)
+	return models.ServiceHealth{
+		Envoy:    envoyHealth,
+		Requests: rqHealth,
+	}
+}
+
+// GetAppHealth returns an app health from just Namespace and app name (thus, it fetches data from K8S and Prometheus)
+func (in *HealthService) GetAppHealth(namespace, app, rateInterval string) (*models.AppHealth, error) {
+	details, err := in.k8s.GetAppDetails(namespace, app)
+	if err != nil {
+		return nil, err
+	}
+	h := in.getAppHealth(namespace, app, rateInterval, details)
+	return &h, nil
+}
+
+func (in *HealthService) getAppHealth(namespace, app, rateInterval string, details kubernetes.AppDetails) models.AppHealth {
+	health := models.EmptyAppHealth()
+
+	var wg sync.WaitGroup
+	wg.Add(len(details.Services))
+
+	for _, service := range details.Services {
+		go func(service v1.Service) {
+			defer wg.Done()
+			var ports []int32
+			for _, port := range service.Spec.Ports {
+				ports = append(ports, port.Port)
+			}
+			envoy, _ := in.prom.GetServiceHealth(namespace, service.Name, ports)
+			health.Envoy = append(health.Envoy, models.EnvoyHealthWrapper{
+				Service:            service.Name,
+				EnvoyServiceHealth: envoy,
+			})
+		}(service)
+	}
+
+	// Fetch services requests rates
+	health.Requests = in.getAppRequestsHealth(namespace, app, rateInterval)
+
+	// Deployment status
+	health.DeploymentStatuses = castDeploymentsStatuses(details.Deployments)
+
+	wg.Wait()
+	return health
+}
+
+// GetWorkloadHealth returns a workload health from just Namespace and workload (thus, it fetches data from K8S and Prometheus)
+func (in *HealthService) GetWorkloadHealth(namespace, workload, rateInterval string) (*models.WorkloadHealth, error) {
+	// Fill all parts
+	health := models.WorkloadHealth{}
+	deployment, err := in.k8s.GetDeployment(namespace, workload)
+	if err != nil {
+		return nil, err
+	}
+	health.DeploymentStatus = models.DeploymentStatus{
+		Name:              deployment.Name,
+		Replicas:          deployment.Status.Replicas,
+		AvailableReplicas: deployment.Status.AvailableReplicas}
+	health.Requests = in.getWorkloadRequestsHealth(namespace, workload, rateInterval)
+	return &health, nil
+}
+
+// GetNamespaceAppHealth returns a health for all apps in given Namespace (thus, it fetches data from K8S and Prometheus)
+func (in *HealthService) GetNamespaceAppHealth(namespace, rateInterval string) (models.NamespaceAppHealth, error) {
+	appEntities, err := in.k8s.GetNamespaceAppsDetails(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return in.getNamespaceAppHealth(namespace, appEntities, rateInterval), nil
+}
+
+func (in *HealthService) getNamespaceAppHealth(namespace string, appEntities kubernetes.NamespaceApps, rateInterval string) models.NamespaceAppHealth {
+	allHealth := make(models.NamespaceAppHealth)
 
 	// Prepare all data
-	for _, item := range sl.Services.Items {
-		allHealth[item.Name] = &models.Health{}
-		sPods := kubernetes.FilterPodsForService(&item, sl.Pods)
-		depls := kubernetes.FilterDeploymentsForService(&item, sPods, sl.Deployments)
-		serviceDetailsMap[item.Name] = &kubernetes.ServiceDetails{
-			Service:     &item,
-			Deployments: &v1beta1.DeploymentList{Items: depls},
-			Pods:        sPods,
+	for app := range appEntities {
+		if app != "" {
+			h := models.EmptyAppHealth()
+			allHealth[app] = &h
 		}
 	}
 
 	// Fetch services requests rates
-	inRates, outRates, _ := in.prom.GetNamespaceRequestRates(namespace, rateInterval)
+	inRates, outRates, _ := in.prom.GetAllRequestRates(namespace, rateInterval)
 
 	// Fill with collected request rates
 	// Note: we must match each service with inRates and outRates separately, else we would generate duplicates
-	fillRequestRates(allHealth, inRates, outRates)
+	fillAppRequestRates(allHealth, inRates, outRates)
 
 	var wg sync.WaitGroup
 	wg.Add(len(allHealth))
 
 	// Finally complete missing health information
-	for s, h := range allHealth {
-		service, health := s, h
-		details := serviceDetailsMap[service]
-		go func() {
+	for app, health := range allHealth {
+		entities := appEntities[app]
+		go func(app string, health *models.AppHealth) {
 			defer wg.Done()
-			// rateinterval not necessary here since we already fetched the request rates
-			in.fillMissingParts(namespace, service, details, "", health)
-		}()
+			if entities != nil {
+				health.DeploymentStatuses = castDeploymentsStatuses(entities.Deployments)
+				for _, service := range entities.Services {
+					var ports []int32
+					for _, port := range service.Spec.Ports {
+						ports = append(ports, port.Port)
+					}
+					envoy, _ := in.prom.GetServiceHealth(namespace, service.Name, ports)
+					health.Envoy = append(health.Envoy, models.EnvoyHealthWrapper{
+						Service:            service.Name,
+						EnvoyServiceHealth: envoy,
+					})
+				}
+			}
+		}(app, health)
 	}
 
 	wg.Wait()
 	return allHealth
 }
 
-// fillRequestRates aggregates requests rates from metrics fetched from Prometheus, and stores the result in the health map.
-func fillRequestRates(allHealth NamespaceHealth, inRates, outRates model.Vector) {
+// GetNamespaceWorkloadHealth returns a health for all workloads in given Namespace (thus, it fetches data from K8S and Prometheus)
+func (in *HealthService) GetNamespaceWorkloadHealth(namespace, rateInterval string) (models.NamespaceWorkloadHealth, error) {
+	depls, err := in.k8s.GetDeployments(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return in.getNamespaceWorkloadHealth(namespace, depls, rateInterval), nil
+}
+
+func (in *HealthService) getNamespaceWorkloadHealth(namespace string, dl *v1beta1.DeploymentList, rateInterval string) models.NamespaceWorkloadHealth {
+	allHealth := make(models.NamespaceWorkloadHealth)
+	deploymentsMap := make(map[string]v1beta1.Deployment)
+
+	// Prepare all data
+	for _, item := range dl.Items {
+		allHealth[item.Name] = &models.WorkloadHealth{}
+		deploymentsMap[item.Name] = item
+	}
+
+	// Fetch services requests rates
+	inRates, outRates, _ := in.prom.GetAllRequestRates(namespace, rateInterval)
+
+	// Fill with collected request rates
+	// Note: we must match each service with inRates and outRates separately, else we would generate duplicates
+	fillWorkloadRequestRates(allHealth, inRates, outRates)
+
+	var wg sync.WaitGroup
+	wg.Add(len(allHealth))
+
+	// Finally complete missing health information
+	for workload, health := range allHealth {
+		depl, hasDepl := deploymentsMap[workload]
+		go func(workload string, health *models.WorkloadHealth) {
+			defer wg.Done() // Pod statuses
+			if hasDepl {
+				health.DeploymentStatus = models.DeploymentStatus{
+					Name:              depl.Name,
+					Replicas:          depl.Status.Replicas,
+					AvailableReplicas: depl.Status.AvailableReplicas}
+			}
+		}(workload, health)
+	}
+
+	wg.Wait()
+	return allHealth
+}
+
+// fillAppRequestRates aggregates requests rates from metrics fetched from Prometheus, and stores the result in the health map.
+func fillAppRequestRates(allHealth models.NamespaceAppHealth, inRates, outRates model.Vector) {
+	lblDest := model.LabelName("destination_app")
+	lblSrc := model.LabelName("source_app")
 	// Inbound
 	for _, sample := range inRates {
-		serviceName := strings.SplitN(string(sample.Metric["destination_service"]), ".", 2)[0]
-		if health, ok := allHealth[serviceName]; ok {
+		name := string(sample.Metric[lblDest])
+		if health, ok := allHealth[name]; ok {
 			sumRequestCounters(&health.Requests, sample)
 		}
 	}
 	// Outbound
 	for _, sample := range outRates {
-		serviceName := strings.SplitN(string(sample.Metric["source_service"]), ".", 2)[0]
-		if health, ok := allHealth[serviceName]; ok {
+		name := string(sample.Metric[lblSrc])
+		if health, ok := allHealth[name]; ok {
 			sumRequestCounters(&health.Requests, sample)
 		}
 	}
-	// Mark all as fetched
-	for _, health := range allHealth {
-		health.Requests.Fetched = true
+}
+
+// fillWorkloadRequestRates aggregates requests rates from metrics fetched from Prometheus, and stores the result in the health map.
+func fillWorkloadRequestRates(allHealth models.NamespaceWorkloadHealth, inRates, outRates model.Vector) {
+	lblDest := model.LabelName("destination_workload")
+	lblSrc := model.LabelName("source_workload")
+	// Inbound
+	for _, sample := range inRates {
+		name := string(sample.Metric[lblDest])
+		if health, ok := allHealth[name]; ok {
+			sumRequestCounters(&health.Requests, sample)
+		}
+	}
+	// Outbound
+	for _, sample := range outRates {
+		name := string(sample.Metric[lblSrc])
+		if health, ok := allHealth[name]; ok {
+			sumRequestCounters(&health.Requests, sample)
+		}
 	}
 }
 
-func (in *HealthService) fillMissingParts(namespace, serviceName string, details *kubernetes.ServiceDetails, rateInterval string, health *models.Health) {
-	var ports []int32
-	var apps []string
-	if details != nil {
-		for _, port := range details.Service.Spec.Ports {
-			ports = append(ports, port.Port)
-		}
-		for _, depl := range details.Deployments.Items {
-			if app, ok := depl.Labels["app"]; ok {
-				apps = append(apps, app)
-			}
-		}
-	}
-
-	// Pod statuses
-	health.FillDeploymentStatusesIfMissing(func() []models.DeploymentStatus {
-		if details != nil {
-			return castDeploymentsStatuses(details.Deployments.Items)
-		}
-		return []models.DeploymentStatus{}
-	})
-
-	// Envoy health
-	health.Envoy.FillIfMissing(func() prometheus.EnvoyHealth {
-		health, _ := in.prom.GetServiceHealth(namespace, serviceName, ports)
-		return health
-	})
-
-	// Request errors
-	health.Requests.FillIfMissing(func() (float64, float64) {
-		rqHealth := in.getRequestsHealth(namespace, apps, rateInterval)
-		return rqHealth.RequestErrorCount, rqHealth.RequestCount
-	})
-}
-
-func (in *HealthService) getRequestsHealth(namespace string, apps []string, rateInterval string) models.RequestHealth {
+func (in *HealthService) getServiceRequestsHealth(namespace, service, rateInterval string) models.RequestHealth {
 	rqHealth := models.RequestHealth{}
-	inbound, outbound, _ := in.prom.GetAppsRequestRates(namespace, apps, rateInterval)
+	inbound, _ := in.prom.GetServiceRequestRates(namespace, service, rateInterval)
+	for _, sample := range inbound {
+		sumRequestCounters(&rqHealth, sample)
+	}
+	return rqHealth
+}
+
+func (in *HealthService) getAppRequestsHealth(namespace, app, rateInterval string) models.RequestHealth {
+	rqHealth := models.RequestHealth{}
+	inbound, outbound, _ := in.prom.GetAppRequestRates(namespace, app, rateInterval)
+	all := append(inbound, outbound...)
+	for _, sample := range all {
+		sumRequestCounters(&rqHealth, sample)
+	}
+	return rqHealth
+}
+
+func (in *HealthService) getWorkloadRequestsHealth(namespace, workload, rateInterval string) models.RequestHealth {
+	rqHealth := models.RequestHealth{}
+	inbound, outbound, _ := in.prom.GetWorkloadRequestRates(namespace, workload, rateInterval)
 	all := append(inbound, outbound...)
 	for _, sample := range all {
 		sumRequestCounters(&rqHealth, sample)

--- a/services/business/health_test.go
+++ b/services/business/health_test.go
@@ -1,0 +1,161 @@
+package business
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/prometheustest"
+)
+
+func TestGetServiceHealth(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	k8s := new(kubetest.K8SClientMock)
+	prom := new(prometheustest.PromClientMock)
+	conf := config.NewConfig()
+	config.Set(conf)
+	hs := HealthService{k8s: k8s, prom: prom}
+	k8s.On("GetServiceDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+		assert.Equal("ns", args[0])
+		assert.Equal("httpbin", args[1])
+	}).Return(k8s.FakeServiceDetails(), nil)
+
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Run(func(args mock.Arguments) {
+		assert.Equal("ns", args[0])
+		assert.Equal("httpbin", args[1])
+	}).Return(prometheus.EnvoyServiceHealth{Inbound: prometheus.EnvoyRatio{Healthy: 1, Total: 1}}, nil)
+
+	prom.On("GetServiceRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeServiceRequestCounters())
+
+	health, _ := hs.GetServiceHealth("ns", "httpbin", "1m")
+
+	k8s.AssertNumberOfCalls(t, "GetServiceDetails", 1)
+	prom.AssertNumberOfCalls(t, "GetServiceHealth", 1)
+	prom.AssertNumberOfCalls(t, "GetServiceRequestRates", 1)
+	assert.Equal(1, health.Envoy.Inbound.Total)
+	assert.Equal(1, health.Envoy.Inbound.Healthy)
+	assert.Equal(float64(15.4), health.Requests.RequestCount)
+	assert.Equal(float64(1.4), health.Requests.RequestErrorCount)
+}
+
+func TestGetAppHealth(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	k8s := new(kubetest.K8SClientMock)
+	prom := new(prometheustest.PromClientMock)
+	conf := config.NewConfig()
+	config.Set(conf)
+	hs := HealthService{k8s: k8s, prom: prom}
+	k8s.On("GetAppDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+		assert.Equal("ns", args[0])
+		assert.Equal("reviews", args[1])
+	}).Return(k8s.FakeAppDetails(), nil)
+
+	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Run(func(args mock.Arguments) {
+		assert.Equal("ns", args[0])
+		assert.Equal("reviews", args[1])
+	}).Return(prometheus.EnvoyServiceHealth{Inbound: prometheus.EnvoyRatio{Healthy: 1, Total: 1}}, nil)
+
+	prom.On("GetAppRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeOtherRequestCounters())
+
+	health, _ := hs.GetAppHealth("ns", "reviews", "1m")
+
+	k8s.AssertNumberOfCalls(t, "GetAppDetails", 1)
+	prom.AssertNumberOfCalls(t, "GetServiceHealth", 1)
+	prom.AssertNumberOfCalls(t, "GetAppRequestRates", 1)
+	assert.Equal(1, len(health.Envoy))
+	assert.Equal(1, health.Envoy[0].Inbound.Total)
+	assert.Equal(1, health.Envoy[0].Inbound.Healthy)
+	assert.Equal(0, health.Envoy[0].Outbound.Total)
+	assert.Equal(0, health.Envoy[0].Outbound.Healthy)
+	assert.Equal(float64(6.6), health.Requests.RequestCount)
+	assert.Equal(float64(1.6), health.Requests.RequestErrorCount)
+}
+
+func TestGetWorkloadHealth(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	k8s := new(kubetest.K8SClientMock)
+	prom := new(prometheustest.PromClientMock)
+	conf := config.NewConfig()
+	config.Set(conf)
+	hs := HealthService{k8s: k8s, prom: prom}
+	k8s.On("GetDeployment", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+		assert.Equal("ns", args[0])
+		assert.Equal("reviews-v1", args[1])
+	}).Return(&k8s.FakeAppDetails().Deployments[0], nil)
+
+	prom.On("GetWorkloadRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeOtherRequestCounters())
+
+	health, _ := hs.GetWorkloadHealth("ns", "reviews-v1", "1m")
+
+	k8s.AssertNumberOfCalls(t, "GetDeployment", 1)
+	prom.AssertNumberOfCalls(t, "GetWorkloadRequestRates", 1)
+	assert.Equal(float64(6.6), health.Requests.RequestCount)
+	assert.Equal(float64(1.6), health.Requests.RequestErrorCount)
+}
+
+var t1 = model.Now()
+var sampleReviewsToHttpbin200 = model.Sample{
+	Metric: model.Metric{
+		"source_service":      "reviews.tutorial.svc.cluster.local",
+		"destination_service": "httpbin.tutorial.svc.cluster.local",
+		"response_code":       "200",
+	},
+	Value:     model.SampleValue(5),
+	Timestamp: t1,
+}
+var sampleUnknownToHttpbin200 = model.Sample{
+	Metric: model.Metric{
+		"destination_service": "httpbin.tutorial.svc.cluster.local",
+		"source_service":      "unknown",
+		"response_code":       "200",
+	},
+	Value:     model.SampleValue(14),
+	Timestamp: t1,
+}
+var sampleUnknownToHttpbin404 = model.Sample{
+	Metric: model.Metric{
+		"destination_service": "httpbin.tutorial.svc.cluster.local",
+		"source_service":      "unknown",
+		"response_code":       "404",
+	},
+	Value:     model.SampleValue(1.4),
+	Timestamp: t1,
+}
+var sampleUnknownToReviews500 = model.Sample{
+	Metric: model.Metric{
+		"destination_service": "reviews.tutorial.svc.cluster.local",
+		"source_service":      "unknown",
+		"response_code":       "500",
+	},
+	Value:     model.SampleValue(1.6),
+	Timestamp: t1,
+}
+
+func fakeServiceRequestCounters() (model.Vector, error) {
+	in := model.Vector{
+		&sampleUnknownToHttpbin200,
+		&sampleUnknownToHttpbin404,
+	}
+	return in, nil
+}
+
+func fakeOtherRequestCounters() (model.Vector, model.Vector, error) {
+	in := model.Vector{
+		&sampleUnknownToReviews500,
+	}
+	out := model.Vector{
+		&sampleReviewsToHttpbin200,
+	}
+	return in, out, nil
+}

--- a/services/business/services.go
+++ b/services/business/services.go
@@ -63,8 +63,7 @@ func (in *SvcService) GetService(namespace, service, interval string) (*models.S
 		return nil, fmt.Errorf("Service details: %s", err.Error())
 	}
 
-	health := models.Health{}
-	in.health.fillMissingParts(namespace, service, serviceDetails, interval, &health)
+	health := in.health.getServiceHealth(namespace, service, interval, serviceDetails)
 
 	istioDetails, err := in.k8s.GetIstioDetails(namespace, service)
 	if err != nil {

--- a/services/business/services_test.go
+++ b/services/business/services_test.go
@@ -2,19 +2,13 @@ package business
 
 import (
 	"testing"
-	"time"
 
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"k8s.io/api/apps/v1beta1"
-	"k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
-	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
 )
 
@@ -23,7 +17,7 @@ func TestServiceListParsing(t *testing.T) {
 
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetFullServices", mock.AnythingOfType("string")).Return(fakeServiceList(), nil)
+	k8s.On("GetFullServices", mock.AnythingOfType("string")).Return(k8s.FakeServiceList(), nil)
 	conf := config.NewConfig()
 	config.Set(conf)
 	svc := SvcService{k8s: k8s}
@@ -39,31 +33,6 @@ func TestServiceListParsing(t *testing.T) {
 	assert.Equal("httpbin", httpbinOverview.Name)
 }
 
-func TestSingleServiceHealthParsing(t *testing.T) {
-	assert := assert.New(t)
-
-	// Setup mocks
-	k8s := new(kubetest.K8SClientMock)
-	prom := new(prometheustest.PromClientMock)
-	k8s.On("GetServiceDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeServiceDetails(), nil)
-	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeIstioDetails(), nil)
-	prom.On("GetSourceWorkloads", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(make(map[string][]prometheus.Workload), nil)
-	prom.On("GetServiceHealth", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]int32")).Return(prometheus.EnvoyHealth{Inbound: prometheus.EnvoyRatio{Healthy: 1, Total: 1}}, nil)
-	prom.On("GetAppsRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), mock.AnythingOfType("string")).Return(fakeServiceRequestCounters())
-	svc := setupServices(k8s, prom)
-
-	service, _ := svc.GetService("Namespace", "httpbin", "1m")
-
-	assert.Equal("Namespace", service.Namespace.Name)
-	assert.Equal("httpbin", service.Name)
-	assert.Equal(1, service.Health.Envoy.Inbound.Total)
-	assert.Equal(1, service.Health.Envoy.Inbound.Healthy)
-	assert.Equal(int32(1), service.Health.DeploymentStatuses[0].AvailableReplicas)
-	assert.Equal(int32(1), service.Health.DeploymentStatuses[0].Replicas)
-	assert.Equal(float64(20.4), service.Health.Requests.RequestCount)
-	assert.Equal(float64(1.4), service.Health.Requests.RequestErrorCount)
-}
-
 func setupServices(k8s *kubetest.K8SClientMock, prom *prometheustest.PromClientMock) SvcService {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -74,191 +43,4 @@ func setupServices(k8s *kubetest.K8SClientMock, prom *prometheustest.PromClientM
 
 func fakeIstioDetails() *kubernetes.IstioDetails {
 	return &kubernetes.IstioDetails{}
-}
-
-func fakeServiceDetails() *kubernetes.ServiceDetails {
-	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
-
-	return &kubernetes.ServiceDetails{
-		Service: &v1.Service{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name:      "httpbin",
-				Namespace: "tutorial",
-				Labels: map[string]string{
-					"app":     "httpbin",
-					"version": "v1"}},
-			Spec: v1.ServiceSpec{
-				ClusterIP: "fromservice",
-				Type:      "ClusterIP",
-				Selector:  map[string]string{"app": "httpbin"},
-				Ports: []v1.ServicePort{
-					{
-						Name:     "http",
-						Protocol: "TCP",
-						Port:     3001},
-					{
-						Name:     "http",
-						Protocol: "TCP",
-						Port:     3000}}}},
-		Deployments: &v1beta1.DeploymentList{
-			Items: []v1beta1.Deployment{
-				v1beta1.Deployment{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:              "httpbin-v1",
-						CreationTimestamp: meta_v1.NewTime(t1),
-						Labels:            map[string]string{"app": "httpbin", "version": "v1"}},
-					Status: v1beta1.DeploymentStatus{
-						Replicas:            1,
-						AvailableReplicas:   1,
-						UnavailableReplicas: 0}}}}}
-}
-
-func fakeServiceList() *kubernetes.ServiceList {
-	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
-	t2, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:45 +0300")
-
-	return &kubernetes.ServiceList{
-		Services: &v1.ServiceList{
-			Items: []v1.Service{
-				v1.Service{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:      "reviews",
-						Namespace: "tutorial",
-						Labels: map[string]string{
-							"app":     "reviews",
-							"version": "v1"}},
-					Spec: v1.ServiceSpec{
-						ClusterIP: "fromservice",
-						Type:      "ClusterIP",
-						Selector:  map[string]string{"app": "reviews"},
-						Ports: []v1.ServicePort{
-							{
-								Name:     "http",
-								Protocol: "TCP",
-								Port:     3001},
-							{
-								Name:     "http",
-								Protocol: "TCP",
-								Port:     3000}}}},
-				v1.Service{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:      "httpbin",
-						Namespace: "tutorial",
-						Labels: map[string]string{
-							"app":     "httpbin",
-							"version": "v1"}},
-					Spec: v1.ServiceSpec{
-						ClusterIP: "fromservice",
-						Type:      "ClusterIP",
-						Selector:  map[string]string{"app": "httpbin"},
-						Ports: []v1.ServicePort{
-							{
-								Name:     "http",
-								Protocol: "TCP",
-								Port:     3001},
-							{
-								Name:     "http",
-								Protocol: "TCP",
-								Port:     3000}}}},
-			}},
-		Pods: &v1.PodList{
-			Items: []v1.Pod{
-				v1.Pod{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:   "reviews-v1",
-						Labels: map[string]string{"app": "reviews", "version": "v1"}}},
-				v1.Pod{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:   "reviews-v2",
-						Labels: map[string]string{"app": "reviews", "version": "v2"}}},
-				v1.Pod{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:   "httpbin-v1",
-						Labels: map[string]string{"app": "httpbin", "version": "v1"}}},
-			}},
-		Deployments: &v1beta1.DeploymentList{
-			Items: []v1beta1.Deployment{
-				v1beta1.Deployment{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:              "reviews-v1",
-						CreationTimestamp: meta_v1.NewTime(t1)},
-					Status: v1beta1.DeploymentStatus{
-						Replicas:            3,
-						AvailableReplicas:   2,
-						UnavailableReplicas: 1},
-					Spec: v1beta1.DeploymentSpec{
-						Selector: &meta_v1.LabelSelector{
-							MatchLabels: map[string]string{"app": "reviews", "version": "v1"}}}},
-				v1beta1.Deployment{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:              "reviews-v2",
-						CreationTimestamp: meta_v1.NewTime(t1)},
-					Status: v1beta1.DeploymentStatus{
-						Replicas:            2,
-						AvailableReplicas:   1,
-						UnavailableReplicas: 1},
-					Spec: v1beta1.DeploymentSpec{
-						Selector: &meta_v1.LabelSelector{
-							MatchLabels: map[string]string{"app": "reviews", "version": "v2"}}}},
-				v1beta1.Deployment{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name:              "httpbin-v1",
-						CreationTimestamp: meta_v1.NewTime(t2)},
-					Status: v1beta1.DeploymentStatus{
-						Replicas:            1,
-						AvailableReplicas:   1,
-						UnavailableReplicas: 0},
-					Spec: v1beta1.DeploymentSpec{
-						Selector: &meta_v1.LabelSelector{
-							MatchLabels: map[string]string{"app": "httpbin", "version": "v1"}}}},
-			}}}
-}
-
-var t1 = model.Now()
-var sampleHttpbinToReviews200 = model.Sample{
-	Metric: model.Metric{
-		"destination_service": "reviews.tutorial.svc.cluster.local",
-		"source_service":      "httpbin.tutorial.svc.cluster.local",
-		"response_code":       "200",
-	},
-	Value:     model.SampleValue(5),
-	Timestamp: t1,
-}
-var sampleUnknownToHttpbin200 = model.Sample{
-	Metric: model.Metric{
-		"destination_service": "httpbin.tutorial.svc.cluster.local",
-		"source_service":      "unknown",
-		"response_code":       "200",
-	},
-	Value:     model.SampleValue(14),
-	Timestamp: t1,
-}
-var sampleUnknownToHttpbin404 = model.Sample{
-	Metric: model.Metric{
-		"destination_service": "httpbin.tutorial.svc.cluster.local",
-		"source_service":      "unknown",
-		"response_code":       "404",
-	},
-	Value:     model.SampleValue(1.4),
-	Timestamp: t1,
-}
-var sampleUnknownToReviews500 = model.Sample{
-	Metric: model.Metric{
-		"destination_service": "reviews.tutorial.svc.cluster.local",
-		"source_service":      "unknown",
-		"response_code":       "500",
-	},
-	Value:     model.SampleValue(1.6),
-	Timestamp: t1,
-}
-
-func fakeServiceRequestCounters() (model.Vector, model.Vector, error) {
-	in := model.Vector{
-		&sampleUnknownToHttpbin200,
-		&sampleUnknownToHttpbin404,
-	}
-	out := model.Vector{
-		&sampleHttpbinToReviews200,
-	}
-	return in, out, nil
 }

--- a/services/models/service.go
+++ b/services/models/service.go
@@ -30,7 +30,7 @@ type Service struct {
 	Dependencies     map[string][]string `json:"dependencies"`
 	Pods             Pods                `json:"pods"`
 	Deployments      Deployments         `json:"deployments"`
-	Health           Health              `json:"health"`
+	Health           ServiceHealth       `json:"health"`
 }
 
 func (s *Service) SetServiceDetails(serviceDetails *kubernetes.ServiceDetails, istioDetails *kubernetes.IstioDetails, prometheusDetails map[string][]prometheus.Workload) {

--- a/swagger.json
+++ b/swagger.json
@@ -47,6 +47,207 @@
         }
       }
     },
+    "/api/namespaces/{namespace}/apps/{app}/health": {
+      "get": {
+        "description": "Get health associated to the given app",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "appHealth",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Namespace",
+            "description": "The namespace scope",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "10m",
+            "x-go-name": "RateInterval",
+            "description": "The rate interval used for fetching error rate",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "App",
+            "description": "The target app",
+            "name": "app",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/appHealthResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/api/namespaces/{namespace}/health": {
+      "get": {
+        "description": "Get health for all objects in the given namespace",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "namespaceHealth",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Namespace",
+            "description": "The namespace scope",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "10m",
+            "x-go-name": "RateInterval",
+            "description": "The rate interval used for fetching error rate",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "pattern": "^(app|workload)$",
+            "type": "string",
+            "default": "app",
+            "x-go-name": "Type",
+            "description": "The type of health, \"app\" or \"workload\".",
+            "name": "type",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/namespaceAppHealthResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/api/namespaces/{namespace}/services/{service}/health": {
+      "get": {
+        "description": "Get health associated to the given service",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "serviceHealth",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Namespace",
+            "description": "The namespace scope",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "10m",
+            "x-go-name": "RateInterval",
+            "description": "The rate interval used for fetching error rate",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Service",
+            "description": "The target service",
+            "name": "service",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/serviceHealthResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/api/namespaces/{namespace}/workloads/{workload}/health": {
+      "get": {
+        "description": "Get health associated to the given workload",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "workloadHealth",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Namespace",
+            "description": "The namespace scope",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "10m",
+            "x-go-name": "RateInterval",
+            "description": "The rate interval used for fetching error rate",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Workload",
+            "description": "The target workload",
+            "name": "workload",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/workloadHealthResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/istio": {
       "get": {
         "description": "Endpoint to get the list of Istio Config of a namespace",
@@ -157,6 +358,98 @@
     }
   },
   "definitions": {
+    "AppHealth": {
+      "description": "AppHealth contains aggregated health from various sources, for a given app",
+      "type": "object",
+      "properties": {
+        "deploymentStatuses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeploymentStatus"
+          },
+          "x-go-name": "DeploymentStatuses"
+        },
+        "envoy": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EnvoyHealthWrapper"
+          },
+          "x-go-name": "Envoy"
+        },
+        "requests": {
+          "$ref": "#/definitions/RequestHealth"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "DeploymentStatus": {
+      "description": "DeploymentStatus gives the available / total replicas in a deployment of a pod",
+      "type": "object",
+      "properties": {
+        "available": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "AvailableReplicas"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "replicas": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "Replicas"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "EnvoyHealthWrapper": {
+      "description": "EnvoyHealthWrapper wraps EnvoyServiceHealth with the service name",
+      "type": "object",
+      "properties": {
+        "inbound": {
+          "$ref": "#/definitions/EnvoyRatio"
+        },
+        "outbound": {
+          "$ref": "#/definitions/EnvoyRatio"
+        },
+        "service": {
+          "type": "string",
+          "x-go-name": "Service"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "EnvoyRatio": {
+      "description": "EnvoyRatio is the number of healthy members versus total members",
+      "type": "object",
+      "properties": {
+        "healthy": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Healthy"
+        },
+        "total": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Total"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/prometheus"
+    },
+    "EnvoyServiceHealth": {
+      "description": "EnvoyServiceHealth is the number of healthy versus total membership (ie. replicas) inside envoy cluster (ie. service)",
+      "type": "object",
+      "properties": {
+        "inbound": {
+          "$ref": "#/definitions/EnvoyRatio"
+        },
+        "outbound": {
+          "$ref": "#/definitions/EnvoyRatio"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/prometheus"
+    },
     "Gateway": {
       "type": "object",
       "properties": {
@@ -198,9 +491,6 @@
         "namespace"
       ],
       "properties": {
-        "destinationPolicies": {
-          "$ref": "#/definitions/destinationPolicies"
-        },
         "destinationRules": {
           "$ref": "#/definitions/destinationRules"
         },
@@ -210,8 +500,11 @@
         "namespace": {
           "$ref": "#/definitions/namespace"
         },
-        "routeRules": {
-          "$ref": "#/definitions/routeRules"
+        "quotaSpecBindings": {
+          "$ref": "#/definitions/QuotaSpecBindings"
+        },
+        "quotaSpecs": {
+          "$ref": "#/definitions/QuotaSpecs"
         },
         "rules": {
           "$ref": "#/definitions/istioRules"
@@ -221,6 +514,101 @@
         },
         "virtualServices": {
           "$ref": "#/definitions/virtualServices"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "NamespaceAppHealth": {
+      "description": "NamespaceAppHealth is an alias of map of app name x health",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/AppHealth"
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "NamespaceWorkloadHealth": {
+      "description": "NamespaceWorkloadHealth is an alias of map of workload name x health",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/WorkloadHealth"
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "QuotaSpec": {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "x-go-name": "CreatedAt"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "resourceVersion": {
+          "type": "string",
+          "x-go-name": "ResourceVersion"
+        },
+        "rules": {
+          "type": "object",
+          "x-go-name": "Rules"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "QuotaSpecBinding": {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "x-go-name": "CreatedAt"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "quotaSpecs": {
+          "type": "object",
+          "x-go-name": "QuotaSpecs"
+        },
+        "resourceVersion": {
+          "type": "string",
+          "x-go-name": "ResourceVersion"
+        },
+        "services": {
+          "type": "object",
+          "x-go-name": "Services"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "QuotaSpecBindings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/QuotaSpecBinding"
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "QuotaSpecs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/QuotaSpec"
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "RequestHealth": {
+      "description": "RequestHealth holds several stats about recent request errors",
+      "type": "object",
+      "properties": {
+        "requestCount": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "RequestCount"
+        },
+        "requestErrorCount": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "RequestErrorCount"
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
@@ -270,6 +658,19 @@
         "resourceVersion": {
           "type": "string",
           "x-go-name": "ResourceVersion"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "ServiceHealth": {
+      "description": "ServiceHealth contains aggregated health from various sources, for a given service",
+      "type": "object",
+      "properties": {
+        "envoy": {
+          "$ref": "#/definitions/EnvoyServiceHealth"
+        },
+        "requests": {
+          "$ref": "#/definitions/RequestHealth"
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
@@ -335,60 +736,17 @@
       },
       "x-go-package": "github.com/kiali/kiali/config"
     },
-    "destinationPolicies": {
-      "description": "This type is used for returning an array of DestinationPolicies",
-      "type": "array",
-      "title": "DestinationPolicies destinationPolicies",
-      "items": {
-        "$ref": "#/definitions/destinationPolicy"
-      },
-      "x-go-name": "DestinationPolicies",
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
-    "destinationPolicy": {
-      "description": "This type is used for returning a DestinationPolicy",
+    "WorkloadHealth": {
+      "description": "WorkloadHealth contains aggregated health from various sources, for a given workload",
       "type": "object",
-      "title": "DestinationPolicy destinationPolicy",
-      "required": [
-        "name",
-        "createdAt",
-        "resourceVersion"
-      ],
       "properties": {
-        "circuitBreaker": {
-          "type": "object",
-          "x-go-name": "CircuitBreaker"
+        "deploymentStatus": {
+          "$ref": "#/definitions/DeploymentStatus"
         },
-        "createdAt": {
-          "description": "The creation date of the destinationPolicy",
-          "type": "string",
-          "pattern": "\\w[\\w-]+",
-          "x-go-name": "CreatedAt"
-        },
-        "destination": {
-          "type": "object",
-          "x-go-name": "Destination"
-        },
-        "loadbalancing": {
-          "type": "object",
-          "x-go-name": "LoadBalancing"
-        },
-        "name": {
-          "description": "The name of the destinationPolicy",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "resourceVersion": {
-          "description": "The resource version of the destinationPolicy",
-          "type": "string",
-          "x-go-name": "ResourceVersion"
-        },
-        "source": {
-          "type": "object",
-          "x-go-name": "Source"
+        "requests": {
+          "$ref": "#/definitions/RequestHealth"
         }
       },
-      "x-go-name": "DestinationPolicy",
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
     "destinationRule": {
@@ -519,107 +877,6 @@
       "x-go-name": "Namespace",
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
-    "routeRule": {
-      "description": "This type is used for returning a RouteRule",
-      "type": "object",
-      "title": "RouteRule routeRule",
-      "required": [
-        "name",
-        "createdAt",
-        "resourceVersion"
-      ],
-      "properties": {
-        "appendHeaders": {
-          "type": "object",
-          "x-go-name": "AppendHeaders"
-        },
-        "corsPolicy": {
-          "type": "object",
-          "x-go-name": "CorsPolicy"
-        },
-        "createdAt": {
-          "description": "The created time",
-          "type": "string",
-          "x-go-name": "CreatedAt",
-          "example": "2018-06-20T07:39:52Z"
-        },
-        "destination": {
-          "type": "object",
-          "x-go-name": "Destination"
-        },
-        "httpFault": {
-          "type": "object",
-          "x-go-name": "HttpFault"
-        },
-        "httpReqRetries": {
-          "type": "object",
-          "x-go-name": "HttpReqRetries"
-        },
-        "httpReqTimeout": {
-          "type": "object",
-          "x-go-name": "HttpReqTimeout"
-        },
-        "l4Fault": {
-          "type": "object",
-          "x-go-name": "L4Fault"
-        },
-        "match": {
-          "type": "object",
-          "x-go-name": "Match"
-        },
-        "mirror": {
-          "type": "object",
-          "x-go-name": "Mirror"
-        },
-        "name": {
-          "description": "The name of the routeRule",
-          "type": "string",
-          "x-go-name": "Name",
-          "example": "details-default"
-        },
-        "precedence": {
-          "type": "object",
-          "x-go-name": "Precedence"
-        },
-        "redirect": {
-          "type": "object",
-          "x-go-name": "Redirect"
-        },
-        "resourceVersion": {
-          "type": "string",
-          "x-go-name": "ResourceVersion",
-          "example": "1507"
-        },
-        "rewrite": {
-          "type": "object",
-          "x-go-name": "Rewrite"
-        },
-        "route": {
-          "type": "object",
-          "x-go-name": "Route"
-        },
-        "routeWarning": {
-          "type": "string",
-          "x-go-name": "RouteWarning"
-        },
-        "websocketUpgrade": {
-          "type": "object",
-          "x-go-name": "WebsocketUpgrade"
-        }
-      },
-      "x-go-name": "RouteRule",
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
-    "routeRules": {
-      "description": "This type is used for returning an array of RouteRule",
-      "type": "array",
-      "title": "RouteRules routeRules",
-      "items": {
-        "$ref": "#/definitions/routeRule"
-      },
-      "x-go-name": "RouteRules",
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
     "virtualService": {
       "description": "This type is used for returning a VirtualService",
       "type": "object",
@@ -677,8 +934,34 @@
     }
   },
   "responses": {
+    "appHealthResponse": {
+      "description": "appHealthResponse contains aggregated health from various sources, for a given app",
+      "schema": {
+        "$ref": "#/definitions/AppHealth"
+      }
+    },
+    "badRequestError": {
+      "description": "BadRequestError: the client request is incorrect",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "HTTP status code",
+            "type": "integer",
+            "format": "int32",
+            "default": 400,
+            "x-go-name": "Code",
+            "example": 400
+          },
+          "message": {
+            "type": "string",
+            "x-go-name": "Message"
+          }
+        }
+      }
+    },
     "genericError": {
-      "description": "A GenericError is the default error message that is generated.",
+      "description": "GenericError: any other kind of error",
       "schema": {
         "type": "object",
         "properties": {
@@ -698,7 +981,7 @@
       }
     },
     "internalError": {
-      "description": "A Internal is the error message that means something has gone wrong",
+      "description": "InternalError: something went wrong server-side",
       "schema": {
         "type": "object",
         "properties": {
@@ -735,8 +1018,20 @@
         }
       }
     },
+    "namespaceAppHealthResponse": {
+      "description": "namespaceAppHealthResponse is a map of app name x health",
+      "schema": {
+        "$ref": "#/definitions/NamespaceAppHealth"
+      }
+    },
+    "namespaceWorkloadHealthResponse": {
+      "description": "namespaceWorkloadHealthResponse is a map of workload x health",
+      "schema": {
+        "$ref": "#/definitions/NamespaceWorkloadHealth"
+      }
+    },
     "notFoundError": {
-      "description": "A NotFoundError is the error message that is generated when server could not find what was requested.",
+      "description": "NotFoundError: the requested resource is not found",
       "schema": {
         "type": "object",
         "properties": {
@@ -753,6 +1048,12 @@
             "x-go-name": "Message"
           }
         }
+      }
+    },
+    "serviceHealthResponse": {
+      "description": "serviceHealthResponse contains aggregated health from various sources, for a given service",
+      "schema": {
+        "$ref": "#/definitions/ServiceHealth"
       }
     },
     "statusInfo": {
@@ -790,6 +1091,12 @@
             "$ref": "#/definitions/TokenGenerated"
           }
         }
+      }
+    },
+    "workloadHealthResponse": {
+      "description": "workloadHealthResponse contains aggregated health from various sources, for a given workload",
+      "schema": {
+        "$ref": "#/definitions/WorkloadHealth"
       }
     }
   }


### PR DESCRIPTION
- New endpoints & business functions for workload-based health and app-based health
- Refactored service-based health to focus on service only (ie. inbound interface, deployment-agnostic)
- From kubernetes client, create new "AppDetails" type that gathers pods, services and deployments that shares the app label
- Move common stubs (service details/list) to k8s mock
