### PR TITLE
KIALI-1185 - WIP: Implement oAuth support for OCP/OKD/Maistra clients

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -7,14 +7,15 @@ import (
 
 // Layer is a container for fast access to inner services
 type Layer struct {
-	Svc         SvcService
-	Health      HealthService
-	Validations IstioValidationsService
-	IstioConfig IstioConfigService
-	Workload    WorkloadService
-	App         AppService
-	Namespace   NamespaceService
-	k8s         kubernetes.IstioClientInterface
+	Svc            SvcService
+	Health         HealthService
+	Validations    IstioValidationsService
+	IstioConfig    IstioConfigService
+	Workload       WorkloadService
+	App            AppService
+	Namespace      NamespaceService
+	k8s            kubernetes.IstioClientInterface
+	OpenshiftOAuth OpenshiftOAuthService
 }
 
 // Global business.Layer; currently only used for tests to inject mocks,
@@ -34,6 +35,7 @@ func Get() (*Layer, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// Business needs to maintain a minimal state as kubernetes package will maintain a cache
 	SetWithBackends(k8s, prom)
 	return layer, nil
@@ -50,6 +52,7 @@ func SetWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	layer.App = AppService{k8s: k8s}
 	layer.Namespace = NewNamespaceService(k8s)
 	layer.k8s = k8s
+	layer.OpenshiftOAuth = OpenshiftOAuthService{k8s: k8s}
 	return layer
 }
 

--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -1,0 +1,125 @@
+package business
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	kube "k8s.io/client-go/kubernetes"
+)
+
+type OpenshiftOAuthService struct {
+	k8s kubernetes.IstioClientInterface
+}
+
+type OAuthMetadata struct {
+	AuthorizationEndpoint string `json:"authorizationEndpoint"`
+	TokenEndpoint         string `json:"tokenEndpoint"`
+}
+
+type MetadataResponse struct {
+	Issuer                        string   `json:"issuer"`
+	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
+	TokenEndpoint                 string   `json:"token_endpoint"`
+	ScopesSupported               []string `json:"scopes_supported"`
+	ResponseTypesSupported        []string `json:"response_types_supported"`
+	GrantTypesSupported           []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported"`
+}
+
+const authServerUrl = "https://openshift.default.svc/.well-known/oauth-authorization-server"
+
+func (in *OpenshiftOAuthService) Metadata() (metadata *OAuthMetadata, err error) {
+	var response *MetadataResponse
+
+	resp, err := httpClient().Get(authServerUrl)
+
+	if err != nil {
+		message := fmt.Errorf("could not get data for the openshift authorization server: %v", err)
+		fmt.Println(message)
+
+		return nil, message
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		message := fmt.Errorf("could not read body for the openshift authorization server: %v", err)
+		fmt.Println(message)
+
+		return nil, message
+	}
+
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		message := fmt.Errorf("could not parse response the openshift authorization server: %v", err)
+		fmt.Println(message)
+
+		return nil, message
+	}
+
+	routeClient, err := kubernetes.NewOSRouteClient()
+
+	if err != nil {
+		message := fmt.Errorf("could not create route client for oauth endpoint: %v", err)
+		fmt.Println(message)
+
+		return nil, message
+	}
+
+	route, err := routeClient.GetRoute(config.Get().IstioNamespace, "kiali")
+
+	if err != nil {
+		message := fmt.Errorf("could not create route client for oauth endpoint: %v", err)
+		fmt.Println(message)
+
+		return nil, message
+	}
+
+	metadata = &OAuthMetadata{}
+	metadata.AuthorizationEndpoint = fmt.Sprintf("%s?client_id=%s&redirect_uri=%s&response_type=%s", response.AuthorizationEndpoint, "kiali", route, "token")
+	metadata.TokenEndpoint = response.TokenEndpoint
+
+	return metadata, nil
+}
+
+func (in *OpenshiftOAuthService) ValidateToken(token string) error {
+	k8sConfig, err := kubernetes.ConfigClient()
+
+	if err != nil {
+		return fmt.Errorf("could not connect to Openshift: %v", err)
+	}
+
+	k8sConfig.BearerToken = token
+
+	k8s, err := kube.NewForConfig(k8sConfig)
+
+	if err != nil {
+		return fmt.Errorf("could not connect to Openshift: %v", err)
+	}
+
+	_, err = k8s.Discovery().ServerVersion()
+
+	if err != nil {
+		return fmt.Errorf("could not get info from Openshift: %v", err)
+	}
+
+	return nil
+}
+
+// We create a new client, and avoid checking the certificates, since this is
+// intra-cluster communication. This is necessary because not necessarily the
+// server certificates are going to be available for Kiali.
+func httpClient() (client *http.Client) {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	client = &http.Client{Transport: tr}
+
+	return
+}

--- a/config/config.go
+++ b/config/config.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/kiali/kiali/config/security"
 	"github.com/kiali/kiali/log"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Environment vars can define some default values.
@@ -58,6 +57,9 @@ const (
 	EnvKubernetesBurst         = "KUBERNETES_BURST"
 	EnvKubernetesQPS           = "KUBERNETES_QPS"
 	EnvKubernetesCacheDuration = "KUBERNETES_CACHE_DURATION"
+
+	EnvOAuthEnabled = "OAUTH_ENABLED"
+	EnvOAuthSecret  = "OAUTH_SECRET"
 )
 
 // The versions that Kiali requires
@@ -141,6 +143,12 @@ type ApiNamespacesConfig struct {
 	Exclude []string
 }
 
+// OAuth for Openshift configuration
+type OAuthConfig struct {
+	Enabled bool   `yaml:"enabled,omitempty"`
+	Secret  string `yaml:"secret,omitempty"`
+}
+
 // Config defines full YAML configuration.
 type Config struct {
 	Identity         security.Identity `yaml:",omitempty"`
@@ -152,6 +160,7 @@ type Config struct {
 	IstioLabels      IstioLabels       `yaml:"istio_labels,omitempty"`
 	KubernetesConfig KubernetesConfig  `yaml:"kubernetes_config,omitempty"`
 	Api              ApiConfig         `yaml:"api,omitempty"`
+	OAuth            OAuthConfig       `yaml:"oauth,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -218,6 +227,8 @@ func NewConfig() (c *Config) {
 		}
 	}
 	c.Api.Namespaces.Exclude = trimmedExclusionPatterns
+	c.OAuth.Enabled = getDefaultBool(EnvOAuthEnabled, false)
+	c.OAuth.Secret = getDefaultString(EnvOAuthSecret, "kiali-oauth")
 
 	return
 }

--- a/deploy/openshift/kiali-configmap.yaml
+++ b/deploy/openshift/kiali-configmap.yaml
@@ -15,6 +15,9 @@ data:
         url: ${JAEGER_URL}
       grafana:
         url: ${GRAFANA_URL}
+    oauth:
+      enabled: ${OAUTH_ENABLED}
+      secret: ${OAUTH_SECRET}
     identity:
       cert_file: /kiali-cert/tls.crt
       private_key_file: /kiali-cert/tls.key

--- a/deploy/openshift/kiali-oauth.yaml
+++ b/deploy/openshift/kiali-oauth.yaml
@@ -1,0 +1,11 @@
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: kiali
+  labels:
+    app: kiali
+secret: ${OAUTH_SECRET}
+redirectURIs:
+  - ${REDIRECT_URL}
+  - localhost:3000
+grantMethod: auto

--- a/handlers/oauth.go
+++ b/handlers/oauth.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+)
+
+// Returns the configuration from Openshift for oAuth, or 500 if not on Openshift
+func OAuthMetadata(w http.ResponseWriter, r *http.Request) {
+	if !config.Get().OAuth.Enabled {
+		err := fmt.Errorf("OAuth is not enabled for this deployment")
+
+		RespondWithJSONIndent(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	business, err := business.Get()
+
+	if err != nil {
+		RespondWithJSONIndent(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	metadata, err := business.OpenshiftOAuth.Metadata()
+	fmt.Printf("%s\n", err)
+
+	if err != nil {
+		RespondWithJSONIndent(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, metadata)
+}

--- a/routing/router.go
+++ b/routing/router.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/handlers"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // NewRouter creates the router with all API routes and the static files handler
@@ -36,7 +36,7 @@ func NewRouter() *mux.Router {
 		var handlerFunction http.Handler = route.HandlerFunc
 		handlerFunction = metricHandler(handlerFunction, route)
 		if route.Authenticated {
-			handlerFunction = config.AuthenticationHandler(handlerFunction)
+			handlerFunction = handlers.AuthenticationHandler(handlerFunction)
 		}
 		appRouter.
 			Methods(route.Method).

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -66,6 +66,30 @@ func NewRoutes() (r *Routes) {
 			handlers.GetToken,
 			true,
 		},
+		// swagger:route GET /oauth-info OAuthMetadata
+		// ---
+		// Endpoint to get the metadata (login path and so on) for OAuth on Openshift
+		//
+		//     Consumes:
+		//     - application/json
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      default: genericError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: metadata
+		{
+			"OAuthInfo",
+			"GET",
+			"/api/oauth-info",
+			handlers.OAuthMetadata,
+			false,
+		},
 		// swagger:route GET /status getStatus
 		// ---
 		// Endpoint to get the status of Kiali


### PR DESCRIPTION
This PR (and the relevant one on the UI client) implements support for using Openshift oAuth when available (and enabled).

It is not ready yet, some stuff is still missing:

* [ ] Get the user info (username) from k8s API using the given token.

**Backwards incompatible?**

No.
