### PR TITLE
KIALI-1497 Create liveliness and ready probes for Kiali pod (fixes #540)

### DIFF
--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -71,6 +71,20 @@ spec:
         - "/kiali-configuration/config.yaml"
         - "-v"
         - "${VERBOSE_MODE}"
+        readinessProbe:
+          httpGet:
+            path: /api/status
+            port: 20001
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          timeoutSeconds: 45
+        livenessProbe:
+          httpGet:
+            path: /api/status
+            port: 20001
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          timeoutSeconds: 45
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:

--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -77,14 +77,12 @@ spec:
             port: 20001
           initialDelaySeconds: 3
           periodSeconds: 3
-          timeoutSeconds: 45
         livenessProbe:
           httpGet:
             path: /api/status
             port: 20001
           initialDelaySeconds: 3
           periodSeconds: 3
-          timeoutSeconds: 45
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -78,12 +78,14 @@ spec:
         - "${VERBOSE_MODE}"
         readinessProbe:
           httpGet:
+            scheme: HTTPS
             path: /api/status
             port: 20001
           initialDelaySeconds: 3
           periodSeconds: 3
         livenessProbe:
           httpGet:
+            scheme: HTTPS
             path: /api/status
             port: 20001
           initialDelaySeconds: 3

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -82,14 +82,12 @@ spec:
             port: 20001
           initialDelaySeconds: 3
           periodSeconds: 3
-          timeoutSeconds: 45
         livenessProbe:
           httpGet:
             path: /api/status
             port: 20001
           initialDelaySeconds: 3
           periodSeconds: 3
-          timeoutSeconds: 45
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -76,6 +76,20 @@ spec:
         - "/kiali-configuration/config.yaml"
         - "-v"
         - "${VERBOSE_MODE}"
+        readinessProbe:
+          httpGet:
+            path: /api/status
+            port: 20001
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          timeoutSeconds: 45
+        livenessProbe:
+          httpGet:
+            path: /api/status
+            port: 20001
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          timeoutSeconds: 45
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:


### PR DESCRIPTION
…

** Describe the change **

The change adds liveness and readiness probes for the Kiali pods for Kubernetes and OpenShift. It does so by probing path "/api/status".

** Issue reference **

KIALI-1497 

** Backwards incompatible? **

- [ ] Is your change introducing backwards incompatible changes? - No

