### PR TITLE
KIALI-1598 Support service node detail graph

### DIFF
--- a/graph/appender/security_policy.go
+++ b/graph/appender/security_policy.go
@@ -1,12 +1,9 @@
 package appender
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"time"
 
-	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
 	"github.com/kiali/kiali/config"
@@ -121,25 +118,4 @@ func (a SecurityPolicyAppender) populateSecurityPolicyMap(securityPolicyMap map[
 		key := fmt.Sprintf("%s %s", sourceId, destId)
 		securityPolicyMap[key] = csp
 	}
-}
-
-func securityPolicyQuery(query string, queryTime time.Time, api v1.API) model.Vector {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// wrap with a round() to be in line with metrics api
-	query = fmt.Sprintf("round(%s,0.001)", query)
-	log.Debugf("Executing query %s&time=%v (now=%v, %v)\n", query, queryTime.Format(graph.TF), time.Now().Format(graph.TF), queryTime.Unix())
-
-	value, err := api.Query(ctx, query, queryTime)
-	checkError(err)
-
-	switch t := value.Type(); t {
-	case model.ValVector: // Instant Vector
-		return value.(model.Vector)
-	default:
-		checkError(errors.New(fmt.Sprintf("No handling for type %v!\n", t)))
-	}
-
-	return nil
 }


### PR DESCRIPTION
- also improve readability:
  - remove some dead code
  - remove escaped-quotes from some query strings
  - use %s (as opposed to %v) where appropriate in sprintf
