### PR TITLE
KIALI-1812 Add API namespace config to support namespace exclusion

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -481,6 +481,18 @@ external_services:
     url: VALUE
 ----
 
+|`API_NAMESPACES_EXCLUDE`
+|An optional list of namespaces/projects excluded from the list of namespaces provided by the API and UI. Regex is supported. This does not affect explicit namespace access.
+[source,yaml]
+----
+api:
+  namespaces:
+    exclude:
+    - namespacePattern1
+    - namespacePattern2
+    - etc..
+----
+
 |`LOGIN_TOKEN_SIGNING_KEY`
 |The signing key used to generate tokens for user authentication. (default is `kiali`)
 [source,yaml]

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -1,6 +1,9 @@
 package business
 
 import (
+	"regexp"
+
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -29,22 +32,39 @@ func NewNamespaceService(k8s kubernetes.IstioClientInterface) NamespaceService {
 
 // Returns a list of the given namespaces / projects
 func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
-
+	namespaces := []models.Namespace{}
 	// If we are running in OpenShift, we will use the project names since these are the list of accessible namespaces
 	if in.hasProjects {
 		projects, err := in.k8s.GetProjects()
 		if err == nil {
 			// Everything is good, return the projects we got from OpenShift / kube-project
-			return models.CastProjectCollection(projects), nil
+			namespaces = models.CastProjectCollection(projects)
+		}
+	} else {
+		services, err := in.k8s.GetNamespaces()
+		if err != nil {
+			return nil, err
+		}
+
+		namespaces = models.CastNamespaceCollection(services)
+	}
+
+	result := namespaces
+	excludes := config.Get().Api.Namespaces.Exclude
+	if len(excludes) > 0 {
+		result = []models.Namespace{}
+	NAMESPACES:
+		for _, namespace := range namespaces {
+			for _, excludePattern := range excludes {
+				if match, _ := regexp.MatchString(excludePattern, namespace.Name); match {
+					continue NAMESPACES
+				}
+			}
+			result = append(result, namespace)
 		}
 	}
 
-	services, err := in.k8s.GetNamespaces()
-	if err != nil {
-		return nil, err
-	}
-
-	return models.CastNamespaceCollection(services), nil
+	return result, nil
 }
 
 // GetNamespace returns the definition of the specified namespace.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,6 +40,18 @@ func TestDefaults(t *testing.T) {
 	if conf.Server.CORSAllowAll {
 		t.Error("server CORS default setting is wrong")
 	}
+
+	if len(conf.Api.Namespaces.Exclude) != 4 {
+		t.Error("Api namespace exclude default setting is wrong")
+	} else {
+		// our default exclusion list: default,istio-operator,kube.*,openshift.*
+		if conf.Api.Namespaces.Exclude[0] != "default" ||
+			conf.Api.Namespaces.Exclude[1] != "istio-operator" ||
+			conf.Api.Namespaces.Exclude[2] != "kube.*" ||
+			conf.Api.Namespaces.Exclude[3] != "openshift.*" {
+			t.Errorf("Api namespace exclude default list is wrong: %+v", conf.Api.Namespaces.Exclude)
+		}
+	}
 }
 
 func TestMarshalUnmarshalStaticContentRootDirectory(t *testing.T) {
@@ -62,6 +74,31 @@ func TestMarshalUnmarshalStaticContentRootDirectory(t *testing.T) {
 	}
 	if conf.Server.StaticContentRootDirectory != "/tmp" {
 		t.Errorf("Failed to unmarshal static content root directory:\n%v", conf)
+	}
+}
+
+func TestMarshalUnmarshalApiConfig(t *testing.T) {
+	testConf := Config{
+		Api: ApiConfig{
+			Namespaces: ApiNamespacesConfig{
+				Exclude: []string{"default", "kube.*"},
+			},
+		},
+	}
+
+	yamlString, err := Marshal(&testConf)
+	if err != nil {
+		t.Errorf("Failed to marshal: %v", err)
+	}
+	if yamlString != "api:\n  namespaces:\n    exclude:\n    - default\n    - kube.*\n" {
+		t.Errorf("Failed to marshal Api:\n%q", yamlString)
+	}
+	conf, err := Unmarshal(yamlString)
+	if err != nil {
+		t.Errorf("Failed to unmarshal: %v", err)
+	}
+	if len(conf.Api.Namespaces.Exclude) != 2 {
+		t.Errorf("Failed to unmarshal Api:\n%+v", conf.Api)
 	}
 }
 


### PR DESCRIPTION
- remove by default the "technical" namespaces so the user gets a more
  focused list and the 'all' namespace does not waste time on them.

![image](https://user-images.githubusercontent.com/2104052/47309749-4410d580-d603-11e8-8902-2038efc877c0.png)
