### PR TITLE
KIALI-1336 Repurpose service metrics endpoint to a strict definition …

### DIFF
--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -20,7 +20,7 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promClientSupplier fu
 	namespace := vars["namespace"]
 	app := vars["app"]
 
-	params := prometheus.MetricsQuery{Namespace: namespace, Apps: []string{app}}
+	params := prometheus.MetricsQuery{Namespace: namespace, App: app}
 	err := extractMetricsQueryParams(r, &params)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -44,20 +44,8 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promClientSupplie
 	namespace := vars["namespace"]
 	service := vars["service"]
 
-	// Get business layer
-	business, err := business.Get()
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
-	apps, err := business.Svc.GetApps(namespace, service)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Could not get apps: "+err.Error())
-		return
-	}
-
-	params := prometheus.MetricsQuery{Namespace: namespace, Apps: apps}
-	err = extractMetricsQueryParams(r, &params)
+	params := prometheus.MetricsQuery{Namespace: namespace, Service: service}
+	err := extractMetricsQueryParams(r, &params)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return

--- a/prometheus/metrics_definitions.go
+++ b/prometheus/metrics_definitions.go
@@ -41,9 +41,9 @@ var (
 	}
 )
 
-func (in *kialiMetric) labelsToUse(labelsIn, labelsOut, labelsErrorIn, labelsErrorOut string) (string, string) {
+func (in *kialiMetric) labelsToUse(labels, labelsError string) string {
 	if in.useErrorLabels {
-		return labelsErrorIn, labelsErrorOut
+		return labelsError
 	}
-	return labelsIn, labelsOut
+	return labels
 }

--- a/services/business/services.go
+++ b/services/business/services.go
@@ -75,31 +75,3 @@ func (in *SvcService) GetService(namespace, service, interval string) (*models.S
 	s.SetServiceDetails(serviceDetails, istioDetails, prometheusDetails)
 	return &s, nil
 }
-
-// GetApps returns a list of "app" label values used for the Deployments covered by this service
-//	DEPRECATED this should only be used temporarily, until it's possible the get metrics for a given app label
-//	Ultimately, service metrics will not gather full apps metrics.
-func (in *SvcService) GetApps(namespace, service string) ([]string, error) {
-	serviceDetails, err := in.k8s.GetServiceDetails(namespace, service)
-	if err != nil {
-		return nil, fmt.Errorf("GetApps: %s", err.Error())
-	}
-
-	// Make a map to avoid repeated values
-	apps := make(map[string]bool)
-	for _, pod := range serviceDetails.Pods {
-		if app, ok := pod.Labels["app"]; ok {
-			apps[app] = true
-		}
-	}
-
-	// Make an array of the apps found
-	uniqueApps := make([]string, len(apps))
-	i := 0
-	for k := range apps {
-		uniqueApps[i] = k
-		i++
-	}
-
-	return uniqueApps, nil
-}


### PR DESCRIPTION
…of service metrics

Service metrics are fetched from "destination_service_name" label. There's no outbound metrics for a service.
Remove temporary code ("GetApp") and save a beer.

JIRA: https://issues.jboss.org/browse/KIALI-1336
