### PR TITLE
Fix incorrect yaml path in documentation for jaeger.service_port

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -484,7 +484,7 @@ external_services:
 ----
 external_services:
   jaeger:
-    service: VALUE
+    service_port: VALUE
 ----
 
 |`LOGIN_TOKEN_SIGNING_KEY`


### PR DESCRIPTION
** Describe the change **

This is a trivial fix for the config documentation. 


** Backwards incompatible? **

no

_describe the changes if appropriate_

The documentation contains the same yaml path for both the jaeger service name and the jaeger service port. This PR changes the yaml path for the service port to jaeger.service_port, as implemented in[ config/config.go#89](https://github.com/kiali/kiali/blob/master/config/config.go#L89)