### PR TITLE
KIALI-1824 Formalize appender names

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -84,7 +84,7 @@ type WorkloadParam struct {
 
 // swagger:parameters graphApp graphAppVersion graphNamespace graphService graphWorkload
 type AppendersParam struct {
-	// Comma-separated list of Appenders to run. Available appenders: [dead_node, istio_details, response_time, security_policy, sidecars_check, unused_node].
+	// Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].
 	//
 	// in: query
 	// required: false

--- a/graph/appender/appender.go
+++ b/graph/appender/appender.go
@@ -72,4 +72,7 @@ type Appender interface {
 	// AppendGraph performs the appender work on the provided traffic map. The map
 	// may be initially empty. An appender is allowed to add or remove map entries.
 	AppendGraph(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo)
+
+	// Name returns a unique appender name and which is the name used to identify the appender (e.g in 'appenders' query param)
+	Name() string
 }

--- a/graph/appender/dead_node.go
+++ b/graph/appender/dead_node.go
@@ -5,6 +5,8 @@ import (
 	"github.com/kiali/kiali/graph"
 )
 
+const DeadNodeAppenderName = "deadNode"
+
 // DeadNodeAppender is responsible for removing from the graph unwanted nodes:
 // - nodes for which there is no traffic reported and the related schema is missing
 //   (presumably removed from K8S). (kiali-621)
@@ -12,7 +14,13 @@ import (
 //   edges (kiali-1326). Kiali-1526 adds an exclusion to this rule. Egress is a special
 //   terminal service node and we want to show it even if it has no incoming traffic
 //   for the time period.
+// Name: deadNode
 type DeadNodeAppender struct{}
+
+// Name implements Appender
+func (a DeadNodeAppender) Name() string {
+	return DeadNodeAppenderName
+}
 
 // AppendGraph implements Appender
 func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo) {

--- a/graph/appender/istio_details.go
+++ b/graph/appender/istio_details.go
@@ -5,7 +5,18 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 )
 
+const IstioAppenderName = "istio"
+
+// IstioAppender is responsible for badging nodes with special Istio significance:
+// - CircuitBreaker: n.Metadata["hasCB"] = true
+// - VirtualService: n.Metadata["hasVS"] = true
+// Name: istio
 type IstioAppender struct{}
+
+// Name implements Appender
+func (a IstioAppender) Name() string {
+	return IstioAppenderName
+}
 
 // AppendGraph implements Appender
 func (a IstioAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo) {

--- a/graph/appender/response_time.go
+++ b/graph/appender/response_time.go
@@ -13,12 +13,14 @@ import (
 )
 
 const (
-	DefaultQuantile = 0.95 // 95th percentile
+	DefaultQuantile          = 0.95 // 95th percentile
+	ResponseTimeAppenderName = "responseTime"
 )
 
 // ResponseTimeAppender is responsible for adding responseTime information to the graph. ResponseTime
 // is represented as a percentile value. The default is 95th percentile, which means that
 // 95% of requests executed in no more than the resulting milliseconds.
+// Name: responseTime
 type ResponseTimeAppender struct {
 	GraphType          string
 	InjectServiceNodes bool
@@ -26,6 +28,11 @@ type ResponseTimeAppender struct {
 	Namespaces         map[string]graph.NamespaceInfo
 	Quantile           float64
 	QueryTime          int64 // unix time in seconds
+}
+
+// Name implements Appender
+func (a ResponseTimeAppender) Name() string {
+	return ResponseTimeAppenderName
 }
 
 // AppendGraph implements Appender

--- a/graph/appender/security_policy.go
+++ b/graph/appender/security_policy.go
@@ -12,13 +12,21 @@ import (
 	"github.com/kiali/kiali/prometheus"
 )
 
+const SecurityPolicyAppenderName = "securityPolicy"
+
 // SecurityPolicyAppender is responsible for adding securityPolicy information to the graph.
 // The appender currently reports only mutual_tls security although is written in a generic way.
+// Name: securityPolicy
 type SecurityPolicyAppender struct {
 	GraphType    string
 	IncludeIstio bool
 	Namespaces   map[string]graph.NamespaceInfo
 	QueryTime    int64 // unix time in seconds
+}
+
+// Name implements Appender
+func (a SecurityPolicyAppender) Name() string {
+	return SecurityPolicyAppenderName
 }
 
 // AppendGraph implements Appender

--- a/graph/appender/sidecars_check.go
+++ b/graph/appender/sidecars_check.go
@@ -6,7 +6,17 @@ import (
 	"github.com/kiali/kiali/graph"
 )
 
+const SidecarsCheckAppenderName = "sidecarsCheck"
+
+// SidecarsCheckAppender flags nodes whose backing workloads are missing at least one Envoy sidecar. Note that
+// a node with no backing workloads is not flagged.
+// Name: sidecarsCheck
 type SidecarsCheckAppender struct{}
+
+// Name implements Appender
+func (a SidecarsCheckAppender) Name() string {
+	return SidecarsCheckAppenderName
+}
 
 // AppendGraph implements Appender
 func (a SidecarsCheckAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo) {

--- a/graph/appender/unused_node.go
+++ b/graph/appender/unused_node.go
@@ -8,9 +8,19 @@ import (
 	"github.com/kiali/kiali/models"
 )
 
+const UnusedNodeAppenderName = "unusedNode"
+
+// UnusedNodeAppender looks for services that have never seen request traffic.  It adds nodes to represent the
+// unused definitions.  The added node types depend on the graph type and/or labeling on the definition.
+// Name: unusedNode
 type UnusedNodeAppender struct {
 	GraphType   string // This appender does not operate on service graphs because it adds workload nodes.
 	IsNodeGraph bool   // This appender does not operate on node detail graphs because we want to focus on the specific node.
+}
+
+// Name implements Appender
+func (a UnusedNodeAppender) Name() string {
+	return UnusedNodeAppenderName
 }
 
 // AppendGraph implements Appender

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -187,10 +187,10 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 	// To reduce processing, next run appenders that don't apply to unused services
 	// Add orphan (unused) services
 	// Run remaining appenders
-	if csl == AppenderAll || strings.Contains(csl, "dead_node") {
+	if csl == AppenderAll || strings.Contains(csl, appender.DeadNodeAppenderName) || strings.Contains(csl, "dead_node") {
 		appenders = append(appenders, appender.DeadNodeAppender{})
 	}
-	if csl == AppenderAll || strings.Contains(csl, "response_time") {
+	if csl == AppenderAll || strings.Contains(csl, appender.ResponseTimeAppenderName) || strings.Contains(csl, "response_time") {
 		quantile := appender.DefaultQuantile
 		if _, ok := params["responseTimeQuantile"]; ok {
 			if responseTimeQuantile, err := strconv.ParseFloat(params.Get("responseTimeQuantile"), 64); err == nil {
@@ -207,7 +207,7 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 		}
 		appenders = append(appenders, a)
 	}
-	if csl == AppenderAll || strings.Contains(csl, "security_policy") {
+	if csl == AppenderAll || strings.Contains(csl, appender.SecurityPolicyAppenderName) || strings.Contains(csl, "security_policy") {
 		a := appender.SecurityPolicyAppender{
 			GraphType:    o.GraphType,
 			IncludeIstio: o.IncludeIstio,
@@ -216,17 +216,17 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 		}
 		appenders = append(appenders, a)
 	}
-	if csl == AppenderAll || strings.Contains(csl, "unused_node") {
+	if csl == AppenderAll || strings.Contains(csl, appender.UnusedNodeAppenderName) || strings.Contains(csl, "unused_node") {
 		hasNodeOptions := o.App != "" || o.Workload != "" || o.Service != ""
 		appenders = append(appenders, appender.UnusedNodeAppender{
 			GraphType:   o.GraphType,
 			IsNodeGraph: hasNodeOptions,
 		})
 	}
-	if csl == AppenderAll || strings.Contains(csl, "istio") {
+	if csl == AppenderAll || strings.Contains(csl, appender.IstioAppenderName) || strings.Contains(csl, "istio") {
 		appenders = append(appenders, appender.IstioAppender{})
 	}
-	if csl == AppenderAll || strings.Contains(csl, "sidecars_check") {
+	if csl == AppenderAll || strings.Contains(csl, appender.SidecarsCheckAppenderName) || strings.Contains(csl, "sidecars_check") {
 		appenders = append(appenders, appender.SidecarsCheckAppender{})
 	}
 

--- a/swagger.json
+++ b/swagger.json
@@ -822,7 +822,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [dead_node, istio_details, response_time, security_policy, sidecars_check, unused_node].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },
@@ -923,7 +923,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [dead_node, istio_details, response_time, security_policy, sidecars_check, unused_node].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },
@@ -1084,7 +1084,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [dead_node, istio_details, response_time, security_policy, sidecars_check, unused_node].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },
@@ -1446,7 +1446,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [dead_node, istio_details, response_time, security_policy, sidecars_check, unused_node].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },
@@ -1650,7 +1650,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [dead_node, istio_details, response_time, security_policy, sidecars_check, unused_node].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },


### PR DESCRIPTION

I left the old queryParam strings in there for backward compatibility.  We can remove them later if we update the UI (or just leave it).