### PR TITLE
Address PR #576 comments

### DIFF
--- a/business/checkers/virtual_services/no_gateway_checker.go
+++ b/business/checkers/virtual_services/no_gateway_checker.go
@@ -14,17 +14,14 @@ type NoGatewayChecker struct {
 
 // Check validates that all the VirtualServices are pointing to an existing Gateway
 func (s NoGatewayChecker) Check() ([]*models.IstioCheck, bool) {
-	valid := false
-	index := -1
 	validations := make([]*models.IstioCheck, 0)
 
-	if valid, index = kubernetes.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.GatewayNames); !valid {
-		path := ""
-		if index != -1 {
-			path = "spec/gateways[" + strconv.Itoa(index) + "]"
-		}
+	valid, index := kubernetes.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.GatewayNames)
+	if !valid {
+		path := "spec/gateways[" + strconv.Itoa(index) + "]"
 		validation := models.BuildCheck("VirtualService is pointing to a non-existent gateway", "error", path)
 		validations = append(validations, &validation)
 	}
+
 	return validations, valid
 }


### PR DESCRIPTION
Due to Github messing up the review on PR #576, here is a patch that should address a code quality issue. Validations should not have dual truth, either we trust the index or we trust the boolean indicating failure. Not a mess of both. This one chooses the boolean since it makes more sense than trying to duplicate the boolean with integers like in C (which is essentially what index -1 does - and since index is a loop counter it can't be negative if valid = false)

Also, simplify code that avoided variable shadowing.
