### PR TITLE
KIALI-1823 Reconciling Kiali Secrets with Istio Helm Charts Secrets

### DIFF
--- a/deploy/kubernetes/kiali-secrets.yaml
+++ b/deploy/kubernetes/kiali-secrets.yaml
@@ -8,4 +8,4 @@ metadata:
 type: Opaque
 data:
   username: YWRtaW4=    # admin
-  password: YWRtaW4=    # admin
+  passphrase: YWRtaW4=    # admin

--- a/deploy/kubernetes/kiali.yaml
+++ b/deploy/kubernetes/kiali.yaml
@@ -85,7 +85,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: kiali
-              key: password
+              key: passphrase
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"

--- a/deploy/openshift/kiali-secrets.yaml
+++ b/deploy/openshift/kiali-secrets.yaml
@@ -8,4 +8,4 @@ metadata:
 type: Opaque
 data:
   username: YWRtaW4=    # admin
-  password: YWRtaW4=    # admin
+  passphrase: YWRtaW4=    # admin

--- a/deploy/openshift/kiali.yaml
+++ b/deploy/openshift/kiali.yaml
@@ -90,7 +90,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: kiali
-              key: password
+              key: passphrase
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"


### PR DESCRIPTION
** Describe the change **
When Kiali was incorporated on Istio, Istio Engineers asked us to change our secrets from password to passphrase (https://github.com/istio/istio/pull/7967/files#r210915209).

That was done on this PR (https://github.com/istio/istio/pull/7326), but it led to a mismatch between our secrets on helm and ansible installer and on the repository, because kiali stills uses password on the master

** Issue reference **

`KIALI-1823`

cc @jmazzitelli 