### PR TITLE
KIALI-2086 Optimize and simplify metrics fetching

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -177,23 +177,23 @@ type AvgParam struct {
 }
 
 // swagger:parameters serviceMetrics appMetrics workloadMetrics
-type ByLabelsInParam struct {
-	// List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).
+type ByLabelsParam struct {
+	// List of labels to use for grouping metrics (via Prometheus 'by' clause).
 	//
 	// in: query
 	// required: false
 	// default: []
-	Name string `json:"byLabelsIn[]"`
+	Name string `json:"byLabels[]"`
 }
 
 // swagger:parameters serviceMetrics appMetrics workloadMetrics
-type ByLabelsOutParam struct {
-	// List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).
+type DirectionParam struct {
+	// Traffic direction: 'inbound' or 'outbound'.
 	//
 	// in: query
 	// required: false
-	// default: []
-	Name string `json:"byLabelsOut[]"`
+	// default: outbound
+	Name string `json:"direction"`
 }
 
 // swagger:parameters serviceMetrics appMetrics workloadMetrics
@@ -248,10 +248,11 @@ type RateIntervalParam struct {
 
 // swagger:parameters serviceMetrics appMetrics workloadMetrics
 type ReporterParam struct {
-	// Istio telemetry reporter: 'source' or 'destination'
+	// Istio telemetry reporter: 'source' or 'destination'.
 	//
 	// in: query
 	// required: false
+	// default: source
 	Name string `json:"reporter"`
 }
 

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -77,12 +77,14 @@ func extractMetricsQueryParams(r *http.Request, q *prometheus.MetricsQuery, name
 			return errors.New("Bad request, cannot parse query parameter 'avg'")
 		}
 	}
-	if lblsin, ok := queryParams["byLabelsIn[]"]; ok && len(lblsin) > 0 {
-		q.ByLabelsIn = lblsin
+	if lbls, ok := queryParams["byLabels[]"]; ok && len(lbls) > 0 {
+		q.ByLabels = lbls
 	}
-	if lblsout, ok := queryParams["byLabelsOut[]"]; ok && len(lblsout) > 0 {
-		q.ByLabelsOut = lblsout
+	dir := queryParams.Get("direction")
+	if dir != "" {
+		q.Direction = dir
 	}
+	q.Reporter = queryParams.Get("reporter")
 
 	// If needed, adjust interval -- Make sure query won't fetch data before the namespace creation
 	intervalStartTime, err := util.GetStartTimeForRateInterval(q.End, q.RateInterval)

--- a/handlers/metrics_test.go
+++ b/handlers/metrics_test.go
@@ -22,8 +22,7 @@ func TestExtractMetricsQueryParams(t *testing.T) {
 	q.Add("step", "10")
 	q.Add("queryTime", "1523364061") // 2018-04-10T12:41:01
 	q.Add("duration", "1000")        // Makes start = 2018-04-10T12:24:21
-	q.Add("byLabelsIn[]", "response_code")
-	q.Add("byLabelsOut[]", "response_code")
+	q.Add("byLabels[]", "response_code")
 	q.Add("filters[]", "request_count")
 	q.Add("filters[]", "request_size")
 	req.URL.RawQuery = q.Encode()
@@ -37,8 +36,7 @@ func TestExtractMetricsQueryParams(t *testing.T) {
 	assert.Equal(t, "5h", mq.RateInterval)
 	assert.Equal(t, "irate", mq.RateFunc)
 	assert.Equal(t, 10*time.Second, mq.Step)
-	assert.Equal(t, []string{"response_code"}, mq.ByLabelsIn)
-	assert.Equal(t, []string{"response_code"}, mq.ByLabelsOut)
+	assert.Equal(t, []string{"response_code"}, mq.ByLabels)
 	assert.Equal(t, []string{"request_count", "request_size"}, mq.Filters)
 
 	// Check that start date is normalized for step

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -39,7 +39,6 @@ func TestNamespaceMetricsDefault(t *testing.T) {
 		assert.Contains(t, query, "_namespace=\"ns\"")
 		assert.Contains(t, query, "[1m]")
 		assert.NotContains(t, query, "histogram_quantile")
-		assert.Contains(t, query, " by (reporter)")
 		atomic.AddUint32(&gaugeSentinel, 1)
 		assert.Equal(t, 15*time.Second, r.Step)
 		assert.WithinDuration(t, now, r.End, delta)
@@ -72,8 +71,7 @@ func TestNamespaceMetricsWithParams(t *testing.T) {
 	q.Add("step", "2")
 	q.Add("queryTime", "1523364075")
 	q.Add("duration", "1000")
-	q.Add("byLabelsIn[]", "response_code")
-	q.Add("byLabelsOut[]", "response_code")
+	q.Add("byLabels[]", "response_code")
 	q.Add("quantiles[]", "0.5")
 	q.Add("quantiles[]", "0.95")
 	q.Add("filters[]", "request_count")
@@ -92,11 +90,11 @@ func TestNamespaceMetricsWithParams(t *testing.T) {
 		assert.Contains(t, query, "[5h]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le,reporter,response_code)")
+			assert.Contains(t, query, " by (le,response_code)")
 			assert.Contains(t, query, "istio_request_bytes")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.Contains(t, query, " by (reporter,response_code)")
+			assert.Contains(t, query, " by (response_code)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 2*time.Second, r.Step)

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -42,7 +42,6 @@ func TestServiceMetricsDefault(t *testing.T) {
 		assert.Contains(t, query, "destination_service_namespace=\"ns\"")
 		assert.Contains(t, query, "[1m]")
 		assert.NotContains(t, query, "histogram_quantile")
-		assert.Contains(t, query, " by (reporter)")
 		atomic.AddUint32(&gaugeSentinel, 1)
 		assert.Equal(t, 15*time.Second, r.Step)
 		assert.WithinDuration(t, now, r.End, delta)
@@ -75,8 +74,7 @@ func TestServiceMetricsWithParams(t *testing.T) {
 	q.Add("step", "2")
 	q.Add("queryTime", "1523364075")
 	q.Add("duration", "1000")
-	q.Add("byLabelsIn[]", "response_code")
-	q.Add("byLabelsOut[]", "response_code")
+	q.Add("byLabels[]", "response_code")
 	q.Add("quantiles[]", "0.5")
 	q.Add("quantiles[]", "0.95")
 	q.Add("filters[]", "request_count")
@@ -97,11 +95,11 @@ func TestServiceMetricsWithParams(t *testing.T) {
 		assert.Contains(t, query, "[5h]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le,reporter,response_code)")
+			assert.Contains(t, query, " by (le,response_code)")
 			assert.Contains(t, query, "istio_request_bytes")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.Contains(t, query, " by (reporter,response_code)")
+			assert.Contains(t, query, " by (response_code)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 2*time.Second, r.Step)

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -3,13 +3,14 @@ package handlers
 import (
 	"errors"
 	"io/ioutil"
-	"k8s.io/api/apps/v1beta2"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"k8s.io/api/apps/v1beta2"
 
 	"github.com/gorilla/mux"
 	"github.com/kiali/kiali/business"
@@ -85,7 +86,6 @@ func TestWorkloadMetricsDefault(t *testing.T) {
 		assert.Contains(t, query, "_namespace=\"ns\"")
 		assert.Contains(t, query, "[1m]")
 		assert.NotContains(t, query, "histogram_quantile")
-		assert.Contains(t, query, " by (reporter)")
 		atomic.AddUint32(&gaugeSentinel, 1)
 		assert.Equal(t, 15*time.Second, r.Step)
 		assert.WithinDuration(t, now, r.End, delta)
@@ -119,8 +119,7 @@ func TestWorkloadMetricsWithParams(t *testing.T) {
 	q.Add("step", "2")
 	q.Add("queryTime", "1523364075")
 	q.Add("duration", "1000")
-	q.Add("byLabelsIn[]", "response_code")
-	q.Add("byLabelsOut[]", "response_code")
+	q.Add("byLabels[]", "response_code")
 	q.Add("quantiles[]", "0.5")
 	q.Add("quantiles[]", "0.95")
 	q.Add("filters[]", "request_count")
@@ -139,11 +138,11 @@ func TestWorkloadMetricsWithParams(t *testing.T) {
 		assert.Contains(t, query, "[5h]")
 		if strings.Contains(query, "histogram_quantile") {
 			// Histogram specific queries
-			assert.Contains(t, query, " by (le,reporter,response_code)")
+			assert.Contains(t, query, " by (le,response_code)")
 			assert.Contains(t, query, "istio_request_bytes")
 			atomic.AddUint32(&histogramSentinel, 1)
 		} else {
-			assert.Contains(t, query, " by (reporter,response_code)")
+			assert.Contains(t, query, " by (response_code)")
 			atomic.AddUint32(&gaugeSentinel, 1)
 		}
 		assert.Equal(t, 2*time.Second, r.Step)

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -190,6 +190,7 @@ func TestGetServiceMetrics(t *testing.T) {
 		Service:   "productpage",
 	}
 	q.FillDefaults()
+	q.Direction = "inbound"
 	q.RateInterval = "5m"
 	q.Quantiles = []string{"0.99"}
 	expectedRange := pv1.Range{
@@ -198,32 +199,32 @@ func TestGetServiceMetrics(t *testing.T) {
 		Step:  q.Step,
 	}
 
-	mockWithRange(api, expectedRange, "round(sum(rate(istio_requests_total{destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 2.5)
-	mockWithRange(api, expectedRange, "round(sum(rate(istio_requests_total{destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])) by (reporter), 0.001)", 4.5)
-	mockWithRange(api, expectedRange, "round(sum(rate(istio_tcp_received_bytes_total{destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 11)
-	mockWithRange(api, expectedRange, "round(sum(rate(istio_tcp_sent_bytes_total{destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 13)
-	mockHistogram(api, "istio_request_bytes", "{destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
-	mockHistogram(api, "istio_request_duration_seconds", "{destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
-	mockHistogram(api, "istio_response_bytes", "{destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
+	mockWithRange(api, expectedRange, "round(sum(rate(istio_requests_total{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m])), 0.001)", 2.5)
+	mockWithRange(api, expectedRange, "round(sum(rate(istio_requests_total{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 4.5)
+	mockWithRange(api, expectedRange, "round(sum(rate(istio_tcp_received_bytes_total{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m])), 0.001)", 11)
+	mockWithRange(api, expectedRange, "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m])), 0.001)", 13)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
+	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
+	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
 
 	// Test that range and rate interval are changed when needed (namespace bounds)
 	metrics := client.GetMetrics(&q)
 
-	assert.Equal(t, 4, len(metrics.Dest.Metrics), "Should have 4 simple metrics")
-	assert.Equal(t, 3, len(metrics.Dest.Histograms), "Should have 3 histograms")
-	rqCountIn := metrics.Dest.Metrics["request_count_in"]
+	assert.Equal(t, 4, len(metrics.Metrics), "Should have 4 simple metrics")
+	assert.Equal(t, 3, len(metrics.Histograms), "Should have 3 histograms")
+	rqCountIn := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountIn)
-	rqErrorCountIn := metrics.Dest.Metrics["request_error_count_in"]
+	rqErrorCountIn := metrics.Metrics["request_error_count"]
 	assert.NotNil(t, rqCountIn)
-	rqSizeIn := metrics.Dest.Histograms["request_size_in"]
+	rqSizeIn := metrics.Histograms["request_size"]
 	assert.NotNil(t, rqSizeIn)
-	rqDurationIn := metrics.Dest.Histograms["request_duration_in"]
+	rqDurationIn := metrics.Histograms["request_duration"]
 	assert.NotNil(t, rqDurationIn)
-	rsSizeIn := metrics.Dest.Histograms["response_size_in"]
+	rsSizeIn := metrics.Histograms["response_size"]
 	assert.NotNil(t, rsSizeIn)
-	tcpRecIn := metrics.Dest.Metrics["tcp_received_in"]
+	tcpRecIn := metrics.Metrics["tcp_received"]
 	assert.NotNil(t, tcpRecIn)
-	tcpSentIn := metrics.Dest.Metrics["tcp_sent_in"]
+	tcpSentIn := metrics.Metrics["tcp_sent"]
 	assert.NotNil(t, tcpSentIn)
 
 	assert.Equal(t, 2.5, float64(rqCountIn.Matrix[0].Values[0].Value))
@@ -241,20 +242,13 @@ func TestGetAppMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 1.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 2.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])) by (reporter), 0.001)", 3.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])) by (reporter), 0.001)", 4.5)
-	mockRange(api, "round(sum(rate(istio_tcp_received_bytes_total{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 10)
-	mockRange(api, "round(sum(rate(istio_tcp_received_bytes_total{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 11)
-	mockRange(api, "round(sum(rate(istio_tcp_sent_bytes_total{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 12)
-	mockRange(api, "round(sum(rate(istio_tcp_sent_bytes_total{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 13)
-	mockHistogram(api, "istio_request_bytes", "{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_duration_seconds", "{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
-	mockHistogram(api, "istio_response_bytes", "{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
-	mockHistogram(api, "istio_request_bytes", "{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
-	mockHistogram(api, "istio_request_duration_seconds", "{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
-	mockHistogram(api, "istio_response_bytes", "{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m])), 0.001)", 1.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 3.5)
+	mockRange(api, "round(sum(rate(istio_tcp_received_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m])), 0.001)", 10)
+	mockRange(api, "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m])), 0.001)", 12)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.4)
+	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.6)
 	q := prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
@@ -264,54 +258,33 @@ func TestGetAppMetrics(t *testing.T) {
 	q.Quantiles = []string{"0.5", "0.95", "0.99"}
 	metrics := client.GetMetrics(&q)
 
-	assert.Equal(t, 8, len(metrics.Dest.Metrics), "Should have 8 simple metrics")
-	assert.Equal(t, 6, len(metrics.Dest.Histograms), "Should have 6 histograms")
-	rqCountIn := metrics.Dest.Metrics["request_count_in"]
+	assert.Equal(t, 4, len(metrics.Metrics), "Should have 4 simple metrics")
+	assert.Equal(t, 3, len(metrics.Histograms), "Should have 3 histograms")
+	rqCountIn := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountIn)
-	rqCountOut := metrics.Dest.Metrics["request_count_out"]
-	assert.NotNil(t, rqCountOut)
-	rqErrorCountIn := metrics.Dest.Metrics["request_error_count_in"]
-	assert.NotNil(t, rqCountIn)
-	rqErrorCountOut := metrics.Dest.Metrics["request_error_count_out"]
-	assert.NotNil(t, rqCountOut)
-	rqSizeIn := metrics.Dest.Histograms["request_size_in"]
+	rqErrorCountIn := metrics.Metrics["request_error_count"]
+	assert.NotNil(t, rqErrorCountIn)
+	rqSizeIn := metrics.Histograms["request_size"]
 	assert.NotNil(t, rqSizeIn)
-	rqSizeOut := metrics.Dest.Histograms["request_size_out"]
-	assert.NotNil(t, rqSizeOut)
-	rqDurationIn := metrics.Dest.Histograms["request_duration_in"]
+	rqDurationIn := metrics.Histograms["request_duration"]
 	assert.NotNil(t, rqDurationIn)
-	rqDurationOut := metrics.Dest.Histograms["request_duration_out"]
-	assert.NotNil(t, rqDurationOut)
-	rsSizeIn := metrics.Dest.Histograms["response_size_in"]
+	rsSizeIn := metrics.Histograms["response_size"]
 	assert.NotNil(t, rsSizeIn)
-	rsSizeOut := metrics.Dest.Histograms["response_size_out"]
-	assert.NotNil(t, rsSizeOut)
-	tcpRecIn := metrics.Dest.Metrics["tcp_received_in"]
+	tcpRecIn := metrics.Metrics["tcp_received"]
 	assert.NotNil(t, tcpRecIn)
-	tcpRecOut := metrics.Dest.Metrics["tcp_received_out"]
-	assert.NotNil(t, tcpRecOut)
-	tcpSentIn := metrics.Dest.Metrics["tcp_sent_in"]
+	tcpSentIn := metrics.Metrics["tcp_sent"]
 	assert.NotNil(t, tcpSentIn)
-	tcpSentOut := metrics.Dest.Metrics["tcp_sent_out"]
-	assert.NotNil(t, tcpSentOut)
 
-	assert.Equal(t, 2.5, float64(rqCountIn.Matrix[0].Values[0].Value))
-	assert.Equal(t, 1.5, float64(rqCountOut.Matrix[0].Values[0].Value))
-	assert.Equal(t, 4.5, float64(rqErrorCountIn.Matrix[0].Values[0].Value))
-	assert.Equal(t, 3.5, float64(rqErrorCountOut.Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.35, float64(rqSizeOut["avg"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.2, float64(rqSizeOut["0.5"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.3, float64(rqSizeOut["0.95"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.4, float64(rqSizeOut["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.5, float64(rqDurationOut["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.6, float64(rsSizeOut["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.7, float64(rqSizeIn["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.8, float64(rqDurationIn["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.9, float64(rsSizeIn["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 11.0, float64(tcpRecIn.Matrix[0].Values[0].Value))
-	assert.Equal(t, 10.0, float64(tcpRecOut.Matrix[0].Values[0].Value))
-	assert.Equal(t, 13.0, float64(tcpSentIn.Matrix[0].Values[0].Value))
-	assert.Equal(t, 12.0, float64(tcpSentOut.Matrix[0].Values[0].Value))
+	assert.Equal(t, 1.5, float64(rqCountIn.Matrix[0].Values[0].Value))
+	assert.Equal(t, 3.5, float64(rqErrorCountIn.Matrix[0].Values[0].Value))
+	assert.Equal(t, 0.35, float64(rqSizeIn["avg"].Matrix[0].Values[0].Value))
+	assert.Equal(t, 0.2, float64(rqSizeIn["0.5"].Matrix[0].Values[0].Value))
+	assert.Equal(t, 0.3, float64(rqSizeIn["0.95"].Matrix[0].Values[0].Value))
+	assert.Equal(t, 0.4, float64(rqSizeIn["0.99"].Matrix[0].Values[0].Value))
+	assert.Equal(t, 0.5, float64(rqDurationIn["0.99"].Matrix[0].Values[0].Value))
+	assert.Equal(t, 0.6, float64(rsSizeIn["0.99"].Matrix[0].Values[0].Value))
+	assert.Equal(t, 10.0, float64(tcpRecIn.Matrix[0].Values[0].Value))
+	assert.Equal(t, 12.0, float64(tcpSentIn.Matrix[0].Values[0].Value))
 }
 
 func TestGetFilteredAppMetrics(t *testing.T) {
@@ -320,10 +293,8 @@ func TestGetFilteredAppMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 1.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 2.5)
-	mockHistogram(api, "istio_request_bytes", "{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_bytes", "{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m])), 0.001)", 1.5)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.4)
 	q := prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
@@ -333,15 +304,11 @@ func TestGetFilteredAppMetrics(t *testing.T) {
 	q.Filters = []string{"request_count", "request_size"}
 	metrics := client.GetMetrics(&q)
 
-	assert.Equal(t, 2, len(metrics.Dest.Metrics), "Should have 2 simple metrics")
-	assert.Equal(t, 2, len(metrics.Dest.Histograms), "Should have 2 histograms")
-	rqCountIn := metrics.Dest.Metrics["request_count_in"]
-	assert.NotNil(t, rqCountIn)
-	rqCountOut := metrics.Dest.Metrics["request_count_out"]
+	assert.Equal(t, 1, len(metrics.Metrics), "Should have 1 simple metric")
+	assert.Equal(t, 1, len(metrics.Histograms), "Should have 1 histogram")
+	rqCountOut := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountOut)
-	rqSizeIn := metrics.Dest.Histograms["request_size_in"]
-	assert.NotNil(t, rqSizeIn)
-	rqSizeOut := metrics.Dest.Histograms["request_size_out"]
+	rqSizeOut := metrics.Histograms["request_size"]
 	assert.NotNil(t, rqSizeOut)
 }
 
@@ -351,8 +318,7 @@ func TestGetAppMetricsInstantRates(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, "round(sum(irate(istio_requests_total{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[1m])) by (reporter), 0.001)", 1.5)
-	mockRange(api, "round(sum(irate(istio_requests_total{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[1m])) by (reporter), 0.001)", 2.5)
+	mockRange(api, "round(sum(irate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[1m])), 0.001)", 1.5)
 	q := prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
@@ -362,11 +328,9 @@ func TestGetAppMetricsInstantRates(t *testing.T) {
 	q.Filters = []string{"request_count"}
 	metrics := client.GetMetrics(&q)
 
-	assert.Equal(t, 2, len(metrics.Dest.Metrics), "Should have 2 simple metrics")
-	assert.Equal(t, 0, len(metrics.Dest.Histograms), "Should have no histogram")
-	rqCountIn := metrics.Dest.Metrics["request_count_in"]
-	assert.NotNil(t, rqCountIn)
-	rqCountOut := metrics.Dest.Metrics["request_count_out"]
+	assert.Equal(t, 1, len(metrics.Metrics), "Should have 1 simple metric")
+	assert.Equal(t, 0, len(metrics.Histograms), "Should have no histogram")
+	rqCountOut := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountOut)
 }
 
@@ -404,10 +368,8 @@ func TestGetAppMetricsUnavailable(t *testing.T) {
 		return
 	}
 	// Mock everything to return empty data
-	mockEmptyRange(api, "round(sum(rate(istio_requests_total{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)")
-	mockEmptyRange(api, "round(sum(rate(istio_requests_total{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)")
-	mockEmptyHistogram(api, "istio_request_bytes", "{source_app=\"productpage\",source_workload_namespace=\"bookinfo\"}[5m]")
-	mockEmptyHistogram(api, "istio_request_bytes", "{destination_app=\"productpage\",destination_workload_namespace=\"bookinfo\"}[5m]")
+	mockEmptyRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m])), 0.001)")
+	mockEmptyHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]")
 	q := prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
@@ -418,11 +380,11 @@ func TestGetAppMetricsUnavailable(t *testing.T) {
 	q.Filters = []string{"request_count", "request_size"}
 	metrics := client.GetMetrics(&q)
 
-	assert.Equal(t, 2, len(metrics.Dest.Metrics), "Should have 2 simple metrics")
-	assert.Equal(t, 2, len(metrics.Dest.Histograms), "Should have 2 histograms")
-	rqCountIn := metrics.Dest.Metrics["request_count_in"]
+	assert.Equal(t, 1, len(metrics.Metrics), "Should have 1 simple metric")
+	assert.Equal(t, 1, len(metrics.Histograms), "Should have 1 histogram")
+	rqCountIn := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountIn)
-	rqSizeIn := metrics.Dest.Histograms["request_size_in"]
+	rqSizeIn := metrics.Histograms["request_size"]
 	assert.NotNil(t, rqSizeIn)
 
 	// Simple metric & histogram are empty
@@ -458,20 +420,13 @@ func TestGetNamespaceMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, "round(sum(rate(istio_requests_total{source_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 1.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 2.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{source_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])) by (reporter), 0.001)", 3.5)
-	mockRange(api, "round(sum(rate(istio_requests_total{destination_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])) by (reporter), 0.001)", 4.5)
-	mockRange(api, "round(sum(rate(istio_tcp_received_bytes_total{source_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 10)
-	mockRange(api, "round(sum(rate(istio_tcp_received_bytes_total{destination_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 11)
-	mockRange(api, "round(sum(rate(istio_tcp_sent_bytes_total{source_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 12)
-	mockRange(api, "round(sum(rate(istio_tcp_sent_bytes_total{destination_workload_namespace=\"bookinfo\"}[5m])) by (reporter), 0.001)", 13)
-	mockHistogram(api, "istio_request_bytes", "{source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_duration_seconds", "{source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
-	mockHistogram(api, "istio_response_bytes", "{source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
-	mockHistogram(api, "istio_request_bytes", "{destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
-	mockHistogram(api, "istio_request_duration_seconds", "{destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
-	mockHistogram(api, "istio_response_bytes", "{destination_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 1.5)
+	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m])), 0.001)", 3.5)
+	mockRange(api, "round(sum(rate(istio_tcp_received_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 10)
+	mockRange(api, "round(sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m])), 0.001)", 12)
+	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
+	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
 	q := prometheus.MetricsQuery{
 		Namespace: "bookinfo",
 	}
@@ -480,40 +435,24 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	q.Quantiles = []string{"0.5", "0.95", "0.99"}
 	metrics := client.GetMetrics(&q)
 
-	assert.Equal(t, 8, len(metrics.Dest.Metrics), "Should have 8 simple metrics")
-	assert.Equal(t, 6, len(metrics.Dest.Histograms), "Should have 6 histograms")
-	rqCountIn := metrics.Dest.Metrics["request_count_in"]
-	assert.NotNil(t, rqCountIn)
-	rqCountOut := metrics.Dest.Metrics["request_count_out"]
+	assert.Equal(t, 4, len(metrics.Metrics), "Should have 4 simple metrics")
+	assert.Equal(t, 3, len(metrics.Histograms), "Should have 3 histograms")
+	rqCountOut := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountOut)
-	rqErrorCountIn := metrics.Dest.Metrics["request_error_count_in"]
-	assert.NotNil(t, rqCountIn)
-	rqErrorCountOut := metrics.Dest.Metrics["request_error_count_out"]
+	rqErrorCountOut := metrics.Metrics["request_error_count"]
 	assert.NotNil(t, rqCountOut)
-	rqSizeIn := metrics.Dest.Histograms["request_size_in"]
-	assert.NotNil(t, rqSizeIn)
-	rqSizeOut := metrics.Dest.Histograms["request_size_out"]
+	rqSizeOut := metrics.Histograms["request_size"]
 	assert.NotNil(t, rqSizeOut)
-	rqDurationIn := metrics.Dest.Histograms["request_duration_in"]
-	assert.NotNil(t, rqDurationIn)
-	rqDurationOut := metrics.Dest.Histograms["request_duration_out"]
+	rqDurationOut := metrics.Histograms["request_duration"]
 	assert.NotNil(t, rqDurationOut)
-	rsSizeIn := metrics.Dest.Histograms["response_size_in"]
-	assert.NotNil(t, rsSizeIn)
-	rsSizeOut := metrics.Dest.Histograms["response_size_out"]
+	rsSizeOut := metrics.Histograms["response_size"]
 	assert.NotNil(t, rsSizeOut)
-	tcpRecIn := metrics.Dest.Metrics["tcp_received_in"]
-	assert.NotNil(t, tcpRecIn)
-	tcpRecOut := metrics.Dest.Metrics["tcp_received_out"]
+	tcpRecOut := metrics.Metrics["tcp_received"]
 	assert.NotNil(t, tcpRecOut)
-	tcpSentIn := metrics.Dest.Metrics["tcp_sent_in"]
-	assert.NotNil(t, tcpSentIn)
-	tcpSentOut := metrics.Dest.Metrics["tcp_sent_out"]
+	tcpSentOut := metrics.Metrics["tcp_sent"]
 	assert.NotNil(t, tcpSentOut)
 
-	assert.Equal(t, 2.5, float64(rqCountIn.Matrix[0].Values[0].Value))
 	assert.Equal(t, 1.5, float64(rqCountOut.Matrix[0].Values[0].Value))
-	assert.Equal(t, 4.5, float64(rqErrorCountIn.Matrix[0].Values[0].Value))
 	assert.Equal(t, 3.5, float64(rqErrorCountOut.Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.35, float64(rqSizeOut["avg"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.2, float64(rqSizeOut["0.5"].Matrix[0].Values[0].Value))
@@ -521,12 +460,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	assert.Equal(t, 0.4, float64(rqSizeOut["0.99"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.5, float64(rqDurationOut["0.99"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.6, float64(rsSizeOut["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.7, float64(rqSizeIn["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.8, float64(rqDurationIn["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.9, float64(rsSizeIn["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 11.0, float64(tcpRecIn.Matrix[0].Values[0].Value))
 	assert.Equal(t, 10.0, float64(tcpRecOut.Matrix[0].Values[0].Value))
-	assert.Equal(t, 13.0, float64(tcpSentIn.Matrix[0].Values[0].Value))
 	assert.Equal(t, 12.0, float64(tcpSentOut.Matrix[0].Values[0].Value))
 }
 
@@ -701,21 +635,21 @@ func mockEmptyRange(api *PromAPIMock, query string) {
 }
 
 func mockHistogram(api *PromAPIMock, baseName string, suffix string, retAvg model.SampleValue, retMed model.SampleValue, ret95 model.SampleValue, ret99 model.SampleValue) {
-	histMetric := "sum(rate(" + baseName + "_bucket" + suffix + ")) by (le,reporter)), 0.001)"
+	histMetric := "sum(rate(" + baseName + "_bucket" + suffix + ")) by (le)), 0.001)"
 	mockRange(api, "round(histogram_quantile(0.5, "+histMetric, retMed)
 	mockRange(api, "round(histogram_quantile(0.95, "+histMetric, ret95)
 	mockRange(api, "round(histogram_quantile(0.99, "+histMetric, ret99)
 	mockRange(api, "round(histogram_quantile(0.999, "+histMetric, ret99)
-	mockRange(api, "round(sum(rate("+baseName+"_sum"+suffix+")) by (reporter) / sum(rate("+baseName+"_count"+suffix+")) by (reporter), 0.001)", retAvg)
+	mockRange(api, "round(sum(rate("+baseName+"_sum"+suffix+")) / sum(rate("+baseName+"_count"+suffix+")), 0.001)", retAvg)
 }
 
 func mockEmptyHistogram(api *PromAPIMock, baseName string, suffix string) {
-	histMetric := "sum(rate(" + baseName + "_bucket" + suffix + ")) by (le,reporter)), 0.001)"
+	histMetric := "sum(rate(" + baseName + "_bucket" + suffix + ")) by (le)), 0.001)"
 	mockEmptyRange(api, "round(histogram_quantile(0.5, "+histMetric)
 	mockEmptyRange(api, "round(histogram_quantile(0.95, "+histMetric)
 	mockEmptyRange(api, "round(histogram_quantile(0.99, "+histMetric)
 	mockEmptyRange(api, "round(histogram_quantile(0.999, "+histMetric)
-	mockEmptyRange(api, "round(sum(rate("+baseName+"_sum"+suffix+")) by (reporter) / sum(rate("+baseName+"_count"+suffix+")) by (reporter), 0.001)")
+	mockEmptyRange(api, "round(sum(rate("+baseName+"_sum"+suffix+")) / sum(rate("+baseName+"_count"+suffix+")), 0.001)")
 }
 
 func mockGetNamespace(k8s *kubetest.K8SClientMock, name string, creationTime time.Time) {

--- a/swagger.json
+++ b/swagger.json
@@ -595,16 +595,16 @@
             "type": "string",
             "default": "[]",
             "x-go-name": "Name",
-            "description": "List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsIn[]",
+            "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
+            "name": "byLabels[]",
             "in": "query"
           },
           {
             "type": "string",
-            "default": "[]",
+            "default": "outbound",
             "x-go-name": "Name",
-            "description": "List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsOut[]",
+            "description": "Traffic direction: 'inbound' or 'outbound'.",
+            "name": "direction",
             "in": "query"
           },
           {
@@ -649,8 +649,9 @@
           },
           {
             "type": "string",
+            "default": "source",
             "x-go-name": "Name",
-            "description": "Istio telemetry reporter: 'source' or 'destination'",
+            "description": "Istio telemetry reporter: 'source' or 'destination'.",
             "name": "reporter",
             "in": "query"
           },
@@ -1345,16 +1346,16 @@
             "type": "string",
             "default": "[]",
             "x-go-name": "Name",
-            "description": "List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsIn[]",
+            "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
+            "name": "byLabels[]",
             "in": "query"
           },
           {
             "type": "string",
-            "default": "[]",
+            "default": "outbound",
             "x-go-name": "Name",
-            "description": "List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsOut[]",
+            "description": "Traffic direction: 'inbound' or 'outbound'.",
+            "name": "direction",
             "in": "query"
           },
           {
@@ -1399,8 +1400,9 @@
           },
           {
             "type": "string",
+            "default": "source",
             "x-go-name": "Name",
-            "description": "Istio telemetry reporter: 'source' or 'destination'",
+            "description": "Istio telemetry reporter: 'source' or 'destination'.",
             "name": "reporter",
             "in": "query"
           },
@@ -1708,16 +1710,16 @@
             "type": "string",
             "default": "[]",
             "x-go-name": "Name",
-            "description": "List of labels to use for grouping inbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsIn[]",
+            "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
+            "name": "byLabels[]",
             "in": "query"
           },
           {
             "type": "string",
-            "default": "[]",
+            "default": "outbound",
             "x-go-name": "Name",
-            "description": "List of labels to use for grouping outbound metrics (via Prometheus 'by' clause).",
-            "name": "byLabelsOut[]",
+            "description": "Traffic direction: 'inbound' or 'outbound'.",
+            "name": "direction",
             "in": "query"
           },
           {
@@ -1762,8 +1764,9 @@
           },
           {
             "type": "string",
+            "default": "source",
             "x-go-name": "Name",
-            "description": "Istio telemetry reporter: 'source' or 'destination'",
+            "description": "Istio telemetry reporter: 'source' or 'destination'.",
             "name": "reporter",
             "in": "query"
           },
@@ -2466,14 +2469,22 @@
       "x-go-package": "github.com/kiali/kiali/prometheus"
     },
     "Metrics": {
-      "description": "Metrics contains all simple metrics and histograms data for both source and destination telemetry",
+      "description": "Metrics contains all simple metrics and histograms data",
       "type": "object",
       "properties": {
-        "dest": {
-          "$ref": "#/definitions/ReporterMetrics"
+        "histograms": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Histogram"
+          },
+          "x-go-name": "Histograms"
         },
-        "source": {
-          "$ref": "#/definitions/ReporterMetrics"
+        "metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Metric"
+          },
+          "x-go-name": "Metrics"
         }
       },
       "x-go-package": "github.com/kiali/kiali/prometheus"
@@ -2917,27 +2928,6 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
-    },
-    "ReporterMetrics": {
-      "description": "ReporterMetrics contains all simple metrics and histograms data for one reporter's telemetry",
-      "type": "object",
-      "properties": {
-        "histograms": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Histogram"
-          },
-          "x-go-name": "Histograms"
-        },
-        "metrics": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Metric"
-          },
-          "x-go-name": "Metrics"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/prometheus"
     },
     "RequestHealth": {
       "description": "RequestHealth holds several stats about recent request errors",


### PR DESCRIPTION
- Queries now must specify reporter and direction (in/out), avoiding to load much more metrics than necessary
- Response model is adapated, not providing reporter/direction anymore

This is removing from backend some of the business logic about reporter and direction

JIRA: https://issues.jboss.org/browse/KIALI-2086

Frontend PR required: https://github.com/kiali/kiali-ui/pull/871

** Backwards incompatible? **

- [x] Is your change introducing backwards incompatible changes?

Yes, metrics API changes, needs frontend PR