### PR TITLE
KIALI-1145 Add TLS support to virtual services

### DIFF
--- a/services/business/checkers/virtual_services/route_checker.go
+++ b/services/business/checkers/virtual_services/route_checker.go
@@ -18,9 +18,16 @@ type RouteChecker struct{ kubernetes.IstioObject }
 // 3. Sum of all weights are 100 (if only one weight, then it assumes that is 100).
 // 4. All the route has to have weight label.
 func (route RouteChecker) Check() ([]*models.IstioCheck, bool) {
-	httpChecks, httpValid := route.checkRoutesFor("http")
-	tcpChecks, tcpValid := route.checkRoutesFor("tcp")
-	return append(httpChecks, tcpChecks...), httpValid && tcpValid
+	checks, valid := make([]*models.IstioCheck, 0), true
+	protocols := []string{"http", "tcp", "tls"}
+
+	for _, protocol := range protocols {
+		cs, v := route.checkRoutesFor(protocol)
+		checks = append(checks, cs...)
+		valid = valid && v
+	}
+
+	return checks, valid
 }
 
 func (route RouteChecker) checkRoutesFor(kind string) ([]*models.IstioCheck, bool) {

--- a/services/models/virtual_service.go
+++ b/services/models/virtual_service.go
@@ -35,6 +35,7 @@ type VirtualService struct {
 	Gateways        interface{} `json:"gateways"`
 	Http            interface{} `json:"http"`
 	Tcp             interface{} `json:"tcp"`
+	Tls             interface{} `json:"tls"`
 }
 
 func (vServices *VirtualServices) Parse(virtualServices []kubernetes.IstioObject) {
@@ -53,4 +54,5 @@ func (vService *VirtualService) Parse(virtualService kubernetes.IstioObject) {
 	vService.Gateways = virtualService.GetSpec()["gateways"]
 	vService.Http = virtualService.GetSpec()["http"]
 	vService.Tcp = virtualService.GetSpec()["tcp"]
+	vService.Tls = virtualService.GetSpec()["tls"]
 }


### PR DESCRIPTION
** Describe the change **

In Istio 1.0 VirtualServices have a new type of routes called tls. This PR adds this new routes to the API.

** Issue reference **

https://issues.jboss.org/browse/KIALI-1145

** Backwards incompatible? **
yes.

Is your change introducing backwards incompatible changes?
NO


![screenshot of kiali-istio-system 192 168 42 123 nip io_api_namespaces_bookinfo_services_reviews](https://user-images.githubusercontent.com/613814/44737331-f6d82200-aaf1-11e8-9cbd-c0173234fa75.png)
