### PR TITLE
KIALI-1097 Add graph support for nodes with TCP traffic

### DIFF
--- a/graph/appender/dead_node.go
+++ b/graph/appender/dead_node.go
@@ -44,9 +44,15 @@ func applyDeadNodes(trafficMap graph.TrafficMap, istioClient kubernetes.IstioCli
 				numRemoved++
 			}
 		default:
-			// a node with traffic is not dead, skip
+			// a node with HTTP traffic is not dead, skip
 			rate, hasRate := n.Metadata["rate"]
 			rateOut, hasRateOut := n.Metadata["rateOut"]
+			if (hasRate && rate.(float64) > 0) || (hasRateOut && rateOut.(float64) > 0) {
+				continue
+			}
+			// a node with TCP Sent traffic is not dead, skip
+			rate, hasRate = n.Metadata["tcpSentRate"]
+			rateOut, hasRateOut = n.Metadata["tcpSentRateOut"]
 			if (hasRate && rate.(float64) > 0) || (hasRateOut && rateOut.(float64) > 0) {
 				continue
 			}

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -23,7 +23,6 @@ const (
 	defaultDuration      string = "10m"
 	defaultGraphType     string = graph.GraphTypeApp
 	defaultGroupBy       string = GroupByVersion
-	defaultMetric        string = "istio_requests_total"
 	defaultVendor        string = "cytoscape"
 )
 
@@ -39,7 +38,6 @@ type Options struct {
 	Appenders    []appender.Appender
 	Duration     time.Duration
 	IncludeIstio bool // include istio-system services. Ignored for istio-system ns. Default false.
-	Metric       string
 	Namespaces   []string
 	QueryTime    int64 // unix time in seconds
 	Workload     string
@@ -59,7 +57,6 @@ func NewOptions(r *http.Request) Options {
 	includeIstio, includeIstioErr := strconv.ParseBool(params.Get("includeIstio"))
 	graphType := params.Get("graphType")
 	groupBy := params.Get("groupBy")
-	metric := params.Get("metric")
 	queryTime, queryTimeErr := strconv.ParseInt(params.Get("queryTime"), 10, 64)
 	namespaces := params.Get("namespaces") // csl of namespaces. Overrides namespace path param if set
 	vendor := params.Get("vendor")
@@ -99,9 +96,6 @@ func NewOptions(r *http.Request) Options {
 	if "" == groupBy {
 		groupBy = defaultGroupBy
 	}
-	if "" == metric {
-		metric = defaultMetric
-	}
 	if queryTimeErr != nil {
 		queryTime = time.Now().Unix()
 	}
@@ -112,7 +106,6 @@ func NewOptions(r *http.Request) Options {
 	options := Options{
 		Duration:     duration,
 		IncludeIstio: includeIstio,
-		Metric:       metric,
 		Namespaces:   namespaceNames,
 		QueryTime:    queryTime,
 		Vendor:       vendor,

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -25,7 +25,6 @@ package handlers
 //   graphType:      Determines how to present the telemetry data. app | versionedApp | workload (default workload)
 //   groupBy:        If supported by vendor, visually group by a specified node attribute (default version)
 //   includeIstio:   Include istio-system (infra) services (default false)
-//   metric:         Prometheus metric name to be used to generate the dependency graph (default istio_request_count)
 //   namespaces:     Comma-separated list of namespace names to use in the graph. Will override namespace path param
 //   queryTime:      Unix time (seconds) for query such that range is queryTime-duration..queryTime (default now)
 //   vendor:         cytoscape | vizceral (default cytoscape)
@@ -145,11 +144,13 @@ func markTrafficGenerators(trafficMap graph.TrafficMap) {
 // buildNamespaceTrafficMap returns a map of all namespace nodes (key=id).  All
 // nodes either directly send and/or receive requests from a node in the namespace.
 func buildNamespaceTrafficMap(namespace string, o options.Options, client *prometheus.Client) graph.TrafficMap {
+	httpMetric := "istio_requests_total"
+
 	// query prometheus for request traffic in three queries:
 	// 1) query for traffic originating from "unknown" (i.e. the internet)
 	groupBy := "source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code"
 	query := fmt.Sprintf("sum(rate(%v{reporter=\"destination\",source_workload=\"unknown\",destination_service_namespace=\"%v\",response_code=~\"%v\"} [%vs])) by (%v)",
-		o.Metric,
+		httpMetric,
 		namespace,
 		"[2345][0-9][0-9]",        // regex for valid response_codes
 		int(o.Duration.Seconds()), // range duration for the query
@@ -160,7 +161,7 @@ func buildNamespaceTrafficMap(namespace string, o options.Options, client *prome
 
 	// 2) query for traffic originating from a workload outside of the namespace
 	query = fmt.Sprintf("sum(rate(%v{reporter=\"source\",source_workload_namespace!=\"%v\",destination_service_namespace=\"%v\",response_code=~\"%v\"} [%vs])) by (%v)",
-		o.Metric,
+		httpMetric,
 		namespace,
 		namespace,
 		"[2345][0-9][0-9]",        // regex for valid response_codes
@@ -172,7 +173,7 @@ func buildNamespaceTrafficMap(namespace string, o options.Options, client *prome
 
 	// 3) query for traffic originating from a workload inside of the namespace
 	query = fmt.Sprintf("sum(rate(%v{reporter=\"source\",source_workload_namespace=\"%v\",response_code=~\"%v\"} [%vs])) by (%v)",
-		o.Metric,
+		httpMetric,
 		namespace,
 		"[2345][0-9][0-9]",        // regex for valid response_codes
 		int(o.Duration.Seconds()), // range duration for the query
@@ -183,9 +184,9 @@ func buildNamespaceTrafficMap(namespace string, o options.Options, client *prome
 
 	// create map to aggregate traffic by response code
 	trafficMap := graph.NewTrafficMap()
-	populateTrafficMap(trafficMap, &unkVector, o)
-	populateTrafficMap(trafficMap, &extVector, o)
-	populateTrafficMap(trafficMap, &intVector, o)
+	populateTrafficMapHttp(trafficMap, &unkVector, o)
+	populateTrafficMapHttp(trafficMap, &extVector, o)
+	populateTrafficMapHttp(trafficMap, &intVector, o)
 
 	// istio component telemetry is only reported destination-side, so we must perform additional queries
 	if o.IncludeIstio {
@@ -194,7 +195,7 @@ func buildNamespaceTrafficMap(namespace string, o options.Options, client *prome
 		// 4) if the target namespace is istioNamespace re-query for traffic originating from a workload outside of the namespace
 		if namespace == istioNamespace {
 			query = fmt.Sprintf("sum(rate(%v{reporter=\"destination\",source_workload_namespace!=\"%v\",destination_service_namespace=\"%v\",response_code=~\"%v\"} [%vs])) by (%v)",
-				o.Metric,
+				httpMetric,
 				namespace,
 				namespace,
 				"[2345][0-9][0-9]",        // regex for valid response_codes
@@ -203,12 +204,12 @@ func buildNamespaceTrafficMap(namespace string, o options.Options, client *prome
 
 			// fetch the externally originating request traffic time-series
 			extIstioVector := promQuery(query, time.Unix(o.QueryTime, 0), client.API())
-			populateTrafficMap(trafficMap, &extIstioVector, o)
+			populateTrafficMapHttp(trafficMap, &extIstioVector, o)
 		}
 
 		// 5) supplemental query for traffic originating from a workload inside of the namespace with istioSystem destination
 		query = fmt.Sprintf("sum(rate(%v{reporter=\"destination\",source_workload_namespace=\"%v\",destination_service_namespace=\"%v\",response_code=~\"%v\"} [%vs])) by (%v)",
-			o.Metric,
+			httpMetric,
 			namespace,
 			istioNamespace,
 			"[2345][0-9][0-9]",        // regex for valid response_codes
@@ -217,13 +218,47 @@ func buildNamespaceTrafficMap(namespace string, o options.Options, client *prome
 
 		// fetch the internally originating request traffic time-series
 		intIstioVector := promQuery(query, time.Unix(o.QueryTime, 0), client.API())
-		populateTrafficMap(trafficMap, &intIstioVector, o)
+		populateTrafficMapHttp(trafficMap, &intIstioVector, o)
 	}
+
+	// Section for TCP services
+	tcpMetric := "istio_tcp_sent_bytes_total"
+
+	// 1) query for traffic originating from "unknown" (i.e. the internet)
+	groupByTcp := "source_workload_namespace,source_workload,source_app,source_version,destination_workload_namespace,destination_service_name,destination_workload,destination_app,destination_version"
+	query = fmt.Sprintf("sum(rate(%v{reporter=\"destination\",source_workload=\"unknown\",destination_workload_namespace=\"%v\"} [%vs])) by (%v)",
+		tcpMetric,
+		namespace,
+		int(o.Duration.Seconds()), // range duration for the query
+		groupByTcp)
+	tcpUnkVector := promQuery(query, time.Unix(o.QueryTime, 0), client.API())
+
+	// 2) query for traffic originating from a workload outside of the namespace
+	groupByTcp = "source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version"
+	query = fmt.Sprintf("sum(rate(%v{reporter=\"source\",source_workload_namespace!=\"%v\",destination_service_namespace=\"%v\"} [%vs])) by (%v)",
+		tcpMetric,
+		namespace,
+		namespace,
+		int(o.Duration.Seconds()), // range duration for the query
+		groupByTcp)
+	tcpExtVector := promQuery(query, time.Unix(o.QueryTime, 0), client.API())
+
+	// 3) query for traffic originating from a workload inside of the namespace
+	query = fmt.Sprintf("sum(rate(%v{reporter=\"source\",source_workload_namespace=\"%v\"} [%vs])) by (%v)",
+		tcpMetric,
+		namespace,
+		int(o.Duration.Seconds()), // range duration for the query
+		groupByTcp)
+	tcpInVector := promQuery(query, time.Unix(o.QueryTime, 0), client.API())
+
+	populateTrafficMapTcp(trafficMap, &tcpUnkVector, o)
+	populateTrafficMapTcp(trafficMap, &tcpExtVector, o)
+	populateTrafficMapTcp(trafficMap, &tcpInVector, o)
 
 	return trafficMap
 }
 
-func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o options.Options) {
+func populateTrafficMapHttp(trafficMap graph.TrafficMap, vector *model.Vector, o options.Options) {
 	for _, s := range *vector {
 		m := s.Metric
 		lSourceWlNs, sourceWlNsOk := m["source_workload_namespace"]
@@ -297,6 +332,73 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o opt
 		addToRate(source.Metadata, "rateOut", val)
 		addToRate(dest.Metadata, ck, val)
 		addToRate(dest.Metadata, "rate", val)
+	}
+}
+
+func populateTrafficMapTcp(trafficMap graph.TrafficMap, vector *model.Vector, o options.Options) {
+	for _, s := range *vector {
+		m := s.Metric
+		lSourceWlNs, sourceWlNsOk := m["source_workload_namespace"]
+		lSourceWl, sourceWlOk := m["source_workload"]
+		lSourceApp, sourceAppOk := m["source_app"]
+		lSourceVer, sourceVerOk := m["source_version"]
+		lDestSvcNs, destSvcNsOk := m["destination_service_namespace"]
+		lDestSvcName, destSvcNameOk := m["destination_service_name"]
+		lDestWl, destWlOk := m["destination_workload"]
+		lDestApp, destAppOk := m["destination_app"]
+		lDestVer, destVerOk := m["destination_version"]
+
+		// TCP queries doesn't use destination_service_namespace for the unknown node.
+		// Check if this is the case and use destination_workload_namespace
+		if !destSvcNsOk {
+			lDestSvcNs, destSvcNsOk = m["destination_workload_namespace"]
+		}
+
+		if !sourceWlNsOk || !sourceWlOk || !sourceAppOk || !sourceVerOk || !destSvcNsOk || !destSvcNameOk || !destWlOk || !destAppOk || !destVerOk {
+			log.Warningf("Skipping %v, missing expected TS labels", m.String())
+			continue
+		}
+
+		sourceWlNs := string(lSourceWlNs)
+		sourceWl := string(lSourceWl)
+		sourceApp := string(lSourceApp)
+		sourceVer := string(lSourceVer)
+		destSvcNs := string(lDestSvcNs)
+		destSvcName := string(lDestSvcName)
+		destWl := string(lDestWl)
+		destApp := string(lDestApp)
+		destVer := string(lDestVer)
+
+		source, sourceFound := addSourceNode(trafficMap, sourceWlNs, sourceWl, sourceApp, sourceVer, o)
+		dest, destFound := addDestNode(trafficMap, destSvcNs, destWl, destApp, destVer, destSvcName, o)
+
+		addToDestServices(dest.Metadata, destSvcName)
+
+		var edge *graph.Edge
+		for _, e := range source.Edges {
+			if dest.ID == e.Dest.ID {
+				edge = e
+				break
+			}
+		}
+		if nil == edge {
+			edge = source.AddEdge(dest)
+		}
+
+		val := float64(s.Value)
+
+		// A workload may mistakenly have multiple app and or version label values.
+		// This is a misconfiguration we need to handle. See Kiali-1309.
+		if sourceFound {
+			handleMisconfiguredLabels(source, sourceApp, sourceVer, val, o)
+		}
+		if destFound {
+			handleMisconfiguredLabels(dest, destApp, destVer, val, o)
+		}
+
+		addToRate(edge.Metadata, "tcpSentRate", val)
+		addToRate(source.Metadata, "tcpSentRateOut", val)
+		addToRate(dest.Metadata, "tcpSentRate", val)
 	}
 }
 

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -285,6 +285,55 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q2m12,
 			Value:  20}}
 
+	q3 := "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"destination\",source_workload=\"unknown\",destination_workload_namespace=\"bookinfo\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_workload_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)"
+	q3m0 := model.Metric{
+		"source_workload_namespace":      "unknown",
+		"source_workload":                "unknown",
+		"source_app":                     "unknown",
+		"source_version":                 "unknown",
+		"destination_workload_namespace": "bookinfo",
+		"destination_service_name":       "tcp",
+		"destination_workload":           "tcp-v1",
+		"destination_app":                "tcp",
+		"destination_version":            "v1"}
+	v3 := model.Vector{
+		&model.Sample{
+			Metric: q3m0,
+			Value:  400}}
+
+	q4 := "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace!=\"bookinfo\",destination_service_namespace=\"bookinfo\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)"
+	q4m0 := model.Metric{
+		"source_workload_namespace":     "istio-system",
+		"source_workload":               "ingressgateway-unknown",
+		"source_app":                    "ingressgateway",
+		"source_version":                "unknown",
+		"destination_service_namespace": "bookinfo",
+		"destination_service_name":      "tcp",
+		"destination_workload":          "tcp-v1",
+		"destination_app":               "tcp",
+		"destination_version":           "v1"}
+	v4 := model.Vector{
+		&model.Sample{
+			Metric: q4m0,
+			Value:  150}}
+
+	q5 := "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)"
+	q5m0 := model.Metric{
+		"source_workload_namespace":     "bookinfo",
+		"source_workload":               "productpage-v1",
+		"source_app":                    "productpage",
+		"source_version":                "v1",
+		"destination_service_namespace": "bookinfo",
+		"destination_service_name":      "tcp",
+		"destination_workload":          "tcp-v1",
+		"destination_app":               "tcp",
+		"destination_version":           "v1"}
+
+	v5 := model.Vector{
+		&model.Sample{
+			Metric: q5m0,
+			Value:  31}}
+
 	client, api, err := setupMocked()
 	if err != nil {
 		t.Error(err)
@@ -293,6 +342,9 @@ func TestNamespaceGraph(t *testing.T) {
 	mockQuery(api, q0, &v0)
 	mockQuery(api, q1, &v1)
 	mockQuery(api, q2, &v2)
+	mockQuery(api, q3, &v3)
+	mockQuery(api, q4, &v4)
+	mockQuery(api, q5, &v5)
 
 	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client)
 
@@ -345,8 +397,17 @@ func TestMultiNamespaceGraph(t *testing.T) {
 	q2 := "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)"
 	v2 := model.Vector{}
 
-	q3 := "round(sum(rate(istio_requests_total{reporter=\"destination\",source_workload=\"unknown\",destination_service_namespace=\"tutorial\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)"
-	q3m0 := model.Metric{
+	q3 := "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"destination\",source_workload=\"unknown\",destination_workload_namespace=\"bookinfo\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_workload_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)"
+	v3 := model.Vector{}
+
+	q4 := "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace!=\"bookinfo\",destination_service_namespace=\"bookinfo\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)"
+	v4 := model.Vector{}
+
+	q5 := "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)"
+	v5 := model.Vector{}
+
+	q6 := "round(sum(rate(istio_requests_total{reporter=\"destination\",source_workload=\"unknown\",destination_service_namespace=\"tutorial\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)"
+	q6m0 := model.Metric{
 		"source_workload_namespace":     "unknown",
 		"source_workload":               "unknown",
 		"source_app":                    "unknown",
@@ -357,16 +418,25 @@ func TestMultiNamespaceGraph(t *testing.T) {
 		"destination_app":               "customer",
 		"destination_version":           "v1",
 		"response_code":                 "200"}
-	v3 := model.Vector{
+	v6 := model.Vector{
 		&model.Sample{
-			Metric: q3m0,
+			Metric: q6m0,
 			Value:  50}}
 
-	q4 := "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace!=\"tutorial\",destination_service_namespace=\"tutorial\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)"
-	v4 := model.Vector{}
+	q7 := "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace!=\"tutorial\",destination_service_namespace=\"tutorial\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)"
+	v7 := model.Vector{}
 
-	q5 := "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"tutorial\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)"
-	v5 := model.Vector{}
+	q8 := "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"tutorial\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)"
+	v8 := model.Vector{}
+
+	q9 := "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"destination\",source_workload=\"unknown\",destination_workload_namespace=\"tutorial\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_workload_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)"
+	v9 := model.Vector{}
+
+	q10 := "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace!=\"tutorial\",destination_service_namespace=\"tutorial\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)"
+	v10 := model.Vector{}
+
+	q11 := "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace=\"tutorial\"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)"
+	v11 := model.Vector{}
 
 	client, api, err := setupMocked()
 	if err != nil {
@@ -379,6 +449,12 @@ func TestMultiNamespaceGraph(t *testing.T) {
 	mockQuery(api, q3, &v3)
 	mockQuery(api, q4, &v4)
 	mockQuery(api, q5, &v5)
+	mockQuery(api, q6, &v6)
+	mockQuery(api, q7, &v7)
+	mockQuery(api, q8, &v8)
+	mockQuery(api, q9, &v9)
+	mockQuery(api, q10, &v10)
+	mockQuery(api, q11, &v11)
 
 	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client)
 

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -41,7 +41,8 @@
             "productpage": true
           },
           "rate": "170.000",
-          "rateOut": "160.000"
+          "rateOut": "160.000",
+          "rateTcpSentOut": "31.000"
         }
       },
       {
@@ -71,11 +72,24 @@
       },
       {
         "data": {
+          "id": "4ee8019fc0454770a401b89d427277bf",
+          "nodeType": "app",
+          "namespace": "bookinfo",
+          "app": "tcp",
+          "destServices": {
+            "tcp": true
+          },
+          "rateTcpSent": "581.000"
+        }
+      },
+      {
+        "data": {
           "id": "19950ddefadd370bf5434953c1944c80",
           "nodeType": "app",
           "namespace": "istio-system",
           "app": "ingressgateway",
           "rateOut": "100.000",
+          "rateTcpSentOut": "150.000",
           "isOutside": true
         }
       },
@@ -88,6 +102,7 @@
           "app": "unknown",
           "version": "unknown",
           "rateOut": "50.000",
+          "rateTcpSentOut": "400.000",
           "isRoot": true
         }
       }
@@ -99,6 +114,14 @@
           "source": "19950ddefadd370bf5434953c1944c80",
           "target": "2c22af42b0c750749399ed2838c56054",
           "rate": "100.000"
+        }
+      },
+      {
+        "data": {
+          "id": "d4fdd9066e627a2afd3171822388fab4",
+          "source": "19950ddefadd370bf5434953c1944c80",
+          "target": "4ee8019fc0454770a401b89d427277bf",
+          "tcpSentRate": "150.000"
         }
       },
       {
@@ -117,6 +140,14 @@
           "target": "37ddc91db761d432f3fff1943802cad7",
           "rate": "60.000",
           "percentRate": "37.500"
+        }
+      },
+      {
+        "data": {
+          "id": "31f1137765289f98de743a8d7d13d2b8",
+          "source": "2c22af42b0c750749399ed2838c56054",
+          "target": "4ee8019fc0454770a401b89d427277bf",
+          "tcpSentRate": "31.000"
         }
       },
       {
@@ -165,6 +196,14 @@
           "source": "5c33c02dc744d0d03513a364935660b7",
           "target": "2c22af42b0c750749399ed2838c56054",
           "rate": "50.000"
+        }
+      },
+      {
+        "data": {
+          "id": "b622398b26d906f5561d70e12cacba74",
+          "source": "5c33c02dc744d0d03513a364935660b7",
+          "target": "4ee8019fc0454770a401b89d427277bf",
+          "tcpSentRate": "400.000"
         }
       }
     ]

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -457,7 +457,6 @@ func NewRoutes() (r *Routes) {
 			// graphType:      Graph type for the telemetry data: app | versionedApp | workload (default workload)
 			// groupByVersion: Visually group versions of the same app (cytoscape only, default true)
 			// includeIstio:   Include istio-system destinations in graph (default false)
-			// metric:         Prometheus metric name used to generate the dependency graph (default=istio_request_count)
 			// namespaces:     Comma-separated list of namespaces will override path param (path param 'all' for all namespaces)
 			// queryTime:      Unix timestamp in seconds is query range end time (default now)
 			// vendor:         Graph format: cytoscape (default) | vizceral


### PR DESCRIPTION
This is adding the required queries to Prometheus and adding the relevant metadata to the graph JSON.

** Backwards incompatible? No
