### PR TITLE
Allow multiple components in WebRoot prefix path

### DIFF
--- a/kiali.go
+++ b/kiali.go
@@ -139,7 +139,7 @@ func validateConfig() error {
 		return fmt.Errorf("server static content root directory does not exist: %v", config.Get().Server.StaticContentRootDirectory)
 	}
 
-	validPathRegEx := regexp.MustCompile(`^\/[a-zA-Z\d_\$]*$`)
+	validPathRegEx := regexp.MustCompile(`^\/[a-zA-Z\d_/\$]*$`)
 	if path := config.Get().Server.WebRoot; !validPathRegEx.MatchString(path) {
 		return fmt.Errorf("web root must begin with a / and contain only alphanumerics: %v", path)
 	}


### PR DESCRIPTION
#### Description
Currently, the WebRoot prefix only allows a single path component, ie. `/kiali`, but fails on a WebRoot with multiple components:

```F1113 10:27:49.548275       1 kiali.go:80] web root must begin with a / and contain only alphanumerics: /istio/kiali```

This PR simply allows a `/` in the web root validation regex.

This change should be backwards compatible. 