### PR TITLE
KIALI-1542 Improve namespaces graph endpoint

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -82,7 +82,7 @@ type WorkloadParam struct {
 // - keep this alphabetized
 /////////////////////
 
-// swagger:parameters graphApp graphAppVersion graphNamespace graphService graphWorkload
+// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
 type AppendersParam struct {
 	// Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].
 	//
@@ -92,7 +92,7 @@ type AppendersParam struct {
 	Name string `json:"appenders"`
 }
 
-// swagger:parameters graphApp graphAppVersion graphNamespace graphService graphWorkload
+// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
 type DurationGraphParam struct {
 	// Query time-range duration (Golang string duration).
 	//
@@ -102,7 +102,7 @@ type DurationGraphParam struct {
 	Name string `json:"duration"`
 }
 
-// swagger:parameters graphApp graphAppVersion graphNamespace graphService graphWorkload
+// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
 type GraphTypeParam struct {
 	// Graph type. Available graph types: [app, service, versionedApp, workload].
 	//
@@ -112,7 +112,7 @@ type GraphTypeParam struct {
 	Name string `json:"graphType"`
 }
 
-// swagger:parameters graphApp graphAppVersion graphNamespace graphService graphWorkload
+// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
 type GroupByParam struct {
 	// App box grouping characteristic. Ignored unless graph type is versionedApp. Available groupings: [version].
 	//
@@ -122,7 +122,7 @@ type GroupByParam struct {
 	Name string `json:"groupBy"`
 }
 
-// swagger:parameters graphApp graphAppVersion graphNamespace graphService graphWorkload
+// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
 type IncludeIstioParam struct {
 	// Flag for including istio-system (infra) services. Ignored if namespace is istio-system.
 	//
@@ -132,17 +132,17 @@ type IncludeIstioParam struct {
 	Name string `json:"includeIstio"`
 }
 
-// swagger:parameters graphNamespace
+// swagger:parameters graphNamespaces
 type NamespacesParam struct {
-	// Comma-separated list of namespaces to include in the graph. Overrides namespace path param.
+	// Comma-separated list of namespaces to include in the graph.
 	//
 	// in: query
 	// required: false
-	// default: namespace path param
+	// default: all accessible namespaces
 	Name string `json:"namespaces"`
 }
 
-// swagger:parameters graphApp graphAppVersion graphNamespace graphService graphWorkload
+// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
 type QueryTimeParam struct {
 	// Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now.
 	//

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -382,7 +382,7 @@ func TestAppGraph(t *testing.T) {
 	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/graph", http.HandlerFunc(
+	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			fut(w, r, client)
 		}))
@@ -390,8 +390,8 @@ func TestAppGraph(t *testing.T) {
 	ts := httptest.NewServer(mr)
 	defer ts.Close()
 
-	fut = graphNamespace
-	url := ts.URL + "/api/namespaces/bookinfo/graph?graphType=app&appenders&queryTime=1523364075"
+	fut = graphNamespaces
+	url := ts.URL + "/api/namespaces/graph?namespaces=bookinfo&graphType=app&appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -416,7 +416,7 @@ func TestVersionedAppGraph(t *testing.T) {
 	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/graph", http.HandlerFunc(
+	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			fut(w, r, client)
 		}))
@@ -424,8 +424,8 @@ func TestVersionedAppGraph(t *testing.T) {
 	ts := httptest.NewServer(mr)
 	defer ts.Close()
 
-	fut = graphNamespace
-	url := ts.URL + "/api/namespaces/bookinfo/graph?graphType=versionedApp&appenders&queryTime=1523364075"
+	fut = graphNamespaces
+	url := ts.URL + "/api/namespaces/graph?namespaces=bookinfo&graphType=versionedApp&appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -450,7 +450,7 @@ func TestServiceGraph(t *testing.T) {
 	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/graph", http.HandlerFunc(
+	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			fut(w, r, client)
 		}))
@@ -458,8 +458,8 @@ func TestServiceGraph(t *testing.T) {
 	ts := httptest.NewServer(mr)
 	defer ts.Close()
 
-	fut = graphNamespace
-	url := ts.URL + "/api/namespaces/bookinfo/graph?graphType=service&appenders&queryTime=1523364075"
+	fut = graphNamespaces
+	url := ts.URL + "/api/namespaces/graph?namespaces=bookinfo&graphType=service&appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -484,7 +484,7 @@ func TestWorkloadGraph(t *testing.T) {
 	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/graph", http.HandlerFunc(
+	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			fut(w, r, client)
 		}))
@@ -492,8 +492,8 @@ func TestWorkloadGraph(t *testing.T) {
 	ts := httptest.NewServer(mr)
 	defer ts.Close()
 
-	fut = graphNamespace
-	url := ts.URL + "/api/namespaces/bookinfo/graph?graphType=workload&appenders&queryTime=1523364075"
+	fut = graphNamespaces
+	url := ts.URL + "/api/namespaces/graph?namespaces=bookinfo&graphType=workload&appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -1297,7 +1297,7 @@ func TestComplexGraph(t *testing.T) {
 	var fut func(w http.ResponseWriter, r *http.Request, c *prometheus.Client)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/graph", http.HandlerFunc(
+	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			fut(w, r, client)
 		}))
@@ -1305,8 +1305,8 @@ func TestComplexGraph(t *testing.T) {
 	ts := httptest.NewServer(mr)
 	defer ts.Close()
 
-	fut = graphNamespace
-	url := ts.URL + "/api/namespaces/bookinfo/graph?graphType=versionedApp&appenders=&queryTime=1523364075&namespaces=bookinfo,tutorial"
+	fut = graphNamespaces
+	url := ts.URL + "/api/namespaces/graph?graphType=versionedApp&appenders=&queryTime=1523364075&namespaces=bookinfo,tutorial"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -519,7 +519,7 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceIstioValidations,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/graph graphs graphNamespace
+		// swagger:route GET /namespaces/graph graphs graphNamespaces
 		// ---
 		// The backing JSON for a namespaces graph.
 		//
@@ -534,10 +534,10 @@ func NewRoutes() (r *Routes) {
 		//      200: graphResponse
 		//
 		{
-			"GraphNamespace",
+			"GraphNamespaces",
 			"GET",
-			"/api/namespaces/{namespace}/graph",
-			handlers.GraphNamespace,
+			"/api/namespaces/graph",
+			handlers.GraphNamespaces,
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/applications/{app}/versions/{version}/graph graphs graphAppVersion

--- a/swagger.json
+++ b/swagger.json
@@ -787,6 +787,91 @@
         }
       }
     },
+    "/namespaces/graph": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "graphs"
+        ],
+        "summary": "The backing JSON for a namespaces graph.",
+        "operationId": "graphNamespaces",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "run all appenders",
+            "x-go-name": "Name",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
+            "name": "appenders",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "10m",
+            "x-go-name": "Name",
+            "description": "Query time-range duration (Golang string duration).",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "workload",
+            "x-go-name": "Name",
+            "description": "Graph type. Available graph types: [app, service, versionedApp, workload].",
+            "name": "graphType",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "version",
+            "x-go-name": "Name",
+            "description": "App box grouping characteristic. Ignored unless graph type is versionedApp. Available groupings: [version].",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "false",
+            "x-go-name": "Name",
+            "description": "Flag for including istio-system (infra) services. Ignored if namespace is istio-system.",
+            "name": "includeIstio",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "all accessible namespaces",
+            "x-go-name": "Name",
+            "description": "Comma-separated list of namespaces to include in the graph.",
+            "name": "namespaces",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "now",
+            "x-go-name": "Name",
+            "description": "Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now.",
+            "name": "queryTime",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/graphResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/applications/{app}/graph": {
       "get": {
         "produces": [
@@ -1053,99 +1138,6 @@
           },
           "404": {
             "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          }
-        }
-      }
-    },
-    "/namespaces/{namespace}/graph": {
-      "get": {
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "graphs"
-        ],
-        "summary": "The backing JSON for a namespaces graph.",
-        "operationId": "graphNamespace",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The namespace id.",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "default": "run all appenders",
-            "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
-            "name": "appenders",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "10m",
-            "x-go-name": "Name",
-            "description": "Query time-range duration (Golang string duration).",
-            "name": "duration",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "workload",
-            "x-go-name": "Name",
-            "description": "Graph type. Available graph types: [app, service, versionedApp, workload].",
-            "name": "graphType",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "version",
-            "x-go-name": "Name",
-            "description": "App box grouping characteristic. Ignored unless graph type is versionedApp. Available groupings: [version].",
-            "name": "groupBy",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "false",
-            "x-go-name": "Name",
-            "description": "Flag for including istio-system (infra) services. Ignored if namespace is istio-system.",
-            "name": "includeIstio",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "namespace path param",
-            "x-go-name": "Name",
-            "description": "Comma-separated list of namespaces to include in the graph. Overrides namespace path param.",
-            "name": "namespaces",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "now",
-            "x-go-name": "Name",
-            "description": "Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now.",
-            "name": "queryTime",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/graphResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
           },
           "500": {
             "$ref": "#/responses/internalError"


### PR DESCRIPTION
This changes the REST endpoint for getting namespace graphs:
 
Endpoint for namespace1:
```
old: .../api/namepaces/namespace1/graph
new: .../api/namepaces/graph?namepaces=namespace1
```

Endpoint for namespace1 and namespace2:
```
old: .../api/namepaces/ignored/graph?namepaces=namespace1,namespaces2
new: .../api/namepaces/graph?namepaces=namespace1,namespaces2
```

Endpoint for all accessible namespaces:
```
old: .../api/namepaces/all/graph
new: .../api/namepaces/graph
```

** Backwards incompatible? **
NO

This requires kiali-ui PR: https://github.com/kiali/kiali-ui/pull/795