### PR TITLE
Revert "KIALI-1661 Provide permissions on istio objects"

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	auth_v1 "k8s.io/api/authorization/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -25,16 +23,6 @@ type IstioConfigCriteria struct {
 	IncludeQuotaSpecBindings bool
 }
 
-var resourceTypesToAPI = map[string]string{
-	"destinationrules":  "networking.istio.io",
-	"virtualservices":   "networking.istio.io",
-	"serviceentries":    "networking.istio.io",
-	"gateways":          "networking.istio.io",
-	"rules":             "config.istio.io",
-	"quotaspecs":        "config.istio.io",
-	"quotaspecbindings": "config.istio.io",
-}
-
 // GetIstioConfig returns a list of Istio routing objects
 // and Mixer Rules per a given Namespace.
 func (in *IstioConfigService) GetIstioConfig(criteria IstioConfigCriteria) (models.IstioConfigList, error) {
@@ -50,13 +38,12 @@ func (in *IstioConfigService) GetIstioConfig(criteria IstioConfigCriteria) (mode
 		Rules:             models.IstioRules{},
 		QuotaSpecs:        models.QuotaSpecs{},
 		QuotaSpecBindings: models.QuotaSpecBindings{},
-		Permissions:       make(map[string]models.ResourcePermissions),
 	}
 	var gg, vs, dr, se, qs, qb []kubernetes.IstioObject
 	var mr *kubernetes.IstioRules
-	var ggErr, vsErr, drErr, seErr, mrErr, qsErr, qbErr, pxErr error
+	var ggErr, vsErr, drErr, seErr, mrErr, qsErr, qbErr error
 	var wg sync.WaitGroup
-	wg.Add(8)
+	wg.Add(7)
 
 	go func() {
 		defer wg.Done()
@@ -121,25 +108,9 @@ func (in *IstioConfigService) GetIstioConfig(criteria IstioConfigCriteria) (mode
 		}
 	}()
 
-	go func() {
-		defer wg.Done()
-		ssars, pxErr := in.k8s.GetSelfSubjectAccessReview(criteria.Namespace, []string{"create", "update", "delete"}, resourceTypesToAPI)
-		if pxErr == nil {
-			for _, ssar := range ssars {
-				resource := ssar.Spec.ResourceAttributes.Resource
-				permission, ok := istioConfigList.Permissions[resource]
-				if !ok {
-					permission = models.ResourcePermissions{}
-				}
-				fillPermission(&permission, ssar)
-				istioConfigList.Permissions[resource] = permission
-			}
-		}
-	}()
-
 	wg.Wait()
 
-	for _, genErr := range []error{ggErr, vsErr, drErr, seErr, mrErr, qsErr, qbErr, pxErr} {
+	for _, genErr := range []error{ggErr, vsErr, drErr, seErr, mrErr, qsErr, qbErr} {
 		if genErr != nil {
 			return models.IstioConfigList{}, genErr
 		}
@@ -155,23 +126,6 @@ func (in *IstioConfigService) GetIstioConfigDetails(namespace string, objectType
 	var gw, vs, dr, se, qs, qb kubernetes.IstioObject
 	var r *kubernetes.IstioRuleDetails
 	var err error
-	permission := models.ResourcePermissions{}
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-		if api, ok := resourceTypesToAPI[objectType]; ok {
-			resourceAndGroup := map[string]string{objectType: api}
-			ssars, permErr := in.k8s.GetSelfSubjectAccessReview(namespace, []string{"create", "update", "delete"}, resourceAndGroup)
-			if permErr == nil {
-				for _, ssar := range ssars {
-					fillPermission(&permission, ssar)
-				}
-			}
-		}
-	}()
-
 	switch objectType {
 	case "gateways":
 		if gw, err = in.k8s.GetGateway(namespace, object); err == nil {
@@ -214,19 +168,5 @@ func (in *IstioConfigService) GetIstioConfigDetails(namespace string, objectType
 		err = fmt.Errorf("Object type not found: %v", objectType)
 	}
 
-	wg.Wait()
-	istioConfigDetail.Permissions = permission
-
 	return istioConfigDetail, err
-}
-
-func fillPermission(permission *models.ResourcePermissions, ssar *auth_v1.SelfSubjectAccessReview) {
-	switch ssar.Spec.ResourceAttributes.Verb {
-	case "create":
-		permission.Create = ssar.Status.Allowed
-	case "update":
-		permission.Update = ssar.Status.Allowed
-	case "delete":
-		permission.Delete = ssar.Status.Allowed
-	}
 }

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	auth_v1 "k8s.io/api/authorization/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
-	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 )
 
@@ -37,11 +35,6 @@ func TestGetIstioConfig(t *testing.T) {
 	assert.Equal(0, len(istioconfigList.Rules))
 	assert.Equal(0, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
-	assert.Equal(models.ResourcePermissions{
-		Create: false,
-		Update: true,
-		Delete: false,
-	}, istioconfigList.Permissions["destinationrules"])
 	assert.Nil(err)
 
 	criteria.IncludeGateways = true
@@ -143,11 +136,6 @@ func TestGetIstioConfigDetails(t *testing.T) {
 
 	istioConfigDetails, err := configService.GetIstioConfigDetails("test", "gateways", "gw-1")
 	assert.Equal("gw-1", istioConfigDetails.Gateway.Name)
-	assert.Equal(models.ResourcePermissions{
-		Create: false,
-		Update: true,
-		Delete: false,
-	}, istioConfigDetails.Permissions)
 	assert.Nil(err)
 
 	istioConfigDetails, err = configService.GetIstioConfigDetails("test", "virtualservices", "reviews")
@@ -179,7 +167,6 @@ func mockGetIstioConfig() IstioConfigService {
 	k8s.On("GetIstioRules", mock.AnythingOfType("string")).Return(fakeGetIstioRules(), nil)
 	k8s.On("GetQuotaSpecs", mock.AnythingOfType("string")).Return(fakeGetQuotaSpecs(), nil)
 	k8s.On("GetQuotaSpecBindings", mock.AnythingOfType("string")).Return(fakeGetQuotaSpecBindings(), nil)
-	k8s.On("GetSelfSubjectAccessReview", "test", mock.AnythingOfType("[]string"), mock.AnythingOfType("map[string]string")).Return(fakeGetSelfSubjectAccessReview(), nil)
 
 	return IstioConfigService{k8s: k8s}
 }
@@ -420,49 +407,6 @@ func fakeGetQuotaSpecBindings() []kubernetes.IstioObject {
 	return []kubernetes.IstioObject{&quotaSpec}
 }
 
-func fakeGetSelfSubjectAccessReview() []*auth_v1.SelfSubjectAccessReview {
-	create := auth_v1.SelfSubjectAccessReview{
-		Spec: auth_v1.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &auth_v1.ResourceAttributes{
-				Namespace: "test",
-				Verb:      "create",
-				Resource:  "destinationrules",
-			},
-		},
-		Status: auth_v1.SubjectAccessReviewStatus{
-			Allowed: false,
-			Reason:  "not authorized",
-		},
-	}
-	update := auth_v1.SelfSubjectAccessReview{
-		Spec: auth_v1.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &auth_v1.ResourceAttributes{
-				Namespace: "test",
-				Verb:      "update",
-				Resource:  "destinationrules",
-			},
-		},
-		Status: auth_v1.SubjectAccessReviewStatus{
-			Allowed: true,
-			Reason:  "authorized",
-		},
-	}
-	delete := auth_v1.SelfSubjectAccessReview{
-		Spec: auth_v1.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &auth_v1.ResourceAttributes{
-				Namespace: "test",
-				Verb:      "delete",
-				Resource:  "destinationrules",
-			},
-		},
-		Status: auth_v1.SubjectAccessReviewStatus{
-			Allowed: false,
-			Reason:  "not authorized",
-		},
-	}
-	return []*auth_v1.SelfSubjectAccessReview{&create, &update, &delete}
-}
-
 func mockGetIstioConfigDetails() IstioConfigService {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetGateway", "test", "gw-1").Return(fakeGetGateways()[0], nil)
@@ -472,7 +416,6 @@ func mockGetIstioConfigDetails() IstioConfigService {
 	k8s.On("GetIstioRuleDetails", "test", "checkfromcustomer").Return(fakeGetIstioRuleDetails(), nil)
 	k8s.On("GetQuotaSpec", "test", "request-count").Return(fakeGetQuotaSpecs()[0], nil)
 	k8s.On("GetQuotaSpecBinding", "test", "request-count").Return(fakeGetQuotaSpecBindings()[0], nil)
-	k8s.On("GetSelfSubjectAccessReview", "test", mock.AnythingOfType("[]string"), mock.AnythingOfType("map[string]string")).Return(fakeGetSelfSubjectAccessReview(), nil)
 
 	return IstioConfigService{k8s: k8s}
 }

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -7,7 +7,6 @@ import (
 
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/apps/v1beta2"
-	auth_v1 "k8s.io/api/authorization/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
@@ -65,7 +64,6 @@ type IstioClientInterface interface {
 	GetQuotaSpecs(namespace string) ([]IstioObject, error)
 	GetQuotaSpecBinding(namespace string, quotaSpecBindingName string) (IstioObject, error)
 	GetQuotaSpecBindings(namespace string) ([]IstioObject, error)
-	GetSelfSubjectAccessReview(namespace string, verbs []string, resourceAndGroups map[string]string) ([]*auth_v1.SelfSubjectAccessReview, error)
 	IsOpenShift() bool
 }
 

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/apps/v1beta2"
-	auth_v1 "k8s.io/api/authorization/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
@@ -203,44 +202,4 @@ func (in *IstioClient) GetJobs(namespace string) ([]batch_v1.Job, error) {
 // This method helps upper layers to send a explicit NotFound error without querying the backend.
 func NewNotFound(name, group, resource string) error {
 	return errors.NewNotFound(schema.GroupResource{Group: group, Resource: resource}, name)
-}
-
-// GetSelfSubjectAccessReview provides information on Kiali permissions
-func (in *IstioClient) GetSelfSubjectAccessReview(namespace string, verbs []string, resourceAndGroups map[string]string) ([]*auth_v1.SelfSubjectAccessReview, error) {
-	calls := len(verbs) * len(resourceAndGroups)
-	ch := make(chan *auth_v1.SelfSubjectAccessReview, calls)
-	errChan := make(chan error)
-	for _, v := range verbs {
-		for r, g := range resourceAndGroups {
-			go func(verb, group, resource string) {
-				res, err := in.k8s.AuthorizationV1().SelfSubjectAccessReviews().Create(&auth_v1.SelfSubjectAccessReview{
-					Spec: auth_v1.SelfSubjectAccessReviewSpec{
-						ResourceAttributes: &auth_v1.ResourceAttributes{
-							Namespace: namespace,
-							Verb:      verb,
-							Group:     group,
-							Resource:  resource,
-						},
-					},
-				})
-				if err != nil {
-					errChan <- err
-				} else {
-					ch <- res
-				}
-			}(v, g, r)
-		}
-	}
-
-	var err error
-	result := []*auth_v1.SelfSubjectAccessReview{}
-	for count := 0; count < calls; count++ {
-		select {
-		case res := <-ch:
-			result = append(result, res)
-		case err = <-errChan:
-			// No op
-		}
-	}
-	return result, err
 }

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -4,7 +4,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/apps/v1beta2"
-	auth_v1 "k8s.io/api/authorization/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
@@ -209,11 +208,6 @@ func (o *K8SClientMock) GetJob(namespace, jobName string) (*batch_v1.Job, error)
 func (o *K8SClientMock) GetJobs(namespace string) ([]batch_v1.Job, error) {
 	args := o.Called(namespace)
 	return args.Get(0).([]batch_v1.Job), args.Error(1)
-}
-
-func (o *K8SClientMock) GetSelfSubjectAccessReview(namespace string, verbs []string, resourceAndGroups map[string]string) ([]*auth_v1.SelfSubjectAccessReview, error) {
-	args := o.Called(namespace, verbs, resourceAndGroups)
-	return args.Get(0).([]*auth_v1.SelfSubjectAccessReview), args.Error(1)
 }
 
 func (o *K8SClientMock) FakeService() *v1.Service {

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -17,28 +17,16 @@ type IstioConfigList struct {
 	Rules             IstioRules        `json:"rules"`
 	QuotaSpecs        QuotaSpecs        `json:"quotaSpecs"`
 	QuotaSpecBindings QuotaSpecBindings `json:"quotaSpecBindings"`
-	// The permissions associated with the Istio objects. This is a map of Istio object kind (destinationrules, virtualservices, etc.) x ResourcePermissions
-	// Example: {"destinationrules": {create: false, update: true, delete: false}}
-	Permissions map[string]ResourcePermissions `json:"permissions"`
 }
 
 type IstioConfigDetails struct {
-	Namespace        Namespace           `json:"namespace"`
-	ObjectType       string              `json:"objectType"`
-	Gateway          *Gateway            `json:"gateway"`
-	VirtualService   *VirtualService     `json:"virtualService"`
-	DestinationRule  *DestinationRule    `json:"destinationRule"`
-	ServiceEntry     *ServiceEntry       `json:"serviceEntry"`
-	Rule             *IstioRuleDetails   `json:"rule"`
-	QuotaSpec        *QuotaSpec          `json:"quotaSpec"`
-	QuotaSpecBinding *QuotaSpecBinding   `json:"quotaSpecBinding"`
-	Permissions      ResourcePermissions `json:"permissions"`
-}
-
-// ResourcePermissions holds permission flags for an object type
-// True means allowed.
-type ResourcePermissions struct {
-	Create bool `json:"create"`
-	Update bool `json:"update"`
-	Delete bool `json:"delete"`
+	Namespace        Namespace         `json:"namespace"`
+	ObjectType       string            `json:"objectType"`
+	Gateway          *Gateway          `json:"gateway"`
+	VirtualService   *VirtualService   `json:"virtualService"`
+	DestinationRule  *DestinationRule  `json:"destinationRule"`
+	ServiceEntry     *ServiceEntry     `json:"serviceEntry"`
+	Rule             *IstioRuleDetails `json:"rule"`
+	QuotaSpec        *QuotaSpec        `json:"quotaSpec"`
+	QuotaSpecBinding *QuotaSpecBinding `json:"quotaSpecBinding"`
 }


### PR DESCRIPTION
Reverts kiali/kiali#554

This PR is logically correct, but introduces a performance penalty.
So we are going to remove it from master until we can put in place a cache (similar as istio uses in adapters to query objects).