### PR TITLE
KIALI-1329 Adding documentation to Metrics endpoints

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -14,7 +14,7 @@ import (
 // A Namespace provide a scope for names.
 // This type used to describe a set of objects.
 //
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails serviceList
 type NamespaceParam struct {
 	// The id of the namespace.
 	//
@@ -36,7 +36,7 @@ type ServiceParam struct {
 
 // Istio Object Type:
 //
-// swagger:parameters objectValidations
+// swagger:parameters objectValidations istioConfigDetails
 type ObjectType struct {
 	// The type of the istio object
 	//
@@ -48,7 +48,7 @@ type ObjectType struct {
 
 // Istio Object name
 //
-// swagger:parameters objectValidations
+// swagger:parameters objectValidations istioConfigDetails
 type ObjectName struct {
 	// The name of the istio object
 	//
@@ -275,6 +275,13 @@ type WorkloadValidationResponse struct {
 	Body TypedIstioValidations
 }
 
+// Listing all services in the namespace
+// swagger:response serviceListResponse
+type ServiceListResponse struct {
+	// in:body
+	Body models.ServiceList
+}
+
 // Listing all workloads in the namespace
 // swagger:response workloadListResponse
 type WorkloadListResponse struct {
@@ -336,6 +343,13 @@ type WorkloadDetailsResponse struct {
 type MetricsResponse struct {
 	// in:body
 	Body prometheus.Metrics
+}
+
+// IstioConfig details of an specific Istio Object
+// swagger:response istioConfigDetailsResponse
+type IstioConfigDetailsResponse struct {
+	// in:body
+	Body models.IstioConfigDetails
 }
 
 //////////////////

--- a/doc.go
+++ b/doc.go
@@ -14,7 +14,7 @@ import (
 // This type used to describe a set of objects.
 //
 
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList
 type NamespaceParam struct {
 	// The id of the namespace.
 	//

--- a/doc.go
+++ b/doc.go
@@ -14,7 +14,7 @@ import (
 // A Namespace provide a scope for names.
 // This type used to describe a set of objects.
 //
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails serviceList
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails serviceList appDetails
 type NamespaceParam struct {
 	// The id of the namespace.
 	//
@@ -68,9 +68,9 @@ type WorkloadParam struct {
 	Name string `json:"workload"`
 }
 
-// Workload name
+// App name
 //
-// swagger:parameters appMetrics
+// swagger:parameters appMetrics appDetails
 type AppParam struct {
 	// The name of the app
 	//
@@ -81,7 +81,7 @@ type AppParam struct {
 
 // Version name
 //
-// swagger:parameters serviceMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics
 type VersionParam struct {
 	// When provided, filters metrics for a specific version of this service
 	//
@@ -92,7 +92,7 @@ type VersionParam struct {
 
 // Step duration
 //
-// swagger:parameters serviceMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics
 type StepParam struct {
 	// Duration indicating desired step between two datapoints, in seconds
 	//
@@ -104,7 +104,7 @@ type StepParam struct {
 
 // Duration query period
 //
-// swagger:parameters serviceMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics
 type DurationParam struct {
 	// Duration indicating desired query period, in seconds
 	//
@@ -116,7 +116,7 @@ type DurationParam struct {
 
 // RateInterval for rate and histogram
 //
-// swagger:parameters serviceMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics
 type RateIntervalParam struct {
 	// Interval used for rate and histogram calculation
 	//
@@ -128,7 +128,7 @@ type RateIntervalParam struct {
 
 // rateFunc: rate function
 //
-// swagger:parameters serviceMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics
 type RateFuncParam struct {
 	// Rate: standard 'rate' or instant 'irate'
 	//
@@ -140,7 +140,7 @@ type RateFuncParam struct {
 
 // Filters: list of metrics to fetch
 //
-// swagger:parameters serviceMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics
 type FiltersParam struct {
 	// List of metrics to fetch. When empty, all metrics are fetched. Expected name here is the Kiali internal metric name
 	//
@@ -152,7 +152,7 @@ type FiltersParam struct {
 
 // ByLabelsIn: labels for grouping input metrics
 //
-// swagger:parameters serviceMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics
 type ByLabelsInParam struct {
 	// List of labels to use for grouping input metrics.
 	//
@@ -164,13 +164,25 @@ type ByLabelsInParam struct {
 
 // ByLabelsOut: labels for grouping output metrics
 //
-// swagger:parameters serviceMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics
 type ByLabelsOutParam struct {
 	// List of labels to use for grouping output metrics
 	//
 	// in: query
 	// required: false
+	// default: []
 	Name string `json:"byLabelsOut[]"`
+}
+
+// Reporter: source or destination metric reporter
+//
+// swagger:parameters serviceMetrics appMetrics workloadMetrics
+type ReporterParam struct {
+	// Reporter: source or destination
+	//
+	// in: query
+	// required: false
+	Name string `json:"reporter"`
 }
 
 /////////////////////
@@ -350,6 +362,13 @@ type MetricsResponse struct {
 type IstioConfigDetailsResponse struct {
 	// in:body
 	Body models.IstioConfigDetails
+}
+
+// Detailed information of an specific app
+// swagger:response appDetails
+type AppDetailsResponse struct {
+	// in:body
+	Body models.App
 }
 
 //////////////////

--- a/doc.go
+++ b/doc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/services/models"
 	"github.com/kiali/kiali/status"
 )
@@ -13,8 +14,7 @@ import (
 // A Namespace provide a scope for names.
 // This type used to describe a set of objects.
 //
-
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics
 type NamespaceParam struct {
 	// The id of the namespace.
 	//
@@ -25,7 +25,7 @@ type NamespaceParam struct {
 
 // Service identify the a service object
 //
-// swagger:parameters serviceValidations serviceDetails
+// swagger:parameters serviceValidations serviceDetails serviceMetrics
 type ServiceParam struct {
 	// The name of the service
 	//
@@ -59,13 +59,118 @@ type ObjectName struct {
 
 // Workload name
 //
-// swagger:parameters workloadDetails workloadValidations
+// swagger:parameters workloadDetails workloadValidations workloadMetrics
 type WorkloadParam struct {
 	// The name of the workload
 	//
 	// in: path
 	// required: true
 	Name string `json:"workload"`
+}
+
+// Workload name
+//
+// swagger:parameters appMetrics
+type AppParam struct {
+	// The name of the app
+	//
+	// in: path
+	// required: true
+	Name string `json:"app"`
+}
+
+// Version name
+//
+// swagger:parameters serviceMetrics
+type VersionParam struct {
+	// When provided, filters metrics for a specific version of this service
+	//
+	// in: query
+	// required: false
+	Name string `json:"version"`
+}
+
+// Step duration
+//
+// swagger:parameters serviceMetrics
+type StepParam struct {
+	// Duration indicating desired step between two datapoints, in seconds
+	//
+	// in: query
+	// required: false
+	// default: 15
+	Name string `json:"step"`
+}
+
+// Duration query period
+//
+// swagger:parameters serviceMetrics
+type DurationParam struct {
+	// Duration indicating desired query period, in seconds
+	//
+	// in: query
+	// required: false
+	// default: 1800
+	Name string `json:"duration"`
+}
+
+// RateInterval for rate and histogram
+//
+// swagger:parameters serviceMetrics
+type RateIntervalParam struct {
+	// Interval used for rate and histogram calculation
+	//
+	// in: query
+	// required: false
+	// default: 1m
+	Name string `json:"rateInterval"`
+}
+
+// rateFunc: rate function
+//
+// swagger:parameters serviceMetrics
+type RateFuncParam struct {
+	// Rate: standard 'rate' or instant 'irate'
+	//
+	// in: query
+	// required: false
+	// default: rate
+	Name string `json:"rateFunc"`
+}
+
+// Filters: list of metrics to fetch
+//
+// swagger:parameters serviceMetrics
+type FiltersParam struct {
+	// List of metrics to fetch. When empty, all metrics are fetched. Expected name here is the Kiali internal metric name
+	//
+	// in: query
+	// required: false
+	// default: []
+	Name string `json:"filters[]"`
+}
+
+// ByLabelsIn: labels for grouping input metrics
+//
+// swagger:parameters serviceMetrics
+type ByLabelsInParam struct {
+	// List of labels to use for grouping input metrics.
+	//
+	// in: query
+	// required: false
+	// default: []
+	Name string `json:"byLabelsIn[]"`
+}
+
+// ByLabelsOut: labels for grouping output metrics
+//
+// swagger:parameters serviceMetrics
+type ByLabelsOutParam struct {
+	// List of labels to use for grouping output metrics
+	//
+	// in: query
+	// required: false
+	Name string `json:"byLabelsOut[]"`
 }
 
 /////////////////////
@@ -224,6 +329,13 @@ type ServiceDetailsResponse struct {
 type WorkloadDetailsResponse struct {
 	// in:body
 	Body models.Workload
+}
+
+// Listing all the information related to a service
+// swagger:response metricsResponse
+type MetricsResponse struct {
+	// in:body
+	Body prometheus.Metrics
 }
 
 //////////////////

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -99,7 +99,7 @@ func NewRoutes() (r *Routes) {
 			handlers.Root,
 			false,
 		},
-		// swagger:route GET /namespaces/{namespace}/istio istioConfigList
+		// swagger:route GET /namespaces/{namespace}/istio config istioConfigList
 		// ---
 		// Endpoint to get the list of Istio Config of a namespace
 		//
@@ -124,6 +124,21 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigList,
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/istio/{object_type}/{object} config istioConfigDetails
+		// ---
+		// Endpoint to get the Istio Config of an Istio object
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      default: genericError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: istioConfigDetailsResponse
+		//
 		{
 			"IstioConfigDetails",
 			"GET",
@@ -131,7 +146,7 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigDetails,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/istio/{object_type}/{object}/istio_validations validations objectValidations
+		// swagger:route GET /namespaces/{namespace}/istio/{object_type}/{object}/istio_validations config objectValidations
 		// ---
 		// Endpoint to get the list of istio object validations for a service
 		//
@@ -156,6 +171,21 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigValidations,
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/services services serviceList
+		// ---
+		// Endpoint to get the details of a given service
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      default: genericError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: serviceListResponse
+		//
 		{
 			"ServiceList",
 			"GET",
@@ -163,7 +193,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceList,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/services/{service} serviceDetails
+		// swagger:route GET /namespaces/{namespace}/services/{service} services serviceDetails
 		// ---
 		// Endpoint to get the details of a given service
 		//
@@ -185,7 +215,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceDetails,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/workloads workloadList
+		// swagger:route GET /namespaces/{namespace}/workloads workloads workloadList
 		// ---
 		// Endpoint to get the list of workloads for a namespace
 		//
@@ -210,7 +240,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadList,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/workloads/{workload} workloadDetails
+		// swagger:route GET /namespaces/{namespace}/workloads/{workload} workloads workloadDetails
 		// ---
 		// Endpoint to get the workload details
 		//
@@ -235,7 +265,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadDetails,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/workloads/{workload}/istio_validations validations workloadValidations
+		// swagger:route GET /namespaces/{namespace}/workloads/{workload}/istio_validations workloads workloadValidations
 		// ---
 		// Endpoint to get the list of istio object validations for a workload
 		//
@@ -260,7 +290,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadValidations,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/apps appList
+		// swagger:route GET /namespaces/{namespace}/apps apps appList
 		// ---
 		// Endpoint to get the list of apps for a namespace
 		//
@@ -318,7 +348,7 @@ func NewRoutes() (r *Routes) {
 			true,
 		},
 		{
-			// swagger:route GET /api/namespaces/{namespace}/services/{service}/metrics serviceMetrics
+			// swagger:route GET /api/namespaces/{namespace}/services/{service}/metrics services serviceMetrics
 			// ---
 			// Endpoint to fetch metrics to be displayed, related to a single service
 			//
@@ -340,7 +370,7 @@ func NewRoutes() (r *Routes) {
 			true,
 		},
 		{
-			// swagger:route GET /api/namespaces/{namespace}/apps/{app}/metrics appMetrics
+			// swagger:route GET /api/namespaces/{namespace}/apps/{app}/metrics apps appMetrics
 			// ---
 			// Endpoint to fetch metrics to be displayed, related to a single app
 			//
@@ -362,7 +392,7 @@ func NewRoutes() (r *Routes) {
 			true,
 		},
 		{
-			// swagger:route GET /api/namespaces/{namespace}/workloads/{workload}/metrics workloadMetrics
+			// swagger:route GET /api/namespaces/{namespace}/workloads/{workload}/metrics workloads workloadMetrics
 			// ---
 			// Endpoint to fetch metrics to be displayed, related to a single workload
 			//
@@ -383,7 +413,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadMetrics,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/services/{service}/health serviceHealth
+		// swagger:route GET /api/namespaces/{namespace}/services/{service}/health services serviceHealth
 		// ---
 		// Get health associated to the given service
 		//
@@ -404,7 +434,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceHealth,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/apps/{app}/health appHealth
+		// swagger:route GET /api/namespaces/{namespace}/apps/{app}/health apps appHealth
 		// ---
 		// Get health associated to the given app
 		//
@@ -425,7 +455,7 @@ func NewRoutes() (r *Routes) {
 			handlers.AppHealth,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/workloads/{workload}/health workloadHealth
+		// swagger:route GET /api/namespaces/{namespace}/workloads/{workload}/health workloads workloadHealth
 		// ---
 		// Get health associated to the given workload
 		//
@@ -446,7 +476,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadHealth,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/services/{service}/istio_validations validations serviceValidations
+		// swagger:route GET /namespaces/{namespace}/services/{service}/istio_validations services serviceValidations
 		// ---
 		// Endpoint to get the list of istio object validations for a service
 		//
@@ -473,7 +503,7 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceMetrics,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/health namespaceHealth
+		// swagger:route GET /api/namespaces/{namespace}/health namespaces namespaceHealth
 		// ---
 		// Get health for all objects in the given namespace
 		//
@@ -494,7 +524,7 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceHealth,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/istio_validations validations namespaceValidations
+		// swagger:route GET /namespaces/{namespace}/istio_validations namespaces namespaceValidations
 		// ---
 		// Endpoint to get the list of istio object validations for a namespace
 		//

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -318,16 +318,21 @@ func NewRoutes() (r *Routes) {
 			true,
 		},
 		{
-			// Supported query parameters:
-			// version:       When provided, filters metrics for a specific version of this service
-			// step:          Duration indicating desired step between two datapoints, in seconds (default 15)
-			// duration:      Duration indicating desired query period, in seconds (default 1800 = 30 minutes)
-			// rateInterval:  Interval used for rate and histogram calculation (default 1m)
-			// rateFunc:      Rate: standard 'rate' or instant 'irate' (default is 'rate')
-			// filters[]:     List of metrics to fetch (empty by default). When empty, all metrics are fetched. Expected name here is the Kiali internal metric name
-			// byLabelsIn[]:  List of labels to use for grouping input metrics (empty by default). Example: response_code,source_version
-			// byLabelsOut[]: List of labels to use for grouping output metrics (empty by default). Example: response_code,destination_version
-
+			// swagger:route GET /api/namespaces/{namespace}/services/{service}/metrics serviceMetrics
+			// ---
+			// Endpoint to fetch metrics to be displayed, related to a single service
+			//
+			//     Produces:
+			//     - application/json
+			//
+			//     Schemes: http, https
+			//
+			// responses:
+			//      default: genericError
+			//      404: notFoundError
+			//      500: internalError
+			//      200: metricsResponse
+			//
 			"ServiceMetrics",
 			"GET",
 			"/api/namespaces/{namespace}/services/{service}/metrics",
@@ -335,14 +340,21 @@ func NewRoutes() (r *Routes) {
 			true,
 		},
 		{
-			// Supported query parameters:
-			// step:          Duration indicating desired step between two datapoints, in seconds (default 15)
-			// duration:      Duration indicating desired query period, in seconds (default 1800 = 30 minutes)
-			// rateInterval:  Interval used for rate and histogram calculation (default 1m)
-			// rateFunc:      Rate: standard 'rate' or instant 'irate' (default is 'rate')
-			// filters[]:     List of metrics to fetch (empty by default). When empty, all metrics are fetched. Expected name here is the Kiali internal metric name
-			// byLabelsIn[]:  List of labels to use for grouping input metrics (empty by default). Example: response_code,source_version
-			// byLabelsOut[]: List of labels to use for grouping output metrics (empty by default). Example: response_code,destination_version
+			// swagger:route GET /api/namespaces/{namespace}/apps/{app}/metrics appMetrics
+			// ---
+			// Endpoint to fetch metrics to be displayed, related to a single app
+			//
+			//     Produces:
+			//     - application/json
+			//
+			//     Schemes: http, https
+			//
+			// responses:
+			//      default: genericError
+			//      404: notFoundError
+			//      500: internalError
+			//      200: metricsResponse
+			//
 			"AppMetrics",
 			"GET",
 			"/api/namespaces/{namespace}/apps/{app}/metrics",
@@ -350,14 +362,21 @@ func NewRoutes() (r *Routes) {
 			true,
 		},
 		{
-			// Supported query parameters:
-			// step:          Duration indicating desired step between two datapoints, in seconds (default 15)
-			// duration:      Duration indicating desired query period, in seconds (default 1800 = 30 minutes)
-			// rateInterval:  Interval used for rate and histogram calculation (default 1m)
-			// rateFunc:      Rate: standard 'rate' or instant 'irate' (default is 'rate')
-			// filters[]:     List of metrics to fetch (empty by default). When empty, all metrics are fetched. Expected name here is the Kiali internal metric name
-			// byLabelsIn[]:  List of labels to use for grouping input metrics (empty by default). Example: response_code,source_version
-			// byLabelsOut[]: List of labels to use for grouping output metrics (empty by default). Example: response_code,destination_version
+			// swagger:route GET /api/namespaces/{namespace}/workloads/{workload}/metrics workloadMetrics
+			// ---
+			// Endpoint to fetch metrics to be displayed, related to a single workload
+			//
+			//     Produces:
+			//     - application/json
+			//
+			//     Schemes: http, https
+			//
+			// responses:
+			//      default: genericError
+			//      404: notFoundError
+			//      500: internalError
+			//      200: metricsResponse
+			//
 			"WorkloadMetrics",
 			"GET",
 			"/api/namespaces/{namespace}/workloads/{workload}/metrics",

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -235,7 +235,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadDetails,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/workloads/{workload}/istio_validations workloadValidations
+		// swagger:route GET /namespaces/{namespace}/workloads/{workload}/istio_validations validations workloadValidations
 		// ---
 		// Endpoint to get the list of istio object validations for a workload
 		//

--- a/swagger.json
+++ b/swagger.json
@@ -130,6 +130,76 @@
             "name": "app",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "When provided, filters metrics for a specific version of this service",
+            "name": "version",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Duration indicating desired step between two datapoints, in seconds",
+            "name": "step",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration indicating desired query period, in seconds",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Rate: standard 'rate' or instant 'irate'",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of metrics to fetch. When empty, all metrics are fetched. Expected name here is the Kiali internal metric name",
+            "name": "filters[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping input metrics.",
+            "name": "byLabelsIn[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping output metrics",
+            "name": "byLabelsOut[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Reporter: source or destination",
+            "name": "reporter",
+            "in": "query"
           }
         ],
         "responses": {
@@ -343,9 +413,17 @@
           },
           {
             "type": "string",
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of labels to use for grouping output metrics",
             "name": "byLabelsOut[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Reporter: source or destination",
+            "name": "reporter",
             "in": "query"
           }
         ],
@@ -448,6 +526,76 @@
             "name": "workload",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "When provided, filters metrics for a specific version of this service",
+            "name": "version",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Duration indicating desired step between two datapoints, in seconds",
+            "name": "step",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration indicating desired query period, in seconds",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Rate: standard 'rate' or instant 'irate'",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of metrics to fetch. When empty, all metrics are fetched. Expected name here is the Kiali internal metric name",
+            "name": "filters[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping input metrics.",
+            "name": "byLabelsIn[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping output metrics",
+            "name": "byLabelsOut[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Reporter: source or destination",
+            "name": "reporter",
+            "in": "query"
           }
         ],
         "responses": {
@@ -496,6 +644,54 @@
         "responses": {
           "200": {
             "$ref": "#/responses/appListResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/apps/{app}": {
+      "get": {
+        "description": "Endpoint to get the app details",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "appDetails",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name of the app",
+            "name": "app",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/appDetails"
           },
           "404": {
             "$ref": "#/responses/notFoundError"
@@ -1084,6 +1280,34 @@
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
+    "App": {
+      "type": "object",
+      "required": [
+        "namespace",
+        "name",
+        "workloads"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the application",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "reviews"
+        },
+        "namespace": {
+          "$ref": "#/definitions/namespace"
+        },
+        "workloads": {
+          "description": "Workloads for a given application",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WorkloadSvc"
+          },
+          "x-go-name": "Workloads"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
     "AppHealth": {
       "description": "AppHealth contains aggregated health from various sources, for a given app",
       "type": "object",
@@ -1537,22 +1761,14 @@
       "x-go-package": "github.com/kiali/kiali/prometheus"
     },
     "Metrics": {
-      "description": "Metrics contains health, all simple metrics and histograms data",
+      "description": "Metrics contains all simple metrics and histograms data for both source and destination telemetry",
       "type": "object",
       "properties": {
-        "histograms": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Histogram"
-          },
-          "x-go-name": "Histograms"
+        "dest": {
+          "$ref": "#/definitions/ReporterMetrics"
         },
-        "metrics": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Metric"
-          },
-          "x-go-name": "Metrics"
+        "source": {
+          "$ref": "#/definitions/ReporterMetrics"
         }
       },
       "x-go-package": "github.com/kiali/kiali/prometheus"
@@ -1734,6 +1950,27 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "ReporterMetrics": {
+      "description": "ReporterMetrics contains all simple metrics and histograms data for one reporter's telemetry",
+      "type": "object",
+      "properties": {
+        "histograms": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Histogram"
+          },
+          "x-go-name": "Histograms"
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Metric"
+          },
+          "x-go-name": "Metrics"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/prometheus"
     },
     "RequestHealth": {
       "description": "RequestHealth holds several stats about recent request errors",
@@ -2271,6 +2508,37 @@
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
+    "WorkloadSvc": {
+      "type": "object",
+      "required": [
+        "workloadName",
+        "istioSidecar",
+        "serviceNames"
+      ],
+      "properties": {
+        "istioSidecar": {
+          "description": "Define if all Pods related to the Workload has an IstioSidecar deployed",
+          "type": "boolean",
+          "x-go-name": "IstioSidecar",
+          "example": true
+        },
+        "serviceNames": {
+          "description": "List of service names linked with a workload",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "ServiceNames"
+        },
+        "workloadName": {
+          "description": "Name of a workload member of an application",
+          "type": "string",
+          "x-go-name": "WorkloadName",
+          "example": "reviews-v1"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
     "destinationRule": {
       "description": "This is used for returning a DestinationRule",
       "type": "object",
@@ -2460,6 +2728,12 @@
       "description": "Listing all istio validations for object in the namespace",
       "schema": {
         "$ref": "#/definitions/TypedIstioValidations"
+      }
+    },
+    "appDetails": {
+      "description": "Detailed information of an specific app",
+      "schema": {
+        "$ref": "#/definitions/App"
       }
     },
     "appHealthResponse": {

--- a/swagger.json
+++ b/swagger.json
@@ -248,6 +248,46 @@
         }
       }
     },
+    "/namespaces/{namespace}/apps": {
+      "get": {
+        "description": "Endpoint to get the list of apps for a namespace",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "appList",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/appListResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/istio": {
       "get": {
         "description": "Endpoint to get the list of Istio Config of a namespace",
@@ -581,6 +621,9 @@
           "http",
           "https"
         ],
+        "tags": [
+          "validations"
+        ],
         "operationId": "workloadValidations",
         "parameters": [
           {
@@ -731,6 +774,50 @@
         },
         "requests": {
           "$ref": "#/definitions/RequestHealth"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "AppList": {
+      "type": "object",
+      "required": [
+        "namespace",
+        "applications"
+      ],
+      "properties": {
+        "applications": {
+          "description": "Applications for a given namespace",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AppListItem"
+          },
+          "x-go-name": "Apps"
+        },
+        "namespace": {
+          "$ref": "#/definitions/namespace"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "AppListItem": {
+      "description": "AppListItem has the necessary information to display the console app list",
+      "type": "object",
+      "required": [
+        "name",
+        "istioSidecar"
+      ],
+      "properties": {
+        "istioSidecar": {
+          "description": "Define if all Pods related to the Workloads of this app has an IstioSidecar deployed",
+          "type": "boolean",
+          "x-go-name": "IstioSidecar",
+          "example": true
+        },
+        "name": {
+          "description": "Name of the application",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "reviews"
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
@@ -1513,13 +1600,13 @@
       ],
       "properties": {
         "appLabel": {
-          "description": "Define if Pods related to this Service has the label App",
+          "description": "Define if Pods related to this Workload has the label App",
           "type": "boolean",
           "x-go-name": "AppLabel",
           "example": true
         },
         "istioSidecar": {
-          "description": "Define if Pods related to this Service has an IstioSidecar deployed",
+          "description": "Define if Pods related to this Workload has an IstioSidecar deployed",
           "type": "boolean",
           "x-go-name": "IstioSidecar",
           "example": true
@@ -1537,7 +1624,7 @@
           "example": "deployment"
         },
         "versionLabel": {
-          "description": "Define if Pods related to this Service has the label Version",
+          "description": "Define if Pods related to this Workload has the label Version",
           "type": "boolean",
           "x-go-name": "VersionLabel",
           "example": true
@@ -1794,6 +1881,12 @@
       "description": "appHealthResponse contains aggregated health from various sources, for a given app",
       "schema": {
         "$ref": "#/definitions/AppHealth"
+      }
+    },
+    "appListResponse": {
+      "description": "Listing all apps in the namespace",
+      "schema": {
+        "$ref": "#/definitions/AppList"
       }
     },
     "badRequestError": {

--- a/swagger.json
+++ b/swagger.json
@@ -97,6 +97,51 @@
         }
       }
     },
+    "/api/namespaces/{namespace}/apps/{app}/metrics": {
+      "get": {
+        "description": "Endpoint to fetch metrics to be displayed, related to a single app",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "appMetrics",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name of the app",
+            "name": "app",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/metricsResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
     "/api/namespaces/{namespace}/health": {
       "get": {
         "description": "Get health for all objects in the given namespace",
@@ -198,6 +243,113 @@
         }
       }
     },
+    "/api/namespaces/{namespace}/services/{service}/metrics": {
+      "get": {
+        "description": "Endpoint to fetch metrics to be displayed, related to a single service",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "serviceMetrics",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name of the service",
+            "name": "service",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "When provided, filters metrics for a specific version of this service",
+            "name": "version",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Duration indicating desired step between two datapoints, in seconds",
+            "name": "step",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration indicating desired query period, in seconds",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Rate: standard 'rate' or instant 'irate'",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of metrics to fetch. When empty, all metrics are fetched. Expected name here is the Kiali internal metric name",
+            "name": "filters[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping input metrics.",
+            "name": "byLabelsIn[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping output metrics",
+            "name": "byLabelsOut[]",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/metricsResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
     "/api/namespaces/{namespace}/workloads/{workload}/health": {
       "get": {
         "description": "Get health associated to the given workload",
@@ -244,6 +396,51 @@
           },
           "500": {
             "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/api/namespaces/{namespace}/workloads/{workload}/metrics": {
+      "get": {
+        "description": "Endpoint to fetch metrics to be displayed, related to a single workload",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "workloadMetrics",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name of the workload",
+            "name": "workload",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/metricsResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
           }
         }
       }
@@ -957,6 +1154,25 @@
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
+    "Histogram": {
+      "description": "Histogram contains Metric objects for several histogram-kind statistics",
+      "type": "object",
+      "properties": {
+        "average": {
+          "$ref": "#/definitions/Metric"
+        },
+        "median": {
+          "$ref": "#/definitions/Metric"
+        },
+        "percentile95": {
+          "$ref": "#/definitions/Metric"
+        },
+        "percentile99": {
+          "$ref": "#/definitions/Metric"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/prometheus"
+    },
     "IstioCheck": {
       "type": "object",
       "title": "IstioCheck represents an individual check.",
@@ -1058,6 +1274,45 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "Matrix": {
+      "type": "array",
+      "title": "Matrix is a list of time series.",
+      "items": {
+        "$ref": "#/definitions/SampleStream"
+      },
+      "x-go-package": "github.com/kiali/kiali/vendor/github.com/prometheus/common/model"
+    },
+    "Metric": {
+      "description": "Metric holds the Prometheus Matrix model, which contains one or more time series (depending on grouping)",
+      "type": "object",
+      "properties": {
+        "matrix": {
+          "$ref": "#/definitions/Matrix"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/prometheus"
+    },
+    "Metrics": {
+      "description": "Metrics contains health, all simple metrics and histograms data",
+      "type": "object",
+      "properties": {
+        "histograms": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Histogram"
+          },
+          "x-go-name": "Histograms"
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Metric"
+          },
+          "x-go-name": "Metrics"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/prometheus"
     },
     "NameIstioValidation": {
       "description": "List of validations grouped by object name",
@@ -1254,6 +1509,42 @@
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
+    "SamplePair": {
+      "type": "object",
+      "title": "SamplePair pairs a SampleValue with a Timestamp.",
+      "properties": {
+        "Timestamp": {
+          "$ref": "#/definitions/Time"
+        },
+        "Value": {
+          "$ref": "#/definitions/SampleValue"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/vendor/github.com/prometheus/common/model"
+    },
+    "SampleStream": {
+      "type": "object",
+      "title": "SampleStream is a stream of Values belonging to an attached COWMetric.",
+      "properties": {
+        "metric": {
+          "$ref": "#/definitions/Metric"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SamplePair"
+          },
+          "x-go-name": "Values"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/vendor/github.com/prometheus/common/model"
+    },
+    "SampleValue": {
+      "description": "A SampleValue is a representation of a value for a given sample at a given\ntime.",
+      "type": "number",
+      "format": "double",
+      "x-go-package": "github.com/kiali/kiali/vendor/github.com/prometheus/common/model"
+    },
     "Service": {
       "type": "object",
       "properties": {
@@ -1436,6 +1727,12 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/status"
+    },
+    "Time": {
+      "description": "Time is the number of milliseconds since the epoch\n(1970-01-01 00:00 UTC) excluding leap seconds.",
+      "type": "integer",
+      "format": "int64",
+      "x-go-package": "github.com/kiali/kiali/vendor/github.com/prometheus/common/model"
     },
     "TokenGenerated": {
       "description": "This is used for returning the token",
@@ -1953,6 +2250,12 @@
       "description": "HTTP status code 200 and IstioConfigList model in data",
       "schema": {
         "$ref": "#/definitions/IstioConfigList"
+      }
+    },
+    "metricsResponse": {
+      "description": "Listing all the information related to a service",
+      "schema": {
+        "$ref": "#/definitions/Metrics"
       }
     },
     "namespaceAppHealthResponse": {

--- a/swagger.json
+++ b/swagger.json
@@ -57,6 +57,9 @@
           "http",
           "https"
         ],
+        "tags": [
+          "apps"
+        ],
         "operationId": "appHealth",
         "parameters": [
           {
@@ -107,6 +110,9 @@
           "http",
           "https"
         ],
+        "tags": [
+          "apps"
+        ],
         "operationId": "appMetrics",
         "parameters": [
           {
@@ -151,6 +157,9 @@
         "schemes": [
           "http",
           "https"
+        ],
+        "tags": [
+          "namespaces"
         ],
         "operationId": "namespaceHealth",
         "parameters": [
@@ -203,6 +212,9 @@
           "http",
           "https"
         ],
+        "tags": [
+          "services"
+        ],
         "operationId": "serviceHealth",
         "parameters": [
           {
@@ -252,6 +264,9 @@
         "schemes": [
           "http",
           "https"
+        ],
+        "tags": [
+          "services"
         ],
         "operationId": "serviceMetrics",
         "parameters": [
@@ -360,6 +375,9 @@
           "http",
           "https"
         ],
+        "tags": [
+          "workloads"
+        ],
         "operationId": "workloadHealth",
         "parameters": [
           {
@@ -410,6 +428,9 @@
           "http",
           "https"
         ],
+        "tags": [
+          "workloads"
+        ],
         "operationId": "workloadMetrics",
         "parameters": [
           {
@@ -458,6 +479,9 @@
           "http",
           "https"
         ],
+        "tags": [
+          "apps"
+        ],
         "operationId": "appList",
         "parameters": [
           {
@@ -498,6 +522,9 @@
           "http",
           "https"
         ],
+        "tags": [
+          "config"
+        ],
         "operationId": "istioConfigList",
         "parameters": [
           {
@@ -525,6 +552,63 @@
         }
       }
     },
+    "/namespaces/{namespace}/istio/{object_type}/{object}": {
+      "get": {
+        "description": "Endpoint to get the Istio Config of an Istio object",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "config"
+        ],
+        "operationId": "istioConfigDetails",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "pattern": "^(gateways|virtualservices|destinationrules|serviceentries|rules|quotaspecs|quotaspecbindings)$",
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The type of the istio object",
+            "name": "object_type",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name of the istio object",
+            "name": "object",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/istioConfigDetailsResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/istio/{object_type}/{object}/istio_validations": {
       "get": {
         "description": "Endpoint to get the list of istio object validations for a service",
@@ -539,7 +623,7 @@
           "https"
         ],
         "tags": [
-          "validations"
+          "config"
         ],
         "operationId": "objectValidations",
         "parameters": [
@@ -599,7 +683,7 @@
           "https"
         ],
         "tags": [
-          "validations"
+          "namespaces"
         ],
         "operationId": "namespaceValidations",
         "parameters": [
@@ -628,6 +712,46 @@
         }
       }
     },
+    "/namespaces/{namespace}/services": {
+      "get": {
+        "description": "Endpoint to get the details of a given service",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "services"
+        ],
+        "operationId": "serviceList",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The id of the namespace.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/serviceListResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          },
+          "default": {
+            "$ref": "#/responses/genericError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/services/{service}": {
       "get": {
         "description": "Endpoint to get the details of a given service",
@@ -637,6 +761,9 @@
         "schemes": [
           "http",
           "https"
+        ],
+        "tags": [
+          "services"
         ],
         "operationId": "serviceDetails",
         "parameters": [
@@ -680,7 +807,7 @@
           "application/json"
         ],
         "tags": [
-          "validations"
+          "services"
         ],
         "operationId": "serviceValidations",
         "parameters": [
@@ -730,6 +857,9 @@
           "http",
           "https"
         ],
+        "tags": [
+          "workloads"
+        ],
         "operationId": "workloadList",
         "parameters": [
           {
@@ -769,6 +899,9 @@
         "schemes": [
           "http",
           "https"
+        ],
+        "tags": [
+          "workloads"
         ],
         "operationId": "workloadDetails",
         "parameters": [
@@ -819,7 +952,7 @@
           "https"
         ],
         "tags": [
-          "validations"
+          "workloads"
         ],
         "operationId": "workloadValidations",
         "parameters": [
@@ -1202,6 +1335,40 @@
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
     },
+    "IstioConfigDetails": {
+      "type": "object",
+      "properties": {
+        "destinationRule": {
+          "$ref": "#/definitions/destinationRule"
+        },
+        "gateway": {
+          "$ref": "#/definitions/Gateway"
+        },
+        "namespace": {
+          "$ref": "#/definitions/namespace"
+        },
+        "objectType": {
+          "type": "string",
+          "x-go-name": "ObjectType"
+        },
+        "quotaSpec": {
+          "$ref": "#/definitions/QuotaSpec"
+        },
+        "quotaSpecBinding": {
+          "$ref": "#/definitions/QuotaSpecBinding"
+        },
+        "rule": {
+          "$ref": "#/definitions/IstioRuleDetails"
+        },
+        "serviceEntry": {
+          "$ref": "#/definitions/ServiceEntry"
+        },
+        "virtualService": {
+          "$ref": "#/definitions/virtualService"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
     "IstioConfigList": {
       "description": "This type is used for returning a response of IstioConfigList",
       "type": "object",
@@ -1233,6 +1400,82 @@
         },
         "virtualServices": {
           "$ref": "#/definitions/virtualServices"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "IstioHandler": {
+      "type": "object",
+      "properties": {
+        "adapter": {
+          "type": "string",
+          "x-go-name": "Adapter"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "spec": {
+          "type": "object",
+          "x-go-name": "Spec"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "IstioInstance": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "spec": {
+          "type": "object",
+          "x-go-name": "Spec"
+        },
+        "template": {
+          "type": "string",
+          "x-go-name": "Template"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "IstioRuleAction": {
+      "type": "object",
+      "properties": {
+        "handler": {
+          "$ref": "#/definitions/IstioHandler"
+        },
+        "instances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IstioInstance"
+          },
+          "x-go-name": "Instances"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "IstioRuleDetails": {
+      "type": "object",
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IstioRuleAction"
+          },
+          "x-go-name": "Actions"
+        },
+        "match": {
+          "type": "object",
+          "x-go-name": "Match"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "namespace": {
+          "$ref": "#/definitions/namespace"
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
@@ -1680,6 +1923,51 @@
         },
         "requests": {
           "$ref": "#/definitions/RequestHealth"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "ServiceList": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "$ref": "#/definitions/namespace"
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceOverview"
+          },
+          "x-go-name": "Services"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/services/models"
+    },
+    "ServiceOverview": {
+      "type": "object",
+      "required": [
+        "name",
+        "istioSidecar",
+        "appLabel"
+      ],
+      "properties": {
+        "appLabel": {
+          "description": "Has label app",
+          "type": "boolean",
+          "x-go-name": "AppLabel",
+          "example": true
+        },
+        "istioSidecar": {
+          "description": "Define if Pods related to this Service has an IstioSidecar deployed",
+          "type": "boolean",
+          "x-go-name": "IstioSidecar",
+          "example": true
+        },
+        "name": {
+          "description": "Name of the Service",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "reviews-v1"
         }
       },
       "x-go-package": "github.com/kiali/kiali/services/models"
@@ -2246,6 +2534,12 @@
         }
       }
     },
+    "istioConfigDetailsResponse": {
+      "description": "IstioConfig details of an specific Istio Object",
+      "schema": {
+        "$ref": "#/definitions/IstioConfigDetails"
+      }
+    },
     "istioConfigList": {
       "description": "HTTP status code 200 and IstioConfigList model in data",
       "schema": {
@@ -2300,6 +2594,12 @@
       "description": "serviceHealthResponse contains aggregated health from various sources, for a given service",
       "schema": {
         "$ref": "#/definitions/ServiceHealth"
+      }
+    },
+    "serviceListResponse": {
+      "description": "Listing all services in the namespace",
+      "schema": {
+        "$ref": "#/definitions/ServiceList"
       }
     },
     "statusInfo": {


### PR DESCRIPTION
** Describe the change **

1. Adding all the query params from metrics endpoints has been adapted to be in swagger format.
2. Fixed missing params in swagger for AppList endpoint.
3. Classified all the endpoints per resource type (Apps, Namespaces, Services, Workloads, Config).
4. Adding swagger documentation to old undocumented endpoints.

** Issue reference **
[KIALI-1329](https://issues.jboss.org/browse/KIALI-1329)

** Backwards incompatible? **
Yes.

![screenshot of api documentation](https://user-images.githubusercontent.com/613814/44666518-ddaf7280-aa18-11e8-89f0-b8612211c68e.png)

NOTE: update your swagger installation to fix a infinit loop (https://github.com/go-swagger/go-swagger/issues/1614) // remove its installation folder and run again `make swagger-install`