### PR TITLE
KIALI-1710 explicitely initialize slices as empty

### DIFF
--- a/services/business/apps.go
+++ b/services/business/apps.go
@@ -2,6 +2,7 @@ package business
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/labels"
 
 	"k8s.io/api/apps/v1beta1"
@@ -60,8 +61,10 @@ func (in *AppService) fetchWorkloadsPerApp(namespace, labelSelector string) (app
 // GetAppList is the API handler to fetch the list of applications in a given namespace
 func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
 	cfg := config.Get()
-	appList := &models.AppList{}
-	appList.Namespace = models.Namespace{Name: namespace}
+	appList := &models.AppList{
+		Namespace: models.Namespace{Name: namespace},
+		Apps:      []models.AppListItem{},
+	}
 	apps, err := in.fetchWorkloadsPerApp(namespace, cfg.IstioLabels.AppLabelName)
 	if err != nil {
 		return *appList, err

--- a/services/business/workloads.go
+++ b/services/business/workloads.go
@@ -17,9 +17,10 @@ func (in *WorkloadService) GetWorkloadList(namespace string) (models.WorkloadLis
 	if err != nil {
 		return models.WorkloadList{}, err
 	}
-
-	workloadList := &models.WorkloadList{}
-	workloadList.Namespace.Name = namespace
+	workloadList := &models.WorkloadList{
+		Namespace: models.Namespace{Name: namespace},
+		Workloads: []models.WorkloadListItem{},
+	}
 	for _, deployment := range ds {
 		selector := labels.FormatLabels(deployment.Spec.Template.Labels)
 		dPods, _ := in.k8s.GetPods(namespace, selector)


### PR DESCRIPTION
0-value of slices is nil, not empty slice. Although nil slice behaves very much like empty slice, it is serialized as nil in json. So should be avoided.

JIRA: https://issues.jboss.org/browse/KIALI-1710