### PR TITLE
Ignore cache files from pytest e2e suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ _output
 
 # Configuration files for the hack scripts
 hack/*.local.sh
+
+# E2E testing files
+tests/e2e/.pytest_cache
+tests/e2e/**/__pycache__


### PR DESCRIPTION
** Describe the change **
Running `pytest` produces some files for caching purposes. As they are not intended to be tracked, I propose to add them into gitignore.

** Backwards incompatible? **
yep.