### PR TITLE
Change default path for console

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ server:
   # web_root: /kiali
 
   # Uncomment static_content_root_directory to set up a different directory for static front-end content.
-  # Default is /static-files
+  # Default is /opt/kiali/console
   # static_content_root_directory: /static-files
 
   # Uncomment cors_allow_all to allow serving front-end from a different host (mainly for development)

--- a/config/config.go
+++ b/config/config.go
@@ -147,7 +147,7 @@ func NewConfig() (c *Config) {
 		Password: getDefaultString(EnvServerCredentialsPassword, ""),
 	}
 	c.Server.WebRoot = strings.TrimSpace(getDefaultString(EnvWebRoot, "/"))
-	c.Server.StaticContentRootDirectory = strings.TrimSpace(getDefaultString(EnvServerStaticContentRootDirectory, "/static-files"))
+	c.Server.StaticContentRootDirectory = strings.TrimSpace(getDefaultString(EnvServerStaticContentRootDirectory, "/opt/kiali/console"))
 	c.Server.CORSAllowAll = getDefaultBool(EnvServerCORSAllowAll, false)
 
 	// Prometheus configuration

--- a/deploy/kubernetes/kiali-configmap.yaml
+++ b/deploy/kubernetes/kiali-configmap.yaml
@@ -9,7 +9,6 @@ data:
   config.yaml: |
     server:
       port: 20001
-      static_content_root_directory: /opt/kiali/console
       web_root: /
     external_services:
       jaeger:

--- a/deploy/openshift/kiali-configmap.yaml
+++ b/deploy/openshift/kiali-configmap.yaml
@@ -9,7 +9,6 @@ data:
   config.yaml: |
     server:
       port: 20001
-      static_content_root_directory: /opt/kiali/console
       web_root: /
     external_services:
       jaeger:


### PR DESCRIPTION
All generated images (both up and downstream) uses the /opt/kiali path
as base, and /opt/kiali/console for the UI. This change reflects that.