### PR TITLE
KIALI-1578 KIALI-1136 Show WARN on all DRs with duplicate hosts

### DIFF
--- a/services/business/checkers/destination_rules/multi_match_checker_test.go
+++ b/services/business/checkers/destination_rules/multi_match_checker_test.go
@@ -27,7 +27,7 @@ func TestMultiHostMatchCorrect(t *testing.T) {
 	}.Check()
 
 	assert.Empty(validations)
-	validation, ok := validations[models.IstioValidationKey{"destinationrules", "rule2"}]
+	validation, ok := validations[models.IstioValidationKey{"destinationrule", "rule2"}]
 	assert.False(ok)
 	assert.Nil(validation)
 }
@@ -48,7 +48,8 @@ func TestMultiHostMatchInvalid(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	validation, ok := validations[models.IstioValidationKey{"destinationrules", "rule2"}]
+	assert.Equal(2, len(validations))
+	validation, ok := validations[models.IstioValidationKey{"destinationrule", "rule2"}]
 	assert.True(ok)
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)
@@ -71,7 +72,7 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	validation, ok := validations[models.IstioValidationKey{"destinationrules", "rule2"}]
+	validation, ok := validations[models.IstioValidationKey{"destinationrule", "rule2"}]
 	assert.True(ok)
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)
@@ -87,7 +88,7 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	validation, ok = validations[models.IstioValidationKey{"destinationrules", "rule1"}]
+	validation, ok = validations[models.IstioValidationKey{"destinationrule", "rule1"}]
 	assert.True(ok)
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)

--- a/services/business/istio_validations.go
+++ b/services/business/istio_validations.go
@@ -2,9 +2,10 @@ package business
 
 import (
 	"fmt"
+	"sync"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"sync"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/services/business/checkers"
@@ -91,15 +92,18 @@ func (in *IstioValidationsService) GetNamespaceValidations(namespace string) (mo
 	errChan := make(chan error, 2)
 
 	gws := make([]kubernetes.IstioObject, 0)
+	drs := make([]kubernetes.IstioObject, 0)
 	ses := make([]kubernetes.IstioObject, 0)
 
-	wg.Add(2)
+	wg.Add(3)
+	go fetch(&drs, namespace, "", in.k8s.GetDestinationRules, &wg, errChan)
 	go fetchNoEntry(&gws, namespace, in.k8s.GetGateways, &wg, errChan)
 	go fetchNoEntry(&ses, namespace, in.k8s.GetServiceEntries, &wg, errChan)
 	wg.Wait()
 	if len(errChan) == 0 {
 		istioDetails.Gateways = gws
 		istioDetails.ServiceEntries = ses
+		istioDetails.DestinationRules = drs
 	} else {
 		err = <-errChan
 		return nil, err
@@ -109,6 +113,7 @@ func (in *IstioValidationsService) GetNamespaceValidations(namespace string) (mo
 		checkers.VirtualServiceChecker{namespace, istioDetails.DestinationRules,
 			istioDetails.VirtualServices},
 		checkers.NoServiceChecker{Namespace: namespace, IstioDetails: istioDetails, Services: services},
+		checkers.DestinationRulesChecker{DestinationRules: drs},
 	}
 
 	return models.NamespaceValidations{namespace: runObjectCheckers(objectCheckers)}, nil
@@ -177,9 +182,16 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 			err = <-errChan
 		}
 	case "destinationrules":
-		if dr, err = in.k8s.GetDestinationRule(namespace, object); err == nil {
-			istioDetails.DestinationRules = []kubernetes.IstioObject{dr}
-			destinationRulesChecker := checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules}
+		if drs, err := in.k8s.GetDestinationRules(namespace, ""); err == nil {
+			for _, o := range drs {
+				meta := o.GetObjectMeta()
+				if meta.Name == object {
+					dr = o
+					break
+				}
+			}
+			istioDetails.DestinationRules = []kubernetes.IstioObject{dr} // Single destination rule only available here, not whole namespace
+			destinationRulesChecker := checkers.DestinationRulesChecker{DestinationRules: drs}
 			objectCheckers = []ObjectChecker{noServiceChecker, destinationRulesChecker}
 		}
 	case "serviceentries":
@@ -208,6 +220,7 @@ func runObjectCheckers(objectCheckers []ObjectChecker) models.IstioValidations {
 	for _, objectChecker := range objectCheckers {
 		objectTypeValidations.MergeValidations(objectChecker.Check())
 	}
+
 	return objectTypeValidations
 }
 


### PR DESCRIPTION
All offending DestinationRules should be flagged with WARN, not just the last one. Also, fix a typo that caused the warnings to be filtered and add the warns to the config listing also.