### PR TITLE
KIALI-1534 Introduce Service GraphType

### DIFF
--- a/graph/appender/unused_node.go
+++ b/graph/appender/unused_node.go
@@ -10,11 +10,16 @@ import (
 )
 
 type UnusedNodeAppender struct {
-	GraphType string
+	GraphType   string // This appender does not operate on service graphs because it adds workload nodes.
+	IsNodeGraph bool   // This appender does not operate on node detail graphs because we want to focus on the specific node.
 }
 
 // AppendGraph implements Appender
 func (a UnusedNodeAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string) {
+	if graph.GraphTypeService == a.GraphType || a.IsNodeGraph {
+		return
+	}
+
 	istioClient, err := kubernetes.NewClient()
 	checkError(err)
 

--- a/graph/appender/unused_node_test.go
+++ b/graph/appender/unused_node_test.go
@@ -22,6 +22,7 @@ func TestNonTrafficScenario(t *testing.T) {
 
 	a := UnusedNodeAppender{
 		graph.GraphTypeVersionedApp,
+		false,
 	}
 	a.addUnusedNodes(trafficMap, "testNamespace", deployments)
 	assert.Equal(4, len(trafficMap))
@@ -66,6 +67,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 
 	a := UnusedNodeAppender{
 		graph.GraphTypeVersionedApp,
+		false,
 	}
 
 	trafficMap := a.oneNodeTraffic()
@@ -120,6 +122,7 @@ func TestVersionWithNoTrafficScenario(t *testing.T) {
 
 	a := UnusedNodeAppender{
 		graph.GraphTypeVersionedApp,
+		false,
 	}
 
 	trafficMap := a.v1Traffic()

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	GraphTypeApp          string = "app"
+	GraphTypeService      string = "service" // Treated as graphType Workload, with service injection, and then condensed
 	GraphTypeVersionedApp string = "versionedApp"
 	GraphTypeWorkload     string = "workload"
 	NodeTypeApp           string = "app"
@@ -134,8 +135,8 @@ func Id(namespace, workload, app, version, service, graphType string) (id, nodeT
 		panic(fmt.Sprintf("Failed ID gen: namespace=[%s] workload=[%s] app=[%s] version=[%s] service=[%s] graphType=[%s]", namespace, workload, app, version, service, graphType))
 	}
 
-	// handle workload graph nodes
-	if graphType == GraphTypeWorkload {
+	// handle workload graph nodes (service graphs are initially processed as workload graphs)
+	if graphType == GraphTypeWorkload || graphType == GraphTypeService {
 		// workload graph nodes are type workload or service
 		if !workloadOk && !serviceOk {
 			panic(fmt.Sprintf("Failed ID gen: namespace=[%s] workload=[%s] app=[%s] version=[%s] service=[%s] graphType=[%s]", namespace, workload, app, version, service, graphType))

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -377,7 +377,7 @@ func TestNamespaceGraph(t *testing.T) {
 	defer ts.Close()
 
 	fut = graphNamespace
-	url := ts.URL + "/api/namespaces/bookinfo/graph?appenders&queryTime=1523364075"
+	url := ts.URL + "/api/namespaces/bookinfo/graph?graphType=versionedApp&appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -487,7 +487,7 @@ func TestMultiNamespaceGraph(t *testing.T) {
 	defer ts.Close()
 
 	fut = graphNamespace
-	url := ts.URL + "/api/namespaces/bookinfo/graph?appenders&queryTime=1523364075&namespaces=bookinfo,tutorial"
+	url := ts.URL + "/api/namespaces/bookinfo/graph?graphType=versionedApp&appenders&queryTime=1523364075&namespaces=bookinfo,tutorial"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)

--- a/handlers/testdata/test_multi_namespace_graph.expected
+++ b/handlers/testdata/test_multi_namespace_graph.expected
@@ -1,14 +1,16 @@
 {
   "timestamp": 1523364075,
-  "graphType": "app",
+  "graphType": "versionedApp",
   "elements": {
     "nodes": [
       {
         "data": {
-          "id": "2c22af42b0c750749399ed2838c56054",
+          "id": "a1ffc0d6abdf480e17b214b85257e633",
           "nodeType": "app",
           "namespace": "bookinfo",
+          "workload": "productpage-v1",
           "app": "productpage",
+          "version": "v1",
           "destServices": {
             "productpage": true
           },
@@ -17,10 +19,12 @@
       },
       {
         "data": {
-          "id": "ba389fce1a74a05e1fcd46aca64941f8",
+          "id": "d75c918a12f72a1ea1797911cb9770f7",
           "nodeType": "app",
           "namespace": "tutorial",
+          "workload": "customer-v1",
           "app": "customer",
+          "version": "v1",
           "destServices": {
             "customer": true
           },
@@ -43,17 +47,17 @@
     "edges": [
       {
         "data": {
-          "id": "efe83e483ada36899c34ef66a7974d31",
+          "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "2c22af42b0c750749399ed2838c56054",
+          "target": "a1ffc0d6abdf480e17b214b85257e633",
           "rate": "50.000"
         }
       },
       {
         "data": {
-          "id": "40ed695fef2389ae374dbc44a9b8938d",
+          "id": "7e12fa53b9413b80e96193555818be7e",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "ba389fce1a74a05e1fcd46aca64941f8",
+          "target": "d75c918a12f72a1ea1797911cb9770f7",
           "rate": "50.000"
         }
       }

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -1,14 +1,16 @@
 {
   "timestamp": 1523364075,
-  "graphType": "app",
+  "graphType": "versionedApp",
   "elements": {
     "nodes": [
       {
         "data": {
-          "id": "66bce9783dc2dbb5fecb178b0108484e",
+          "id": "87100ff76f5122d56e8aa75d018b5d67",
           "nodeType": "app",
           "namespace": "bankapp",
+          "workload": "pricing-v1",
           "app": "pricing",
+          "version": "v1",
           "destServices": {
             "pricing": true
           },
@@ -19,10 +21,21 @@
       },
       {
         "data": {
-          "id": "6cdb3cf3ee9a17772f13b295368e112a",
+          "id": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
           "namespace": "bookinfo",
+          "app": "reviews",
+          "isGroup": "version"
+        }
+      },
+      {
+        "data": {
+          "id": "50113397f439f05f3280ad0772b9b307",
+          "nodeType": "app",
+          "namespace": "bookinfo",
+          "workload": "details-v1",
           "app": "details",
+          "version": "v1",
           "destServices": {
             "details": true
           },
@@ -34,10 +47,12 @@
       },
       {
         "data": {
-          "id": "2c22af42b0c750749399ed2838c56054",
+          "id": "a1ffc0d6abdf480e17b214b85257e633",
           "nodeType": "app",
           "namespace": "bookinfo",
+          "workload": "productpage-v1",
           "app": "productpage",
+          "version": "v1",
           "destServices": {
             "productpage": true
           },
@@ -48,10 +63,12 @@
       },
       {
         "data": {
-          "id": "c219903556c3afdb05eda7e610aba628",
+          "id": "08d6a5dd6e290fbc42e259053b86a762",
           "nodeType": "app",
           "namespace": "bookinfo",
+          "workload": "ratings-v1",
           "app": "ratings",
+          "version": "v1",
           "destServices": {
             "ratings": true
           },
@@ -60,23 +77,59 @@
       },
       {
         "data": {
-          "id": "37ddc91db761d432f3fff1943802cad7",
+          "id": "acd188a125352509e86ce104323c5d4f",
+          "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
           "namespace": "bookinfo",
+          "workload": "reviews-v1",
           "app": "reviews",
+          "version": "v1",
           "destServices": {
             "reviews": true
           },
-          "rate": "100.000",
-          "rateOut": "100.000"
+          "rate": "20.000"
         }
       },
       {
         "data": {
-          "id": "4ee8019fc0454770a401b89d427277bf",
+          "id": "5cb6f79f37cb95cf40ea6fb23779b0e6",
+          "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
           "namespace": "bookinfo",
+          "workload": "reviews-v2",
+          "app": "reviews",
+          "version": "v2",
+          "destServices": {
+            "reviews": true
+          },
+          "rate": "40.000",
+          "rateOut": "40.000"
+        }
+      },
+      {
+        "data": {
+          "id": "dd4c5162b7f38a52e7f984766f88d807",
+          "parent": "4dbce17737348d2e200a0b22fea3145b",
+          "nodeType": "app",
+          "namespace": "bookinfo",
+          "workload": "reviews-v3",
+          "app": "reviews",
+          "version": "v3",
+          "destServices": {
+            "reviews": true
+          },
+          "rate": "40.000",
+          "rateOut": "60.000"
+        }
+      },
+      {
+        "data": {
+          "id": "2a4ce65a837db250466f2cbf1cdd7357",
+          "nodeType": "app",
+          "namespace": "bookinfo",
+          "workload": "tcp-v1",
           "app": "tcp",
+          "version": "v1",
           "destServices": {
             "tcp": true
           },
@@ -85,10 +138,12 @@
       },
       {
         "data": {
-          "id": "19950ddefadd370bf5434953c1944c80",
+          "id": "933d90e5172f69af1baa035e8a8ad27c",
           "nodeType": "app",
           "namespace": "istio-system",
+          "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
+          "version": "unknown",
           "rateOut": "100.000",
           "rateTcpSentOut": "150.000",
           "isInaccessible": true,
@@ -113,51 +168,51 @@
     "edges": [
       {
         "data": {
-          "id": "2c8bf7e7efb0982b18c76d507200a8b7",
-          "source": "19950ddefadd370bf5434953c1944c80",
-          "target": "2c22af42b0c750749399ed2838c56054",
-          "rate": "100.000"
+          "id": "ddf45549de5e603dee9a0cd9c83f9cfb",
+          "source": "5cb6f79f37cb95cf40ea6fb23779b0e6",
+          "target": "08d6a5dd6e290fbc42e259053b86a762",
+          "rate": "20.000",
+          "percentRate": "50.000"
         }
       },
       {
         "data": {
-          "id": "18fa6836a929941e8deabad5fa1cae62",
-          "source": "19950ddefadd370bf5434953c1944c80",
-          "target": "4ee8019fc0454770a401b89d427277bf",
+          "id": "e23d51a059f4d5e45ed6ae625f9b9a5f",
+          "source": "5cb6f79f37cb95cf40ea6fb23779b0e6",
+          "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
+          "rate": "20.000",
+          "percentRate": "50.000"
+        }
+      },
+      {
+        "data": {
+          "id": "9f5ad0240b6a9e430d3dc2bcb2b3daaa",
+          "source": "933d90e5172f69af1baa035e8a8ad27c",
+          "target": "2a4ce65a837db250466f2cbf1cdd7357",
           "tcpSentRate": "150.000"
         }
       },
       {
         "data": {
-          "id": "e9ffbf24e385c93dfa124d81e2ac33a7",
-          "source": "2c22af42b0c750749399ed2838c56054",
-          "target": "2c22af42b0c750749399ed2838c56054",
-          "rate": "20.000",
-          "percentRate": "12.500"
+          "id": "8088ca79aa13e423747334c532144c4f",
+          "source": "933d90e5172f69af1baa035e8a8ad27c",
+          "target": "a1ffc0d6abdf480e17b214b85257e633",
+          "rate": "100.000"
         }
       },
       {
         "data": {
-          "id": "ff5217a9064e30e4fb875256dab56037",
-          "source": "2c22af42b0c750749399ed2838c56054",
-          "target": "37ddc91db761d432f3fff1943802cad7",
-          "rate": "60.000",
-          "percentRate": "37.500"
-        }
-      },
-      {
-        "data": {
-          "id": "16a0c4225bbdbd471e6e7b8fd438733d",
-          "source": "2c22af42b0c750749399ed2838c56054",
-          "target": "4ee8019fc0454770a401b89d427277bf",
+          "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
+          "source": "a1ffc0d6abdf480e17b214b85257e633",
+          "target": "2a4ce65a837db250466f2cbf1cdd7357",
           "tcpSentRate": "31.000"
         }
       },
       {
         "data": {
-          "id": "89fa162a49acca6ff974afd30aab2ff0",
-          "source": "2c22af42b0c750749399ed2838c56054",
-          "target": "6cdb3cf3ee9a17772f13b295368e112a",
+          "id": "9f6a2ed75734d99002d37ac867190b9e",
+          "source": "a1ffc0d6abdf480e17b214b85257e633",
+          "target": "50113397f439f05f3280ad0772b9b307",
           "rate": "80.000",
           "rate3XX": "20.000",
           "rate4XX": "20.000",
@@ -168,45 +223,81 @@
       },
       {
         "data": {
-          "id": "4aaf7cb151db415f3ba4918be2296c38",
-          "source": "37ddc91db761d432f3fff1943802cad7",
-          "target": "37ddc91db761d432f3fff1943802cad7",
-          "rate": "40.000",
-          "percentRate": "40.000"
-        }
-      },
-      {
-        "data": {
-          "id": "edb2cdfc2a757d260aa847d55e9eadde",
-          "source": "37ddc91db761d432f3fff1943802cad7",
-          "target": "66bce9783dc2dbb5fecb178b0108484e",
+          "id": "0d38eb7edb4da38dac33b79a24c3c208",
+          "source": "a1ffc0d6abdf480e17b214b85257e633",
+          "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
           "rate": "20.000",
-          "percentRate": "20.000"
+          "percentRate": "12.500"
         }
       },
       {
         "data": {
-          "id": "a553e38605904d17c50ab1d0db84f113",
-          "source": "37ddc91db761d432f3fff1943802cad7",
-          "target": "c219903556c3afdb05eda7e610aba628",
-          "rate": "40.000",
-          "percentRate": "40.000"
+          "id": "4ab6875deb3c0cbec4c8f260841f3d24",
+          "source": "a1ffc0d6abdf480e17b214b85257e633",
+          "target": "a1ffc0d6abdf480e17b214b85257e633",
+          "rate": "20.000",
+          "percentRate": "12.500"
         }
       },
       {
         "data": {
-          "id": "efe83e483ada36899c34ef66a7974d31",
+          "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
+          "source": "a1ffc0d6abdf480e17b214b85257e633",
+          "target": "acd188a125352509e86ce104323c5d4f",
+          "rate": "20.000",
+          "percentRate": "12.500"
+        }
+      },
+      {
+        "data": {
+          "id": "d99fa824b2d85a2053f51fe3bd94ef60",
+          "source": "a1ffc0d6abdf480e17b214b85257e633",
+          "target": "dd4c5162b7f38a52e7f984766f88d807",
+          "rate": "20.000",
+          "percentRate": "12.500"
+        }
+      },
+      {
+        "data": {
+          "id": "d5054f4fd0140de3542ad2764d0f20bf",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "2c22af42b0c750749399ed2838c56054",
+          "target": "2a4ce65a837db250466f2cbf1cdd7357",
+          "tcpSentRate": "400.000"
+        }
+      },
+      {
+        "data": {
+          "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
+          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
+          "target": "a1ffc0d6abdf480e17b214b85257e633",
           "rate": "50.000"
         }
       },
       {
         "data": {
-          "id": "d4fc7bd6594937fa94402fcfcc9f3a95",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "4ee8019fc0454770a401b89d427277bf",
-          "tcpSentRate": "400.000"
+          "id": "4fe76972070982cc0fe01b5d42836ca1",
+          "source": "dd4c5162b7f38a52e7f984766f88d807",
+          "target": "08d6a5dd6e290fbc42e259053b86a762",
+          "rate": "20.000",
+          "percentRate": "33.333"
+        }
+      },
+      {
+        "data": {
+          "id": "5d3f0ce188557ed9741bda52cb245ff4",
+          "source": "dd4c5162b7f38a52e7f984766f88d807",
+          "target": "87100ff76f5122d56e8aa75d018b5d67",
+          "rate": "20.000",
+          "percentRate": "33.333"
+        }
+      },
+      {
+        "data": {
+          "id": "1959f1719d95c1a853a435a5807df1c3",
+          "source": "dd4c5162b7f38a52e7f984766f88d807",
+          "target": "dd4c5162b7f38a52e7f984766f88d807",
+          "rate": "20.000",
+          "percentRate": "33.333"
         }
       }
     ]


### PR DESCRIPTION
- Service graphs are produced by generating a workload graph with service injection,
and then reducing it to only service nodes by removing the workload nodes
aggregating their outgoing edges.
- add logic to unused_appender to decide if it is applicable (it's not applicable to service graphs)
Also:
- change default graph type to workload (not related to this but makes sense)
- remove some unnecessary fields on graph.Options
