### PR TITLE
KIALI-1952 Change IsOpenShift endpoint to support k8s 3.11

### DIFF
--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -69,7 +69,7 @@ func (in *IstioClient) GetProjects() ([]osv1.Project, error) {
 func (in *IstioClient) IsOpenShift() bool {
 	if in.isOpenShift == nil {
 		isOpenShift := false
-		_, err := in.k8s.RESTClient().Get().AbsPath("/version/openshift").Do().Raw()
+		_, err := in.k8s.RESTClient().Get().AbsPath("/apis/project.openshift.io").Do().Raw()
 		if err == nil {
 			isOpenShift = true
 		}


### PR DESCRIPTION
- Openshift based in 3.11 deprecated /version/openshift endpoint

Check if /apis/project.openshift.io exist works to determine if kiali is deployed in an OpenShift cluster based in 3.10 and 3.11.