### PR TITLE
KIALI-1730 Unify logic to fetch workload list and workload details

### DIFF
--- a/business/health_test.go
+++ b/business/health_test.go
@@ -1,6 +1,7 @@
 package business
 
 import (
+	"fmt"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/apps/v1beta2"
 	batch_v1 "k8s.io/api/batch/v1"
@@ -97,15 +98,24 @@ func TestGetWorkloadHealth(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
+	notfound := fmt.Errorf("not found")
 	k8s := new(kubetest.K8SClientMock)
 	prom := new(prometheustest.PromClientMock)
 	conf := config.NewConfig()
 	config.Set(conf)
 	hs := HealthService{k8s: k8s, prom: prom}
+	k8s.On("IsOpenShift").Return(true)
 	k8s.On("GetDeployment", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
 		assert.Equal("ns", args[0])
 		assert.Equal("reviews-v1", args[1])
 	}).Return(&fakeDeploymentsHealthReview()[0], nil)
+	k8s.On("GetDeploymentConfig", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&osappsv1.DeploymentConfig{}, notfound)
+	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1beta2.ReplicaSet{}, nil)
+	k8s.On("GetReplicationControllers", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.ReplicationController{}, nil)
+	k8s.On("GetStatefulSet", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&v1beta2.StatefulSet{}, notfound)
+	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsFromDaemonSet(), nil)
+	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
+	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
 	prom.On("GetWorkloadRequestRates", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeOtherRequestCounters())

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -86,6 +86,37 @@ func FakeDeployments() []v1beta1.Deployment {
 	}
 }
 
+func FakeDuplicatedDeployments() []v1beta1.Deployment {
+	conf := config.NewConfig()
+	config.Set(conf)
+	appLabel := conf.IstioLabels.AppLabelName
+	versionLabel := conf.IstioLabels.VersionLabelName
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	return []v1beta1.Deployment{
+		{
+			TypeMeta: meta_v1.TypeMeta{
+				Kind: "Deployment",
+			},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:              "duplicated-v1",
+				CreationTimestamp: meta_v1.NewTime(t1),
+			},
+			Spec: v1beta1.DeploymentSpec{
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{appLabel: "duplicated", versionLabel: "v1"},
+					},
+				},
+			},
+			Status: v1beta1.DeploymentStatus{
+				Replicas:            1,
+				AvailableReplicas:   1,
+				UnavailableReplicas: 0,
+			},
+		},
+	}
+}
+
 func FakeReplicaSets() []v1beta2.ReplicaSet {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -154,6 +185,43 @@ func FakeReplicaSets() []v1beta2.ReplicaSet {
 				Replicas:          2,
 				AvailableReplicas: 0,
 				ReadyReplicas:     2,
+			},
+		},
+	}
+}
+
+func FakeDuplicatedReplicaSets() []v1beta2.ReplicaSet {
+	conf := config.NewConfig()
+	config.Set(conf)
+	appLabel := conf.IstioLabels.AppLabelName
+	versionLabel := conf.IstioLabels.VersionLabelName
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	controller := true
+	return []v1beta2.ReplicaSet{
+		{
+			TypeMeta: meta_v1.TypeMeta{
+				Kind: "ReplicaSet",
+			},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:              "duplicated-v1-12345",
+				CreationTimestamp: meta_v1.NewTime(t1),
+				OwnerReferences: []meta_v1.OwnerReference{meta_v1.OwnerReference{
+					Controller: &controller,
+					Kind:       "Deployment",
+					Name:       "duplicated-v1",
+				}},
+			},
+			Spec: v1beta2.ReplicaSetSpec{
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{appLabel: "duplicated", versionLabel: "v1"},
+					},
+				},
+			},
+			Status: v1beta2.ReplicaSetStatus{
+				Replicas:          1,
+				AvailableReplicas: 1,
+				ReadyReplicas:     1,
 			},
 		},
 	}
@@ -375,6 +443,36 @@ func FakeStatefulSets() []v1beta2.StatefulSet {
 	}
 }
 
+func FakeDuplicatedStatefulSets() []v1beta2.StatefulSet {
+	conf := config.NewConfig()
+	config.Set(conf)
+	appLabel := conf.IstioLabels.AppLabelName
+	versionLabel := conf.IstioLabels.VersionLabelName
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	return []v1beta2.StatefulSet{
+		{
+			TypeMeta: meta_v1.TypeMeta{
+				Kind: "StatefulSet",
+			},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:              "duplicated-v1",
+				CreationTimestamp: meta_v1.NewTime(t1),
+			},
+			Spec: v1beta2.StatefulSetSpec{
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{appLabel: "duplicated", versionLabel: "v1"},
+					},
+				},
+			},
+			Status: v1beta2.StatefulSetStatus{
+				Replicas:      1,
+				ReadyReplicas: 1,
+			},
+		},
+	}
+}
+
 func FakeDepSyncedWithRS() []v1beta1.Deployment {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -460,6 +558,61 @@ func FakePodsSyncedWithDeployments() []v1.Pod {
 					Controller: &controller,
 					Kind:       "ReplicaSet",
 					Name:       "details-v1-3618568057",
+				}},
+				Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					v1.Container{Name: "details", Image: "whatever"},
+					v1.Container{Name: "istio-proxy", Image: "docker.io/istio/proxy:0.7.1"},
+				},
+				InitContainers: []v1.Container{
+					v1.Container{Name: "istio-init", Image: "docker.io/istio/proxy_init:0.7.1"},
+					v1.Container{Name: "enable-core-dump", Image: "alpine"},
+				},
+			},
+		},
+	}
+}
+
+func FakePodsSyncedWithDuplicated() []v1.Pod {
+	conf := config.NewConfig()
+	config.Set(conf)
+	appLabel := conf.IstioLabels.AppLabelName
+	versionLabel := conf.IstioLabels.VersionLabelName
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	controller := true
+	return []v1.Pod{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:              "duplicated-v1-3618568057-1",
+				CreationTimestamp: meta_v1.NewTime(t1),
+				Labels:            map[string]string{appLabel: "duplicated", versionLabel: "v1"},
+				OwnerReferences: []meta_v1.OwnerReference{meta_v1.OwnerReference{
+					Controller: &controller,
+					Kind:       "StatefulSet",
+					Name:       "duplicated-v1",
+				}},
+				Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					v1.Container{Name: "details", Image: "whatever"},
+					v1.Container{Name: "istio-proxy", Image: "docker.io/istio/proxy:0.7.1"},
+				},
+				InitContainers: []v1.Container{
+					v1.Container{Name: "istio-init", Image: "docker.io/istio/proxy_init:0.7.1"},
+					v1.Container{Name: "enable-core-dump", Image: "alpine"},
+				},
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:              "duplicated-v1-3618568057-3",
+				CreationTimestamp: meta_v1.NewTime(t1),
+				Labels:            map[string]string{appLabel: "duplicated", versionLabel: "v1"},
+				OwnerReferences: []meta_v1.OwnerReference{meta_v1.OwnerReference{
+					Controller: &controller,
+					Kind:       "StatefulSet",
+					Name:       "duplicated-v1",
 				}},
 				Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
 			Spec: v1.PodSpec{

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -522,30 +522,30 @@ func fetchWorkloads(k8s kubernetes.IstioClientInterface, namespace string, label
 }
 
 func fetchWorkload(k8s kubernetes.IstioClientInterface, namespace string, workloadName string) (*models.Workload, error) {
+	var pods []v1.Pod
+	var repcon []v1.ReplicationController
+	var dep *v1beta1.Deployment
+	var repset []v1beta2.ReplicaSet
+	var depcon *osappsv1.DeploymentConfig
+	var fulset *v1beta2.StatefulSet
+	var jbs []batch_v1.Job
+	var conjbs []batch_v1beta1.CronJob
+
 	wl := &models.Workload{
 		Pods:     models.Pods{},
 		Services: models.Services{},
 	}
 
-	var pods []v1.Pod
-	var dp *v1beta1.Deployment
-	var rs *v1beta2.ReplicaSet
-	var rc *v1.ReplicationController
-	var dc *osappsv1.DeploymentConfig
-	var sf *v1beta2.StatefulSet
-	var cj *batch_v1beta1.CronJob
-	var jb *batch_v1.Job
-
 	wg := sync.WaitGroup{}
-	wg.Add(2)
-	errChan := make(chan error, 1)
+	wg.Add(8)
+	errChan := make(chan error, 8)
 
 	go func() {
 		defer wg.Done()
 		var err error
 		pods, err = k8s.GetPods(namespace, "")
 		if err != nil {
-			log.Errorf("Error fetching Deployments per namespace %s: %s", namespace, err)
+			log.Errorf("Error fetching Pods per namespace %s: %s", namespace, err)
 			errChan <- err
 		}
 	}()
@@ -553,35 +553,69 @@ func fetchWorkload(k8s kubernetes.IstioClientInterface, namespace string, worklo
 	go func() {
 		defer wg.Done()
 		var err error
-		dp, err = k8s.GetDeployment(namespace, workloadName)
+		dep, err = k8s.GetDeployment(namespace, workloadName)
 		if err != nil {
-			dp = nil
-			rs, err = k8s.GetReplicaSet(namespace, workloadName)
+			dep = nil
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		var err error
+		repset, err = k8s.GetReplicaSets(namespace)
+		if err != nil {
+			log.Errorf("Error fetching ReplicaSets per namespace %s: %s", namespace, err)
+			errChan <- err
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		var err error
+		repcon, err = k8s.GetReplicationControllers(namespace)
+		if err != nil {
+			log.Errorf("Error fetching GetReplicationControllers per namespace %s: %s", namespace, err)
+			errChan <- err
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		var err error
+		if k8s.IsOpenShift() {
+			depcon, err = k8s.GetDeploymentConfig(namespace, workloadName)
 			if err != nil {
-				rs = nil
-				rc, err = k8s.GetReplicationController(namespace, workloadName)
-				if err != nil {
-					rc = nil
-					sf, err = k8s.GetStatefulSet(namespace, workloadName)
-					if err != nil {
-						sf = nil
-						cj, err = k8s.GetCronJob(namespace, workloadName)
-						if err != nil {
-							cj = nil
-							jb, err = k8s.GetJob(namespace, workloadName)
-							if err != nil {
-								jb = nil
-								if k8s.IsOpenShift() {
-									dc, err = k8s.GetDeploymentConfig(namespace, workloadName)
-									if err != nil {
-										dc = nil
-									}
-								}
-							}
-						}
-					}
-				}
+				depcon = nil
 			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		var err error
+		fulset, err = k8s.GetStatefulSet(namespace, workloadName)
+		if err != nil {
+			fulset = nil
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		var err error
+		conjbs, err = k8s.GetCronJobs(namespace)
+		if err != nil {
+			log.Errorf("Error fetching CronJobs per namespace %s: %s", namespace, err)
+			errChan <- err
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		var err error
+		jbs, err = k8s.GetJobs(namespace)
+		if err != nil {
+			log.Errorf("Error fetching Jobs per namespace %s: %s", namespace, err)
+			errChan <- err
 		}
 	}()
 
@@ -591,94 +625,290 @@ func fetchWorkload(k8s kubernetes.IstioClientInterface, namespace string, worklo
 		return wl, err
 	}
 
-	if dp != nil {
-		selector := labels.Set(dp.Spec.Template.Labels).AsSelector()
-		wl.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
-		wl.ParseDeployment(dp)
-		return wl, nil
-	}
+	// Key: name of controller; Value: type of controller
+	controllers := map[string]string{}
 
-	if rs != nil {
-		selector := labels.Set(rs.Spec.Template.Labels).AsSelector()
-		wl.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
-		wl.ParseReplicaSet(rs)
-		return wl, nil
-	}
-
-	if rc != nil {
-		selector := labels.Set(rc.Spec.Template.Labels).AsSelector()
-		wl.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
-		wl.ParseReplicationController(rc)
-		return wl, nil
-	}
-
-	if sf != nil {
-		selector := labels.Set(sf.Spec.Template.Labels).AsSelector()
-		wl.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
-		wl.ParseStatefulSet(sf)
-		return wl, nil
-	}
-
-	if cj != nil {
-		selector := labels.Set(cj.Spec.JobTemplate.Spec.Template.Labels).AsSelector()
-		wl.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
-		wl.ParseCronJob(cj)
-		return wl, nil
-	}
-
-	if jb != nil {
-		selector := labels.Set(jb.Spec.Template.Labels).AsSelector()
-		wl.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
-		wl.ParseJob(jb)
-		return wl, nil
-	}
-
-	if dc != nil {
-		selector := labels.Set(dc.Spec.Template.Labels).AsSelector()
-		wl.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
-		wl.ParseDeploymentConfig(dc)
-		return wl, nil
-	}
-
-	// Workload is a controller not listed or a pod
-	ctype := ""
-	found := false
-	iFound := -1
-	for i, pod := range pods {
-		if pod.Name == workloadName {
-			ctype = "Pod"
-			found = true
-			iFound = i
-			break
-		}
-		for _, ref := range pod.OwnerReferences {
-			if ref.Controller != nil && *ref.Controller && ref.Name == workloadName {
-				ctype = ref.Kind
-				break
+	// Find controllers from pods
+	for _, pod := range pods {
+		if len(pod.OwnerReferences) != 0 {
+			for _, ref := range pod.OwnerReferences {
+				if ref.Controller != nil && *ref.Controller {
+					if _, exist := controllers[ref.Name]; !exist {
+						controllers[ref.Name] = ref.Kind
+					} else {
+						if controllers[ref.Name] != ref.Kind {
+							controllers[ref.Name] = controllerPriority(controllers[ref.Name], ref.Kind)
+						}
+					}
+				}
+			}
+		} else {
+			if _, exist := controllers[pod.Name]; !exist {
+				// Pod without controller
+				controllers[pod.Name] = "Pod"
 			}
 		}
-		if ctype != "" {
-			break
+	}
+
+	// Resolve ReplicaSets from Deployments
+	// Resolve ReplicationControllers from DeploymentConfigs
+	// Resolve Jobs from CronJobs
+	for cname, ctype := range controllers {
+		if ctype == "ReplicaSet" {
+			found := false
+			iFound := -1
+			for i, rs := range repset {
+				if rs.Name == cname {
+					iFound = i
+					found = true
+					break
+				}
+			}
+			if found && len(repset[iFound].OwnerReferences) > 0 {
+				for _, ref := range repset[iFound].OwnerReferences {
+					if ref.Controller != nil && *ref.Controller {
+						// Delete the child ReplicaSet and add the parent controller
+						if _, exist := controllers[ref.Name]; !exist {
+							controllers[ref.Name] = ref.Kind
+						} else {
+							if controllers[ref.Name] != ref.Kind {
+								controllers[ref.Name] = controllerPriority(controllers[ref.Name], ref.Kind)
+							}
+						}
+						delete(controllers, cname)
+					}
+				}
+			}
+		}
+		if ctype == "ReplicationController" {
+			found := false
+			iFound := -1
+			for i, rc := range repcon {
+				if rc.Name == cname {
+					iFound = i
+					found = true
+					break
+				}
+			}
+			if found && len(repcon[iFound].OwnerReferences) > 0 {
+				for _, ref := range repcon[iFound].OwnerReferences {
+					if ref.Controller != nil && *ref.Controller {
+						// Delete the child ReplicationController and add the parent controller
+						if _, exist := controllers[ref.Name]; !exist {
+							controllers[ref.Name] = ref.Kind
+						} else {
+							if controllers[ref.Name] != ref.Kind {
+								controllers[ref.Name] = controllerPriority(controllers[ref.Name], ref.Kind)
+							}
+						}
+						delete(controllers, cname)
+					}
+				}
+			}
+		}
+		if ctype == "Job" {
+			found := false
+			iFound := -1
+			for i, jb := range jbs {
+				if jb.Name == cname {
+					iFound = i
+					found = true
+					break
+				}
+			}
+			if found && len(jbs[iFound].OwnerReferences) > 0 {
+				for _, ref := range jbs[iFound].OwnerReferences {
+					if ref.Controller != nil && *ref.Controller {
+						// Delete the child Job and add the parent controller
+						if _, exist := controllers[ref.Name]; !exist {
+							controllers[ref.Name] = ref.Kind
+						} else {
+							if controllers[ref.Name] != ref.Kind {
+								controllers[ref.Name] = controllerPriority(controllers[ref.Name], ref.Kind)
+							}
+						}
+						// Jobs are special as deleting CronJob parent doesn't delete children
+						// So we need to check that parent exists before to delete children controller
+						cnExist := false
+						for _, cnj := range conjbs {
+							if cnj.Name == ref.Name {
+								cnExist = true
+								break
+							}
+						}
+						if cnExist {
+							delete(controllers, cname)
+						}
+					}
+				}
+			}
 		}
 	}
 
-	if found && ctype == "Pod" {
-		wl.ParsePod(&pods[iFound])
-		wl.SetPods([]v1.Pod{pods[iFound]})
-		return wl, nil
+	// Cornercase, check for controllers without pods, to show them as a workload
+	if dep != nil {
+		if _, exist := controllers[dep.Name]; !exist {
+			controllers[dep.Name] = "Deployment"
+		}
+	}
+	for _, rs := range repset {
+		if _, exist := controllers[rs.Name]; !exist && len(rs.OwnerReferences) == 0 {
+			controllers[rs.Name] = "ReplicaSet"
+		}
+	}
+	if depcon != nil {
+		if _, exist := controllers[depcon.Name]; !exist {
+			controllers[depcon.Name] = "DeploymentConfig"
+		}
+	}
+	for _, rc := range repcon {
+		if _, exist := controllers[rc.Name]; !exist && len(rc.OwnerReferences) == 0 {
+			controllers[rc.Name] = "ReplicationController"
+		}
+	}
+	if fulset != nil {
+		if _, exist := controllers[fulset.Name]; !exist {
+			controllers[fulset.Name] = "StatefulSet"
+		}
 	}
 
-	if ctype != "" {
-		cPods := kubernetes.FilterPodsForController(workloadName, ctype, pods)
-		wl.ParsePods(workloadName, ctype, cPods)
-		wl.SetPods(cPods)
-		return wl, nil
-	} else {
-		// Workload Not found
-		return wl, kubernetes.NewNotFound("kiali", "workload", workloadName)
-	}
+	// Build workload from controllers
 
-	return wl, nil
+	if _, exist := controllers[workloadName]; exist {
+		w := models.Workload{
+			Pods:     models.Pods{},
+			Services: models.Services{},
+		}
+		ctype := controllers[workloadName]
+		// Flag to add a controller if it is found
+		cnFound := true
+		switch ctype {
+		case "Deployment":
+			if dep.Name == workloadName {
+				selector := labels.Set(dep.Spec.Template.Labels).AsSelector()
+				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
+				w.ParseDeployment(dep)
+			} else {
+				log.Errorf("Workload %s is not found as Deployment", workloadName)
+				cnFound = false
+			}
+		case "ReplicaSet":
+			found := false
+			iFound := -1
+			for i, rs := range repset {
+				if rs.Name == workloadName {
+					found = true
+					iFound = i
+					break
+				}
+			}
+			if found {
+				selector := labels.Set(repset[iFound].Spec.Template.Labels).AsSelector()
+				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
+				w.ParseReplicaSet(&repset[iFound])
+			} else {
+				log.Errorf("Workload %s is not found as ReplicaSet", workloadName)
+				cnFound = false
+			}
+		case "ReplicationController":
+			found := false
+			iFound := -1
+			for i, rc := range repcon {
+				if rc.Name == workloadName {
+					found = true
+					iFound = i
+					break
+				}
+			}
+			if found {
+				selector := labels.Set(repcon[iFound].Spec.Template.Labels).AsSelector()
+				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
+				w.ParseReplicationController(&repcon[iFound])
+			} else {
+				log.Errorf("Workload %s is not found as ReplicationController", workloadName)
+				cnFound = false
+			}
+		case "DeploymentConfig":
+			if depcon.Name == workloadName {
+				selector := labels.Set(depcon.Spec.Template.Labels).AsSelector()
+				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
+				w.ParseDeploymentConfig(depcon)
+			} else {
+				log.Errorf("Workload %s is not found as DeploymentConfig", workloadName)
+				cnFound = false
+			}
+		case "StatefulSet":
+			if fulset.Name == workloadName {
+				selector := labels.Set(fulset.Spec.Template.Labels).AsSelector()
+				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
+				w.ParseStatefulSet(fulset)
+			} else {
+				log.Errorf("Workload %s is not found as StatefulSet", workloadName)
+				cnFound = false
+			}
+		case "Pod":
+			found := false
+			iFound := -1
+			for i, pod := range pods {
+				if pod.Name == workloadName {
+					found = true
+					iFound = i
+					break
+				}
+			}
+			if found {
+				w.SetPods([]v1.Pod{pods[iFound]})
+				w.ParsePod(&pods[iFound])
+			} else {
+				log.Errorf("Workload %s is not found as Pod", workloadName)
+				cnFound = false
+			}
+		case "Job":
+			found := false
+			iFound := -1
+			for i, jb := range jbs {
+				if jb.Name == workloadName {
+					found = true
+					iFound = i
+					break
+				}
+			}
+			if found {
+				selector := labels.Set(jbs[iFound].Spec.Template.Labels).AsSelector()
+				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
+				w.ParseJob(&jbs[iFound])
+			} else {
+				log.Errorf("Workload %s is not found as Job", workloadName)
+				cnFound = false
+			}
+		case "CronJob":
+			found := false
+			iFound := -1
+			for i, cjb := range conjbs {
+				if cjb.Name == workloadName {
+					found = true
+					iFound = i
+					break
+				}
+			}
+			if found {
+				selector := labels.Set(conjbs[iFound].Spec.JobTemplate.Spec.Template.Labels).AsSelector()
+				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
+				w.ParseCronJob(&conjbs[iFound])
+			} else {
+				log.Warningf("Workload %s is not found as CronJob (CronJob could be deleted but children are still in the namespace)", workloadName)
+				cnFound = false
+			}
+		default:
+			cPods := kubernetes.FilterPodsForController(workloadName, ctype, pods)
+			w.SetPods(cPods)
+			w.ParsePods(workloadName, ctype, cPods)
+		}
+		if cnFound {
+			return &w, nil
+		}
+	}
+	return wl, kubernetes.NewNotFound(workloadName, "Kiali", "Workload")
 }
 
 // KIALI-1730


### PR DESCRIPTION
Fetch workload details was wrongly simplified and some corner cases as described in KIALI-1730 were showing different workloads in list/details pages.

