### PR TITLE
KIALI-1281 Introduce NodeType

### DIFF
--- a/graph/appender/response_time.go
+++ b/graph/appender/response_time.go
@@ -29,7 +29,6 @@ type ResponseTimeAppender struct {
 	IncludeIstio bool
 	Quantile     float64
 	QueryTime    int64 // unix time in seconds
-	Versioned    bool
 }
 
 // AppendGraph implements Appender
@@ -160,11 +159,8 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		destApp := string(lDestApp)
 		destVer := string(lDestVer)
 
-		// handle any changes to dest field values given telemetry and graph type
-		destApp, destWl = graph.DestFields(sourceApp, destApp, destWl, destSvcName, a.GraphType)
-
-		sourceId, _ := graph.Id(sourceWlNs, sourceWl, sourceApp, sourceVer, a.GraphType, a.Versioned)
-		destId, _ := graph.Id(destSvcNs, destWl, destApp, destVer, a.GraphType, a.Versioned)
+		sourceId, _ := graph.Id(sourceWlNs, sourceWl, sourceApp, sourceVer, "", a.GraphType)
+		destId, _ := graph.Id(destSvcNs, destWl, destApp, destVer, destSvcName, a.GraphType)
 		key := fmt.Sprintf("%s %s", sourceId, destId)
 		val := float64(s.Value)
 		responseTimeMap[key] += val

--- a/graph/appender/unused_node.go
+++ b/graph/appender/unused_node.go
@@ -11,7 +11,6 @@ import (
 
 type UnusedNodeAppender struct {
 	GraphType string
-	Versioned bool
 }
 
 // AppendGraph implements Appender
@@ -56,11 +55,11 @@ func (a UnusedNodeAppender) buildUnusedTrafficMap(trafficMap graph.TrafficMap, n
 		if v, ok := labels[versionLabel]; ok {
 			version = v
 		}
-		id, isWorkload := graph.Id(namespace, d.Name, app, version, a.GraphType, a.Versioned)
+		id, nodeType := graph.Id(namespace, d.Name, app, version, "", a.GraphType)
 		if _, found := trafficMap[id]; !found {
 			if _, found = unusedTrafficMap[id]; !found {
 				log.Debugf("Adding unused node for deployment [%s] with labels [%v]", d.Name, labels)
-				node := graph.NewNodeExplicit(id, namespace, d.Name, app, version, isWorkload, a.Versioned)
+				node := graph.NewNodeExplicit(id, namespace, d.Name, app, version, "", nodeType, a.GraphType)
 				node.Metadata = map[string]interface{}{"rate": 0.0, "rateOut": 0.0, "isUnused": true}
 				unusedTrafficMap[id] = &node
 			}

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -25,7 +25,6 @@ const (
 	defaultGroupBy       string = GroupByVersion
 	defaultMetric        string = "istio_requests_total"
 	defaultVendor        string = "cytoscape"
-	defaultVersioned     bool   = true
 )
 
 // VendorOptions are those that are supplied to the vendor-specific generators.
@@ -33,7 +32,6 @@ type VendorOptions struct {
 	GraphType string
 	GroupBy   string
 	Timestamp int64
-	Versioned bool
 }
 
 // Options are all supported graph generation options.
@@ -65,7 +63,6 @@ func NewOptions(r *http.Request) Options {
 	queryTime, queryTimeErr := strconv.ParseInt(params.Get("queryTime"), 10, 64)
 	namespaces := params.Get("namespaces") // csl of namespaces. Overrides namespace path param if set
 	vendor := params.Get("vendor")
-	versioned, versionedErr := strconv.ParseBool(params.Get("versioned"))
 
 	var namespaceNames []string
 	fetchNamespaces := namespaces == NamespaceAll || (namespaces == "" && (namespace == NamespaceAll))
@@ -111,9 +108,6 @@ func NewOptions(r *http.Request) Options {
 	if "" == vendor {
 		vendor = defaultVendor
 	}
-	if versionedErr != nil {
-		versioned = defaultVersioned
-	}
 
 	options := Options{
 		Duration:     duration,
@@ -127,7 +121,6 @@ func NewOptions(r *http.Request) Options {
 			GraphType: graphType,
 			GroupBy:   groupBy,
 			Timestamp: queryTime,
-			Versioned: versioned,
 		},
 	}
 
@@ -166,24 +159,19 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 			GraphType:    o.GraphType,
 			IncludeIstio: o.IncludeIstio,
 			QueryTime:    o.QueryTime,
-			Versioned:    o.Versioned,
 		}
 		appenders = append(appenders, a)
 	}
 	if csl == AppenderAll || strings.Contains(csl, "unused_node") {
 		appenders = append(appenders, appender.UnusedNodeAppender{
 			GraphType: o.GraphType,
-			Versioned: o.Versioned,
 		})
 	}
 	if csl == AppenderAll || strings.Contains(csl, "istio") {
 		appenders = append(appenders, appender.IstioAppender{})
 	}
 	if csl == AppenderAll || strings.Contains(csl, "sidecars_check") {
-		appenders = append(appenders, appender.SidecarsCheckAppender{
-			GraphType: o.GraphType,
-			Versioned: o.Versioned,
-		})
+		appenders = append(appenders, appender.SidecarsCheckAppender{})
 	}
 
 	return appenders

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -272,6 +272,7 @@ func NewRoutes() (r *Routes) {
 			// Supported query parameters:
 			// appenders:      Comma-separated list of desired appenders (default all)
 			// duration:       Duration indicating desired query period (default 10m)
+			// graphType:      Graph type for the telemetry data: app | versionedApp | workload (default workload)
 			// groupByVersion: Visually group versions of the same app (cytoscape only, default true)
 			// includeIstio:   Include istio-system destinations in graph (default false)
 			// metric:         Prometheus metric name used to generate the dependency graph (default=istio_request_count)


### PR DESCRIPTION
- remove isWorkload for more robust nodeType
- change node ids to use workloadName instead of app+version label value. This
  is better when anti-pattern labeling is used.
