### PR TITLE
KIALI-1616 A VirtualService sharing a host is valid if it has gateway

### DIFF
--- a/business/checkers/virtual_services/single_host_checker.go
+++ b/business/checkers/virtual_services/single_host_checker.go
@@ -41,7 +41,9 @@ func (in SingleHostChecker) Check() models.IstioValidations {
 					// - there is one virtual service with wildcard and there are other virtual services pointing
 					//   a host for that namespace
 					if targetSameHost || isNamespaceWildcard && otherServiceHosts {
-						multipleVirtualServiceCheck(*virtualService, validations)
+						if !hasGateways(virtualService) {
+							multipleVirtualServiceCheck(*virtualService, validations)
+						}
 					}
 				}
 			}
@@ -139,4 +141,12 @@ func formatHostForSearch(hostName, virtualServiceNamespace string) Host {
 	}
 
 	return host
+}
+
+func hasGateways(virtualService *kubernetes.IstioObject) bool {
+	if gateways, ok := (*virtualService).GetSpec()["gateways"]; ok {
+		vsGateways, ok := (gateways).([]interface{})
+		return ok && vsGateways != nil && len(vsGateways) > 0
+	}
+	return false
 }


### PR DESCRIPTION
** Describe the change **
Starting with Istio 1.0.1, multiple virtual services for the same host are allowed if the VSs are bound to a gateway.
This PR prevent Kiali to show a warning in whenever this situation is reached.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1616

** Backwards incompatible? **
Yes.

** Screenshot **

Before:
![screenshot of kiali console 6](https://user-images.githubusercontent.com/613814/46415779-4e3b6480-c726-11e8-9a63-0bfd61921d3b.png)

After:
When the VS has a gateway:
![screenshot of kiali console 7](https://user-images.githubusercontent.com/613814/46415825-657a5200-c726-11e8-9264-aa4ae28252a4.png)

When the VS doesn't have any gateway:
![screenshot of kiali console 8](https://user-images.githubusercontent.com/613814/46416108-239ddb80-c727-11e8-95a3-aa8200e2958b.png)
(warning message: More than one virtual service for the same host)

When the VS doesn't target the same host:
![screenshot of kiali console 9](https://user-images.githubusercontent.com/613814/46416195-58aa2e00-c727-11e8-9530-53fddee0d7b4.png)
(host changed to myapp.org)

