### PR TITLE
KIALI-1210 Adding WorkloadList endpoint

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,7 @@ import (
 // A Namespace provide a scope for names.
 // This type used to describe a set of objects.
 //
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations deploymentList
 type NamespaceParam struct {
 	// The id of the namespace.
 	//
@@ -135,6 +135,13 @@ type NamespaceValidationResponse struct {
 type ServiceValidationResponse struct {
 	// in:body
 	Body TypedIstioValidations
+}
+
+// Listing all deployments in the namespace
+// swagger:response deploymentListResponse
+type DeploymentListResponse struct {
+	// in:body
+	Body models.Deployments
 }
 
 //////////////////

--- a/doc.go
+++ b/doc.go
@@ -141,7 +141,7 @@ type ServiceValidationResponse struct {
 // swagger:response deploymentListResponse
 type DeploymentListResponse struct {
 	// in:body
-	Body models.Deployments
+	Body models.DeploymentList
 }
 
 //////////////////

--- a/handlers/deployments.go
+++ b/handlers/deployments.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/kiali/kiali/services/business"
+	"net/http"
+)
+
+func DeploymentList(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+
+	// Get business layer
+	business, err := business.Get()
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+		return
+	}
+	namespace := params["namespace"]
+
+	// Fetch and build deployments
+	serviceList, err := business.DeploymentService.GetDeploymentList(namespace)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, serviceList)
+}

--- a/handlers/deployments_test.go
+++ b/handlers/deployments_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/prometheus/prometheustest"
+	"github.com/kiali/kiali/services/business"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/api/apps/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func setupDeploymentList() (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
+	k8s := new(kubetest.K8SClientMock)
+	prom := new(prometheustest.PromClientMock)
+	business.SetWithBackends(k8s, prom)
+
+	mr := mux.NewRouter()
+	mr.HandleFunc("/api/namespaces/{namespace}/workloads", DeploymentList)
+
+	ts := httptest.NewServer(mr)
+	return ts, k8s, prom
+}
+
+func TestDeploymentList(t *testing.T) {
+	ts, k8s, _ := setupDeploymentList()
+	defer ts.Close()
+
+	k8s.On("GetDeployments", mock.AnythingOfType("string")).Return(fakeDeploymentList(), nil)
+
+	url := ts.URL + "/api/namespaces/ns/workloads"
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := ioutil.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	k8s.AssertNumberOfCalls(t, "GetDeployments", 1)
+}
+
+func fakeDeploymentList() *v1beta1.DeploymentList {
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	return &v1beta1.DeploymentList{
+		Items: []v1beta1.Deployment{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:              "httpbin-v1",
+					CreationTimestamp: meta_v1.NewTime(t1),
+					Labels:            map[string]string{"app": "httpbin", "version": "v1"}},
+				Status: v1beta1.DeploymentStatus{
+					Replicas:            1,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 0,
+				},
+			},
+		},
+	}
+}

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -39,6 +39,7 @@ type IstioClientInterface interface {
 	GetFullServices(namespace string) (*ServiceList, error)
 	GetServices(namespace string) (*v1.ServiceList, error)
 	GetServiceDetails(namespace string, serviceName string) (*ServiceDetails, error)
+	GetDeployments(namespace string) (*v1beta1.DeploymentList, error)
 	GetPods(namespace, labelSelector string) (*v1.PodList, error)
 	GetNamespacePods(namespace string) (*v1.PodList, error)
 	GetServicePods(namespace string, serviceName string, serviceVersion string) (*v1.PodList, error)

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/kubernetes"
+	"k8s.io/api/apps/v1beta1"
 )
 
 type K8SClientMock struct {
@@ -29,6 +30,11 @@ func (o *K8SClientMock) GetFullServices(namespace string) (*kubernetes.ServiceLi
 func (o *K8SClientMock) GetServices(namespace string) (*v1.ServiceList, error) {
 	args := o.Called(namespace)
 	return args.Get(0).(*v1.ServiceList), args.Error(1)
+}
+
+func (o *K8SClientMock) GetDeployments(namespace string) (*v1beta1.DeploymentList, error) {
+	args := o.Called(namespace)
+	return args.Get(0).(*v1beta1.DeploymentList), args.Error(1)
 }
 
 func (o *K8SClientMock) GetPods(namespace, labelSelector string) (*v1.PodList, error) {

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -170,6 +170,31 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceDetails,
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/deployments deploymentList
+		// ---
+		// Endpoint to get the list of deployments for a namespace
+		//
+		//     Consumes:
+		//     - application/json
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      default: genericError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: deploymentListResponse
+		//
+		{
+			"DeploymentList",
+			"GET",
+			"/api/namespaces/{namespace}/deployments",
+			handlers.DeploymentList,
+			true,
+		},
 		{
 			"NamespaceList",
 			"GET",

--- a/services/business/deployments.go
+++ b/services/business/deployments.go
@@ -11,13 +11,13 @@ type DeploymentService struct {
 }
 
 // ServiceList is the API handler to fetch the list of deployments in a given namespace
-func (in *DeploymentService) GetDeploymentList(namespace string) (models.Deployments, error) {
+func (in *DeploymentService) GetDeploymentList(namespace string) (models.DeploymentList, error) {
 	deployments, err := in.k8s.GetDeployments(namespace)
 	if err != nil {
-		return nil, err
+		return models.DeploymentList{}, err
 	}
 
-	models := &models.Deployments{}
-	models.Parse(deployments)
+	models := &models.DeploymentList{}
+	models.Parse(namespace, deployments)
 	return *models, nil
 }

--- a/services/business/deployments.go
+++ b/services/business/deployments.go
@@ -1,0 +1,23 @@
+package business
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/models"
+)
+
+// DeploymentService deals with fetching istio/kubernetes deployments related content and convert to kiali model
+type DeploymentService struct {
+	k8s kubernetes.IstioClientInterface
+}
+
+// ServiceList is the API handler to fetch the list of deployments in a given namespace
+func (in *DeploymentService) GetDeploymentList(namespace string) (models.Deployments, error) {
+	deployments, err := in.k8s.GetDeployments(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	models := &models.Deployments{}
+	models.Parse(deployments)
+	return *models, nil
+}

--- a/services/business/deployments_test.go
+++ b/services/business/deployments_test.go
@@ -1,0 +1,84 @@
+package business
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/api/apps/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+func setupDeploymentService(k8s *kubetest.K8SClientMock) DeploymentService {
+	return DeploymentService{k8s: k8s}
+}
+
+func TestDeploymentListHandler(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	k8s := new(kubetest.K8SClientMock)
+	k8s.On("GetDeployments", mock.AnythingOfType("string")).Return(fakeDeploymentList(), nil)
+	svc := setupDeploymentService(k8s)
+
+	services, _ := svc.GetDeploymentList("Namespace")
+
+	assert.Equal(3, len(services))
+	assert.Equal("httpbin-v1", services[0].Name)
+	assert.Equal(int32(1), services[0].Replicas)
+	assert.Equal(int32(1), services[0].AvailableReplicas)
+	assert.Equal(int32(0), services[0].UnavailableReplicas)
+
+	assert.Equal("httpbin-v2", services[1].Name)
+	assert.Equal(int32(2), services[1].Replicas)
+	assert.Equal(int32(1), services[1].AvailableReplicas)
+	assert.Equal(int32(1), services[1].UnavailableReplicas)
+
+	assert.Equal("httpbin-v3", services[2].Name)
+	assert.Equal(int32(2), services[2].Replicas)
+	assert.Equal(int32(0), services[2].AvailableReplicas)
+	assert.Equal(int32(2), services[2].UnavailableReplicas)
+}
+
+func fakeDeploymentList() *v1beta1.DeploymentList {
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	return &v1beta1.DeploymentList{
+		Items: []v1beta1.Deployment{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:              "httpbin-v1",
+					CreationTimestamp: meta_v1.NewTime(t1),
+					Labels:            map[string]string{"app": "httpbin", "version": "v1"}},
+				Status: v1beta1.DeploymentStatus{
+					Replicas:            1,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 0,
+				},
+			},
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:              "httpbin-v2",
+					CreationTimestamp: meta_v1.NewTime(t1),
+					Labels:            map[string]string{"app": "httpbin", "version": "v2"}},
+				Status: v1beta1.DeploymentStatus{
+					Replicas:            2,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 1,
+				},
+			},
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:              "httpbin-v3",
+					CreationTimestamp: meta_v1.NewTime(t1),
+					Labels:            map[string]string{"app": "httpbin", "version": "v3"}},
+				Status: v1beta1.DeploymentStatus{
+					Replicas:            2,
+					AvailableReplicas:   0,
+					UnavailableReplicas: 2,
+				},
+			},
+		},
+	}
+}

--- a/services/business/deployments_test.go
+++ b/services/business/deployments_test.go
@@ -23,23 +23,15 @@ func TestDeploymentListHandler(t *testing.T) {
 	k8s.On("GetDeployments", mock.AnythingOfType("string")).Return(fakeDeploymentList(), nil)
 	svc := setupDeploymentService(k8s)
 
-	services, _ := svc.GetDeploymentList("Namespace")
+	deploymentList, _ := svc.GetDeploymentList("Namespace")
+	deployments := deploymentList.Deployments
 
-	assert.Equal(3, len(services))
-	assert.Equal("httpbin-v1", services[0].Name)
-	assert.Equal(int32(1), services[0].Replicas)
-	assert.Equal(int32(1), services[0].AvailableReplicas)
-	assert.Equal(int32(0), services[0].UnavailableReplicas)
+	assert.Equal("Namespace", deploymentList.Namespace.Name)
 
-	assert.Equal("httpbin-v2", services[1].Name)
-	assert.Equal(int32(2), services[1].Replicas)
-	assert.Equal(int32(1), services[1].AvailableReplicas)
-	assert.Equal(int32(1), services[1].UnavailableReplicas)
-
-	assert.Equal("httpbin-v3", services[2].Name)
-	assert.Equal(int32(2), services[2].Replicas)
-	assert.Equal(int32(0), services[2].AvailableReplicas)
-	assert.Equal(int32(2), services[2].UnavailableReplicas)
+	assert.Equal(3, len(deployments))
+	assert.Equal("httpbin-v1", deployments[0].Name)
+	assert.Equal("httpbin-v2", deployments[1].Name)
+	assert.Equal("httpbin-v3", deployments[2].Name)
 }
 
 func fakeDeploymentList() *v1beta1.DeploymentList {

--- a/services/business/deployments_test.go
+++ b/services/business/deployments_test.go
@@ -2,13 +2,13 @@ package business
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/api/apps/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 func setupDeploymentService(k8s *kubetest.K8SClientMock) DeploymentService {

--- a/services/business/layer.go
+++ b/services/business/layer.go
@@ -7,10 +7,11 @@ import (
 
 // Layer is a container for fast access to inner services
 type Layer struct {
-	Svc         SvcService
-	Health      HealthService
-	Validations IstioValidationsService
-	IstioConfig IstioConfigService
+	Svc               SvcService
+	Health            HealthService
+	Validations       IstioValidationsService
+	IstioConfig       IstioConfigService
+	DeploymentService DeploymentService
 }
 
 // Global business.Layer; currently only used for tests to inject mocks,
@@ -36,6 +37,7 @@ func Get() (*Layer, error) {
 	temporaryLayer.Svc = SvcService{prom: prom, k8s: k8s, health: &temporaryLayer.Health}
 	temporaryLayer.Validations = IstioValidationsService{k8s: k8s}
 	temporaryLayer.IstioConfig = IstioConfigService{k8s: k8s}
+	temporaryLayer.DeploymentService = DeploymentService{k8s: k8s}
 	return temporaryLayer, nil
 }
 
@@ -46,5 +48,6 @@ func SetWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	layer.Svc = SvcService{prom: prom, k8s: k8s, health: &layer.Health}
 	layer.Validations = IstioValidationsService{k8s: k8s}
 	layer.IstioConfig = IstioConfigService{k8s: k8s}
+	layer.DeploymentService = DeploymentService{k8s: k8s}
 	return layer
 }

--- a/services/models/deployment.go
+++ b/services/models/deployment.go
@@ -7,15 +7,46 @@ import (
 
 type Deployments []*Deployment
 type Deployment struct {
-	Name                string            `json:"name"`
+	// Deployment name
+	// required: true
+	// example: reviews
+	Name string `json:"name"`
+
+	// Kubernetes annotations
+	// required: true
 	TemplateAnnotations map[string]string `json:"templateAnnotations"`
-	Labels              map[string]string `json:"labels"`
-	CreatedAt           string            `json:"createdAt"`
-	ResourceVersion     string            `json:"resourceVersion"`
-	Replicas            int32             `json:"replicas"`
-	AvailableReplicas   int32             `json:"availableReplicas"`
-	UnavailableReplicas int32             `json:"unavailableReplicas"`
-	Autoscaler          Autoscaler        `json:"autoscaler"`
+
+	// Kubernetes labels
+	// required: true
+	Labels map[string]string `json:"labels"`
+
+	// Creation timestamp (in RFC3339 format)
+	// required: true
+	// example: 2018-07-31T12:24:17Z
+	CreatedAt string `json:"createdAt"`
+
+	// Kubernetes ResourceVersion
+	// required: true
+	// example: 192892127
+	ResourceVersion string `json:"resourceVersion"`
+
+	// Number of desired replicas
+	// required: true
+	// example: 2
+	Replicas int32 `json:"replicas"`
+
+	// Number of available replicas
+	// required: true
+	// example: 1
+	AvailableReplicas int32 `json:"availableReplicas"`
+
+	// Number of unavailable replicas
+	// required: true
+	// example: 1
+	UnavailableReplicas int32 `json:"unavailableReplicas"`
+
+	// Autoscaler bound to the deployment
+	Autoscaler Autoscaler `json:"autoscaler"`
 }
 
 func (deployments *Deployments) Parse(ds *v1beta1.DeploymentList) {

--- a/services/models/deployment.go
+++ b/services/models/deployment.go
@@ -5,6 +5,24 @@ import (
 	"k8s.io/api/autoscaling/v1"
 )
 
+type DeploymentList struct {
+	// Namespace where the deployments live in
+	// required: true
+	// example: bookinfo
+	Namespace Namespace `json:"namespace"`
+
+	// Deployments for a given namespace
+	// required: true
+	Deployments []DeploymentOverview `json:"deployments"`
+}
+
+type DeploymentOverview struct {
+	// Name of the deployment
+	// required: true
+	// example: reviews-v1
+	Name string `json:"name"`
+}
+
 type Deployments []*Deployment
 type Deployment struct {
 	// Deployment name
@@ -70,6 +88,24 @@ func (deployment *Deployment) Parse(d *v1beta1.Deployment) {
 	deployment.Replicas = d.Status.Replicas
 	deployment.AvailableReplicas = d.Status.AvailableReplicas
 	deployment.UnavailableReplicas = d.Status.UnavailableReplicas
+}
+
+func (deploymentList *DeploymentList) Parse(namespace string, ds *v1beta1.DeploymentList) {
+	if ds == nil {
+		return
+	}
+
+	deploymentList.Namespace.Name = namespace
+
+	for _, deployment := range ds.Items {
+		casted := DeploymentOverview{}
+		casted.Parse(deployment)
+		(*deploymentList).Deployments = append((*deploymentList).Deployments, casted)
+	}
+}
+
+func (deployment *DeploymentOverview) Parse(d v1beta1.Deployment) {
+	deployment.Name = d.Name
 }
 
 func (deployments *Deployments) AddAutoscalers(as *v1.HorizontalPodAutoscalerList) {

--- a/swagger.json
+++ b/swagger.json
@@ -47,6 +47,46 @@
         }
       }
     },
+    "/namespaces/{namespace}/deployments": {
+      "get": {
+        "description": "Endpoint to get the list of deployments for a namespace",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "deploymentList",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/deploymentListResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/istio": {
       "get": {
         "description": "Endpoint to get the list of Istio Config of a namespace",
@@ -311,6 +351,149 @@
     }
   },
   "definitions": {
+    "Autoscaler": {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "x-go-name": "CreatedAt"
+        },
+        "currentCPUUtilizationPercentage": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "CurrentCPUUtilizationPercentage"
+        },
+        "currentReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "CurrentReplicas"
+        },
+        "desiredReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "DesiredReplicas"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Labels"
+        },
+        "lastScaleTime": {
+          "type": "string",
+          "x-go-name": "LastScaleTime"
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "MaxReplicas"
+        },
+        "minReplicas": {
+          "description": "Spec",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "MinReplicas"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "observedGeneration": {
+          "description": "Status",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ObservedGeneration"
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "TargetCPUUtilizationPercentage"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "Deployment": {
+      "type": "object",
+      "required": [
+        "name",
+        "templateAnnotations",
+        "labels",
+        "createdAt",
+        "resourceVersion",
+        "replicas",
+        "availableReplicas",
+        "unavailableReplicas"
+      ],
+      "properties": {
+        "autoscaler": {
+          "$ref": "#/definitions/Autoscaler"
+        },
+        "availableReplicas": {
+          "description": "Number of available replicas",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "AvailableReplicas",
+          "example": 1
+        },
+        "createdAt": {
+          "description": "Creation timestamp (in RFC3339 format)",
+          "type": "string",
+          "x-go-name": "CreatedAt",
+          "example": "2018-07-31T12:24:17Z"
+        },
+        "labels": {
+          "description": "Kubernetes labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Labels"
+        },
+        "name": {
+          "description": "Deployment name",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "reviews"
+        },
+        "replicas": {
+          "description": "Number of desired replicas",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "Replicas",
+          "example": 2
+        },
+        "resourceVersion": {
+          "description": "Kubernetes ResourceVersion",
+          "type": "string",
+          "x-go-name": "ResourceVersion",
+          "example": "192892127"
+        },
+        "templateAnnotations": {
+          "description": "Kubernetes annotations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "TemplateAnnotations"
+        },
+        "unavailableReplicas": {
+          "description": "Number of unavailable replicas",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "UnavailableReplicas",
+          "example": 1
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "Deployments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Deployment"
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
     "Gateway": {
       "type": "object",
       "properties": {
@@ -827,6 +1010,12 @@
     }
   },
   "responses": {
+    "deploymentListResponse": {
+      "description": "Listing all deployments in the namespace",
+      "schema": {
+        "$ref": "#/definitions/Deployments"
+      }
+    },
     "genericError": {
       "description": "A GenericError is the default error message that is generated.",
       "schema": {

--- a/swagger.json
+++ b/swagger.json
@@ -351,146 +351,39 @@
     }
   },
   "definitions": {
-    "Autoscaler": {
-      "type": "object",
-      "properties": {
-        "createdAt": {
-          "type": "string",
-          "x-go-name": "CreatedAt"
-        },
-        "currentCPUUtilizationPercentage": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "CurrentCPUUtilizationPercentage"
-        },
-        "currentReplicas": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "CurrentReplicas"
-        },
-        "desiredReplicas": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "DesiredReplicas"
-        },
-        "labels": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-go-name": "Labels"
-        },
-        "lastScaleTime": {
-          "type": "string",
-          "x-go-name": "LastScaleTime"
-        },
-        "maxReplicas": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "MaxReplicas"
-        },
-        "minReplicas": {
-          "description": "Spec",
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "MinReplicas"
-        },
-        "name": {
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "observedGeneration": {
-          "description": "Status",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ObservedGeneration"
-        },
-        "targetCPUUtilizationPercentage": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "TargetCPUUtilizationPercentage"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
-    "Deployment": {
+    "DeploymentList": {
       "type": "object",
       "required": [
-        "name",
-        "templateAnnotations",
-        "labels",
-        "createdAt",
-        "resourceVersion",
-        "replicas",
-        "availableReplicas",
-        "unavailableReplicas"
+        "namespace",
+        "deployments"
       ],
       "properties": {
-        "autoscaler": {
-          "$ref": "#/definitions/Autoscaler"
-        },
-        "availableReplicas": {
-          "description": "Number of available replicas",
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "AvailableReplicas",
-          "example": 1
-        },
-        "createdAt": {
-          "description": "Creation timestamp (in RFC3339 format)",
-          "type": "string",
-          "x-go-name": "CreatedAt",
-          "example": "2018-07-31T12:24:17Z"
-        },
-        "labels": {
-          "description": "Kubernetes labels",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+        "deployments": {
+          "description": "Deployments for a given namespace",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeploymentOverview"
           },
-          "x-go-name": "Labels"
+          "x-go-name": "Deployments"
         },
-        "name": {
-          "description": "Deployment name",
-          "type": "string",
-          "x-go-name": "Name",
-          "example": "reviews"
-        },
-        "replicas": {
-          "description": "Number of desired replicas",
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "Replicas",
-          "example": 2
-        },
-        "resourceVersion": {
-          "description": "Kubernetes ResourceVersion",
-          "type": "string",
-          "x-go-name": "ResourceVersion",
-          "example": "192892127"
-        },
-        "templateAnnotations": {
-          "description": "Kubernetes annotations",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-go-name": "TemplateAnnotations"
-        },
-        "unavailableReplicas": {
-          "description": "Number of unavailable replicas",
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "UnavailableReplicas",
-          "example": 1
+        "namespace": {
+          "$ref": "#/definitions/namespace"
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
-    "Deployments": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Deployment"
+    "DeploymentOverview": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the deployment",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "reviews-v1"
+        }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
@@ -1013,7 +906,7 @@
     "deploymentListResponse": {
       "description": "Listing all deployments in the namespace",
       "schema": {
-        "$ref": "#/definitions/Deployments"
+        "$ref": "#/definitions/DeploymentList"
       }
     },
     "genericError": {


### PR DESCRIPTION
Adding a WorkloadList endpoint returning the list of deployments of a namespace.

![screenshot of kiali-istio-system 192 168 42 123 nip io_api_namespaces_bookinfo_deployments](https://user-images.githubusercontent.com/613814/43534287-3af60a1a-95b7-11e8-9822-9cc5af597787.jpg)

** Questions **
We say it is a Workload list, but in our backend is a deployment list with toppings. Should we rename endpoints, models and so on?

** Issue reference **
[KIALI-1210](https://issues.jboss.org/browse/KIALI-1278) 

** Backwards incompatible? **
Yes.