### PR TITLE
KIALI-1379 Fix service metric support

### DIFF
--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -39,10 +39,10 @@ func TestAppMetricsDefault(t *testing.T) {
 		assert.Contains(t, query, "[1m]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le)")
+			assert.Contains(t, query, " by (le,reporter)")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.NotContains(t, query, " by ")
+			assert.Contains(t, query, " by (reporter)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 15*time.Second, r.Step)
@@ -96,11 +96,11 @@ func TestAppMetricsWithParams(t *testing.T) {
 		assert.Contains(t, query, "[5h]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le,response_code)")
+			assert.Contains(t, query, " by (le,reporter,response_code)")
 			assert.Contains(t, query, "istio_request_bytes")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.Contains(t, query, " by (response_code)")
+			assert.Contains(t, query, " by (reporter,response_code)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 2*time.Second, r.Step)

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -132,9 +132,7 @@ func markTrafficGenerators(trafficMap graph.TrafficMap) {
 			continue
 		}
 		if _, isDest := destMap[n.ID]; !isDest {
-			if _, isOutside := n.Metadata["isOutside"]; !isOutside {
-				n.Metadata["isRoot"] = true
-			}
+			n.Metadata["isRoot"] = true
 		}
 	}
 }

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -36,10 +36,10 @@ func TestNamespaceMetricsDefault(t *testing.T) {
 		assert.Contains(t, query, "[1m]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le)")
+			assert.Contains(t, query, " by (le,reporter)")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.NotContains(t, query, " by ")
+			assert.Contains(t, query, " by (reporter)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 15*time.Second, r.Step)
@@ -92,11 +92,11 @@ func TestNamespaceMetricsWithParams(t *testing.T) {
 		assert.Contains(t, query, "[5h]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le,response_code)")
+			assert.Contains(t, query, " by (le,reporter,response_code)")
 			assert.Contains(t, query, "istio_request_bytes")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.Contains(t, query, " by (response_code)")
+			assert.Contains(t, query, " by (reporter,response_code)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 2*time.Second, r.Step)

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -40,10 +40,10 @@ func TestServiceMetricsDefault(t *testing.T) {
 		assert.Contains(t, query, "[1m]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le)")
+			assert.Contains(t, query, " by (le,reporter)")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.NotContains(t, query, " by ")
+			assert.Contains(t, query, " by (reporter)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 15*time.Second, r.Step)
@@ -98,11 +98,11 @@ func TestServiceMetricsWithParams(t *testing.T) {
 		assert.Contains(t, query, "[5h]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le,response_code)")
+			assert.Contains(t, query, " by (le,reporter,response_code)")
 			assert.Contains(t, query, "istio_request_bytes")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.Contains(t, query, " by (response_code)")
+			assert.Contains(t, query, " by (reporter,response_code)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 2*time.Second, r.Step)

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -90,7 +90,8 @@
           "app": "ingressgateway",
           "rateOut": "100.000",
           "rateTcpSentOut": "150.000",
-          "isOutside": true
+          "isOutside": true,
+          "isRoot": true
         }
       },
       {

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -131,10 +131,10 @@ func TestWorkloadMetricsDefault(t *testing.T) {
 		assert.Contains(t, query, "[1m]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le)")
+			assert.Contains(t, query, " by (le,reporter)")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.NotContains(t, query, " by ")
+			assert.Contains(t, query, " by (reporter)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 15*time.Second, r.Step)
@@ -188,11 +188,11 @@ func TestWorkloadMetricsWithParams(t *testing.T) {
 		assert.Contains(t, query, "[5h]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le,response_code)")
+			assert.Contains(t, query, " by (le,reporter,response_code)")
 			assert.Contains(t, query, "istio_request_bytes")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.Contains(t, query, " by (response_code)")
+			assert.Contains(t, query, " by (reporter,response_code)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 2*time.Second, r.Step)


### PR DESCRIPTION
- update getMetrics to return both source and destination telemetry to allow the client to use what he needs.
- use source telemetry and add more label qualifiers to ensure only service metrics are retrieved.
