### PR TITLE
KIALI-1267 [1.0] includeIstio changes

### DIFF
--- a/graph/appender/response_time_test.go
+++ b/graph/appender/response_time_test.go
@@ -134,9 +134,10 @@ func TestResponseTime(t *testing.T) {
 	duration, _ := time.ParseDuration("60s")
 	appender := ResponseTimeAppender{
 		Duration:  duration,
+		GraphType: graph.GraphTypeApp,
+		false,
 		Quantile:  0.95,
 		QueryTime: time.Now().Unix(),
-		GraphType: graph.GraphTypeApp,
 		Versioned: true,
 	}
 

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -161,11 +161,12 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 			}
 		}
 		a := appender.ResponseTimeAppender{
-			Duration:  o.Duration,
-			Quantile:  quantile,
-			QueryTime: o.QueryTime,
-			GraphType: o.GraphType,
-			Versioned: o.Versioned,
+			Duration:     o.Duration,
+			Quantile:     quantile,
+			GraphType:    o.GraphType,
+			IncludeIstio: o.IncludeIstio,
+			QueryTime:    o.QueryTime,
+			Versioned:    o.Versioned,
 		}
 		appenders = append(appenders, a)
 	}

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -58,9 +58,6 @@ func extractMetricsQueryParams(r *http.Request, q *prometheus.MetricsQuery) erro
 	if lblsout, ok := queryParams["byLabelsOut[]"]; ok && len(lblsout) > 0 {
 		q.ByLabelsOut = lblsout
 	}
-	if includeIstio, err := strconv.ParseBool(queryParams.Get("includeIstio")); err == nil {
-		q.IncludeIstio = includeIstio
-	}
 
 	// Adjust start & end times to be a multiple of step
 	stepInSecs := int64(q.Step.Seconds())

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -61,8 +61,12 @@ func (in *Client) Inject(api v1.API) {
 // Returned map has a destination version as a key and a list of workloads as values.
 // It returns an error on any problem.
 func (in *Client) GetSourceWorkloads(namespace string, servicename string) (map[string][]Workload, error) {
-	query := fmt.Sprintf("istio_requests_total{reporter=\"source\",destination_service_name=\"%s\",destination_service_namespace=\"%s\"}",
-		servicename, namespace)
+	reporter := "source"
+	if config.Get().IstioNamespace == namespace {
+		reporter = "destination"
+	}
+	query := fmt.Sprintf("istio_requests_total{reporter=\"%s\",destination_service_name=\"%s\",destination_service_namespace=\"%s\"}",
+		reporter, servicename, namespace)
 	result, err := in.api.Query(context.Background(), query, time.Now())
 	if err != nil {
 		return nil, err

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -211,7 +211,6 @@ func NewRoutes() (r *Routes) {
 			// filters[]:     List of metrics to fetch (empty by default). When empty, all metrics are fetched. Expected name here is the Kiali internal metric name
 			// byLabelsIn[]:  List of labels to use for grouping input metrics (empty by default). Example: response_code,source_version
 			// byLabelsOut[]: List of labels to use for grouping output metrics (empty by default). Example: response_code,destination_version
-			// includeIstio:  Include istio-system destinations in collected metrics (default false)
 
 			"ServiceMetrics",
 			"GET",
@@ -228,7 +227,6 @@ func NewRoutes() (r *Routes) {
 			// filters[]:     List of metrics to fetch (empty by default). When empty, all metrics are fetched. Expected name here is the Kiali internal metric name
 			// byLabelsIn[]:  List of labels to use for grouping input metrics (empty by default). Example: response_code,source_version
 			// byLabelsOut[]: List of labels to use for grouping output metrics (empty by default). Example: response_code,destination_version
-			// includeIstio:  Include istio-system destinations in collected metrics (default false)
 			"WorkloadMetrics",
 			"GET",
 			"/api/namespaces/{namespace}/workloads/{workload}/metrics",
@@ -272,34 +270,19 @@ func NewRoutes() (r *Routes) {
 		},
 		{
 			// Supported query parameters:
-			// appenders:      comma-separated list of desired appenders (default all)
+			// appenders:      Comma-separated list of desired appenders (default all)
 			// duration:       Duration indicating desired query period (default 10m)
-			// groupByVersion: visually group versions of the same service (cytoscape only, default true)
-			// includeIstio    include istio-system services in graph (default false)
+			// groupByVersion: Visually group versions of the same app (cytoscape only, default true)
+			// includeIstio:   Include istio-system destinations in graph (default false)
 			// metric:         Prometheus metric name used to generate the dependency graph (default=istio_request_count)
-			// namespaces:     comma-separated list of namespaces will override path param (path param 'all' for all namespaces)
+			// namespaces:     Comma-separated list of namespaces will override path param (path param 'all' for all namespaces)
 			// queryTime:      Unix timestamp in seconds is query range end time (default now)
-			// vendor:         cytoscape (default) | vizceral
+			// vendor:         Graph format: cytoscape (default) | vizceral
 
 			"GraphNamespace",
 			"GET",
 			"/api/namespaces/{namespace}/graph",
 			handlers.GraphNamespace,
-			true,
-		},
-		{
-			// Supported query parameters:
-			// appenders:      comma-separated list of desired appenders (default all)
-			// duration:       Duration indicating desired query period (default 10m)
-			// groupByVersion: visually group versions of the same service (cytoscape only, default true)
-			// includeIstio    include istio-system services in graph (default false)
-			// metric:         Prometheus metric name used to generate the dependency graph (default=istio_request_count)
-			// queryTime:      Unix timestamp in seconds is query range end time (default now)
-
-			"GraphService",
-			"GET",
-			"/api/namespaces/{namespace}/services/{service}/graph",
-			handlers.GraphService,
 			true,
 		},
 		{


### PR DESCRIPTION
Telemetry surrounding istio-system namespace has changed in Istio 1.0.
With the exception of ingressgateway istio-system components only support
destination-side telemetry (reporter="destination").  Also, some prior
telemetry is now not reported since the traffic changed from http to gRPC.

- update the graph "includeIstio" support to perform additional queries as necessary
- remove "includeIstio" option from metrics support in favor of just changing
  queries from source to destination telemetry when dealing with the
  istio-system namespace. Remove the special filtering for istio-system as
  the source-side reporting will not include it anyway.
