### PR TITLE
KIALI-1674 - Increase Timeouts For Badge Tests

### DIFF
--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -24,7 +24,7 @@ def kiali_client():
     yield __get_kiali_client__(config)
     __remove_assets()
 
-def get_bookinfo_endpoint():
+def get_bookinfo_namespace():
     return __get_environment_config__(ENV_FILE).get('mesh_bookinfo_namespace')
 
 def __get_kiali_client__(config):
@@ -34,7 +34,6 @@ def __get_kiali_client__(config):
     else:
         return KialiClient(host=config.get('kiali_hostname'),
                            username=config.get('kiali_username'), password=config.get('kiali_password'))
-    print ("\nGet Kiali Client for Kiali hostname: {}\n".format(config.get('kiali_hostname')))
 
 def __get_environment_config__(env_file):
     with open(env_file) as yamlfile:
@@ -43,7 +42,7 @@ def __get_environment_config__(env_file):
 
 def __remove_assets():
   print('Cleanning up: ')
-  namespace = get_bookinfo_endpoint()
+  namespace = get_bookinfo_namespace()
   file_count = 0
   for root, dirs, files in os.walk('./assets'):
     file_count = len(files)

--- a/tests/e2e/tests/test_kiali_application_endpoint.py
+++ b/tests/e2e/tests/test_kiali_application_endpoint.py
@@ -6,7 +6,7 @@ APPLICATION_TO_VALIDATE = 'productpage'
 PARAMS = {'graphType': 'versionedApp', 'duration': '60s'}
 
 def test_application_list_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     app_list = kiali_client.app_list(namespace=bookinfo_namespace)
     assert app_list != None
@@ -17,7 +17,7 @@ def test_application_list_endpoint(kiali_client):
     assert app_list.get('namespace').get('name') == bookinfo_namespace
 
 def test_application_details_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     app_details = kiali_client.app_details(namespace=bookinfo_namespace, app=APPLICATION_TO_VALIDATE)
 
@@ -35,7 +35,7 @@ def test_application_details_endpoint(kiali_client):
 
 
 def test_application_health_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     app_health = kiali_client.app_health(namespace=bookinfo_namespace, app=APPLICATION_TO_VALIDATE)
     assert app_health != None
@@ -49,7 +49,7 @@ def test_application_health_endpoint(kiali_client):
     assert 'deploymentStatuses' in app_health
 
 def test_application_metrics_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     app_metrics = kiali_client.app_metrics(namespace=bookinfo_namespace, app=APPLICATION_TO_VALIDATE)
     assert app_metrics != None

--- a/tests/e2e/tests/test_kiali_bookinfo_namespace_endpoint.py
+++ b/tests/e2e/tests/test_kiali_bookinfo_namespace_endpoint.py
@@ -20,7 +20,7 @@ def test_service_graph_rest_endpoint(kiali_json):
     assert len(kiali_json.get('elements').get('edges')) >= 1
 
 def test_service_graph_bookinfo_namespace_(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     # Validate Node count
     nodes = kiali_client.graph_namespace(namespace=bookinfo_namespace, params=PARAMS)["elements"]['nodes']

--- a/tests/e2e/tests/test_kiali_graph_badges.py
+++ b/tests/e2e/tests/test_kiali_graph_badges.py
@@ -30,7 +30,7 @@ def test_kiali_virtual_service_app(kiali_client):
 
 def do_test(kiali_client, graph_params, yaml_file, badge):
     environment_configmap = conftest.__get_environment_config__(conftest.ENV_FILE)
-    bookinfo_namespace = bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     appType = kiali_client.graph_namespace(namespace=bookinfo_namespace, params=graph_params)['graphType']
     assert appType == graph_params.get('graphType')
@@ -43,7 +43,7 @@ def do_test(kiali_client, graph_params, yaml_file, badge):
       graph = kiali_client.graph_namespace(namespace=bookinfo_namespace, params=graph_params)
       assert graph is not None
 
-      with timeout(seconds=5, error_message='Timed out waiting for Create'):
+      with timeout(seconds=30, error_message='Timed out waiting for Create'):
           while True:
               new_count = get_badge_count(kiali_client, bookinfo_namespace, graph_params, badge)
               if new_count != 0 and new_count >= count:
@@ -54,7 +54,7 @@ def do_test(kiali_client, graph_params, yaml_file, badge):
     finally:
       assert command_exec.oc_delete(yaml_file, bookinfo_namespace) == True
 
-      with timeout(seconds=5, error_message='Timed out waiting for Delete'):
+      with timeout(seconds=30, error_message='Timed out waiting for Delete'):
           while True:
               # Validate that JSON no longer has Virtual Service
               if get_badge_count(kiali_client, bookinfo_namespace, graph_params, badge) <= count:

--- a/tests/e2e/tests/test_kiali_istio_endpoint.py
+++ b/tests/e2e/tests/test_kiali_istio_endpoint.py
@@ -4,7 +4,7 @@ import tests.conftest as conftest
 OBJECT_TYPE = 'virtualservices'
 
 def test_istio_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
     istio = kiali_client.istio(namespace=bookinfo_namespace)
 
     assert istio != None
@@ -13,14 +13,14 @@ def test_istio_endpoint(kiali_client):
     assert bookinfo_namespace in istio.get('namespace').get('name')
 
 def test_istio_validations_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
     istio_validations = kiali_client.istio_validations(namespace=bookinfo_namespace)
 
     assert istio_validations != None
     assert bookinfo_namespace in istio_validations
 
 def _test_istio_object_type(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     istio_object_type = kiali_client.istio_object_type(bookinfo_namespace, OBJECT_TYPE, bookinfo_namespace)
     assert istio_object_type != None
@@ -28,7 +28,7 @@ def _test_istio_object_type(kiali_client):
     assert bookinfo_namespace in istio_object_type.get('namespace').get('name')
 
 def _test_istio_object_istio_validations(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     istio_validations = kiali_client.istio_object_istio_validations(bookinfo_namespace, OBJECT_TYPE, bookinfo_namespace)
     assert istio_validations != None

--- a/tests/e2e/tests/test_kiali_service_endpoint.py
+++ b/tests/e2e/tests/test_kiali_service_endpoint.py
@@ -11,7 +11,7 @@ VIRTUAL_SERVICE_FILE = 'assets/bookinfo-reviews-80-20.yaml'
 DESTINATION_RULE_FILE = 'assets/bookinfo-destination-rule-reviews.yaml'
 
 def test_service_list_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     service_list_json = kiali_client.service_list(namespace=bookinfo_namespace)
     assert service_list_json.get('namespace').get('name') == bookinfo_namespace
@@ -26,7 +26,7 @@ def test_service_list_endpoint(kiali_client):
       assert service.get('appLabel') == True
 
 def test_service_detail_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     service_details = kiali_client.service_details(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
     assert service_details != None
@@ -41,7 +41,7 @@ def test_service_detail_endpoint(kiali_client):
     assert 'health' in service_details
 
 def test_service_detail_with_virtual_service(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     try:
       # Add a virtual service that will be tested
@@ -92,7 +92,7 @@ def test_service_detail_with_virtual_service(kiali_client):
           time.sleep(1)
 
 def test_service_detail_with_destination_rule(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     try:
       # Add a destination rule that will be tested
@@ -138,7 +138,7 @@ def test_service_detail_with_destination_rule(kiali_client):
           time.sleep(1)
 
 def test_service_metrics_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     service = kiali_client.service_metrics(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
     for direction in ['dest', 'source']:
@@ -156,7 +156,7 @@ def test_service_metrics_endpoint(kiali_client):
       assert 'response_size_in' in histograms
 
 def test_service_health_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     service_health = kiali_client.service_health(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
     assert service_health != None
@@ -169,7 +169,7 @@ def test_service_health_endpoint(kiali_client):
     assert 'requests' in service_health
 
 def test_service_validations_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     service_validations = kiali_client.service_validations(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
     assert service_validations != None

--- a/tests/e2e/tests/test_kiali_workload_endpoint.py
+++ b/tests/e2e/tests/test_kiali_workload_endpoint.py
@@ -5,7 +5,7 @@ WORKLOAD_TO_VALIDATE = 'details-v1'
 WORKLOAD_TYPE = 'Deployment'
 
 def test_workload_list_endpoint(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     workload_list = kiali_client.workload_list(namespace=bookinfo_namespace)
     assert workload_list != None
@@ -17,7 +17,7 @@ def test_workload_list_endpoint(kiali_client):
       assert workload.get('versionLabel') == True
 
 def test_workload_details(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     workload = kiali_client.workload_details(namespace=bookinfo_namespace, workload=WORKLOAD_TO_VALIDATE)
     assert workload != None
@@ -29,7 +29,7 @@ def test_workload_details(kiali_client):
     assert 'services' in workload
 
 def test_workload_metrics(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     workload = kiali_client.workload_metrics(namespace=bookinfo_namespace, workload=WORKLOAD_TO_VALIDATE)
     for direction in ['dest', 'source']:
@@ -54,7 +54,7 @@ def test_workload_metrics(kiali_client):
       assert 'response_size_out' in histograms
 
 def test_workload_health(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     workload = kiali_client.workload_health(namespace=bookinfo_namespace, workload=WORKLOAD_TO_VALIDATE)
     assert workload != None
@@ -62,7 +62,7 @@ def test_workload_health(kiali_client):
     assert 'requests' in workload
 
 def test_workload_istio_validations(kiali_client):
-    bookinfo_namespace = conftest.get_bookinfo_endpoint()
+    bookinfo_namespace = conftest.get_bookinfo_namespace()
 
     workload = kiali_client.workload_istio_validations(namespace=bookinfo_namespace, workload=WORKLOAD_TO_VALIDATE)
     assert workload != None


### PR DESCRIPTION
Increase timeouts around Badge tests 'oc' commands due to slow Openshift cluster response.

Method name change, as well.