### PR TITLE
[KIALI-1373] Revert "Moving ImagePullPolicy Always (#441)"

### DIFF
--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -82,7 +82,6 @@ spec:
       containers:
       - image: ${IMAGE_NAME}:${IMAGE_VERSION}
         name: kiali
-        imagePullPolicy: Always
         command:
         - "/opt/kiali/kiali"
         - "-config"

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -83,7 +83,6 @@ spec:
       serviceAccount: kiali
       containers:
       - image: ${IMAGE_NAME}:${IMAGE_VERSION}
-        imagePullPolicy: Always
         name: kiali
         command:
         - "/opt/kiali/kiali"


### PR DESCRIPTION
This reverts commit bc3934ce5e97c5636e5238585bba81285f433849 and removes `imagepullpolicy:always` from deployment template.

Best Regards,
Guilherme Baufaker Rêgo