### PR TITLE
KIALI-1399 Keep Kiali versions in sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL=/bin/bash
 
 # Identifies the current build.
 # These will be embedded in the app and displayed when it starts.
-VERSION ?= v0.6.1-SNAPSHOT
+VERSION ?= v0.7.0-SNAPSHOT
 COMMIT_HASH ?= $(shell git rev-parse HEAD)
 
 # Indicates which version of the UI console is to be embedded


### PR DESCRIPTION
Currently the Kiali UI version is set to 0.7.0 snapshot and the Kiali version is set to 0.6.1 snapshot. They versions are suppose to be kept in sync and they should both be 0.7.0 snapshot.