### PR TITLE
KIALI-1140 Add destination services for workload details endpoint

### DIFF
--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -68,7 +68,7 @@ func mockWorkLoadService() WorkloadService {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakePods().Items, nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 	return svc
 }
 
@@ -88,7 +88,8 @@ func mockCombinedValidationService(istioObjects *kubernetes.IstioDetails, servic
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().VirtualServices, nil)
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().DestinationRules, nil)
 	k8s.On("GetServiceEntries", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().ServiceEntries, nil)
-	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(fakeNamespace(), nil)
+	k8s.On("GetGateways", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().Gateways, nil)
+	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(kubetest.FakeNamespace("test"), nil)
 
 	k8s.On("GetGateways", "test", mock.AnythingOfType("string")).Return(getGateway("first"), nil)
 	k8s.On("GetGateways", "test2", mock.AnythingOfType("string")).Return(getGateway("second"), nil)
@@ -118,14 +119,6 @@ func getGateway(name string) []kubernetes.IstioObject {
 		data.CreateEmptyGateway(name, map[string]string{
 			"app": "real",
 		}))}
-}
-
-func fakeNamespace() *v1.Namespace {
-	return &v1.Namespace{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "test",
-		},
-	}
 }
 
 func fakeNamespaces() []v1.Namespace {

--- a/business/layer.go
+++ b/business/layer.go
@@ -51,8 +51,8 @@ func NewWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	temporaryLayer.Health = HealthService{prom: prom, k8s: k8s}
 	temporaryLayer.Svc = SvcService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.IstioConfig = IstioConfigService{k8s: k8s}
-	temporaryLayer.Workload = WorkloadService{k8s: k8s}
 	temporaryLayer.Validations = IstioValidationsService{k8s: k8s, ws: temporaryLayer.Workload}
+	temporaryLayer.Workload = WorkloadService{k8s: k8s, prom: prom, businessLayer: temporaryLayer}
 	temporaryLayer.App = AppService{k8s: k8s}
 	temporaryLayer.Namespace = NewNamespaceService(k8s)
 	temporaryLayer.k8s = k8s

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -15,10 +15,12 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/prometheustest"
 )
 
-func setupWorkloadService(k8s *kubetest.K8SClientMock) WorkloadService {
-	return WorkloadService{k8s: k8s}
+func setupWorkloadService(k8s *kubetest.K8SClientMock, prom *prometheustest.PromClientMock) WorkloadService {
+	return WorkloadService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom)}
 }
 
 func TestGetWorkloadListFromDeployments(t *testing.T) {
@@ -38,7 +40,7 @@ func TestGetWorkloadListFromDeployments(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -77,7 +79,7 @@ func TestGetWorkloadListFromReplicaSets(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -116,7 +118,7 @@ func TestGetWorkloadListFromReplicationControllers(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -155,7 +157,7 @@ func TestGetWorkloadListFromDeploymentConfigs(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -194,7 +196,7 @@ func TestGetWorkloadListFromStatefulSets(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -233,7 +235,7 @@ func TestGetWorkloadListFromDepRCPod(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsSyncedWithDeployments(), nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -264,7 +266,7 @@ func TestGetWorkloadListFromPod(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsNoController(), nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -295,7 +297,7 @@ func TestGetWorkloadListFromPods(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsFromDaemonSet(), nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -327,7 +329,7 @@ func TestGetWorkloadFromDeployment(t *testing.T) {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workload, _ := svc.GetWorkload("Namespace", "details-v1", false)
 
@@ -335,6 +337,58 @@ func TestGetWorkloadFromDeployment(t *testing.T) {
 	assert.Equal("Deployment", workload.Type)
 	assert.Equal(true, workload.AppLabel)
 	assert.Equal(true, workload.VersionLabel)
+}
+
+func TestGetWorkloadDestinationServices(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	destServices := []prometheus.Service{
+		{
+			Namespace:   "bookinfo",
+			ServiceName: "reviews",
+			App:         "reviews"},
+		{
+			Namespace:   "bookinfo",
+			ServiceName: "details",
+			App:         "details"},
+	}
+
+	// Setup mocks
+	notfound := fmt.Errorf("not found")
+	k8s := new(kubetest.K8SClientMock)
+	prom := new(prometheustest.PromClientMock)
+
+	k8s.On("IsOpenShift").Return(false)
+	k8s.On("GetDeployment", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&FakeDepSyncedWithRS()[0], nil)
+	k8s.On("GetDeploymentConfig", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&osappsv1.DeploymentConfig{}, notfound)
+	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1beta2.ReplicaSet{}, nil)
+	k8s.On("GetReplicationControllers", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.ReplicationController{}, nil)
+	k8s.On("GetStatefulSet", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&v1beta2.StatefulSet{}, notfound)
+	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsSyncedWithDeployments(), nil)
+	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
+	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
+	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return([]v1.Service{}, nil)
+	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(kubetest.FakeNamespace("bookinfo"), nil)
+	prom.On("GetDestinationServices", mock.AnythingOfType("string"), mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(destServices, nil)
+
+	svc := setupWorkloadService(k8s, prom)
+
+	workload, _ := svc.GetWorkload("bookinfo", "details-v1", true)
+
+	assert.Equal(2, len(workload.DestinationServices))
+	if len(workload.DestinationServices) < 2 {
+		return
+	}
+
+	destService := workload.DestinationServices[0]
+	assert.Equal("reviews", destService.Name)
+	assert.Equal("bookinfo", destService.Namespace)
+
+	destService = workload.DestinationServices[1]
+	assert.Equal("details", destService.Name)
+	assert.Equal("bookinfo", destService.Namespace)
 }
 
 func TestGetWorkloadFromPods(t *testing.T) {
@@ -354,7 +408,7 @@ func TestGetWorkloadFromPods(t *testing.T) {
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsFromDaemonSet(), nil)
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workload, _ := svc.GetWorkload("Namespace", "daemon-controller", false)
 
@@ -372,8 +426,9 @@ func TestGetPods(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsSyncedWithDeployments(), nil)
+	k8s.On("IsOpenShift").Return(false)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	pods, _ := svc.GetPods("Namespace", "app=httpbin")
 
@@ -403,7 +458,7 @@ func TestDuplicatedControllers(t *testing.T) {
 	k8s.On("GetDeploymentConfig", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&osappsv1.DeploymentConfig{}, notfound)
 	k8s.On("GetStatefulSet", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&FakeDuplicatedStatefulSets()[0], nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, nil)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -324,3 +324,11 @@ func FakePodList() []v1.Pod {
 				Labels: map[string]string{"app": "httpbin", "version": "v1"}}},
 	}
 }
+
+func FakeNamespace(name string) *v1.Namespace {
+	return &v1.Namespace{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: name,
+		},
+	}
+}

--- a/models/workload.go
+++ b/models/workload.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/prometheus"
 )
 
 type WorkloadList struct {
@@ -94,6 +95,14 @@ type Workload struct {
 
 	// Services that match workload selector
 	Services Services `json:"services"`
+
+	DestinationServices []DestinationService `json:"destinationServices"`
+}
+
+// DestinationService holds service identifiers used for workload dependencies
+type DestinationService struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }
 
 type Workloads []*Workload
@@ -348,4 +357,14 @@ func (workload *Workload) SetPods(pods []v1.Pod) {
 
 func (workload *Workload) SetServices(svcs []v1.Service) {
 	workload.Services.Parse(svcs)
+}
+
+func (workload *Workload) SetDestinationServices(dss []prometheus.Service) {
+	workload.DestinationServices = make([]DestinationService, 0, len(dss))
+	for _, service := range dss {
+		workload.DestinationServices = append(workload.DestinationServices, DestinationService{
+			Name:      service.ServiceName,
+			Namespace: service.Namespace,
+		})
+	}
 }

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -43,6 +43,14 @@ type Workload struct {
 	Version   string
 }
 
+// Service describes a service with contextual information
+type Service struct {
+	Namespace   string
+	App         string
+	ServiceName string
+	Service     string
+}
+
 // NewClient creates a new client to the Prometheus API.
 // It returns an error on any problem.
 func NewClient() (*Client, error) {
@@ -112,6 +120,43 @@ func (in *Client) GetSourceWorkloads(namespace string, namespaceCreationTime tim
 			} else {
 				routes[index] = []Workload{source}
 			}
+		}
+	}
+	return routes, nil
+}
+
+func (in *Client) GetDestinationServices(namespace string, namespaceCreationTime time.Time, workloadname string) ([]Service, error) {
+	reporter := "source"
+	if config.Get().IstioNamespace == namespace {
+		reporter = "destination"
+	}
+
+	queryTime := util.Clock.Now()
+	queryInterval := queryTime.Sub(namespaceCreationTime)
+	groupBy := "(destination_service_namespace, destination_service_name, destination_service)"
+	query := fmt.Sprintf("sum(rate(istio_requests_total{reporter=\"%s\",source_workload=\"%s\",source_workload_namespace=\"%s\"}[%vs])) by %s",
+		reporter, workloadname, namespace, int(queryInterval.Seconds()), groupBy)
+	log.Debugf("GetDestinationServices query: %s", query)
+	promtimer := internalmetrics.GetPrometheusProcessingTimePrometheusTimer("GetDestinationServices")
+	result, err := in.api.Query(context.Background(), query, queryTime)
+	if err != nil {
+		return nil, err
+	}
+	promtimer.ObserveDuration() // notice we only collect metrics for successful prom queries
+
+	routes := make([]Service, 0, 0)
+	switch result.Type() {
+	case model.ValVector:
+		matrix := result.(model.Vector)
+		for _, sample := range matrix {
+			metric := sample.Metric
+			destination := Service{
+				App:         string(metric["destination_app"]),
+				Service:     string(metric["destination_service"]),
+				ServiceName: string(metric["destination_service_name"]),
+				Namespace:   string(metric["destination_service_namespace"]),
+			}
+			routes = append(routes, destination)
 		}
 	}
 	return routes, nil

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -25,6 +25,7 @@ type ClientInterface interface {
 	GetAppRequestRates(namespace, app, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 	GetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 	GetSourceWorkloads(namespace string, namespaceCreationTime time.Time, servicename string) (map[string][]Workload, error)
+	GetDestinationServices(namespace string, namespaceCreationTime time.Time, workloadname string) ([]Service, error)
 }
 
 // Client for Prometheus API.
@@ -48,7 +49,6 @@ type Service struct {
 	Namespace   string
 	App         string
 	ServiceName string
-	Service     string
 }
 
 // NewClient creates a new client to the Prometheus API.
@@ -144,7 +144,7 @@ func (in *Client) GetDestinationServices(namespace string, namespaceCreationTime
 	}
 	promtimer.ObserveDuration() // notice we only collect metrics for successful prom queries
 
-	routes := make([]Service, 0, 0)
+	routes := make([]Service, 0)
 	switch result.Type() {
 	case model.ValVector:
 		matrix := result.(model.Vector)
@@ -152,7 +152,6 @@ func (in *Client) GetDestinationServices(namespace string, namespaceCreationTime
 			metric := sample.Metric
 			destination := Service{
 				App:         string(metric["destination_app"]),
-				Service:     string(metric["destination_service"]),
 				ServiceName: string(metric["destination_service_name"]),
 				Namespace:   string(metric["destination_service_namespace"]),
 			}

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -169,13 +169,11 @@ func TestGetDestinationServices(t *testing.T) {
 
 	svc := destinations[0]
 	assert.Equal("reviews", svc.App)
-	assert.Equal("reviews.bookinfo.svc.cluster.local", svc.Service)
 	assert.Equal("reviews", svc.ServiceName)
 	assert.Equal("bookinfo", svc.Namespace)
 
 	svc = destinations[1]
 	assert.Equal("details", svc.App)
-	assert.Equal("details.bookinfo.svc.cluster.local", svc.Service)
 	assert.Equal("details", svc.ServiceName)
 	assert.Equal("bookinfo", svc.Namespace)
 }

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -122,3 +122,8 @@ func (o *PromClientMock) GetSourceWorkloads(namespace string, namespaceCreationT
 	args := o.Called(namespace, namespaceCreationTime, servicename)
 	return args.Get(0).(map[string][]prometheus.Workload), args.Error(1)
 }
+
+func (o *PromClientMock) GetDestinationServices(namespace string, namespaceCreationTime time.Time, workloadname string) ([]prometheus.Service, error) {
+	args := o.Called(namespace, namespaceCreationTime, workloadname)
+	return args.Get(0).([]prometheus.Service), args.Error(1)
+}

--- a/swagger.json
+++ b/swagger.json
@@ -2019,6 +2019,21 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
+    "DestinationService": {
+      "description": "DestinationService holds service identifiers used for workload dependencies",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "namespace": {
+          "type": "string",
+          "x-go-name": "Namespace"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
     "EdgeData": {
       "type": "object",
       "properties": {
@@ -3436,6 +3451,13 @@
           "type": "string",
           "x-go-name": "CreatedAt",
           "example": "2018-07-31T12:24:17Z"
+        },
+        "destinationServices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DestinationService"
+          },
+          "x-go-name": "DestinationServices"
         },
         "istioSidecar": {
           "description": "Define if Pods related to this Workload has an IstioSidecar deployed",


### PR DESCRIPTION
** Describe the change **

Adding the services that are called by an specific workload.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1140

This goes along a UI feature that will list those services in the workload details: https://github.com/kiali/kiali-ui/pull/839

![destination-services](https://user-images.githubusercontent.com/613814/48941187-cc440c80-ef1a-11e8-956f-8a32ccf4f902.png)