### PR TITLE
[KIALI-1846] Update Bookinfo Ansible Playbooks

### DIFF
--- a/hack/istio/playbooks/README.adoc
+++ b/hack/istio/playbooks/README.adoc
@@ -12,6 +12,9 @@
 All the Bookinfo Demo pods and services are installed in the "bookinfo" namespace by default. If you want to define a different namespace from bookinfo, please set `-e bookinfo_namespace='your_namespace'`
 
 
+[NOTE]
+Bookinfo Version should be defined according to Istio Release. Check https://github.com/istio/istio/blob/master/samples/bookinfo/platform/kube/bookinfo.yaml
+
 - In order to uninstall it, simply delete that namespace via something like `kubectl delete namespace bookinfo` or
 `oc delete project bookinfo` (or namespace that you used)
 

--- a/hack/istio/playbooks/files/bookinfo-mongodb.yaml
+++ b/hack/istio/playbooks/files/bookinfo-mongodb.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: mongodb
-        image: istio/examples-bookinfo-mongodb:1.8.0
+        image: istio/examples-bookinfo-mongodb:${VERSION}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/hack/istio/playbooks/files/bookinfo-mysql.yaml
+++ b/hack/istio/playbooks/files/bookinfo-mysql.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: istio/examples-bookinfo-mysqldb:1.8.0
+        image: istio/examples-bookinfo-mysqldb:${VERSION}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/hack/istio/playbooks/files/bookinfo-ratings-v2-mongodb.yaml
+++ b/hack/istio/playbooks/files/bookinfo-ratings-v2-mongodb.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.8.0
+        image: istio/examples-bookinfo-ratings-v2:${VERSION}
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/hack/istio/playbooks/files/bookinfo-ratings-v2-mysql.yaml
+++ b/hack/istio/playbooks/files/bookinfo-ratings-v2-mysql.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.8.0
+        image: istio/examples-bookinfo-ratings-v2:${VERSION}
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/hack/istio/playbooks/files/bookinfo.yaml
+++ b/hack/istio/playbooks/files/bookinfo.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details-container
-        image: istio/examples-bookinfo-details-v1:1.8.0
+        image: istio/examples-bookinfo-details-v1:${VERSION}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: ratings-container
-        image: istio/examples-bookinfo-ratings-v1:1.8.0
+        image: istio/examples-bookinfo-ratings-v1:${VERSION}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
       - name: reviews-container
-        image: istio/examples-bookinfo-reviews-v1:1.8.0
+        image: istio/examples-bookinfo-reviews-v1:${VERSION}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -131,7 +131,7 @@ spec:
     spec:
       containers:
       - name: reviews-container
-        image: istio/examples-bookinfo-reviews-v2:1.8.0
+        image: istio/examples-bookinfo-reviews-v2:${VERSION}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -150,7 +150,7 @@ spec:
     spec:
       containers:
       - name: reviews-container
-        image: istio/examples-bookinfo-reviews-v3:1.8.0
+        image: istio/examples-bookinfo-reviews-v3:${VERSION}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
       - name: productpage-container
-        image: istio/examples-bookinfo-productpage-v1:1.8.0
+        image: istio/examples-bookinfo-productpage-v1:${VERSION}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/hack/istio/playbooks/install_bookinfo.yml
+++ b/hack/istio/playbooks/install_bookinfo.yml
@@ -16,6 +16,11 @@
         bookinfo_namespace: 'bookinfo'
       when: bookinfo_namespace is not defined
 
+    - name: Define Bookinfo Version if is not defined
+      set_fact:
+        bookinfo_version: '1.9.0'
+      when: bookinfo_version is not defined
+
     - name: Define Rename Label if is not defined
       set_fact:
         rename_label: ''
@@ -50,7 +55,7 @@
       shell: "oc adm policy add-scc-to-user privileged -z default -n {{bookinfo_namespace}}"
 
     - name: Deploy Bookinfo
-      shell: "cat {{item}} | LABEL={{ rename_label }} envsubst  | istioctl kube-inject -f - | oc apply -n {{bookinfo_namespace}} -f -  "
+      shell: "cat {{item}} | LABEL={{ rename_label }} VERSION={{ bookinfo_version }} envsubst   | istioctl kube-inject -f - | oc apply -n {{bookinfo_namespace}} -f -  "
       with_items:
         - "{{ istio_bookinfo_deployment_path }}"
 
@@ -60,14 +65,14 @@
         - "{{ istio_bookinfo_gateway_path }}"
 
     - name: Deploy MongoDB
-      shell: "cat {{item}} |  LABEL={{ rename_label }} envsubst  | istioctl kube-inject -f - | oc apply -n {{bookinfo_namespace}} -f -  "
+      shell: "cat {{item}} |  LABEL={{ rename_label }} VERSION={{ bookinfo_version }} envsubst   | istioctl kube-inject -f - | oc apply -n {{bookinfo_namespace}} -f -  "
       when: "mongodb is defined and mongodb == 'true'"
       with_items:
         - "{{ istio_bookinfo_mongodb_deployment_path }}"
         - "{{ istio_bookinfo_mongodb_service_path }}"
 
     - name: Deploy MySQL
-      shell: "cat {{item}} |  LABEL={{ rename_label }} envsubst   | istioctl kube-inject -f - | oc apply -n {{bookinfo_namespace}} -f -  "
+      shell: "cat {{item}} |  LABEL={{ rename_label }} VERSION={{ bookinfo_version }} envsubst    | istioctl kube-inject -f - | oc apply -n {{bookinfo_namespace}} -f -  "
       when: "mysql is defined and mysql == 'true'"
       with_items:
         - "{{ istio_bookinfo_mysql_deployment_path }}"


### PR DESCRIPTION
## Describe the change 

- Bookinfo ansible playbooks (https://github.com/kiali/kiali/tree/master/hack/istio/playbooks) differ from standard bookinfo playbooks available on Istio repository. We use some labeling which is very helpful to differ service, workload, app and pod name (that was created before the complex-mesh on kiali-test-mesh).

- Bookinfo have been updated from 1.8.0 to 1.9.0 (https://github.com/istio/istio/blob/master/samples/bookinfo/platform/kube/bookinfo.yaml) on 1.0.3, so I have added a variable to make it changeable 

- It is causing failures on PR tester (https://paste.fedoraproject.org/paste/T6AiNU9g0EBfGPC~VgyCFA)

## Issue reference 

`KIALI-1846 Update Bookinfo Ansible Playbooks`