### PR TITLE
KIALI-1059 Support custom context root

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -320,7 +320,13 @@ server:
   credentials:
     password: VALUE
 ----
-
+|`SERVER_WEB_ROOT`
+|Context root path to serve Kiali API and webapp from. (Default: /)
+[source,yaml]
+----
+server:
+  web_root: /VALUE
+----
 |`SERVER_CORS_ALLOW_ALL`
 |When true, allows the web console to send requests to other domains other than where the console came from. Typically used for development environments only.
 [source,yaml]

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,10 @@ server:
   #  username: admin
   #  password: admin
 
+  # Web context path to serve Kiali API and frontend from.
+  # Default is /
+  # web_root: /kiali
+
   # Uncomment static_content_root_directory to set up a different directory for static front-end content.
   # Default is /static-files
   # static_content_root_directory: /static-files

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ const (
 	EnvServerPort                       = "SERVER_PORT"
 	EnvServerCredentialsUsername        = "SERVER_CREDENTIALS_USERNAME"
 	EnvServerCredentialsPassword        = "SERVER_CREDENTIALS_PASSWORD"
+	EnvWebRoot                          = "SERVER_WEB_ROOT"
 	EnvServerStaticContentRootDirectory = "SERVER_STATIC_CONTENT_ROOT_DIRECTORY"
 	EnvServerCORSAllowAll               = "SERVER_CORS_ALLOW_ALL"
 
@@ -62,6 +63,7 @@ type Server struct {
 	Address                    string               `yaml:",omitempty"`
 	Port                       int                  `yaml:",omitempty"`
 	Credentials                security.Credentials `yaml:",omitempty"`
+	WebRoot                    string               `yaml:"web_root,omitempty"`
 	StaticContentRootDirectory string               `yaml:"static_content_root_directory,omitempty"`
 	CORSAllowAll               bool                 `yaml:"cors_allow_all,omitempty"`
 }
@@ -140,6 +142,7 @@ func NewConfig() (c *Config) {
 		Username: getDefaultString(EnvServerCredentialsUsername, ""),
 		Password: getDefaultString(EnvServerCredentialsPassword, ""),
 	}
+	c.Server.WebRoot = strings.TrimSpace(getDefaultString(EnvWebRoot, "/"))
 	c.Server.StaticContentRootDirectory = strings.TrimSpace(getDefaultString(EnvServerStaticContentRootDirectory, "/static-files"))
 	c.Server.CORSAllowAll = getDefaultBool(EnvServerCORSAllowAll, false)
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -5,8 +5,13 @@ LABEL maintainer="kiali-dev@googlegroups.com"
 ENV KIALI_HOME=/opt/kiali \
     PATH=$KIALI_HOME:$PATH
 
+WORKDIR $KIALI_HOME
+
 COPY kiali $KIALI_HOME/
 
 ADD console $KIALI_HOME/console/
+
+RUN chgrp -R 0 $KIALI_HOME/console && \
+    chmod -R g=u $KIALI_HOME/console
 
 ENTRYPOINT ["/opt/kiali/kiali"]

--- a/deploy/kubernetes/kiali-configmap.yaml
+++ b/deploy/kubernetes/kiali-configmap.yaml
@@ -10,6 +10,7 @@ data:
     server:
       port: 20001
       static_content_root_directory: /opt/kiali/console
+      web_root: /
     external_services:
       jaeger:
         url: ${JAEGER_URL}

--- a/deploy/openshift/kiali-configmap.yaml
+++ b/deploy/openshift/kiali-configmap.yaml
@@ -10,6 +10,7 @@ data:
     server:
       port: 20001
       static_content_root_directory: /opt/kiali/console
+      web_root: /
     external_services:
       jaeger:
         url: ${JAEGER_URL}

--- a/routing/router.go
+++ b/routing/router.go
@@ -4,40 +4,57 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-
 	"github.com/kiali/kiali/config"
 )
 
 // NewRouter creates the router with all API routes and the static files handler
 func NewRouter() *mux.Router {
 
-	router := mux.NewRouter().StrictSlash(true)
+	conf := config.Get()
+	webRoot := conf.Server.WebRoot
+	webRootWithSlash := webRoot + "/"
+
+	rootRouter := mux.NewRouter().StrictSlash(false)
+	appRouter := rootRouter
+
+	// Due to PathPrefix matching behavoir on sub-routers
+	// we need to explicitly redirect /foo -> /foo/
+	// See https://github.com/gorilla/mux/issues/31
+	if webRoot != "/" {
+		rootRouter.HandleFunc(webRoot, func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, webRootWithSlash, http.StatusFound)
+		})
+		appRouter = rootRouter.PathPrefix(conf.Server.WebRoot).Subrouter().StrictSlash(true)
+	}
 
 	// Build our API server routes and install them.
-	routes := NewRoutes()
-	for _, route := range routes.Routes {
+	apiRoutes := NewRoutes()
+	for _, route := range apiRoutes.Routes {
 		var handlerFunction http.Handler
 		if handlerFunction = route.HandlerFunc; route.Authenticated {
 			handlerFunction = config.AuthenticationHandler(handlerFunction)
 		}
-		router.
+		appRouter.
 			Methods(route.Method).
 			Path(route.Pattern).
 			Name(route.Name).
 			Handler(handlerFunction)
 	}
-	conf := config.Get()
+
 	// All client-side routes are prefixed with /console.
 	// They are forwarded to index.html and will be handled by react-router.
-	router.PathPrefix("/console").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	appRouter.PathPrefix("/console").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, conf.Server.StaticContentRootDirectory+"/index.html")
 	})
 
 	// Build our static files routes by first creating the file server handler that will serve
 	// the webapp js files and other static content. Then tell the router about our fixed
 	// routes which pass all static file requests to the file handler.
-	fileServerHandler := http.FileServer(http.Dir(conf.Server.StaticContentRootDirectory))
-	router.PathPrefix("/").Handler(fileServerHandler)
+	staticFileServer := http.FileServer(http.Dir(conf.Server.StaticContentRootDirectory))
+	if webRoot != "/" {
+		staticFileServer = http.StripPrefix(webRootWithSlash, staticFileServer)
+	}
+	appRouter.PathPrefix("/").Handler(staticFileServer)
 
-	return router
+	return rootRouter
 }

--- a/server/server.go
+++ b/server/server.go
@@ -40,7 +40,7 @@ func NewServer() *Server {
 // Start HTTP server asynchronously. TLS may be active depending on the global configuration.
 func (s *Server) Start() {
 	conf := config.Get()
-	log.Infof("Server endpoint will start at [%v]", s.httpServer.Addr)
+	log.Infof("Server endpoint will start at [%v%v]", s.httpServer.Addr, conf.Server.WebRoot)
 	log.Infof("Server endpoint will serve static content from [%v]", conf.Server.StaticContentRootDirectory)
 	secure := conf.Identity.CertFile != "" && conf.Identity.PrivateKeyFile != ""
 	go func() {

--- a/util/config_to_js.go
+++ b/util/config_to_js.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
+)
+
+// ConfigToJS generates env.js file from Kiali config
+func ConfigToJS() {
+	log.Info("Generating env.js from config")
+	path, _ := filepath.Abs("./console/env.js")
+
+	content := "window.WEB_ROOT='" + config.Get().Server.WebRoot + "';"
+
+	log.Debugf("The content of %v will be:\n%v", path, content)
+
+	err := ioutil.WriteFile(path, []byte(content), 0)
+	if isError(err) {
+		return
+	}
+}

--- a/util/update_base_url.go
+++ b/util/update_base_url.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/kiali/kiali/log"
+)
+
+// UpdateBaseURL updates index.html base href with web root string
+func UpdateBaseURL(webRootPath string) {
+	log.Infof("Updating base URL in index.html with [%v]", webRootPath)
+	path, _ := filepath.Abs("./console/index.html")
+	b, err := ioutil.ReadFile(path)
+	if isError(err) {
+		return
+	}
+
+	html := string(b)
+
+	searchStr := `<base href="/">`
+	newStr := `<base href="` + webRootPath + `/">`
+	newHTML := strings.Replace(html, searchStr, newStr, -1)
+
+	err = ioutil.WriteFile(path, []byte(newHTML), 0)
+	if isError(err) {
+		return
+	}
+}
+
+func isError(err error) bool {
+	if err != nil {
+		log.Errorf("File I/O error [%v]", err.Error())
+	}
+
+	return (err != nil)
+}


### PR DESCRIPTION
** Describe the change **
Introduce optional context root to serve Kiali API and frontend under.  Users can customize the path by editing config.yaml `server.web_root` or passing SERVER_WEB_ROOT env (recommended) to the docker container. 

SERVER_WEB_ROOT not defined
-> `http://<fqdn>/`

SERVER_WEB_ROOT=/kiali
-> `http://<fqdn>/kiali`

The crux of the problem is injecting the path value into Kiali frontend code at deployment time since create-react-app doesn't have any support for doing that. I resorted to shell script trickery to dynamically generate an env js file to be imported by index.html as well as updating `<base href="/path/">` in index.html

** Issue reference **

- KIALI-1059
- https://github.com/kiali/kiali/issues/321

** Backwards compatible? **
Yes

------
Unit test
```
# With custom root context /foos
# docker run -d -e SERVER_WEB_ROOT=/foos -e SERVER_PORT=8090 -e SERVER_STATIC_CONTENT_ROOT_DIRECTORY=/opt/kiali/console  -p 8090:8090 kiali/kiali:dev 

# docker logs -f c24be72c8001
window.WEB_ROOT='/foos';
I0809 16:23:58.416294       1 kiali.go:59] Kiali: Version: v0.5.1-SNAPSHOT, Commit: 2ddaeedc4c8a46276a34498f6c697e48747493ba
I0809 16:23:58.418200       1 kiali.go:70] No configuration file specified. Will rely on environment for configuration.
I0809 16:23:58.418411       1 kiali.go:80] Kiali: Console version: 0.6.0-SNAPSHOT.1857-local-99080840a92159f9f376cf610527fb38c9b0737d
I0809 16:23:58.420793       1 server.go:43] Server endpoint will start at [:8090/foos]

#  curl -L localhost:8090
404 page not found

# curl -L localhost:8090/foos
<!DOCTYPE html><html lang="en" class="layout-pf layout-pf-fixed"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"><meta name="theme-color" content="#000000"><base href="/foos/"><script type="text/javascript" src="./env.js"></script><link rel="manifest" href="./manifest.json"><link rel="shortcut icon" href="./favicon.ico"> ...

```
Test 2
```
# Default behavior root=/
# docker run -d -e SERVER_WEB_ROOT=/ -e SERVER_PORT=8090 -e SERVER_STATIC_CONTENT_ROOT_DIRECTORY=/opt/kiali/console  -p 8090:8090 kiali/kiali:dev 

# docker logs -f c9bc5b975e4a
window.WEB_ROOT='/';
I0809 16:28:49.687022       1 kiali.go:59] Kiali: Version: v0.5.1-SNAPSHOT, Commit: 2ddaeedc4c8a46276a34498f6c697e48747493ba
I0809 16:28:49.689646       1 kiali.go:70] No configuration file specified. Will rely on environment for configuration.
I0809 16:28:49.689835       1 kiali.go:80] Kiali: Console version: 0.6.0-SNAPSHOT.1857-local-99080840a92159f9f376cf610527fb38c9b0737d
I0809 16:28:49.690572       1 server.go:43] Server endpoint will start at [:8090/]

# curl localhost:8090
<!DOCTYPE html><html lang="en" class="layout-pf layout-pf-fixed"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"><meta name="theme-color" content="#000000"><base href="/"><script type="text/javascript" src="./env.js">
```
Test 3
```
# container exited with error on invalid format //myapp
# docker run -d -e SERVER_WEB_ROOT=//myapp -e SERVER_PORT=8090 -e SERVER_STATIC_CONTENT_ROOT_DIRECTORY=/opt/kiali/console  -p 8090:8090 kiali/kiali:dev 

# docker ps -a
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                      PORTS               NAMES
ae7d10da0d94        kiali/kiali:dev     "/opt/kiali/kiali-ser"   23 seconds ago      Exited (1) 21 seconds ago                       condescending_babbage

# docker logs -f ae7d10da0d94
SERVER_WEB_ROOT invalid format. Example, /kiali
```