### PR TITLE
KIALI-1783 Resource endpoint now return 404

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -20,6 +20,11 @@ type ObjectChecker interface {
 // GetServiceValidations returns an IstioValidations object with all the checks found when running
 // all the enabled checkers.
 func (in *IstioValidationsService) GetServiceValidations(namespace, service string) (models.IstioValidations, error) {
+	// Ensure the service exists
+	if _, err := in.k8s.GetService(namespace, service); err != nil {
+		return nil, err
+	}
+
 	// Get Gateways and ServiceEntries to validate VirtualServices
 	var err error
 	wg := sync.WaitGroup{}
@@ -46,6 +51,11 @@ func (in *IstioValidationsService) GetServiceValidations(namespace, service stri
 }
 
 func (in *IstioValidationsService) GetNamespaceValidations(namespace string) (models.NamespaceValidations, error) {
+	// Ensure the Namespace exists
+	if _, err := in.k8s.GetNamespace(namespace); err != nil {
+		return nil, err
+	}
+
 	// Get all the Istio objects from a Namespace
 	istioDetails, err := in.k8s.GetIstioDetails(namespace, "")
 	if err != nil {

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -58,6 +58,7 @@ func mockCombinedValidationService(istioObjects *kubernetes.IstioDetails, servic
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().DestinationRules, nil)
 	k8s.On("GetServiceEntries", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().ServiceEntries, nil)
 	k8s.On("GetGateways", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().Gateways, nil)
+	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(fakeNamespace(), nil)
 
 	return IstioValidationsService{k8s: k8s}
 }
@@ -77,6 +78,14 @@ func fakeCombinedIstioDetails() *kubernetes.IstioDetails {
 				data.CreateEmptyDestinationRule("test", "customer-dr", "customer"))),
 	}
 	return &istioDetails
+}
+
+func fakeNamespace() *v1.Namespace {
+	return &v1.Namespace{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "test",
+		},
+	}
 }
 
 func fakeCombinedServices(services []string) []v1.Service {

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -52,7 +53,11 @@ func NamespaceIstioValidations(w http.ResponseWriter, r *http.Request) {
 
 	istioValidations, err := business.Validations.GetNamespaceValidations(namespace)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Error checking istio object consistency: "+err.Error())
+		if errors.IsNotFound(err) {
+			RespondWithError(w, http.StatusNotFound, err.Error())
+		} else {
+			RespondWithError(w, http.StatusInternalServerError, "Error checking istio object consistency: "+err.Error())
+		}
 		return
 	}
 	RespondWithJSON(w, http.StatusOK, istioValidations)

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -88,7 +88,11 @@ func ServiceIstioValidations(w http.ResponseWriter, r *http.Request) {
 
 	istioValidations, err := business.Validations.GetServiceValidations(namespace, service)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Error checking istio object consistency: "+err.Error())
+		if errors.IsNotFound(err) {
+			RespondWithError(w, http.StatusNotFound, err.Error())
+		} else {
+			RespondWithError(w, http.StatusInternalServerError, "Error checking istio object consistency: "+err.Error())
+		}
 		return
 	}
 	RespondWithJSON(w, http.StatusOK, istioValidations)

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -221,6 +221,7 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//      500: internalError
+		//      404: notFoundError
 		//      200: workloadDetails
 		//
 		{
@@ -261,6 +262,7 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//      500: internalError
+		//      404: notFoundError
 		//      200: appDetails
 		//
 		{
@@ -422,6 +424,7 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//      500: internalError
+		//      404: notFoundError
 		//      200: typeValidationsResponse
 		//
 		{
@@ -484,6 +487,7 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//      500: internalError
+		//      404: notFoundError
 		//      200: namespaceValidationsResponse
 		//
 		{

--- a/swagger.json
+++ b/swagger.json
@@ -1051,6 +1051,9 @@
           "200": {
             "$ref": "#/responses/appDetails"
           },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
           "500": {
             "$ref": "#/responses/internalError"
           }
@@ -1326,6 +1329,9 @@
           "200": {
             "$ref": "#/responses/namespaceValidationsResponse"
           },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
           "500": {
             "$ref": "#/responses/internalError"
           }
@@ -1533,6 +1539,9 @@
           "200": {
             "$ref": "#/responses/typeValidationsResponse"
           },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
           "500": {
             "$ref": "#/responses/internalError"
           }
@@ -1608,6 +1617,9 @@
         "responses": {
           "200": {
             "$ref": "#/responses/workloadDetails"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
           },
           "500": {
             "$ref": "#/responses/internalError"


### PR DESCRIPTION
** Describe the change **

 - workloadDetails and appDetails already returned 404, only updated the docs
 - Additional checks were added to  serviceValidations and
   namespaceValidations to verify the existance of the namespace
   and the service.


** Backwards incompatible? **

- [x] Is your change introducing backwards incompatible changes?

 serviceValidations and namespaceValidations now return 404 instead of 500 if the namespace or service does not exist

~Edit: I need to update the tests.~
