### PR TITLE
added regex to enabled all 2xx response codes in response_time query

### DIFF
--- a/graph/appender/response_time.go
+++ b/graph/appender/response_time.go
@@ -92,7 +92,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 
 		// 4) if the target namespace is istioNamespace re-query for traffic originating from a workload outside of the namespace
 		if namespace == istioNamespace {
-			query = fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"destination\",source_workload_namespace!=\"%v\",destination_service_namespace=\"%v\",response_code=\"200\"}[%vs])) by (%s))",
+			query = fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"destination\",source_workload_namespace!=\"%v\",destination_service_namespace=\"%v\",response_code=~\"2[0-9]{2}\"}[%vs])) by (%s))",
 				quantile,
 				"istio_request_duration_seconds_bucket",
 				namespace,
@@ -106,7 +106,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 		}
 
 		// 5) supplemental query for traffic originating from a workload inside of the namespace with istioSystem destination
-		query = fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"destination\",source_workload_namespace=\"%v\",destination_service_namespace=\"%v\",response_code=\"200\"}[%vs])) by (%s))",
+		query = fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"destination\",source_workload_namespace=\"%v\",destination_service_namespace=\"%v\",response_code=~\"2[0-9]{2}\"}[%vs])) by (%s))",
 			quantile,
 			"istio_request_duration_seconds_bucket",
 			namespace,

--- a/graph/appender/response_time.go
+++ b/graph/appender/response_time.go
@@ -53,7 +53,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	// query prometheus for the responseTime info in three queries:
 	// 1) query for responseTime originating from "unknown" (i.e. the internet)
 	groupBy := "le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version"
-	query := fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"destination\",source_workload=\"unknown\",destination_service_namespace=\"%v\",response_code=\"200\"}[%vs])) by (%s))",
+	query := fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"destination\",source_workload=\"unknown\",destination_service_namespace=\"%v\",response_code=~\"2[0-9]{2}\"}[%vs])) by (%s))",
 		quantile,
 		"istio_request_duration_seconds_bucket",
 		namespace,
@@ -62,7 +62,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	unkVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
 
 	// 2) query for responseTime originating from a workload outside of the namespace
-	query = fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"source\",source_workload_namespace!=\"%v\",destination_service_namespace=\"%v\",response_code=\"200\"}[%vs])) by (%s))",
+	query = fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"source\",source_workload_namespace!=\"%v\",destination_service_namespace=\"%v\",response_code=~\"2[0-9]{2}\"}[%vs])) by (%s))",
 		quantile,
 		"istio_request_duration_seconds_bucket",
 		namespace,
@@ -72,7 +72,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	outVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
 
 	// 3) query for responseTime originating from a workload inside of the namespace
-	query = fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"source\",source_workload_namespace=\"%v\",response_code=\"200\"}[%vs])) by (%s))",
+	query = fmt.Sprintf("histogram_quantile(%.2f, sum(rate(%s{reporter=\"source\",source_workload_namespace=\"%v\",response_code=~\"2[0-9]{2}\"}[%vs])) by (%s))",
 		quantile,
 		"istio_request_duration_seconds_bucket",
 		namespace,

--- a/graph/appender/response_time_test.go
+++ b/graph/appender/response_time_test.go
@@ -13,10 +13,10 @@ import (
 func TestResponseTime(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := "round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter=\"destination\",source_workload=\"unknown\",destination_service_namespace=\"bookinfo\",response_code=\"200\"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)"
+	q0 := "round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter=\"destination\",source_workload=\"unknown\",destination_service_namespace=\"bookinfo\",response_code=~\"2[0-9]{2}\"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)"
 	v0 := model.Vector{}
 
-	q1 := "round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter=\"source\",source_workload_namespace!=\"bookinfo\",destination_service_namespace=\"bookinfo\",response_code=\"200\"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)"
+	q1 := "round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter=\"source\",source_workload_namespace!=\"bookinfo\",destination_service_namespace=\"bookinfo\",response_code=~\"2[0-9]{2}\"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)"
 	q1m0 := model.Metric{
 		"source_workload_namespace":     "istio-system",
 		"source_workload":               "ingressgateway-unknown",
@@ -32,7 +32,7 @@ func TestResponseTime(t *testing.T) {
 			Metric: q1m0,
 			Value:  10.0}}
 
-	q2 := "round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter=\"source\",source_workload_namespace=\"bookinfo\",response_code=\"200\"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)"
+	q2 := "round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter=\"source\",source_workload_namespace=\"bookinfo\",response_code=~\"2[0-9]{2}\"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)"
 	q2m0 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
 		"source_workload":               "productpage-v1",


### PR DESCRIPTION
** Describe the change **
Added regex to get all 2xx response_codes in  response_time promtheus query.

** Issue reference **
https://github.com/kiali/kiali/issues/435

** Backwards incompatible? **
no

- [ ] Is your change introducing backwards incompatible changes?

_describe the changes if appropriate_

The prometheus query response_times query was only returning requests that were ```response_code=\"200\"``` . However some other responses codes are also acceptable in a  restfull environment like  201 (created). This change allows the query to also return those valid 2xx response codes