### PR TITLE
KIALI-1313 Fix Apps not being resoved correctly for a service

### DIFF
--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/api/apps/v1beta1"
+	kv1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
@@ -29,7 +30,11 @@ var detailsForLabels = kubernetes.ServiceDetails{
 		Items: []v1beta1.Deployment{
 			v1beta1.Deployment{
 				ObjectMeta: meta_v1.ObjectMeta{
-					Labels: map[string]string{"app": "svc"}}}}}}
+					Labels: map[string]string{"app": "svc"}}}}},
+	Pods: []kv1.Pod{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Labels: map[string]string{"app": "svc"}}}}}
 
 // TestServiceMetricsDefault is unit test (testing request handling, not the prometheus client behaviour)
 func TestServiceMetricsDefault(t *testing.T) {

--- a/services/business/services.go
+++ b/services/business/services.go
@@ -90,11 +90,21 @@ func (in *SvcService) GetApps(namespace, service string) ([]string, error) {
 		return nil, fmt.Errorf("GetApps: %s", err.Error())
 	}
 
-	var apps []string
-	for _, depl := range serviceDetails.Deployments.Items {
-		if app, ok := depl.Labels["app"]; ok {
-			apps = append(apps, app)
+	// Make a map to avoid repeated values
+	apps := make(map[string]bool)
+	for _, pod := range serviceDetails.Pods {
+		if app, ok := pod.Labels["app"]; ok {
+			apps[app] = true
 		}
 	}
-	return apps, nil
+
+	// Make an array of the apps found
+	uniqueApps := make([]string, len(apps))
+	i := 0
+	for k := range apps {
+		uniqueApps[i] = k
+		i++
+	}
+
+	return uniqueApps, nil
 }


### PR DESCRIPTION
Apps were being resolved using k8s-deployments. This is incorrect since
a service can cover several kinds of "deployments".

This issue was found because metrics were being fetched incorrectly for
services that are backed by something else than a k8s-deployment.

Using pods to resolve apps involved in a k8s-service.
