### PR TITLE
KIALI-1969 KIALI-1994 Some Endpoints have double /api when swagger file is parsed / Root Swagger API is directing to an error

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -17,7 +17,7 @@ func NewRouter() *mux.Router {
 	webRoot := conf.Server.WebRoot
 	webRootWithSlash := webRoot + "/"
 
-	rootRouter := mux.NewRouter().StrictSlash(false)
+	rootRouter := mux.NewRouter().StrictSlash(true)
 	appRouter := rootRouter
 
 	// Due to PathPrefix matching behavoir on sub-routers

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -386,7 +386,7 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceList,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/services/{service}/metrics services serviceMetrics
+		// swagger:route GET /namespaces/{namespace}/services/{service}/metrics services serviceMetrics
 		// ---
 		// Endpoint to fetch metrics to be displayed, related to a single service
 		//
@@ -407,7 +407,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceMetrics,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/apps/{app}/metrics apps appMetrics
+		// swagger:route GET /namespaces/{namespace}/apps/{app}/metrics apps appMetrics
 		// ---
 		// Endpoint to fetch metrics to be displayed, related to a single app
 		//
@@ -428,7 +428,7 @@ func NewRoutes() (r *Routes) {
 			handlers.AppMetrics,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/workloads/{workload}/metrics workloads workloadMetrics
+		// swagger:route GET /namespaces/{namespace}/workloads/{workload}/metrics workloads workloadMetrics
 		// ---
 		// Endpoint to fetch metrics to be displayed, related to a single workload
 		//
@@ -449,7 +449,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadMetrics,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/services/{service}/health services serviceHealth
+		// swagger:route GET /namespaces/{namespace}/services/{service}/health services serviceHealth
 		// ---
 		// Get health associated to the given service
 		//
@@ -470,7 +470,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceHealth,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/apps/{app}/health apps appHealth
+		// swagger:route GET /namespaces/{namespace}/apps/{app}/health apps appHealth
 		// ---
 		// Get health associated to the given app
 		//
@@ -491,7 +491,7 @@ func NewRoutes() (r *Routes) {
 			handlers.AppHealth,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/workloads/{workload}/health workloads workloadHealth
+		// swagger:route GET /namespaces/{namespace}/workloads/{workload}/health workloads workloadHealth
 		// ---
 		// Get health associated to the given workload
 		//
@@ -528,7 +528,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceIstioValidations,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/metrics namespaces namespaceMetrics
+		// swagger:route GET /namespaces/{namespace}/metrics namespaces namespaceMetrics
 		// ---
 		// Endpoint to fetch metrics to be displayed, related to a namespace
 		//
@@ -549,7 +549,7 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceMetrics,
 			true,
 		},
-		// swagger:route GET /api/namespaces/{namespace}/health namespaces namespaceHealth
+		// swagger:route GET /namespaces/{namespace}/health namespaces namespaceHealth
 		// ---
 		// Get health for all objects in the given namespace
 		//

--- a/swagger.json
+++ b/swagger.json
@@ -38,677 +38,6 @@
         }
       }
     },
-    "/api/namespaces/{namespace}/apps/{app}/health": {
-      "get": {
-        "description": "Get health associated to the given app",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "apps"
-        ],
-        "operationId": "appHealth",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Namespace",
-            "description": "The namespace scope",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "default": "10m",
-            "x-go-name": "RateInterval",
-            "description": "The rate interval used for fetching error rate",
-            "name": "rateInterval",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "format": "date-time",
-            "description": "The time to use for the prometheus query",
-            "name": "QueryTime",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "App",
-            "description": "The target app",
-            "name": "app",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/appHealthResponse"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          }
-        }
-      }
-    },
-    "/api/namespaces/{namespace}/apps/{app}/metrics": {
-      "get": {
-        "description": "Endpoint to fetch metrics to be displayed, related to a single app",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "apps"
-        ],
-        "operationId": "appMetrics",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The app name (label value).",
-            "name": "app",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The namespace id.",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "default": "true",
-            "x-go-name": "Name",
-            "description": "Flag for fetching histogram average. Default is true.",
-            "name": "avg",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsIn[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsOut[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "1800",
-            "x-go-name": "Name",
-            "description": "Duration of the query period, in seconds.",
-            "name": "duration",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
-            "name": "filters[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
-            "name": "quantiles[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "rate",
-            "x-go-name": "Name",
-            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
-            "name": "rateFunc",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "1m",
-            "x-go-name": "Name",
-            "description": "Interval used for rate and histogram calculation.",
-            "name": "rateInterval",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Istio telemetry reporter: 'source' or 'destination'",
-            "name": "reporter",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "15",
-            "x-go-name": "Name",
-            "description": "Step between [graph] datapoints, in seconds.",
-            "name": "step",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Filters metrics by the specified version.",
-            "name": "version",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/metricsResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "503": {
-            "$ref": "#/responses/serviceUnavailableError"
-          }
-        }
-      }
-    },
-    "/api/namespaces/{namespace}/health": {
-      "get": {
-        "description": "Get health for all objects in the given namespace",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "namespaces"
-        ],
-        "operationId": "namespaceHealth",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Namespace",
-            "description": "The namespace scope",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "default": "10m",
-            "x-go-name": "RateInterval",
-            "description": "The rate interval used for fetching error rate",
-            "name": "rateInterval",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "format": "date-time",
-            "description": "The time to use for the prometheus query",
-            "name": "QueryTime",
-            "in": "query"
-          },
-          {
-            "pattern": "^(app|service|workload)$",
-            "type": "string",
-            "default": "app",
-            "x-go-name": "Type",
-            "description": "The type of health, \"app\", \"service\" or \"workload\".",
-            "name": "type",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/namespaceAppHealthResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          }
-        }
-      }
-    },
-    "/api/namespaces/{namespace}/metrics": {
-      "get": {
-        "description": "Endpoint to fetch metrics to be displayed, related to a namespace",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "namespaces"
-        ],
-        "operationId": "namespaceMetrics",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The namespace id.",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/metricsResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "503": {
-            "$ref": "#/responses/serviceUnavailableError"
-          }
-        }
-      }
-    },
-    "/api/namespaces/{namespace}/services/{service}/health": {
-      "get": {
-        "description": "Get health associated to the given service",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "services"
-        ],
-        "operationId": "serviceHealth",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Namespace",
-            "description": "The namespace scope",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "default": "10m",
-            "x-go-name": "RateInterval",
-            "description": "The rate interval used for fetching error rate",
-            "name": "rateInterval",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "format": "date-time",
-            "description": "The time to use for the prometheus query",
-            "name": "QueryTime",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "Service",
-            "description": "The target service",
-            "name": "service",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/serviceHealthResponse"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          }
-        }
-      }
-    },
-    "/api/namespaces/{namespace}/services/{service}/metrics": {
-      "get": {
-        "description": "Endpoint to fetch metrics to be displayed, related to a single service",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "services"
-        ],
-        "operationId": "serviceMetrics",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The namespace id.",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The service name.",
-            "name": "service",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "default": "true",
-            "x-go-name": "Name",
-            "description": "Flag for fetching histogram average. Default is true.",
-            "name": "avg",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsIn[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsOut[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "1800",
-            "x-go-name": "Name",
-            "description": "Duration of the query period, in seconds.",
-            "name": "duration",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
-            "name": "filters[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
-            "name": "quantiles[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "rate",
-            "x-go-name": "Name",
-            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
-            "name": "rateFunc",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "1m",
-            "x-go-name": "Name",
-            "description": "Interval used for rate and histogram calculation.",
-            "name": "rateInterval",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Istio telemetry reporter: 'source' or 'destination'",
-            "name": "reporter",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "15",
-            "x-go-name": "Name",
-            "description": "Step between [graph] datapoints, in seconds.",
-            "name": "step",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Filters metrics by the specified version.",
-            "name": "version",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/metricsResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "503": {
-            "$ref": "#/responses/serviceUnavailableError"
-          }
-        }
-      }
-    },
-    "/api/namespaces/{namespace}/workloads/{workload}/health": {
-      "get": {
-        "description": "Get health associated to the given workload",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "workloads"
-        ],
-        "operationId": "workloadHealth",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Namespace",
-            "description": "The namespace scope",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "default": "10m",
-            "x-go-name": "RateInterval",
-            "description": "The rate interval used for fetching error rate",
-            "name": "rateInterval",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "format": "date-time",
-            "description": "The time to use for the prometheus query",
-            "name": "QueryTime",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "Workload",
-            "description": "The target workload",
-            "name": "workload",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/workloadHealthResponse"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          }
-        }
-      }
-    },
-    "/api/namespaces/{namespace}/workloads/{workload}/metrics": {
-      "get": {
-        "description": "Endpoint to fetch metrics to be displayed, related to a single workload",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "workloads"
-        ],
-        "operationId": "workloadMetrics",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The namespace id.",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The workload name.",
-            "name": "workload",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "default": "true",
-            "x-go-name": "Name",
-            "description": "Flag for fetching histogram average. Default is true.",
-            "name": "avg",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsIn[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsOut[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "1800",
-            "x-go-name": "Name",
-            "description": "Duration of the query period, in seconds.",
-            "name": "duration",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
-            "name": "filters[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "[]",
-            "x-go-name": "Name",
-            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
-            "name": "quantiles[]",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "rate",
-            "x-go-name": "Name",
-            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
-            "name": "rateFunc",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "1m",
-            "x-go-name": "Name",
-            "description": "Interval used for rate and histogram calculation.",
-            "name": "rateInterval",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Istio telemetry reporter: 'source' or 'destination'",
-            "name": "reporter",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "15",
-            "x-go-name": "Name",
-            "description": "Step between [graph] datapoints, in seconds.",
-            "name": "step",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Filters metrics by the specified version.",
-            "name": "version",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/metricsResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "503": {
-            "$ref": "#/responses/serviceUnavailableError"
-          }
-        }
-      }
-    },
     "/config": {
       "get": {
         "description": "Endpoint to get the config of Kiali",
@@ -1163,6 +492,258 @@
         }
       }
     },
+    "/namespaces/{namespace}/apps/{app}/health": {
+      "get": {
+        "description": "Get health associated to the given app",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "apps"
+        ],
+        "operationId": "appHealth",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Namespace",
+            "description": "The namespace scope",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "10m",
+            "x-go-name": "RateInterval",
+            "description": "The rate interval used for fetching error rate",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "The time to use for the prometheus query",
+            "name": "QueryTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "App",
+            "description": "The target app",
+            "name": "app",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/appHealthResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/apps/{app}/metrics": {
+      "get": {
+        "description": "Endpoint to fetch metrics to be displayed, related to a single app",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "apps"
+        ],
+        "operationId": "appMetrics",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The app name (label value).",
+            "name": "app",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "true",
+            "x-go-name": "Name",
+            "description": "Flag for fetching histogram average. Default is true.",
+            "name": "avg",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).",
+            "name": "byLabelsIn[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).",
+            "name": "byLabelsOut[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration of the query period, in seconds.",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
+            "name": "filters[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
+            "name": "quantiles[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation.",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Istio telemetry reporter: 'source' or 'destination'",
+            "name": "reporter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Step between [graph] datapoints, in seconds.",
+            "name": "step",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Filters metrics by the specified version.",
+            "name": "version",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/metricsResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "503": {
+            "$ref": "#/responses/serviceUnavailableError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/health": {
+      "get": {
+        "description": "Get health for all objects in the given namespace",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "namespaces"
+        ],
+        "operationId": "namespaceHealth",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Namespace",
+            "description": "The namespace scope",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "10m",
+            "x-go-name": "RateInterval",
+            "description": "The rate interval used for fetching error rate",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "The time to use for the prometheus query",
+            "name": "QueryTime",
+            "in": "query"
+          },
+          {
+            "pattern": "^(app|service|workload)$",
+            "type": "string",
+            "default": "app",
+            "x-go-name": "Type",
+            "description": "The type of health, \"app\", \"service\" or \"workload\".",
+            "name": "type",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/namespaceAppHealthResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/istio": {
       "get": {
         "description": "Endpoint to get the list of Istio Config of a namespace",
@@ -1414,6 +995,43 @@
         }
       }
     },
+    "/namespaces/{namespace}/metrics": {
+      "get": {
+        "description": "Endpoint to fetch metrics to be displayed, related to a namespace",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "namespaces"
+        ],
+        "operationId": "namespaceMetrics",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/metricsResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "503": {
+            "$ref": "#/responses/serviceUnavailableError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/services": {
       "get": {
         "description": "Endpoint to get the details of a given service",
@@ -1586,6 +1204,66 @@
         }
       }
     },
+    "/namespaces/{namespace}/services/{service}/health": {
+      "get": {
+        "description": "Get health associated to the given service",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "services"
+        ],
+        "operationId": "serviceHealth",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Namespace",
+            "description": "The namespace scope",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "10m",
+            "x-go-name": "RateInterval",
+            "description": "The rate interval used for fetching error rate",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "The time to use for the prometheus query",
+            "name": "QueryTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Service",
+            "description": "The target service",
+            "name": "service",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/serviceHealthResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/services/{service}/istio_validations": {
       "get": {
         "description": "Endpoint to get the list of istio object validations for a service",
@@ -1620,6 +1298,137 @@
           },
           "500": {
             "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/services/{service}/metrics": {
+      "get": {
+        "description": "Endpoint to fetch metrics to be displayed, related to a single service",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "services"
+        ],
+        "operationId": "serviceMetrics",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The service name.",
+            "name": "service",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "true",
+            "x-go-name": "Name",
+            "description": "Flag for fetching histogram average. Default is true.",
+            "name": "avg",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).",
+            "name": "byLabelsIn[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).",
+            "name": "byLabelsOut[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration of the query period, in seconds.",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
+            "name": "filters[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
+            "name": "quantiles[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation.",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Istio telemetry reporter: 'source' or 'destination'",
+            "name": "reporter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Step between [graph] datapoints, in seconds.",
+            "name": "step",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Filters metrics by the specified version.",
+            "name": "version",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/metricsResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "503": {
+            "$ref": "#/responses/serviceUnavailableError"
           }
         }
       }
@@ -1792,6 +1601,197 @@
           },
           "500": {
             "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/workloads/{workload}/health": {
+      "get": {
+        "description": "Get health associated to the given workload",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "workloads"
+        ],
+        "operationId": "workloadHealth",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Namespace",
+            "description": "The namespace scope",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "10m",
+            "x-go-name": "RateInterval",
+            "description": "The rate interval used for fetching error rate",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "The time to use for the prometheus query",
+            "name": "QueryTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Workload",
+            "description": "The target workload",
+            "name": "workload",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/workloadHealthResponse"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/workloads/{workload}/metrics": {
+      "get": {
+        "description": "Endpoint to fetch metrics to be displayed, related to a single workload",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "workloads"
+        ],
+        "operationId": "workloadMetrics",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The workload name.",
+            "name": "workload",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "true",
+            "x-go-name": "Name",
+            "description": "Flag for fetching histogram average. Default is true.",
+            "name": "avg",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).",
+            "name": "byLabelsIn[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).",
+            "name": "byLabelsOut[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration of the query period, in seconds.",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
+            "name": "filters[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
+            "name": "quantiles[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation.",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Istio telemetry reporter: 'source' or 'destination'",
+            "name": "reporter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Step between [graph] datapoints, in seconds.",
+            "name": "step",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Filters metrics by the specified version.",
+            "name": "version",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/metricsResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "503": {
+            "$ref": "#/responses/serviceUnavailableError"
           }
         }
       }


### PR DESCRIPTION
** Describe the change **

- Rename description swagger to be consistent with convetion
  - GetToken => getToken
  - Root => root
- Set StrictSlash to true to 

```go
When true, if the route path is "/path/", accessing "/path" will perform a redirect
// to the former and vice versa. In other words, your application will always
// see the path as specified in the route.
```

** Issue reference **

JIRA: [KIALI-1969](https://issues.jboss.org/browse/KIALI-1969
)  [KIALI-1994](https://issues.jboss.org/browse/KIALI-1994)


@gbaufake Can you check if tehre is /api/api routes? I didn't see them
