### PR TITLE
KIALI-1820 prometheus scrape endpoint

### DIFF
--- a/graph/appender/response_time.go
+++ b/graph/appender/response_time.go
@@ -68,7 +68,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 		namespace,
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	unkVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
+	unkVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 
 	// 2) query for responseTime originating from a workload outside of the namespace. Exclude any "unknown" source telemetry (an unusual corner case)
 	query = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace!="%v",source_workload!="unknown",destination_service_namespace="%v",response_code=~"2[0-9]{2}"}[%vs])) by (%s))`,
@@ -78,7 +78,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 		namespace,
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	outVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
+	outVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 
 	// 3) query for responseTime originating from a workload inside of the namespace
 	query = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v",response_code=~"2[0-9]{2}"}[%vs])) by (%s))`,
@@ -87,7 +87,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 		namespace,
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	inVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
+	inVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 
 	// create map to quickly look up responseTime
 	responseTimeMap := make(map[string]float64)
@@ -110,7 +110,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 				groupBy)
 
 			// fetch the externally originating request traffic time-series
-			outIstioVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
+			outIstioVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 			a.populateResponseTimeMap(responseTimeMap, &outIstioVector)
 		}
 
@@ -124,7 +124,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 			groupBy)
 
 		// fetch the internally originating request traffic time-series
-		inIstioVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
+		inIstioVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 		a.populateResponseTimeMap(responseTimeMap, &inIstioVector)
 	}
 

--- a/graph/appender/security_policy.go
+++ b/graph/appender/security_policy.go
@@ -58,7 +58,7 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 		"[2345][0-9][0-9]",      // regex for valid response_codes
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	outVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
+	outVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 
 	// 2) query for active_security originating from a workload inside of the namespace
 	istioCondition := ""
@@ -72,7 +72,7 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 		"[2345][0-9][0-9]",      // regex for valid response_codes
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	inVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API())
+	inVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 
 	// create map to quickly look up responseTime
 	securityPolicyMap := make(map[string]string)

--- a/graph/appender/util.go
+++ b/graph/appender/util.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
@@ -20,7 +21,7 @@ func checkError(err error) {
 	}
 }
 
-func promQuery(query string, queryTime time.Time, api v1.API) model.Vector {
+func promQuery(query string, queryTime time.Time, api v1.API, a Appender) model.Vector {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -28,8 +29,10 @@ func promQuery(query string, queryTime time.Time, api v1.API) model.Vector {
 	query = fmt.Sprintf("round(%s,0.001)", query)
 	log.Debugf("Appender query:\n%s&time=%v (now=%v, %v)\n", query, queryTime.Format(graph.TF), time.Now().Format(graph.TF), queryTime.Unix())
 
+	promtimer := internalmetrics.GetPrometheusProcessingTimePrometheusTimer("Graph-Appender-" + a.Name())
 	value, err := api.Query(ctx, query, queryTime)
 	checkError(err)
+	promtimer.ObserveDuration() // notice we only collect metrics for successful prom queries
 
 	switch t := value.Type(); t {
 	case model.ValVector: // Instant Vector

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -1,4 +1,4 @@
-// Options package holds the option settings for a single graph generation.
+// Package options holds the option settings for a single graph generation.
 package options
 
 import (
@@ -28,6 +28,11 @@ const (
 	defaultIncludeIstio       bool   = false
 	defaultInjectServiceNodes bool   = false
 	defaultVendor             string = "cytoscape"
+)
+
+const (
+	graphKindNamespace string = "namespace"
+	graphKindNode      string = "node"
 )
 
 // NodeOptions are those that apply only to node-detail graphs
@@ -172,6 +177,18 @@ func NewOptions(r *http.Request) Options {
 	options.Appenders = appenders
 
 	return options
+}
+
+// GetGraphKind will return the kind of graph represented by the options.
+func (o *Options) GetGraphKind() string {
+	if o.NodeOptions.App != "" ||
+		o.NodeOptions.Version != "" ||
+		o.NodeOptions.Workload != "" ||
+		o.NodeOptions.Service != "" {
+		return graphKindNode
+	} else {
+		return graphKindNamespace
+	}
 }
 
 func parseAppenders(params url.Values, o Options) []appender.Appender {

--- a/hack/run-prometheus.sh
+++ b/hack/run-prometheus.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+##############################################################################
+# run-prometheus.sh
+#
+# Runs a local Prometheus in docker and scrapes the Kiali server.
+# Kiali must have an exposed OpenShift route for this to work.
+# You must have "docker" in your PATH as well as one of kubectl, oc, istiooc.
+#
+##############################################################################
+
+# Make sure we have everything we need
+
+if ! which docker > /dev/null ; then
+  echo "You must have docker in your PATH"
+  exit 1
+fi
+
+for exe in kubectl oc istiooc ; do
+  if which $exe > /dev/null ; then
+    CLIENT_EXE=`which $exe`
+    break
+  fi
+done
+
+if [ "$CLIENT_EXE" == "" ]; then
+  echo "You must have one of these in your PATH: kubectl, oc, istiooc"
+  exit 1
+fi
+
+# Find out where Kiali is - this will be the scrape endpoint that Prometheus will use
+
+KIALI_ROUTE=$(${CLIENT_EXE} -n istio-system get route kiali -o jsonpath='{.spec.host}')
+if [ "$?" == "0" ]; then
+   echo "Kiali route endpoint is found here: $KIALI_ROUTE"
+else
+   echo "Kiali does not have a route - Prometheus will not be able to see it. Aborting."
+   exit 1
+fi
+
+# Create a simple Prometheus configuration file to tell it how to scrape Kiali
+
+cat <<EOF > /tmp/prometheus-kiali.yaml
+global:
+  scrape_interval: 10s
+scrape_configs:
+- job_name: 'kiali'
+  scheme: 'https'
+  tls_config:
+    insecure_skip_verify: true
+  static_configs:
+  - targets: ['${KIALI_ROUTE}']
+EOF
+
+# Run Prometheus
+
+docker run -p 9090:9090 -v /tmp/prometheus-kiali.yaml:/etc/prometheus/prometheus.yml prom/prometheus &
+DOCKER_PID=$!
+echo "Docker started (pid: ${DOCKER_PID})"
+
+# Point the user's browser to Prometheus
+
+xdg-open http://localhost:9090
+
+# Keep this script in foreground - killing this script will shutdown Prometheus
+
+wait ${DOCKER_PID}

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -50,6 +50,7 @@ import (
 	"github.com/kiali/kiali/graph/options"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 // GraphNamespace is a REST http.HandlerFunc handling namespace-wide graph
@@ -66,8 +67,17 @@ func GraphNamespace(w http.ResponseWriter, r *http.Request) {
 // graphNamespace provides a testing hook that can supply a mock client
 func graphNamespace(w http.ResponseWriter, r *http.Request, client *prometheus.Client) {
 	o := options.NewOptions(r)
+
+	// time how long it takes to generate this graph
+	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer(internalmetrics.GRAPH_KIND_NAMESPACE, o.GraphType, o.InjectServiceNodes)
+	defer promtimer.ObserveDuration()
+
 	trafficMap := graphNamespaces(o, client)
 	generateGraph(trafficMap, w, o)
+
+	// update metrics
+	internalmetrics.IncrementGraphsGenerated(internalmetrics.GRAPH_KIND_NAMESPACE, o.GraphType, o.InjectServiceNodes)
+	internalmetrics.SetGraphNodes(internalmetrics.GRAPH_KIND_NAMESPACE, o.GraphType, o.InjectServiceNodes, len(trafficMap))
 }
 
 func graphNamespaces(o options.Options, client *prometheus.Client) graph.TrafficMap {
@@ -87,7 +97,9 @@ func graphNamespaces(o options.Options, client *prometheus.Client) graph.Traffic
 		namespaceTrafficMap := buildNamespaceTrafficMap(namespace.Name, o, client)
 		namespaceInfo := appender.NewNamespaceInfo(namespace.Name)
 		for _, a := range o.Appenders {
+			appenderTimer := internalmetrics.GetGraphAppenderTimePrometheusTimer(a)
 			a.AppendGraph(namespaceTrafficMap, globalInfo, namespaceInfo)
+			appenderTimer.ObserveDuration()
 		}
 		mergeTrafficMaps(trafficMap, namespace.Name, namespaceTrafficMap)
 	}
@@ -645,6 +657,10 @@ func graphNode(w http.ResponseWriter, r *http.Request, client *prometheus.Client
 		checkError(errors.New(fmt.Sprintf("Node graph does not support the 'namespaces' query parameter or the 'all' namespace")))
 	}
 
+	// time how long it takes to generate this graph
+	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer(internalmetrics.GRAPH_KIND_NODE, o.GraphType, o.InjectServiceNodes)
+	defer promtimer.ObserveDuration()
+
 	// Here, it's true that o.Namespaces has only one item. So, it's safe to use "for" knowing
 	// that only one iteration will happen.
 	var n graph.Node
@@ -661,7 +677,9 @@ func graphNode(w http.ResponseWriter, r *http.Request, client *prometheus.Client
 	namespaceInfo := appender.NewNamespaceInfo(namespace.Name)
 
 	for _, a := range o.Appenders {
+		appenderTimer := internalmetrics.GetGraphAppenderTimePrometheusTimer(a)
 		a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+		appenderTimer.ObserveDuration()
 	}
 
 	// The appenders can add/remove/alter nodes. After the manipulations are complete
@@ -672,6 +690,10 @@ func graphNode(w http.ResponseWriter, r *http.Request, client *prometheus.Client
 	markTrafficGenerators(trafficMap)
 
 	generateGraph(trafficMap, w, o)
+
+	// update metrics
+	internalmetrics.IncrementGraphsGenerated(internalmetrics.GRAPH_KIND_NODE, o.GraphType, o.InjectServiceNodes)
+	internalmetrics.SetGraphNodes(internalmetrics.GRAPH_KIND_NODE, o.GraphType, o.InjectServiceNodes, len(trafficMap))
 }
 
 // buildNodeTrafficMap returns a map of all nodes requesting or requested by the target node (key=id).

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -69,15 +69,15 @@ func graphNamespace(w http.ResponseWriter, r *http.Request, client *prometheus.C
 	o := options.NewOptions(r)
 
 	// time how long it takes to generate this graph
-	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer(internalmetrics.GRAPH_KIND_NAMESPACE, o.GraphType, o.InjectServiceNodes)
+	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer(o.GetGraphKind(), o.GraphType, o.InjectServiceNodes)
 	defer promtimer.ObserveDuration()
 
 	trafficMap := graphNamespaces(o, client)
-	generateGraph(trafficMap, w, o, internalmetrics.GRAPH_KIND_NAMESPACE)
+	generateGraph(trafficMap, w, o)
 
 	// update metrics
-	internalmetrics.IncrementGraphsGenerated(internalmetrics.GRAPH_KIND_NAMESPACE, o.GraphType, o.InjectServiceNodes)
-	internalmetrics.SetGraphNodes(internalmetrics.GRAPH_KIND_NAMESPACE, o.GraphType, o.InjectServiceNodes, len(trafficMap))
+	internalmetrics.IncrementGraphsGenerated(o.GetGraphKind(), o.GraphType, o.InjectServiceNodes)
+	internalmetrics.SetGraphNodes(o.GetGraphKind(), o.GraphType, o.InjectServiceNodes, len(trafficMap))
 }
 
 func graphNamespaces(o options.Options, client *prometheus.Client) graph.TrafficMap {
@@ -658,7 +658,7 @@ func graphNode(w http.ResponseWriter, r *http.Request, client *prometheus.Client
 	}
 
 	// time how long it takes to generate this graph
-	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer(internalmetrics.GRAPH_KIND_NODE, o.GraphType, o.InjectServiceNodes)
+	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer(o.GetGraphKind(), o.GraphType, o.InjectServiceNodes)
 	defer promtimer.ObserveDuration()
 
 	// Here, it's true that o.Namespaces has only one item. So, it's safe to use "for" knowing
@@ -689,11 +689,11 @@ func graphNode(w http.ResponseWriter, r *http.Request, client *prometheus.Client
 	markOutsiders(trafficMap, o)
 	markTrafficGenerators(trafficMap)
 
-	generateGraph(trafficMap, w, o, internalmetrics.GRAPH_KIND_NODE)
+	generateGraph(trafficMap, w, o)
 
 	// update metrics
-	internalmetrics.IncrementGraphsGenerated(internalmetrics.GRAPH_KIND_NODE, o.GraphType, o.InjectServiceNodes)
-	internalmetrics.SetGraphNodes(internalmetrics.GRAPH_KIND_NODE, o.GraphType, o.InjectServiceNodes, len(trafficMap))
+	internalmetrics.IncrementGraphsGenerated(o.GetGraphKind(), o.GraphType, o.InjectServiceNodes)
+	internalmetrics.SetGraphNodes(o.GetGraphKind(), o.GraphType, o.InjectServiceNodes, len(trafficMap))
 }
 
 // buildNodeTrafficMap returns a map of all nodes requesting or requested by the target node (key=id).
@@ -932,10 +932,10 @@ func buildNodeTrafficMap(namespace string, n graph.Node, o options.Options, clie
 	return trafficMap
 }
 
-func generateGraph(trafficMap graph.TrafficMap, w http.ResponseWriter, o options.Options, graphKind string) {
+func generateGraph(trafficMap graph.TrafficMap, w http.ResponseWriter, o options.Options) {
 	log.Debugf("Generating config for [%s] service graph...", o.Vendor)
 
-	promtimer := internalmetrics.GetGraphMarshalTimePrometheusTimer(graphKind, o.GraphType, o.InjectServiceNodes)
+	promtimer := internalmetrics.GetGraphMarshalTimePrometheusTimer(o.GetGraphKind(), o.GraphType, o.InjectServiceNodes)
 	defer promtimer.ObserveDuration()
 
 	var vendorConfig interface{}

--- a/kiali.go
+++ b/kiali.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 	"github.com/kiali/kiali/server"
 	"github.com/kiali/kiali/status"
 	"github.com/kiali/kiali/util"
@@ -90,6 +91,9 @@ func main() {
 		util.UpdateBaseURL(webRoot)
 		util.ConfigToJS()
 	}
+
+	// prepare our internal metrics so Prometheus can scrape them
+	internalmetrics.RegisterInternalMetrics()
 
 	// Start listening to requests
 	server := server.NewServer()

--- a/prometheus/internalmetrics/internal_metrics.go
+++ b/prometheus/internalmetrics/internal_metrics.go
@@ -24,11 +24,11 @@ const (
 type MetricsType struct {
 	GraphsGenerated          *prometheus.CounterVec
 	GraphNodes               *prometheus.GaugeVec
-	GraphGenerationTime      *prometheus.SummaryVec
-	GraphAppenderTime        *prometheus.SummaryVec
-	GraphMarshalTime         *prometheus.SummaryVec
-	APIProcessingTime        *prometheus.SummaryVec
-	PrometheusProcessingTime *prometheus.SummaryVec
+	GraphGenerationTime      *prometheus.HistogramVec
+	GraphAppenderTime        *prometheus.HistogramVec
+	GraphMarshalTime         *prometheus.HistogramVec
+	APIProcessingTime        *prometheus.HistogramVec
+	PrometheusProcessingTime *prometheus.HistogramVec
 }
 
 // Metrics contains all of Kiali's own internal metrics.
@@ -49,36 +49,36 @@ var Metrics = MetricsType{
 		},
 		[]string{labelGraphKind, labelGraphType, labelWithServiceNodes},
 	),
-	GraphGenerationTime: prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	GraphGenerationTime: prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Name: "kiali_graph_generation_duration_seconds",
 			Help: "The time required to generate a graph.",
 		},
 		[]string{labelGraphKind, labelGraphType, labelWithServiceNodes},
 	),
-	GraphAppenderTime: prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	GraphAppenderTime: prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Name: "kiali_graph_appender_duration_seconds",
 			Help: "The time required to execute an appender while generating a graph.",
 		},
 		[]string{labelAppender},
 	),
-	GraphMarshalTime: prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	GraphMarshalTime: prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Name: "kiali_graph_marshal_duration_seconds",
 			Help: "The time required to marshal and return the JSON for a graph.",
 		},
 		[]string{labelGraphKind, labelGraphType, labelWithServiceNodes},
 	),
-	APIProcessingTime: prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	APIProcessingTime: prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Name: "kiali_api_processing_duration_seconds",
 			Help: "The time required to execute an API request.",
 		},
 		[]string{labelName},
 	),
-	PrometheusProcessingTime: prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	PrometheusProcessingTime: prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Name: "kiali_prometheus_processing_duration_seconds",
 			Help: "The time required to execute a Prometheus query.",
 		},

--- a/prometheus/internalmetrics/internal_metrics.go
+++ b/prometheus/internalmetrics/internal_metrics.go
@@ -1,16 +1,13 @@
+// Package internalmetrics provides functionality to collect Prometheus metrics.
 package internalmetrics
 
 import (
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
-)
-
-const (
-	// GRAPH_KIND_NAMESPACE is a main graph showing everything in namespace(s)
-	GRAPH_KIND_NAMESPACE string = "namespace"
-	// GRAPH_KIND_NODE is a "drilled down" graph that is focused on a particular node
-	GRAPH_KIND_NODE string = "node"
+	// Because this package is used all throughout the codebase, be VERY careful adding new
+	// kiali imports here. Most likely you will encounter an import cycle error that will
+	// cause a compilation failure.
 )
 
 // These constants define the different label names for the different metric timeseries

--- a/prometheus/internalmetrics/internal_metrics.go
+++ b/prometheus/internalmetrics/internal_metrics.go
@@ -1,0 +1,151 @@
+package internalmetrics
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/kiali/kiali/graph/appender"
+)
+
+const (
+	// GRAPH_KIND_NAMESPACE is a main graph showing everything in namespace(s)
+	GRAPH_KIND_NAMESPACE string = "namespace"
+	// GRAPH_KIND_NODE is a "drilled down" graph that is focused on a particular node
+	GRAPH_KIND_NODE string = "node"
+)
+
+// These constants define the different label names for the different metric timeseries
+const (
+	labelGraphKind        = "graph_kind"
+	labelGraphType        = "graph_type"
+	labelWithServiceNodes = "with_service_nodes"
+	labelAppender         = "appender"
+	labelName             = "name"
+)
+
+// MetricsType defines all of Kiali's own internal metrics.
+type MetricsType struct {
+	GraphsGenerated     *prometheus.CounterVec
+	GraphNodes          *prometheus.GaugeVec
+	GraphGenerationTime *prometheus.SummaryVec
+	GraphAppenderTime   *prometheus.SummaryVec
+	APIProcessingTime   *prometheus.SummaryVec
+}
+
+// Metrics contains all of Kiali's own internal metrics.
+// These metrics can be accessed directly to update their values, or
+// you can use available utility functions defined below.
+var Metrics = MetricsType{
+	GraphsGenerated: prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kiali_graphs_generated_total",
+			Help: "The total number of graphs Kiali has generated.",
+		},
+		[]string{labelGraphKind, labelGraphType, labelWithServiceNodes},
+	),
+	GraphNodes: prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kiali_graph_nodes",
+			Help: "The number of nodes in a generated graph.",
+		},
+		[]string{labelGraphKind, labelGraphType, labelWithServiceNodes},
+	),
+	GraphGenerationTime: prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "kiali_graph_generation_duration_seconds",
+			Help: "The time required to generate a graph.",
+		},
+		[]string{labelGraphKind, labelGraphType, labelWithServiceNodes},
+	),
+	GraphAppenderTime: prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "kiali_graph_appender_duration_seconds",
+			Help: "The time required to execute an appender while generating a graph.",
+		},
+		[]string{labelAppender},
+	),
+	APIProcessingTime: prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "kiali_api_processing_duration_seconds",
+			Help: "The time required to execute an API request.",
+		},
+		[]string{labelName},
+	),
+}
+
+// RegisterInternalMetrics must be called at startup to prepare the Prometheus scrape endpoint.
+func RegisterInternalMetrics() {
+	prometheus.MustRegister(
+		Metrics.GraphsGenerated,
+		Metrics.GraphNodes,
+		Metrics.GraphGenerationTime,
+		Metrics.GraphAppenderTime,
+		Metrics.APIProcessingTime,
+	)
+}
+
+//
+// The following are utility functions that can be used to update the internal metrics.
+//
+
+// IncrementGraphsGenerated increments the counter for the given graph type
+func IncrementGraphsGenerated(graphKind string, graphType string, withServiceNodes bool) {
+	Metrics.GraphsGenerated.With(prometheus.Labels{
+		labelGraphKind:        graphKind,
+		labelGraphType:        graphType,
+		labelWithServiceNodes: strconv.FormatBool(withServiceNodes),
+	}).Inc()
+}
+
+// SetGraphNodes sets the node count metric
+func SetGraphNodes(graphKind string, graphType string, withServiceNodes bool, nodeCount int) {
+	Metrics.GraphNodes.With(prometheus.Labels{
+		labelGraphKind:        graphKind,
+		labelGraphType:        graphType,
+		labelWithServiceNodes: strconv.FormatBool(withServiceNodes),
+	}).Set(float64(nodeCount))
+}
+
+// GetGraphGenerationTimePrometheusTimer returns a timer that can be used to store
+// a value for the graph generation time metric. The timer is ticking immediately
+// when this function returns.
+// Typical usage is as follows:
+//    promtimer := GetGraphGenerationTimePrometheusTimer(...)
+//    defer promtimer.ObserveDuration()
+func GetGraphGenerationTimePrometheusTimer(graphKind string, graphType string, withServiceNodes bool) *prometheus.Timer {
+	timer := prometheus.NewTimer(Metrics.GraphGenerationTime.With(prometheus.Labels{
+		labelGraphKind:        graphKind,
+		labelGraphType:        graphType,
+		labelWithServiceNodes: strconv.FormatBool(withServiceNodes),
+	}))
+	return timer
+}
+
+// GetGraphAppenderTimePrometheusTimer returns a timer that can be used to store
+// a value for the graph appender time metric. The timer is ticking immediately
+// when this function returns.
+// Typical usage is as follows:
+//    promtimer := GetGraphAppenderTimePrometheusTimer(...)
+//    ... run the appender ...
+//    promtimer.ObserveDuration()
+func GetGraphAppenderTimePrometheusTimer(appender appender.Appender) *prometheus.Timer {
+	appenderName := appender.Name()
+	timer := prometheus.NewTimer(Metrics.GraphAppenderTime.With(prometheus.Labels{
+		labelAppender: appenderName,
+	}))
+	return timer
+}
+
+// GetAPIProcessingTimePrometheusTimer returns a timer that can be used to store
+// a value for the API processing time metric. The timer is ticking immediately
+// when this function returns.
+// Typical usage is as follows:
+//    promtimer := GetAPIProcessingTimePrometheusTimer(...)
+//    defer promtimer.ObserveDuration()
+func GetAPIProcessingTimePrometheusTimer(apiName string) *prometheus.Timer {
+	timer := prometheus.NewTimer(Metrics.APIProcessingTime.With(prometheus.Labels{
+		labelName: apiName,
+	}))
+	return timer
+}

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 var (
@@ -495,9 +496,11 @@ func getItemRequestRates(api v1.API, namespace, item, itemLabelSuffix string, qu
 
 func getRequestRatesForLabel(api v1.API, time time.Time, labels, ratesInterval string) (model.Vector, error) {
 	query := fmt.Sprintf("rate(istio_requests_total{%s}[%s])", labels, ratesInterval)
+	promtimer := internalmetrics.GetPrometheusProcessingTimePrometheusTimer("Metrics-GetRequestRates")
 	result, err := api.Query(context.Background(), query, time)
 	if err != nil {
 		return model.Vector{}, err
 	}
+	promtimer.ObserveDuration() // notice we only collect metrics for successful prom queries
 	return result.(model.Vector), nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -77,6 +77,7 @@ func TestSecureComm(t *testing.T) {
 	serverURL := fmt.Sprintf("https://%v", testServerHostPort)
 	apiURLWithAuthentication := serverURL + "/api/token"
 	apiURL := serverURL + "/api"
+	metricsURL := serverURL + "/metrics"
 
 	config.Set(conf)
 
@@ -129,6 +130,16 @@ func TestSecureComm(t *testing.T) {
 
 	if _, err = getRequestResults(t, httpClient, apiURL, basicCredentials); err != nil {
 		t.Fatalf("Failed: Basic Auth API URL: %v", err)
+	}
+
+	// this makes sure the Prometheus metrics endpoint can start (we made an API call above; there should be metrics)
+	if s, err := getRequestResults(t, httpClient, metricsURL, basicCredentials); err != nil {
+		t.Fatalf("Failed: Basic Auth Metrics URL: %v", err)
+	} else {
+		// makes sure we did get the metrics endpoint
+		if !strings.Contains(s, "HELP go_") || !strings.Contains(s, "TYPE go_") {
+				t.Fatalf("Failed: Metrics URL returned bad results - there are no kial metrics:\n%s", s)
+		}
 	}
 
 	// TEST WITH AN INVALID USER

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -138,7 +138,7 @@ func TestSecureComm(t *testing.T) {
 	} else {
 		// makes sure we did get the metrics endpoint
 		if !strings.Contains(s, "HELP go_") || !strings.Contains(s, "TYPE go_") {
-				t.Fatalf("Failed: Metrics URL returned bad results - there are no kial metrics:\n%s", s)
+			t.Fatalf("Failed: Metrics URL returned bad results - there are no kial metrics:\n%s", s)
 		}
 	}
 


### PR DESCRIPTION
This adds a Prometheus scrape endpoint to Kiali and it collects/exposes several metrics to help detect performance issues within Kiali itself.

This also includes a hack script that lets you run a local Prometheus server that can scrape the Kiali endpoint so you can examine the data (this hack script requires you to have Kiali installed with an exposed OpenShift route - you don't have to worry about this if you are deploying via "make openshift-deploy" because that creates the route for you).