### PR TITLE
KIALI-1843 Enable/disable k8s cache from config

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -528,7 +528,7 @@ kubernetes_config:
 
 Kubernetes cache is not compatible with reduced permissions scenearios.
 
-(default is true)
+(default is false)
 [source,yaml]
 ----
 kubernetes_config:

--- a/README.adoc
+++ b/README.adoc
@@ -515,12 +515,35 @@ kubernetes_config:
   burst: VALUE
 ----
 |`KUBERNETES_QPS`
-|The QPS value of Kubernetes client (default is 100)
+|The QPS value of Kubernetes client (default is 175)
 [source,yaml]
 ----
 kubernetes_config:
   qps: VALUE
 ----
+|`KUBERNETES_CACHE_ENABLED`
+|Flag to use a Kubernetes cache for watching changes and updating pods and controllers data asynchronously.
+
+*Important*
+
+Kubernetes cache is not compatible with reduced permissions scenearios.
+
+(default is true)
+[source,yaml]
+----
+kubernetes_config:
+  cache_enabled: VALUE
+----
+|`KUBERNETES_CACHE_DURATION`
+|The ratio interval (expressed in nanoseconds) used for the cache to perform a full refresh.
+
+(default is 300000000)
+[source,yaml]
+----
+kubernetes_config:
+  cache_duration: VALUE
+----
+
 |===
 
 == Configure External Services

--- a/config/config.go
+++ b/config/config.go
@@ -208,7 +208,7 @@ func NewConfig() (c *Config) {
 	// Kubernetes client Configuration
 	c.KubernetesConfig.Burst = getDefaultInt(EnvKubernetesBurst, 200)
 	c.KubernetesConfig.QPS = getDefaultFloat32(EnvKubernetesQPS, 175)
-	c.KubernetesConfig.CacheEnabled = getDefaultBool(EnvKubernetesCacheEnabled, true)
+	c.KubernetesConfig.CacheEnabled = getDefaultBool(EnvKubernetesCacheEnabled, false)
 	c.KubernetesConfig.CacheDuration = getDefaultInt64(EnvKubernetesCacheDuration, time.Duration(5*time.Minute).Nanoseconds())
 
 	trimmedExclusionPatterns := []string{}

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ const (
 
 	EnvKubernetesBurst         = "KUBERNETES_BURST"
 	EnvKubernetesQPS           = "KUBERNETES_QPS"
+	EnvKubernetesCacheEnabled  = "KUBERNETES_CACHE_ENABLED"
 	EnvKubernetesCacheDuration = "KUBERNETES_CACHE_DURATION"
 )
 
@@ -128,6 +129,7 @@ type IstioLabels struct {
 type KubernetesConfig struct {
 	Burst         int     `yaml:"burst,omitempty"`
 	QPS           float32 `yaml:"qps,omitempty"`
+	CacheEnabled  bool    `yaml:"cache_enabled,omitempty"`
 	CacheDuration int64   `yaml:"cache_duration,omitempty"`
 }
 
@@ -206,6 +208,7 @@ func NewConfig() (c *Config) {
 	// Kubernetes client Configuration
 	c.KubernetesConfig.Burst = getDefaultInt(EnvKubernetesBurst, 200)
 	c.KubernetesConfig.QPS = getDefaultFloat32(EnvKubernetesQPS, 175)
+	c.KubernetesConfig.CacheEnabled = getDefaultBool(EnvKubernetesCacheEnabled, true)
 	c.KubernetesConfig.CacheDuration = getDefaultInt64(EnvKubernetesCacheDuration, time.Duration(5*time.Minute).Nanoseconds())
 
 	trimmedExclusionPatterns := []string{}


### PR DESCRIPTION
Main discussion for this issue can be found under the JIRA:
https://issues.jboss.org/browse/KIALI-1843

Reducing permissions scenarios won't work well with k8s cache.
So, instead to add complexity including cache per namespace (and per token in a future) I think it's doable to disable the cache.

I put the cache enabled by default as main scenarios are without security, but it's open to change that on the PR.
