### PR TITLE
KIALI-1654 Add support to modify Istio config objects

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -336,12 +336,12 @@ func getUpdateDeletePermissions(k8s kubernetes.IstioClientInterface, namespace, 
 		if objectSubtype != "" {
 			resourceType = objectSubtype
 		}
-		ssars, permErr := k8s.GetSelfSubjectAccessReview(namespace, api, resourceType, []string{"update", "delete"})
+		ssars, permErr := k8s.GetSelfSubjectAccessReview(namespace, api, resourceType, []string{"patch", "update", "delete"})
 		if permErr == nil {
 			for _, ssar := range ssars {
 				if ssar.Spec.ResourceAttributes != nil {
 					switch ssar.Spec.ResourceAttributes.Verb {
-					case "update":
+					case "patch", "update":
 						canUpdate = ssar.Status.Allowed
 					case "delete":
 						canDelete = ssar.Status.Allowed

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -666,3 +666,41 @@ func mockDeleteIstioConfigDetails() IstioConfigService {
 	k8s.On("DeleteIstioObject", "config.istio.io", "test", "listcheckers", "listchecker-to-delete").Return(nil)
 	return IstioConfigService{k8s: k8s}
 }
+
+func TestUpdateIstioConfigDetails(t *testing.T) {
+	assert := assert.New(t)
+	configService := mockUpdateIstioConfigDetails()
+
+	updatedVirtualService, err := configService.UpdateIstioConfigDetail("networking.istio.io", "test", "virtualservices", "", "reviews-to-update", "{}")
+	assert.Equal("test", updatedVirtualService.Namespace.Name)
+	assert.Equal("virtualservices", updatedVirtualService.ObjectType)
+	assert.Equal("reviews-to-update", updatedVirtualService.VirtualService.Metadata.Name)
+	assert.Nil(err)
+
+	updatedTemplate, err := configService.UpdateIstioConfigDetail("config.istio.io", "test", "templates", "listcheckers", "listchecker-to-update", "{}")
+	assert.Equal("test", updatedTemplate.Namespace.Name)
+	assert.Equal("templates", updatedTemplate.ObjectType)
+	assert.Equal("listchecker-to-update", updatedTemplate.Template.Metadata.Name)
+	assert.Nil(err)
+}
+
+func mockUpdateIstioConfigDetails() IstioConfigService {
+	k8s := new(kubetest.K8SClientMock)
+	var updatedVirtualService, updatedTemplate kubernetes.IstioObject
+
+	updatedVirtualService = &kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "reviews-to-update",
+			Namespace: "test",
+		},
+	}
+	updatedTemplate = &kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "listchecker-to-update",
+			Namespace: "test",
+		},
+	}
+	k8s.On("UpdateIstioObject", "networking.istio.io", "test", "virtualservices", "reviews-to-update", mock.AnythingOfType("string")).Return(updatedVirtualService, nil)
+	k8s.On("UpdateIstioObject", "config.istio.io", "test", "listcheckers", "listchecker-to-update", mock.AnythingOfType("string")).Return(updatedTemplate, nil)
+	return IstioConfigService{k8s: k8s}
+}

--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -60,6 +60,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups: ["networking.istio.io"]
   resources:
@@ -71,6 +72,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups: ["monitoring.kiali.io"]
   resources:

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -60,6 +60,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups: ["networking.istio.io"]
   resources:
@@ -71,6 +72,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups: ["apps.openshift.io"]
   resources:

--- a/doc.go
+++ b/doc.go
@@ -31,7 +31,7 @@ type AppVersionParam struct {
 	Name string `json:"version"`
 }
 
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigAdapterTemplateDetails serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics
 type NamespaceParam struct {
 	// The namespace id.
 	//
@@ -40,7 +40,7 @@ type NamespaceParam struct {
 	Name string `json:"namespace"`
 }
 
-// swagger:parameters objectValidations istioConfigDetails istioConfigAdapterTemplateDetails
+// swagger:parameters objectValidations istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype
 type ObjectNameParam struct {
 	// The Istio object name.
 	//
@@ -49,7 +49,7 @@ type ObjectNameParam struct {
 	Name string `json:"object"`
 }
 
-// swagger:parameters objectValidations istioConfigDetails istioConfigAdapterTemplateDetails
+// swagger:parameters objectValidations istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype
 type ObjectTypeParam struct {
 	// The Istio object type.
 	//
@@ -59,13 +59,12 @@ type ObjectTypeParam struct {
 	Name string `json:"object_type"`
 }
 
-// swagger:parameters istioConfigAdapterTemplateDetails
+// swagger:parameters istioConfigDetailsSubtype istioConfigDeleteSubtype istioConfigUpdateSubtype
 type ObjectSubtypeParam struct {
 	// The Istio object subtype.
 	//
 	// in: path
 	// required: true
-	// pattern: ^(adapters|templates)$
 	Name string `json:"object_subtype"`
 }
 

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -75,6 +75,7 @@ type IstioClientInterface interface {
 	GetVirtualServices(namespace string, serviceName string) ([]IstioObject, error)
 	IsOpenShift() bool
 	Stop()
+	UpdateIstioObject(api, namespace, resourteType, name, jsonPatch string) (IstioObject, error)
 }
 
 // IstioClient is the client struct for Kubernetes and Istio APIs

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -238,6 +238,11 @@ func (o *K8SClientMock) IsOpenShift() bool {
 func (o *K8SClientMock) Stop() {
 }
 
+func (o *K8SClientMock) UpdateIstioObject(api, namespace, resourceType, name, jsonPatch string) (kubernetes.IstioObject, error) {
+	args := o.Called(api, namespace, resourceType, name, jsonPatch)
+	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
+}
+
 // Fake methods doesn't need an entry point
 
 func FakeService() *v1.Service {

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -177,7 +177,7 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigValidations,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/istio/{object_type}/{object_subtype}/{object} config istioConfigAdapterTemplateDetails
+		// swagger:route GET /namespaces/{namespace}/istio/{object_type}/{object_subtype}/{object} config istioConfigDetailsSubtype
 		// ---
 		// Endpoint to get the Istio Config of an Istio object used for templates and adapters that is necessary to define a subtype
 		//
@@ -199,7 +199,7 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigDetails,
 			true,
 		},
-		// swagger:route DELETE /namespaces/{namespace}/istio/{object_type}/{object_subtype}/{object}
+		// swagger:route DELETE /namespaces/{namespace}/istio/{object_type}/{object_subtype}/{object} config istioConfigDeleteSubtype
 		// ---
 		// Endpoint to delete the Istio Config of an Istio object used for templates and adapters
 		//
@@ -209,10 +209,9 @@ func NewRoutes() (r *Routes) {
 		//     Schemes: http, https
 		//
 		// responses:
-		//      default: genericError
 		//      404: notFoundError
 		//      500: internalError
-		//      200: delete
+		//      200
 		//
 		{
 			"IstioConfigDeleteSubtype",
@@ -221,7 +220,32 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigDelete,
 			true,
 		},
-		// swagger:route DELETE /namespaces/{namespace}/istio/{object_type}/{object}
+		// swagger:route PATCH /namespaces/{namespace}/istio/{object_type}/{object_subtype}/{object} config istioConfigUpdateSubtype
+		// ---
+		// Endpoint to update the Istio Config of an Istio object used for templates and adapters using Json Merge Patch strategy.
+		//
+		//     Consumes:
+		//	   - application/json
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      400: badRequestError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: istioConfigDetailsResponse
+		//
+		{
+			"IstioConfigUpdateSubtype",
+			"PATCH",
+			"/api/namespaces/{namespace}/istio/{object_type}/{object_subtype}/{object}",
+			handlers.IstioConfigUpdate,
+			true,
+		},
+		// swagger:route DELETE /namespaces/{namespace}/istio/{object_type}/{object} config istioConfigDelete
 		// ---
 		// Endpoint to delete the Istio Config of an (arbitrary) Istio object
 		//
@@ -231,16 +255,40 @@ func NewRoutes() (r *Routes) {
 		//     Schemes: http, https
 		//
 		// responses:
-		//      default: genericError
 		//      404: notFoundError
 		//      500: internalError
-		//      200: delete
+		//      200
 		//
 		{
 			"IstioConfigDelete",
 			"DELETE",
 			"/api/namespaces/{namespace}/istio/{object_type}/{object}",
 			handlers.IstioConfigDelete,
+			true,
+		},
+		// swagger:route PATCH /namespaces/{namespace}/istio/{object_type}/{object} config istioConfigUpdate
+		// ---
+		// Endpoint to update the Istio Config of an Istio object used for templates and adapters using Json Merge Patch strategy.
+		//
+		//     Consumes:
+		//	   - application/json
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      400: badRequestError
+		//      404: notFoundError
+		//      500: internalError
+		//      200: istioConfigDetailsResponse
+		//
+		{
+			"IstioConfigUpdate",
+			"PATCH",
+			"/api/namespaces/{namespace}/istio/{object_type}/{object}",
+			handlers.IstioConfigUpdate,
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/services services serviceList

--- a/swagger.json
+++ b/swagger.json
@@ -792,7 +792,7 @@
         "tags": [
           "config"
         ],
-        "operationId": "istioConfigAdapterTemplateDetails",
+        "operationId": "istioConfigDetailsSubtype",
         "parameters": [
           {
             "type": "string",
@@ -820,7 +820,129 @@
             "required": true
           },
           {
-            "pattern": "^(adapters|templates)$",
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object subtype.",
+            "name": "object_subtype",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/istioConfigDetailsResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      },
+      "delete": {
+        "description": "Endpoint to delete the Istio Config of an Istio object used for templates and adapters",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "config"
+        ],
+        "operationId": "istioConfigDeleteSubtype",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object name.",
+            "name": "object",
+            "in": "path",
+            "required": true
+          },
+          {
+            "pattern": "^(gateways|virtualservices|destinationrules|serviceentries|rules|quotaspecs|quotaspecbindings)$",
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object type.",
+            "name": "object_type",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object subtype.",
+            "name": "object_subtype",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      },
+      "patch": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "config"
+        ],
+        "summary": "Endpoint to update the Istio Config of an Istio object used for templates and adapters using Json Merge Patch strategy.",
+        "operationId": "istioConfigUpdateSubtype",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object name.",
+            "name": "object",
+            "in": "path",
+            "required": true
+          },
+          {
+            "pattern": "^(gateways|virtualservices|destinationrules|serviceentries|rules|quotaspecs|quotaspecbindings)$",
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object type.",
+            "name": "object_type",
+            "in": "path",
+            "required": true
+          },
+          {
             "type": "string",
             "x-go-name": "Name",
             "description": "The Istio object subtype.",
@@ -859,6 +981,113 @@
           "config"
         ],
         "operationId": "istioConfigDetails",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object name.",
+            "name": "object",
+            "in": "path",
+            "required": true
+          },
+          {
+            "pattern": "^(gateways|virtualservices|destinationrules|serviceentries|rules|quotaspecs|quotaspecbindings)$",
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object type.",
+            "name": "object_type",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/istioConfigDetailsResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      },
+      "delete": {
+        "description": "Endpoint to delete the Istio Config of an (arbitrary) Istio object",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "config"
+        ],
+        "operationId": "istioConfigDelete",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object name.",
+            "name": "object",
+            "in": "path",
+            "required": true
+          },
+          {
+            "pattern": "^(gateways|virtualservices|destinationrules|serviceentries|rules|quotaspecs|quotaspecbindings)$",
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The Istio object type.",
+            "name": "object_type",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      },
+      "patch": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "config"
+        ],
+        "summary": "Endpoint to update the Istio Config of an Istio object used for templates and adapters using Json Merge Patch strategy.",
+        "operationId": "istioConfigUpdate",
         "parameters": [
           {
             "type": "string",


### PR DESCRIPTION
Expose a PATCH endpoint to support modification on Istio objects [1][2] with more flexibility.

The new enpoint can be tested as described in the following examples.

Update a DestinationRule
```
PATCH http://admin:admin@localhost:8000/api/namespaces/bookinfo/istio/destinationrules/reviews
Content-Type: application/json

{
  "spec": {
    "host": "reviews",
    "trafficPolicy": null,
    "subsets": [
      {
        "labels": {
          "version": "v1"
        },
        "name": "v1"
      },
      {
        "labels": {
          "version": "v2"
        },
        "name": "v2"
      },
      {
        "labels": {
          "version": "v3"
        },
        "name": "v3"
      },
      {
        "labels": {
          "version": "v4"
        },
        "name": "v4"
      }
    ]
  }
}
```

Update an Adapter/Template:
```
PATCH http://admin:admin@localhost:8000/api/namespaces/istio-system/istio/templates/quotas/requestcount
Content-Type: application/json

{
  "spec": {
    "dimensions": {
      "destination": "destination.labels[\"app\"] | destination.service | \"unknown\"",
      "destinationVersion": "destination.labels[\"version\"] | \"unknown\"",
      "source": "source.labels[\"app\"] | source.service | \"unknown\"",
      "sourceVersion": "source.labels[\"version\"] | \"unknown\""
    }
  }
}
```

This PR won't break the UI as it is adding new feature without modifying existing one.


[1] https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/
[2] https://tools.ietf.org/html/rfc7386