### PR TITLE
KIALI-2021 Modify the behavior of the NoDestinationChecker

### DIFF
--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -9,7 +9,7 @@ import (
 
 type NoDestinationChecker struct {
 	Namespace       string
-	Services        map[string][]string
+	WorkloadList    models.WorkloadList
 	DestinationRule kubernetes.IstioObject
 }
 
@@ -21,19 +21,36 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 	if host, ok := n.DestinationRule.GetSpec()["host"]; ok {
 		if dHost, ok := host.(string); ok {
 			fqdn := FormatHostnameForPrefixSearch(dHost, n.DestinationRule.GetObjectMeta().Namespace, n.DestinationRule.GetObjectMeta().ClusterName)
-			if versions, found := n.Services[fqdn.Service]; found {
-				if hasSubsets(n.DestinationRule) {
-					indexes := kubernetes.ValidateDestinationRulesSubsets([]kubernetes.IstioObject{n.DestinationRule}, fqdn.Service, versions)
-					for _, i := range indexes {
-						validation := models.BuildCheck("This subset is not found from the host", "error", "spec/subsets["+strconv.Itoa(i)+"]/version")
-						validations = append(validations, &validation)
-						valid = false
+			if subsets, ok := n.DestinationRule.GetSpec()["subsets"]; ok {
+				if dSubsets, ok := subsets.([]interface{}); ok {
+					// Check that each subset has a matching workload somewhere..
+					for i, subset := range dSubsets {
+						if innerSubset, ok := subset.(map[string]interface{}); ok {
+							if labels, ok := innerSubset["labels"]; ok {
+								if dLabels, ok := labels.(map[string]interface{}); ok {
+									stringLabels := make(map[string]string, len(dLabels))
+									for k, v := range dLabels {
+										if s, ok := v.(string); ok {
+											stringLabels[k] = s
+										}
+									}
+									if !n.hasMatchingWorkload(fqdn.Service, stringLabels) {
+										validation := models.BuildCheck("This subset's labels are not found from any matching host", "error", "spec/subsets["+strconv.Itoa(i)+"]")
+										validations = append(validations, &validation)
+										valid = false
+									}
+								}
+							}
+						}
 					}
+
 				}
 			} else {
-				validation := models.BuildCheck("Host doesn't have a valid service", "error", "spec/host")
-				validations = append(validations, &validation)
-				valid = false
+				if !n.hasMatchingService(fqdn.Service) {
+					validation := models.BuildCheck("This host has no matching workloads", "error", "spec/host")
+					validations = append(validations, &validation)
+					valid = false
+				}
 			}
 		}
 	}
@@ -41,12 +58,25 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 	return validations, valid
 }
 
-func hasSubsets(dr kubernetes.IstioObject) bool {
-	if subsets, ok := dr.GetSpec()["subsets"]; ok {
-		if subsetsSI, ok := subsets.([]interface{}); ok {
-			if len(subsetsSI) > 0 {
+func (n NoDestinationChecker) hasMatchingWorkload(service string, labels map[string]string) bool {
+	for _, wl := range n.WorkloadList.Workloads {
+		if service == wl.Labels["app"] {
+			for k, v := range labels {
+				wlv, found := wl.Labels[k]
+				if !found || wlv != v {
+					break
+				}
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func (n NoDestinationChecker) hasMatchingService(service string) bool {
+	for _, wl := range n.WorkloadList.Workloads {
+		if service == wl.Labels["app"] {
+			return true
 		}
 	}
 	return false

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -61,11 +61,15 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 func (n NoDestinationChecker) hasMatchingWorkload(service string, labels map[string]string) bool {
 	for _, wl := range n.WorkloadList.Workloads {
 		if service == wl.Labels["app"] {
+			valid := true
 			for k, v := range labels {
 				wlv, found := wl.Labels[k]
 				if !found || wlv != v {
+					valid = false
 					break
 				}
+			}
+			if valid {
 				return true
 			}
 		}

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -3,6 +3,7 @@ package destinationrules
 import (
 	"strconv"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -59,8 +60,9 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 }
 
 func (n NoDestinationChecker) hasMatchingWorkload(service string, labels map[string]string) bool {
+	appLabel := config.Get().IstioLabels.AppLabelName
 	for _, wl := range n.WorkloadList.Workloads {
-		if service == wl.Labels["app"] {
+		if service == wl.Labels[appLabel] {
 			valid := true
 			for k, v := range labels {
 				wlv, found := wl.Labels[k]
@@ -78,8 +80,9 @@ func (n NoDestinationChecker) hasMatchingWorkload(service string, labels map[str
 }
 
 func (n NoDestinationChecker) hasMatchingService(service string) bool {
+	appLabel := config.Get().IstioLabels.AppLabelName
 	for _, wl := range n.WorkloadList.Workloads {
-		if service == wl.Labels["app"] {
+		if service == wl.Labels[appLabel] {
 			return true
 		}
 	}

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -9,12 +9,21 @@ import (
 	"github.com/kiali/kiali/tests/data"
 )
 
+func appVersionLabel(app, version string) map[string]string {
+	return map[string]string{
+		"app":     app,
+		"version": version,
+	}
+}
 func TestValidHost(t *testing.T) {
 	assert := assert.New(t)
 
 	validations, valid := NoDestinationChecker{
-		Namespace:       "test-namespace",
-		Services:        getServices([]string{"reviews", "other"}),
+		Namespace: "test-namespace",
+		WorkloadList: data.CreateWorkloadList("test-namespace",
+			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
+			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
+		),
 		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 
@@ -30,16 +39,19 @@ func TestNoValidHost(t *testing.T) {
 
 	// reviews is not part of service names
 	validations, valid := NoDestinationChecker{
-		Namespace:       "test-namespace",
-		Services:        getServices([]string{"details", "other"}),
+		Namespace: "test-namespace",
+		WorkloadList: data.CreateWorkloadList("test-namespace",
+			data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
+			data.CreateWorkloadListItem("otherv1", appVersionLabel("other", "v1")),
+		),
 		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
-	assert.Equal("Host doesn't have a valid service", validations[0].Message)
-	assert.Equal("spec/host", validations[0].Path)
+	assert.Equal("This subset's labels are not found from any matching host", validations[0].Message)
+	assert.Equal("spec/subsets[0]", validations[0].Path)
 }
 
 func TestNoMatchingSubset(t *testing.T) {
@@ -48,21 +60,20 @@ func TestNoMatchingSubset(t *testing.T) {
 
 	assert := assert.New(t)
 
-	services := getServices([]string{"reviews"})
-	services["reviews"] = []string{"v1"}
-
 	// reviews does not have v2 in known services
 	validations, valid := NoDestinationChecker{
-		Namespace:       "test-namespace",
-		Services:        services,
+		Namespace: "test-namespace",
+		WorkloadList: data.CreateWorkloadList("test-namespace",
+			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
+		),
 		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
-	assert.Equal("This subset is not found from the host", validations[0].Message)
-	assert.Equal("spec/subsets[0]/version", validations[0].Path)
+	assert.Equal("This subset's labels are not found from any matching host", validations[0].Message)
+	assert.Equal("spec/subsets[0]", validations[0].Path)
 }
 
 func getServices(services []string) map[string][]string {

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -33,7 +33,17 @@ func TestAllIstioObjectWithServices(t *testing.T) {
 	assert := assert.New(t)
 
 	validations := NoServiceChecker{
-		Namespace:    "test",
+		Namespace: "test",
+		WorkloadList: data.CreateWorkloadList("test",
+			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
+			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
+			data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
+			data.CreateWorkloadListItem("detailsv2", appVersionLabel("details", "v2")),
+			data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
+			data.CreateWorkloadListItem("productv2", appVersionLabel("product", "v2")),
+			data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
+			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
+		),
 		IstioDetails: fakeIstioDetails(),
 		Services:     fakeServiceDetails([]string{"reviews", "details", "product", "customer"}),
 	}.Check()
@@ -54,7 +64,15 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	validations := NoServiceChecker{
 		Namespace:    "test",
 		IstioDetails: fakeIstioDetails(),
-		Services:     fakeServiceDetails([]string{"reviews", "details", "product"}),
+		WorkloadList: data.CreateWorkloadList("test",
+			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
+			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
+			data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
+			data.CreateWorkloadListItem("detailsv2", appVersionLabel("details", "v2")),
+			data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
+			data.CreateWorkloadListItem("productv2", appVersionLabel("product", "v2")),
+		),
+		Services: fakeServiceDetails([]string{"reviews", "details", "product"}),
 	}.Check()
 
 	assert.NotEmpty(validations)
@@ -63,10 +81,18 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.False(customerDr.Valid)
 	assert.Equal(1, len(customerDr.Checks))
 	assert.Equal("spec/host", customerDr.Checks[0].Path)
-	assert.Equal("Host doesn't have a valid service", customerDr.Checks[0].Message)
+	assert.Equal("This host has no matching workloads", customerDr.Checks[0].Message)
 
 	validations = NoServiceChecker{
-		Namespace:    "test",
+		Namespace: "test",
+		WorkloadList: data.CreateWorkloadList("test",
+			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
+			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
+			data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
+			data.CreateWorkloadListItem("detailsv2", appVersionLabel("details", "v2")),
+			data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
+			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
+		),
 		IstioDetails: fakeIstioDetails(),
 		Services:     fakeServiceDetails([]string{"reviews", "details", "customer"}),
 	}.Check()
@@ -82,7 +108,15 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", productVs.Checks[1].Message)
 
 	validations = NoServiceChecker{
-		Namespace:    "test",
+		Namespace: "test",
+		WorkloadList: data.CreateWorkloadList("test",
+			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
+			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
+			data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
+			data.CreateWorkloadListItem("productv2", appVersionLabel("product", "v2")),
+			data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
+			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
+		),
 		IstioDetails: fakeIstioDetails(),
 		Services:     fakeServiceDetails([]string{"reviews", "product", "customer"}),
 	}.Check()
@@ -91,7 +125,15 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.True(validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "customer-dr"}].Valid)
 
 	validations = NoServiceChecker{
-		Namespace:    "test",
+		Namespace: "test",
+		WorkloadList: data.CreateWorkloadList("test",
+			data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
+			data.CreateWorkloadListItem("productv2", appVersionLabel("product", "v2")),
+			data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
+			data.CreateWorkloadListItem("detailsv2", appVersionLabel("details", "v2")),
+			data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
+			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
+		),
 		IstioDetails: fakeIstioDetails(),
 		Services:     fakeServiceDetails([]string{"details", "product", "customer"}),
 	}.Check()
@@ -150,4 +192,11 @@ func fakeServiceDetails(services []string) []v1.Service {
 		})
 	}
 	return items
+}
+
+func appVersionLabel(app, version string) map[string]string {
+	return map[string]string{
+		"app":     app,
+		"version": version,
+	}
 }

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -29,8 +29,7 @@ func TestGetNamespaceValidations(t *testing.T) {
 
 	validations, _ := vs.GetNamespaceValidations("test")
 	assert.NotEmpty(validations)
-	assert.True(validations["test"][models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}].Valid)
-	assert.True(validations["test"][models.IstioValidationKey{ObjectType: "destinationrule", Name: "customer-dr"}].Valid)
+	assert.True(validations["test"][models.IstioValidationKey{"virtualservice", "product-vs"}].Valid)
 }
 
 func TestGetIstioObjectValidations(t *testing.T) {

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -24,60 +24,6 @@ func TestFilterByHost(t *testing.T) {
 	assert.False(t, FilterByHost("reviews.bookinfo-bad.svc.cluster.local", "reviews", "bookinfo"))
 }
 
-func TestGetDestinationRulesSubsets(t *testing.T) {
-	conf := config.NewConfig()
-	config.Set(conf)
-
-	assert.Equal(t, []string{}, GetDestinationRulesSubsets(nil, "", ""))
-
-	destinationRule1 := GenericIstioObject{
-		Spec: map[string]interface{}{
-			"host": "reviews",
-			"subsets": []interface{}{
-				map[string]interface{}{
-					"name": "v1",
-					"labels": map[string]interface{}{
-						"version": "v1",
-					},
-				},
-				map[string]interface{}{
-					"name": "v2",
-					"labels": map[string]interface{}{
-						"version": "v2",
-					},
-				},
-			},
-		},
-	}
-	destinationRule2 := GenericIstioObject{
-		Spec: map[string]interface{}{
-			"host": "reviews",
-			"trafficPolicy": map[string]interface{}{
-				"loadBalancer": map[string]interface{}{
-					"simple": "LEAST_CONN",
-				},
-			},
-			"subsets": []interface{}{
-				map[string]interface{}{
-					"name": "testversion",
-					"labels": map[string]interface{}{
-						"version": "v2",
-					},
-					"trafficPolicy": map[string]interface{}{
-						"loadBalancer": map[string]interface{}{
-							"simple": "ROUND_ROBIN",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	destinationRules := []IstioObject{&destinationRule1, &destinationRule2}
-
-	assert.Equal(t, []string{"v2", "testversion"}, GetDestinationRulesSubsets(destinationRules, "reviews", "v2"))
-}
-
 func TestFQDNHostname(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/tests/data/workload_data.go
+++ b/tests/data/workload_data.go
@@ -1,0 +1,27 @@
+package data
+
+import "github.com/kiali/kiali/models"
+
+func CreateWorkloadList(namespace string, items ...models.WorkloadListItem) models.WorkloadList {
+	return models.WorkloadList{
+		Namespace: models.Namespace{Name: namespace},
+		Workloads: items,
+	}
+}
+
+func CreateWorkloadListItem(name string, labels map[string]string) models.WorkloadListItem {
+	wli := models.WorkloadListItem{
+		Name:   name,
+		Labels: labels,
+	}
+
+	if _, found := labels["app"]; found {
+		wli.AppLabel = true
+	}
+
+	if _, found := labels["version"]; found {
+		wli.VersionLabel = true
+	}
+
+	return wli
+}


### PR DESCRIPTION
** Describe the change **

Modifies the behavior of NoDestinationChecker to allow any combination of labels, thus stopping the requirement for version & app labels. Adds also simplified way of creating some WorkloadListItems for testing.

** Issue reference **

KIALI-2021
