### PR TITLE
KIALI-1873 Provide inbound and outbound error ratios in RequestHealth

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2779,6 +2779,16 @@
           "type": "number",
           "format": "double",
           "x-go-name": "ErrorRatio"
+        },
+        "inboundErrorRatio": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "InboundErrorRatio"
+        },
+        "outboundErrorRatio": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "OutboundErrorRatio"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"


### PR DESCRIPTION
The overall error rate is detailed into inbound and outbound error rates. This will bring a better idea about where to look for issues.

https://issues.jboss.org/browse/KIALI-1873

** Backwards compatible? ** *yes*

Related UI PR: https://github.com/kiali/kiali-ui/pull/810