### PR TITLE
KIALI-1429 Fix channel read race condition

### DIFF
--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -92,7 +92,6 @@ func getServiceHealth(api v1.API, namespace, servicename string, ports []int32) 
 	now := time.Now()
 
 	inboundHealthyChan, inboundTotalChan, outboundHealthyChan, outboundTotalChan := make(chan model.SampleValue, len(ports)), make(chan model.SampleValue, len(ports)), make(chan model.SampleValue, len(ports)), make(chan model.SampleValue, len(ports))
-	done := make(chan bool)
 	errChan := make(chan error)
 
 	// Note: metric names below probably depend on some istio configuration.
@@ -102,46 +101,50 @@ func getServiceHealth(api v1.API, namespace, servicename string, ports []int32) 
 	for _, _port := range ports {
 		// Inbound
 		go func(port int) {
-			defer func() { done <- true }()
 			vec, err := fetchTimestamp(api, fmt.Sprintf("envoy_cluster_inbound_%d__%s_membership_healthy", port, queryPart), now)
 			if err != nil {
 				errChan <- err
 			} else if len(vec) > 0 {
 				inboundHealthyChan <- vec[0].Value
+			} else {
+				inboundHealthyChan <- 0
 			}
 		}(int(_port))
 		go func(port int) {
-			defer func() { done <- true }()
 			vec, err := fetchTimestamp(api, fmt.Sprintf("envoy_cluster_inbound_%d__%s_membership_total", port, queryPart), now)
 			if err != nil {
 				errChan <- err
 			} else if len(vec) > 0 {
 				inboundTotalChan <- vec[0].Value
+			} else {
+				inboundTotalChan <- 0
 			}
 		}(int(_port))
 		// Outbound
 		go func(port int) {
-			defer func() { done <- true }()
 			vec, err := fetchTimestamp(api, fmt.Sprintf("envoy_cluster_outbound_%d__%s_membership_healthy", port, queryPart), now)
 			if err != nil {
 				errChan <- err
 			} else if len(vec) > 0 {
 				outboundHealthyChan <- vec[0].Value
+			} else {
+				outboundHealthyChan <- 0
 			}
 		}(int(_port))
 		go func(port int) {
-			defer func() { done <- true }()
 			vec, err := fetchTimestamp(api, fmt.Sprintf("envoy_cluster_outbound_%d__%s_membership_total", port, queryPart), now)
 			if err != nil {
 				errChan <- err
 			} else if len(vec) > 0 {
 				outboundTotalChan <- vec[0].Value
+			} else {
+				outboundTotalChan <- 0
 			}
 		}(int(_port))
 	}
 
 	var err error
-	for count := 0; count < len(ports)*4; {
+	for count := 0; count < len(ports)*4; count++ {
 		select {
 		case v := <-inboundHealthyChan:
 			ret.Inbound.Healthy += int(v)
@@ -152,8 +155,7 @@ func getServiceHealth(api v1.API, namespace, servicename string, ports []int32) 
 		case v := <-outboundTotalChan:
 			ret.Outbound.Total += int(v)
 		case err = <-errChan:
-		case <-done:
-			count++
+			// No op
 		}
 	}
 	return ret, err


### PR DESCRIPTION
In a "select block" of channels, Go does not guarantee any priority of evaluation. This was leading to a race condition when reading between the "done" channel and the data channels: the "count" variable may be incremented even before respective data was read. This was leading to early termination of the for loop, causing not all data being collected.

The extreme case was if Go evaluates first the "done" case  on all iterations. Under this circumstance, no data will be read and getServiceHealth would return EnvoyServiceHealth{} with zeroes.

The channel read-race condition was also leading to sporadic test failures in CI.

To fix the issue, the "done" channel is removed by ensuring that data and error channels always return a value.

** Backwards incompatible? **

- [ ] Is your change introducing backwards incompatible changes? **No**