### PR TITLE
KIALI-1210 DeploymentsList endpoint renamed to WorkloadList

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,7 @@ import (
 // A Namespace provide a scope for names.
 // This type used to describe a set of objects.
 //
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations deploymentList
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList
 type NamespaceParam struct {
 	// The id of the namespace.
 	//
@@ -137,11 +137,11 @@ type ServiceValidationResponse struct {
 	Body TypedIstioValidations
 }
 
-// Listing all deployments in the namespace
-// swagger:response deploymentListResponse
-type DeploymentListResponse struct {
+// Listing all workloads in the namespace
+// swagger:response workloadListResponse
+type WorkloadListResponse struct {
 	// in:body
-	Body models.DeploymentList
+	Body models.WorkloadList
 }
 
 //////////////////

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-func DeploymentList(w http.ResponseWriter, r *http.Request) {
+func WorkloadList(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
 	// Get business layer
@@ -17,12 +17,12 @@ func DeploymentList(w http.ResponseWriter, r *http.Request) {
 	}
 	namespace := params["namespace"]
 
-	// Fetch and build deployments
-	serviceList, err := business.DeploymentService.GetDeploymentList(namespace)
+	// Fetch and build workloads
+	workloadList, err := business.Workload.GetWorkloadList(namespace)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	RespondWithJSON(w, http.StatusOK, serviceList)
+	RespondWithJSON(w, http.StatusOK, workloadList)
 }

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -23,7 +23,7 @@ func setupDeploymentList() (*httptest.Server, *kubetest.K8SClientMock, *promethe
 	business.SetWithBackends(k8s, prom)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/workloads", DeploymentList)
+	mr.HandleFunc("/api/namespaces/{namespace}/workloads", WorkloadList)
 
 	ts := httptest.NewServer(mr)
 	return ts, k8s, prom

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -170,9 +170,9 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceDetails,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/deployments deploymentList
+		// swagger:route GET /namespaces/{namespace}/workloads workloadList
 		// ---
-		// Endpoint to get the list of deployments for a namespace
+		// Endpoint to get the list of workloads for a namespace
 		//
 		//     Consumes:
 		//     - application/json
@@ -186,13 +186,13 @@ func NewRoutes() (r *Routes) {
 		//      default: genericError
 		//      404: notFoundError
 		//      500: internalError
-		//      200: deploymentListResponse
+		//      200: workloadListResponse
 		//
 		{
-			"DeploymentList",
+			"WorkloadList",
 			"GET",
-			"/api/namespaces/{namespace}/deployments",
-			handlers.DeploymentList,
+			"/api/namespaces/{namespace}/workloads",
+			handlers.WorkloadList,
 			true,
 		},
 		{

--- a/services/business/layer.go
+++ b/services/business/layer.go
@@ -7,11 +7,11 @@ import (
 
 // Layer is a container for fast access to inner services
 type Layer struct {
-	Svc               SvcService
-	Health            HealthService
-	Validations       IstioValidationsService
-	IstioConfig       IstioConfigService
-	DeploymentService DeploymentService
+	Svc         SvcService
+	Health      HealthService
+	Validations IstioValidationsService
+	IstioConfig IstioConfigService
+	Workload    WorkloadService
 }
 
 // Global business.Layer; currently only used for tests to inject mocks,
@@ -37,7 +37,7 @@ func Get() (*Layer, error) {
 	temporaryLayer.Svc = SvcService{prom: prom, k8s: k8s, health: &temporaryLayer.Health}
 	temporaryLayer.Validations = IstioValidationsService{k8s: k8s}
 	temporaryLayer.IstioConfig = IstioConfigService{k8s: k8s}
-	temporaryLayer.DeploymentService = DeploymentService{k8s: k8s}
+	temporaryLayer.Workload = WorkloadService{k8s: k8s}
 	return temporaryLayer, nil
 }
 
@@ -48,6 +48,6 @@ func SetWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	layer.Svc = SvcService{prom: prom, k8s: k8s, health: &layer.Health}
 	layer.Validations = IstioValidationsService{k8s: k8s}
 	layer.IstioConfig = IstioConfigService{k8s: k8s}
-	layer.DeploymentService = DeploymentService{k8s: k8s}
+	layer.Workload = WorkloadService{k8s: k8s}
 	return layer
 }

--- a/services/business/workloads.go
+++ b/services/business/workloads.go
@@ -5,19 +5,19 @@ import (
 	"github.com/kiali/kiali/services/models"
 )
 
-// DeploymentService deals with fetching istio/kubernetes deployments related content and convert to kiali model
-type DeploymentService struct {
+// Workload deals with fetching istio/kubernetes deployments related content and convert to kiali model
+type WorkloadService struct {
 	k8s kubernetes.IstioClientInterface
 }
 
 // ServiceList is the API handler to fetch the list of deployments in a given namespace
-func (in *DeploymentService) GetDeploymentList(namespace string) (models.DeploymentList, error) {
+func (in *WorkloadService) GetWorkloadList(namespace string) (models.WorkloadList, error) {
 	deployments, err := in.k8s.GetDeployments(namespace)
 	if err != nil {
-		return models.DeploymentList{}, err
+		return models.WorkloadList{}, err
 	}
 
-	models := &models.DeploymentList{}
+	models := &models.WorkloadList{}
 	models.Parse(namespace, deployments)
 	return *models, nil
 }

--- a/services/business/workloads_test.go
+++ b/services/business/workloads_test.go
@@ -4,15 +4,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/api/apps/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
-func setupDeploymentService(k8s *kubetest.K8SClientMock) DeploymentService {
-	return DeploymentService{k8s: k8s}
+func setupDeploymentService(k8s *kubetest.K8SClientMock) WorkloadService {
+	return WorkloadService{k8s: k8s}
 }
 
 func TestDeploymentListHandler(t *testing.T) {
@@ -23,15 +24,15 @@ func TestDeploymentListHandler(t *testing.T) {
 	k8s.On("GetDeployments", mock.AnythingOfType("string")).Return(fakeDeploymentList(), nil)
 	svc := setupDeploymentService(k8s)
 
-	deploymentList, _ := svc.GetDeploymentList("Namespace")
-	deployments := deploymentList.Deployments
+	workloadList, _ := svc.GetWorkloadList("Namespace")
+	workloads := workloadList.Workloads
 
-	assert.Equal("Namespace", deploymentList.Namespace.Name)
+	assert.Equal("Namespace", workloadList.Namespace.Name)
 
-	assert.Equal(3, len(deployments))
-	assert.Equal("httpbin-v1", deployments[0].Name)
-	assert.Equal("httpbin-v2", deployments[1].Name)
-	assert.Equal("httpbin-v3", deployments[2].Name)
+	assert.Equal(3, len(workloads))
+	assert.Equal("httpbin-v1", workloads[0].Name)
+	assert.Equal("httpbin-v2", workloads[1].Name)
+	assert.Equal("httpbin-v3", workloads[2].Name)
 }
 
 func fakeDeploymentList() *v1beta1.DeploymentList {

--- a/services/models/deployment.go
+++ b/services/models/deployment.go
@@ -5,24 +5,6 @@ import (
 	"k8s.io/api/autoscaling/v1"
 )
 
-type DeploymentList struct {
-	// Namespace where the deployments live in
-	// required: true
-	// example: bookinfo
-	Namespace Namespace `json:"namespace"`
-
-	// Deployments for a given namespace
-	// required: true
-	Deployments []DeploymentOverview `json:"deployments"`
-}
-
-type DeploymentOverview struct {
-	// Name of the deployment
-	// required: true
-	// example: reviews-v1
-	Name string `json:"name"`
-}
-
 type Deployments []*Deployment
 type Deployment struct {
 	// Deployment name
@@ -88,24 +70,6 @@ func (deployment *Deployment) Parse(d *v1beta1.Deployment) {
 	deployment.Replicas = d.Status.Replicas
 	deployment.AvailableReplicas = d.Status.AvailableReplicas
 	deployment.UnavailableReplicas = d.Status.UnavailableReplicas
-}
-
-func (deploymentList *DeploymentList) Parse(namespace string, ds *v1beta1.DeploymentList) {
-	if ds == nil {
-		return
-	}
-
-	deploymentList.Namespace.Name = namespace
-
-	for _, deployment := range ds.Items {
-		casted := DeploymentOverview{}
-		casted.Parse(deployment)
-		(*deploymentList).Deployments = append((*deploymentList).Deployments, casted)
-	}
-}
-
-func (deployment *DeploymentOverview) Parse(d v1beta1.Deployment) {
-	deployment.Name = d.Name
 }
 
 func (deployments *Deployments) AddAutoscalers(as *v1.HorizontalPodAutoscalerList) {

--- a/services/models/workload.go
+++ b/services/models/workload.go
@@ -1,0 +1,39 @@
+package models
+
+import "k8s.io/api/apps/v1beta1"
+
+type WorkloadList struct {
+	// Namespace where the workloads live in
+	// required: true
+	// example: bookinfo
+	Namespace Namespace `json:"namespace"`
+
+	// Workloads for a given namespace
+	// required: true
+	Workloads []WorkloadOverview `json:"workloads"`
+}
+
+type WorkloadOverview struct {
+	// Name of the workload
+	// required: true
+	// example: reviews-v1
+	Name string `json:"name"`
+}
+
+func (workloadList *WorkloadList) Parse(namespace string, ds *v1beta1.DeploymentList) {
+	if ds == nil {
+		return
+	}
+
+	workloadList.Namespace.Name = namespace
+
+	for _, deployment := range ds.Items {
+		casted := WorkloadOverview{}
+		casted.Parse(deployment)
+		(*workloadList).Workloads = append((*workloadList).Workloads, casted)
+	}
+}
+
+func (workload *WorkloadOverview) Parse(d v1beta1.Deployment) {
+	workload.Name = d.Name
+}

--- a/swagger.json
+++ b/swagger.json
@@ -47,46 +47,6 @@
         }
       }
     },
-    "/namespaces/{namespace}/deployments": {
-      "get": {
-        "description": "Endpoint to get the list of deployments for a namespace",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "operationId": "deploymentList",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The id of the namespace.",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/deploymentListResponse"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          },
-          "default": {
-            "$ref": "#/responses/genericError"
-          }
-        }
-      }
-    },
     "/namespaces/{namespace}/istio": {
       "get": {
         "description": "Endpoint to get the list of Istio Config of a namespace",
@@ -281,6 +241,46 @@
         }
       }
     },
+    "/namespaces/{namespace}/workloads": {
+      "get": {
+        "description": "Endpoint to get the list of workloads for a namespace",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "workloadList",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/workloadListResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
     "/status": {
       "get": {
         "description": "Endpoint to get the status of Kiali",
@@ -351,42 +351,6 @@
     }
   },
   "definitions": {
-    "DeploymentList": {
-      "type": "object",
-      "required": [
-        "namespace",
-        "deployments"
-      ],
-      "properties": {
-        "deployments": {
-          "description": "Deployments for a given namespace",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/DeploymentOverview"
-          },
-          "x-go-name": "Deployments"
-        },
-        "namespace": {
-          "$ref": "#/definitions/namespace"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
-    "DeploymentOverview": {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "description": "Name of the deployment",
-          "type": "string",
-          "x-go-name": "Name",
-          "example": "reviews-v1"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
     "Gateway": {
       "type": "object",
       "properties": {
@@ -718,6 +682,42 @@
       },
       "x-go-package": "github.com/kiali/kiali"
     },
+    "WorkloadList": {
+      "type": "object",
+      "required": [
+        "namespace",
+        "workloads"
+      ],
+      "properties": {
+        "namespace": {
+          "$ref": "#/definitions/namespace"
+        },
+        "workloads": {
+          "description": "Workloads for a given namespace",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WorkloadOverview"
+          },
+          "x-go-name": "Workloads"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "WorkloadOverview": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the workload",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "reviews-v1"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
     "destinationRule": {
       "description": "This is used for returning a DestinationRule",
       "type": "object",
@@ -903,12 +903,6 @@
     }
   },
   "responses": {
-    "deploymentListResponse": {
-      "description": "Listing all deployments in the namespace",
-      "schema": {
-        "$ref": "#/definitions/DeploymentList"
-      }
-    },
     "genericError": {
       "description": "A GenericError is the default error message that is generated.",
       "schema": {
@@ -997,6 +991,12 @@
       "description": "Listing all istio validations for object in the namespace",
       "schema": {
         "$ref": "#/definitions/TypedIstioValidations"
+      }
+    },
+    "workloadListResponse": {
+      "description": "Listing all workloads in the namespace",
+      "schema": {
+        "$ref": "#/definitions/WorkloadList"
       }
     }
   }


### PR DESCRIPTION
** Describe the change **

Renaming DeploymentList by WorkloadList.
URL listening: `api/namespaces/bookinfo/workloads`

![screenshot of kiali-istio-system 192 168 42 123 nip io_api_namespaces_bookinfo_workloads](https://user-images.githubusercontent.com/613814/43772574-cf1a9d66-9a42-11e8-974c-a2baac5222d8.jpg)

** Issue reference **

[KIALI-1210](https://issues.jboss.org/browse/KIALI-1210)

** Backwards incompatible? **
Yes.
