### PR TITLE
KIALI-1728 Add support for namespace service health

### DIFF
--- a/models/health.go
+++ b/models/health.go
@@ -7,6 +7,9 @@ import (
 // NamespaceAppHealth is an alias of map of app name x health
 type NamespaceAppHealth map[string]*AppHealth
 
+// NamespaceServiceHealth is an alias of map of service name x health
+type NamespaceServiceHealth map[string]*ServiceHealth
+
 // NamespaceWorkloadHealth is an alias of map of workload name x health
 type NamespaceWorkloadHealth map[string]*WorkloadHealth
 

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -17,6 +17,7 @@ import (
 type ClientInterface interface {
 	GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyServiceHealth, error)
 	GetAllRequestRates(namespace, ratesInterval string) (model.Vector, error)
+	GetNamespaceRequestRates(namespace, ratesInterval string) (model.Vector, error)
 	GetServiceRequestRates(namespace, service, ratesInterval string) (model.Vector, error)
 	GetAppRequestRates(namespace, app, ratesInterval string) (model.Vector, model.Vector, error)
 	GetWorkloadRequestRates(namespace, workload, ratesInterval string) (model.Vector, model.Vector, error)
@@ -117,10 +118,18 @@ func (in *Client) GetServiceHealth(namespace, servicename string, ports []int32)
 	return getServiceHealth(in.api, namespace, servicename, ports)
 }
 
-// GetAllRequestRates queries Prometheus to fetch request counters rates over a time interval within a namespace
+// GetAllRequestRates queries Prometheus to fetch request counter rates, over a time interval, for requests
+// into, internal to, or out of the namespace.
 // Returns (rates, error)
 func (in *Client) GetAllRequestRates(namespace string, ratesInterval string) (model.Vector, error) {
 	return getAllRequestRates(in.api, namespace, ratesInterval)
+}
+
+// GetNamespaceRequestRates queries Prometheus to fetch request counter rates, over a time interval, limited to
+// requests for services in the namespace.
+// Returns (rates, error)
+func (in *Client) GetNamespaceRequestRates(namespace string, ratesInterval string) (model.Vector, error) {
+	return getNamespaceRequestRates(in.api, namespace, ratesInterval)
 }
 
 // GetServiceRequestRates queries Prometheus to fetch request counters rates over a time interval

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -512,6 +512,48 @@ func TestGetAllRequestRatesIstioSystem(t *testing.T) {
 	assert.Equal(t, vectorQ2[0], rates[1])
 }
 
+func TestGetNamespaceRequestRates(t *testing.T) {
+	client, api, err := setupMocked()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	vectorQ1 := model.Vector{
+		&model.Sample{
+			Timestamp: model.Now(),
+			Value:     model.SampleValue(1),
+			Metric:    model.Metric{"foo": "bar"},
+		},
+	}
+	mockQuery(api, `rate(istio_requests_total{reporter="source",destination_service_namespace="ns"}[5m])`, &vectorQ1)
+
+	rates, err := client.GetNamespaceRequestRates("ns", "5m")
+	assert.Equal(t, 1, rates.Len())
+	assert.Equal(t, vectorQ1[0], rates[0])
+}
+
+func TestGetNamespaceRequestRatesIstioSystem(t *testing.T) {
+	client, api, err := setupMocked()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	vectorQ1 := model.Vector{
+		&model.Sample{
+			Timestamp: model.Now(),
+			Value:     model.SampleValue(1),
+			Metric:    model.Metric{"foo": "bar"},
+		},
+	}
+	mockQuery(api, `rate(istio_requests_total{reporter="destination",destination_service_namespace="istio-system"}[5m])`, &vectorQ1)
+
+	rates, err := client.GetNamespaceRequestRates("istio-system", "5m")
+	assert.Equal(t, 1, rates.Len())
+	assert.Equal(t, vectorQ1[0], rates[0])
+}
+
 func mockQuery(api *PromAPIMock, query string, ret *model.Vector) {
 	api.On(
 		"Query",

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -98,6 +98,11 @@ func (o *PromClientMock) GetAllRequestRates(namespace, ratesInterval string) (mo
 	return args.Get(0).(model.Vector), args.Error(1)
 }
 
+func (o *PromClientMock) GetNamespaceRequestRates(namespace, ratesInterval string) (model.Vector, error) {
+	args := o.Called(namespace, ratesInterval)
+	return args.Get(0).(model.Vector), args.Error(1)
+}
+
 func (o *PromClientMock) GetAppRequestRates(namespace, app, ratesInterval string) (model.Vector, model.Vector, error) {
 	args := o.Called(namespace, app, ratesInterval)
 	return args.Get(0).(model.Vector), args.Get(1).(model.Vector), args.Error(2)


### PR DESCRIPTION
This is to support health indication on service nodes in the graph.  See kiali-ui PR https://github.com/kiali/kiali-ui/pull/744

@jotak Please take a look.  The changes should be analogous to what was already there for namespace app and namespace workload health.