### PR TITLE
Fix Travis deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,6 @@ script:
 # Docker version is the branch name (where master==latest)
 deploy:
   provider: script
-  script:  |
-    export COMMIT_HASH=${TRAVIS_COMMIT};
-    export DOCKER_VERSION=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi);
-    export DOCKER_USER=$(if [ "$DOCKER_USER" == "" ]; then echo "unknown"; else echo $DOCKER_USER ; fi);
-    export DOCKER_PASS=$(if [ "$DOCKER_PASS" == "" ]; then echo "unknown"; else echo $DOCKER_PASS ; fi);
-    echo DOCKER_VERSION=$DOCKER_VERSION;
-    docker login -u "$DOCKER_USER" -p "$DOCKER_PASS";
-    make docker-build;
-    docker push kiali/kiali;
+  script:  bash deploy/travis-deploy.sh
   on:
     branch: master

--- a/deploy/travis-deploy.sh
+++ b/deploy/travis-deploy.sh
@@ -1,0 +1,12 @@
+# This script is used to deploy a snapshot of Kiali
+# when a Travis build is triggered in the master branch
+
+export COMMIT_HASH=${TRAVIS_COMMIT}
+export DOCKER_VERSION=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi)
+export DOCKER_USER=$(if [ "$DOCKER_USER" == "" ]; then echo "unknown"; else echo $DOCKER_USER ; fi)
+export DOCKER_PASS=$(if [ "$DOCKER_PASS" == "" ]; then echo "unknown"; else echo $DOCKER_PASS ; fi)
+
+echo DOCKER_VERSION=$DOCKER_VERSION
+docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+make docker-build
+docker push kiali/kiali


### PR DESCRIPTION
Seems multi-line script in the deploy block are not parsed correctly.
Moving the script to a file.
