### PR TITLE
KIALI-1383 do version checks for both Maistra and Istio

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,10 +48,14 @@ const (
 	EnvLoginTokenExpirationSeconds = "LOGIN_TOKEN_EXPIRATION_SECONDS"
 	EnvIstioNamespace              = "ISTIO_NAMESPACE"
 
-	IstioVersionSupported = ">= 1.0"
-
 	EnvIstioLabelNameApp     = "ISTIO_LABEL_NAME_APP"
 	EnvIstioLabelNameVersion = "ISTIO_LABEL_NAME_VERSION"
+)
+
+// The versions that Kiali requires
+const (
+	IstioVersionSupported   = ">= 1.0"
+	MaistraVersionSupported = ">= 0.1.0"
 )
 
 // Global configuration for the application.

--- a/status/versions.go
+++ b/status/versions.go
@@ -13,12 +13,16 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 )
 
 type externalService func() (*ExternalServiceInfo, error)
 
 var (
-	expVersion = regexp.MustCompile("[0-9]\\.[0-9]\\.[0-9]")
+	// Example Maistra version is:
+	//   redhat@redhat-docker.io/maistra-0.1.0-1-3a136c90ec5e308f236e0d7ebb5c4c5e405217f4-unknown
+	maistraVersionExpr = regexp.MustCompile(".*maistra-([0-9]+\\.[0-9]+\\.[0-9]+).*")
+	istioVersionExpr   = regexp.MustCompile(".*([0-9]+\\.[0-9]+\\.[0-9]+).*")
 )
 
 func getVersions() {
@@ -62,7 +66,7 @@ func validateVersion(istioReq string, installedVersion string) bool {
 }
 
 func istioVersion() (*ExternalServiceInfo, error) {
-	product := ExternalServiceInfo{Name: "Istio", Version: "Unknown"}
+	product := ExternalServiceInfo{Name: "Unknown", Version: "Unknown"}
 	istioConfig := config.Get().ExternalServices.Istio
 	resp, err := http.Get(istioConfig.UrlServiceVersion)
 	if err == nil {
@@ -70,16 +74,43 @@ func istioVersion() (*ExternalServiceInfo, error) {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err == nil {
 			rawVersion := string(body)
-			version := expVersion.FindStringSubmatch(rawVersion)
-			if version != nil {
-				product.Version = version[0]
-				if !validateVersion(config.IstioVersionSupported, product.Version) {
-					info.WarningMessages = append(info.WarningMessages, "Istio version "+product.Version+" is not supported, the version should be "+config.IstioVersionSupported)
+
+			// First see if we detect Maistra. If it is not Maistra, see if it is upstream Istio.
+			// If it is neither then it is some unknown Istio implementation that we do not support.
+
+			maistraVersionStringArr := maistraVersionExpr.FindStringSubmatch(rawVersion)
+			if maistraVersionStringArr != nil {
+				log.Debugf("Detected Maistra version [%v]", rawVersion)
+				if len(maistraVersionStringArr) > 1 {
+					product.Name = "Maistra"
+					product.Version = maistraVersionStringArr[1] // get regex group #1 ,which is the "#.#.#" version string
+					if !validateVersion(config.MaistraVersionSupported, product.Version) {
+						info.WarningMessages = append(info.WarningMessages, "Maistra version "+product.Version+" is not supported, the version should be "+config.MaistraVersionSupported)
+					}
+
+					// we know this is Maistra - either a supported or unsupported version - return now
+					return &product, nil
 				}
-			} else {
-				product.Version = rawVersion
-				info.WarningMessages = append(info.WarningMessages, "Istio version "+product.Version+" is not recognized, thus not supported.")
 			}
+
+			istioVersionStringArr := istioVersionExpr.FindStringSubmatch(rawVersion)
+			if istioVersionStringArr != nil {
+				log.Debugf("Detected Istio version [%v]", rawVersion)
+				if len(istioVersionStringArr) > 1 {
+					product.Name = "Istio"
+					product.Version = istioVersionStringArr[1] // get regex group #1 ,which is the "#.#.#" version string
+					if !validateVersion(config.IstioVersionSupported, product.Version) {
+						info.WarningMessages = append(info.WarningMessages, "Istio version "+product.Version+" is not supported, the version should be "+config.IstioVersionSupported)
+					}
+					// we know this is Istio upstream - either a supported or unsupported version - return now
+					return &product, nil
+				}
+			}
+
+			log.Debugf("Detected unknown Istio implementation version [%v]", rawVersion)
+			product.Name = "Unknown Istio Implementation"
+			product.Version = rawVersion
+			info.WarningMessages = append(info.WarningMessages, "Unknown Istio implementation version "+product.Version+" is not recognized, thus not supported.")
 			return &product, nil
 		}
 	}


### PR DESCRIPTION
This now checks if the Istio implementation is upstream Istio or Maistra.

If the version string is of the form "...maistra-#.#.#..." then we assume it is Maistra and we check the #.#.# version for the versions we support. Note that the # in the version string can be multiple digits (i.e. don't assume the versions will all be of the form 1.1.1 or 0.5.0 - it could be something like 1.0.10 or 11.13.1).

If not a Maistra version string then we look at the version string for any form of "...#.#.#..." and if so, we'll assume it is upstream Istio and check the version to see if its one we support (again, we cannot assume # are single-digits - so the regex now checks for multiple digits).

If it matches neither of the above, we report the raw version string but we report that we do not support it because it is some unknown Istio implementation.