### PR TITLE
rename Config.Api -> Config.API

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -58,7 +58,7 @@ func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
 	}
 
 	result := namespaces
-	excludes := config.Get().Api.Namespaces.Exclude
+	excludes := config.Get().API.Namespaces.Exclude
 	if len(excludes) > 0 {
 		result = []models.Namespace{}
 	NAMESPACES:

--- a/config/config.go
+++ b/config/config.go
@@ -153,7 +153,7 @@ type Config struct {
 	IstioNamespace   string            `yaml:"istio_namespace,omitempty"`
 	IstioLabels      IstioLabels       `yaml:"istio_labels,omitempty"`
 	KubernetesConfig KubernetesConfig  `yaml:"kubernetes_config,omitempty"`
-	Api              ApiConfig         `yaml:"api,omitempty"`
+	API              ApiConfig         `yaml:"api,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -166,7 +166,7 @@ func NewConfig() (c *Config) {
 	c.IstioNamespace = strings.TrimSpace(getDefaultString(EnvIstioNamespace, "istio-system"))
 	c.IstioLabels.AppLabelName = strings.TrimSpace(getDefaultString(EnvIstioLabelNameApp, "app"))
 	c.IstioLabels.VersionLabelName = strings.TrimSpace(getDefaultString(EnvIstioLabelNameVersion, "version"))
-	c.Api.Namespaces.Exclude = getDefaultStringArray(EnvApiNamespacesExclude, "istio-operator,kube.*,openshift.*")
+	c.API.Namespaces.Exclude = getDefaultStringArray(EnvApiNamespacesExclude, "istio-operator,kube.*,openshift.*")
 
 	// Server configuration
 	c.Server.Address = strings.TrimSpace(getDefaultString(EnvServerAddress, ""))
@@ -212,7 +212,7 @@ func NewConfig() (c *Config) {
 	c.KubernetesConfig.CacheDuration = getDefaultInt64(EnvKubernetesCacheDuration, time.Duration(5*time.Minute).Nanoseconds())
 
 	trimmedExclusionPatterns := []string{}
-	for _, entry := range c.Api.Namespaces.Exclude {
+	for _, entry := range c.API.Namespaces.Exclude {
 		exclusionPattern := strings.TrimSpace(entry)
 		if _, err := regexp.Compile(exclusionPattern); err != nil {
 			log.Errorf("Invalid namespace exclude entry, [%s] is not a valid regex pattern: %v", exclusionPattern, err)
@@ -220,7 +220,7 @@ func NewConfig() (c *Config) {
 			trimmedExclusionPatterns = append(trimmedExclusionPatterns, strings.TrimSpace(exclusionPattern))
 		}
 	}
-	c.Api.Namespaces.Exclude = trimmedExclusionPatterns
+	c.API.Namespaces.Exclude = trimmedExclusionPatterns
 
 	return
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,14 +41,14 @@ func TestDefaults(t *testing.T) {
 		t.Error("server CORS default setting is wrong")
 	}
 
-	if len(conf.Api.Namespaces.Exclude) != 3 {
+	if len(conf.API.Namespaces.Exclude) != 3 {
 		t.Error("Api namespace exclude default setting is wrong")
 	} else {
 		// our default exclusion list: istio-operator,kube.*,openshift.*
-		if conf.Api.Namespaces.Exclude[0] != "istio-operator" ||
-			conf.Api.Namespaces.Exclude[1] != "kube.*" ||
-			conf.Api.Namespaces.Exclude[2] != "openshift.*" {
-			t.Errorf("Api namespace exclude default list is wrong: %+v", conf.Api.Namespaces.Exclude)
+		if conf.API.Namespaces.Exclude[0] != "istio-operator" ||
+			conf.API.Namespaces.Exclude[1] != "kube.*" ||
+			conf.API.Namespaces.Exclude[2] != "openshift.*" {
+			t.Errorf("Api namespace exclude default list is wrong: %+v", conf.API.Namespaces.Exclude)
 		}
 	}
 }
@@ -78,7 +78,7 @@ func TestMarshalUnmarshalStaticContentRootDirectory(t *testing.T) {
 
 func TestMarshalUnmarshalApiConfig(t *testing.T) {
 	testConf := Config{
-		Api: ApiConfig{
+		API: ApiConfig{
 			Namespaces: ApiNamespacesConfig{
 				Exclude: []string{"istio-operator", "kube.*"},
 			},
@@ -96,8 +96,8 @@ func TestMarshalUnmarshalApiConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to unmarshal: %v", err)
 	}
-	if len(conf.Api.Namespaces.Exclude) != 2 {
-		t.Errorf("Failed to unmarshal Api:\n%+v", conf.Api)
+	if len(conf.API.Namespaces.Exclude) != 2 {
+		t.Errorf("Failed to unmarshal Api:\n%+v", conf.API)
 	}
 }
 


### PR DESCRIPTION
I was starting to go through the kiali code and noticed some of it doesn't line up with some basic go linting.  I am volunteering to go through the code and clean it up a bit... This will be the first of many PR's if you are interested. 

** Issue reference **
n/a

** Backwards incompatible? **
Yes
