### PR TITLE
KIALI-2014 make sure dead nodes appender doesn't strip egress nodes

### DIFF
--- a/graph/appender/appender.go
+++ b/graph/appender/appender.go
@@ -14,8 +14,8 @@ import (
 // is initially empty.
 type GlobalInfo struct {
 	Business         *business.Layer
-	PromClient       *prometheus.Client
 	ExternalServices map[string]bool
+	PromClient       *prometheus.Client
 }
 
 func NewGlobalInfo() *GlobalInfo {

--- a/graph/appender/appender.go
+++ b/graph/appender/appender.go
@@ -13,8 +13,9 @@ import (
 // can re-use the information.  A new instance is generated for graph and
 // is initially empty.
 type GlobalInfo struct {
-	Business   *business.Layer
-	PromClient *prometheus.Client
+	Business         *business.Layer
+	PromClient       *prometheus.Client
+	ExternalServices map[string]bool
 }
 
 func NewGlobalInfo() *GlobalInfo {
@@ -26,9 +27,8 @@ func NewGlobalInfo() *GlobalInfo {
 // A new instance is generated for each namespace of a single graph and is initially
 // seeded with only Namespace.
 type NamespaceInfo struct {
-	Namespace        string // always provided
-	ExternalServices map[string]bool
-	WorkloadList     *models.WorkloadList
+	Namespace    string // always provided
+	WorkloadList *models.WorkloadList
 }
 
 func NewNamespaceInfo(namespace string) *NamespaceInfo {

--- a/graph/appender/dead_node.go
+++ b/graph/appender/dead_node.go
@@ -129,11 +129,10 @@ func (a DeadNodeAppender) applyDeadNodes(trafficMap graph.TrafficMap, globalInfo
 // can be in any namespace and it will still work).
 // However, an egress service will have its namespace set to "default" in the telemetry.
 func (a DeadNodeAppender) isExternalService(service string, namespaceInfo *NamespaceInfo, globalInfo *GlobalInfo) bool {
-	if namespaceInfo.ExternalServices == nil {
-		namespaceInfo.ExternalServices = make(map[string]bool)
+	if globalInfo.ExternalServices == nil {
+		globalInfo.ExternalServices = make(map[string]bool)
 
 		for ns := range a.AccessibleNamespaces {
-			// Currently no other appenders use ServiceEntries, so they are not cached in NamespaceInfo
 			istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(business.IstioConfigCriteria{
 				IncludeServiceEntries: true,
 				Namespace:             ns,
@@ -143,13 +142,13 @@ func (a DeadNodeAppender) isExternalService(service string, namespaceInfo *Names
 			for _, entry := range istioCfg.ServiceEntries {
 				if entry.Spec.Hosts != nil && entry.Spec.Location == "MESH_EXTERNAL" {
 					for _, host := range entry.Spec.Hosts.([]interface{}) {
-						namespaceInfo.ExternalServices[host.(string)] = true
+						globalInfo.ExternalServices[host.(string)] = true
 					}
 				}
 			}
 		}
-		log.Tracef("Found [%v] egress service entries", len(namespaceInfo.ExternalServices))
+		log.Tracef("Found [%v] egress service entries", len(globalInfo.ExternalServices))
 	}
 
-	return namespaceInfo.ExternalServices[service]
+	return globalInfo.ExternalServices[service]
 }

--- a/graph/appender/dead_node_test.go
+++ b/graph/appender/dead_node_test.go
@@ -118,12 +118,12 @@ func TestDeadNode(t *testing.T) {
 
 	globalInfo := GlobalInfo{
 		Business: businessLayer,
-	}
-	namespaceInfo := NamespaceInfo{
-		Namespace: "testNamespace",
 		ExternalServices: map[string]bool{
 			"localhost.local": true,
 			"egress.io":       true},
+	}
+	namespaceInfo := NamespaceInfo{
+		Namespace: "testNamespace",
 	}
 
 	a := DeadNodeAppender{}

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -207,7 +207,10 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 	// Add orphan (unused) services
 	// Run remaining appenders
 	if csl == AppenderAll || strings.Contains(csl, appender.DeadNodeAppenderName) || strings.Contains(csl, "dead_node") {
-		appenders = append(appenders, appender.DeadNodeAppender{})
+		a := appender.DeadNodeAppender{
+			AccessibleNamespaces: o.AccessibleNamespaces,
+		}
+		appenders = append(appenders, a)
 	}
 	if csl == AppenderAll || strings.Contains(csl, appender.ResponseTimeAppenderName) || strings.Contains(csl, "response_time") {
 		quantile := appender.DefaultQuantile


### PR DESCRIPTION
** Describe the change **

ServiceEntry objects with MESH_EXTERNAL definitions were getting stripped out by the dead node appender. This fixes it.

** Issue reference **

KIALI-2014 Support ServiceEntry in Graph

** Backwards incompatible? **

No

Here's what the new graph will look like - notice the egress service node is now showing:

![image](https://user-images.githubusercontent.com/2029470/49154614-d719eb00-f2e6-11e8-9652-f6e02048ec94.png)
