### PR TITLE
kiali-1383 support multiple versions check

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,8 @@ server:
   # Default is false
   # cors_allow_all: true
 external_services:
+  istio:
+    istio_version_supported: [">= 1.0", ">= 0.1.0"]
   prometheus_service_url: http://prometheus-istio-system.127.0.0.1.nip.io
   # Uncomment istio_identity_domain to set a different value. This value must match the Istio configuration.
   # Default is "svc.cluster.local" (which matches Istio's default)

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ const (
 	EnvLoginTokenExpirationSeconds = "LOGIN_TOKEN_EXPIRATION_SECONDS"
 	EnvIstioNamespace              = "ISTIO_NAMESPACE"
 
-	IstioVersionSupported = ">= 1.0"
+	IstioVersionSupported = "ISTIO_VERSION_SUPPORTED"
 
 	EnvIstioLabelNameApp     = "ISTIO_LABEL_NAME_APP"
 	EnvIstioLabelNameVersion = "ISTIO_LABEL_NAME_VERSION"
@@ -86,9 +86,10 @@ type JaegerConfig struct {
 
 // IstioConfig describes configuration used for istio links
 type IstioConfig struct {
-	UrlServiceVersion      string `yaml:"url_service_version"`
-	IstioIdentityDomain    string `yaml:"istio_identity_domain,omitempty"`
-	IstioSidecarAnnotation string `yaml:"istio_sidecar_annotation,omitempty"`
+	UrlServiceVersion      string   `yaml:"url_service_version"`
+	IstioIdentityDomain    string   `yaml:"istio_identity_domain,omitempty"`
+	IstioSidecarAnnotation string   `yaml:"istio_sidecar_annotation,omitempty"`
+	IstioVersionSupported  []string `yaml:"istio_version_supported,omitempty"`
 }
 
 // ExternalServices holds configurations for other systems that Kiali depends on
@@ -161,6 +162,8 @@ func NewConfig() (c *Config) {
 	c.ExternalServices.Jaeger.URL = strings.TrimSpace(getDefaultString(EnvJaegerURL, ""))
 
 	// Istio Configuration
+	csvVersionSupported := strings.TrimSpace(getDefaultString(IstioVersionSupported, ">= 1.0"))
+	c.ExternalServices.Istio.IstioVersionSupported = strings.Split(csvVersionSupported, ",")
 	c.ExternalServices.Istio.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))
 	c.ExternalServices.Istio.IstioSidecarAnnotation = strings.TrimSpace(getDefaultString(EnvIstioSidecarAnnotation, "sidecar.istio.io/status"))
 	c.ExternalServices.Istio.UrlServiceVersion = strings.TrimSpace(getDefaultString(EnvIstioUrlServiceVersion, "http://istio-pilot:9093/version"))

--- a/deploy/kubernetes/kiali-configmap.yaml
+++ b/deploy/kubernetes/kiali-configmap.yaml
@@ -11,6 +11,8 @@ data:
       port: 20001
       static_content_root_directory: /opt/kiali/console
     external_services:
+      istio:
+        istio_version_supported: [">= 1.0", ">= 0.1.0"]    
       jaeger:
         url: ${JAEGER_URL}
       grafana:

--- a/deploy/openshift/kiali-configmap.yaml
+++ b/deploy/openshift/kiali-configmap.yaml
@@ -11,6 +11,8 @@ data:
       port: 20001
       static_content_root_directory: /opt/kiali/console
     external_services:
+      istio:
+        istio_version_supported: [">= 1.0", ">= 0.1.0"]
       jaeger:
         url: ${JAEGER_URL}
       grafana:


### PR DESCRIPTION
** Describe the change **
Change version check logic to support multiple versions.  Kiali config map now has an entry where we can specify one or multiple version check expressions. There will be no warnings if actual Istio version satisfies _any_ of the expressions.  Note: make sure you have a space between `>=` and `1.0`.
```
    external_services:
      istio:
        istio_version_supported: [">= 1.0", ">= 0.1.0"]
```

** Issue reference **

KIALI-1383 Kiali is showing mismatch version when is running with Maistra

** Backwards compatible? **
Yes

Verification instructions:
---

1. Deploy Kiali to Openshift with Maistra
2. The version check only performs once at login so make sure you log out and relogin
3. Verify version mismatch warning no longer there. 

if you are running upstream instead of Maistra you can edit Kiali config map and change `istio_version_supported` to something different than Istio version to trigger the warning. (again you need to logout/re-login).

You can also inspect Kiali pod console log for the debug message `Checking actual Istio version`.

No warnings
![kiali-1383-console log](https://user-images.githubusercontent.com/3805254/45325163-09485780-b505-11e8-8b9e-840c53ec6ad7.png)

With warnings
![kiali-1838-warning-console](https://user-images.githubusercontent.com/3805254/45325190-18c7a080-b505-11e8-9222-f22be906f0bd.png)
![kiali-1383-ui-warning](https://user-images.githubusercontent.com/3805254/45325191-19603700-b505-11e8-947b-0ea2734624a1.png)
