### PR TITLE
KIALI-2031 Add service_entry appender (appenders=serviceEntry)

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -94,7 +94,7 @@ type WorkloadParam struct {
 
 // swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
 type AppendersParam struct {
-	// Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].
+	// Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, unusedNode].
 	//
 	// in: query
 	// required: false

--- a/graph/appender/appender.go
+++ b/graph/appender/appender.go
@@ -13,9 +13,9 @@ import (
 // can re-use the information.  A new instance is generated for graph and
 // is initially empty.
 type GlobalInfo struct {
-	Business         *business.Layer
-	ExternalServices map[string]bool
-	PromClient       *prometheus.Client
+	Business       *business.Layer
+	PromClient     *prometheus.Client
+	ServiceEntries map[string]string
 }
 
 func NewGlobalInfo() *GlobalInfo {

--- a/graph/appender/dead_node_test.go
+++ b/graph/appender/dead_node_test.go
@@ -118,9 +118,6 @@ func TestDeadNode(t *testing.T) {
 
 	globalInfo := GlobalInfo{
 		Business: businessLayer,
-		ExternalServices: map[string]bool{
-			"localhost.local": true,
-			"egress.io":       true},
 	}
 	namespaceInfo := NamespaceInfo{
 		Namespace: "testNamespace",
@@ -149,11 +146,10 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal(true, ok)
 	assert.Equal(true, isDead)
 
-	// Check that external services are flagged
+	// Check that external services are not removed
 	id, _ = graph.Id("testNamespace", "", "", "", "egress.io", graph.GraphTypeVersionedApp)
-	externalNode, okExternal := trafficMap[id]
+	_, okExternal := trafficMap[id]
 	assert.Equal(true, okExternal)
-	assert.Equal(true, externalNode.Metadata["isEgress"])
 }
 
 func testTrafficMap() map[string]*graph.Node {
@@ -185,6 +181,7 @@ func testTrafficMap() map[string]*graph.Node {
 
 	n9 := graph.NewNode("testNamespace", "", "", "", "egress.io", graph.GraphTypeVersionedApp)
 	n9.Metadata["rate"] = 0.8
+	n9.Metadata["isServiceEntry"] = "MESH_EXTERNAL"
 
 	n10 := graph.NewNode("testNamespace", "", "", "", "egress.not.defined", graph.GraphTypeVersionedApp)
 	n10.Metadata["rate"] = 0.8

--- a/graph/appender/service_entry.go
+++ b/graph/appender/service_entry.go
@@ -57,7 +57,7 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 	}
 }
 
-// isServiceEntry queries the cluster API to resolve service entries
+// getServiceEntry queries the cluster API to resolve service entries
 // across all accessible namespaces in the cluster. All ServiceEntries are needed because
 // Istio does not distinguish where a ServiceEntry is created when routing traffic (i.e.
 // a ServiceEntry can be in any namespace and it will still work).

--- a/graph/appender/service_entry.go
+++ b/graph/appender/service_entry.go
@@ -1,0 +1,88 @@
+package appender
+
+import (
+	"time"
+
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/log"
+)
+
+const ServiceEntryAppenderName = "serviceEntry"
+
+// ServiceEntryAppender is responsible for identifying service nodes that are
+// Istio Service Entries.
+// Name: serviceEntry
+type ServiceEntryAppender struct {
+	AccessibleNamespaces map[string]time.Time
+}
+
+// Name implements Appender
+func (a ServiceEntryAppender) Name() string {
+	return ServiceEntryAppenderName
+}
+
+// AppendGraph implements Appender
+func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo) {
+	if len(trafficMap) == 0 {
+		return
+	}
+
+	var err error
+	if globalInfo.Business == nil {
+		globalInfo.Business, err = business.Get()
+		checkError(err)
+	}
+
+	a.applyServiceEntries(trafficMap, globalInfo, namespaceInfo)
+}
+
+func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, globalInfo *GlobalInfo, namespaceInfo *NamespaceInfo) {
+	for _, n := range trafficMap {
+		// only a service node can be a service entry
+		if n.NodeType != graph.NodeTypeService {
+			continue
+		}
+		// only a terminal node can be a service entry (no outgoing edges because the service is performed outside the mesh)
+		if len(n.Edges) > 0 {
+			continue
+		}
+
+		// A service node with no outgoing edges may be an egress.
+		// If so flag it, don't discard it (kiali-1526, see also kiali-2014).
+		// The flag will be passed to the UI to inhibit links to non-existent detail pages.
+		if location, ok := a.getServiceEntry(n.Service, globalInfo); ok {
+			n.Metadata["isServiceEntry"] = location
+		}
+	}
+}
+
+// isServiceEntry queries the cluster API to resolve service entries
+// across all accessible namespaces in the cluster. All ServiceEntries are needed because
+// Istio does not distinguish where a ServiceEntry is created when routing traffic (i.e.
+// a ServiceEntry can be in any namespace and it will still work).
+func (a ServiceEntryAppender) getServiceEntry(service string, globalInfo *GlobalInfo) (string, bool) {
+	if globalInfo.ServiceEntries == nil {
+		globalInfo.ServiceEntries = make(map[string]string)
+
+		for ns := range a.AccessibleNamespaces {
+			istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(business.IstioConfigCriteria{
+				IncludeServiceEntries: true,
+				Namespace:             ns,
+			})
+			checkError(err)
+
+			for _, entry := range istioCfg.ServiceEntries {
+				if entry.Spec.Hosts != nil && (entry.Spec.Location == "MESH_EXTERNAL" || entry.Spec.Location == "MESH_INTERNAL") {
+					for _, host := range entry.Spec.Hosts.([]interface{}) {
+						globalInfo.ServiceEntries[host.(string)] = entry.Spec.Location.(string)
+					}
+				}
+			}
+		}
+		log.Tracef("Found [%v] service entries", len(globalInfo.ServiceEntries))
+	}
+
+	location, ok := globalInfo.ServiceEntries[service]
+	return location, ok
+}

--- a/graph/appender/service_entry_test.go
+++ b/graph/appender/service_entry_test.go
@@ -1,0 +1,107 @@
+package appender
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+)
+
+func setupServiceEntries() *business.Layer {
+	k8s := kubetest.NewK8SClientMock()
+
+	externalServiceEntry := kubernetes.GenericIstioObject{
+		Spec: map[string]interface{}{
+			"hosts":    []interface{}{"ExternalServiceEntry"},
+			"location": "MESH_EXTERNAL",
+		},
+	}
+	internalServiceEntry := kubernetes.GenericIstioObject{
+		Spec: map[string]interface{}{
+			"hosts":    []interface{}{"InternalServiceEntry"},
+			"location": "MESH_INTERNAL",
+		},
+	}
+
+	k8s.On("GetServiceEntries", mock.AnythingOfType("string")).Return([]kubernetes.IstioObject{&externalServiceEntry, &internalServiceEntry}, nil)
+	config.Set(config.NewConfig())
+
+	businessLayer := business.SetWithBackends(k8s, nil)
+	return businessLayer
+}
+
+func TestServiceEntry(t *testing.T) {
+	assert := assert.New(t)
+
+	businessLayer := setupServiceEntries()
+	trafficMap := serviceEntriesTrafficMap()
+
+	assert.Equal(5, len(trafficMap))
+	notServiceEntryId, _ := graph.Id("testNamespace", "", "", "", "NotServiceEntry", graph.GraphTypeVersionedApp)
+	notServiceEntryNode, found := trafficMap[notServiceEntryId]
+	assert.Equal(true, found)
+	assert.Equal(1, len(notServiceEntryNode.Edges))
+	assert.Equal(nil, notServiceEntryNode.Metadata["isServiceEntry"])
+
+	extServiceEntryId, _ := graph.Id("testNamespace", "", "", "", "ExternalServiceEntry", graph.GraphTypeVersionedApp)
+	extServiceEntryNode, found2 := trafficMap[extServiceEntryId]
+	assert.Equal(true, found2)
+	assert.Equal(0, len(extServiceEntryNode.Edges))
+	assert.Equal(nil, extServiceEntryNode.Metadata["isServiceEntry"])
+
+	intServiceEntryId, _ := graph.Id("testNamespace", "", "", "", "InternalServiceEntry", graph.GraphTypeVersionedApp)
+	intServiceEntryNode, found3 := trafficMap[intServiceEntryId]
+	assert.Equal(true, found3)
+	assert.Equal(0, len(intServiceEntryNode.Edges))
+	assert.Equal(nil, extServiceEntryNode.Metadata["isServiceEntry"])
+
+	globalInfo := GlobalInfo{
+		Business: businessLayer,
+	}
+	namespaceInfo := NamespaceInfo{
+		Namespace: "testNamespace",
+	}
+
+	a := ServiceEntryAppender{
+		AccessibleNamespaces: map[string]time.Time{"testNamespace": time.Now()},
+	}
+	a.AppendGraph(trafficMap, &globalInfo, &namespaceInfo)
+
+	assert.Equal(nil, notServiceEntryNode.Metadata["isServiceEntry"])
+	assert.Equal("MESH_EXTERNAL", extServiceEntryNode.Metadata["isServiceEntry"])
+	assert.Equal("MESH_INTERNAL", intServiceEntryNode.Metadata["isServiceEntry"])
+}
+
+func serviceEntriesTrafficMap() map[string]*graph.Node {
+	trafficMap := make(map[string]*graph.Node)
+
+	n0 := graph.NewNode(graph.UnknownNamespace, graph.UnknownWorkload, graph.UnknownApp, graph.UnknownVersion, "", graph.GraphTypeVersionedApp)
+
+	n1 := graph.NewNode("testNamespace", "", "", "", "NotServiceEntry", graph.GraphTypeVersionedApp)
+
+	n2 := graph.NewNode("testNamespace", "TestWorkload-v1", "TestApp", "v1", "NotServiceEntry", graph.GraphTypeVersionedApp)
+
+	n3 := graph.NewNode("testNamespace", "", "", "", "ExternalServiceEntry", graph.GraphTypeVersionedApp)
+
+	n4 := graph.NewNode("testNamespace", "", "", "", "InternalServiceEntry", graph.GraphTypeVersionedApp)
+
+	trafficMap[n0.ID] = &n0
+	trafficMap[n1.ID] = &n1
+	trafficMap[n2.ID] = &n2
+	trafficMap[n3.ID] = &n3
+	trafficMap[n4.ID] = &n4
+
+	n0.AddEdge(&n1)
+	n1.AddEdge(&n2)
+	n2.AddEdge(&n3)
+	n2.AddEdge(&n4)
+
+	return trafficMap
+}

--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -46,12 +46,12 @@ type NodeData struct {
 	HasMissingSC    bool            `json:"hasMissingSC,omitempty"`    // true (has missing sidecar) | false
 	HasVS           bool            `json:"hasVS,omitempty"`           // true (has route rule) | false
 	IsDead          bool            `json:"isDead,omitempty"`          // true (has no pods) | false
-	IsEgress        bool            `json:"isEgress,omitempty"`        // true | false
-	IsGroup         string          `json:"isGroup,omitempty"`         // set to the grouping type, current values: [ 'version' ]
+	IsGroup         string          `json:"isGroup,omitempty"`         // set to the grouping type, current values: [ 'app', 'version' ]
 	IsInaccessible  bool            `json:"isInaccessible,omitempty"`  // true if the node exists in an inaccessible namespace
 	IsMisconfigured string          `json:"isMisconfigured,omitempty"` // set to misconfiguration list, current values: [ 'labels' ]
 	IsOutside       bool            `json:"isOutside,omitempty"`       // true | false
 	IsRoot          bool            `json:"isRoot,omitempty"`          // true | false
+	IsServiceEntry  string          `json:"isServiceEntry,omitempty"`  // set to the location, current values: [ 'MESH_EXTERNAL', 'MESH_INTERNAL' ]
 	IsUnused        bool            `json:"isUnused,omitempty"`        // true | false
 }
 
@@ -225,9 +225,9 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 			nd.DestServices = val.(map[string]bool)
 		}
 
-		// node may be an egress service
-		if val, ok := n.Metadata["isEgress"]; ok {
-			nd.IsEgress = val.(bool)
+		// node may be a service entry
+		if val, ok := n.Metadata["isServiceEntry"]; ok {
+			nd.IsServiceEntry = val.(string)
 		}
 
 		nw := NodeWrapper{

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -202,14 +202,19 @@ func parseAppenders(params url.Values, o Options) []appender.Appender {
 	}
 
 	// The appender order is important
-	// To reduce processing, filter dead services first
+	// Apply any decorating information, run service_entry appender first
+	// To reduce processing, filter dead nodes next
 	// To reduce processing, next run appenders that don't apply to unused services
 	// Add orphan (unused) services
 	// Run remaining appenders
-	if csl == AppenderAll || strings.Contains(csl, appender.DeadNodeAppenderName) || strings.Contains(csl, "dead_node") {
-		a := appender.DeadNodeAppender{
+	if csl == AppenderAll || strings.Contains(csl, appender.ServiceEntryAppenderName) || strings.Contains(csl, "service_entry") {
+		a := appender.ServiceEntryAppender{
 			AccessibleNamespaces: o.AccessibleNamespaces,
 		}
+		appenders = append(appenders, a)
+	}
+	if csl == AppenderAll || strings.Contains(csl, appender.DeadNodeAppenderName) || strings.Contains(csl, "dead_node") {
+		a := appender.DeadNodeAppender{}
 		appenders = append(appenders, a)
 	}
 	if csl == AppenderAll || strings.Contains(csl, appender.ResponseTimeAppenderName) || strings.Contains(csl, "response_time") {

--- a/swagger.json
+++ b/swagger.json
@@ -827,7 +827,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },
@@ -928,7 +928,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },
@@ -1029,7 +1029,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },
@@ -1531,7 +1531,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },
@@ -1741,7 +1741,7 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, sidecarsCheck, unusedNode].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [deadNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, unusedNode].",
             "name": "appenders",
             "in": "query"
           },
@@ -2525,10 +2525,6 @@
           "type": "boolean",
           "x-go-name": "IsDead"
         },
-        "isEgress": {
-          "type": "boolean",
-          "x-go-name": "IsEgress"
-        },
         "isGroup": {
           "type": "string",
           "x-go-name": "IsGroup"
@@ -2548,6 +2544,10 @@
         "isRoot": {
           "type": "boolean",
           "x-go-name": "IsRoot"
+        },
+        "isServiceEntry": {
+          "type": "string",
+          "x-go-name": "IsServiceEntry"
         },
         "isUnused": {
           "type": "boolean",


### PR DESCRIPTION
- extracts service entry handling from dead_node appender into more robust dedicated appender
- changes node flagging from isEgress=true to isServiceEntry="MESH_EXTERNAL"|"MESH_INTERNAL"

** Backwards incompatible? **
not totally, will require UI update along with server update to get proper handling for service entries

This PR works with UI PR https://github.com/kiali/kiali-ui/pull/854