### PR TITLE
KIALI-1401 Allow one edge for HTTP and one for TCP

### DIFF
--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -97,8 +97,8 @@ func nodeHash(id string) string {
 	return fmt.Sprintf("%x", md5.Sum([]byte(id)))
 }
 
-func edgeHash(from string, to string) string {
-	return fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s.%s", from, to))))
+func edgeHash(from, to, protocol string) string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s.%s.%s", from, to, protocol))))
 }
 
 func NewConfig(trafficMap graph.TrafficMap, o options.VendorOptions) (result Config) {
@@ -228,7 +228,11 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		for _, e := range n.Edges {
 			sourceIdHash := nodeHash(n.ID)
 			destIdHash := nodeHash(e.Dest.ID)
-			edgeId := edgeHash(sourceIdHash, destIdHash)
+			protocol := ""
+			if e.Metadata["protocol"] != nil {
+				protocol = e.Metadata["protocol"].(string)
+			}
+			edgeId := edgeHash(sourceIdHash, destIdHash, protocol)
 			ed := EdgeData{
 				Id:     edgeId,
 				Source: sourceIdHash,

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -320,13 +320,14 @@ func addHttpTraffic(trafficMap graph.TrafficMap, val float64, code, sourceWlNs, 
 
 	var edge *graph.Edge
 	for _, e := range source.Edges {
-		if dest.ID == e.Dest.ID {
+		if dest.ID == e.Dest.ID && e.Metadata["protocol"] == "http" {
 			edge = e
 			break
 		}
 	}
 	if nil == edge {
 		edge = source.AddEdge(dest)
+		edge.Metadata["protocol"] = "http"
 	}
 
 	// A workload may mistakenly have multiple app and or version label values.
@@ -416,13 +417,14 @@ func addTcpTraffic(trafficMap graph.TrafficMap, val float64, sourceWlNs, sourceW
 
 	var edge *graph.Edge
 	for _, e := range source.Edges {
-		if dest.ID == e.Dest.ID {
+		if dest.ID == e.Dest.ID && e.Metadata["procotol"] == "tcp" {
 			edge = e
 			break
 		}
 	}
 	if nil == edge {
 		edge = source.AddEdge(dest)
+		edge.Metadata["protocol"] = "tcp"
 	}
 
 	// A workload may mistakenly have multiple app and or version label values.
@@ -501,7 +503,7 @@ func mergeTrafficMaps(trafficMap, nsTrafficMap graph.TrafficMap) {
 			for _, nsEdge := range nsNode.Edges {
 				isDupEdge := false
 				for _, e := range node.Edges {
-					if nsEdge.Dest.ID == e.Dest.ID {
+					if nsEdge.Dest.ID == e.Dest.ID && nsEdge.Metadata["protocol"] == e.Metadata["protocol"] {
 						isDupEdge = true
 						break
 					}

--- a/handlers/testdata/test_multi_namespace_graph.expected
+++ b/handlers/testdata/test_multi_namespace_graph.expected
@@ -43,7 +43,7 @@
     "edges": [
       {
         "data": {
-          "id": "423f97a4c2e70e194b7295c6055efd76",
+          "id": "a5ad258d84d10f69c74faaaea9fe568c",
           "source": "5c33c02dc744d0d03513a364935660b7",
           "target": "2c22af42b0c750749399ed2838c56054",
           "rate": "50.000"
@@ -51,7 +51,7 @@
       },
       {
         "data": {
-          "id": "0ab99fcb65f50cbe6ca0c882a771cdef",
+          "id": "a662b629518d737f9cdf0152da3a67e2",
           "source": "5c33c02dc744d0d03513a364935660b7",
           "target": "ba389fce1a74a05e1fcd46aca64941f8",
           "rate": "50.000"

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -113,7 +113,7 @@
     "edges": [
       {
         "data": {
-          "id": "27371b83763afee92cf29adef487d844",
+          "id": "2c8bf7e7efb0982b18c76d507200a8b7",
           "source": "19950ddefadd370bf5434953c1944c80",
           "target": "2c22af42b0c750749399ed2838c56054",
           "rate": "100.000"
@@ -121,7 +121,7 @@
       },
       {
         "data": {
-          "id": "d4fdd9066e627a2afd3171822388fab4",
+          "id": "18fa6836a929941e8deabad5fa1cae62",
           "source": "19950ddefadd370bf5434953c1944c80",
           "target": "4ee8019fc0454770a401b89d427277bf",
           "tcpSentRate": "150.000"
@@ -129,7 +129,7 @@
       },
       {
         "data": {
-          "id": "e4bbf3d92788d59cf068bc4ef80629f5",
+          "id": "e9ffbf24e385c93dfa124d81e2ac33a7",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "2c22af42b0c750749399ed2838c56054",
           "rate": "20.000",
@@ -138,7 +138,7 @@
       },
       {
         "data": {
-          "id": "6ea64c772fbc440bce9306cb06919143",
+          "id": "ff5217a9064e30e4fb875256dab56037",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "37ddc91db761d432f3fff1943802cad7",
           "rate": "60.000",
@@ -147,7 +147,7 @@
       },
       {
         "data": {
-          "id": "31f1137765289f98de743a8d7d13d2b8",
+          "id": "16a0c4225bbdbd471e6e7b8fd438733d",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "4ee8019fc0454770a401b89d427277bf",
           "tcpSentRate": "31.000"
@@ -155,7 +155,7 @@
       },
       {
         "data": {
-          "id": "4fa8419f0227769ceb054eab86fe33f9",
+          "id": "89fa162a49acca6ff974afd30aab2ff0",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "6cdb3cf3ee9a17772f13b295368e112a",
           "rate": "80.000",
@@ -168,7 +168,7 @@
       },
       {
         "data": {
-          "id": "3609dd39b2e93d3eb4f921d64e7bc430",
+          "id": "4aaf7cb151db415f3ba4918be2296c38",
           "source": "37ddc91db761d432f3fff1943802cad7",
           "target": "37ddc91db761d432f3fff1943802cad7",
           "rate": "40.000",
@@ -177,7 +177,7 @@
       },
       {
         "data": {
-          "id": "725fdb0f9f3633b4da2aac68601b000e",
+          "id": "edb2cdfc2a757d260aa847d55e9eadde",
           "source": "37ddc91db761d432f3fff1943802cad7",
           "target": "66bce9783dc2dbb5fecb178b0108484e",
           "rate": "20.000",
@@ -186,7 +186,7 @@
       },
       {
         "data": {
-          "id": "979c7a2119351f897d70c74dbed2265c",
+          "id": "a553e38605904d17c50ab1d0db84f113",
           "source": "37ddc91db761d432f3fff1943802cad7",
           "target": "c219903556c3afdb05eda7e610aba628",
           "rate": "40.000",
@@ -195,7 +195,7 @@
       },
       {
         "data": {
-          "id": "423f97a4c2e70e194b7295c6055efd76",
+          "id": "a5ad258d84d10f69c74faaaea9fe568c",
           "source": "5c33c02dc744d0d03513a364935660b7",
           "target": "2c22af42b0c750749399ed2838c56054",
           "rate": "50.000"
@@ -203,7 +203,7 @@
       },
       {
         "data": {
-          "id": "b622398b26d906f5561d70e12cacba74",
+          "id": "8803fe0a978f5ad0341e06c15d5f9a98",
           "source": "5c33c02dc744d0d03513a364935660b7",
           "target": "4ee8019fc0454770a401b89d427277bf",
           "tcpSentRate": "400.000"


### PR DESCRIPTION
Per UXD, when there is both HTTP and TCP traffic between two nodes, there should be two edges between those nodes representing each kind of traffic.

These changes will generate to a graph like this:

![image](https://user-images.githubusercontent.com/23639005/45980609-0460c900-c018-11e8-9101-94593a943227.png)

