### PR TITLE
KIALI-1954 Subset Presence Checker does not invalidate any object

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -69,7 +69,7 @@ func addError(validations models.IstioValidations, gatewayRuleName string, serve
 	rrValidation := &models.IstioValidation{
 		Name:       gatewayRuleName,
 		ObjectType: GatewayCheckerType,
-		Valid:      false,
+		Valid:      true,
 		Checks: []*models.IstioCheck{
 			&checks,
 		},

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -59,7 +59,7 @@ func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 	assert.Equal(2, len(validations))
 	validation, ok := validations[models.IstioValidationKey{"gateway", "stillvalid"}]
 	assert.True(ok)
-	assert.False(validation.Valid)
+	assert.True(validation.Valid)
 }
 
 func TestWildCardMatchingHost(t *testing.T) {
@@ -95,7 +95,7 @@ func TestWildCardMatchingHost(t *testing.T) {
 	assert.Equal(3, len(validations))
 	validation, ok := validations[models.IstioValidationKey{"gateway", "stillvalid"}]
 	assert.True(ok)
-	assert.False(validation.Valid)
+	assert.True(validation.Valid)
 
 }
 
@@ -126,5 +126,5 @@ func TestTwoWildCardsMatching(t *testing.T) {
 	assert.Equal(2, len(validations))
 	validation, ok := validations[models.IstioValidationKey{"gateway", "stillvalid"}]
 	assert.True(ok)
-	assert.False(validation.Valid)
+	assert.True(validation.Valid)
 }

--- a/business/checkers/virtual_service_checker_test.go
+++ b/business/checkers/virtual_service_checker_test.go
@@ -54,7 +54,7 @@ func TestVirtualServiceMultipleCheck(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(validation.Name, "reviews-multiple")
 	assert.Equal(validation.ObjectType, "virtualservice")
-	assert.False(validation.Valid)
+	assert.True(validation.Valid)
 	assert.Len(validation.Checks, 2)
 }
 
@@ -99,7 +99,7 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(validation.Name, "reviews-multiple")
 	assert.Equal(validation.ObjectType, "virtualservice")
-	assert.False(validation.Valid)
+	assert.True(validation.Valid)
 	assert.Len(validation.Checks, 2)
 }
 

--- a/business/checkers/virtual_services/subset_presence_checker.go
+++ b/business/checkers/virtual_services/subset_presence_checker.go
@@ -70,7 +70,6 @@ func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
 				}
 
 				if !checker.subsetPresent(host, subset) {
-					valid = false
 					path := fmt.Sprintf("spec/%s[%d]/route[%d]/destination", protocol, routeIdx, destWeightIdx)
 					validation := models.BuildCheck("Subset not found", "warning", path)
 					validations = append(validations, &validation)

--- a/business/checkers/virtual_services/subset_presence_checker_test.go
+++ b/business/checkers/virtual_services/subset_presence_checker_test.go
@@ -89,7 +89,7 @@ func TestSubsetsNotFound(t *testing.T) {
 			destinationList, fakeWrongSubsets(protocol)}.Check()
 
 		// There are no pods no deployments
-		assert.False(valid)
+		assert.True(valid)
 		assert.NotEmpty(validations)
 		assert.Len(validations, 2)
 		assert.Equal(validations[0].Message, "Subset not found")
@@ -188,7 +188,7 @@ func TestWrongDestinationRule(t *testing.T) {
 		validations, valid := SubsetPresenceChecker{"bookinfo",
 			destinationList, fakeCorrectVersions(protocol)}.Check()
 
-		assert.False(valid)
+		assert.True(valid)
 		assert.NotEmpty(validations)
 		assert.Len(validations, 2)
 		assert.Equal(validations[0].Message, "Subset not found")


### PR DESCRIPTION
** Describe the change **
'Subset not found' validations doesn't leave the validation as invalid since it is a warning.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1954

** Backwards incompatible? **
yes

Before:
![48569741-d5bdeb00-e902-11e8-9835-36df690d267b](https://user-images.githubusercontent.com/613814/49451773-2f1d8980-f7e0-11e8-8422-4b26952ff042.png)

After:
![screenshot of https___kiali-istio-system 192 168 42 18 nip io_api_namespaces_bookinfo_istio_virtualservices_reviews_istio_validations](https://user-images.githubusercontent.com/613814/49451732-22009a80-f7e0-11e8-849a-ecbfecad5874.png)
