### PR TITLE
KIALI-1757 Perf improvements for graph appenders

### DIFF
--- a/graph/appender/appender.go
+++ b/graph/appender/appender.go
@@ -1,8 +1,69 @@
 package appender
 
 import (
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus"
 )
+
+// GlobalInfo caches information relevant to a single graph. It allows
+// an appender to populate the cache and then it, or another appender
+// can re-use the information.  A new instance is generated for graph and
+// is initially empty.
+type GlobalInfo struct {
+	Business    *business.Layer
+	IstioClient *kubernetes.IstioClient
+	PromClient  *prometheus.Client
+}
+
+func NewGlobalInfo() *GlobalInfo {
+	return &GlobalInfo{}
+}
+
+// NamespaceInfo caches information relevant to a single namespace. It allows
+// one appender to populate the cache and another to then re-use the information.
+// A new instance is generated for each namespace of a single graph and is initially
+// seeded with only Namespace.
+type NamespaceInfo struct {
+	Namespace        string // always provided
+	ExternalServices map[string]bool
+	WorkloadList     *models.WorkloadList
+}
+
+func NewNamespaceInfo(namespace string) *NamespaceInfo {
+	return &NamespaceInfo{Namespace: namespace}
+}
+
+func getWorkload(workloadName string, workloadList *models.WorkloadList) (*models.WorkloadListItem, bool) {
+	for _, workload := range workloadList.Workloads {
+		if workload.Name == workloadName {
+			return &workload, true
+		}
+	}
+	return nil, false
+}
+
+func getAppWorkloads(app, version string, workloadList *models.WorkloadList) []models.WorkloadListItem {
+	cfg := config.Get()
+	appLabel := cfg.IstioLabels.AppLabelName
+	versionLabel := cfg.IstioLabels.VersionLabelName
+
+	result := []models.WorkloadListItem{}
+	versionOk := version != "" && version != graph.UnknownVersion
+	for _, workload := range workloadList.Workloads {
+		if appVal, ok := workload.Labels[appLabel]; ok && app == appVal {
+			if !versionOk {
+				result = append(result, workload)
+			} else if versionVal, ok := workload.Labels[versionLabel]; ok && version == versionVal {
+				result = append(result, workload)
+			}
+		}
+	}
+	return result
+}
 
 // Appender is implemented by any code offering to append a service graph with
 // supplemental information.  On error the appender should panic and it will be
@@ -10,5 +71,5 @@ import (
 type Appender interface {
 	// AppendGraph performs the appender work on the provided traffic map. The map
 	// may be initially empty. An appender is allowed to add or remove map entries.
-	AppendGraph(trafficMap graph.TrafficMap, namespace string)
+	AppendGraph(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo)
 }

--- a/graph/appender/response_time.go
+++ b/graph/appender/response_time.go
@@ -29,15 +29,18 @@ type ResponseTimeAppender struct {
 }
 
 // AppendGraph implements Appender
-func (a ResponseTimeAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string) {
+func (a ResponseTimeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
 
-	client, err := prometheus.NewClient()
-	checkError(err)
+	if globalInfo.PromClient == nil {
+		var err error
+		globalInfo.PromClient, err = prometheus.NewClient()
+		checkError(err)
+	}
 
-	a.appendGraph(trafficMap, namespace, client)
+	a.appendGraph(trafficMap, namespaceInfo.Namespace, globalInfo.PromClient)
 }
 
 func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace string, client *prometheus.Client) {

--- a/graph/appender/security_policy.go
+++ b/graph/appender/security_policy.go
@@ -22,15 +22,18 @@ type SecurityPolicyAppender struct {
 }
 
 // AppendGraph implements Appender
-func (a SecurityPolicyAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string) {
+func (a SecurityPolicyAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
 
-	client, err := prometheus.NewClient()
-	checkError(err)
+	if globalInfo.PromClient == nil {
+		var err error
+		globalInfo.PromClient, err = prometheus.NewClient()
+		checkError(err)
+	}
 
-	a.appendGraph(trafficMap, namespace, client)
+	a.appendGraph(trafficMap, namespaceInfo.Namespace, globalInfo.PromClient)
 }
 
 func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespace string, client *prometheus.Client) {

--- a/graph/appender/sidecars_check.go
+++ b/graph/appender/sidecars_check.go
@@ -1,40 +1,41 @@
 package appender
 
 import (
-	"fmt"
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
-	"github.com/kiali/kiali/log"
-	"github.com/kiali/kiali/models"
 )
 
-type SidecarsCheckAppender struct {
-	AccessibleNamespaces map[string]bool
-}
+type SidecarsCheckAppender struct{}
 
 // AppendGraph implements Appender
-func (a SidecarsCheckAppender) AppendGraph(trafficMap graph.TrafficMap, _ string) {
+func (a SidecarsCheckAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
 
-	business, err := business.Get()
-	checkError(err)
+	if globalInfo.Business == nil {
+		var err error
+		globalInfo.Business, err = business.Get()
+		checkError(err)
+	}
+	if namespaceInfo.WorkloadList == nil {
+		workloadList, err := globalInfo.Business.Workload.GetWorkloadList(namespaceInfo.Namespace)
+		checkError(err)
+		namespaceInfo.WorkloadList = &workloadList
+	}
 
-	a.applySidecarsChecks(trafficMap, business)
+	a.applySidecarsChecks(trafficMap, namespaceInfo)
 }
 
-func (a *SidecarsCheckAppender) applySidecarsChecks(trafficMap graph.TrafficMap, business *business.Layer) {
+func (a *SidecarsCheckAppender) applySidecarsChecks(trafficMap graph.TrafficMap, namespaceInfo *NamespaceInfo) {
 	cfg := config.Get()
-	appLabel := cfg.IstioLabels.AppLabelName
-	versionLabel := cfg.IstioLabels.VersionLabelName
 	istioNamespace := cfg.IstioNamespace
+	workloadList := namespaceInfo.WorkloadList
 
 	for _, n := range trafficMap {
-
-		// Skip the check on the sidecars if we don't have access to the namespace
-		if _, found := a.AccessibleNamespaces[n.Namespace]; !found {
+		// Skip the check if this node is outside the requested namespace, we limit badging to the requested namespaces
+		if n.Namespace != namespaceInfo.Namespace {
 			continue
 		}
 
@@ -48,38 +49,31 @@ func (a *SidecarsCheckAppender) applySidecarsChecks(trafficMap graph.TrafficMap,
 			continue
 		}
 
-		// get the pods for the node, either by app+version labels, or workload deployment
-		var err error
-		var pods models.Pods
+		// get the workloads for the node and check to see if they have sidecars. Note that
+		// if there are no workloads/pods we don't flag it as missing sidecars.  No pods means
+		// no missing sidecars.  (In most cases this means it was flagged as dead, and handled above)
+		hasIstioSidecar := true
 		switch n.NodeType {
 		case graph.NodeTypeWorkload:
-			workload, err := business.Workload.GetWorkload(n.Namespace, n.Workload, false)
-			if err == nil {
-				pods = workload.Pods
+			if workload, found := getWorkload(n.Workload, workloadList); found {
+				hasIstioSidecar = workload.IstioSidecar
 			}
 		case graph.NodeTypeApp:
-			podLabels := a.getAppLabels(appLabel, n.App, versionLabel, n.Version)
-			pods, err = business.Workload.GetPods(n.Namespace, podLabels)
+			workloads := getAppWorkloads(n.App, n.Version, workloadList)
+			if len(workloads) > 0 {
+				for _, workload := range workloads {
+					if !workload.IstioSidecar {
+						hasIstioSidecar = false
+						break
+					}
+				}
+			}
 		default:
 			continue
 		}
-		checkError(err)
 
-		if len(pods) == 0 {
-			log.Warningf("Sidecar check found no pods Checking sidecars node [%s]", n.ID)
-			continue
-		}
-
-		if !pods.HasIstioSideCar() {
+		if !hasIstioSidecar {
 			n.Metadata["hasMissingSC"] = true
 		}
 	}
-}
-
-func (a *SidecarsCheckAppender) getAppLabels(appLabel, app, versionLabel, version string) string {
-	versionOk := version != "" && version != graph.UnknownVersion
-	if versionOk {
-		return fmt.Sprintf("%s=%s,%s=%s", appLabel, app, versionLabel, version)
-	}
-	return fmt.Sprintf("%s=%s", appLabel, app)
 }

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -217,9 +217,7 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 		appenders = append(appenders, appender.IstioAppender{})
 	}
 	if csl == AppenderAll || strings.Contains(csl, "sidecars_check") {
-		appenders = append(appenders, appender.SidecarsCheckAppender{
-			AccessibleNamespaces: o.AccessibleNamespaces,
-		})
+		appenders = append(appenders, appender.SidecarsCheckAppender{})
 	}
 
 	return appenders

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -89,7 +89,7 @@ func graphNamespaces(o options.Options, client *prometheus.Client) graph.Traffic
 		for _, a := range o.Appenders {
 			a.AppendGraph(namespaceTrafficMap, globalInfo, namespaceInfo)
 		}
-		mergeTrafficMaps(trafficMap, namespaceTrafficMap)
+		mergeTrafficMaps(trafficMap, namespace, namespaceTrafficMap)
 	}
 
 	// The appenders can add/remove/alter nodes. After the manipulations are complete
@@ -107,13 +107,22 @@ func graphNamespaces(o options.Options, client *prometheus.Client) graph.Traffic
 }
 
 // mergeTrafficMaps ensures that we only have unique nodes by removing duplicate
-// nodes and merging their edges.  We also need to avoid duplicate edges, it can
+// nodes and merging their edges.  When removing a duplicate prefer an instance
+// from the namespace being merged-in because it is guaranteed to have all appender
+// information applied. We also need to avoid duplicate edges, it can
 // happen when an terminal node of one namespace is a root node of another:
 //   ns1 graph: unknown -> ns1:A -> ns2:B
 //   ns2 graph:   ns1:A -> ns2:B -> ns2:C
-func mergeTrafficMaps(trafficMap, nsTrafficMap graph.TrafficMap) {
+func mergeTrafficMaps(trafficMap graph.TrafficMap, ns string, nsTrafficMap graph.TrafficMap) {
 	for nsId, nsNode := range nsTrafficMap {
 		if node, isDup := trafficMap[nsId]; isDup {
+			if nsNode.Namespace == ns {
+				// prefer nsNode (see above comment), so do a swap
+				trafficMap[nsId] = nsNode
+				temp := node
+				node = nsNode
+				nsNode = temp
+			}
 			for _, nsEdge := range nsNode.Edges {
 				isDupEdge := false
 				for _, e := range node.Edges {

--- a/models/workload.go
+++ b/models/workload.go
@@ -61,6 +61,11 @@ type WorkloadListItem struct {
 	// required: true
 	// example: true
 	VersionLabel bool `json:"versionLabel"`
+
+	// Number of current workload pods
+	// required: true
+	// example: 1
+	PodCount int `json:"podCount"`
 }
 
 type WorkloadOverviews []*WorkloadListItem
@@ -101,6 +106,7 @@ func (workload *WorkloadListItem) ParseWorkload(w *Workload) {
 	workload.ResourceVersion = w.ResourceVersion
 	workload.IstioSidecar = w.Pods.HasIstioSideCar()
 	workload.Labels = w.Labels
+	workload.PodCount = len(w.Pods)
 
 	/** Check the labels app and version required by Istio in template Pods*/
 	_, workload.AppLabel = w.Labels[conf.IstioLabels.AppLabelName]


### PR DESCRIPTION
- cache global and namespace-level info so appenders can reuse it
- update sidecars_check appender to leverage business package support because it already determines whether the backing workload's pods have a sidecar
- redo dead_node appender logic for flagging egress nodes, it was very slow
    
    TODO: Update tests
    TODO: replace business layer call in dead_node appepender when it performs

@jmazzitelli This can be tested/reviewed but is not ready for merge until the TODOs are complete
