### PR TITLE
KIALI-1304 Service details update - workloads added, deployments/pods removed

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,7 @@ import (
 // A Namespace provide a scope for names.
 // This type used to describe a set of objects.
 //
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails
 type NamespaceParam struct {
 	// The id of the namespace.
 	//
@@ -24,7 +24,7 @@ type NamespaceParam struct {
 
 // Service identify the a service object
 //
-// swagger:parameters serviceValidations
+// swagger:parameters serviceValidations serviceDetails
 type ServiceParam struct {
 	// The name of the service
 	//
@@ -195,6 +195,13 @@ type workloadHealthResponse struct {
 type namespaceAppHealthResponse struct {
 	// in:body
 	Body models.NamespaceAppHealth
+}
+
+// Listing all the information related to a workload
+// swagger:response serviceDetailsResponse
+type ServiceDetailsResponse struct {
+	// in:body
+	Body models.ServiceDetails
 }
 
 // Listing all the information related to a workload

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -163,6 +163,21 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceList,
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/services/{service} serviceDetails
+		// ---
+		// Endpoint to get the details of a given service
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      default: genericError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: serviceDetailsResponse
+		//
 		{
 			"ServiceDetails",
 			"GET",

--- a/services/business/services.go
+++ b/services/business/services.go
@@ -68,10 +68,7 @@ func (in *SvcService) GetService(namespace, service, interval string) (*models.S
 		return nil, fmt.Errorf("Source services: %s", err.Error())
 	}
 
-	s := models.ServiceDetails{
-		Namespace: models.Namespace{Name: namespace},
-		Name:      service,
-		Health:    health}
+	s := models.ServiceDetails{Health: health}
 	s.SetServiceDetails(serviceDetails, istioDetails, prometheusDetails)
 	return &s, nil
 }

--- a/services/business/workloads.go
+++ b/services/business/workloads.go
@@ -23,14 +23,14 @@ func (in *WorkloadService) GetWorkloadList(namespace string) (models.WorkloadLis
 		selector, _ := in.k8s.GetDeploymentSelector(namespace, deployment.Name)
 		dPods, _ := in.k8s.GetPods(namespace, selector)
 
-		casted := &models.WorkloadListItem{}
-		casted.Parse(deployment)
+		cast := &models.WorkloadListItem{}
+		cast.Parse(deployment)
 
 		mPods := models.Pods{}
 		mPods.Parse(dPods.Items)
-		casted.IstioSidecar = mPods.HasIstioSideCar()
+		cast.IstioSidecar = mPods.HasIstioSideCar()
 
-		(*workloadList).Workloads = append((*workloadList).Workloads, *casted)
+		(*workloadList).Workloads = append((*workloadList).Workloads, *cast)
 	}
 	return *workloadList, nil
 }

--- a/services/business/workloads.go
+++ b/services/business/workloads.go
@@ -22,11 +22,14 @@ func (in *WorkloadService) GetWorkloadList(namespace string) (models.WorkloadLis
 	for _, deployment := range deployments.Items {
 		selector, _ := in.k8s.GetDeploymentSelector(namespace, deployment.Name)
 		dPods, _ := in.k8s.GetPods(namespace, selector)
-		casted := &models.WorkloadOverview{}
+
+		casted := &models.WorkloadListItem{}
 		casted.Parse(deployment)
+
 		mPods := models.Pods{}
 		mPods.Parse(dPods.Items)
 		casted.IstioSidecar = mPods.HasIstioSideCar()
+
 		(*workloadList).Workloads = append((*workloadList).Workloads, *casted)
 	}
 	return *workloadList, nil

--- a/services/models/pod.go
+++ b/services/models/pod.go
@@ -96,10 +96,6 @@ func lookupImage(containerName string, containers []v1.Container) string {
 	return ""
 }
 
-func (pod *Pod) HasIstioSideCar() bool {
-	return len(pod.IstioContainers) > 0
-}
-
 func (pods Pods) HasIstioSideCar() bool {
 	for _, pod := range pods {
 		if pod.HasIstioSideCar() {
@@ -107,4 +103,8 @@ func (pods Pods) HasIstioSideCar() bool {
 		}
 	}
 	return false
+}
+
+func (pod Pod) HasIstioSideCar() bool {
+	return len(pod.IstioContainers) > 0
 }

--- a/services/models/service.go
+++ b/services/models/service.go
@@ -28,15 +28,12 @@ type ServiceList struct {
 }
 
 type ServiceDetails struct {
-	Name             string              `json:"name"`
-	Namespace        Namespace           `json:"namespace"`
 	Service          Service             `json:"service"`
 	Endpoints        Endpoints           `json:"endpoints"`
 	VirtualServices  VirtualServices     `json:"virtualServices"`
 	DestinationRules DestinationRules    `json:"destinationRules"`
 	Dependencies     map[string][]string `json:"dependencies"`
-	Pods             Pods                `json:"pods"`
-	Workloads        Workloads           `json:"deployments"`
+	Workloads        WorkloadOverviews   `json:"workloads"`
 	Health           ServiceHealth       `json:"health"`
 }
 
@@ -86,9 +83,7 @@ func (s *ServiceDetails) SetServiceDetails(serviceDetails *kubernetes.ServiceDet
 func (s *ServiceDetails) setKubernetesDetails(serviceDetails *kubernetes.ServiceDetails) {
 	s.Service.Parse(serviceDetails.Service)
 	(&s.Endpoints).Parse(serviceDetails.Endpoints)
-	(&s.Pods).Parse(serviceDetails.Pods)
 	(&s.Workloads).Parse(serviceDetails.Deployments)
-	(&s.Workloads).AddAutoscalers(serviceDetails.Autoscalers)
 }
 
 func (s *ServiceDetails) setIstioDetails(istioDetails *kubernetes.IstioDetails) {

--- a/services/models/service.go
+++ b/services/models/service.go
@@ -29,6 +29,7 @@ type ServiceList struct {
 
 type ServiceDetails struct {
 	Service          Service             `json:"service"`
+	IstioSidecar     bool                `json:"istioSidecar"`
 	Endpoints        Endpoints           `json:"endpoints"`
 	VirtualServices  VirtualServices     `json:"virtualServices"`
 	DestinationRules DestinationRules    `json:"destinationRules"`
@@ -81,6 +82,10 @@ func (s *ServiceDetails) SetServiceDetails(serviceDetails *kubernetes.ServiceDet
 }
 
 func (s *ServiceDetails) setKubernetesDetails(serviceDetails *kubernetes.ServiceDetails) {
+	mPods := Pods{}
+	mPods.Parse(serviceDetails.Pods)
+	s.IstioSidecar = mPods.HasIstioSideCar()
+
 	s.Service.Parse(serviceDetails.Service)
 	(&s.Endpoints).Parse(serviceDetails.Endpoints)
 	(&s.Workloads).Parse(serviceDetails.Deployments)

--- a/services/models/service_test.go
+++ b/services/models/service_test.go
@@ -18,13 +18,12 @@ func TestServiceDetailParsing(t *testing.T) {
 	assert := assert.New(t)
 
 	service := ServiceDetails{}
-	service.Name = "service"
-	service.Namespace = Namespace{"namespace"}
 	service.SetServiceDetails(fakeServiceDetails(), fakeIstioDetails(), fakePrometheusDetails())
 
 	// Kubernetes Details
-	assert.Equal(service.Name, "service")
-	assert.Equal(service.Namespace.Name, "namespace")
+
+	assert.Equal(service.Service.Name, "Name")
+	assert.Equal(service.Service.Namespace.Name, "Namespace")
 	assert.Equal(service.Service.CreatedAt, "2018-03-08T17:44:00+03:00")
 	assert.Equal(service.Service.ResourceVersion, "1234")
 	assert.Equal(service.Service.Type, "ClusterIP")
@@ -44,48 +43,15 @@ func TestServiceDetailParsing(t *testing.T) {
 				Port{Name: "http", Protocol: "TCP", Port: 3000},
 			}}})
 
-	assert.Len(service.Pods, 2)
-	assert.Equal(service.Pods[0].Name, "reviews-v1-1234")
-	assert.Equal(service.Pods[1].Name, "reviews-v2-1234")
-	assert.Equal(*service.Workloads[0], Workload{
-		Name:                "reviews-v1",
-		Labels:              map[string]string{"apps": "reviews", "version": "v1"},
-		CreatedAt:           "2018-03-08T17:44:00+03:00",
-		ResourceVersion:     "1234",
-		Replicas:            3,
-		AvailableReplicas:   1,
-		UnavailableReplicas: 2,
-		Autoscaler: Autoscaler{
-			Name:                            "reviews-v1",
-			Labels:                          map[string]string{"apps": "reviews", "version": "v1"},
-			CreatedAt:                       "2018-03-08T17:44:00+03:00",
-			MinReplicas:                     1,
-			MaxReplicas:                     10,
-			TargetCPUUtilizationPercentage:  50,
-			CurrentReplicas:                 3,
-			DesiredReplicas:                 4,
-			ObservedGeneration:              50,
-			CurrentCPUUtilizationPercentage: 70}})
+	assert.Equal(*service.Workloads[0], WorkloadOverview{
+		Name:   "reviews-v1",
+		Labels: map[string]string{"apps": "reviews", "version": "v1"},
+	})
 
-	assert.Equal(*service.Workloads[1], Workload{
-		Name:                "reviews-v2",
-		Labels:              map[string]string{"apps": "reviews", "version": "v2"},
-		CreatedAt:           "2018-03-08T17:45:00+03:00",
-		ResourceVersion:     "1234",
-		Replicas:            3,
-		AvailableReplicas:   3,
-		UnavailableReplicas: 0,
-		Autoscaler: Autoscaler{
-			Name:                            "reviews-v2",
-			Labels:                          map[string]string{"apps": "reviews", "version": "v2"},
-			CreatedAt:                       "2018-03-08T17:45:00+03:00",
-			MinReplicas:                     1,
-			MaxReplicas:                     10,
-			TargetCPUUtilizationPercentage:  50,
-			CurrentReplicas:                 3,
-			DesiredReplicas:                 2,
-			ObservedGeneration:              50,
-			CurrentCPUUtilizationPercentage: 30}})
+	assert.Equal(*service.Workloads[1], WorkloadOverview{
+		Name:   "reviews-v2",
+		Labels: map[string]string{"apps": "reviews", "version": "v2"},
+	})
 
 	// Istio Details
 
@@ -311,6 +277,7 @@ func fakeServiceDetails() *kubernetes.ServiceDetails {
 			v1beta1.Deployment{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:              "reviews-v1",
+					Namespace:         "Namespace",
 					CreationTimestamp: meta_v1.NewTime(t1),
 					ResourceVersion:   "1234",
 					Labels:            map[string]string{"apps": "reviews", "version": "v1"}},
@@ -321,6 +288,7 @@ func fakeServiceDetails() *kubernetes.ServiceDetails {
 			v1beta1.Deployment{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:              "reviews-v2",
+					Namespace:         "Namespace",
 					CreationTimestamp: meta_v1.NewTime(t2),
 					ResourceVersion:   "1234",
 					Labels:            map[string]string{"apps": "reviews", "version": "v2"}},

--- a/services/models/service_test.go
+++ b/services/models/service_test.go
@@ -44,13 +44,19 @@ func TestServiceDetailParsing(t *testing.T) {
 			}}})
 
 	assert.Equal(*service.Workloads[0], WorkloadOverview{
-		Name:   "reviews-v1",
-		Labels: map[string]string{"apps": "reviews", "version": "v1"},
+		Name:            "reviews-v1",
+		Labels:          map[string]string{"apps": "reviews", "version": "v1"},
+		Type:            "Deployment",
+		CreatedAt:       "2018-03-08T17:44:00+03:00",
+		ResourceVersion: "1234",
 	})
 
 	assert.Equal(*service.Workloads[1], WorkloadOverview{
-		Name:   "reviews-v2",
-		Labels: map[string]string{"apps": "reviews", "version": "v2"},
+		Name:            "reviews-v2",
+		Labels:          map[string]string{"apps": "reviews", "version": "v2"},
+		Type:            "Deployment",
+		CreatedAt:       "2018-03-08T17:45:00+03:00",
+		ResourceVersion: "4567",
 	})
 
 	// Istio Details
@@ -290,7 +296,7 @@ func fakeServiceDetails() *kubernetes.ServiceDetails {
 					Name:              "reviews-v2",
 					Namespace:         "Namespace",
 					CreationTimestamp: meta_v1.NewTime(t2),
-					ResourceVersion:   "1234",
+					ResourceVersion:   "4567",
 					Labels:            map[string]string{"apps": "reviews", "version": "v2"}},
 				Status: v1beta1.DeploymentStatus{
 					Replicas:            3,

--- a/services/models/workload.go
+++ b/services/models/workload.go
@@ -17,6 +17,7 @@ type WorkloadList struct {
 	Workloads []WorkloadListItem `json:"workloads"`
 }
 
+// WorkloadListItem has the necessary information to display the console workload list
 type WorkloadListItem struct {
 	// Name of the workload
 	// required: true
@@ -43,18 +44,36 @@ type WorkloadListItem struct {
 }
 
 type WorkloadOverviews []*WorkloadOverview
+
+// WorkloadOverview has the summary information of a workload.
+// Useful to display a link to the workload details page.
 type WorkloadOverview struct {
 	// Name of the workload
 	// required: true
 	// example: reviews-v1
 	Name string `json:"name"`
 
+	// Type of the workload
+	// required: true
+	// example: deployment
+	Type string `json:"type"`
+
+	// Creation timestamp (in RFC3339 format)
+	// required: true
+	// example: 2018-07-31T12:24:17Z
+	CreatedAt string `json:"createdAt"`
+
+	// Kubernetes ResourceVersion
+	// required: true
+	// example: 192892127
+	ResourceVersion string `json:"resourceVersion"`
+
 	// Kubernetes labels
 	// required: true
 	Labels map[string]string `json:"labels"`
 }
 
-type Workloads []*Workload
+// Workload has the details of a workload
 type Workload struct {
 	// Workload name
 	// required: true
@@ -109,9 +128,9 @@ func (workloadList *WorkloadList) Parse(namespace string, ds *v1beta1.Deployment
 	workloadList.Namespace.Name = namespace
 
 	for _, deployment := range ds.Items {
-		casted := WorkloadListItem{}
-		casted.Parse(deployment)
-		(*workloadList).Workloads = append((*workloadList).Workloads, casted)
+		cast := WorkloadListItem{}
+		cast.Parse(deployment)
+		(*workloadList).Workloads = append((*workloadList).Workloads, cast)
 	}
 }
 
@@ -130,27 +149,18 @@ func (workloadList *WorkloadOverviews) Parse(ds *v1beta1.DeploymentList) {
 	}
 
 	for _, deployment := range ds.Items {
-		casted := &WorkloadOverview{}
-		casted.Parse(deployment)
-		*workloadList = append(*workloadList, casted)
-	}
-}
-
-func (workloads *Workloads) Parse(ds *v1beta1.DeploymentList) {
-	if ds == nil {
-		return
-	}
-
-	for _, deployment := range ds.Items {
-		casted := Workload{}
-		casted.Parse(&deployment)
-		*workloads = append(*workloads, &casted)
+		cast := &WorkloadOverview{}
+		cast.Parse(deployment)
+		*workloadList = append(*workloadList, cast)
 	}
 }
 
 func (workload *WorkloadOverview) Parse(d v1beta1.Deployment) {
 	workload.Name = d.Name
 	workload.Labels = d.Labels
+	workload.CreatedAt = formatTime(d.CreationTimestamp.Time)
+	workload.ResourceVersion = d.ResourceVersion
+	workload.Type = "Deployment"
 }
 
 func (workload *Workload) Parse(d *v1beta1.Deployment) {

--- a/services/models/workload_test.go
+++ b/services/models/workload_test.go
@@ -26,6 +26,20 @@ func TestDeploymentInvidividualParse(t *testing.T) {
 	assert.Equal(int32(0), deployment.UnavailableReplicas)
 }
 
+func TestDeploymentWorkloadOverview(t *testing.T) {
+	assert := assert.New(t)
+
+	deployment := WorkloadOverview{}
+	k18sDeployment := fakeDeployment()
+	deployment.Parse(*k18sDeployment)
+
+	assert.Equal("reviews-v1", deployment.Name)
+	assert.Equal("bar", deployment.Labels["foo"])
+	assert.Equal("v1", deployment.Labels["version"])
+	assert.Equal("2709198702082918", deployment.ResourceVersion)
+	assert.Equal("2018-03-08T17:44:00+03:00", deployment.CreatedAt)
+}
+
 func fakeDeployment() *v1beta1.Deployment {
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
 

--- a/swagger.json
+++ b/swagger.json
@@ -1180,6 +1180,10 @@
         "health": {
           "$ref": "#/definitions/ServiceHealth"
         },
+        "istioSidecar": {
+          "type": "boolean",
+          "x-go-name": "IstioSidecar"
+        },
         "service": {
           "$ref": "#/definitions/Service"
         },
@@ -1452,13 +1456,13 @@
       ],
       "properties": {
         "appLabel": {
-          "description": "Has label app",
+          "description": "Define if Pods related to this Service has the label App",
           "type": "boolean",
           "x-go-name": "AppLabel",
           "example": true
         },
         "istioSidecar": {
-          "description": "Has IstioSidecar",
+          "description": "Define if Pods related to this Service has an IstioSidecar deployed",
           "type": "boolean",
           "x-go-name": "IstioSidecar",
           "example": true
@@ -1476,7 +1480,7 @@
           "example": "deployment"
         },
         "versionLabel": {
-          "description": "Has version label",
+          "description": "Define if Pods related to this Service has the label Version",
           "type": "boolean",
           "x-go-name": "VersionLabel",
           "example": true

--- a/swagger.json
+++ b/swagger.json
@@ -391,6 +391,51 @@
         }
       }
     },
+    "/namespaces/{namespace}/services/{service}": {
+      "get": {
+        "description": "Endpoint to get the details of a given service",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "serviceDetails",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name of the service",
+            "name": "service",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/serviceDetailsResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/services/{service}/istio_validations": {
       "get": {
         "description": "Endpoint to get the list of istio object validations for a service",
@@ -593,6 +638,31 @@
     }
   },
   "definitions": {
+    "Address": {
+      "type": "object",
+      "properties": {
+        "ip": {
+          "type": "string",
+          "x-go-name": "IP"
+        },
+        "kind": {
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "Addresses": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Address"
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
     "AppHealth": {
       "description": "AppHealth contains aggregated health from various sources, for a given app",
       "type": "object",
@@ -613,68 +683,6 @@
         },
         "requests": {
           "$ref": "#/definitions/RequestHealth"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/services/models"
-    },
-    "Autoscaler": {
-      "type": "object",
-      "properties": {
-        "createdAt": {
-          "type": "string",
-          "x-go-name": "CreatedAt"
-        },
-        "currentCPUUtilizationPercentage": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "CurrentCPUUtilizationPercentage"
-        },
-        "currentReplicas": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "CurrentReplicas"
-        },
-        "desiredReplicas": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "DesiredReplicas"
-        },
-        "labels": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-go-name": "Labels"
-        },
-        "lastScaleTime": {
-          "type": "string",
-          "x-go-name": "LastScaleTime"
-        },
-        "maxReplicas": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "MaxReplicas"
-        },
-        "minReplicas": {
-          "description": "Spec",
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "MinReplicas"
-        },
-        "name": {
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "observedGeneration": {
-          "description": "Status",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ObservedGeneration"
-        },
-        "targetCPUUtilizationPercentage": {
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "TargetCPUUtilizationPercentage"
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
@@ -712,6 +720,25 @@
           "format": "int32",
           "x-go-name": "Replicas"
         }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "Endpoint": {
+      "type": "object",
+      "properties": {
+        "addresses": {
+          "$ref": "#/definitions/Addresses"
+        },
+        "ports": {
+          "$ref": "#/definitions/Ports"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "Endpoints": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Endpoint"
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
@@ -1131,6 +1158,40 @@
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
+    "ServiceDetails": {
+      "type": "object",
+      "properties": {
+        "dependencies": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "x-go-name": "Dependencies"
+        },
+        "destinationRules": {
+          "$ref": "#/definitions/destinationRules"
+        },
+        "endpoints": {
+          "$ref": "#/definitions/Endpoints"
+        },
+        "health": {
+          "$ref": "#/definitions/ServiceHealth"
+        },
+        "service": {
+          "$ref": "#/definitions/Service"
+        },
+        "virtualServices": {
+          "$ref": "#/definitions/virtualServices"
+        },
+        "workloads": {
+          "$ref": "#/definitions/WorkloadOverviews"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
     "ServiceEntries": {
       "type": "array",
       "items": {
@@ -1282,9 +1343,6 @@
         "unavailableReplicas"
       ],
       "properties": {
-        "autoscaler": {
-          "$ref": "#/definitions/Autoscaler"
-        },
         "availableReplicas": {
           "description": "Number of available replicas",
           "type": "integer",
@@ -1376,14 +1434,14 @@
           "description": "Workloads for a given namespace",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/WorkloadOverview"
+            "$ref": "#/definitions/WorkloadListItem"
           },
           "x-go-name": "Workloads"
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
-    "WorkloadOverview": {
+    "WorkloadListItem": {
       "type": "object",
       "required": [
         "name",
@@ -1423,6 +1481,37 @@
           "x-go-name": "VersionLabel",
           "example": true
         }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "WorkloadOverview": {
+      "type": "object",
+      "required": [
+        "name",
+        "labels"
+      ],
+      "properties": {
+        "labels": {
+          "description": "Kubernetes labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Labels"
+        },
+        "name": {
+          "description": "Name of the workload",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "reviews-v1"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "WorkloadOverviews": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/WorkloadOverview"
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
@@ -1713,6 +1802,12 @@
             "x-go-name": "Message"
           }
         }
+      }
+    },
+    "serviceDetailsResponse": {
+      "description": "Listing all the information related to a workload",
+      "schema": {
+        "$ref": "#/definitions/ServiceDetails"
       }
     },
     "serviceHealthResponse": {

--- a/swagger.json
+++ b/swagger.json
@@ -1492,9 +1492,18 @@
       "type": "object",
       "required": [
         "name",
+        "type",
+        "createdAt",
+        "resourceVersion",
         "labels"
       ],
       "properties": {
+        "createdAt": {
+          "description": "Creation timestamp (in RFC3339 format)",
+          "type": "string",
+          "x-go-name": "CreatedAt",
+          "example": "2018-07-31T12:24:17Z"
+        },
         "labels": {
           "description": "Kubernetes labels",
           "type": "object",
@@ -1508,6 +1517,18 @@
           "type": "string",
           "x-go-name": "Name",
           "example": "reviews-v1"
+        },
+        "resourceVersion": {
+          "description": "Kubernetes ResourceVersion",
+          "type": "string",
+          "x-go-name": "ResourceVersion",
+          "example": "192892127"
+        },
+        "type": {
+          "description": "Type of the workload",
+          "type": "string",
+          "x-go-name": "Type",
+          "example": "deployment"
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"


### PR DESCRIPTION
** Describe the change **
This PR works towards istio1.0 upgrade. Updates the service details endpoint:

- Removing Pods
- Removing Deployments
- Adding workloads

#404 Needs to be merged first.

** Issue reference **

[KIALI-1304](https://issues.jboss.org/browse/KIALI-1304)

** Backwards incompatible? **
No. It needs frontend to be adapted to this change.
There is actually an ongoing PR for that:  https://github.com/kiali/kiali-ui/pull/566 ([KIALI-1218](https://issues.jboss.org/browse/KIALI-1218))

_describe the changes if appropriate_

New output for service details:
![screenshot of kiali-istio-system 192 168 42 123 nip io_api_namespaces_bookinfo_services_reviews](https://user-images.githubusercontent.com/613814/43954596-5c737f78-9c9d-11e8-8dae-e959266d4776.png)