### PR TITLE
KIALI-1235 Security appender sensitive to policy switch

### DIFF
--- a/graph/appender/security_policy.go
+++ b/graph/appender/security_policy.go
@@ -40,7 +40,7 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 	// query prometheus for mutual_tls info in two queries:
 	// 1) query for active security originating from a workload outside the namespace
 	groupBy := "source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,connection_security_policy"
-	query := fmt.Sprintf("sum(rate(%s{reporter=\"destination\",source_workload_namespace!=\"%v\",destination_service_namespace=\"%v\",connection_security_policy!=\"none\",response_code=~\"%v\"}[%vs])) by (%s)",
+	query := fmt.Sprintf("sum(rate(%s{reporter=\"destination\",source_workload_namespace!=\"%v\",destination_service_namespace=\"%v\",connection_security_policy!=\"none\",response_code=~\"%v\"}[%vs]) > 0) by (%s)",
 		"istio_requests_total",
 		namespace,
 		namespace,
@@ -54,7 +54,7 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 	if !a.IncludeIstio {
 		istioCondition = fmt.Sprintf(",destination_service_namespace!=\"%s\"", config.Get().IstioNamespace)
 	}
-	query = fmt.Sprintf("sum(rate(%s{reporter=\"destination\",source_workload_namespace=\"%v\"%s,connection_security_policy!=\"none\",response_code=~\"%v\"}[%vs])) by (%s)",
+	query = fmt.Sprintf("sum(rate(%s{reporter=\"destination\",source_workload_namespace=\"%v\"%s,connection_security_policy!=\"none\",response_code=~\"%v\"}[%vs]) > 0) by (%s)",
 		"istio_requests_total",
 		namespace,
 		istioCondition,

--- a/graph/appender/security_policy_test.go
+++ b/graph/appender/security_policy_test.go
@@ -13,10 +13,10 @@ import (
 func TestSecurityPolicy(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := "round(sum(rate(istio_requests_total{reporter=\"destination\",source_workload_namespace!=\"bookinfo\",destination_service_namespace=\"bookinfo\",connection_security_policy!=\"none\",response_code=~\"[2345][0-9][0-9]\"}[60s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,connection_security_policy),0.001)"
+	q0 := "round(sum(rate(istio_requests_total{reporter=\"destination\",source_workload_namespace!=\"bookinfo\",destination_service_namespace=\"bookinfo\",connection_security_policy!=\"none\",response_code=~\"[2345][0-9][0-9]\"}[60s]) > 0) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,connection_security_policy),0.001)"
 	v0 := model.Vector{}
 
-	q1 := "round(sum(rate(istio_requests_total{reporter=\"destination\",source_workload_namespace=\"bookinfo\",destination_service_namespace!=\"istio-system\",connection_security_policy!=\"none\",response_code=~\"[2345][0-9][0-9]\"}[60s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,connection_security_policy),0.001)"
+	q1 := "round(sum(rate(istio_requests_total{reporter=\"destination\",source_workload_namespace=\"bookinfo\",destination_service_namespace!=\"istio-system\",connection_security_policy!=\"none\",response_code=~\"[2345][0-9][0-9]\"}[60s]) > 0) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,connection_security_policy),0.001)"
 	q1m0 := model.Metric{
 		"source_workload_namespace":     "istio-system",
 		"source_workload":               "ingressgateway-unknown",


### PR DESCRIPTION
** Describe the change **

Making security appender sensitive to policy switch (from non-secure to secure and viceversa).
Prom queries only took secure data points (connection_security_policy != none) which isn't an accurate query. It turns out that secure data points are also present in queries even if mtls is switched off in istio.
This PR takes all the data points and compute the `isMTLS` flag.

In this solution, there is only one unknown scenario which is when you have secure and non-secure data points with a 0 value. Meaning that there is no traffic for that edge. In that case, `isMTLS` is set to `false` (taking a conservative approach).

** Issue reference **
When switching from mtls to non-tls security policy, graph doesn't change.

https://issues.jboss.org/browse/KIALI-1235

** Backwards incompatible? **
Yes.
