### PR TITLE
KIALI-616 Support limited access to namespaces

### DIFF
--- a/graph/appender/dead_node_test.go
+++ b/graph/appender/dead_node_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func setupWorkloadService() business.WorkloadService {
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
 
 	k8s.On("GetDeployment", mock.AnythingOfType("string"), "testPodsWithTraffic-v1").Return(
 		&v1beta1.Deployment{

--- a/graph/appender/sidecars_check.go
+++ b/graph/appender/sidecars_check.go
@@ -12,7 +12,9 @@ import (
 	"github.com/kiali/kiali/log"
 )
 
-type SidecarsCheckAppender struct{}
+type SidecarsCheckAppender struct {
+	AccessibleNamespaces map[string]bool
+}
 
 // AppendGraph implements Appender
 func (a SidecarsCheckAppender) AppendGraph(trafficMap graph.TrafficMap, _ string) {
@@ -33,6 +35,12 @@ func (a *SidecarsCheckAppender) applySidecarsChecks(trafficMap graph.TrafficMap,
 	istioNamespace := cfg.IstioNamespace
 
 	for _, n := range trafficMap {
+
+		// Skip the check on the sidecars if we don't have access to the namespace
+		if _, found := a.AccessibleNamespaces[n.Namespace]; !found {
+			continue
+		}
+
 		// We whitelist istio components because they may not report telemetry using injected sidecars.
 		if n.Namespace == istioNamespace {
 			continue

--- a/graph/appender/sidecars_check_test.go
+++ b/graph/appender/sidecars_check_test.go
@@ -19,12 +19,13 @@ import (
 
 func TestWorkloadSidecarsPasses(t *testing.T) {
 	config.Set(config.NewConfig())
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
+
 	k8s.On("GetDeployment", "testing", "workload-1").Return(buildFakeWorkloadDeployment(), nil)
 	k8s.On("GetPods", "testing", "wk=wk-1").Return(buildFakeWorkloadPods(), nil)
 
 	trafficMap := buildWorkloadTrafficMap()
-	sidecarsAppender := SidecarsCheckAppender{}
+	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
 	business := business.SetWithBackends(k8s, nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)
@@ -37,12 +38,13 @@ func TestWorkloadSidecarsPasses(t *testing.T) {
 
 func TestWorkloadWithMissingSidecarsIsFlagged(t *testing.T) {
 	config.Set(config.NewConfig())
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
+
 	k8s.On("GetDeployment", "testing", "workload-1").Return(buildFakeWorkloadDeployment(), nil)
 	k8s.On("GetPods", "testing", "wk=wk-1").Return(buildFakeWorkloadPodsNoSidecar(), nil)
 
 	trafficMap := buildWorkloadTrafficMap()
-	sidecarsAppender := SidecarsCheckAppender{}
+	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
 	business := business.SetWithBackends(k8s, nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)
@@ -56,11 +58,12 @@ func TestWorkloadWithMissingSidecarsIsFlagged(t *testing.T) {
 
 func TestAppSidecarsPasses(t *testing.T) {
 	config.Set(config.NewConfig())
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
+
 	k8s.On("GetPods", "testing", fmt.Sprintf("%v=myTest", config.Get().IstioLabels.AppLabelName)).Return(buildFakeWorkloadPods(), nil)
 
 	trafficMap := buildAppTrafficMap()
-	sidecarsAppender := SidecarsCheckAppender{}
+	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
 	business := business.SetWithBackends(k8s, nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)
@@ -73,11 +76,11 @@ func TestAppSidecarsPasses(t *testing.T) {
 
 func TestAppWithMissingSidecarsIsFlagged(t *testing.T) {
 	config.Set(config.NewConfig())
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
 	k8s.On("GetPods", "testing", fmt.Sprintf("%v=myTest", config.Get().IstioLabels.AppLabelName)).Return(buildFakeWorkloadPodsNoSidecar(), nil)
 
 	trafficMap := buildAppTrafficMap()
-	sidecarsAppender := SidecarsCheckAppender{}
+	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
 	business := business.SetWithBackends(k8s, nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)
@@ -91,10 +94,10 @@ func TestAppWithMissingSidecarsIsFlagged(t *testing.T) {
 
 func TestServicesAreAlwaysValid(t *testing.T) {
 	config.Set(config.NewConfig())
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
 
 	trafficMap := buildServiceTrafficMap()
-	sidecarsAppender := SidecarsCheckAppender{}
+	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
 	business := business.SetWithBackends(k8s, nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -146,7 +146,7 @@ func setupAppMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.Pr
 
 func setupAppListEndpoint() (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
 	config.Set(config.NewConfig())
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
 	business.SetWithBackends(k8s, prom)
 

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -49,7 +49,7 @@ func TestNamespaceAppHealth(t *testing.T) {
 }
 
 func setupNamespaceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
 	business.SetWithBackends(k8s, prom)
 
@@ -93,7 +93,7 @@ func TestAppHealth(t *testing.T) {
 }
 
 func setupAppHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
 	business.SetWithBackends(k8s, prom)
 
@@ -137,7 +137,7 @@ func TestServiceHealth(t *testing.T) {
 }
 
 func setupServiceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
 	business.SetWithBackends(k8s, prom)
 

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -8,11 +8,18 @@ import (
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/services/business"
-	"github.com/kiali/kiali/services/models"
 )
 
 func NamespaceList(w http.ResponseWriter, r *http.Request) {
-	namespaces, err := models.GetNamespaces()
+
+	business, err := business.Get()
+	if err != nil {
+		log.Error(err)
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	namespaces, err := business.Namespace.GetNamespaces()
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -246,7 +246,8 @@ func TestServiceMetricsBadRateFunc(t *testing.T) {
 
 func setupServiceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.PromAPIMock) {
 	config.Set(config.NewConfig())
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
+
 	api := new(prometheustest.PromAPIMock)
 	prom, err := prometheus.NewClient()
 	if err != nil {

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -13,6 +13,7 @@
             "pricing": true
           },
           "rate": "20.000",
+          "isInaccessible": true,
           "isOutside": true
         }
       },
@@ -90,6 +91,7 @@
           "app": "ingressgateway",
           "rateOut": "100.000",
           "rateTcpSentOut": "150.000",
+          "isInaccessible": true,
           "isOutside": true,
           "isRoot": true
         }

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func setupDeploymentList() (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
-	k8s := new(kubetest.K8SClientMock)
+	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
 	business.SetWithBackends(k8s, prom)
 

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/client-go/rest"
 
 	kialiConfig "github.com/kiali/kiali/config"
+
+	osv1 "github.com/openshift/api/project/v1"
 )
 
 const (
@@ -46,6 +48,7 @@ type IstioClientInterface interface {
 	GetNamespaceAppsDetails(namespace string) (NamespaceApps, error)
 	GetNamespaces() ([]v1.Namespace, error)
 	GetPods(namespace, labelSelector string) ([]v1.Pod, error)
+	GetProjects() (*osv1.ProjectList, error)
 	GetService(namespace string, serviceName string) (*v1.Service, error)
 	GetServices(namespace string, selectorLabels map[string]string) ([]v1.Service, error)
 	GetServiceEntries(namespace string) ([]IstioObject, error)
@@ -56,6 +59,7 @@ type IstioClientInterface interface {
 	GetQuotaSpecs(namespace string) ([]IstioObject, error)
 	GetQuotaSpecBinding(namespace string, quotaSpecBindingName string) (IstioObject, error)
 	GetQuotaSpecBindings(namespace string) ([]IstioObject, error)
+	IsOpenShift() bool
 }
 
 // IstioClient is the client struct for Kubernetes and Istio APIs

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
+
+	osv1 "github.com/openshift/api/project/v1"
 )
 
 type servicesResponse struct {
@@ -39,6 +41,26 @@ func (in *IstioClient) GetNamespaces() ([]v1.Namespace, error) {
 	}
 
 	return namespaces.Items, nil
+}
+
+func (in *IstioClient) GetProjects() (*osv1.ProjectList, error) {
+	result := &osv1.ProjectList{}
+
+	err := in.k8s.RESTClient().Get().Prefix("apis", "project.openshift.io", "v1", "projects").Do().Into(result)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (in *IstioClient) IsOpenShift() bool {
+	_, err := in.k8s.RESTClient().Get().AbsPath("/version/openshift").Do().Raw()
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 // GetNamespaceAppsDetails returns a map of apps details (services, deployments and pods) in the given namespace.

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -9,15 +9,33 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/kubernetes"
+
+	osv1 "github.com/openshift/api/project/v1"
 )
 
 type K8SClientMock struct {
 	mock.Mock
 }
 
+func NewK8SClientMock() *K8SClientMock {
+	k8s := new(K8SClientMock)
+	k8s.On("IsOpenShift").Return(true)
+	return k8s
+}
+
 func (o *K8SClientMock) GetNamespaces() ([]v1.Namespace, error) {
 	args := o.Called()
 	return args.Get(0).([]v1.Namespace), args.Error(1)
+}
+
+func (o *K8SClientMock) GetProjects() (*osv1.ProjectList, error) {
+	args := o.Called()
+	return args.Get(0).(*osv1.ProjectList), args.Error(1)
+}
+
+func (o *K8SClientMock) IsOpenShift() bool {
+	args := o.Called()
+	return args.Get(0).(bool)
 }
 
 func (o *K8SClientMock) GetDeployment(namespace string, deploymentName string) (*v1beta1.Deployment, error) {

--- a/services/business/layer.go
+++ b/services/business/layer.go
@@ -13,6 +13,7 @@ type Layer struct {
 	IstioConfig IstioConfigService
 	Workload    WorkloadService
 	App         AppService
+	Namespace   NamespaceService
 }
 
 // Global business.Layer; currently only used for tests to inject mocks,
@@ -40,6 +41,7 @@ func Get() (*Layer, error) {
 	temporaryLayer.IstioConfig = IstioConfigService{k8s: k8s}
 	temporaryLayer.Workload = WorkloadService{k8s: k8s}
 	temporaryLayer.App = AppService{k8s: k8s}
+	temporaryLayer.Namespace = NewNamespaceService(k8s)
 	return temporaryLayer, nil
 }
 
@@ -52,5 +54,6 @@ func SetWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	layer.IstioConfig = IstioConfigService{k8s: k8s}
 	layer.Workload = WorkloadService{k8s: k8s}
 	layer.App = AppService{k8s: k8s}
+	layer.Namespace = NewNamespaceService(k8s)
 	return layer
 }

--- a/services/business/namespaces.go
+++ b/services/business/namespaces.go
@@ -1,0 +1,48 @@
+package business
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/services/models"
+)
+
+// Namespace deals with fetching k8s namespaces / OpenShift projects and convert to kiali model
+type NamespaceService struct {
+	k8s         kubernetes.IstioClientInterface
+	hasProjects bool
+}
+
+func NewNamespaceService(k8s kubernetes.IstioClientInterface) NamespaceService {
+
+	var hasProjects bool
+
+	if k8s != nil && k8s.IsOpenShift() {
+		hasProjects = true
+	} else {
+		hasProjects = false
+	}
+
+	return NamespaceService{
+		k8s:         k8s,
+		hasProjects: hasProjects,
+	}
+}
+
+// Returns a list of the given namespaces / projects
+func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
+
+	// If we are running in OpenShift, we will use the project names since these are the list of accessible namespaces
+	if in.hasProjects {
+		projects, err := in.k8s.GetProjects()
+		if err == nil {
+			// Everything is good, return the projects we got from OpenShift / kube-project
+			return models.CastProjectCollection(projects), nil
+		}
+	}
+
+	services, err := in.k8s.GetNamespaces()
+	if err != nil {
+		return nil, err
+	}
+
+	return models.CastNamespaceCollection(services), nil
+}

--- a/services/models/namespace.go
+++ b/services/models/namespace.go
@@ -3,7 +3,7 @@ package models
 import (
 	"k8s.io/api/core/v1"
 
-	"github.com/kiali/kiali/kubernetes"
+	osv1 "github.com/openshift/api/project/v1"
 )
 
 // A Namespace provide a scope for names
@@ -18,20 +18,6 @@ type Namespace struct {
 	Name string `json:"name"`
 }
 
-func GetNamespaces() ([]Namespace, error) {
-	istioClient, err := kubernetes.NewClient()
-	if err != nil {
-		return nil, err
-	}
-
-	namespaces, err := istioClient.GetNamespaces()
-	if err != nil {
-		return nil, err
-	}
-
-	return CastNamespaceCollection(namespaces), nil
-}
-
 func CastNamespaceCollection(ns []v1.Namespace) []Namespace {
 	namespaces := make([]Namespace, len(ns))
 	for i, item := range ns {
@@ -44,6 +30,22 @@ func CastNamespaceCollection(ns []v1.Namespace) []Namespace {
 func CastNamespace(ns v1.Namespace) Namespace {
 	namespace := Namespace{}
 	namespace.Name = ns.Name
+
+	return namespace
+}
+
+func CastProjectCollection(pl *osv1.ProjectList) []Namespace {
+	namespaces := make([]Namespace, len(pl.Items))
+	for i, item := range pl.Items {
+		namespaces[i] = CastProject(item)
+	}
+
+	return namespaces
+}
+
+func CastProject(p osv1.Project) Namespace {
+	namespace := Namespace{}
+	namespace.Name = p.Name
 
 	return namespace
 }


### PR DESCRIPTION
** Describe the change **

Allows user to run Kiali without granting them cluster wide permissions.

A user will be able to remove the cluser-wide 'kiali' role and the be able to select which namespaces it wants Kiali to have access to.

From the console, it will just appear like that namespace doesn't exist in the OpenShift cluster.

Caveats
- this only affects access to namespaces using the k8s RBAC. Kiali still has access to all the metrics and we don't do anything new in the PR to prevent access to these metrics. The purpose of this is to reduce and control access Kiali has to k8s objects.
- this only really works with Openshift. There really isn't a way in k8s to ask what namespaces a user has access to. Once k8s has that ability it should be easy to add it in. But for now its really only for Openshift (or if someone were to run https://github.com/openshift/kube-projects but I don't think that is being maintained anymore).

How to use (before we have official docs for it)
1) install Kiali as normal on OpenShift
2) remove the clusterrolebinding for Kiali (eg `oc delete clusterrolebinding kiali`)
3) grant permissions to Kiali only for specific namespaces (eg `oc adm policy add-role-to-user kiali system:serviceaccount:istio-system:kiali -n $NAMESPACE_NAME`)
4) Notice that only the namespaces the user has access to show up in the Kiali console.


Short Gif: we can see that there is a few namespaces in this cluster but the cluster role has been removed so we don't see them namespace drop down. We then grant the role in various namespaces and the namespace data starts to populate the dropdown and the graph. This works the same way in the details pages.

![kiali-namespaces-2](https://user-images.githubusercontent.com/691166/44494257-12968080-a639-11e8-9f45-9dece1219bc3.gif)


** Issue reference **

https://issues.jboss.org/browse/KIALI-616

** Backwards incompatible? **

There shouldn't be any perceivable change to the user if they use the default cluster wide permissions.

If they decide to remove the cluster wide permissions, then namespaces they don't have access to anymore wont show up in the console.