### PR TITLE
Fix server_test waiting 60s

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -120,7 +120,7 @@ func TestSecureComm(t *testing.T) {
 	noCredentials := &security.Credentials{}
 
 	// wait for our test http server to come up
-	checkHTTPReady(httpClient, serverURL)
+	checkHTTPReady(httpClient, serverURL+"/status")
 
 	// TEST WITH AN AUTHORIZED USER
 


### PR DESCRIPTION
Test is stuck for 60s in function "checkHTTPReady", because it gets an error when probing "/" URL (too many redirects).
Fixed by probing "/status".
