### PR TITLE
KIALI-1186 Use user tokens when accessing the k8s master

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -33,6 +33,12 @@ func Get() (*Layer, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	userk8s, err := kubernetes.NewUserClient()
+	if err != nil {
+		return nil, err
+	}
+
 	// We don't update the global layer here to keep it stateless
 	temporaryLayer := &Layer{}
 	temporaryLayer.Health = HealthService{prom: prom, k8s: k8s}
@@ -41,12 +47,12 @@ func Get() (*Layer, error) {
 	temporaryLayer.IstioConfig = IstioConfigService{k8s: k8s}
 	temporaryLayer.Workload = WorkloadService{k8s: k8s}
 	temporaryLayer.App = AppService{k8s: k8s}
-	temporaryLayer.Namespace = NewNamespaceService(k8s)
+	temporaryLayer.Namespace = NewNamespaceService(userk8s)
 	return temporaryLayer, nil
 }
 
 // SetWithBackends creates all services with injected clients to external APIs
-func SetWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.ClientInterface) *Layer {
+func SetWithBackends(k8s kubernetes.IstioClientInterface, k8sUserClient kubernetes.UserClientInterface, prom prometheus.ClientInterface) *Layer {
 	layer = &Layer{}
 	layer.Health = HealthService{prom: prom, k8s: k8s}
 	layer.Svc = SvcService{prom: prom, k8s: k8s, health: &layer.Health}
@@ -54,6 +60,6 @@ func SetWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	layer.IstioConfig = IstioConfigService{k8s: k8s}
 	layer.Workload = WorkloadService{k8s: k8s}
 	layer.App = AppService{k8s: k8s}
-	layer.Namespace = NewNamespaceService(k8s)
+	layer.Namespace = NewNamespaceService(k8sUserClient)
 	return layer
 }

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -7,42 +7,48 @@ import (
 
 // Namespace deals with fetching k8s namespaces / OpenShift projects and convert to kiali model
 type NamespaceService struct {
-	k8s         kubernetes.IstioClientInterface
 	hasProjects bool
+	userClient  kubernetes.UserClientInterface
 }
 
-func NewNamespaceService(k8s kubernetes.IstioClientInterface) NamespaceService {
-
+func NewNamespaceService(userClient kubernetes.UserClientInterface) NamespaceService {
 	var hasProjects bool
 
-	if k8s != nil && k8s.IsOpenShift() {
+	// TODO: figure out a better way to handle endpoints that don't need authentication
+	client, _ := userClient.NewClient("")
+	if client != nil && client.IsOpenShift() {
 		hasProjects = true
 	} else {
 		hasProjects = false
 	}
 
 	return NamespaceService{
-		k8s:         k8s,
 		hasProjects: hasProjects,
+		userClient:  userClient,
 	}
 }
 
 // Returns a list of the given namespaces / projects
-func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
+func (in *NamespaceService) GetNamespaces(userToken string) ([]models.Namespace, error) {
+
+	client, err := in.userClient.NewClient(userToken)
+	if err != nil {
+		return nil, err
+	}
 
 	// If we are running in OpenShift, we will use the project names since these are the list of accessible namespaces
 	if in.hasProjects {
-		projects, err := in.k8s.GetProjects()
+		projects, err := client.GetProjects()
 		if err == nil {
 			// Everything is good, return the projects we got from OpenShift / kube-project
 			return models.CastProjectCollection(projects), nil
 		}
 	}
 
-	services, err := in.k8s.GetNamespaces()
+	namespaces, err := client.GetNamespaces()
 	if err != nil {
 		return nil, err
 	}
 
-	return models.CastNamespaceCollection(services), nil
+	return models.CastNamespaceCollection(namespaces), nil
 }

--- a/graph/appender/appender.go
+++ b/graph/appender/appender.go
@@ -10,5 +10,5 @@ import (
 type Appender interface {
 	// AppendGraph performs the appender work on the provided traffic map. The map
 	// may be initially empty. An appender is allowed to add or remove map entries.
-	AppendGraph(trafficMap graph.TrafficMap, namespace string)
+	AppendGraph(trafficMap graph.TrafficMap, namespace string, usertoken string)
 }

--- a/graph/appender/dead_node.go
+++ b/graph/appender/dead_node.go
@@ -19,7 +19,7 @@ type DeadNodeAppender struct {
 }
 
 // AppendGraph implements Appender
-func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, _ string) {
+func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, _ string, usertoken string) {
 	if len(trafficMap) == 0 {
 		return
 	}
@@ -28,7 +28,7 @@ func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, _ string) {
 	checkError(err)
 
 	if a.externalServices == nil {
-		a.externalServices = resolveExternalServices(business)
+		a.externalServices = resolveExternalServices(business, usertoken)
 	}
 
 	applyDeadNodes(trafficMap, business.Workload, a.externalServices)
@@ -38,8 +38,8 @@ func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, _ string) {
 // by using ServiceEntries resources across all namespaces in the cluster.
 // All ServiceEntries are needed, because Istio does not distinguish where the
 // ServiceEntries are created when routing egress traffic.
-func resolveExternalServices(bLayer *business.Layer) map[string]bool {
-	namespaces, err := bLayer.Namespace.GetNamespaces()
+func resolveExternalServices(bLayer *business.Layer, usertoken string) map[string]bool {
+	namespaces, err := bLayer.Namespace.GetNamespaces(usertoken)
 	checkError(err)
 
 	serviceEntries := make(map[string]bool)

--- a/graph/appender/dead_node_test.go
+++ b/graph/appender/dead_node_test.go
@@ -116,7 +116,7 @@ func setupWorkloadService() business.WorkloadService {
 
 	config.Set(config.NewConfig())
 
-	return business.SetWithBackends(k8s, nil).Workload
+	return business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), nil).Workload
 }
 
 func TestDeadNode(t *testing.T) {

--- a/graph/appender/istio_details.go
+++ b/graph/appender/istio_details.go
@@ -8,7 +8,7 @@ import (
 type IstioAppender struct{}
 
 // AppendGraph implements Appender
-func (a IstioAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string) {
+func (a IstioAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string, _ string) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/appender/response_time.go
+++ b/graph/appender/response_time.go
@@ -29,7 +29,7 @@ type ResponseTimeAppender struct {
 }
 
 // AppendGraph implements Appender
-func (a ResponseTimeAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string) {
+func (a ResponseTimeAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string, _ string) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/appender/security_policy.go
+++ b/graph/appender/security_policy.go
@@ -22,7 +22,7 @@ type SecurityPolicyAppender struct {
 }
 
 // AppendGraph implements Appender
-func (a SecurityPolicyAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string) {
+func (a SecurityPolicyAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string, _ string) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/appender/sidecars_check.go
+++ b/graph/appender/sidecars_check.go
@@ -14,7 +14,7 @@ type SidecarsCheckAppender struct {
 }
 
 // AppendGraph implements Appender
-func (a SidecarsCheckAppender) AppendGraph(trafficMap graph.TrafficMap, _ string) {
+func (a SidecarsCheckAppender) AppendGraph(trafficMap graph.TrafficMap, _ string, _ string) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/appender/sidecars_check_test.go
+++ b/graph/appender/sidecars_check_test.go
@@ -27,7 +27,7 @@ func TestWorkloadSidecarsPasses(t *testing.T) {
 
 	trafficMap := buildWorkloadTrafficMap()
 	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
-	business := business.SetWithBackends(k8s, nil)
+	business := business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)
 
@@ -46,7 +46,7 @@ func TestWorkloadWithMissingSidecarsIsFlagged(t *testing.T) {
 
 	trafficMap := buildWorkloadTrafficMap()
 	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
-	business := business.SetWithBackends(k8s, nil)
+	business := business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)
 
@@ -65,7 +65,7 @@ func TestAppSidecarsPasses(t *testing.T) {
 
 	trafficMap := buildAppTrafficMap()
 	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
-	business := business.SetWithBackends(k8s, nil)
+	business := business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)
 
@@ -82,7 +82,7 @@ func TestAppWithMissingSidecarsIsFlagged(t *testing.T) {
 
 	trafficMap := buildAppTrafficMap()
 	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
-	business := business.SetWithBackends(k8s, nil)
+	business := business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)
 
@@ -99,7 +99,7 @@ func TestServicesAreAlwaysValid(t *testing.T) {
 
 	trafficMap := buildServiceTrafficMap()
 	sidecarsAppender := SidecarsCheckAppender{AccessibleNamespaces: map[string]bool{"testing": true}}
-	business := business.SetWithBackends(k8s, nil)
+	business := business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), nil)
 
 	sidecarsAppender.applySidecarsChecks(trafficMap, business)
 

--- a/graph/appender/unused_node.go
+++ b/graph/appender/unused_node.go
@@ -14,7 +14,7 @@ type UnusedNodeAppender struct {
 }
 
 // AppendGraph implements Appender
-func (a UnusedNodeAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string) {
+func (a UnusedNodeAppender) AppendGraph(trafficMap graph.TrafficMap, namespace string, _ string) {
 	if graph.GraphTypeService == a.GraphType || a.IsNodeGraph {
 		return
 	}

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -141,7 +141,8 @@ func setupAppMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.Pr
 		}))
 
 	ts := httptest.NewServer(mr)
-	business.SetWithBackends(nil, prom)
+        k8s := kubetest.NewK8SClientMock()
+	business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), prom)
 	return ts, api
 }
 
@@ -149,7 +150,7 @@ func setupAppListEndpoint() (*httptest.Server, *kubetest.K8SClientMock, *prometh
 	config.Set(config.NewConfig())
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
-	business.SetWithBackends(k8s, prom)
+	business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), prom)
 
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/apps", AppList)

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -84,7 +84,7 @@ func graphNamespaces(o options.Options, client *prometheus.Client) graph.Traffic
 		namespaceTrafficMap := buildNamespaceTrafficMap(namespace, o, client)
 
 		for _, a := range o.Appenders {
-			a.AppendGraph(namespaceTrafficMap, namespace)
+			a.AppendGraph(namespaceTrafficMap, namespace, o.Token)
 		}
 		mergeTrafficMaps(trafficMap, namespaceTrafficMap)
 	}
@@ -639,8 +639,10 @@ func graphNode(w http.ResponseWriter, r *http.Request, client *prometheus.Client
 
 	trafficMap := buildNodeTrafficMap(namespace, n, o, client)
 
+	usertoken := r.Context().Value("user-token").(string)
+
 	for _, a := range o.Appenders {
-		a.AppendGraph(trafficMap, namespace)
+		a.AppendGraph(trafficMap, namespace, usertoken)
 	}
 
 	// The appenders can add/remove/alter nodes. After the manipulations are complete

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -62,7 +62,7 @@ func setupMocked() (*prometheus.Client, *prometheustest.PromAPIMock, error) {
 	}
 	client.Inject(api)
 
-	business.SetWithBackends(k8s, nil)
+	business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), nil)
 	return client, api, nil
 }
 

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -87,7 +87,7 @@ func TestNamespaceAppHealth(t *testing.T) {
 func setupNamespaceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
-	business.SetWithBackends(k8s, prom)
+	business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), prom)
 
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/health", NamespaceHealth)
@@ -161,7 +161,7 @@ func TestAppHealth(t *testing.T) {
 func setupAppHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
-	business.SetWithBackends(k8s, prom)
+	business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), prom)
 
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/apps/{app}/health", AppHealth)
@@ -207,7 +207,7 @@ func TestServiceHealth(t *testing.T) {
 func setupServiceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
-	business.SetWithBackends(k8s, prom)
+	business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), prom)
 
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/services/{service}/health", ServiceHealth)

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -19,7 +19,9 @@ func NamespaceList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	namespaces, err := business.Namespace.GetNamespaces()
+	userToken := r.Context().Value("user-token").(string)
+
+	namespaces, err := business.Namespace.GetNamespaces(userToken)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -322,7 +322,7 @@ func setupServiceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustes
 		}))
 
 	ts := httptest.NewServer(mr)
-	business.SetWithBackends(k8s, prom)
+	business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), prom)
 	return ts, api
 	// return nil, ts, api
 }

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -28,7 +28,7 @@ import (
 func setupWorkloadList() (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
-	business.SetWithBackends(k8s, prom)
+	business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), prom)
 
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/workloads", WorkloadList)
@@ -300,6 +300,7 @@ func setupWorkloadMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheuste
 		}))
 
 	ts := httptest.NewServer(mr)
-	business.SetWithBackends(nil, prom)
+        k8s := kubetest.NewK8SClientMock()
+	business.SetWithBackends(k8s, kubetest.NewUserClientMock(k8s), prom)
 	return ts, api
 }

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -19,10 +19,26 @@ type K8SClientMock struct {
 	mock.Mock
 }
 
+type K8SUserClientMock struct {
+	mock.Mock
+	k8s	*K8SClientMock
+}
+
 func NewK8SClientMock() *K8SClientMock {
 	k8s := new(K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
 	return k8s
+}
+
+func NewUserClientMock(k8s *K8SClientMock) *K8SUserClientMock {
+        userClient := new(K8SUserClientMock)
+        userClient.k8s = k8s
+        userClient.On("NewClient").Return(k8s)
+        return userClient
+}
+
+func (u *K8SUserClientMock) NewClient(token string) (kubernetes.IstioClientInterface, error) {
+	return u.k8s, nil
 }
 
 func (o *K8SClientMock) GetNamespaces() ([]v1.Namespace, error) {

--- a/routing/router.go
+++ b/routing/router.go
@@ -29,10 +29,12 @@ func NewRouter() *mux.Router {
 
 	// Build our API server routes and install them.
 	apiRoutes := NewRoutes()
+
+	authenticationHandler, _ := config.NewAuthenticationHandler()
 	for _, route := range apiRoutes.Routes {
 		var handlerFunction http.Handler
 		if handlerFunction = route.HandlerFunc; route.Authenticated {
-			handlerFunction = config.AuthenticationHandler(handlerFunction)
+			handlerFunction = authenticationHandler.Handle(handlerFunction)
 		}
 		appRouter.
 			Methods(route.Method).


### PR DESCRIPTION
Part of the mulitenancy tasks and is currently preliminary work. Looking for feedback before fully completing it.

** Describe the change **

When accessing the k8s master we need to be able to use the token associated with an individual user (or the SA token if using the Kiali basic auth login).

This only uses the SA token when logging into to Kiali using the current login mechanism, but once KIALI-1185 is done we can also provide the user's oauth token instead.

This is currently only modifying how we get the list of namespaces from the k8s master. All the other endpoints will have to be updated as well and we will need to remove access to these endpoints that don't require a user token.

This only changes how the backend code functions. There shouldn't be any changes to any of the other behaviour of Kiali.