### PR TITLE
KIALI-1539 : Backport Maistra check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,10 +48,14 @@ const (
 	EnvLoginTokenExpirationSeconds = "LOGIN_TOKEN_EXPIRATION_SECONDS"
 	EnvIstioNamespace              = "ISTIO_NAMESPACE"
 
-	IstioVersionSupported = ">= 1.0"
-
 	EnvIstioLabelNameApp     = "ISTIO_LABEL_NAME_APP"
 	EnvIstioLabelNameVersion = "ISTIO_LABEL_NAME_VERSION"
+)
+
+// The versions that Kiali requires
+const (
+	IstioVersionSupported   = ">= 1.0"
+	MaistraVersionSupported = ">= 0.1.0"
 )
 
 // Global configuration for the application.

--- a/status/versions.go
+++ b/status/versions.go
@@ -13,12 +13,16 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 )
 
 type externalService func() (*ExternalServiceInfo, error)
 
 var (
-	expVersion = regexp.MustCompile("[0-9]\\.[0-9]\\.[0-9]")
+	// Example Maistra version is:
+	//   redhat@redhat-docker.io/maistra-0.1.0-1-3a136c90ec5e308f236e0d7ebb5c4c5e405217f4-unknown
+	maistraVersionExpr = regexp.MustCompile(".*maistra-([0-9]+\\.[0-9]+\\.[0-9]+).*")
+	istioVersionExpr   = regexp.MustCompile(".*([0-9]+\\.[0-9]+\\.[0-9]+).*")
 )
 
 func getVersions() {
@@ -62,7 +66,7 @@ func validateVersion(istioReq string, installedVersion string) bool {
 }
 
 func istioVersion() (*ExternalServiceInfo, error) {
-	product := ExternalServiceInfo{Name: "Istio", Version: "Unknown"}
+	product := ExternalServiceInfo{Name: "Unknown", Version: "Unknown"}
 	istioConfig := config.Get().ExternalServices.Istio
 	resp, err := http.Get(istioConfig.UrlServiceVersion)
 	if err == nil {
@@ -70,16 +74,43 @@ func istioVersion() (*ExternalServiceInfo, error) {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err == nil {
 			rawVersion := string(body)
-			version := expVersion.FindStringSubmatch(rawVersion)
-			if version != nil {
-				product.Version = version[0]
-				if !validateVersion(config.IstioVersionSupported, product.Version) {
-					info.WarningMessages = append(info.WarningMessages, "Istio version "+product.Version+" is not supported, the version should be "+config.IstioVersionSupported)
+
+			// First see if we detect Maistra. If it is not Maistra, see if it is upstream Istio.
+			// If it is neither then it is some unknown Istio implementation that we do not support.
+
+			maistraVersionStringArr := maistraVersionExpr.FindStringSubmatch(rawVersion)
+			if maistraVersionStringArr != nil {
+				log.Debugf("Detected Maistra version [%v]", rawVersion)
+				if len(maistraVersionStringArr) > 1 {
+					product.Name = "Maistra"
+					product.Version = maistraVersionStringArr[1] // get regex group #1 ,which is the "#.#.#" version string
+					if !validateVersion(config.MaistraVersionSupported, product.Version) {
+						info.WarningMessages = append(info.WarningMessages, "Maistra version "+product.Version+" is not supported, the version should be "+config.MaistraVersionSupported)
+					}
+
+					// we know this is Maistra - either a supported or unsupported version - return now
+					return &product, nil
 				}
-			} else {
-				product.Version = rawVersion
-				info.WarningMessages = append(info.WarningMessages, "Istio version "+product.Version+" is not recognized, thus not supported.")
 			}
+
+			istioVersionStringArr := istioVersionExpr.FindStringSubmatch(rawVersion)
+			if istioVersionStringArr != nil {
+				log.Debugf("Detected Istio version [%v]", rawVersion)
+				if len(istioVersionStringArr) > 1 {
+					product.Name = "Istio"
+					product.Version = istioVersionStringArr[1] // get regex group #1 ,which is the "#.#.#" version string
+					if !validateVersion(config.IstioVersionSupported, product.Version) {
+						info.WarningMessages = append(info.WarningMessages, "Istio version "+product.Version+" is not supported, the version should be "+config.IstioVersionSupported)
+					}
+					// we know this is Istio upstream - either a supported or unsupported version - return now
+					return &product, nil
+				}
+			}
+
+			log.Debugf("Detected unknown Istio implementation version [%v]", rawVersion)
+			product.Name = "Unknown Istio Implementation"
+			product.Version = rawVersion
+			info.WarningMessages = append(info.WarningMessages, "Unknown Istio implementation version "+product.Version+" is not recognized, thus not supported.")
 			return &product, nil
 		}
 	}

--- a/status/versions.go
+++ b/status/versions.go
@@ -21,8 +21,8 @@ type externalService func() (*ExternalServiceInfo, error)
 var (
 	// Example Maistra version is:
 	//   redhat@redhat-docker.io/maistra-0.1.0-1-3a136c90ec5e308f236e0d7ebb5c4c5e405217f4-unknown
-	maistraVersionExpr = regexp.MustCompile(".*maistra-([0-9]+\\.[0-9]+\\.[0-9]+).*")
-	istioVersionExpr   = regexp.MustCompile(".*([0-9]+\\.[0-9]+\\.[0-9]+).*")
+	maistraVersionExpr = regexp.MustCompile("maistra-([0-9]+\\.[0-9]+\\.[0-9]+)")
+	istioVersionExpr   = regexp.MustCompile("([0-9]+\\.[0-9]+\\.[0-9]+)")
 )
 
 func getVersions() {
@@ -66,7 +66,6 @@ func validateVersion(istioReq string, installedVersion string) bool {
 }
 
 func istioVersion() (*ExternalServiceInfo, error) {
-	product := ExternalServiceInfo{Name: "Unknown", Version: "Unknown"}
 	istioConfig := config.Get().ExternalServices.Istio
 	resp, err := http.Get(istioConfig.UrlServiceVersion)
 	if err == nil {
@@ -74,47 +73,53 @@ func istioVersion() (*ExternalServiceInfo, error) {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err == nil {
 			rawVersion := string(body)
-
-			// First see if we detect Maistra. If it is not Maistra, see if it is upstream Istio.
-			// If it is neither then it is some unknown Istio implementation that we do not support.
-
-			maistraVersionStringArr := maistraVersionExpr.FindStringSubmatch(rawVersion)
-			if maistraVersionStringArr != nil {
-				log.Debugf("Detected Maistra version [%v]", rawVersion)
-				if len(maistraVersionStringArr) > 1 {
-					product.Name = "Maistra"
-					product.Version = maistraVersionStringArr[1] // get regex group #1 ,which is the "#.#.#" version string
-					if !validateVersion(config.MaistraVersionSupported, product.Version) {
-						info.WarningMessages = append(info.WarningMessages, "Maistra version "+product.Version+" is not supported, the version should be "+config.MaistraVersionSupported)
-					}
-
-					// we know this is Maistra - either a supported or unsupported version - return now
-					return &product, nil
-				}
-			}
-
-			istioVersionStringArr := istioVersionExpr.FindStringSubmatch(rawVersion)
-			if istioVersionStringArr != nil {
-				log.Debugf("Detected Istio version [%v]", rawVersion)
-				if len(istioVersionStringArr) > 1 {
-					product.Name = "Istio"
-					product.Version = istioVersionStringArr[1] // get regex group #1 ,which is the "#.#.#" version string
-					if !validateVersion(config.IstioVersionSupported, product.Version) {
-						info.WarningMessages = append(info.WarningMessages, "Istio version "+product.Version+" is not supported, the version should be "+config.IstioVersionSupported)
-					}
-					// we know this is Istio upstream - either a supported or unsupported version - return now
-					return &product, nil
-				}
-			}
-
-			log.Debugf("Detected unknown Istio implementation version [%v]", rawVersion)
-			product.Name = "Unknown Istio Implementation"
-			product.Version = rawVersion
-			info.WarningMessages = append(info.WarningMessages, "Unknown Istio implementation version "+product.Version+" is not recognized, thus not supported.")
-			return &product, nil
+			product, err := parseIstioRawVersion(rawVersion)
+			return product, err
 		}
 	}
 	return nil, err
+}
+
+func parseIstioRawVersion(rawVersion string) (*ExternalServiceInfo, error) {
+	product := ExternalServiceInfo{Name: "Unknown", Version: "Unknown"}
+
+	// First see if we detect Maistra. If it is not Maistra, see if it is upstream Istio.
+	// If it is neither then it is some unknown Istio implementation that we do not support.
+
+	maistraVersionStringArr := maistraVersionExpr.FindStringSubmatch(rawVersion)
+	if maistraVersionStringArr != nil {
+		log.Debugf("Detected Maistra version [%v]", rawVersion)
+		if len(maistraVersionStringArr) > 1 {
+			product.Name = "Maistra"
+			product.Version = maistraVersionStringArr[1] // get regex group #1 ,which is the "#.#.#" version string
+			if !validateVersion(config.MaistraVersionSupported, product.Version) {
+				info.WarningMessages = append(info.WarningMessages, "Maistra version "+product.Version+" is not supported, the version should be "+config.MaistraVersionSupported)
+			}
+
+			// we know this is Maistra - either a supported or unsupported version - return now
+			return &product, nil
+		}
+	}
+
+	istioVersionStringArr := istioVersionExpr.FindStringSubmatch(rawVersion)
+	if istioVersionStringArr != nil {
+		log.Debugf("Detected Istio version [%v]", rawVersion)
+		if len(istioVersionStringArr) > 1 {
+			product.Name = "Istio"
+			product.Version = istioVersionStringArr[1] // get regex group #1 ,which is the "#.#.#" version string
+			if !validateVersion(config.IstioVersionSupported, product.Version) {
+				info.WarningMessages = append(info.WarningMessages, "Istio version "+product.Version+" is not supported, the version should be "+config.IstioVersionSupported)
+			}
+			// we know this is Istio upstream - either a supported or unsupported version - return now
+			return &product, nil
+		}
+	}
+
+	log.Debugf("Detected unknown Istio implementation version [%v]", rawVersion)
+	product.Name = "Unknown Istio Implementation"
+	product.Version = rawVersion
+	info.WarningMessages = append(info.WarningMessages, "Unknown Istio implementation version "+product.Version+" is not recognized, thus not supported.")
+	return &product, nil
 }
 
 type p8sResponseVersion struct {

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -4,6 +4,81 @@ import (
 	"testing"
 )
 
+func TestParseIstioRawVersion(t *testing.T) {
+	type versionsToTestStruct struct {
+		rawVersion string
+		name       string
+		version    string
+		supported  bool
+	}
+
+	// see config.go/[Maistra,Istio]VersionSupported for what versions are supported
+	versionsToTest := []versionsToTestStruct{
+		{
+			rawVersion: "redhat@redhat-docker.io/maistra-0.1.0-1-3a13-unknown",
+			name:       "Maistra",
+			version:    "0.1.0",
+			supported:  true,
+		},
+		{
+			rawVersion: "foobar-maistra-11.12.13-wotgorilla?",
+			name:       "Maistra",
+			version:    "11.12.13",
+			supported:  true,
+		},
+		{
+			rawVersion: "foobar-maistra-0.0.987-wotgorilla?",
+			name:       "Maistra",
+			version:    "0.0.987",
+			supported:  false,
+		},
+		{
+			rawVersion: "foo-istio-1.2.3-bar",
+			name:       "Istio",
+			version:    "1.2.3",
+			supported:  true,
+		},
+		{
+			rawVersion: "foo-istio-10.11.122-bar",
+			name:       "Istio",
+			version:    "10.11.122",
+			supported:  true,
+		},
+		{
+			rawVersion: "foo-istio-0.123.789-bar",
+			name:       "Istio",
+			version:    "0.123.789",
+			supported:  false,
+		},
+		{
+			rawVersion: "some-unknown-version-string",
+			name:       "Unknown Istio Implementation",
+			version:    "some-unknown-version-string",
+			supported:  false,
+		},
+	}
+
+	for _, versionToTest := range versionsToTest {
+		info.WarningMessages = []string{} // reset before we test
+		p, err := parseIstioRawVersion(versionToTest.rawVersion)
+		if err != nil {
+			t.Errorf("Got an error trying to validate [%+v]: %+v", versionToTest, err)
+		}
+		if p.Name != versionToTest.name {
+			t.Errorf("Cannot validate [%+v] - name is incorrect: %+v", versionToTest, p)
+		}
+		if p.Version != versionToTest.version {
+			t.Errorf("Cannot validate [%+v] - version is incorrect: %+v", versionToTest, p)
+		}
+		if versionToTest.supported && len(info.WarningMessages) > 0 {
+			t.Errorf("Version [%+v] is supported but the parsed version [%+v] caused a warning: %+v", versionToTest, p, info.WarningMessages)
+		}
+		if !versionToTest.supported && len(info.WarningMessages) == 0 {
+			t.Errorf("Version [%+v] is not supported but the parsed version [%+v] did not cause a warning", versionToTest, p)
+		}
+	}
+}
+
 func TestValidateVersion(t *testing.T) {
 	result := validateVersion(">= 0.7.1", "0.7.1")
 


### PR DESCRIPTION
This backports the Maistra version check in the Kiali v0.7 branch.

See https://issues.jboss.org/browse/KIALI-1539