### PR TITLE
KIALI-1180 Update grafana info for istio-1 dashboards

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,13 +32,15 @@ const (
 	EnvServerStaticContentRootDirectory = "SERVER_STATIC_CONTENT_ROOT_DIRECTORY"
 	EnvServerCORSAllowAll               = "SERVER_CORS_ALLOW_ALL"
 
-	EnvGrafanaDisplayLink      = "GRAFANA_DISPLAY_LINK"
-	EnvGrafanaURL              = "GRAFANA_URL"
-	EnvGrafanaServiceNamespace = "GRAFANA_SERVICE_NAMESPACE"
-	EnvGrafanaService          = "GRAFANA_SERVICE"
-	EnvGrafanaDashboard        = "GRAFANA_DASHBOARD"
-	EnvGrafanaVarServiceSource = "GRAFANA_VAR_SERVICE_SOURCE"
-	EnvGrafanaVarServiceDest   = "GRAFANA_VAR_SERVICE_DEST"
+	EnvGrafanaDisplayLink              = "GRAFANA_DISPLAY_LINK"
+	EnvGrafanaURL                      = "GRAFANA_URL"
+	EnvGrafanaServiceNamespace         = "GRAFANA_SERVICE_NAMESPACE"
+	EnvGrafanaService                  = "GRAFANA_SERVICE"
+	EnvGrafanaWorkloadDashboardPattern = "GRAFANA_WORKLOAD_DASHBOARD_PATTERN"
+	EnvGrafanaServiceDashboardPattern  = "GRAFANA_SERVICE_DASHBOARD_PATTERN"
+	EnvGrafanaVarNamespace             = "GRAFANA_VAR_NAMESPACE"
+	EnvGrafanaVarService               = "GRAFANA_VAR_SERVICE"
+	EnvGrafanaVarWorkload              = "GRAFANA_VAR_WORKLOAD"
 
 	EnvJaegerURL              = "JAEGER_URL"
 	EnvJaegerServiceNamespace = "JAEGER_SERVICE_NAMESPACE"
@@ -69,13 +71,15 @@ type Server struct {
 
 // GrafanaConfig describes configuration used for Grafana links
 type GrafanaConfig struct {
-	DisplayLink      bool   `yaml:"display_link"`
-	URL              string `yaml:"url"`
-	ServiceNamespace string `yaml:"service_namespace"`
-	Service          string `yaml:"service"`
-	Dashboard        string `yaml:"dashboard"`
-	VarServiceSource string `yaml:"var_service_source"`
-	VarServiceDest   string `yaml:"var_service_dest"`
+	DisplayLink              bool   `yaml:"display_link"`
+	URL                      string `yaml:"url"`
+	ServiceNamespace         string `yaml:"service_namespace"`
+	Service                  string `yaml:"service"`
+	WorkloadDashboardPattern string `yaml:"workload_dashboard_pattern"`
+	ServiceDashboardPattern  string `yaml:"service_dashboard_pattern"`
+	VarNamespace             string `yaml:"var_namespace"`
+	VarService               string `yaml:"var_service"`
+	VarWorkload              string `yaml:"var_workload"`
 }
 
 // JaegerConfig describes configuration used for jaeger links
@@ -147,9 +151,11 @@ func NewConfig() (c *Config) {
 	c.ExternalServices.Grafana.URL = strings.TrimSpace(getDefaultString(EnvGrafanaURL, ""))
 	c.ExternalServices.Grafana.ServiceNamespace = strings.TrimSpace(getDefaultString(EnvGrafanaServiceNamespace, "istio-system"))
 	c.ExternalServices.Grafana.Service = strings.TrimSpace(getDefaultString(EnvGrafanaService, "grafana"))
-	c.ExternalServices.Grafana.Dashboard = strings.TrimSpace(getDefaultString(EnvGrafanaDashboard, "istio-dashboard"))
-	c.ExternalServices.Grafana.VarServiceSource = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceSource, "var-source"))
-	c.ExternalServices.Grafana.VarServiceDest = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceDest, "var-http_destination"))
+	c.ExternalServices.Grafana.WorkloadDashboardPattern = strings.TrimSpace(getDefaultString(EnvGrafanaWorkloadDashboardPattern, "Istio%20Workload%20Dashboard"))
+	c.ExternalServices.Grafana.ServiceDashboardPattern = strings.TrimSpace(getDefaultString(EnvGrafanaServiceDashboardPattern, "Istio%20Service%20Dashboard"))
+	c.ExternalServices.Grafana.VarNamespace = strings.TrimSpace(getDefaultString(EnvGrafanaVarNamespace, "var-namespace"))
+	c.ExternalServices.Grafana.VarService = strings.TrimSpace(getDefaultString(EnvGrafanaVarService, "var-service"))
+	c.ExternalServices.Grafana.VarWorkload = strings.TrimSpace(getDefaultString(EnvGrafanaVarWorkload, "var-workload"))
 
 	// Jaeger Configuration
 	c.ExternalServices.Jaeger.URL = strings.TrimSpace(getDefaultString(EnvJaegerURL, ""))

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"k8s.io/api/core/v1"
@@ -14,11 +16,12 @@ import (
 
 type osRouteSupplier func(string, string) (string, error)
 type serviceSupplier func(string, string) (*v1.ServiceSpec, error)
+type dashboardSupplier func(string, string) (string, error)
 
 // GetGrafanaInfo provides the Grafana URL and other info, first by checking if a config exists
 // then (if not) by inspecting the Kubernetes Grafana service in namespace istio-system
 func GetGrafanaInfo(w http.ResponseWriter, r *http.Request) {
-	info, code, err := getGrafanaInfo(getOpenshiftRouteURL, getService)
+	info, code, err := getGrafanaInfo(getOpenshiftRouteURL, getService, findDashboardPath)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, code, err.Error())
@@ -28,22 +31,50 @@ func GetGrafanaInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 // getGrafanaInfo returns the Grafana URL and other info, the HTTP status code (int) and eventually an error
-func getGrafanaInfo(osRouteSupplier osRouteSupplier, serviceSupplier serviceSupplier) (*models.GrafanaInfo, int, error) {
-	suffix := config.Get().ExternalServices.Istio.IstioIdentityDomain
+func getGrafanaInfo(osRouteSupplier osRouteSupplier, serviceSupplier serviceSupplier, dashboardSupplier dashboardSupplier) (*models.GrafanaInfo, int, error) {
 	grafanaConfig := config.Get().ExternalServices.Grafana
 	if !grafanaConfig.DisplayLink {
 		return nil, http.StatusNoContent, nil
 	}
+
+	// Find the in-cluster URL to reach Grafana's REST API
+	spec, err := serviceSupplier(grafanaConfig.ServiceNamespace, grafanaConfig.Service)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if len(spec.Ports) == 0 {
+		return nil, http.StatusInternalServerError, errors.New("No port found for Grafana service, cannot access in-cluster service")
+	}
+	if len(spec.Ports) > 1 {
+		log.Warning("Several ports found for Grafana service, picking the first one")
+	}
+	internalURL := fmt.Sprintf("http://%s.%s:%d", grafanaConfig.Service, grafanaConfig.ServiceNamespace, spec.Ports[0].Port)
+
+	// Call Grafana REST API to get dashboard urls
+	serviceDashboardPath, err := dashboardSupplier(internalURL, grafanaConfig.ServiceDashboardPattern)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	workloadDashboardPath, err := dashboardSupplier(internalURL, grafanaConfig.WorkloadDashboardPattern)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+
 	grafanaInfo := models.GrafanaInfo{
-		URL:              grafanaConfig.URL,
-		VariablesSuffix:  suffix,
-		Dashboard:        grafanaConfig.Dashboard,
-		VarServiceSource: grafanaConfig.VarServiceSource,
-		VarServiceDest:   grafanaConfig.VarServiceDest}
+		URL:                   grafanaConfig.URL,
+		ServiceDashboardPath:  serviceDashboardPath,
+		WorkloadDashboardPath: workloadDashboardPath,
+		VarNamespace:          grafanaConfig.VarNamespace,
+		VarService:            grafanaConfig.VarService,
+		VarWorkload:           grafanaConfig.VarWorkload,
+	}
+
+	// Case of overridden URL from config: use it and return immediately
 	if grafanaInfo.URL != "" {
 		return &grafanaInfo, http.StatusOK, nil
 	}
 
+	// OpenShift case: find any associated route
 	url, err := osRouteSupplier(grafanaConfig.ServiceNamespace, grafanaConfig.Service)
 	if err == nil {
 		grafanaInfo.URL = url
@@ -51,28 +82,41 @@ func getGrafanaInfo(osRouteSupplier osRouteSupplier, serviceSupplier serviceSupp
 	}
 	// Else on error, silently continue. Might not be running on OpenShift.
 
-	spec, err := serviceSupplier(grafanaConfig.ServiceNamespace, grafanaConfig.Service)
-	if err != nil {
-		return nil, http.StatusInternalServerError, err
-	}
-
+	// Fallback scenario, try to find any external IP.
 	if len(spec.ExternalIPs) == 0 {
 		return nil, http.StatusNotFound, errors.New("Unable to find Grafana URL: no route defined. ExternalIPs not defined on service 'grafana'")
 	}
-	var port int32
-	port = 80
-
 	if len(spec.ExternalIPs) > 1 {
-		log.Warning("Several IPs found for service 'grafana', only the first will be used")
-	}
-	if len(spec.Ports) > 0 {
-		port = spec.Ports[0].Port
-		if len(spec.Ports) > 1 {
-			log.Warning("Several ports found for service 'grafana', only the first will be used")
-		}
+		log.Warning("Several IPs found for Grafana service, picking the first one")
 	}
 
 	// detect https?
-	grafanaInfo.URL = fmt.Sprintf("http://%s:%d", spec.ExternalIPs[0], port)
+	grafanaInfo.URL = fmt.Sprintf("http://%s:%d", spec.ExternalIPs[0], spec.Ports[0].Port)
 	return &grafanaInfo, http.StatusOK, nil
+}
+
+func findDashboardPath(url, searchPattern string) (string, error) {
+	resp, err := http.Get(url + "/api/search?query=" + searchPattern)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	var f interface{}
+	err = json.Unmarshal(body, &f)
+	if err != nil {
+		return "", err
+	}
+	dashboards := f.([]interface{})
+	if len(dashboards) == 0 {
+		return "", fmt.Errorf("No Grafana dashboard found for pattern '%s'", searchPattern)
+	}
+	if len(dashboards) > 1 {
+		log.Infof("Several Grafana dashboards found for pattern '%s', picking the first one", searchPattern)
+	}
+	dashPath := dashboards[0].(map[string]interface{})["url"]
+	return dashPath.(string), nil
 }

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -22,6 +22,8 @@ func TestGetGrafanaInfoDisabled(t *testing.T) {
 			ClusterIP: "fromservice",
 			Ports: []v1.ServicePort{
 				v1.ServicePort{Port: 3000}}}, nil
+	}, func(_, _ string) (string, error) {
+		return "/dash", nil
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusNoContent, code)
@@ -38,11 +40,12 @@ func TestGetGrafanaInfoFromOpenshift(t *testing.T) {
 			ClusterIP: "fromservice",
 			Ports: []v1.ServicePort{
 				v1.ServicePort{Port: 3000}}}, nil
+	}, func(_, _ string) (string, error) {
+		return "/dash", nil
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
 	assert.Equal(t, "http://fromopenshift", info.URL)
-	assert.Equal(t, "svc.cluster.local", info.VariablesSuffix)
 }
 
 func TestGetGrafanaInfoFromService(t *testing.T) {
@@ -55,11 +58,12 @@ func TestGetGrafanaInfoFromService(t *testing.T) {
 			ExternalIPs: []string{"fromservice"},
 			Ports: []v1.ServicePort{
 				v1.ServicePort{Port: 3000}}}, nil
+	}, func(_, _ string) (string, error) {
+		return "/dash", nil
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
 	assert.Equal(t, "http://fromservice:3000", info.URL)
-	assert.Equal(t, "svc.cluster.local", info.VariablesSuffix)
 }
 
 func TestGetGrafanaInfoFromConfig(t *testing.T) {
@@ -73,27 +77,12 @@ func TestGetGrafanaInfoFromConfig(t *testing.T) {
 			ExternalIPs: []string{"fromservice"},
 			Ports: []v1.ServicePort{
 				v1.ServicePort{Port: 3000}}}, nil
+	}, func(_, _ string) (string, error) {
+		return "/dash", nil
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
 	assert.Equal(t, "http://fromconfig:3001", info.URL)
-	assert.Equal(t, "svc.cluster.local", info.VariablesSuffix)
-}
-
-func TestGetGrafanaInfoNoPort(t *testing.T) {
-	conf := config.NewConfig()
-	config.Set(conf)
-	info, code, err := getGrafanaInfo(func(_, _ string) (string, error) {
-		return "", errors.New("")
-	}, func(_, _ string) (*v1.ServiceSpec, error) {
-		return &v1.ServiceSpec{
-			ExternalIPs: []string{"10.0.0.1"},
-			Ports:       []v1.ServicePort{}}, nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, code)
-	assert.Equal(t, "http://10.0.0.1:80", info.URL)
-	assert.Equal(t, "svc.cluster.local", info.VariablesSuffix)
 }
 
 func TestGetGrafanaInfoNoExternalIP(t *testing.T) {
@@ -106,6 +95,8 @@ func TestGetGrafanaInfoNoExternalIP(t *testing.T) {
 			ExternalIPs: []string{},
 			Ports: []v1.ServicePort{
 				v1.ServicePort{Port: 3000}}}, nil
+	}, func(_, _ string) (string, error) {
+		return "/dash", nil
 	})
 	assert.NotNil(t, err)
 	assert.Equal(t, http.StatusNotFound, code)

--- a/services/models/grafana_info.go
+++ b/services/models/grafana_info.go
@@ -2,9 +2,10 @@ package models
 
 // GrafanaInfo provides information to access Grafana dashboards
 type GrafanaInfo struct {
-	URL              string `json:"url"`
-	VariablesSuffix  string `json:"variablesSuffix"`
-	Dashboard        string `json:"dashboard"`
-	VarServiceSource string `json:"varServiceSource"`
-	VarServiceDest   string `json:"varServiceDest"`
+	URL                   string `json:"url"`
+	ServiceDashboardPath  string `json:"serviceDashboardPath"`
+	WorkloadDashboardPath string `json:"workloadDashboardPath"`
+	VarNamespace          string `json:"varNamespace"`
+	VarService            string `json:"varService"`
+	VarWorkload           string `json:"varWorkload"`
 }


### PR DESCRIPTION
We now need to fetch the grafana REST API in order to get the dashboard path because they now include some random id.

Also, istio now provides two different dashboards for workloads and services
