### PR TITLE
KIALI-1840 added a new metric that can let us track the behavior of individual Go funcs

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -2,14 +2,16 @@ package business
 
 import (
 	"fmt"
-	"github.com/kiali/kiali/log"
+	"sync"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"sync"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 // AppService deals with fetching Workloads group by "app" label, which will be identified as an "application"
@@ -40,6 +42,9 @@ func (in *AppService) fetchWorkloadsPerApp(namespace, labelSelector string) (app
 
 // GetAppList is the API handler to fetch the list of applications in a given namespace
 func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "AppService", "GetAppList")
+	defer promtimer.ObserveDuration()
+
 	appList := &models.AppList{
 		Namespace: models.Namespace{Name: namespace},
 		Apps:      []models.AppListItem{},
@@ -66,6 +71,9 @@ func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
 
 // GetApp is the API handler to fetch the details for a given namespace and app name
 func (in *AppService) GetApp(namespace string, appName string) (models.App, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "AppService", "GetApp")
+	defer promtimer.ObserveDuration()
+
 	appInstance := &models.App{Namespace: models.Namespace{Name: namespace}, Name: appName}
 	namespaceApps, err := fetchNamespaceApps(in.k8s, namespace, appName)
 	if err != nil {

--- a/business/health.go
+++ b/business/health.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 // HealthService deals with fetching health from various sources and convert to kiali model
@@ -23,6 +24,9 @@ type HealthService struct {
 
 // GetServiceHealth returns a service health from just Namespace and service (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetServiceHealth(namespace, service, rateInterval string, queryTime time.Time) (*models.ServiceHealth, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetServiceHealth")
+	defer promtimer.ObserveDuration()
+
 	svc, err := in.k8s.GetService(namespace, service)
 	if err != nil {
 		return nil, err
@@ -47,6 +51,9 @@ func (in *HealthService) getServiceHealth(namespace, service, rateInterval strin
 
 // GetAppHealth returns an app health from just Namespace and app name (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetAppHealth(namespace, app, rateInterval string, queryTime time.Time) (*models.AppHealth, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetAppHealth")
+	defer promtimer.ObserveDuration()
+
 	var services []v1.Service
 	var ws models.Workloads
 
@@ -123,6 +130,9 @@ func (in *HealthService) getAppHealth(namespace, app, rateInterval string, query
 
 // GetWorkloadHealth returns a workload health from just Namespace and workload (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetWorkloadHealth(namespace, workload, rateInterval string, queryTime time.Time) (*models.WorkloadHealth, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetWorkloadHealth")
+	defer promtimer.ObserveDuration()
+
 	// Fill all parts
 	health := models.WorkloadHealth{}
 	w, err := fetchWorkload(in.k8s, namespace, workload)
@@ -140,6 +150,9 @@ func (in *HealthService) GetWorkloadHealth(namespace, workload, rateInterval str
 
 // GetNamespaceAppHealth returns a health for all apps in given Namespace (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetNamespaceAppHealth(namespace, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetNamespaceAppHealth")
+	defer promtimer.ObserveDuration()
+
 	appEntities, err := fetchNamespaceApps(in.k8s, namespace, "")
 	if err != nil {
 		return nil, err
@@ -194,6 +207,9 @@ func (in *HealthService) getNamespaceAppHealth(namespace string, appEntities nam
 
 // GetNamespaceServiceHealth returns a health for all services in given Namespace (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetNamespaceServiceHealth(namespace, rateInterval string, queryTime time.Time) (models.NamespaceServiceHealth, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetNamespaceServiceHealth")
+	defer promtimer.ObserveDuration()
+
 	services, err := in.k8s.GetServices(namespace, nil)
 	if err != nil {
 		return nil, err
@@ -238,6 +254,9 @@ func (in *HealthService) getNamespaceServiceHealth(namespace string, services []
 
 // GetNamespaceWorkloadHealth returns a health for all workloads in given Namespace (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetNamespaceWorkloadHealth(namespace, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetNamespaceWorkloadHealth")
+	defer promtimer.ObserveDuration()
+
 	wl, err := fetchWorkloads(in.k8s, namespace, "")
 	if err != nil {
 		return nil, err

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 type IstioConfigService struct {
@@ -40,6 +41,9 @@ var resourceTypesToAPI = map[string]string{
 // GetIstioConfigList returns a list of Istio routing objects, Mixer Rules, (etc.)
 // per a given Namespace.
 func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (models.IstioConfigList, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "IstioConfigService", "GetIstioConfigList")
+	defer promtimer.ObserveDuration()
+
 	if criteria.Namespace == "" {
 		return models.IstioConfigList{}, errors.New("GetIstioConfigList needs a non empty Namespace")
 	}
@@ -134,6 +138,9 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 }
 
 func (in *IstioConfigService) GetIstioConfigDetails(namespace string, objectType string, object string) (models.IstioConfigDetails, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "IstioConfigService", "GetIstioConfigDetails")
+	defer promtimer.ObserveDuration()
+
 	istioConfigDetail := models.IstioConfigDetails{}
 	istioConfigDetail.Namespace = models.Namespace{Name: namespace}
 	istioConfigDetail.ObjectType = objectType
@@ -225,5 +232,7 @@ func GetIstioAPI(resourceType string) string {
 
 // DeleteIstioConfigDetail deletes the given Istio resource
 func (in *IstioConfigService) DeleteIstioConfigDetail(api, namespace, resourceType, name string) error {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "IstioConfigService", "DeleteIstioConfigDetail")
+	defer promtimer.ObserveDuration()
 	return in.k8s.DeleteIstioObject(api, namespace, resourceType, name)
 }

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 type IstioValidationsService struct {
@@ -20,6 +21,9 @@ type ObjectChecker interface {
 // GetServiceValidations returns an IstioValidations object with all the checks found when running
 // all the enabled checkers.
 func (in *IstioValidationsService) GetServiceValidations(namespace, service string) (models.IstioValidations, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "IstioValidationsService", "GetServiceValidations")
+	defer promtimer.ObserveDuration()
+
 	// Ensure the service exists
 	if _, err := in.k8s.GetService(namespace, service); err != nil {
 		return nil, err
@@ -51,6 +55,9 @@ func (in *IstioValidationsService) GetServiceValidations(namespace, service stri
 }
 
 func (in *IstioValidationsService) GetNamespaceValidations(namespace string) (models.NamespaceValidations, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "IstioValidationsService", "GetNamespaceValidations")
+	defer promtimer.ObserveDuration()
+
 	// Ensure the Namespace exists
 	if _, err := in.k8s.GetNamespace(namespace); err != nil {
 		return nil, err
@@ -100,6 +107,9 @@ func (in *IstioValidationsService) GetNamespaceValidations(namespace string) (mo
 }
 
 func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, objectType string, object string) (models.IstioValidations, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "IstioValidationsService", "GetIstioObjectValidations")
+	defer promtimer.ObserveDuration()
+
 	services, err := in.k8s.GetServices(namespace, nil)
 	if err != nil {
 		return nil, err

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 // Namespace deals with fetching k8s namespaces / OpenShift projects and convert to kiali model
@@ -32,6 +33,9 @@ func NewNamespaceService(k8s kubernetes.IstioClientInterface) NamespaceService {
 
 // Returns a list of the given namespaces / projects
 func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "NamespaceService", "GetNamespaces")
+	defer promtimer.ObserveDuration()
+
 	namespaces := []models.Namespace{}
 	// If we are running in OpenShift, we will use the project names since these are the list of accessible namespaces
 	if in.hasProjects {

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -73,6 +73,9 @@ func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
 
 // GetNamespace returns the definition of the specified namespace.
 func (in *NamespaceService) GetNamespace(namespace string) (*models.Namespace, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "NamespaceService", "GetNamespace")
+	defer promtimer.ObserveDuration()
+
 	if in.hasProjects {
 		if project, err := in.k8s.GetProject(namespace); err == nil {
 			result := models.CastProject(*project)

--- a/business/services.go
+++ b/business/services.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 // SvcService deals with fetching istio/kubernetes services related content and convert to kiali model
@@ -23,6 +24,8 @@ type SvcService struct {
 
 // GetServiceList returns a list of all services for a given Namespace
 func (in *SvcService) GetServiceList(namespace string) (*models.ServiceList, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "SvcService", "GetServiceList")
+	defer promtimer.ObserveDuration()
 
 	var svcs []v1.Service
 	var pods []v1.Pod
@@ -85,6 +88,9 @@ func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []v1.Ser
 
 // GetService returns a single service
 func (in *SvcService) GetService(namespace, service, interval string, queryTime time.Time) (*models.ServiceDetails, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "SvcService", "GetService")
+	defer promtimer.ObserveDuration()
+
 	var svc *v1.Service
 	var eps *v1.Endpoints
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -3,19 +3,20 @@ package business
 import (
 	"sort"
 	"sync"
+	"time"
 
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/log"
-	"github.com/kiali/kiali/models"
 	osappsv1 "github.com/openshift/api/apps/v1"
-
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/apps/v1beta2"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"time"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 // Workload deals with fetching istio/kubernetes workloads related content and convert to kiali model
@@ -25,6 +26,8 @@ type WorkloadService struct {
 
 // GetWorkloadList is the API handler to fetch the list of workloads in a given namespace.
 func (in *WorkloadService) GetWorkloadList(namespace string) (models.WorkloadList, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "WorkloadService", "GetWorkloadList")
+	defer promtimer.ObserveDuration()
 
 	workloadList := &models.WorkloadList{
 		Namespace: models.Namespace{namespace, time.Time{}},
@@ -47,6 +50,9 @@ func (in *WorkloadService) GetWorkloadList(namespace string) (models.WorkloadLis
 // GetWorkload is the API handler to fetch details of a specific workload.
 // If includeServices is set true, the Workload will fetch all services related
 func (in *WorkloadService) GetWorkload(namespace string, workloadName string, includeServices bool) (*models.Workload, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "WorkloadService", "GetWorkload")
+	defer promtimer.ObserveDuration()
+
 	workload, err := fetchWorkload(in.k8s, namespace, workloadName)
 	if err != nil {
 		return nil, err
@@ -64,6 +70,9 @@ func (in *WorkloadService) GetWorkload(namespace string, workloadName string, in
 }
 
 func (in *WorkloadService) GetPods(namespace string, labelSelector string) (models.Pods, error) {
+	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "WorkloadService", "GetPods")
+	defer promtimer.ObserveDuration()
+
 	ps, err := in.k8s.GetPods(namespace, labelSelector)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The idea was to first collect this metric for all business layer functions. We can add more as we go.
I only include a single metric collection to the GetNamespaces business function in the first commit because I didn't want to conflict with work currently going on. We can add more as we go along.