### PR TITLE
Allow to build docker images for snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ after_success:
 branches:
   only:
   - master
-  - /^v(\d+\.){1,2}(\d+){1}(\.[a-zA-Z\d]+)?$/
+  - /^v(\d+\.){1,2}(\d+){1}(\.[a-zA-Z\d]+|\-snapshot.(\d))?$/


### PR DESCRIPTION
@jmazzitelli @cfcosta @xeviknal 
In our documented process to release snapshots, we ask to modify this part of the travis script: see https://docs.jboss.org/display/KIALI/How+to+create+the+weekly+snapshot+version+for+KIALI#app-switcher

But is there a reason why this isn't commited directly in master? Would it damage anything to have travis always building *-snapshot branches or tags?