### PR TITLE
Kiali-1497 Undo health checks

### DIFF
--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -71,18 +71,6 @@ spec:
         - "/kiali-configuration/config.yaml"
         - "-v"
         - "${VERBOSE_MODE}"
-        readinessProbe:
-          httpGet:
-            path: /api/status
-            port: 20001
-          initialDelaySeconds: 3
-          periodSeconds: 3
-        livenessProbe:
-          httpGet:
-            path: /api/status
-            port: 20001
-          initialDelaySeconds: 3
-          periodSeconds: 3
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -76,20 +76,6 @@ spec:
         - "/kiali-configuration/config.yaml"
         - "-v"
         - "${VERBOSE_MODE}"
-        readinessProbe:
-          httpGet:
-            scheme: HTTPS
-            path: /api/status
-            port: 20001
-          initialDelaySeconds: 3
-          periodSeconds: 3
-        livenessProbe:
-          httpGet:
-            scheme: HTTPS
-            path: /api/status
-            port: 20001
-          initialDelaySeconds: 3
-          periodSeconds: 3
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:


### PR DESCRIPTION
** Describe the change **
Undoing https://github.com/kiali/kiali/pull/563 for now until we come up with a better solution.  I was hoping to simply increase the polling intervals, but I discovered that the probe endpoints won't work if users deploy Kiali under a custom web root. (see comments in KIALI-1497 for more details).

** Issue reference **
KIALI-1497

** Backwards compatible? **
Yes