### PR TITLE
KIALI-1373 Set the imagePullPolicy to always for vX.Y tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,21 @@ DOCKER_NAME ?= kiali/kiali
 DOCKER_VERSION ?= dev
 DOCKER_TAG = ${DOCKER_NAME}:${DOCKER_VERSION}
 
+# If the IMAGE_PULL_POLICY is not defined and its the short version (eg vX.Y and not vX.Y.Z)
+# then we need to use the image pull policy of 'Always' otherwise the latest update to that
+# branch may not be brought in for users
+ifndef IMAGE_PULL_POLICY
+	SHORT_VERSION=$(shell if [[ ${DOCKER_VERSION} =~ ^v[0-9]+\.[0-9]+$$ ]]; then echo true; fi)
+	ifeq (${SHORT_VERSION}, true)
+		IMAGE_PULL_POLICY = Always
+	endif
+endif
+# If the IMAGE_PULL_POLICY is defined, then we need to update the token so it can be added
+# Otherwise we just use the k8s defaults.
+ifdef IMAGE_PULL_POLICY
+	IMAGE_PULL_POLICY_TOKEN="imagePullPolicy: ${IMAGE_PULL_POLICY}"
+endif
+
 # Indicates the log level the app will use when started.
 # <4=INFO
 #  4=DEBUG
@@ -235,7 +250,8 @@ openshift-deploy: openshift-undeploy
 	@echo Deploying to OpenShift project ${NAMESPACE}
 	cat deploy/openshift/kiali-configmap.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${OC} create -n ${NAMESPACE} -f -
 	cat deploy/openshift/kiali-secrets.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${OC} create -n ${NAMESPACE} -f -
-	cat deploy/openshift/kiali.yaml | IMAGE_NAME=${DOCKER_NAME} IMAGE_VERSION=${DOCKER_VERSION} NAMESPACE=${NAMESPACE} VERSION_LABEL=${VERSION_LABEL} VERBOSE_MODE=${VERBOSE_MODE} envsubst | ${OC} create -n ${NAMESPACE} -f -
+	cat deploy/openshift/kiali.yaml | IMAGE_NAME=${DOCKER_NAME} IMAGE_VERSION=${DOCKER_VERSION} NAMESPACE=${NAMESPACE} VERSION_LABEL=${VERSION_LABEL} VERBOSE_MODE=${VERBOSE_MODE} IMAGE_PULL_POLICY_TOKEN=${IMAGE_PULL_POLICY_TOKEN} envsubst | ${OC} create -n ${NAMESPACE} -f -
+
 
 ## openshift-undeploy: Undeploy from Openshift project.
 openshift-undeploy: .openshift-validate
@@ -257,7 +273,7 @@ k8s-deploy: k8s-undeploy
 	@echo Deploying to Kubernetes namespace ${NAMESPACE}
 	cat deploy/kubernetes/kiali-configmap.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
 	cat deploy/kubernetes/kiali-secrets.yaml | VERSION_LABEL=${VERSION_LABEL} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
-	cat deploy/kubernetes/kiali.yaml | IMAGE_NAME=${DOCKER_NAME} IMAGE_VERSION=${DOCKER_VERSION} NAMESPACE=${NAMESPACE} VERSION_LABEL=${VERSION_LABEL} VERBOSE_MODE=${VERBOSE_MODE} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
+	cat deploy/kubernetes/kiali.yaml | IMAGE_NAME=${DOCKER_NAME} IMAGE_VERSION=${DOCKER_VERSION} NAMESPACE=${NAMESPACE} VERSION_LABEL=${VERSION_LABEL} VERBOSE_MODE=${VERBOSE_MODE} IMAGE_PULL_POLICY_TOKEN=${IMAGE_PULL_POLICY_TOKEN} envsubst | ${KUBECTL} create -n ${NAMESPACE} -f -
 
 ## k8s-undeploy: Undeploy docker image in Kubernetes namespace.
 k8s-undeploy: .k8s-validate

--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -81,6 +81,7 @@ spec:
       serviceAccount: kiali
       containers:
       - image: ${IMAGE_NAME}:${IMAGE_VERSION}
+        ${IMAGE_PULL_POLICY_TOKEN}
         name: kiali
         command:
         - "/opt/kiali/kiali"

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -83,6 +83,7 @@ spec:
       serviceAccount: kiali
       containers:
       - image: ${IMAGE_NAME}:${IMAGE_VERSION}
+        ${IMAGE_PULL_POLICY_TOKEN}
         name: kiali
         command:
         - "/opt/kiali/kiali"


### PR DESCRIPTION
** Describe the change **

If we are using an image tag of vX.Y then we should be using an imagePullPolicy of 'Always'.

The vX.Y releases represent the latest vX.Y.Z release, and if someone is using vX.Y we want them to always pull in the latest since those will have bug fixes.

The PR also allows someone to override the imagePullPolicy so they can set it to whatever they want.

Note: we don't explicitly set the imagePullPolicy if its doesn't match vX.Y, we let the system use the defaults in that case (which is IfNotPresent unless its 'latest' which will use 'Always'). This is why we use the IMAGE_PULL_POLICY_TOKEN in the yaml files, if its not specified then nothing extra is added to the yaml.

** Issue reference **

https://issues.jboss.org/browse/KIALI-1373
