### PR TITLE
KIALI-1346 Fix to parse correctly the Jaeger proxy

### DIFF
--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -35,8 +35,10 @@ func GetJaegerInfo(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Scheme != "" {
 		scheme = r.URL.Scheme
 	}
+	// r.Host can be set as "host" or "host:port", we always remove the :port as it is updated by the proxy
+	kialiHost := strings.Split(r.Host, ":")
 	info := models.JaegerInfo{
-		URL: fmt.Sprintf("%s://%s:%s", scheme, r.Host, "32439"),
+		URL: fmt.Sprintf("%s://%s:%s", scheme, kialiHost[0], "32439"),
 	}
 	RespondWithJSON(w, http.StatusOK, info)
 }


### PR DESCRIPTION
** Describe the change **

The service used to fetch the Jaeger proxy url builds incorrectly the URL in some scenarios, as the host:port is not correctly parsed.

** Issue reference **
https://github.com/kiali/kiali/issues/416
https://issues.jboss.org/browse/KIALI-1346

** Backwards incompatible? **
No