### PR TITLE
KIALI-1736 Update e2e test to validate that all kinds of workloads are listed

### DIFF
--- a/tests/e2e/assets/bookinfo-workloads.yaml
+++ b/tests/e2e/assets/bookinfo-workloads.yaml
@@ -1,0 +1,71 @@
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: reviews-v4
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v4
+    spec:
+      containers:
+      - name: reviews
+        image: istio/examples-bookinfo-reviews-v1:1.8.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: reviews-v5
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v5
+    spec:
+      containers:
+      - name: reviews
+        image: istio/examples-bookinfo-reviews-v2:1.8.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: reviews-v6
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v6
+    spec:
+      containers:
+      - name: reviews
+        image: istio/examples-bookinfo-reviews-v3:1.8.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: details-v2
+  labels:
+    app: details
+    version: v2
+spec:
+  containers:
+  - name: details
+    image: istio/examples-bookinfo-details-v1:1.8.0
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 9080

--- a/tests/e2e/tests/test_kiali_service_endpoint.py
+++ b/tests/e2e/tests/test_kiali_service_endpoint.py
@@ -47,7 +47,7 @@ def test_service_detail_with_virtual_service(kiali_client):
       # Add a virtual service that will be tested
       assert command_exec.oc_apply(VIRTUAL_SERVICE_FILE, bookinfo_namespace) == True
 
-      with timeout(seconds=10, error_message='Timed out waiting for virtual service creation'):
+      with timeout(seconds=30, error_message='Timed out waiting for virtual service creation'):
         while True:
           service_details = kiali_client.service_details(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
           if service_details != None and service_details.get('virtualServices') != None and len(service_details.get('virtualServices').get('items')) > 0:
@@ -91,7 +91,7 @@ def test_service_detail_with_virtual_service(kiali_client):
     finally:
       assert command_exec.oc_delete(VIRTUAL_SERVICE_FILE, bookinfo_namespace) == True
 
-      with timeout(seconds=20, error_message='Timed out waiting for virtual service deletion'):
+      with timeout(seconds=30, error_message='Timed out waiting for virtual service deletion'):
         while True:
           service_details = kiali_client.service_details(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
           if service_details != None and len(service_details.get('virtualServices').get('items')) == 0:
@@ -106,7 +106,7 @@ def test_service_detail_with_destination_rule(kiali_client):
       # Add a destination rule that will be tested
       assert command_exec.oc_apply(DESTINATION_RULE_FILE, bookinfo_namespace) == True
 
-      with timeout(seconds=10, error_message='Timed out waiting for destination rule creation'):
+      with timeout(seconds=30, error_message='Timed out waiting for destination rule creation'):
         while True:
           service_details = kiali_client.service_details(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
           if service_details != None and service_details.get('destinationRules') != None and len(service_details.get('destinationRules').get('items')) > 0:
@@ -145,7 +145,7 @@ def test_service_detail_with_destination_rule(kiali_client):
     finally:
       assert command_exec.oc_delete(DESTINATION_RULE_FILE, bookinfo_namespace) == True
 
-      with timeout(seconds=20, error_message='Timed out waiting for destination rule deletion'):
+      with timeout(seconds=30, error_message='Timed out waiting for destination rule deletion'):
         while True:
           service_details = kiali_client.service_details(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
           if service_details != None and len(service_details.get('destinationRules').get('items')) == 0:

--- a/tests/e2e/tests/test_kiali_service_endpoint.py
+++ b/tests/e2e/tests/test_kiali_service_endpoint.py
@@ -50,14 +50,22 @@ def test_service_detail_with_virtual_service(kiali_client):
       with timeout(seconds=10, error_message='Timed out waiting for virtual service creation'):
         while True:
           service_details = kiali_client.service_details(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
-          if service_details != None and service_details.get('virtualServices') != None and len(service_details.get('virtualServices')) > 0:
+          if service_details != None and service_details.get('virtualServices') != None and len(service_details.get('virtualServices').get('items')) > 0:
             break
 
           time.sleep(1)
 
       assert service_details != None
 
-      virtual_service = service_details.get('virtualServices')[0]
+      virtual_service_descriptor = service_details.get('virtualServices')
+      assert virtual_service_descriptor != None
+
+      permissions = virtual_service_descriptor.get('permissions')
+      assert permissions != None
+      assert permissions.get('update') == False
+      assert permissions.get('delete') == True
+
+      virtual_service = virtual_service_descriptor.get('items')[0]
       assert virtual_service != None
       assert virtual_service.get('name') == 'reviews'
 
@@ -83,10 +91,10 @@ def test_service_detail_with_virtual_service(kiali_client):
     finally:
       assert command_exec.oc_delete(VIRTUAL_SERVICE_FILE, bookinfo_namespace) == True
 
-      with timeout(seconds=10, error_message='Timed out waiting for virtual service deletion'):
+      with timeout(seconds=20, error_message='Timed out waiting for virtual service deletion'):
         while True:
           service_details = kiali_client.service_details(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
-          if service_details != None and service_details.get('virtualServices') == None:
+          if service_details != None and len(service_details.get('virtualServices').get('items')) == 0:
             break
 
           time.sleep(1)
@@ -101,14 +109,22 @@ def test_service_detail_with_destination_rule(kiali_client):
       with timeout(seconds=10, error_message='Timed out waiting for destination rule creation'):
         while True:
           service_details = kiali_client.service_details(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
-          if service_details != None and service_details.get('destinationRules') != None and len(service_details.get('destinationRules')) > 0:
+          if service_details != None and service_details.get('destinationRules') != None and len(service_details.get('destinationRules').get('items')) > 0:
             break
 
           time.sleep(1)
 
       assert service_details != None
 
-      destination_rule = service_details.get('destinationRules')[0]
+      destination_rule_descriptor = service_details.get('destinationRules')
+      assert destination_rule_descriptor != None
+
+      permissions = destination_rule_descriptor.get('permissions')
+      assert permissions != None
+      assert permissions.get('update') == False
+      assert permissions.get('delete') == True
+
+      destination_rule = destination_rule_descriptor.get('items')[0]
       assert destination_rule != None
       assert destination_rule.get('name') == 'reviews'
       assert 'trafficPolicy' in destination_rule
@@ -129,10 +145,10 @@ def test_service_detail_with_destination_rule(kiali_client):
     finally:
       assert command_exec.oc_delete(DESTINATION_RULE_FILE, bookinfo_namespace) == True
 
-      with timeout(seconds=10, error_message='Timed out waiting for destination rule deletion'):
+      with timeout(seconds=20, error_message='Timed out waiting for destination rule deletion'):
         while True:
           service_details = kiali_client.service_details(namespace=bookinfo_namespace, service=SERVICE_TO_VALIDATE)
-          if service_details != None and service_details.get('destinationRules') == None:
+          if service_details != None and len(service_details.get('destinationRules').get('items')) == 0:
             break
 
           time.sleep(1)


### PR DESCRIPTION
** Describe the change **

Workload list shows now Pods, ReplicationControllers, StatefulSets and ReplicaSets. I have added e2e test verifying that all this types are listed in that endpoint.

In addition, I fixed couple of failing tests from feature of adding permissions to VS and DR (https://github.com/kiali/kiali/pull/612)

** Issue reference **
https://issues.jboss.org/browse/KIALI-1736
