### PR TITLE
exclude ibm namespaces

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -166,7 +166,7 @@ func NewConfig() (c *Config) {
 	c.IstioNamespace = strings.TrimSpace(getDefaultString(EnvIstioNamespace, "istio-system"))
 	c.IstioLabels.AppLabelName = strings.TrimSpace(getDefaultString(EnvIstioLabelNameApp, "app"))
 	c.IstioLabels.VersionLabelName = strings.TrimSpace(getDefaultString(EnvIstioLabelNameVersion, "version"))
-	c.Api.Namespaces.Exclude = getDefaultStringArray(EnvApiNamespacesExclude, "istio-operator,kube.*,openshift.*")
+	c.Api.Namespaces.Exclude = getDefaultStringArray(EnvApiNamespacesExclude, "istio-operator,kube.*,openshift.*,ibm.*")
 
 	// Server configuration
 	c.Server.Address = strings.TrimSpace(getDefaultString(EnvServerAddress, ""))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,10 +44,11 @@ func TestDefaults(t *testing.T) {
 	if len(conf.Api.Namespaces.Exclude) != 3 {
 		t.Error("Api namespace exclude default setting is wrong")
 	} else {
-		// our default exclusion list: istio-operator,kube.*,openshift.*
+		// our default exclusion list: istio-operator,kube.*,openshift.*,ibm.*
 		if conf.Api.Namespaces.Exclude[0] != "istio-operator" ||
 			conf.Api.Namespaces.Exclude[1] != "kube.*" ||
-			conf.Api.Namespaces.Exclude[2] != "openshift.*" {
+			conf.Api.Namespaces.Exclude[2] != "openshift.*" ||
+			conf.Api.Namespaces.Exclude[3] != "ibm.*" {
 			t.Errorf("Api namespace exclude default list is wrong: %+v", conf.Api.Namespaces.Exclude)
 		}
 	}


### PR DESCRIPTION
** Describe the change **
This PR excludes ibm vendor namespaces from kiali.  I am assuming other vendor's will want to do this as well so I am more than happy to modify the logic a bit to make it easier for vendors to exclude their namespaces

** Backwards incompatible? **
Yes
