### PR TITLE
KIALI-1813 / istio-1.0.4 Envoy Health Membership model changed

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -106,7 +106,7 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 
 	wg := sync.WaitGroup{}
 	wg.Add(8)
-	errChan := make(chan error, 6)
+	errChan := make(chan error, 7)
 
 	labelsSelector := labels.Set(svc.Spec.Selector).String()
 
@@ -121,7 +121,11 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 
 	go func() {
 		defer wg.Done()
-		hth = in.businessLayer.Health.getServiceHealth(namespace, service, interval, queryTime, svc)
+		var err2 error
+		hth, err2 = in.businessLayer.Health.GetServiceHealth(namespace, service, interval, queryTime)
+		if err2 != nil {
+			errChan <- err2
+		}
 	}()
 
 	go func() {

--- a/models/health.go
+++ b/models/health.go
@@ -16,15 +16,14 @@ type NamespaceWorkloadHealth map[string]*WorkloadHealth
 
 // ServiceHealth contains aggregated health from various sources, for a given service
 type ServiceHealth struct {
-	Envoy    prometheus.EnvoyServiceHealth `json:"envoy"`
-	Requests RequestHealth                 `json:"requests"`
+	Requests RequestHealth `json:"requests"`
 }
 
 // AppHealth contains aggregated health from various sources, for a given app
 type AppHealth struct {
-	Envoy            []EnvoyHealthWrapper `json:"envoy"`
-	WorkloadStatuses []WorkloadStatus     `json:"workloadStatuses"`
-	Requests         RequestHealth        `json:"requests"`
+	Envoy            prometheus.EnvoyMembershipRatio `json:"envoy"`
+	WorkloadStatuses []WorkloadStatus                `json:"workloadStatuses"`
+	Requests         RequestHealth                   `json:"requests"`
 }
 
 func NewEmptyRequestHealth() RequestHealth {
@@ -34,7 +33,6 @@ func NewEmptyRequestHealth() RequestHealth {
 // EmptyAppHealth create an empty AppHealth
 func EmptyAppHealth() AppHealth {
 	return AppHealth{
-		Envoy:            []EnvoyHealthWrapper{},
 		WorkloadStatuses: []WorkloadStatus{},
 		Requests:         NewEmptyRequestHealth(),
 	}
@@ -43,7 +41,6 @@ func EmptyAppHealth() AppHealth {
 // EmptyServiceHealth create an empty ServiceHealth
 func EmptyServiceHealth() ServiceHealth {
 	return ServiceHealth{
-		Envoy:    prometheus.EnvoyServiceHealth{},
 		Requests: NewEmptyRequestHealth(),
 	}
 }
@@ -52,12 +49,6 @@ func EmptyServiceHealth() ServiceHealth {
 type WorkloadHealth struct {
 	WorkloadStatus WorkloadStatus `json:"workloadStatus"`
 	Requests       RequestHealth  `json:"requests"`
-}
-
-// EnvoyHealthWrapper wraps EnvoyServiceHealth with the service name
-type EnvoyHealthWrapper struct {
-	prometheus.EnvoyServiceHealth
-	Service string `json:"service"`
 }
 
 // WorkloadStatus gives the available / total replicas in a deployment of a pod

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -18,7 +18,7 @@ import (
 
 // ClientInterface for mocks (only mocked function are necessary here)
 type ClientInterface interface {
-	GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyServiceHealth, error)
+	GetEnvoyMembershipRatio(namespace, app string) (EnvoyMembershipRatio, error)
 	GetAllRequestRates(namespace, ratesInterval string, queryTime time.Time) (model.Vector, error)
 	GetNamespaceServicesRequestRates(namespace, ratesInterval string, queryTime time.Time) (model.Vector, error)
 	GetServiceRequestRates(namespace, service, ratesInterval string, queryTime time.Time) (model.Vector, error)
@@ -169,11 +169,10 @@ func (in *Client) GetMetrics(query *IstioMetricsQuery) Metrics {
 	return getMetrics(in.api, query)
 }
 
-// GetServiceHealth returns the Health related to the provided service identified by its namespace and service name.
-// It reads Envoy metrics, inbound and outbound
+// GetEnvoyMembershipRatio returns the Envoy Health (Membership ratio) related to the provided app and namespace.
 // When the health is unavailable, total number of members will be 0.
-func (in *Client) GetServiceHealth(namespace, servicename string, ports []int32) (EnvoyServiceHealth, error) {
-	return getServiceHealth(in.api, namespace, servicename, ports)
+func (in *Client) GetEnvoyMembershipRatio(namespace, app string) (EnvoyMembershipRatio, error) {
+	return getEnvoyMembershipRatio(in.api, namespace, app)
 }
 
 // GetAllRequestRates queries Prometheus to fetch request counter rates, over a time interval, for requests

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -88,9 +88,29 @@ type PromClientMock struct {
 	mock.Mock
 }
 
-func (o *PromClientMock) GetServiceHealth(namespace, servicename string, ports []int32) (prometheus.EnvoyServiceHealth, error) {
-	args := o.Called(namespace, servicename, ports)
-	return args.Get(0).(prometheus.EnvoyServiceHealth), args.Error(1)
+// MockEnvoyMembershipRatio mocks GetEnvoyMembershipRatio for given namespace and app, returning provided healthy/total
+func (o *PromClientMock) MockEnvoyMembershipRatio(namespace, app string, healthy, total int) {
+	o.On("GetEnvoyMembershipRatio", namespace, app).Return(prometheus.EnvoyMembershipRatio{Healthy: healthy, Total: total}, nil)
+}
+
+// MockAppRequestRates mocks GetAppRequestRates for given namespace and app, returning in & out vectors
+func (o *PromClientMock) MockAppRequestRates(namespace, app string, in, out model.Vector) {
+	o.On("GetAppRequestRates", namespace, app, mock.AnythingOfType("string"), mock.AnythingOfType("time.Time")).Return(in, out, nil)
+}
+
+// MockServiceRequestRates mocks GetServiceRequestRates for given namespace and service, returning in vector
+func (o *PromClientMock) MockServiceRequestRates(namespace, service string, in model.Vector) {
+	o.On("GetServiceRequestRates", namespace, service, mock.AnythingOfType("string"), mock.AnythingOfType("time.Time")).Return(in, nil)
+}
+
+// MockWorkloadRequestRates mocks GetWorkloadRequestRates for given namespace and workload, returning in & out vectors
+func (o *PromClientMock) MockWorkloadRequestRates(namespace, wkld string, in, out model.Vector) {
+	o.On("GetWorkloadRequestRates", namespace, wkld, mock.AnythingOfType("string"), mock.AnythingOfType("time.Time")).Return(in, out, nil)
+}
+
+func (o *PromClientMock) GetEnvoyMembershipRatio(namespace, app string) (prometheus.EnvoyMembershipRatio, error) {
+	args := o.Called(namespace, app)
+	return args.Get(0).(prometheus.EnvoyMembershipRatio), args.Error(1)
 }
 
 func (o *PromClientMock) GetAllRequestRates(namespace, ratesInterval string, queryTime time.Time) (model.Vector, error) {

--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -74,14 +74,8 @@ type Metric struct {
 // Histogram contains Metric objects for several histogram-kind statistics
 type Histogram = map[string]*Metric
 
-// EnvoyServiceHealth is the number of healthy versus total membership (ie. replicas) inside envoy cluster for inbound and outbound traffic
-type EnvoyServiceHealth struct {
-	Inbound  EnvoyRatio `json:"inbound"`
-	Outbound EnvoyRatio `json:"outbound"`
-}
-
-// EnvoyRatio is the number of healthy members versus total members
-type EnvoyRatio struct {
+// EnvoyMembershipRatio is the number of healthy members versus total members
+type EnvoyMembershipRatio struct {
 	Healthy int `json:"healthy"`
 	Total   int `json:"total"`
 }

--- a/swagger.json
+++ b/swagger.json
@@ -2629,11 +2629,7 @@
       "type": "object",
       "properties": {
         "envoy": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EnvoyHealthWrapper"
-          },
-          "x-go-name": "Envoy"
+          "$ref": "#/definitions/EnvoyMembershipRatio"
         },
         "requests": {
           "$ref": "#/definitions/RequestHealth"
@@ -2879,25 +2875,8 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
-    "EnvoyHealthWrapper": {
-      "description": "EnvoyHealthWrapper wraps EnvoyServiceHealth with the service name",
-      "type": "object",
-      "properties": {
-        "inbound": {
-          "$ref": "#/definitions/EnvoyRatio"
-        },
-        "outbound": {
-          "$ref": "#/definitions/EnvoyRatio"
-        },
-        "service": {
-          "type": "string",
-          "x-go-name": "Service"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/models"
-    },
-    "EnvoyRatio": {
-      "description": "EnvoyRatio is the number of healthy members versus total members",
+    "EnvoyMembershipRatio": {
+      "description": "EnvoyMembershipRatio is the number of healthy members versus total members",
       "type": "object",
       "properties": {
         "healthy": {
@@ -2909,19 +2888,6 @@
           "type": "integer",
           "format": "int64",
           "x-go-name": "Total"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/prometheus"
-    },
-    "EnvoyServiceHealth": {
-      "description": "EnvoyServiceHealth is the number of healthy versus total membership (ie. replicas) inside envoy cluster for inbound and outbound traffic",
-      "type": "object",
-      "properties": {
-        "inbound": {
-          "$ref": "#/definitions/EnvoyRatio"
-        },
-        "outbound": {
-          "$ref": "#/definitions/EnvoyRatio"
         }
       },
       "x-go-package": "github.com/kiali/kiali/prometheus"
@@ -3891,9 +3857,6 @@
       "description": "ServiceHealth contains aggregated health from various sources, for a given service",
       "type": "object",
       "properties": {
-        "envoy": {
-          "$ref": "#/definitions/EnvoyServiceHealth"
-        },
         "requests": {
           "$ref": "#/definitions/RequestHealth"
         }

--- a/util/coalesce.go
+++ b/util/coalesce.go
@@ -1,0 +1,11 @@
+package util
+
+// CoalesceErrors returns the first non-nil error
+func CoalesceErrors(args ...error) error {
+	for _, obj := range args {
+		if obj != nil {
+			return obj
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- Envoy metrics are now more prometheus-friendly, with labels
- Now related to app instead of services. This makes it a lot easier to manage (lot of code removed because of that)
- Some improvements in mocks/tests

UI PR: https://github.com/kiali/kiali-ui/pull/775/files

JIRA: https://issues.jboss.org/browse/KIALI-1813

This change **is backward incompatible with Istio < 1.1.0**
