### PR TITLE
KIALI-1670 Support option groupBy=app to group nodes by app label

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -114,11 +114,11 @@ type GraphTypeParam struct {
 
 // swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
 type GroupByParam struct {
-	// App box grouping characteristic. Ignored unless graph type is versionedApp. Available groupings: [version].
+	// App box grouping characteristic. Available groupings: [app, none, version].
 	//
 	// in: query
 	// required: false
-	// default: version
+	// default: none
 	Name string `json:"groupBy"`
 }
 

--- a/graph/appender/istio_details_test.go
+++ b/graph/appender/istio_details_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/business"
@@ -57,6 +58,8 @@ func TestCBAll(t *testing.T) {
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{
 		dRule.DeepCopyIstioObject(),
 	}, nil)
+	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&coreV1.Endpoints{}, nil)
+	k8s.On("GetService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&coreV1.Service{}, nil)
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{}, nil)
 
 	businessLayer := business.SetWithBackends(k8s, nil)
@@ -119,6 +122,8 @@ func TestCBSubset(t *testing.T) {
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{
 		dRule.DeepCopyIstioObject(),
 	}, nil)
+	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&coreV1.Endpoints{}, nil)
+	k8s.On("GetService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&coreV1.Service{}, nil)
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{}, nil)
 
 	businessLayer := business.SetWithBackends(k8s, nil)
@@ -175,6 +180,8 @@ func TestVS(t *testing.T) {
 		},
 	}
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{}, nil)
+	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&coreV1.Endpoints{}, nil)
+	k8s.On("GetService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&coreV1.Service{}, nil)
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{
 		vService.DeepCopyIstioObject(),
 	}, nil)

--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/graph/options"
+	"github.com/kiali/kiali/log"
 )
 
 type NodeData struct {
@@ -107,9 +108,18 @@ func NewConfig(trafficMap graph.TrafficMap, o options.VendorOptions) (result Con
 
 	buildConfig(trafficMap, &nodes, &edges, o)
 
-	// Add compound nodes that group together different versions of the same node
-	if o.GraphType == graph.GraphTypeVersionedApp && o.GroupBy == options.GroupByVersion {
-		groupByVersion(&nodes)
+	// Add compound nodes as needed
+	switch o.GroupBy {
+	case options.GroupByApp:
+		if o.GraphType != graph.GraphTypeService {
+			groupByApp(&nodes)
+		}
+	case options.GroupByVersion:
+		if o.GraphType == graph.GraphTypeVersionedApp {
+			groupByVersion(&nodes)
+		}
+	default:
+		// no grouping
 	}
 
 	// sort nodes and edges for better json presentation (and predictable testing)
@@ -346,18 +356,38 @@ func addEdgeTelemetry(ed *EdgeData, e *graph.Edge, o options.VendorOptions) {
 
 // groupByVersion adds compound nodes to group multiple versions of the same app
 func groupByVersion(nodes *[]*NodeWrapper) {
-	grouped := make(map[string][]*NodeData)
+	log.Warningf("GroupByVersion...")
+	appBox := make(map[string][]*NodeData)
 
 	for _, nw := range *nodes {
 		if nw.Data.NodeType == graph.NodeTypeApp {
 			k := fmt.Sprintf("box_%s_%s", nw.Data.Namespace, nw.Data.App)
-			grouped[k] = append(grouped[k], nw.Data)
+			appBox[k] = append(appBox[k], nw.Data)
 		}
 	}
 
-	for k, members := range grouped {
+	generateGroupCompoundNodes(appBox, nodes, options.GroupByVersion)
+}
+
+// groupByApp adds compound nodes to group all nodes for the same app
+func groupByApp(nodes *[]*NodeWrapper) {
+	appBox := make(map[string][]*NodeData)
+
+	for _, nw := range *nodes {
+		if nw.Data.App != "unknown" && nw.Data.App != "" {
+			k := fmt.Sprintf("box_%s_%s", nw.Data.Namespace, nw.Data.App)
+			appBox[k] = append(appBox[k], nw.Data)
+		}
+	}
+
+	generateGroupCompoundNodes(appBox, nodes, options.GroupByApp)
+}
+
+func generateGroupCompoundNodes(appBox map[string][]*NodeData, nodes *[]*NodeWrapper, groupBy string) {
+	for k, members := range appBox {
 		if len(members) > 1 {
-			// create the compound grouping all versions of the app
+			// create the compound (parent) node for the member nodes
+			log.Warningf("GroupBy %s adding node %s...", groupBy, k)
 			nodeId := nodeHash(k)
 			nd := NodeData{
 				Id:        nodeId,
@@ -365,14 +395,14 @@ func groupByVersion(nodes *[]*NodeWrapper) {
 				Namespace: members[0].Namespace,
 				App:       members[0].App,
 				Version:   "",
-				IsGroup:   options.GroupByVersion,
+				IsGroup:   groupBy,
 			}
 
 			nw := NodeWrapper{
 				Data: &nd,
 			}
 
-			// assign each app version node to the compound parent
+			// assign each member node to the compound parent
 			nd.HasMissingSC = false // TODO: this is probably unecessarily noisy
 			nd.IsInaccessible = false
 			nd.IsOutside = false

--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/graph/options"
-	"github.com/kiali/kiali/log"
 )
 
 type NodeData struct {
@@ -356,7 +355,6 @@ func addEdgeTelemetry(ed *EdgeData, e *graph.Edge, o options.VendorOptions) {
 
 // groupByVersion adds compound nodes to group multiple versions of the same app
 func groupByVersion(nodes *[]*NodeWrapper) {
-	log.Warningf("GroupByVersion...")
 	appBox := make(map[string][]*NodeData)
 
 	for _, nw := range *nodes {
@@ -387,7 +385,6 @@ func generateGroupCompoundNodes(appBox map[string][]*NodeData, nodes *[]*NodeWra
 	for k, members := range appBox {
 		if len(members) > 1 {
 			// create the compound (parent) node for the member nodes
-			log.Warningf("GroupBy %s adding node %s...", groupBy, k)
 			nodeId := nodeHash(k)
 			nd := NodeData{
 				Id:        nodeId,

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -64,8 +64,8 @@ func NewNodeExplicit(id, namespace, workload, app, version, service, nodeType, g
 	// trim unnecessary fields
 	switch nodeType {
 	case NodeTypeWorkload:
-		// maintain the app+version labeling if it is set, it can be useful for
-		// for identifying destination rules, and providing additional links
+		// maintain the app+version labeling if it is set, it can be useful
+		// for identifying destination rules, providing links, and grouping
 		if app == UnknownApp {
 			app = ""
 		}
@@ -153,12 +153,22 @@ func Id(namespace, workload, app, version, service, graphType string) (id, nodeT
 		return fmt.Sprintf("wl_%v_%v", namespace, workload), NodeTypeWorkload
 	}
 
-	// handle app nodes
+	// handle app and versionedApp graphs
+	versionOk := version != "" && version != UnknownVersion
 	if appOk {
-		// For a versionedApp graph we use workload as the Id, it allows us some protection against labeling
-		// anti-patterns. For versionless we  just use the app label to aggregate versions/workloads into one node
+		// For a versionedApp graph use workload as the Id, if available. It allows us some protection
+		// against labeling anti-patterns. It won't be there in a few cases like:
+		//   - root node of a node graph
+		//   - app box node
+		// Otherwise use what we have and alter node type as necessary
+		// For a [versionless] App graph use the app label to aggregate versions/workloads into one node
 		if graphType == GraphTypeVersionedApp {
-			return fmt.Sprintf("vapp_%v_%v", namespace, workload), NodeTypeApp
+			if workloadOk {
+				return fmt.Sprintf("vapp_%v_%v", namespace, workload), NodeTypeApp
+			}
+			if versionOk {
+				return fmt.Sprintf("vapp_%v_%v_%v", namespace, app, version), NodeTypeApp
+			}
 		}
 		return fmt.Sprintf("app_%v_%v", namespace, app), NodeTypeApp
 	}

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -19,14 +19,17 @@ import (
 
 const (
 	AppenderAll               string = "_all_"
+	GroupByApp                string = "app"
+	GroupByNone               string = "none"
 	GroupByVersion            string = "version"
 	NamespaceIstio            string = "istio-system"
+	VendorCytoscape           string = "cytoscape"
 	defaultDuration           string = "10m"
 	defaultGraphType          string = graph.GraphTypeWorkload
-	defaultGroupBy            string = GroupByVersion
+	defaultGroupBy            string = GroupByNone
 	defaultIncludeIstio       bool   = false
 	defaultInjectServiceNodes bool   = false
-	defaultVendor             string = "cytoscape"
+	defaultVendor             string = VendorCytoscape
 )
 
 const (
@@ -88,10 +91,10 @@ func NewOptions(r *http.Request) Options {
 	if durationErr != nil {
 		duration, _ = time.ParseDuration(defaultDuration)
 	}
-	if "" == graphType {
+	if graphType != graph.GraphTypeApp && graphType != graph.GraphTypeService && graphType != graph.GraphTypeVersionedApp && graphType != graph.GraphTypeWorkload {
 		graphType = defaultGraphType
 	}
-	if "" == groupBy {
+	if groupBy != GroupByApp && groupBy != GroupByNone && groupBy != GroupByVersion {
 		groupBy = defaultGroupBy
 	}
 	if includeIstioErr != nil {
@@ -103,7 +106,7 @@ func NewOptions(r *http.Request) Options {
 	if queryTimeErr != nil {
 		queryTime = time.Now().Unix()
 	}
-	if "" == vendor {
+	if vendor != VendorCytoscape {
 		vendor = defaultVendor
 	}
 

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -391,7 +391,7 @@ func TestAppGraph(t *testing.T) {
 	defer ts.Close()
 
 	fut = graphNamespaces
-	url := ts.URL + "/api/namespaces/graph?namespaces=bookinfo&graphType=app&appenders&queryTime=1523364075"
+	url := ts.URL + "/api/namespaces/graph?namespaces=bookinfo&graphType=app&groupBy=app&appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -425,7 +425,7 @@ func TestVersionedAppGraph(t *testing.T) {
 	defer ts.Close()
 
 	fut = graphNamespaces
-	url := ts.URL + "/api/namespaces/graph?namespaces=bookinfo&graphType=versionedApp&appenders&queryTime=1523364075"
+	url := ts.URL + "/api/namespaces/graph?namespaces=bookinfo&graphType=versionedApp&groupBy=app&appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -697,7 +697,7 @@ func TestAppNodeGraph(t *testing.T) {
 	defer ts.Close()
 
 	fut = graphNode
-	url := ts.URL + "/api/namespaces/bookinfo/applications/productpage/graph?graphType=versionedApp&appenders&queryTime=1523364075"
+	url := ts.URL + "/api/namespaces/bookinfo/applications/productpage/graph?graphType=versionedApp&groupBy=app&appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -901,7 +901,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 	defer ts.Close()
 
 	fut = graphNode
-	url := ts.URL + "/api/namespaces/bookinfo/applications/productpage/versions/v1/graph?graphType=versionedApp&appenders&queryTime=1523364075"
+	url := ts.URL + "/api/namespaces/bookinfo/applications/productpage/versions/v1/graph?graphType=versionedApp&groupBy=app&appenders&queryTime=1523364075"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -1306,7 +1306,7 @@ func TestComplexGraph(t *testing.T) {
 	defer ts.Close()
 
 	fut = graphNamespaces
-	url := ts.URL + "/api/namespaces/graph?graphType=versionedApp&appenders=&queryTime=1523364075&namespaces=bookinfo,tutorial"
+	url := ts.URL + "/api/namespaces/graph?graphType=versionedApp&groupBy=app&appenders=&queryTime=1523364075&namespaces=bookinfo,tutorial"
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)

--- a/handlers/testdata/test_app_node_graph.expected
+++ b/handlers/testdata/test_app_node_graph.expected
@@ -9,7 +9,7 @@
           "nodeType": "app",
           "namespace": "bookinfo",
           "app": "reviews",
-          "isGroup": "version"
+          "isGroup": "app"
         }
       },
       {

--- a/handlers/testdata/test_versioned_app_graph.expected
+++ b/handlers/testdata/test_versioned_app_graph.expected
@@ -25,7 +25,7 @@
           "nodeType": "app",
           "namespace": "bookinfo",
           "app": "reviews",
-          "isGroup": "version"
+          "isGroup": "app"
         }
       },
       {

--- a/handlers/testdata/test_versioned_app_node_graph.expected
+++ b/handlers/testdata/test_versioned_app_node_graph.expected
@@ -9,7 +9,7 @@
           "nodeType": "app",
           "namespace": "bookinfo",
           "app": "reviews",
-          "isGroup": "version"
+          "isGroup": "app"
         }
       },
       {

--- a/swagger.json
+++ b/swagger.json
@@ -849,9 +849,9 @@
           },
           {
             "type": "string",
-            "default": "version",
+            "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Ignored unless graph type is versionedApp. Available groupings: [version].",
+            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
             "name": "groupBy",
             "in": "query"
           },
@@ -950,9 +950,9 @@
           },
           {
             "type": "string",
-            "default": "version",
+            "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Ignored unless graph type is versionedApp. Available groupings: [version].",
+            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
             "name": "groupBy",
             "in": "query"
           },
@@ -1051,9 +1051,9 @@
           },
           {
             "type": "string",
-            "default": "version",
+            "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Ignored unless graph type is versionedApp. Available groupings: [version].",
+            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
             "name": "groupBy",
             "in": "query"
           },
@@ -1487,9 +1487,9 @@
           },
           {
             "type": "string",
-            "default": "version",
+            "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Ignored unless graph type is versionedApp. Available groupings: [version].",
+            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
             "name": "groupBy",
             "in": "query"
           },
@@ -1697,9 +1697,9 @@
           },
           {
             "type": "string",
-            "default": "version",
+            "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Ignored unless graph type is versionedApp. Available groupings: [version].",
+            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
             "name": "groupBy",
             "in": "query"
           },


### PR DESCRIPTION
This PR is provides the backend support for adding groupBy=app support.  Currently we support only groupBy=version (only for versionedApp graphs) .

There are some ui-side challenges here so the PR is currently set to DoNotMerge, and exists only to support the investigation.  In particular, the expanded compound nodes (App Boxes) need to render well a graph subset, minimally at least a two-deep graph from a source service node to one or more destination nodes.  Until now an app box could contain only a grouping of version nodes (typically presented vertically)