### PR TITLE
KIALI-1848 add error counters for go function metrics

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -42,8 +42,9 @@ func (in *AppService) fetchWorkloadsPerApp(namespace, labelSelector string) (app
 
 // GetAppList is the API handler to fetch the list of applications in a given namespace
 func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "AppService", "GetAppList")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "AppService", "GetAppList")
+	defer promtimer.ObserveNow(&err)
 
 	appList := &models.AppList{
 		Namespace: models.Namespace{Name: namespace},
@@ -71,8 +72,9 @@ func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
 
 // GetApp is the API handler to fetch the details for a given namespace and app name
 func (in *AppService) GetApp(namespace string, appName string) (models.App, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "AppService", "GetApp")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "AppService", "GetApp")
+	defer promtimer.ObserveNow(&err)
 
 	appInstance := &models.App{Namespace: models.Namespace{Name: namespace}, Name: appName}
 	namespaceApps, err := fetchNamespaceApps(in.k8s, namespace, appName)

--- a/business/health.go
+++ b/business/health.go
@@ -24,8 +24,9 @@ type HealthService struct {
 
 // GetServiceHealth returns a service health from just Namespace and service (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetServiceHealth(namespace, service, rateInterval string, queryTime time.Time) (*models.ServiceHealth, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetServiceHealth")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "HealthService", "GetServiceHealth")
+	defer promtimer.ObserveNow(&err)
 
 	svc, err := in.k8s.GetService(namespace, service)
 	if err != nil {
@@ -51,8 +52,9 @@ func (in *HealthService) getServiceHealth(namespace, service, rateInterval strin
 
 // GetAppHealth returns an app health from just Namespace and app name (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetAppHealth(namespace, app, rateInterval string, queryTime time.Time) (*models.AppHealth, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetAppHealth")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "HealthService", "GetAppHealth")
+	defer promtimer.ObserveNow(&err)
 
 	var services []v1.Service
 	var ws models.Workloads
@@ -130,8 +132,9 @@ func (in *HealthService) getAppHealth(namespace, app, rateInterval string, query
 
 // GetWorkloadHealth returns a workload health from just Namespace and workload (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetWorkloadHealth(namespace, workload, rateInterval string, queryTime time.Time) (*models.WorkloadHealth, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetWorkloadHealth")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "HealthService", "GetWorkloadHealth")
+	defer promtimer.ObserveNow(&err)
 
 	// Fill all parts
 	health := models.WorkloadHealth{}
@@ -150,8 +153,9 @@ func (in *HealthService) GetWorkloadHealth(namespace, workload, rateInterval str
 
 // GetNamespaceAppHealth returns a health for all apps in given Namespace (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetNamespaceAppHealth(namespace, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetNamespaceAppHealth")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "HealthService", "GetNamespaceAppHealth")
+	defer promtimer.ObserveNow(&err)
 
 	appEntities, err := fetchNamespaceApps(in.k8s, namespace, "")
 	if err != nil {
@@ -207,8 +211,9 @@ func (in *HealthService) getNamespaceAppHealth(namespace string, appEntities nam
 
 // GetNamespaceServiceHealth returns a health for all services in given Namespace (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetNamespaceServiceHealth(namespace, rateInterval string, queryTime time.Time) (models.NamespaceServiceHealth, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetNamespaceServiceHealth")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "HealthService", "GetNamespaceServiceHealth")
+	defer promtimer.ObserveNow(&err)
 
 	services, err := in.k8s.GetServices(namespace, nil)
 	if err != nil {
@@ -254,8 +259,9 @@ func (in *HealthService) getNamespaceServiceHealth(namespace string, services []
 
 // GetNamespaceWorkloadHealth returns a health for all workloads in given Namespace (thus, it fetches data from K8S and Prometheus)
 func (in *HealthService) GetNamespaceWorkloadHealth(namespace, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "HealthService", "GetNamespaceWorkloadHealth")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "HealthService", "GetNamespaceWorkloadHealth")
+	defer promtimer.ObserveNow(&err)
 
 	wl, err := fetchWorkloads(in.k8s, namespace, "")
 	if err != nil {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -21,8 +21,9 @@ type ObjectChecker interface {
 // GetServiceValidations returns an IstioValidations object with all the checks found when running
 // all the enabled checkers.
 func (in *IstioValidationsService) GetServiceValidations(namespace, service string) (models.IstioValidations, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "IstioValidationsService", "GetServiceValidations")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "IstioValidationsService", "GetServiceValidations")
+	defer promtimer.ObserveNow(&err)
 
 	// Ensure the service exists
 	if _, err := in.k8s.GetService(namespace, service); err != nil {
@@ -30,7 +31,6 @@ func (in *IstioValidationsService) GetServiceValidations(namespace, service stri
 	}
 
 	// Get Gateways and ServiceEntries to validate VirtualServices
-	var err error
 	wg := sync.WaitGroup{}
 	errChan := make(chan error, 2)
 
@@ -55,8 +55,9 @@ func (in *IstioValidationsService) GetServiceValidations(namespace, service stri
 }
 
 func (in *IstioValidationsService) GetNamespaceValidations(namespace string) (models.NamespaceValidations, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "IstioValidationsService", "GetNamespaceValidations")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "IstioValidationsService", "GetNamespaceValidations")
+	defer promtimer.ObserveNow(&err)
 
 	// Ensure the Namespace exists
 	if _, err := in.k8s.GetNamespace(namespace); err != nil {
@@ -107,8 +108,9 @@ func (in *IstioValidationsService) GetNamespaceValidations(namespace string) (mo
 }
 
 func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, objectType string, object string) (models.IstioValidations, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "IstioValidationsService", "GetIstioObjectValidations")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "IstioValidationsService", "GetIstioObjectValidations")
+	defer promtimer.ObserveNow(&err)
 
 	services, err := in.k8s.GetServices(namespace, nil)
 	if err != nil {

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -33,14 +33,15 @@ func NewNamespaceService(k8s kubernetes.IstioClientInterface) NamespaceService {
 
 // Returns a list of the given namespaces / projects
 func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "NamespaceService", "GetNamespaces")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "NamespaceService", "GetNamespaces")
+	defer promtimer.ObserveNow(&err)
 
 	namespaces := []models.Namespace{}
 	// If we are running in OpenShift, we will use the project names since these are the list of accessible namespaces
 	if in.hasProjects {
-		projects, err := in.k8s.GetProjects()
-		if err == nil {
+		projects, err2 := in.k8s.GetProjects()
+		if err2 == nil {
 			// Everything is good, return the projects we got from OpenShift / kube-project
 			namespaces = models.CastProjectCollection(projects)
 		}
@@ -73,11 +74,12 @@ func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
 
 // GetNamespace returns the definition of the specified namespace.
 func (in *NamespaceService) GetNamespace(namespace string) (*models.Namespace, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "NamespaceService", "GetNamespace")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "NamespaceService", "GetNamespace")
+	defer promtimer.ObserveNow(&err)
 
 	if in.hasProjects {
-		if project, err := in.k8s.GetProject(namespace); err == nil {
+		if project, err2 := in.k8s.GetProject(namespace); err2 == nil {
 			result := models.CastProject(*project)
 			return &result, nil
 		}

--- a/business/services.go
+++ b/business/services.go
@@ -24,8 +24,9 @@ type SvcService struct {
 
 // GetServiceList returns a list of all services for a given Namespace
 func (in *SvcService) GetServiceList(namespace string) (*models.ServiceList, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "SvcService", "GetServiceList")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "SvcService", "GetServiceList")
+	defer promtimer.ObserveNow(&err)
 
 	var svcs []v1.Service
 	var pods []v1.Pod
@@ -36,27 +37,27 @@ func (in *SvcService) GetServiceList(namespace string) (*models.ServiceList, err
 
 	go func() {
 		defer wg.Done()
-		var err error
-		svcs, err = in.k8s.GetServices(namespace, nil)
-		if err != nil {
-			log.Errorf("Error fetching Services per namespace %s: %s", namespace, err)
-			errChan <- err
+		var err2 error
+		svcs, err2 = in.k8s.GetServices(namespace, nil)
+		if err2 != nil {
+			log.Errorf("Error fetching Services per namespace %s: %s", namespace, err2)
+			errChan <- err2
 		}
 	}()
 
 	go func() {
 		defer wg.Done()
-		var err error
-		pods, err = in.k8s.GetPods(namespace, "")
-		if err != nil {
-			log.Errorf("Error fetching Pods per namespace %s: %s", namespace, err)
-			errChan <- err
+		var err2 error
+		pods, err2 = in.k8s.GetPods(namespace, "")
+		if err2 != nil {
+			log.Errorf("Error fetching Pods per namespace %s: %s", namespace, err2)
+			errChan <- err2
 		}
 	}()
 
 	wg.Wait()
 	if len(errChan) != 0 {
-		err := <-errChan
+		err = <-errChan
 		return nil, err
 	}
 
@@ -88,8 +89,9 @@ func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []v1.Ser
 
 // GetService returns a single service
 func (in *SvcService) GetService(namespace, service, interval string, queryTime time.Time) (*models.ServiceDetails, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "SvcService", "GetService")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "SvcService", "GetService")
+	defer promtimer.ObserveNow(&err)
 
 	var svc *v1.Service
 	var eps *v1.Endpoints
@@ -100,27 +102,27 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 
 	go func() {
 		defer wg.Done()
-		var err error
-		svc, err = in.k8s.GetService(namespace, service)
-		if err != nil {
-			log.Errorf("Error fetching Service per namespace %s and service %s: %s", namespace, service, err)
-			errChan <- err
+		var err2 error
+		svc, err2 = in.k8s.GetService(namespace, service)
+		if err2 != nil {
+			log.Errorf("Error fetching Service per namespace %s and service %s: %s", namespace, service, err2)
+			errChan <- err2
 		}
 	}()
 
 	go func() {
 		defer wg.Done()
-		var err error
-		eps, err = in.k8s.GetEndpoints(namespace, service)
-		if err != nil {
-			log.Errorf("Error fetching Endpoints per namespace %s and service %s: %s", namespace, service, err)
-			errChan <- err
+		var err2 error
+		eps, err2 = in.k8s.GetEndpoints(namespace, service)
+		if err2 != nil {
+			log.Errorf("Error fetching Endpoints per namespace %s and service %s: %s", namespace, service, err2)
+			errChan <- err2
 		}
 	}()
 
 	wg.Wait()
 	if len(errChan) != 0 {
-		err := <-errChan
+		err = <-errChan
 		return nil, err
 	}
 
@@ -138,10 +140,10 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 
 	go func() {
 		defer wg.Done()
-		var err error
-		pods, err = in.k8s.GetPods(namespace, labelsSelector)
-		if err != nil {
-			errChan <- err
+		var err2 error
+		pods, err2 = in.k8s.GetPods(namespace, labelsSelector)
+		if err2 != nil {
+			errChan <- err2
 		}
 	}()
 
@@ -152,51 +154,51 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 
 	go func() {
 		defer wg.Done()
-		var err error
-		vs, err = in.k8s.GetVirtualServices(namespace, service)
-		if err != nil {
-			errChan <- err
+		var err2 error
+		vs, err2 = in.k8s.GetVirtualServices(namespace, service)
+		if err2 != nil {
+			errChan <- err2
 		}
 	}()
 
 	go func() {
 		defer wg.Done()
-		var err error
-		dr, err = in.k8s.GetDestinationRules(namespace, service)
-		if err != nil {
-			errChan <- err
+		var err2 error
+		dr, err2 = in.k8s.GetDestinationRules(namespace, service)
+		if err2 != nil {
+			errChan <- err2
 		}
 	}()
 
 	go func() {
 		defer wg.Done()
-		var err error
-		ns, err := in.businessLayer.Namespace.GetNamespace(namespace)
-		if err != nil {
-			log.Errorf("Error fetching details of namespace %s: %s", namespace, err)
-			errChan <- err
+		var err2 error
+		ns, err2 := in.businessLayer.Namespace.GetNamespace(namespace)
+		if err2 != nil {
+			log.Errorf("Error fetching details of namespace %s: %s", namespace, err2)
+			errChan <- err2
 		}
 
-		sWk, err = in.prom.GetSourceWorkloads(ns.Name, ns.CreationTimestamp, service)
-		if err != nil {
-			log.Errorf("Error fetching SourceWorkloads per namespace %s and service %s: %s", namespace, service, err)
-			errChan <- err
+		sWk, err2 = in.prom.GetSourceWorkloads(ns.Name, ns.CreationTimestamp, service)
+		if err2 != nil {
+			log.Errorf("Error fetching SourceWorkloads per namespace %s and service %s: %s", namespace, service, err2)
+			errChan <- err2
 		}
 	}()
 
 	go func() {
 		defer wg.Done()
-		var err error
-		ws, err = fetchWorkloads(in.k8s, namespace, labelsSelector)
-		if err != nil {
-			log.Errorf("Error fetching Workloads per namespace %s and service %s: %s", namespace, service, err)
-			errChan <- err
+		var err2 error
+		ws, err2 = fetchWorkloads(in.k8s, namespace, labelsSelector)
+		if err2 != nil {
+			log.Errorf("Error fetching Workloads per namespace %s and service %s: %s", namespace, service, err2)
+			errChan <- err2
 		}
 	}()
 
 	wg.Wait()
 	if len(errChan) != 0 {
-		err := <-errChan
+		err = <-errChan
 		return nil, err
 	}
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -26,8 +26,9 @@ type WorkloadService struct {
 
 // GetWorkloadList is the API handler to fetch the list of workloads in a given namespace.
 func (in *WorkloadService) GetWorkloadList(namespace string) (models.WorkloadList, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "WorkloadService", "GetWorkloadList")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "WorkloadService", "GetWorkloadList")
+	defer promtimer.ObserveNow(&err)
 
 	workloadList := &models.WorkloadList{
 		Namespace: models.Namespace{namespace, time.Time{}},
@@ -50,8 +51,9 @@ func (in *WorkloadService) GetWorkloadList(namespace string) (models.WorkloadLis
 // GetWorkload is the API handler to fetch details of a specific workload.
 // If includeServices is set true, the Workload will fetch all services related
 func (in *WorkloadService) GetWorkload(namespace string, workloadName string, includeServices bool) (*models.Workload, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "WorkloadService", "GetWorkload")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "WorkloadService", "GetWorkload")
+	defer promtimer.ObserveNow(&err)
 
 	workload, err := fetchWorkload(in.k8s, namespace, workloadName)
 	if err != nil {
@@ -70,8 +72,9 @@ func (in *WorkloadService) GetWorkload(namespace string, workloadName string, in
 }
 
 func (in *WorkloadService) GetPods(namespace string, labelSelector string) (models.Pods, error) {
-	promtimer := internalmetrics.GetGoFunctionProcessingTimePrometheusTimer("business", "WorkloadService", "GetPods")
-	defer promtimer.ObserveDuration()
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "WorkloadService", "GetPods")
+	defer promtimer.ObserveNow(&err)
 
 	ps, err := in.k8s.GetPods(namespace, labelSelector)
 	if err != nil {

--- a/prometheus/internalmetrics/internal_metrics_test.go
+++ b/prometheus/internalmetrics/internal_metrics_test.go
@@ -1,0 +1,79 @@
+package internalmetrics
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestSuccessOrFailureMetric ensures that using defer with the ObserveNow(*error) function works.
+func TestSuccessOrFailureMetric(t *testing.T) {
+	// put back the original default registry when we are done
+	originalRegistry := prometheus.DefaultRegisterer
+	defer func() { prometheus.DefaultRegisterer = originalRegistry }()
+
+	// setup our internal metric registry for this test
+	registry := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = registry
+	RegisterInternalMetrics()
+
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Errorf("Cannot test initial state of metrics: %v", err)
+	}
+	if len(metrics) != 0 {
+		t.Errorf("Should not have any metrics yet")
+	}
+
+	// simulate a failure - our failure counter metric should increment to 1
+	doSomeWork(true)
+	metrics, err = registry.Gather()
+	if len(metrics) != 2 {
+		t.Errorf("Should have metrics now")
+	}
+
+	// not guaranteed what order the metrics are returned in - just look for the failures counter
+	for _, m := range metrics {
+		if m.GetName() == "kiali_go_function_failures_total" {
+			if m.GetMetric()[0].Counter.GetValue() != 1 {
+				t.Errorf("Failure counter metric should have a value of 1: %+v", m)
+			}
+		} else if m.GetName() == "kiali_go_function_processing_duration_seconds" {
+			if m.GetMetric()[0].Histogram.GetSampleCount() != 0 {
+				t.Errorf("Histogram metric sample count should still be 0: %+v", m)
+			}
+		}
+	}
+
+	// simulate a success
+	doSomeWork(false)
+	metrics, err = registry.Gather()
+
+	for _, m := range metrics {
+		if m.GetName() == "kiali_go_function_failures_total" {
+			if m.GetMetric()[0].Counter.GetValue() != 1 {
+				t.Errorf("Failure counter metric should not have increased: %+v", m)
+			}
+		} else if m.GetName() == "kiali_go_function_processing_duration_seconds" {
+			if m.GetMetric()[0].Histogram.GetSampleCount() != 1 {
+				t.Errorf("Histogram metric sample count should now have a value of 1: %+v", m)
+			}
+		}
+	}
+
+}
+
+func doSomeWork(simulateFailure bool) error {
+	var err error
+	promtimer := GetGoFunctionMetric("test", "", "doSomeWork")
+	defer promtimer.ObserveNow(&err)
+
+	if simulateFailure {
+		err = fmt.Errorf("FAILURE")
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	return err
+}


### PR DESCRIPTION
This adds a kiali_go_function_failures_total metric.

See the go doc for the GetGoFunctionMetric() method and the SuccessOrFailureMetricType struct for details on typical usage.

Trying to keep the amount of boilerplate code down to a minimum.