### PR TITLE
KIALI-1727 Fix how multimatch destination rule validation is shown in ACEditor

### DIFF
--- a/services/business/checkers/destination_rules/multi_match_checker.go
+++ b/services/business/checkers/destination_rules/multi_match_checker.go
@@ -115,7 +115,7 @@ func addError(validations models.IstioValidations, destinationRuleNames []string
 	for _, destinationRuleName := range destinationRuleNames {
 		key := models.IstioValidationKey{Name: destinationRuleName, ObjectType: DestinationRulesCheckerType}
 		checks := models.BuildCheck("More than one DestinationRules for same host subset combination",
-			"warning", "spec/hosts")
+			"warning", "spec/host")
 		rrValidation := &models.IstioValidation{
 			Name:       destinationRuleName,
 			ObjectType: DestinationRulesCheckerType,


### PR DESCRIPTION
** Describe the change **
Showing multimatch DR validation properly in ACEditor. See the screenshots for better understanding.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1727

Error:
![screenshot of kiali console 3](https://user-images.githubusercontent.com/613814/46735393-69622300-cc96-11e8-9496-9da02b76dbcb.png)


Fix:
![screenshot of kiali console 2](https://user-images.githubusercontent.com/613814/46734915-dffe2100-cc94-11e8-849f-21551c8b301e.png)
