### PR TITLE
KIALI-1738 Support app without workload

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -2,6 +2,10 @@ package business
 
 import (
 	"fmt"
+	"github.com/kiali/kiali/log"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sync"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -36,20 +40,22 @@ func (in *AppService) fetchWorkloadsPerApp(namespace, labelSelector string) (app
 
 // GetAppList is the API handler to fetch the list of applications in a given namespace
 func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
-	cfg := config.Get()
 	appList := &models.AppList{
 		Namespace: models.Namespace{Name: namespace},
 		Apps:      []models.AppListItem{},
 	}
-	apps, err := in.fetchWorkloadsPerApp(namespace, cfg.IstioLabels.AppLabelName)
+	apps, err := fetchNamespaceApps(in.k8s, namespace, "")
 	if err != nil {
 		return *appList, err
 	}
 
 	for keyApp, valueApp := range apps {
 		appItem := &models.AppListItem{Name: keyApp}
-		appItem.IstioSidecar = true
-		for _, w := range valueApp {
+		appItem.IstioSidecar = false
+		if len(valueApp.Workloads) > 0 {
+			appItem.IstioSidecar = true
+		}
+		for _, w := range valueApp.Workloads {
 			appItem.IstioSidecar = appItem.IstioSidecar && w.Pods.HasIstioSideCar()
 		}
 		(*appList).Apps = append((*appList).Apps, *appItem)
@@ -59,34 +65,120 @@ func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
 }
 
 // GetApp is the API handler to fetch the details for a given namespace and app name
-func (in *AppService) GetApp(namespace string, app string) (models.App, error) {
-	cfg := config.Get()
-	appInstance := &models.App{Namespace: models.Namespace{Name: namespace}, Name: app}
-	apps, err := in.fetchWorkloadsPerApp(namespace, fmt.Sprintf("%s=%s", cfg.IstioLabels.AppLabelName, app))
+func (in *AppService) GetApp(namespace string, appName string) (models.App, error) {
+	appInstance := &models.App{Namespace: models.Namespace{Name: namespace}, Name: appName}
+	namespaceApps, err := fetchNamespaceApps(in.k8s, namespace, appName)
 	if err != nil {
 		return *appInstance, err
 	}
 
-	var appWkd []*models.Workload
+	var appDetails *appDetails
 	var ok bool
 	// Send a NewNotFound if the app is not found in the deployment list, instead to send an empty result
-	if appWkd, ok = apps[app]; !ok {
-		return *appInstance, kubernetes.NewNotFound(app, "Kiali", "App")
+	if appDetails, ok = namespaceApps[appName]; !ok {
+		return *appInstance, kubernetes.NewNotFound(appName, "Kiali", "App")
 	}
 
-	(*appInstance).Workloads = make([]models.WorkloadSvc, len(appWkd))
-	for i, wkd := range appWkd {
-		wkdSvc := &models.WorkloadSvc{WorkloadName: wkd.Name}
-		services, _ := in.k8s.GetServices(namespace, wkd.Labels)
-		if err != nil {
-			return *appInstance, err
-		}
+	(*appInstance).Workloads = make([]models.WorkloadItem, len(appDetails.Workloads))
+	for i, wkd := range appDetails.Workloads {
+		wkdSvc := &models.WorkloadItem{WorkloadName: wkd.Name}
 		wkdSvc.IstioSidecar = wkd.Pods.HasIstioSideCar()
-		wkdSvc.ServiceNames = make([]string, len(services))
-		for j, service := range services {
-			wkdSvc.ServiceNames[j] = service.Name
-		}
 		(*appInstance).Workloads[i] = *wkdSvc
 	}
+
+	(*appInstance).ServiceNames = make([]string, len(appDetails.Services))
+	for i, svc := range appDetails.Services {
+		(*appInstance).ServiceNames[i] = svc.Name
+	}
 	return *appInstance, nil
+}
+
+// AppDetails holds Services and Workloads having the same "app" label
+type appDetails struct {
+	app       string
+	Services  []v1.Service
+	Workloads models.Workloads
+}
+
+// NamespaceApps is a map of app_name x AppDetails
+type namespaceApps = map[string]*appDetails
+
+func castAppDetails(services []v1.Service, ws models.Workloads) namespaceApps {
+	allEntities := make(namespaceApps)
+	appLabel := config.Get().IstioLabels.AppLabelName
+	for _, service := range services {
+		if app, ok := service.Spec.Selector[appLabel]; ok {
+			if appEntities, ok := allEntities[app]; ok {
+				appEntities.Services = append(appEntities.Services, service)
+			} else {
+				allEntities[app] = &appDetails{
+					app:      app,
+					Services: []v1.Service{service},
+				}
+			}
+		}
+	}
+	for _, w := range ws {
+		if app, ok := w.Labels[appLabel]; ok {
+			if appEntities, ok := allEntities[app]; ok {
+				appEntities.Workloads = append(appEntities.Workloads, w)
+			} else {
+				allEntities[app] = &appDetails{
+					app:       app,
+					Workloads: models.Workloads{w},
+				}
+			}
+		}
+	}
+	return allEntities
+}
+
+// Helper method to fetch all applications for a given namespace.
+// Optionally if appName parameter is provided, it filters apps for that name.
+// Return an error on any problem.
+func fetchNamespaceApps(k8s kubernetes.IstioClientInterface, namespace string, appName string) (namespaceApps, error) {
+	var services []v1.Service
+	var ws models.Workloads
+	cfg := config.Get()
+
+	labelSelector := cfg.IstioLabels.AppLabelName
+	if appName != "" {
+		labelSelector = fmt.Sprintf("%s=%s", cfg.IstioLabels.AppLabelName, appName)
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	errChan := make(chan error, 2)
+
+	go func() {
+		defer wg.Done()
+		var err error
+		services, err = k8s.GetServices(namespace, nil)
+		if appName != "" {
+			selector := labels.Set(map[string]string{cfg.IstioLabels.AppLabelName: appName}).AsSelector()
+			services = kubernetes.FilterServicesForSelector(selector, services)
+		}
+		if err != nil {
+			log.Errorf("Error fetching Services per namespace %s: %s", namespace, err)
+			errChan <- err
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		var err error
+		ws, err = fetchWorkloads(k8s, namespace, labelSelector)
+		if err != nil {
+			log.Errorf("Error fetching Workload per namespace %s: %s", namespace, err)
+			errChan <- err
+		}
+	}()
+
+	wg.Wait()
+	if len(errChan) != 0 {
+		err := <-errChan
+		return nil, err
+	}
+
+	return castAppDetails(services, ws), nil
 }

--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -35,6 +35,7 @@ func TestGetAppListFromDeployments(t *testing.T) {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
+	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return([]v1.Service{}, nil)
 	svc := setupAppService(k8s)
 
 	appList, _ := svc.GetAppList("Namespace")
@@ -72,6 +73,8 @@ func TestGetAppFromDeployments(t *testing.T) {
 	assert.Equal(2, len(appDetails.Workloads))
 	assert.Equal("httpbin-v1", appDetails.Workloads[0].WorkloadName)
 	assert.Equal("httpbin-v2", appDetails.Workloads[1].WorkloadName)
+	assert.Equal(1, len(appDetails.ServiceNames))
+	assert.Equal("httpbin", appDetails.ServiceNames[0])
 }
 
 func TestGetAppListFromReplicaSets(t *testing.T) {
@@ -91,6 +94,7 @@ func TestGetAppListFromReplicaSets(t *testing.T) {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
+	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return([]v1.Service{}, nil)
 	svc := setupAppService(k8s)
 
 	appList, _ := svc.GetAppList("Namespace")
@@ -128,4 +132,6 @@ func TestGetAppFromReplicaSets(t *testing.T) {
 	assert.Equal(2, len(appDetails.Workloads))
 	assert.Equal("httpbin-v1", appDetails.Workloads[0].WorkloadName)
 	assert.Equal("httpbin-v2", appDetails.Workloads[1].WorkloadName)
+	assert.Equal(1, len(appDetails.ServiceNames))
+	assert.Equal("httpbin", appDetails.ServiceNames[0])
 }

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -544,6 +544,9 @@ func FakeServices() []v1.Service {
 	return []v1.Service{
 		{
 			ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin"},
+			Spec: v1.ServiceSpec{
+				Selector: map[string]string{"app": "httpbin"},
+			},
 		},
 	}
 }

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -47,7 +48,11 @@ func AppDetails(w http.ResponseWriter, r *http.Request) {
 	// Fetch and build app
 	appDetails, err := business.App.GetApp(namespace, app)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		if errors.IsNotFound(err) {
+			RespondWithError(w, http.StatusNotFound, err.Error())
+		} else {
+			RespondWithError(w, http.StatusInternalServerError, err.Error())
+		}
 		return
 	}
 

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -171,6 +171,7 @@ func TestAppsEndpoint(t *testing.T) {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]corev1.Pod{}, nil)
+	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return([]corev1.Service{}, nil)
 
 	url := ts.URL + "/api/namespaces/ns/apps"
 
@@ -212,5 +213,5 @@ func TestAppDetailsEndpoint(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode, string(actual))
 	k8s.AssertNumberOfCalls(t, "GetDeployments", 1)
 	k8s.AssertNumberOfCalls(t, "GetPods", 1)
-	k8s.AssertNumberOfCalls(t, "GetServices", 2)
+	k8s.AssertNumberOfCalls(t, "GetServices", 1)
 }

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -48,7 +49,11 @@ func WorkloadDetails(w http.ResponseWriter, r *http.Request) {
 	// Fetch and build workload
 	workloadDetails, err := business.Workload.GetWorkload(namespace, workload, true)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		if errors.IsNotFound(err) {
+			RespondWithError(w, http.StatusNotFound, err.Error())
+		} else {
+			RespondWithError(w, http.StatusInternalServerError, err.Error())
+		}
 		return
 	}
 

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -58,3 +58,13 @@ func FilterPodsForController(controllerName string, controllerType string, allPo
 	}
 	return pods
 }
+
+func FilterServicesForSelector(selector labels.Selector, allServices []v1.Service) []v1.Service {
+	var services []v1.Service
+	for _, svc := range allServices {
+		if selector.Matches(labels.Set(svc.Spec.Selector)) {
+			services = append(services, svc)
+		}
+	}
+	return services
+}

--- a/models/app.go
+++ b/models/app.go
@@ -24,7 +24,7 @@ type AppListItem struct {
 	IstioSidecar bool `json:"istioSidecar"`
 }
 
-type WorkloadSvc struct {
+type WorkloadItem struct {
 	// Name of a workload member of an application
 	// required: true
 	// example: reviews-v1
@@ -34,10 +34,6 @@ type WorkloadSvc struct {
 	// required: true
 	// example: true
 	IstioSidecar bool `json:"istioSidecar"`
-
-	// List of service names linked with a workload
-	// required: true
-	ServiceNames []string `json:"serviceNames"`
 }
 
 type App struct {
@@ -53,5 +49,9 @@ type App struct {
 
 	// Workloads for a given application
 	// required: true
-	Workloads []WorkloadSvc `json:"workloads"`
+	Workloads []WorkloadItem `json:"workloads"`
+
+	// List of service names linked with an application
+	// required: true
+	ServiceNames []string `json:"serviceNames"`
 }

--- a/models/health.go
+++ b/models/health.go
@@ -69,5 +69,9 @@ func (in *RequestHealth) Aggregate(sample *model.Sample) {
 	if responseCode == '5' || responseCode == '4' {
 		in.errorRate += float64(sample.Value)
 	}
-	in.ErrorRatio = in.errorRate / in.requestRate
+	if in.requestRate == 0 {
+		in.ErrorRatio = -1
+	} else {
+		in.ErrorRatio = in.errorRate / in.requestRate
+	}
 }


### PR DESCRIPTION
** Describe the change **

There is a corner case that may happen.
Application with Pods as workload with no controllers; at some point, Pods are deleted, but a service is still active.
On this scenario an app with no workloads it's necessary as it is not covered and there could be an app in the graph linking to a non valid app.
