### PR TITLE
Remove some dead code and fix a log in token generation

### DIFF
--- a/config/authentication.go
+++ b/config/authentication.go
@@ -14,7 +14,7 @@ func AuthenticationHandler(next http.Handler) http.Handler {
 		if strings.Contains(r.Header.Get("Authorization"), "Bearer") {
 			err := ValidateToken(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
 			if err != nil {
-				log.Warning("Error token %+v", err)
+				log.Warning("Token error: ", err)
 				statusCode = http.StatusUnauthorized
 			}
 		} else if conf.Server.Credentials.Username != "" || conf.Server.Credentials.Password != "" {

--- a/config/token.go
+++ b/config/token.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
-
-	"github.com/kiali/kiali/log"
 )
 
 // Structured version of Claims Section, as referenced at
@@ -70,20 +68,6 @@ func ValidateToken(tokenString string) error {
 	}
 	if token.Valid {
 		return nil
-	} else if ve, ok := err.(*jwt.ValidationError); ok {
-		if ve.Errors&jwt.ValidationErrorMalformed != 0 {
-			log.Debugf("That's not even a token")
-			return errors.New("That's not even a token")
-		} else if ve.Errors&(jwt.ValidationErrorExpired|jwt.ValidationErrorNotValidYet) != 0 {
-			// Token is either expired or not active yet
-			log.Debugf("Token expired ... Timing is everything")
-			return errors.New("Token expired ... Timing is everything")
-		} else {
-			log.Debugf("Couldn't handle this token:", err)
-			return err
-		}
-	} else {
-		log.Debugf("Couldn't handle this token:", err)
-		return err
 	}
+	return errors.New("Invalid token")
 }


### PR DESCRIPTION
About dead code: what I removed is some error handling part, but:

- it never ran into that code (see line 65)
- the initial error message is actually already accurate so it's not necessary to replace it