### PR TITLE
KIALI-1185 - Implement oAuth support for OCP/OKD/Maistra clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ GO_BUILD_ENVVARS = \
 	GOARCH=amd64 \
 	CGO_ENABLED=0 \
 
+# What kind of strategy should we use to login an user.
+# Values: oauth/login/none
+AUTH_STRATEGY ?= login
+
 .PHONY: help
 all: help
 help: Makefile
@@ -259,6 +263,7 @@ NAMESPACE="${NAMESPACE}" \
 JAEGER_URL="${JAEGER_URL}" \
 GRAFANA_URL="${GRAFANA_URL}"  \
 VERBOSE_MODE="${VERBOSE_MODE}" \
+AUTH_STRATEGY="${AUTH_STRATEGY}" \
 deploy/openshift/deploy-kiali-to-openshift.sh
 
 ## openshift-undeploy: Undeploy from Openshift project.
@@ -285,6 +290,7 @@ NAMESPACE="${NAMESPACE}" \
 JAEGER_URL="${JAEGER_URL}" \
 GRAFANA_URL="${GRAFANA_URL}"  \
 VERBOSE_MODE="${VERBOSE_MODE}" \
+AUTH_STRATEGY="${AUTH_STRATEGY}" \
 deploy/kubernetes/deploy-kiali-to-kubernetes.sh
 
 ## k8s-undeploy: Undeploy docker image in Kubernetes namespace.

--- a/README.adoc
+++ b/README.adoc
@@ -529,7 +529,7 @@ api:
 ----
 
 |`AUTH_STRATEGY`
-|The authentication strategy to be used by Kiali. The possible values are `none`, for no checking of credentials, `oauth` for using Openshift oauth, and `login` for the default login page (default).
+|The authentication strategy to be used by Kiali. The possible values are `none`, for no checking of credentials, `openshift` for using Openshift's oauth, and `login` for the default login page (default).
 [source,yaml]
 ----
 auth_strategy: VALUE

--- a/README.adoc
+++ b/README.adoc
@@ -528,6 +528,12 @@ api:
     - etc..
 ----
 
+|`AUTH_STRATEGY`
+|The authentication strategy to be used by Kiali. The possible values are `none`, for no checking of credentials, `oauth` for using Openshift oauth, and `login` for the default login page (default).
+[source,yaml]
+----
+auth_strategy: VALUE
+----
 |`LOGIN_TOKEN_SIGNING_KEY`
 |The signing key used to generate tokens for user authentication. (default is `kiali`)
 [source,yaml]

--- a/config/authentication.go
+++ b/config/authentication.go
@@ -13,12 +13,11 @@ func AuthenticationHandler(next http.Handler) http.Handler {
 		conf := Get()
 
 		switch strategy := conf.AuthStrategy; strategy {
-		case "oauth":
-			// Oauth is the default strategy for openshift, and for it, we just need
-			// to make sure the header is available. The token is generated and
-			// verified by the proxy.
+		case "openshift":
+			// For openshift logins, we just need to make sure the header is
+			// available. The token is generated and verified by the proxy.
 			//
-			// If it's not present, we just return a 403.
+			// If it's not present, return 403.
 			if r.Header.Get("X-Forwarded-Access-Token") == "" {
 				statusCode = http.StatusUnauthorized
 			} else {

--- a/config/authentication.go
+++ b/config/authentication.go
@@ -11,14 +11,20 @@ func AuthenticationHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		statusCode := http.StatusOK
 		conf := Get()
-		if strings.Contains(r.Header.Get("Authorization"), "Bearer") {
+
+		token := r.Header.Get("X-Forwarded-Access-Token")
+		if token != "" {
+			// No-op, user is logged in (request is not proxied if user is available)
+		} else if strings.Contains(r.Header.Get("Authorization"), "Bearer") {
 			err := ValidateToken(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+
 			if err != nil {
 				log.Warning("Token error: ", err)
 				statusCode = http.StatusUnauthorized
 			}
 		} else if conf.Server.Credentials.Username != "" || conf.Server.Credentials.Password != "" {
 			u, p, ok := r.BasicAuth()
+
 			if !ok || conf.Server.Credentials.Username != u || conf.Server.Credentials.Password != p {
 				statusCode = http.StatusUnauthorized
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,8 @@ const (
 
 	EnvJaegerURL = "JAEGER_URL"
 
+	EnvAuthStrategy = "AUTH_STRATEGY"
+
 	EnvLoginTokenSigningKey        = "LOGIN_TOKEN_SIGNING_KEY"
 	EnvLoginTokenExpirationSeconds = "LOGIN_TOKEN_EXPIRATION_SECONDS"
 	EnvIstioNamespace              = "ISTIO_NAMESPACE"
@@ -162,6 +164,7 @@ type Config struct {
 	IstioLabels      IstioLabels       `yaml:"istio_labels,omitempty"`
 	KubernetesConfig KubernetesConfig  `yaml:"kubernetes_config,omitempty"`
 	API              ApiConfig         `yaml:"api,omitempty"`
+	AuthStrategy     string            `yaml:"auth_strategy,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -175,6 +178,9 @@ func NewConfig() (c *Config) {
 	c.IstioLabels.AppLabelName = strings.TrimSpace(getDefaultString(EnvIstioLabelNameApp, "app"))
 	c.IstioLabels.VersionLabelName = strings.TrimSpace(getDefaultString(EnvIstioLabelNameVersion, "version"))
 	c.API.Namespaces.Exclude = getDefaultStringArray(EnvApiNamespacesExclude, "istio-operator,kube.*,openshift.*,ibm.*")
+
+	// Auth configuration
+	c.AuthStrategy = strings.TrimSpace(getDefaultString(EnvAuthStrategy, "login"))
 
 	// Server configuration
 	c.Server.Address = strings.TrimSpace(getDefaultString(EnvServerAddress, ""))

--- a/config/token.go
+++ b/config/token.go
@@ -22,12 +22,19 @@ type TokenClaim struct {
 //
 // swagger:model TokenGenerated
 type TokenGenerated struct {
+	// The provided username
+	// A string representing the username for the user
+	// example: admin
+	// required: true
+	Username string `json:"username"`
+
 	// The authentication token
 	// A string with the authentication token for the user
 	//
 	// example: zI1NiIsIsR5cCI6IkpXVCJ9.ezJ1c2VybmFtZSI6ImFkbWluIiwiZXhwIjoxNTI5NTIzNjU0fQ.PPZvRGnR6VA4v7FmgSfQcGQr-VD
 	// required: true
 	Token string `json:"token"`
+
 	// The expired time for the token
 	// A string with the Datetime when the token will be expired
 	//
@@ -52,7 +59,7 @@ func GenerateToken(username string) (TokenGenerated, error) {
 		return TokenGenerated{}, err
 	}
 
-	return TokenGenerated{Token: ss, ExpiredAt: timeExpire.String()}, nil
+	return TokenGenerated{Username: username, Token: ss, ExpiredAt: timeExpire.String()}, nil
 }
 
 // ValidateToken checks if the input token is still valid

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -19,3 +19,4 @@ data:
     identity:
       cert_file: /kiali-cert/cert-chain.pem
       private_key_file: /kiali-cert/key.pem
+    auth_strategy: ${AUTH_STRATEGY}

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -81,6 +81,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 - apiGroups: ["project.openshift.io"]
   resources:
   - projects

--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -16,3 +16,4 @@ data:
         url: ${JAEGER_URL}
       grafana:
         url: ${GRAFANA_URL}
+    auth_strategy: ${AUTH_STRATEGY}

--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -16,6 +16,3 @@ data:
         url: ${JAEGER_URL}
       grafana:
         url: ${GRAFANA_URL}
-    identity:
-      cert_file: /kiali-cert/tls.crt
-      private_key_file: /kiali-cert/tls.key

--- a/deploy/openshift/deploy-kiali-to-openshift.sh
+++ b/deploy/openshift/deploy-kiali-to-openshift.sh
@@ -22,7 +22,7 @@
 # - openshift: OAuth from Openshift
 # - login: username/password
 # - none:  anonymous usage
-export AUTH_STRATEGY="${AUTH_STRATEGY:-oauth}"
+export AUTH_STRATEGY="${AUTH_STRATEGY:-login}"
 
 # If OAuth is enabled, we just use the default proxy configuration. If not, we
 # ask for credentials and use the default login page strategy, as well as

--- a/deploy/openshift/deploy-kiali-to-openshift.sh
+++ b/deploy/openshift/deploy-kiali-to-openshift.sh
@@ -19,7 +19,7 @@
 ##############################################################################
 
 # The Auth Strategy we are going to use:
-# - oauth: OAuth from Openshift
+# - openshift: OAuth from Openshift
 # - login: username/password
 # - none:  anonymous usage
 export AUTH_STRATEGY="${AUTH_STRATEGY:-oauth}"
@@ -27,7 +27,7 @@ export AUTH_STRATEGY="${AUTH_STRATEGY:-oauth}"
 # If OAuth is enabled, we just use the default proxy configuration. If not, we
 # ask for credentials and use the default login page strategy, as well as
 # setting the proxy to bypass everything.
-if [ "${AUTH_STRATEGY}" == "oauth" ]; then
+if [ "${AUTH_STRATEGY}" == "openshift" ]; then
   export AUTH_BYPASS=""
 else
   # The credentials can be specified either as already base64 encoded, or in plain text.

--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -44,6 +44,7 @@ spec:
         - -cookie-secret=kiali-16bytes-1234
         - -skip-provider-button
         - -pass-access-token
+        ${AUTH_BYPASS}
         ports:
         - containerPort: 20002
           name: proxy

--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - -http-address=
         - -email-domain=*
         - -upstream=http://localhost:20001
-        - -openshift-service-account=kiali
+        - -openshift-service-account=kiali-service-account
         - '-openshift-sar={"namespace":"istio-system","resource":"services","name":"kiali","verb":"get"}'
         - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
         - -tls-cert=/etc/tls/private/tls.crt

--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -34,8 +34,6 @@ spec:
         - -email-domain=*
         - -upstream=http://localhost:20001
         - -openshift-service-account=kiali-service-account
-        - '-openshift-sar={"namespace":"istio-system","resource":"services","name":"kiali","verb":"get"}'
-        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
         - -tls-cert=/etc/tls/private/tls.crt
         - -tls-key=/etc/tls/private/tls.key
         - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
@@ -44,6 +42,7 @@ spec:
         - -cookie-secret=kiali-16bytes-1234
         - -skip-provider-button
         - -pass-access-token
+        - "-scope=role:cluster-admin:istio-system"
         ${AUTH_BYPASS}
         ports:
         - containerPort: 20002

--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -25,6 +25,32 @@ spec:
     spec:
       serviceAccount: kiali-service-account
       containers:
+      - image: openshift/oauth-proxy:v1.1.0
+        name: kiali-proxy
+        args:
+        - -provider=openshift
+        - -https-address=:20002
+        - -http-address=
+        - -email-domain=*
+        - -upstream=http://localhost:20001
+        - -openshift-service-account=kiali
+        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+        - -tls-cert=/etc/tls/private/tls.crt
+        - -tls-key=/etc/tls/private/tls.key
+        - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - -openshift-ca=/etc/pki/tls/cert.pem
+        - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -cookie-secret=kiali-16bytes-1234
+        - -skip-provider-button
+        - -pass-access-token
+        ports:
+        - containerPort: 20002
+          name: proxy
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: kiali-cert
       - image: ${IMAGE_NAME}:${IMAGE_VERSION}
         ${IMAGE_PULL_POLICY_TOKEN}
         name: kiali

--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - -email-domain=*
         - -upstream=http://localhost:20001
         - -openshift-service-account=kiali
-        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - '-openshift-sar={"namespace":"istio-system","resource":"services","name":"kiali","verb":"get"}'
         - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
         - -tls-cert=/etc/tls/private/tls.crt
         - -tls-key=/etc/tls/private/tls.key

--- a/deploy/openshift/route.yaml
+++ b/deploy/openshift/route.yaml
@@ -10,5 +10,5 @@ spec:
     termination: reencrypt
   to:
     kind: Service
-    targetPort: 20001
+    targetPort: 20002
     name: kiali

--- a/deploy/openshift/service.yaml
+++ b/deploy/openshift/service.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
   - name: tcp
     protocol: TCP
-    port: 20001
+    port: 20002
   selector:
     app: kiali
     version: ${VERSION_LABEL}

--- a/deploy/openshift/serviceaccount.yaml
+++ b/deploy/openshift/serviceaccount.yaml
@@ -5,3 +5,5 @@ metadata:
   labels:
     app: kiali
     version: ${VERSION_LABEL}
+  annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"kiali"}}'

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -9,6 +9,7 @@ import (
 // PublicConfig is a subset of Kiali configuration that can be exposed to clients to
 // help them interact with the system.
 type PublicConfig struct {
+	AuthStrategy   string             `json:"authStrategy,omitempty"`
 	IstioNamespace string             `json:"istioNamespace,omitempty"`
 	IstioLabels    config.IstioLabels `json:"istioLabels,omitempty"`
 }
@@ -20,6 +21,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 
 	config := config.Get()
 	publicConfig := PublicConfig{
+		AuthStrategy:   config.AuthStrategy,
 		IstioNamespace: config.IstioNamespace,
 		IstioLabels:    config.IstioLabels,
 	}

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -1,17 +1,23 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/kiali/kiali/config"
+	"k8s.io/client-go/rest"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube "k8s.io/client-go/kubernetes"
 )
 
 // PublicConfig is a subset of Kiali configuration that can be exposed to clients to
 // help them interact with the system.
 type PublicConfig struct {
-	AuthStrategy   string             `json:"authStrategy,omitempty"`
-	IstioNamespace string             `json:"istioNamespace,omitempty"`
-	IstioLabels    config.IstioLabels `json:"istioLabels,omitempty"`
+	AuthStrategy            string             `json:"authStrategy,omitempty"`
+	OauthUserHasPermissions bool               `json:"oauthUserHasPermissions"`
+	IstioNamespace          string             `json:"istioNamespace,omitempty"`
+	IstioLabels             config.IstioLabels `json:"istioLabels,omitempty"`
 }
 
 // GraphNamespace is a REST http.HandlerFunc handling namespace-wide graph
@@ -20,11 +26,50 @@ func Config(w http.ResponseWriter, r *http.Request) {
 	defer handlePanic(w)
 
 	config := config.Get()
+
 	publicConfig := PublicConfig{
-		AuthStrategy:   config.AuthStrategy,
-		IstioNamespace: config.IstioNamespace,
-		IstioLabels:    config.IstioLabels,
+		AuthStrategy:            config.AuthStrategy,
+		IstioNamespace:          config.IstioNamespace,
+		IstioLabels:             config.IstioLabels,
+		OauthUserHasPermissions: checkOauthPermissions(r.Header.Get("X-Forwarded-Access-Token")),
 	}
 
 	RespondWithJSONIndent(w, http.StatusOK, publicConfig)
+}
+
+// Check if an user has permissions to use Kiali.
+// It is the naivest implementation possible, to check if the user can at least
+// list the services on istio-system.
+func checkOauthPermissions(token string) bool {
+	if token == "" {
+		return false
+	}
+
+	config, err := rest.InClusterConfig()
+
+	if err != nil {
+		fmt.Println("Failed on in cluster config")
+		return false
+	}
+
+	config.BearerToken = token
+
+	client, err := kube.NewForConfig(config)
+
+	if err != nil {
+		fmt.Println("Failed on in creating kube client")
+		return false
+	}
+
+	services, err := client.CoreV1().Services("istio-system").Get("kiali", metav1.GetOptions{})
+
+	fmt.Printf("%+v\n", services)
+
+	if err != nil {
+		fmt.Println("failed on getting kiali service")
+		fmt.Printf("%+v\n", err)
+		return false
+	}
+
+	return true
 }

--- a/handlers/root.go
+++ b/handlers/root.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/status"
@@ -16,15 +18,33 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetToken(w http.ResponseWriter, r *http.Request) {
-	u, _, ok := r.BasicAuth()
-	if !ok {
-		RespondWithJSONIndent(w, http.StatusInternalServerError, u)
-		return
+	token := r.Header.Get("X-Forwarded-Access-Token")
+
+	if r.Header.Get("Gap-Signature") != "" {
+		username := strings.Split(r.Header.Get("Gap-Auth"), "@")[0]
+
+		if username == "" {
+			RespondWithJSONIndent(w, http.StatusInternalServerError, username)
+			return
+		}
+
+		expiresAt := time.Now().Add(time.Second * time.Duration(config.Get().LoginToken.ExpirationSeconds))
+		token := config.TokenGenerated{Username: username, Token: token, ExpiredAt: expiresAt.String()}
+
+		RespondWithJSONIndent(w, http.StatusOK, token)
+	} else {
+		u, _, ok := r.BasicAuth()
+
+		if !ok {
+			RespondWithJSONIndent(w, http.StatusInternalServerError, u)
+			return
+		}
+
+		token, error := config.GenerateToken(u)
+		if error != nil {
+			RespondWithJSONIndent(w, http.StatusInternalServerError, error)
+			return
+		}
+		RespondWithJSONIndent(w, http.StatusOK, token)
 	}
-	token, error := config.GenerateToken(u)
-	if error != nil {
-		RespondWithJSONIndent(w, http.StatusInternalServerError, error)
-		return
-	}
-	RespondWithJSONIndent(w, http.StatusOK, token)
 }


### PR DESCRIPTION
** Describe the change **

This PR implements the server-side support for oauth-proxy, enabled only on Openshift. It uses the oauth token (the same that we can use to connect to k8s) and handles most of the use cases.

** What still needs to be done **

* [x] Handle signout gracefully.

** Backwards incompatible? **

No.
