### PR TITLE
KIALI-1423 Move Jaeger iFrame to external links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ COMMIT_HASH ?= $(shell git rev-parse HEAD)
 CONSOLE_VERSION ?= latest
 CONSOLE_LOCAL_DIR ?= ../../../../../kiali-ui
 
+# External Services Configuration
+JAEGER_URL ?= http://jaeger-query-istio-system.127.0.0.1.nip.io
+GRAFANA_URL ?= http://grafana-istio-system.127.0.0.1.nip.io
+
 # Version label is used in the OpenShift/K8S resources to identify
 # their specific instances. Kiali resources will have labels of
 # "app: kiali" and "version: ${VERSION_LABEL}"
@@ -223,7 +227,7 @@ docker-push:
 openshift-deploy: openshift-undeploy
 	@if ! which envsubst > /dev/null 2>&1; then echo "You are missing 'envsubst'. Please install it and retry. If on MacOS, you can get this by installing the gettext package"; exit 1; fi
 	@echo Deploying to OpenShift project ${NAMESPACE}
-	cat deploy/openshift/kiali-configmap.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${OC} create -n ${NAMESPACE} -f -
+	cat deploy/openshift/kiali-configmap.yaml | VERSION_LABEL=${VERSION_LABEL} JAEGER_URL=${JAEGER_URL} GRAFANA_URL=${GRAFANA_URL} envsubst | ${OC} create -n ${NAMESPACE} -f -
 	cat deploy/openshift/kiali-secrets.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${OC} create -n ${NAMESPACE} -f -
 	cat deploy/openshift/kiali.yaml | IMAGE_NAME=${DOCKER_NAME} IMAGE_VERSION=${DOCKER_VERSION} NAMESPACE=${NAMESPACE} VERSION_LABEL=${VERSION_LABEL} VERBOSE_MODE=${VERBOSE_MODE} envsubst | ${OC} create -n ${NAMESPACE} -f -
 
@@ -245,7 +249,7 @@ openshift-reload-image: .openshift-validate
 k8s-deploy: k8s-undeploy
 	@if ! which envsubst > /dev/null 2>&1; then echo "You are missing 'envsubst'. Please install it and retry. If on MacOS, you can get this by installing the gettext package"; exit 1; fi
 	@echo Deploying to Kubernetes namespace ${NAMESPACE}
-	cat deploy/kubernetes/kiali-configmap.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
+	cat deploy/kubernetes/kiali-configmap.yaml | VERSION_LABEL=${VERSION_LABEL} JAEGER_URL=${JAEGER_URL} GRAFANA_URL=${GRAFANA_URL} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
 	cat deploy/kubernetes/kiali-secrets.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
 	cat deploy/kubernetes/kiali.yaml | IMAGE_NAME=${DOCKER_NAME} IMAGE_VERSION=${DOCKER_VERSION} NAMESPACE=${NAMESPACE} VERSION_LABEL=${VERSION_LABEL} VERBOSE_MODE=${VERBOSE_MODE} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
 

--- a/README.adoc
+++ b/README.adoc
@@ -137,6 +137,11 @@ The deploy and undeploy commands are automated in the Makefile. The following wi
 make openshift-deploy
 ----
 
+If you need to set the **JAEGER** or **GRAFANA** services, set the URL in the environment variable **JAEGER_URL** and **GRAFANA_URL**
+
+==== Deploying Kiali to OpenShift with commands
+
+
 ==== Undeploying Kiali from OpenShift
 
 If you want to remove Kiali from your OpenShift environment, you can do so by running the following command:
@@ -194,6 +199,8 @@ The deploy and undeploy commands are automated in the Makefile. The following wi
 ----
 make k8s-deploy
 ----
+
+If you need to set the **JAEGER** or **GRAFANA** services, set the URL in the environment variable **JAEGER_URL** and **GRAFANA_URL**
 
 ==== Undeploying Kiali from Kubernetes
 
@@ -389,7 +396,7 @@ external_services:
 ----
 
 |`GRAFANA_URL`
-|The URL to the Grafana server. When not set, the URL may be automatically detected from OpenShift or Kubernetes API.
+|The URL to the Grafana service. When not set, Kiali throw an error when the user try request to Grafana (/api/grafana).
 [source,yaml]
 ----
 external_services:
@@ -460,31 +467,13 @@ external_services:
     var_workload: VALUE
 ----
 
-|`JAEGER_SERVICE_NAMESPACE`
-|The Kubernetes namespace that holds the Jaeger service. (default is `istio-system`)
+|`JAEGER_URL`
+|The URL to the Jaeger service. When not set, Kiali throw an error when the user try request to Jaeger (/api/jaeger).
 [source,yaml]
 ----
 external_services:
   jaeger:
-    service_namespace: VALUE
-----
-
-|`JAEGER_SERVICE`
-|The Kubernetes service name for Jaeger. (default is `jaeger-query`)
-[source,yaml]
-----
-external_services:
-  jaeger:
-    service: VALUE
-----
-
-|`JAEGER_SERVICE_PORT`
-|The Kubernetes service port for Jaeger. (default is `16686`)
-[source,yaml]
-----
-external_services:
-  jaeger:
-    service: VALUE
+    url: VALUE
 ----
 
 |`LOGIN_TOKEN_SIGNING_KEY`
@@ -502,6 +491,73 @@ login_token:
   expiration_seconds: VALUE
 ----
 |===
+
+== Configure External Services
+
+=== Jaeger
+
+To configure the Jaeger Service you need to expose the service and set the URL parameter in the config.yaml
+
+[source,yaml]
+----
+external_services:
+  jaeger:
+    url: https://jaeger-query-istio-system.127.0.0.1.nip.io
+----
+
+If you are using the Make task **openshift-deploy** or **k8s-deploy** you need to change in the **kiali-configmap.yaml** the value of the jaeger > url
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali
+  labels:
+    app: kiali
+    version: ${VERSION_LABEL}
+data:
+  config.yaml: |
+    server:
+      port: 20001
+      static_content_root_directory: /opt/kiali/console
+    external_services:
+      jaeger:
+        url: http://jaeger-query-istio-system.127.0.0.1.nip.io
+      grafana:
+        url: http://grafana-istio-system.127.0.0.1.nip.io
+----
+=== Grafana
+
+To configure the Grafana Service you need to expose the service and set the URL parameter in the config.yaml
+
+[source,yaml]
+----
+
+external_services:
+  grafana:
+    url: http://grafana-istio-system.127.0.0.1.nip.io
+----
+If you are using the Make task **openshift-deploy** or **k8s-deploy** you need to change in the **kiali-configmap.yaml** the value of the grafana > url
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali
+  labels:
+    app: kiali
+    version: ${VERSION_LABEL}
+data:
+  config.yaml: |
+    server:
+      port: 20001
+      static_content_root_directory: /opt/kiali/console
+    external_services:
+      jaeger:
+        url: http://jaeger-query-istio-system.127.0.0.1.nip.io
+      grafana:
+        url: http://grafana-istio-system.127.0.0.1.nip.io
+----
 
 == Additional Notes
 
@@ -541,6 +597,62 @@ If you git cloned the Kiali UI repository in directory `/my/git/repo` and have b
 [source,shell]
 ----
 CONSOLE_VERSION=local CONSOLE_LOCAL_DIR=/my/git/repo make docker-build
+----
+
+=== Running Kiali with commands
+
+==== Download the files and configure
+[NOTE]
+Before deploying and running Kiali, you must first install and deploy link:https://istio.io[Istio]. *Required Istio Version: 1.0*. There are a few places that you can reference in order to learn how to do this such as link:https://github.com/redhat-developer-demos/istio-tutorial[here], link:https://blog.openshift.com/evaluate-istio-openshift/[here], and link:https://istio.io/docs/setup/kubernetes/quick-start.html[here].
+
+[NOTE]
+The following make targets assume that the `oc` command is available in the user's PATH and that the user is logged in. If you have `istiooc` instead, create a symlink in your PATH pointing `oc` to your `istiooc` binary.
+
+===== Get the kiali-configmap.yaml
+[source,bash]
+----
+$ curl https://raw.githubusercontent.com/kiali/kiali/master/deploy/kubernetes/kiali-configmap.yaml | \
+VERSION_LABEL=master envsubst > kiali-configmap.yaml
+----
+If you need to set the JAEGER and GRAFANA services set the URL configuration.
+[source,bash]
+----
+$ curl https://raw.githubusercontent.com/kiali/kiali/master/deploy/kubernetes/kiali-configmap.yaml | \
+VERSION_LABEL=master JAEGER_URL=http://jaeger-query-istio-system.127.0.0.1.nip.io GRAFANA_URL=http://grafana-istio-system.127.0.0.1.nip.io envsubst > kiali-configmap.yaml
+----
+
+===== Get the kiali-secrets.yaml
+[source,bash]
+----
+$ curl https://raw.githubusercontent.com/kiali/kiali/master/deploy/kubernetes/kiali-secrets.yaml | \
+VERSION_LABEL=master envsubst > kiali-secrets.yaml
+----
+
+===== Get the kiali.yaml
+[source,bash]
+----
+curl https://raw.githubusercontent.com/kiali/kiali/master/deploy/kubernetes/kiali.yaml | \
+IMAGE_NAME=kiali/kiali \
+IMAGE_VERSION=latest \
+NAMESPACE=istio-system \
+VERSION_LABEL=master \
+VERBOSE_MODE=4 envsubst > kiali.yaml
+----
+
+==== Running in Openshift
+[source,bash]
+----
+oc create -f kiali-configmap.yaml -n istio-system
+oc create -f kiali-secrets.yaml -n istio-system
+oc create -f kiali.yaml -n istio-system
+----
+
+==== Running in kubernetes
+[source,bash]
+----
+kubectl create -f kiali-configmap.yaml -n istio-system
+kubectl create -f kiali-secrets.yaml -n istio-system
+kubectl create -f kiali.yaml -n istio-system
 ----
 
 == Contributing

--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,10 @@ external_services:
   # Uncomment istio_identity_domain to set a different value. This value must match the Istio configuration.
   # Default is "svc.cluster.local" (which matches Istio's default)
   # istio_identity_domain: svc.cluster.local
-
+  jaeger:
+    url: http://jaeger-query-istio-system.127.0.0.1.nip.io
+  grafana:
+    url: http://grafana-istio-system.127.0.0.1.nip.io
   # Uncomment grafana_service_url, used to generate links to Grafana
   # If unset, the Grafana service URL will be looked up from Kubernetes Grafana service. It may not always be available.
   # grafana_service_url: http://grafana-istio-system.127.0.0.1.nip.io

--- a/config/config.go
+++ b/config/config.go
@@ -42,9 +42,7 @@ const (
 	EnvGrafanaVarService               = "GRAFANA_VAR_SERVICE"
 	EnvGrafanaVarWorkload              = "GRAFANA_VAR_WORKLOAD"
 
-	EnvJaegerServiceNamespace = "JAEGER_SERVICE_NAMESPACE"
-	EnvJaegerService          = "JAEGER_SERVICE"
-	EnvJaegerServicePort      = "JAEGER_SERVICE_PORT"
+	EnvJaegerURL = "JAEGER_URL"
 
 	EnvLoginTokenSigningKey        = "LOGIN_TOKEN_SIGNING_KEY"
 	EnvLoginTokenExpirationSeconds = "LOGIN_TOKEN_EXPIRATION_SECONDS"
@@ -84,9 +82,7 @@ type GrafanaConfig struct {
 
 // JaegerConfig describes configuration used for jaeger links
 type JaegerConfig struct {
-	ServiceNamespace string `yaml:"service_namespace"`
-	Service          string `yaml:"service"`
-	ServicePort      string `yaml:"service_port"`
+	URL string `yaml:"url"`
 }
 
 // IstioConfig describes configuration used for istio links
@@ -165,9 +161,7 @@ func NewConfig() (c *Config) {
 	c.ExternalServices.Grafana.VarWorkload = strings.TrimSpace(getDefaultString(EnvGrafanaVarWorkload, "var-workload"))
 
 	// Jaeger Configuration
-	c.ExternalServices.Jaeger.ServiceNamespace = strings.TrimSpace(getDefaultString(EnvJaegerServiceNamespace, "istio-system"))
-	c.ExternalServices.Jaeger.Service = strings.TrimSpace(getDefaultString(EnvJaegerService, "jaeger-query"))
-	c.ExternalServices.Jaeger.ServicePort = strings.TrimSpace(getDefaultString(EnvJaegerServicePort, "16686"))
+	c.ExternalServices.Jaeger.URL = strings.TrimSpace(getDefaultString(EnvJaegerURL, ""))
 
 	// Istio Configuration
 	c.ExternalServices.Istio.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))

--- a/deploy/kubernetes/kiali-configmap.yaml
+++ b/deploy/kubernetes/kiali-configmap.yaml
@@ -10,3 +10,8 @@ data:
     server:
       port: 20001
       static_content_root_directory: /opt/kiali/console
+    external_services:
+      jaeger:
+        url: ${JAEGER_URL}
+      grafana:
+        url: ${GRAFANA_URL}

--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -23,24 +23,6 @@ spec:
     app: kiali
     version: ${VERSION_LABEL}
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: kiali-jaeger
-  labels:
-    app: kiali
-    version: ${VERSION_LABEL}
-spec:
-  type: NodePort
-  ports:
-  - name: jaeger
-    protocol: TCP
-    nodePort: 32439
-    port: 20002
-  selector:
-    app: kiali
-    version: ${VERSION_LABEL}
----
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/deploy/openshift/kiali-configmap.yaml
+++ b/deploy/openshift/kiali-configmap.yaml
@@ -10,3 +10,8 @@ data:
     server:
       port: 20001
       static_content_root_directory: /opt/kiali/console
+    external_services:
+      jaeger:
+        url: ${JAEGER_URL}
+      grafana:
+        url: ${GRAFANA_URL}

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -24,25 +24,6 @@ spec:
     version: ${VERSION_LABEL}
 ---
 apiVersion: v1
-kind: Service
-metadata:
-  name: kiali-jaeger
-  labels:
-    app: kiali
-    version: ${VERSION_LABEL}
-spec:
-  type: NodePort
-  ports:
-  - name: jaeger
-    nodePort: 32439
-    port: 20002
-    protocol: TCP
-    targetPort: 20002
-  selector:
-    app: kiali
-    version: ${VERSION_LABEL}
----
-apiVersion: v1
 kind: Route
 metadata:
   name: kiali

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -1,44 +1,31 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"strings"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/services/models"
 )
 
-func ProxyJaeger(w http.ResponseWriter, r *http.Request) {
+// Get JaegerInfo provides the proxy Jaeger URL
+func GetJaegerInfo(w http.ResponseWriter, r *http.Request) {
 	jaegerConfig := config.Get().ExternalServices.Jaeger
-	// It assumes that jaeger internally is accessible through http. This is how it works in Istio 1.0 GA.
-	url, err := url.Parse(fmt.Sprintf("http://%s.%s:%s/", jaegerConfig.Service, jaegerConfig.ServiceNamespace, jaegerConfig.ServicePort))
-	if err != nil {
-		log.Error(err)
+	info := models.JaegerInfo{
+		URL: jaegerConfig.URL,
+	}
+
+	// Check if URL is in the configuration
+	if info.URL == "" {
+		RespondWithError(w, http.StatusNotFound, "You need to set the Jaeger URL configuration.")
 		return
 	}
-	proxy := httputil.ReverseProxy{Director: func(r *http.Request) {
-		r.URL.Scheme = url.Scheme
-		r.URL.Host = url.Host
-		r.URL.Path = strings.Replace(r.URL.Path, "/api/jaeger", "", -1)
-		r.Host = url.Host
-	}}
-	proxy.ServeHTTP(w, r)
-}
 
-// GetJaegerInfo provides the proxy Jaeger URL
-func GetJaegerInfo(w http.ResponseWriter, r *http.Request) {
-	scheme := "http"
-	if r.URL.Scheme != "" {
-		scheme = r.URL.Scheme
+	// Check if URL is valid
+	_, error := validateURL(info.URL)
+	if error != nil {
+		RespondWithError(w, http.StatusNotAcceptable, "You need to set a correct format for Jaeger URL in the configuration error: "+error.Error())
+		return
 	}
-	// r.Host can be set as "host" or "host:port", we always remove the :port as it is updated by the proxy
-	kialiHost := strings.Split(r.Host, ":")
-	info := models.JaegerInfo{
-		URL: fmt.Sprintf("%s://%s:%s", scheme, kialiHost[0], "32439"),
-	}
+
 	RespondWithJSON(w, http.StatusOK, info)
 }

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"net/url"
+
 	"k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/kubernetes"
@@ -24,4 +26,8 @@ func getService(namespace string, service string) (*v1.ServiceSpec, error) {
 		return nil, err
 	}
 	return &details.Service.Spec, nil
+}
+
+func validateURL(serviceURL string) (*url.URL, error) {
+	return url.ParseRequestURI(serviceURL)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/handlers"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/routing"
 )
@@ -53,13 +52,6 @@ func (s *Server) Start() {
 		}
 		log.Warning(err)
 	}()
-	/** Proxy solution Jaeger*/
-	go func() {
-		server20002 := http.NewServeMux()
-		server20002.HandleFunc("/", handlers.ProxyJaeger)
-		log.Error(http.ListenAndServe(":20002", server20002))
-	}()
-	/** End Proxy solution Jaeger*/
 }
 
 // Stop the HTTP server


### PR DESCRIPTION
** Describe the change **

Remove proxy configuration for Jaeger

UI Side https://github.com/kiali/kiali-ui/pull/619
** Issue reference **
[KIALI-1423](
https://issues.jboss.org/browse/KIALI-1423)
## Grafana
### Correct Information
![grafana_correct](https://user-images.githubusercontent.com/3019213/44714518-d0949100-aab5-11e8-9ef6-a93ad6724c52.png)
### Grafana configuration needed
![grafana_need_config](https://user-images.githubusercontent.com/3019213/44714520-d12d2780-aab5-11e8-995e-6159cb8c96de.png)
### Grafana URL bad format (Example: Need schema)
![grafana_bad_format](https://user-images.githubusercontent.com/3019213/44714519-d12d2780-aab5-11e8-89ab-975232d888a7.png)

## Jaeger

### Jaeger correct
![jaeger_correct](https://user-images.githubusercontent.com/3019213/44714522-d1c5be00-aab5-11e8-9b6c-4444195d7e1a.png)
### Jaeger  configuration needed
![jaeger_no_config](https://user-images.githubusercontent.com/3019213/44714632-19e4e080-aab6-11e8-8cff-e8a8302eaba5.png)
### Jaeger URL bad format (Example: Need schema)
![jaeger_mal_format](https://user-images.githubusercontent.com/3019213/44714521-d12d2780-aab5-11e8-8e1c-fd7c3b17726b.png)


## Launch with the kiali-configmap

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: kiali
  labels:
    app: kiali
    version: ${VERSION_LABEL}
data:
  config.yaml: |
    server:
      port: 20001
      static_content_root_directory: /opt/kiali/console
    external_services:
      jaeger:
        url: https://jaeger-query-istio-system.127.0.0.1.nip.io
      grafana:
        url: http://grafana-istio-system.127.0.0.1.nip.io
```

