### PR TITLE
KIALI-2056 Few fixes around grafana links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -392,7 +392,7 @@ external_services:
 ----
 
 |`GRAFANA_DISPLAY_LINK`
-|When true, a link to Grafana will be displayed for more metrics.
+|When `true`, a link to Grafana will be displayed for more dashboards. (default is `true`)
 [source,yaml]
 ----
 external_services:
@@ -401,7 +401,7 @@ external_services:
 ----
 
 |`GRAFANA_URL`
-|The URL to the Grafana service. When not set, Kiali throw an error when the user try request to Grafana (/api/grafana).
+|The URL to the Grafana service. When not set, Kiali will report an error as it cannot generate links to Grafana. To avoid this error, either set a valid URL (it must be accessible from user browser), or turn off `GRAFANA_DISPLAY_LINK` options.
 [source,yaml]
 ----
 external_services:
@@ -410,7 +410,7 @@ external_services:
 ----
 
 |`GRAFANA_SERVICE_NAMESPACE`
-|The Kubernetes namespace that holds the Grafana service. This configuration is ignored if `GRAFANA_URL` is set. (default is `istio-system`)
+|The Kubernetes namespace that holds the Grafana service. (default is `istio-system`)
 [source,yaml]
 ----
 external_services:
@@ -419,7 +419,7 @@ external_services:
 ----
 
 |`GRAFANA_SERVICE`
-|The OpenShift route name or the Kubernetes service name for Grafana. This configuration is ignored if `GRAFANA_URL` is set. (default is `grafana`)
+|The Kubernetes service name for Grafana. (default is `grafana`)
 [source,yaml]
 ----
 external_services:

--- a/doc.go
+++ b/doc.go
@@ -279,6 +279,19 @@ type VersionParam struct {
 // SWAGGER RESPONSES
 /////////////////////
 
+// NoContent: the response is empty
+// swagger:response noContent
+type NoContent struct {
+	// in: body
+	Body struct {
+		// HTTP status code
+		// example: 204
+		// default: 204
+		Code    int32 `json:"code"`
+		Message error `json:"message"`
+	} `json:"body"`
+}
+
 // BadRequestError: the client request is incorrect
 //
 // swagger:response badRequestError

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -13,7 +13,6 @@ import (
 func TestGetGrafanaInfoDisabled(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Grafana.DisplayLink = false
-	conf.ExternalServices.Grafana.URL = "https://grafana.url/"
 	config.Set(conf)
 	info, code, err := getGrafanaInfo(func(_, _ string) (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
@@ -57,5 +56,5 @@ func TestGetGrafanaInfoNoExternalIP(t *testing.T) {
 		return "/dash", nil
 	})
 	assert.NotNil(t, err)
-	assert.Equal(t, http.StatusNotFound, code)
+	assert.Equal(t, http.StatusServiceUnavailable, code)
 }

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -707,11 +707,10 @@ func NewRoutes() (r *Routes) {
 		//     Schemes: http, https
 		//
 		// responses:
-		//      404: notFoundError
-		//      406: notAcceptableError
 		//      500: internalError
+		//      503: serviceUnavailableError
 		//      200: grafanaInfoResponse
-		//      204: grafanaInfoResponse
+		//      204: noContent
 		//
 		{
 			"GrafanaURL",

--- a/swagger.json
+++ b/swagger.json
@@ -746,16 +746,13 @@
             "$ref": "#/responses/grafanaInfoResponse"
           },
           "204": {
-            "$ref": "#/responses/grafanaInfoResponse"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "406": {
-            "$ref": "#/responses/notAcceptableError"
+            "$ref": "#/responses/noContent"
           },
           "500": {
             "$ref": "#/responses/internalError"
+          },
+          "503": {
+            "$ref": "#/responses/serviceUnavailableError"
           }
         }
       }
@@ -4059,6 +4056,26 @@
       "description": "Listing all istio validations for object in the namespace",
       "schema": {
         "$ref": "#/definitions/NamespaceValidations"
+      }
+    },
+    "noContent": {
+      "description": "NoContent: the response is empty",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "HTTP status code",
+            "type": "integer",
+            "format": "int32",
+            "default": 204,
+            "x-go-name": "Code",
+            "example": 204
+          },
+          "message": {
+            "type": "string",
+            "x-go-name": "Message"
+          }
+        }
       }
     },
     "notAcceptableError": {


### PR DESCRIPTION
- Fix documentation
- Fix when grafanaConfig.DisplayLink=false, should not expect an URL to be set
- Fix returned HTTP codes (must be 5xx and not 4xx for invalid configuration)
- Regenerate swagger

JIRA: https://issues.jboss.org/browse/KIALI-2056
cf also #690