### PR TITLE
KIALI-1319 Add multi-namespace gateway multi-match checker

### DIFF
--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -1,0 +1,17 @@
+package checkers
+
+import (
+	"github.com/kiali/kiali/business/checkers/gateways"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type GatewayChecker struct {
+	GatewaysPerNamespace [][]kubernetes.IstioObject
+}
+
+func (g GatewayChecker) Check() models.IstioValidations {
+	return gateways.MultiMatchChecker{
+		GatewaysPerNamespace: g.GatewaysPerNamespace,
+	}.Check()
+}

--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -1,0 +1,123 @@
+package gateways
+
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type MultiMatchChecker struct {
+	GatewaysPerNamespace [][]kubernetes.IstioObject
+	existingList         []Host
+}
+
+const (
+	GatewayCheckerType = "gateway"
+	wildCardMatch      = "*"
+)
+
+type Host struct {
+	Port     uint32
+	Hostname string
+	Index    int
+}
+
+// Check validates that no two gateways share the same host+port combination
+func (m MultiMatchChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+	m.existingList = make([]Host, 0)
+
+	for _, nsG := range m.GatewaysPerNamespace {
+		for _, g := range nsG {
+			gatewayRuleName := g.GetObjectMeta().Name
+			if specServers, found := g.GetSpec()["servers"]; found {
+				if servers, ok := specServers.([]interface{}); ok {
+					for i, def := range servers {
+						if serverDef, ok := def.(map[string]interface{}); ok {
+							hosts := parsePortAndHostnames(serverDef)
+							for _, host := range hosts {
+								duplicate := m.findMatch(host)
+								if !duplicate {
+									m.existingList = append(m.existingList, host)
+								} else {
+									validations = addError(validations, gatewayRuleName, i)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return validations
+}
+
+func addError(validations models.IstioValidations, gatewayRuleName string, index int) models.IstioValidations {
+	key := models.IstioValidationKey{Name: gatewayRuleName, ObjectType: GatewayCheckerType}
+	checks := models.BuildCheck("More than one Gateway for same host port combination",
+		"warning", "spec/servers["+strconv.Itoa(index)+"]")
+	rrValidation := &models.IstioValidation{
+		Name:       gatewayRuleName,
+		ObjectType: GatewayCheckerType,
+		Valid:      false,
+		Checks: []*models.IstioCheck{
+			&checks,
+		},
+	}
+
+	if _, exists := validations[key]; !exists {
+		validations.MergeValidations(models.IstioValidations{key: rrValidation})
+	}
+	return validations
+}
+
+func parsePortAndHostnames(serverDef map[string]interface{}) []Host {
+	var port uint32
+	if portDef, found := serverDef["port"]; found {
+		if ports, ok := portDef.(map[string]interface{}); ok {
+			if numberDef, found := ports["number"]; found {
+				if portNumber, ok := numberDef.(uint32); ok {
+					port = portNumber
+				}
+			}
+		}
+	}
+
+	if hostDef, found := serverDef["hosts"]; found {
+		if hostnames, ok := hostDef.([]interface{}); ok {
+			hosts := make([]Host, 0, len(hostnames))
+			for _, hostinterface := range hostnames {
+				if hostname, ok := hostinterface.(string); ok {
+					hosts = append(hosts, Host{
+						Port:     port,
+						Hostname: hostname,
+					})
+				}
+			}
+			return hosts
+		}
+	}
+	return nil
+}
+
+// findMatch uses a linear search with regexp to check for matching gateway host + port combinations. If this becomes a bottleneck for performance, replace with a graph or trie algorithm.
+func (m MultiMatchChecker) findMatch(host Host) bool {
+	for _, h := range m.existingList {
+		if h.Port == host.Port {
+			// wildcardMatches will always match
+			if host.Hostname == wildCardMatch || h.Hostname == wildCardMatch {
+				return true
+			}
+			// Either one could include wildcards, so we need to check both ways
+			if regexp.MustCompile(host.Hostname).MatchString(h.Hostname) {
+				return true
+			}
+			if regexp.MustCompile(h.Hostname).MatchString(host.Hostname) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -1,0 +1,124 @@
+package gateways
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCorrectGateways(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
+		data.CreateEmptyGateway("validgateway", map[string]string{
+			"app": "real",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.Empty(validations)
+	_, ok := validations[models.IstioValidationKey{"gateway", "validgateway"}]
+	assert.False(ok)
+}
+
+func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
+		data.CreateEmptyGateway("validgateway", map[string]string{
+			"app": "real",
+		}))
+
+	// Another namespace
+	gwObject2 := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
+		data.CreateEmptyGateway("stillvalid", map[string]string{
+			"app": "someother",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}, []kubernetes.IstioObject{gwObject2}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	validation, ok := validations[models.IstioValidationKey{"gateway", "stillvalid"}]
+	assert.True(ok)
+	assert.False(validation.Valid)
+}
+
+func TestWildCardMatchingHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
+		data.CreateEmptyGateway("validgateway", map[string]string{
+			"app": "real",
+		}))
+
+	// Another namespace
+	gwObject2 := data.AddServerToGateway(data.CreateServer([]string{"*"}, 80, "http", "http"),
+		data.CreateEmptyGateway("stillvalid", map[string]string{
+			"app": "someother",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}, []kubernetes.IstioObject{gwObject2}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	validation, ok := validations[models.IstioValidationKey{"gateway", "stillvalid"}]
+	assert.True(ok)
+	assert.False(validation.Valid)
+
+}
+
+func TestTwoWildCardsMatching(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer([]string{"*"}, 80, "http", "http"),
+		data.CreateEmptyGateway("validgateway", map[string]string{
+			"app": "real",
+		}))
+
+	// Another namespace
+	gwObject2 := data.AddServerToGateway(data.CreateServer([]string{"*"}, 80, "http", "http"),
+		data.CreateEmptyGateway("stillvalid", map[string]string{
+			"app": "someother",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}, []kubernetes.IstioObject{gwObject2}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	validation, ok := validations[models.IstioValidationKey{"gateway", "stillvalid"}]
+	assert.True(ok)
+	assert.False(validation.Valid)
+}

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -56,7 +56,7 @@ func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+	assert.Equal(2, len(validations))
 	validation, ok := validations[models.IstioValidationKey{"gateway", "stillvalid"}]
 	assert.True(ok)
 	assert.False(validation.Valid)
@@ -79,14 +79,20 @@ func TestWildCardMatchingHost(t *testing.T) {
 			"app": "someother",
 		}))
 
-	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}, []kubernetes.IstioObject{gwObject2}}
+	// Another namespace
+	gwObject3 := data.AddServerToGateway(data.CreateServer([]string{"*.justhost.com"}, 80, "http", "http"),
+		data.CreateEmptyGateway("keepsvalid", map[string]string{
+			"app": "someother",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}, []kubernetes.IstioObject{gwObject2, gwObject3}}
 
 	validations := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
 	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+	assert.Equal(3, len(validations))
 	validation, ok := validations[models.IstioValidationKey{"gateway", "stillvalid"}]
 	assert.True(ok)
 	assert.False(validation.Valid)
@@ -117,7 +123,7 @@ func TestTwoWildCardsMatching(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+	assert.Equal(2, len(validations))
 	validation, ok := validations[models.IstioValidationKey{"gateway", "stillvalid"}]
 	assert.True(ok)
 	assert.False(validation.Valid)

--- a/tests/data/gateway_data.go
+++ b/tests/data/gateway_data.go
@@ -21,6 +21,33 @@ func CreateEmptyGateway(name string, selector map[string]string) kubernetes.Isti
 	return &gateway
 }
 
+func AddServerToGateway(server map[string]interface{}, gw kubernetes.IstioObject) kubernetes.IstioObject {
+	if serversTypeExists, found := gw.GetSpec()["servers"]; found {
+		if serversTypeCasted, ok := serversTypeExists.([]interface{}); ok {
+			serversTypeCasted = append(serversTypeCasted, server)
+			gw.GetSpec()["servers"] = serversTypeCasted
+		}
+	} else {
+		gw.GetSpec()["servers"] = []interface{}{server}
+	}
+	return gw
+}
+
+func CreateServer(hosts []string, port uint32, portName, protocolName string) map[string]interface{} {
+	hostSlice := make([]interface{}, 0, len(hosts))
+	for _, h := range hosts {
+		hostSlice = append(hostSlice, h)
+	}
+	return map[string]interface{}{
+		"port": map[string]interface{}{
+			"number":   port,
+			"name":     portName,
+			"protocol": protocolName,
+		},
+		"hosts": hostSlice,
+	}
+}
+
 func AddGatewaysToVirtualService(gateways []string, vs kubernetes.IstioObject) kubernetes.IstioObject {
 	gates := make([]interface{}, 0, len(gateways))
 	for _, v := range gateways {


### PR DESCRIPTION
Checks that there are no duplicate gateways in any of the namespaces that the application can see. Some notes on scaling though:

* Uses linear search to check for matching hosts
  * If performance becomes a real issue, then something more complex like a hostname graph structure or a trie is required. This feels like an overkill in my opinion however at this point.
* Since golang has no unbounded channels, the errChan could get blocked. I've increased the size to 64 and try to avoid writing there, but in theory there's a possibility that the errChan returns len = 0 and it is actually full. In theory.