### PR TITLE
KIALI-1776 Gateway validation shown in wrong place

### DIFF
--- a/business/checkers/virtual_services/no_gateway_checker.go
+++ b/business/checkers/virtual_services/no_gateway_checker.go
@@ -1,6 +1,8 @@
 package virtual_services
 
 import (
+	"strconv"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -13,10 +15,15 @@ type NoGatewayChecker struct {
 // Check validates that all the VirtualServices are pointing to an existing Gateway
 func (s NoGatewayChecker) Check() ([]*models.IstioCheck, bool) {
 	valid := false
+	index := -1
 	validations := make([]*models.IstioCheck, 0)
 
-	if valid = kubernetes.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.GatewayNames); !valid {
-		validation := models.BuildCheck("VirtualService is pointing to a non-existent gateway", "error", "")
+	if valid, index = kubernetes.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.GatewayNames); !valid {
+		path := ""
+		if index != -1 {
+			path = "spec/gateways[" + strconv.Itoa(index) + "]"
+		}
+		validation := models.BuildCheck("VirtualService is pointing to a non-existent gateway", "error", path)
 		validations = append(validations, &validation)
 	}
 	return validations, valid

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -575,19 +575,19 @@ func GatewayNames(gateways []IstioObject) map[string]struct{} {
 	return names
 }
 
-// ValidateVirtualServiceGateways checks all VirtualService gateways (except mesh, which is reserved word) and checks that they're found from the given list of gatewayNames
-func ValidateVirtualServiceGateways(spec map[string]interface{}, gatewayNames map[string]struct{}) bool {
+// ValidateVirtualServiceGateways checks all VirtualService gateways (except mesh, which is reserved word) and checks that they're found from the given list of gatewayNames. Also return index of missing gatways to show clearer error path in editor
+func ValidateVirtualServiceGateways(spec map[string]interface{}, gatewayNames map[string]struct{}) (bool, int) {
 	if gatewaysSpec, found := spec["gateways"]; found {
 		if gateways, ok := gatewaysSpec.([]interface{}); ok {
-			for _, g := range gateways {
+			for index, g := range gateways {
 				if gate, ok := g.(string); ok {
 					if _, found := gatewayNames[gate]; !found && gate != "mesh" {
-						return false
+						return false, index
 					}
 				}
 			}
 		}
 	}
-	// No gateways defined or all found
-	return true
+	// No gateways defined or all found. Return -1 indicates no missing gateway
+	return true, -1
 }


### PR DESCRIPTION
** Describe the change **

Gateway validation shown in wrong place

** Issue reference **
https://issues.jboss.org/browse/KIALI-1776

** Backwards incompatible? **
Yes


The bug is because "path" field in validation result is empty, so the error showed on the first line of ACE editor. And this pr will get the index number of missing gateway during validation, and pass it back to generate full path right at the missing gateway index number. And the result will be like: 

![screen shot 2018-10-19 at 17 47 09](https://user-images.githubusercontent.com/7776218/47211025-0fb0d580-d3c7-11e8-8103-e406913ad30c.png)


