### PR TITLE
KIALI-1974 Load custom metrics & dashboard

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -49,7 +49,7 @@ func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, 
 		go func(idx int, chart kubernetes.MonitoringDashboardChart) {
 			defer wg.Done()
 			filledCharts[idx] = models.ConvertChart(chart)
-			if chart.MetricType == "counter" {
+			if chart.MetricType == kubernetes.Counter {
 				filledCharts[idx].CounterRate = in.prom.FetchRateRange(chart.MetricName, labels, grouping, &params.BaseMetricsQuery)
 			} else {
 				filledCharts[idx].Histogram = in.prom.FetchHistogramRange(chart.MetricName, labels, grouping, &params.BaseMetricsQuery)

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -1,0 +1,59 @@
+package business
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus"
+)
+
+// DashboardsService deals with fetching dashboards from k8s client
+type DashboardsService struct {
+	prom prometheus.ClientInterface
+	mon  *kubernetes.KialiMonitoringClient
+}
+
+// NewDashboardsService initializes this business service
+func NewDashboardsService(mon *kubernetes.KialiMonitoringClient, prom prometheus.ClientInterface) DashboardsService {
+	return DashboardsService{prom: prom, mon: mon}
+}
+
+// GetDashboard returns a dashboard filled-in with target data
+func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, template string) (*models.MonitoringDashboard, error) {
+	dashboard, err := in.mon.GetDashboard(params.Namespace, template)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := fmt.Sprintf(`{namespace="%s",app="%s"`, params.Namespace, params.App)
+	if params.Version != "" {
+		labels += fmt.Sprintf(`,version="%s"`, params.Version)
+	}
+	labels += "}"
+	grouping := strings.Join(params.ByLabels, ",")
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(dashboard.Spec.Charts))
+	filledCharts := make([]models.Chart, len(dashboard.Spec.Charts))
+
+	for i, c := range dashboard.Spec.Charts {
+		go func(idx int, chart kubernetes.MonitoringDashboardChart) {
+			defer wg.Done()
+			filledCharts[idx] = models.ConvertChart(chart)
+			if chart.MetricType == "counter" {
+				filledCharts[idx].CounterRate = in.prom.FetchRateRange(chart.MetricName, labels, grouping, &params.BaseMetricsQuery)
+			} else {
+				filledCharts[idx].Histogram = in.prom.FetchHistogramRange(chart.MetricName, labels, grouping, &params.BaseMetricsQuery)
+			}
+		}(i, c)
+	}
+
+	wg.Wait()
+	return &models.MonitoringDashboard{
+		Title:  dashboard.Spec.Title,
+		Charts: filledCharts,
+	}, nil
+}

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
@@ -13,11 +14,11 @@ import (
 // DashboardsService deals with fetching dashboards from k8s client
 type DashboardsService struct {
 	prom prometheus.ClientInterface
-	mon  *kubernetes.KialiMonitoringClient
+	mon  kubernetes.KialiMonitoringInterface
 }
 
 // NewDashboardsService initializes this business service
-func NewDashboardsService(mon *kubernetes.KialiMonitoringClient, prom prometheus.ClientInterface) DashboardsService {
+func NewDashboardsService(mon kubernetes.KialiMonitoringInterface, prom prometheus.ClientInterface) DashboardsService {
 	return DashboardsService{prom: prom, mon: mon}
 }
 
@@ -25,7 +26,12 @@ func NewDashboardsService(mon *kubernetes.KialiMonitoringClient, prom prometheus
 func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, template string) (*models.MonitoringDashboard, error) {
 	dashboard, err := in.mon.GetDashboard(params.Namespace, template)
 	if err != nil {
-		return nil, err
+		// Dashboard might be in Kiali namespace
+		cfg := config.Get()
+		dashboard, err = in.mon.GetDashboard(cfg.IstioNamespace, template)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	labels := fmt.Sprintf(`{namespace="%s",app="%s"`, params.Namespace, params.App)
@@ -53,7 +59,90 @@ func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, 
 
 	wg.Wait()
 	return &models.MonitoringDashboard{
-		Title:  dashboard.Spec.Title,
-		Charts: filledCharts,
+		Title:        dashboard.Spec.Title,
+		Charts:       filledCharts,
+		Aggregations: models.ConvertAggregations(dashboard.Spec),
 	}, nil
+}
+
+type istioChart struct {
+	models.Chart
+	refName string
+}
+
+var istioCharts = []istioChart{
+	istioChart{
+		Chart: models.Chart{
+			Name:  "Request volume",
+			Unit:  "ops",
+			Spans: 12,
+		},
+		refName: "request_count",
+	},
+	istioChart{
+		Chart: models.Chart{
+			Name:  "Request duration",
+			Unit:  "s",
+			Spans: 12,
+		},
+		refName: "request_duration",
+	},
+	istioChart{
+		Chart: models.Chart{
+			Name:  "Request size",
+			Unit:  "B",
+			Spans: 12,
+		},
+		refName: "request_size",
+	},
+	istioChart{
+		Chart: models.Chart{
+			Name:  "Response size",
+			Unit:  "B",
+			Spans: 12,
+		},
+		refName: "response_size",
+	},
+	istioChart{
+		Chart: models.Chart{
+			Name:  "TCP received",
+			Unit:  "bps",
+			Spans: 12,
+		},
+		refName: "tcp_received",
+	},
+	istioChart{
+		Chart: models.Chart{
+			Name:  "TCP sent",
+			Unit:  "bps",
+			Spans: 12,
+		},
+		refName: "tcp_sent",
+	},
+}
+
+// GetIstioDashboard returns Istio dashboard (currently hard-coded) filled-in with metrics
+func (in *DashboardsService) GetIstioDashboard(params prometheus.IstioMetricsQuery) (*models.MonitoringDashboard, error) {
+	var dashboard models.MonitoringDashboard
+	// Copy dashboard
+	if params.Direction == "inbound" {
+		dashboard = models.PrepareIstioDashboard("Inbound", "destination", "source")
+	} else {
+		dashboard = models.PrepareIstioDashboard("Outbound", "source", "destination")
+	}
+
+	metrics := in.prom.GetMetrics(&params)
+
+	for _, chartTpl := range istioCharts {
+		newChart := chartTpl.Chart
+		if metric, ok := metrics.Metrics[chartTpl.refName]; ok {
+			newChart.CounterRate = metric
+		}
+		if histo, ok := metrics.Histograms[chartTpl.refName]; ok {
+			newChart.Histogram = histo
+		}
+		dashboard.Charts = append(dashboard.Charts, newChart)
+	}
+
+	return &dashboard, nil
 }

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -24,9 +24,11 @@ func NewDashboardsService(mon kubernetes.KialiMonitoringInterface, prom promethe
 
 // GetDashboard returns a dashboard filled-in with target data
 func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, template string) (*models.MonitoringDashboard, error) {
+	// There is an override mechanism with dashboards: default dashboards can be provided in Kiali namespace,
+	// and can be overriden in app namespace.
+	// So we look for the one in app namespace first, and only if not found fallback to the one in istio-system.
 	dashboard, err := in.mon.GetDashboard(params.Namespace, template)
 	if err != nil {
-		// Dashboard might be in Kiali namespace
 		cfg := config.Get()
 		dashboard, err = in.mon.GetDashboard(cfg.IstioNamespace, template)
 		if err != nil {
@@ -71,7 +73,7 @@ type istioChart struct {
 }
 
 var istioCharts = []istioChart{
-	istioChart{
+	{
 		Chart: models.Chart{
 			Name:  "Request volume",
 			Unit:  "ops",
@@ -79,7 +81,7 @@ var istioCharts = []istioChart{
 		},
 		refName: "request_count",
 	},
-	istioChart{
+	{
 		Chart: models.Chart{
 			Name:  "Request duration",
 			Unit:  "s",
@@ -87,7 +89,7 @@ var istioCharts = []istioChart{
 		},
 		refName: "request_duration",
 	},
-	istioChart{
+	{
 		Chart: models.Chart{
 			Name:  "Request size",
 			Unit:  "B",
@@ -95,7 +97,7 @@ var istioCharts = []istioChart{
 		},
 		refName: "request_size",
 	},
-	istioChart{
+	{
 		Chart: models.Chart{
 			Name:  "Response size",
 			Unit:  "B",
@@ -103,7 +105,7 @@ var istioCharts = []istioChart{
 		},
 		refName: "response_size",
 	},
-	istioChart{
+	{
 		Chart: models.Chart{
 			Name:  "TCP received",
 			Unit:  "bps",
@@ -111,7 +113,7 @@ var istioCharts = []istioChart{
 		},
 		refName: "tcp_received",
 	},
-	istioChart{
+	{
 		Chart: models.Chart{
 			Name:  "TCP sent",
 			Unit:  "bps",

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -1,0 +1,142 @@
+package business
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/prometheustest"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type k8sKialiMonitoringClientMock struct {
+	mock.Mock
+}
+
+func (o *k8sKialiMonitoringClientMock) GetDashboard(namespace string, name string) (*kubernetes.MonitoringDashboard, error) {
+	args := o.Called(namespace, name)
+	if args.Error(1) != nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*kubernetes.MonitoringDashboard), nil
+}
+
+func TestGetDashboard(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	k8s := new(k8sKialiMonitoringClientMock)
+	prom := new(prometheustest.PromClientMock)
+	conf := config.NewConfig()
+	config.Set(conf)
+	service := NewDashboardsService(k8s, prom)
+	k8s.On("GetDashboard", "my-namespace", "dashboard1").Return(fakeDashboard("1"), nil)
+
+	expectedLabels := "{namespace=\"my-namespace\",app=\"my-app\"}"
+	query := prometheus.CustomMetricsQuery{
+		Namespace: "my-namespace",
+		App:       "my-app",
+	}
+	query.FillDefaults()
+	prom.On("FetchRateRange", "my_metric_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter())
+	prom.On("FetchHistogramRange", "my_metric_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram())
+
+	dashboard, err := service.GetDashboard(query, "dashboard1")
+
+	assert.Nil(err)
+	k8s.AssertNumberOfCalls(t, "GetDashboard", 1)
+	assert.Equal("Dashboard 1", dashboard.Title)
+	assert.Len(dashboard.Aggregations, 2)
+	assert.Len(dashboard.Charts, 2)
+	assert.Equal("My chart 1", dashboard.Charts[0].Name)
+	assert.Equal("My chart 2", dashboard.Charts[1].Name)
+	assert.Nil(dashboard.Charts[0].Histogram)
+	assert.Nil(dashboard.Charts[1].CounterRate)
+	assert.Equal(model.SampleValue(10), dashboard.Charts[0].CounterRate.Matrix[0].Values[0].Value)
+	assert.Equal(model.SampleValue(10), dashboard.Charts[1].Histogram["avg"].Matrix[0].Values[0].Value)
+}
+
+func TestGetDashboardFromKialiNamespace(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	k8s := new(k8sKialiMonitoringClientMock)
+	prom := new(prometheustest.PromClientMock)
+	conf := config.NewConfig()
+	config.Set(conf)
+	service := NewDashboardsService(k8s, prom)
+	k8s.On("GetDashboard", "my-namespace", "dashboard1").Return(nil, errors.New("denied"))
+	k8s.On("GetDashboard", "istio-system", "dashboard1").Return(fakeDashboard("1"), nil)
+
+	expectedLabels := "{namespace=\"my-namespace\",app=\"my-app\"}"
+	query := prometheus.CustomMetricsQuery{
+		Namespace: "my-namespace",
+		App:       "my-app",
+	}
+	query.FillDefaults()
+	prom.On("FetchRateRange", "my_metric_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter())
+	prom.On("FetchHistogramRange", "my_metric_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram())
+
+	dashboard, err := service.GetDashboard(query, "dashboard1")
+
+	assert.Nil(err)
+	k8s.AssertNumberOfCalls(t, "GetDashboard", 2)
+	assert.Equal("Dashboard 1", dashboard.Title)
+}
+
+func fakeCounter() *prometheus.Metric {
+	return &prometheus.Metric{
+		Matrix: model.Matrix{
+			&model.SampleStream{
+				Metric: model.Metric{},
+				Values: []model.SamplePair{model.SamplePair{Timestamp: 0, Value: 10}},
+			},
+		},
+	}
+}
+
+func fakeHistogram() prometheus.Histogram {
+	return prometheus.Histogram{
+		"avg": fakeCounter(),
+	}
+}
+
+func fakeDashboard(id string) *kubernetes.MonitoringDashboard {
+	return &kubernetes.MonitoringDashboard{
+		Spec: kubernetes.MonitoringDashboardSpec{
+			Title: "Dashboard " + id,
+			Charts: []kubernetes.MonitoringDashboardChart{
+				kubernetes.MonitoringDashboardChart{
+					Name:       "My chart 1",
+					Unit:       "s",
+					Spans:      6,
+					MetricName: "my_metric_1",
+					MetricType: "counter",
+					Aggregations: []kubernetes.MonitoringDashboardAggregation{
+						kubernetes.MonitoringDashboardAggregation{
+							DisplayName: "Agg 1",
+							Label:       "agg_1",
+						},
+					},
+				},
+				kubernetes.MonitoringDashboardChart{
+					Name:       "My chart 2",
+					Unit:       "s",
+					Spans:      6,
+					MetricName: "my_metric_2",
+					MetricType: "histogram",
+					Aggregations: []kubernetes.MonitoringDashboardAggregation{
+						kubernetes.MonitoringDashboardAggregation{
+							DisplayName: "Agg 2",
+							Label:       "agg_2",
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -42,8 +42,8 @@ func TestGetDashboard(t *testing.T) {
 		App:       "my-app",
 	}
 	query.FillDefaults()
-	prom.On("FetchRateRange", "my_metric_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter())
-	prom.On("FetchHistogramRange", "my_metric_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram())
+	prom.On("FetchRateRange", "my_metric_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter(10))
+	prom.On("FetchHistogramRange", "my_metric_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram(11))
 
 	dashboard, err := service.GetDashboard(query, "dashboard1")
 
@@ -57,7 +57,7 @@ func TestGetDashboard(t *testing.T) {
 	assert.Nil(dashboard.Charts[0].Histogram)
 	assert.Nil(dashboard.Charts[1].CounterRate)
 	assert.Equal(model.SampleValue(10), dashboard.Charts[0].CounterRate.Matrix[0].Values[0].Value)
-	assert.Equal(model.SampleValue(10), dashboard.Charts[1].Histogram["avg"].Matrix[0].Values[0].Value)
+	assert.Equal(model.SampleValue(11), dashboard.Charts[1].Histogram["avg"].Matrix[0].Values[0].Value)
 }
 
 func TestGetDashboardFromKialiNamespace(t *testing.T) {
@@ -78,8 +78,8 @@ func TestGetDashboardFromKialiNamespace(t *testing.T) {
 		App:       "my-app",
 	}
 	query.FillDefaults()
-	prom.On("FetchRateRange", "my_metric_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter())
-	prom.On("FetchHistogramRange", "my_metric_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram())
+	prom.On("FetchRateRange", "my_metric_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter(10))
+	prom.On("FetchHistogramRange", "my_metric_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram(11))
 
 	dashboard, err := service.GetDashboard(query, "dashboard1")
 
@@ -88,20 +88,57 @@ func TestGetDashboardFromKialiNamespace(t *testing.T) {
 	assert.Equal("Dashboard 1", dashboard.Title)
 }
 
-func fakeCounter() *prometheus.Metric {
+func TestGetIstioDashboard(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup mocks
+	prom := new(prometheustest.PromClientMock)
+	conf := config.NewConfig()
+	config.Set(conf)
+	service := NewDashboardsService(nil, prom)
+
+	query := prometheus.IstioMetricsQuery{
+		Namespace: "my-namespace",
+		App:       "my-app",
+	}
+	query.FillDefaults()
+	query.Direction = "inbound"
+	prom.On("GetMetrics", &query).Return(fakeMetrics())
+
+	dashboard, err := service.GetIstioDashboard(query)
+
+	assert.Nil(err)
+	assert.Equal("Inbound Metrics", dashboard.Title)
+	assert.Len(dashboard.Aggregations, 4)
+	assert.Equal("Local version", dashboard.Aggregations[0].DisplayName)
+	assert.Equal("destination_version", dashboard.Aggregations[0].Label)
+	assert.Equal("Remote app", dashboard.Aggregations[1].DisplayName)
+	assert.Equal("source_app", dashboard.Aggregations[1].Label)
+	assert.Len(dashboard.Charts, 6)
+	assert.Equal("Request volume", dashboard.Charts[0].Name)
+	assert.Equal("Request duration", dashboard.Charts[1].Name)
+	assert.Equal("TCP sent", dashboard.Charts[5].Name)
+	assert.Nil(dashboard.Charts[0].Histogram)
+	assert.Nil(dashboard.Charts[1].CounterRate)
+	assert.Equal(model.SampleValue(10), dashboard.Charts[0].CounterRate.Matrix[0].Values[0].Value)
+	assert.Equal(model.SampleValue(20), dashboard.Charts[1].Histogram["avg"].Matrix[0].Values[0].Value)
+	assert.Equal(model.SampleValue(13), dashboard.Charts[5].CounterRate.Matrix[0].Values[0].Value)
+}
+
+func fakeCounter(value int) *prometheus.Metric {
 	return &prometheus.Metric{
 		Matrix: model.Matrix{
 			&model.SampleStream{
 				Metric: model.Metric{},
-				Values: []model.SamplePair{model.SamplePair{Timestamp: 0, Value: 10}},
+				Values: []model.SamplePair{model.SamplePair{Timestamp: 0, Value: model.SampleValue(value)}},
 			},
 		},
 	}
 }
 
-func fakeHistogram() prometheus.Histogram {
+func fakeHistogram(avg int) prometheus.Histogram {
 	return prometheus.Histogram{
-		"avg": fakeCounter(),
+		"avg": fakeCounter(avg),
 	}
 }
 
@@ -137,6 +174,22 @@ func fakeDashboard(id string) *kubernetes.MonitoringDashboard {
 					},
 				},
 			},
+		},
+	}
+}
+
+func fakeMetrics() prometheus.Metrics {
+	return prometheus.Metrics{
+		Metrics: map[string]*prometheus.Metric{
+			"request_count":       fakeCounter(10),
+			"request_error_count": fakeCounter(11),
+			"tcp_received":        fakeCounter(12),
+			"tcp_sent":            fakeCounter(13),
+		},
+		Histograms: map[string]prometheus.Histogram{
+			"request_duration": fakeHistogram(20),
+			"request_size":     fakeHistogram(21),
+			"response_size":    fakeHistogram(22),
 		},
 	}
 }

--- a/deploy/dashboards/vertx.yaml
+++ b/deploy/dashboards/vertx.yaml
@@ -13,7 +13,15 @@ spec:
       aggregations:
         - label: "path"
           displayName: "Path"
-    - name: "Request count rate"
+    - name: "Client response time"
+      unit: "s"
+      spans: 6
+      metricName: "vertx_http_client_responseTime_seconds"
+      metricType: "histogram"
+      aggregations:
+        - label: "path"
+          displayName: "Path"
+    - name: "Server request count rate"
       unit: "ops"
       spans: 6
       metricName: "vertx_http_server_requestCount_total"

--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,7 @@ import (
 // - keep this alphabetized
 /////////////////////
 
-// swagger:parameters appMetrics appDetails graphApp graphAppVersion customMetrics
+// swagger:parameters appMetrics appDetails graphApp graphAppVersion customDashboard
 type AppParam struct {
 	// The app name (label value).
 	//
@@ -31,7 +31,7 @@ type AppVersionParam struct {
 	Name string `json:"version"`
 }
 
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customMetrics
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard
 type NamespaceParam struct {
 	// The namespace id.
 	//
@@ -77,7 +77,7 @@ type ServiceParam struct {
 	Name string `json:"service"`
 }
 
-// swagger:parameters customMetrics
+// swagger:parameters customDashboard
 type TemplateParam struct {
 	// The dashboard template name.
 	//
@@ -174,7 +174,7 @@ type QueryTimeParam struct {
 // - keep this alphabetized
 /////////////////////
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
 type AvgParam struct {
 	// Flag for fetching histogram average. Default is true.
 	//
@@ -184,7 +184,7 @@ type AvgParam struct {
 	Name string `json:"avg"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
 type ByLabelsParam struct {
 	// List of labels to use for grouping metrics (via Prometheus 'by' clause).
 	//
@@ -204,7 +204,7 @@ type DirectionParam struct {
 	Name string `json:"direction"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
 type DurationParam struct {
 	// Duration of the query period, in seconds.
 	//
@@ -224,7 +224,7 @@ type FiltersParam struct {
 	Name string `json:"filters[]"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
 type QuantilesParam struct {
 	// List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].
 	//
@@ -234,7 +234,7 @@ type QuantilesParam struct {
 	Name string `json:"quantiles[]"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
 type RateFuncParam struct {
 	// Prometheus function used to calculate rate: 'rate' or 'irate'.
 	//
@@ -244,7 +244,7 @@ type RateFuncParam struct {
 	Name string `json:"rateFunc"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
 type RateIntervalParam struct {
 	// Interval used for rate and histogram calculation.
 	//
@@ -264,7 +264,7 @@ type ReporterParam struct {
 	Name string `json:"reporter"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
 type StepParam struct {
 	// Step between [graph] datapoints, in seconds.
 	//
@@ -274,7 +274,7 @@ type StepParam struct {
 	Name string `json:"step"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
 type VersionParam struct {
 	// Filters metrics by the specified version.
 	//
@@ -475,11 +475,18 @@ type WorkloadDetailsResponse struct {
 	Body models.Workload
 }
 
-// Listing all the information related to a service
+// Metrics response model
 // swagger:response metricsResponse
 type MetricsResponse struct {
 	// in:body
 	Body prometheus.Metrics
+}
+
+// Dashboard response model
+// swagger:response dashboardResponse
+type DashboardResponse struct {
+	// in:body
+	Body models.MonitoringDashboard
 }
 
 // IstioConfig details of an specific Istio Object

--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,7 @@ import (
 // - keep this alphabetized
 /////////////////////
 
-// swagger:parameters appMetrics appDetails graphApp graphAppVersion customDashboard
+// swagger:parameters appMetrics appDetails graphApp graphAppVersion appDashboard customDashboard
 type AppParam struct {
 	// The app name (label value).
 	//
@@ -31,7 +31,7 @@ type AppVersionParam struct {
 	Name string `json:"version"`
 }
 
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard
 type NamespaceParam struct {
 	// The namespace id.
 	//
@@ -68,7 +68,7 @@ type ObjectSubtypeParam struct {
 	Name string `json:"object_subtype"`
 }
 
-// swagger:parameters serviceValidations serviceDetails serviceMetrics graphService
+// swagger:parameters serviceValidations serviceDetails serviceMetrics graphService serviceDashboard
 type ServiceParam struct {
 	// The service name.
 	//
@@ -86,7 +86,7 @@ type TemplateParam struct {
 	Name string `json:"template"`
 }
 
-// swagger:parameters workloadDetails workloadValidations workloadMetrics graphWorkload
+// swagger:parameters workloadDetails workloadValidations workloadMetrics graphWorkload workloadDashboard
 type WorkloadParam struct {
 	// The workload name.
 	//
@@ -174,7 +174,7 @@ type QueryTimeParam struct {
 // - keep this alphabetized
 /////////////////////
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard appDashboard serviceDashboard workloadDashboard
 type AvgParam struct {
 	// Flag for fetching histogram average. Default is true.
 	//
@@ -184,7 +184,7 @@ type AvgParam struct {
 	Name string `json:"avg"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard appDashboard serviceDashboard workloadDashboard
 type ByLabelsParam struct {
 	// List of labels to use for grouping metrics (via Prometheus 'by' clause).
 	//
@@ -194,7 +194,7 @@ type ByLabelsParam struct {
 	Name string `json:"byLabels[]"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics appDashboard serviceDashboard workloadDashboard
 type DirectionParam struct {
 	// Traffic direction: 'inbound' or 'outbound'.
 	//
@@ -204,7 +204,7 @@ type DirectionParam struct {
 	Name string `json:"direction"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard appDashboard serviceDashboard workloadDashboard
 type DurationParam struct {
 	// Duration of the query period, in seconds.
 	//
@@ -224,7 +224,7 @@ type FiltersParam struct {
 	Name string `json:"filters[]"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard appDashboard serviceDashboard workloadDashboard
 type QuantilesParam struct {
 	// List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].
 	//
@@ -234,7 +234,7 @@ type QuantilesParam struct {
 	Name string `json:"quantiles[]"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard appDashboard serviceDashboard workloadDashboard
 type RateFuncParam struct {
 	// Prometheus function used to calculate rate: 'rate' or 'irate'.
 	//
@@ -244,7 +244,7 @@ type RateFuncParam struct {
 	Name string `json:"rateFunc"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard appDashboard serviceDashboard workloadDashboard
 type RateIntervalParam struct {
 	// Interval used for rate and histogram calculation.
 	//
@@ -254,7 +254,7 @@ type RateIntervalParam struct {
 	Name string `json:"rateInterval"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics appDashboard serviceDashboard workloadDashboard
 type ReporterParam struct {
 	// Istio telemetry reporter: 'source' or 'destination'.
 	//
@@ -264,7 +264,7 @@ type ReporterParam struct {
 	Name string `json:"reporter"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customDashboard appDashboard serviceDashboard workloadDashboard
 type StepParam struct {
 	// Step between [graph] datapoints, in seconds.
 	//

--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,7 @@ import (
 // - keep this alphabetized
 /////////////////////
 
-// swagger:parameters appMetrics appDetails graphApp graphAppVersion
+// swagger:parameters appMetrics appDetails graphApp graphAppVersion customMetrics
 type AppParam struct {
 	// The app name (label value).
 	//
@@ -31,7 +31,7 @@ type AppVersionParam struct {
 	Name string `json:"version"`
 }
 
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics
+// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customMetrics
 type NamespaceParam struct {
 	// The namespace id.
 	//
@@ -75,6 +75,15 @@ type ServiceParam struct {
 	// in: path
 	// required: true
 	Name string `json:"service"`
+}
+
+// swagger:parameters customMetrics
+type TemplateParam struct {
+	// The dashboard template name.
+	//
+	// in: path
+	// required: true
+	Name string `json:"template"`
 }
 
 // swagger:parameters workloadDetails workloadValidations workloadMetrics graphWorkload
@@ -165,7 +174,7 @@ type QueryTimeParam struct {
 // - keep this alphabetized
 /////////////////////
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
 type AvgParam struct {
 	// Flag for fetching histogram average. Default is true.
 	//
@@ -175,7 +184,7 @@ type AvgParam struct {
 	Name string `json:"avg"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
 type ByLabelsParam struct {
 	// List of labels to use for grouping metrics (via Prometheus 'by' clause).
 	//
@@ -195,7 +204,7 @@ type DirectionParam struct {
 	Name string `json:"direction"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
 type DurationParam struct {
 	// Duration of the query period, in seconds.
 	//
@@ -215,7 +224,7 @@ type FiltersParam struct {
 	Name string `json:"filters[]"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
 type QuantilesParam struct {
 	// List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].
 	//
@@ -225,7 +234,7 @@ type QuantilesParam struct {
 	Name string `json:"quantiles[]"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
 type RateFuncParam struct {
 	// Prometheus function used to calculate rate: 'rate' or 'irate'.
 	//
@@ -235,7 +244,7 @@ type RateFuncParam struct {
 	Name string `json:"rateFunc"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
 type RateIntervalParam struct {
 	// Interval used for rate and histogram calculation.
 	//
@@ -255,7 +264,7 @@ type ReporterParam struct {
 	Name string `json:"reporter"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
 type StepParam struct {
 	// Step between [graph] datapoints, in seconds.
 	//
@@ -265,7 +274,7 @@ type StepParam struct {
 	Name string `json:"step"`
 }
 
-// swagger:parameters serviceMetrics appMetrics workloadMetrics
+// swagger:parameters serviceMetrics appMetrics workloadMetrics customMetrics
 type VersionParam struct {
 	// Filters metrics by the specified version.
 	//

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -13,9 +14,28 @@ import (
 	"github.com/kiali/kiali/util"
 )
 
-func extractMetricsQueryParams(r *http.Request, q *prometheus.MetricsQuery, namespaceInfo *models.Namespace) error {
+func extractIstioMetricsQueryParams(r *http.Request, q *prometheus.IstioMetricsQuery, namespaceInfo *models.Namespace) error {
 	q.FillDefaults()
 	queryParams := r.URL.Query()
+	if filters, ok := queryParams["filters[]"]; ok && len(filters) > 0 {
+		q.Filters = filters
+	}
+	dir := queryParams.Get("direction")
+	if dir != "" {
+		q.Direction = dir
+	}
+	q.Reporter = queryParams.Get("reporter")
+	return extractBaseMetricsQueryParams(queryParams, &q.BaseMetricsQuery, namespaceInfo)
+}
+
+func extractCustomMetricsQueryParams(r *http.Request, q *prometheus.CustomMetricsQuery, namespaceInfo *models.Namespace) error {
+	q.FillDefaults()
+	queryParams := r.URL.Query()
+	q.Version = queryParams.Get("version")
+	return extractBaseMetricsQueryParams(queryParams, &q.BaseMetricsQuery, namespaceInfo)
+}
+
+func extractBaseMetricsQueryParams(queryParams url.Values, q *prometheus.BaseMetricsQuery, namespaceInfo *models.Namespace) error {
 	if rateIntervals, ok := queryParams["rateInterval"]; ok && len(rateIntervals) > 0 {
 		// Only first is taken into consideration
 		q.RateInterval = rateIntervals[0]
@@ -52,9 +72,6 @@ func extractMetricsQueryParams(r *http.Request, q *prometheus.MetricsQuery, name
 			// Bad request
 			return errors.New("Bad request, cannot parse query parameter 'step'")
 		}
-	}
-	if filters, ok := queryParams["filters[]"]; ok && len(filters) > 0 {
-		q.Filters = filters
 	}
 	if quantiles, ok := queryParams["quantiles[]"]; ok && len(quantiles) > 0 {
 		for _, quantile := range quantiles {
@@ -117,7 +134,7 @@ func extractMetricsQueryParams(r *http.Request, q *prometheus.MetricsQuery, name
 			// This means that the query range does not fall in the range
 			// of life of the namespace. So, there are no metrics to query.
 			log.Debugf("[extractMetricsQueryParams] Query end time = %v; not querying metrics.", q.End)
-			return errors.New("after checks, query start time is after end time")
+			return errors.New("After checks, query start time is after end time")
 		}
 	}
 

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -22,9 +22,18 @@ func extractIstioMetricsQueryParams(r *http.Request, q *prometheus.IstioMetricsQ
 	}
 	dir := queryParams.Get("direction")
 	if dir != "" {
+		if dir != "inbound" && dir != "outbound" {
+			return errors.New("Bad request, query parameter 'direction' must be either 'inbound' or 'outbound'")
+		}
 		q.Direction = dir
 	}
-	q.Reporter = queryParams.Get("reporter")
+	reporter := queryParams.Get("reporter")
+	if reporter != "" {
+		if reporter != "source" && reporter != "destination" {
+			return errors.New("Bad request, query parameter 'reporter' must be either 'source' or 'destination'")
+		}
+		q.Reporter = reporter
+	}
 	return extractBaseMetricsQueryParams(queryParams, &q.BaseMetricsQuery, namespaceInfo)
 }
 
@@ -96,20 +105,6 @@ func extractBaseMetricsQueryParams(queryParams url.Values, q *prometheus.BaseMet
 	}
 	if lbls, ok := queryParams["byLabels[]"]; ok && len(lbls) > 0 {
 		q.ByLabels = lbls
-	}
-	dir := queryParams.Get("direction")
-	if dir != "" {
-		if dir != "inbound" && dir != "outbound" {
-			return errors.New("Bad request, query parameter 'direction' must be either 'inbound' or 'outbound'")
-		}
-		q.Direction = dir
-	}
-	reporter := queryParams.Get("reporter")
-	if reporter != "" {
-		if reporter != "source" && reporter != "destination" {
-			return errors.New("Bad request, query parameter 'reporter' must be either 'source' or 'destination'")
-		}
-		q.Reporter = reporter
 	}
 
 	// If needed, adjust interval -- Make sure query won't fetch data before the namespace creation

--- a/handlers/metrics_test.go
+++ b/handlers/metrics_test.go
@@ -27,8 +27,8 @@ func TestExtractMetricsQueryParams(t *testing.T) {
 	q.Add("filters[]", "request_size")
 	req.URL.RawQuery = q.Encode()
 
-	mq := prometheus.MetricsQuery{Namespace: "ns"}
-	err = extractMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
+	mq := prometheus.IstioMetricsQuery{Namespace: "ns"}
+	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,8 +58,8 @@ func TestExtractMetricsQueryParamsStepLimitCase(t *testing.T) {
 	q.Add("duration", "1000")        // Makes start = 2018-04-10T12:24:20
 	req.URL.RawQuery = q.Encode()
 
-	mq := prometheus.MetricsQuery{Namespace: "ns"}
-	err = extractMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
+	mq := prometheus.IstioMetricsQuery{Namespace: "ns"}
+	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,8 +83,8 @@ func TestExtractMetricsQueryIntervalBoundary(t *testing.T) {
 	q.Add("rateInterval", "35m")
 	req.URL.RawQuery = q.Encode()
 
-	mq := prometheus.MetricsQuery{Namespace: "ns"}
-	err = extractMetricsQueryParams(req, &mq, buildNamespace("ns", time.Date(2018, 4, 10, 12, 10, 0, 0, time.UTC)))
+	mq := prometheus.IstioMetricsQuery{Namespace: "ns"}
+	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Date(2018, 4, 10, 12, 10, 0, 0, time.UTC)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,10 +105,10 @@ func TestExtractMetricsQueryStartTimeBoundary(t *testing.T) {
 	q.Add("rateInterval", "1m")
 	req.URL.RawQuery = q.Encode()
 
-	mq := prometheus.MetricsQuery{Namespace: "ns"}
+	mq := prometheus.IstioMetricsQuery{Namespace: "ns"}
 	namespaceTimestamp := time.Date(2018, 4, 10, 12, 30, 0, 0, time.UTC)
 
-	err = extractMetricsQueryParams(req, &mq, buildNamespace("ns", namespaceTimestamp))
+	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", namespaceTimestamp))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -71,8 +71,8 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 		return
 	}
 
-	params := prometheus.MetricsQuery{Namespace: namespace}
-	err := extractMetricsQueryParams(r, &params, namespaceInfo)
+	params := prometheus.IstioMetricsQuery{Namespace: namespace}
+	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -50,8 +50,8 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 		return
 	}
 
-	params := prometheus.MetricsQuery{Namespace: namespace, Service: service}
-	err := extractMetricsQueryParams(r, &params, namespaceInfo)
+	params := prometheus.IstioMetricsQuery{Namespace: namespace, Service: service}
+	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -76,8 +76,8 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 		return
 	}
 
-	params := prometheus.MetricsQuery{Namespace: namespace, Workload: workload}
-	err := extractMetricsQueryParams(r, &params, namespaceInfo)
+	params := prometheus.IstioMetricsQuery{Namespace: namespace, Workload: workload}
+	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -86,3 +86,31 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 	metrics := prom.GetMetrics(&params)
 	RespondWithJSON(w, http.StatusOK, metrics)
 }
+
+// WorkloadDashboard is the API handler to fetch Istio dashboard, related to a single workload
+func WorkloadDashboard(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	namespace := vars["namespace"]
+	workload := vars["workload"]
+
+	prom, _, namespaceInfo := initClientsForMetrics(w, defaultPromClientSupplier, defaultK8SClientSupplier, namespace)
+	if prom == nil {
+		// any returned value nil means error & response already written
+		return
+	}
+
+	params := prometheus.IstioMetricsQuery{Namespace: namespace, Workload: workload}
+	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
+	if err != nil {
+		RespondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	svc := business.NewDashboardsService(nil, prom)
+	dashboard, err := svc.GetIstioDashboard(params)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	RespondWithJSON(w, http.StatusOK, dashboard)
+}

--- a/kubernetes/kiali_monitoring_client.go
+++ b/kubernetes/kiali_monitoring_client.go
@@ -7,9 +7,15 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// KialiMonitoringInterface for mocks (only mocked function are necessary here)
+type KialiMonitoringInterface interface {
+	GetDashboard(namespace string, name string) (*MonitoringDashboard, error)
+}
+
 // KialiMonitoringClient is the client struct for Kiali Monitoring API over Kubernetes
 // API to get MonitoringDashboards
 type KialiMonitoringClient struct {
+	KialiMonitoringInterface
 	client *rest.RESTClient
 }
 

--- a/kubernetes/kiali_monitoring_types.go
+++ b/kubernetes/kiali_monitoring_types.go
@@ -19,10 +19,11 @@ type MonitoringDashboardSpec struct {
 }
 
 type MonitoringDashboardChart struct {
-	Name         string
-	Unit         string
-	Spans        int
-	MetricName   string
+	Name       string
+	Unit       string
+	Spans      int
+	MetricName string
+	// MetricType is either "counter" or "histogram"
 	MetricType   string
 	Aggregations []MonitoringDashboardAggregation
 }

--- a/kubernetes/kiali_monitoring_types.go
+++ b/kubernetes/kiali_monitoring_types.go
@@ -4,6 +4,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	// Counter constant for MetricType
+	Counter = "counter"
+	// Histogram constant for MetricType
+	Histogram = "histogram"
+)
+
 var kialiMonitoringGroupVersion = schema.GroupVersion{
 	Group:   "monitoring.kiali.io",
 	Version: "v1alpha1",
@@ -19,12 +26,11 @@ type MonitoringDashboardSpec struct {
 }
 
 type MonitoringDashboardChart struct {
-	Name       string
-	Unit       string
-	Spans      int
-	MetricName string
-	// MetricType is either "counter" or "histogram"
-	MetricType   string
+	Name         string
+	Unit         string
+	Spans        int
+	MetricName   string
+	MetricType   string // MetricType is either "counter" or "histogram"
 	Aggregations []MonitoringDashboardAggregation
 }
 

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -1,38 +1,88 @@
 package models
 
 import (
+	"fmt"
+	"sort"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/prometheus"
 )
 
+// MonitoringDashboard is the model representing custom monitoring dashboard, transformed from MonitoringDashboard k8s resource
 type MonitoringDashboard struct {
-	Title  string  `json:"title"`
-	Charts []Chart `json:"charts"`
+	Title        string        `json:"title"`
+	Charts       []Chart       `json:"charts"`
+	Aggregations []Aggregation `json:"aggregations"`
 }
 
+// Chart is the model representing a custom chart, transformed from charts in MonitoringDashboard k8s resource
 type Chart struct {
-	Name         string               `json:"name"`
-	Unit         string               `json:"unit"`
-	Spans        int                  `json:"spans"`
-	CounterRate  *prometheus.Metric   `json:"counterRate"`
-	Histogram    prometheus.Histogram `json:"histogram"`
-	Aggregations []Aggregation        `json:"aggregations"`
+	Name        string               `json:"name"`
+	Unit        string               `json:"unit"`
+	Spans       int                  `json:"spans"`
+	CounterRate *prometheus.Metric   `json:"counterRate"`
+	Histogram   prometheus.Histogram `json:"histogram"`
 }
 
+// ConvertChart converts a k8s chart (from MonitoringDashboard k8s resource) into this models chart
+func ConvertChart(from kubernetes.MonitoringDashboardChart) Chart {
+	return Chart{
+		Name:  from.Name,
+		Unit:  from.Unit,
+		Spans: from.Spans,
+	}
+}
+
+// Aggregation is the model representing label's allowed aggregation, transformed from aggregation in MonitoringDashboard k8s resource
 type Aggregation struct {
 	Label       string `json:"label"`
 	DisplayName string `json:"displayName"`
 }
 
-func ConvertChart(from kubernetes.MonitoringDashboardChart) Chart {
-	aggs := []Aggregation{}
-	for _, agg := range from.Aggregations {
-		aggs = append(aggs, Aggregation{Label: agg.Label, DisplayName: agg.DisplayName})
+// ConvertAggregations converts a k8s aggregations (from MonitoringDashboard k8s resource) into this models aggregations
+// Results are sorted by DisplayName
+func ConvertAggregations(from kubernetes.MonitoringDashboardSpec) []Aggregation {
+	uniqueAggs := make(map[string]Aggregation)
+	for _, chart := range from.Charts {
+		for _, agg := range chart.Aggregations {
+			uniqueAggs[agg.DisplayName] = Aggregation{Label: agg.Label, DisplayName: agg.DisplayName}
+		}
 	}
-	return Chart{
-		Name:         from.Name,
-		Unit:         from.Unit,
-		Spans:        from.Spans,
-		Aggregations: aggs,
+	aggs := []Aggregation{}
+	for _, agg := range uniqueAggs {
+		aggs = append(aggs, agg)
+	}
+	sort.Slice(aggs, func(i, j int) bool {
+		return aggs[i].DisplayName < aggs[j].DisplayName
+	})
+	return aggs
+}
+
+func buildIstioAggregations(local, remote string) []Aggregation {
+	return []Aggregation{
+		Aggregation{
+			Label:       fmt.Sprintf("%s_version", local),
+			DisplayName: "Local version",
+		},
+		Aggregation{
+			Label:       fmt.Sprintf("%s_app", remote),
+			DisplayName: "Remote app",
+		},
+		Aggregation{
+			Label:       fmt.Sprintf("%s_version", remote),
+			DisplayName: "Remote version",
+		},
+		Aggregation{
+			Label:       "response_code",
+			DisplayName: "Response code",
+		},
+	}
+}
+
+// PrepareIstioDashboard prepares the Istio dashboard title and aggregations dynamically for input values
+func PrepareIstioDashboard(direction, local, remote string) MonitoringDashboard {
+	return MonitoringDashboard{
+		Title:        fmt.Sprintf("%s Metrics", direction),
+		Aggregations: buildIstioAggregations(local, remote),
 	}
 }

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -60,19 +60,19 @@ func ConvertAggregations(from kubernetes.MonitoringDashboardSpec) []Aggregation 
 
 func buildIstioAggregations(local, remote string) []Aggregation {
 	return []Aggregation{
-		Aggregation{
+		{
 			Label:       fmt.Sprintf("%s_version", local),
 			DisplayName: "Local version",
 		},
-		Aggregation{
+		{
 			Label:       fmt.Sprintf("%s_app", remote),
 			DisplayName: "Remote app",
 		},
-		Aggregation{
+		{
 			Label:       fmt.Sprintf("%s_version", remote),
 			DisplayName: "Remote version",
 		},
-		Aggregation{
+		{
 			Label:       "response_code",
 			DisplayName: "Response code",
 		},

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/prometheus"
+)
+
+type MonitoringDashboard struct {
+	Title  string  `json:"title"`
+	Charts []Chart `json:"charts"`
+}
+
+type Chart struct {
+	Name         string               `json:"name"`
+	Unit         string               `json:"unit"`
+	Spans        int                  `json:"spans"`
+	CounterRate  *prometheus.Metric   `json:"counterRate"`
+	Histogram    prometheus.Histogram `json:"histogram"`
+	Aggregations []Aggregation        `json:"aggregations"`
+}
+
+type Aggregation struct {
+	Label       string `json:"label"`
+	DisplayName string `json:"displayName"`
+}
+
+func ConvertChart(from kubernetes.MonitoringDashboardChart) Chart {
+	aggs := []Aggregation{}
+	for _, agg := range from.Aggregations {
+		aggs = append(aggs, Aggregation{Label: agg.Label, DisplayName: agg.DisplayName})
+	}
+	return Chart{
+		Name:         from.Name,
+		Unit:         from.Unit,
+		Spans:        from.Spans,
+		Aggregations: aggs,
+	}
+}

--- a/models/dashboards_test.go
+++ b/models/dashboards_test.go
@@ -1,0 +1,63 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+func TestConvertAggregations(t *testing.T) {
+	assert := assert.New(t)
+
+	dashboardSpec := kubernetes.MonitoringDashboardSpec{
+		Charts: []kubernetes.MonitoringDashboardChart{
+			kubernetes.MonitoringDashboardChart{
+				Aggregations: []kubernetes.MonitoringDashboardAggregation{
+					kubernetes.MonitoringDashboardAggregation{
+						DisplayName: "Path",
+						Label:       "path",
+					},
+					kubernetes.MonitoringDashboardAggregation{
+						DisplayName: "Error code",
+						Label:       "error_code",
+					},
+				},
+			},
+			kubernetes.MonitoringDashboardChart{
+				Aggregations: []kubernetes.MonitoringDashboardAggregation{
+					kubernetes.MonitoringDashboardAggregation{
+						DisplayName: "Address",
+						Label:       "address",
+					},
+					kubernetes.MonitoringDashboardAggregation{
+						DisplayName: "Error code",
+						Label:       "error_code",
+					},
+				},
+			},
+		},
+	}
+
+	converted := ConvertAggregations(dashboardSpec)
+
+	// Results must be aggregated, unique and sorted
+	assert.Len(converted, 3)
+	assert.Equal(converted[0], Aggregation{DisplayName: "Address", Label: "address"})
+	assert.Equal(converted[1], Aggregation{DisplayName: "Error code", Label: "error_code"})
+	assert.Equal(converted[2], Aggregation{DisplayName: "Path", Label: "path"})
+}
+
+func TestPrepareIstioDashboard(t *testing.T) {
+	assert := assert.New(t)
+
+	dashboard := PrepareIstioDashboard("Outbound", "source", "destination")
+
+	assert.Equal(dashboard.Title, "Outbound Metrics")
+	assert.Len(dashboard.Aggregations, 4)
+	assert.Equal(Aggregation{Label: "source_version", DisplayName: "Local version"}, dashboard.Aggregations[0])
+	assert.Equal(Aggregation{Label: "destination_app", DisplayName: "Remote app"}, dashboard.Aggregations[1])
+	assert.Equal(Aggregation{Label: "destination_version", DisplayName: "Remote version"}, dashboard.Aggregations[2])
+	assert.Equal(Aggregation{Label: "response_code", DisplayName: "Response code"}, dashboard.Aggregations[3])
+}

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -26,6 +26,8 @@ type ClientInterface interface {
 	GetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 	GetSourceWorkloads(namespace string, namespaceCreationTime time.Time, servicename string) (map[string][]Workload, error)
 	GetDestinationServices(namespace string, namespaceCreationTime time.Time, workloadname string) ([]Service, error)
+	FetchRateRange(metricName, labels, grouping string, q *BaseMetricsQuery) *Metric
+	FetchHistogramRange(metricName, labels, grouping string, q *BaseMetricsQuery) Histogram
 }
 
 // Client for Prometheus API.
@@ -162,7 +164,7 @@ func (in *Client) GetDestinationServices(namespace string, namespaceCreationTime
 }
 
 // GetMetrics returns the Metrics related to the provided query options.
-func (in *Client) GetMetrics(query *MetricsQuery) Metrics {
+func (in *Client) GetMetrics(query *IstioMetricsQuery) Metrics {
 	return getMetrics(in.api, query)
 }
 
@@ -206,6 +208,16 @@ func (in *Client) GetAppRequestRates(namespace, app, ratesInterval string, query
 // Returns (in, out, error)
 func (in *Client) GetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error) {
 	return getItemRequestRates(in.api, namespace, workload, "workload", queryTime, ratesInterval)
+}
+
+// FetchRateRange fetches a counter's rate in given range
+func (in *Client) FetchRateRange(metricName, labels, grouping string, q *BaseMetricsQuery) *Metric {
+	return fetchRateRange(in.api, metricName, labels, grouping, q)
+}
+
+// FetchHistogramRange fetches bucketed metric as histogram in given range
+func (in *Client) FetchHistogramRange(metricName, labels, grouping string, q *BaseMetricsQuery) Histogram {
+	return fetchHistogramRange(in.api, metricName, labels, grouping, q)
 }
 
 // API returns the Prometheus V1 HTTP API for performing calls not supported natively by this client

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -28,6 +28,7 @@ type ClientInterface interface {
 	GetDestinationServices(namespace string, namespaceCreationTime time.Time, workloadname string) ([]Service, error)
 	FetchRateRange(metricName, labels, grouping string, q *BaseMetricsQuery) *Metric
 	FetchHistogramRange(metricName, labels, grouping string, q *BaseMetricsQuery) Histogram
+	GetMetrics(query *IstioMetricsQuery) Metrics
 }
 
 // Client for Prometheus API.

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -160,17 +160,17 @@ func fetchAllMetrics(api v1.API, q *IstioMetricsQuery, labels, labelsError, grou
 	type resultHolder struct {
 		metric     *Metric
 		histo      Histogram
-		definition IstioMetric
+		definition istioMetric
 	}
-	maxResults := len(IstioMetrics)
+	maxResults := len(istioMetrics)
 	results := make([]*resultHolder, maxResults, maxResults)
 
-	for i, istioMetric := range IstioMetrics {
+	for i, istioMetric := range istioMetrics {
 		// if filters is empty, fetch all anyway
 		doFetch := len(q.Filters) == 0
 		if !doFetch {
 			for _, filter := range q.Filters {
-				if filter == istioMetric.KialiName {
+				if filter == istioMetric.kialiName {
 					doFetch = true
 					break
 				}
@@ -180,11 +180,11 @@ func fetchAllMetrics(api v1.API, q *IstioMetricsQuery, labels, labelsError, grou
 			wg.Add(1)
 			result := resultHolder{definition: istioMetric}
 			results[i] = &result
-			if istioMetric.IsHisto {
-				go fetchHisto(istioMetric.IstioName, &result.histo)
+			if istioMetric.isHisto {
+				go fetchHisto(istioMetric.istioName, &result.histo)
 			} else {
 				labelsToUse := istioMetric.labelsToUse(labels, labelsError)
-				go fetchRate(istioMetric.IstioName, &result.metric, labelsToUse)
+				go fetchRate(istioMetric.istioName, &result.metric, labelsToUse)
 			}
 		}
 	}
@@ -195,10 +195,10 @@ func fetchAllMetrics(api v1.API, q *IstioMetricsQuery, labels, labelsError, grou
 	histograms := make(map[string]Histogram)
 	for _, result := range results {
 		if result != nil {
-			if result.definition.IsHisto {
-				histograms[result.definition.KialiName] = result.histo
+			if result.definition.isHisto {
+				histograms[result.definition.kialiName] = result.histo
 			} else {
-				metrics[result.definition.KialiName] = result.metric
+				metrics[result.definition.kialiName] = result.metric
 			}
 		}
 	}

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -160,17 +160,17 @@ func fetchAllMetrics(api v1.API, q *IstioMetricsQuery, labels, labelsError, grou
 	type resultHolder struct {
 		metric     *Metric
 		histo      Histogram
-		definition kialiMetric
+		definition IstioMetric
 	}
-	maxResults := len(kialiMetrics)
+	maxResults := len(IstioMetrics)
 	results := make([]*resultHolder, maxResults, maxResults)
 
-	for i, kialiMetric := range kialiMetrics {
+	for i, istioMetric := range IstioMetrics {
 		// if filters is empty, fetch all anyway
 		doFetch := len(q.Filters) == 0
 		if !doFetch {
 			for _, filter := range q.Filters {
-				if filter == kialiMetric.name {
+				if filter == istioMetric.KialiName {
 					doFetch = true
 					break
 				}
@@ -178,13 +178,13 @@ func fetchAllMetrics(api v1.API, q *IstioMetricsQuery, labels, labelsError, grou
 		}
 		if doFetch {
 			wg.Add(1)
-			result := resultHolder{definition: kialiMetric}
+			result := resultHolder{definition: istioMetric}
 			results[i] = &result
-			if kialiMetric.isHisto {
-				go fetchHisto(kialiMetric.istioName, &result.histo)
+			if istioMetric.IsHisto {
+				go fetchHisto(istioMetric.IstioName, &result.histo)
 			} else {
-				labelsToUse := kialiMetric.labelsToUse(labels, labelsError)
-				go fetchRate(kialiMetric.istioName, &result.metric, labelsToUse)
+				labelsToUse := istioMetric.labelsToUse(labels, labelsError)
+				go fetchRate(istioMetric.IstioName, &result.metric, labelsToUse)
 			}
 		}
 	}
@@ -195,10 +195,10 @@ func fetchAllMetrics(api v1.API, q *IstioMetricsQuery, labels, labelsError, grou
 	histograms := make(map[string]Histogram)
 	for _, result := range results {
 		if result != nil {
-			if result.definition.isHisto {
-				histograms[result.definition.name] = result.histo
+			if result.definition.IsHisto {
+				histograms[result.definition.KialiName] = result.histo
 			} else {
-				metrics[result.definition.name] = result.metric
+				metrics[result.definition.KialiName] = result.metric
 			}
 		}
 	}

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -12,68 +12,13 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 var (
 	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 )
-
-// MetricsQuery holds query parameters for a typical metrics query
-type MetricsQuery struct {
-	v1.Range
-	RateInterval string
-	RateFunc     string
-	Filters      []string
-	Quantiles    []string
-	Avg          bool
-	ByLabels     []string
-	Namespace    string
-	App          string
-	Workload     string
-	Service      string
-	Direction    string // outbound | inbound
-	Reporter     string // source | destination, defaults to source if not provided
-}
-
-// FillDefaults fills the struct with default parameters
-func (q *MetricsQuery) FillDefaults() {
-	q.End = time.Now()
-	q.Start = q.End.Add(-30 * time.Minute)
-	q.Step = 15 * time.Second
-	q.RateInterval = "1m"
-	q.RateFunc = "rate"
-	q.Avg = true
-	q.Reporter = "source"
-	q.Direction = "outbound"
-}
-
-// Metrics contains all simple metrics and histograms data
-type Metrics struct {
-	Metrics    map[string]*Metric   `json:"metrics"`
-	Histograms map[string]Histogram `json:"histograms"`
-}
-
-// Metric holds the Prometheus Matrix model, which contains one or more time series (depending on grouping)
-type Metric struct {
-	Matrix model.Matrix `json:"matrix"`
-	err    error
-}
-
-// Histogram contains Metric objects for several histogram-kind statistics
-type Histogram = map[string]*Metric
-
-// EnvoyServiceHealth is the number of healthy versus total membership (ie. replicas) inside envoy cluster for inbound and outbound traffic
-type EnvoyServiceHealth struct {
-	Inbound  EnvoyRatio `json:"inbound"`
-	Outbound EnvoyRatio `json:"outbound"`
-}
-
-// EnvoyRatio is the number of healthy members versus total members
-type EnvoyRatio struct {
-	Healthy int `json:"healthy"`
-	Total   int `json:"total"`
-}
 
 func getServiceHealth(api v1.API, namespace, servicename string, ports []int32) (EnvoyServiceHealth, error) {
 	ret := EnvoyServiceHealth{}
@@ -160,14 +105,14 @@ func getServiceHealth(api v1.API, namespace, servicename string, ports []int32) 
 	return ret, err
 }
 
-func getMetrics(api v1.API, q *MetricsQuery) Metrics {
+func getMetrics(api v1.API, q *IstioMetricsQuery) Metrics {
 	labels, labelsError := buildLabelStrings(q)
 	grouping := strings.Join(q.ByLabels, ",")
 	metrics := fetchAllMetrics(api, q, labels, labelsError, grouping)
 	return metrics
 }
 
-func buildLabelStrings(q *MetricsQuery) (string, string) {
+func buildLabelStrings(q *IstioMetricsQuery) (string, string) {
 	labels := []string{fmt.Sprintf(`reporter="%s"`, q.Reporter)}
 	ref := "destination"
 	if q.Direction == "outbound" {
@@ -198,17 +143,17 @@ func buildLabelStrings(q *MetricsQuery) (string, string) {
 	return full, errors
 }
 
-func fetchAllMetrics(api v1.API, q *MetricsQuery, labels, labelsError, grouping string) Metrics {
+func fetchAllMetrics(api v1.API, q *IstioMetricsQuery, labels, labelsError, grouping string) Metrics {
 	var wg sync.WaitGroup
 	fetchRate := func(p8sFamilyName string, metric **Metric, lbl string) {
 		defer wg.Done()
-		m := fetchRateRange(api, p8sFamilyName, lbl, grouping, q)
+		m := fetchRateRange(api, p8sFamilyName, lbl, grouping, &q.BaseMetricsQuery)
 		*metric = m
 	}
 
 	fetchHisto := func(p8sFamilyName string, histo *Histogram) {
 		defer wg.Done()
-		h := fetchHistogramRange(api, p8sFamilyName, labels, grouping, q)
+		h := fetchHistogramRange(api, p8sFamilyName, labels, grouping, &q.BaseMetricsQuery)
 		*histo = h
 	}
 
@@ -263,7 +208,7 @@ func fetchAllMetrics(api v1.API, q *MetricsQuery, labels, labelsError, grouping 
 	}
 }
 
-func fetchRateRange(api v1.API, metricName string, labels string, grouping string, q *MetricsQuery) *Metric {
+func fetchRateRange(api v1.API, metricName, labels, grouping string, q *BaseMetricsQuery) *Metric {
 	var query string
 	// Example: round(sum(rate(my_counter{foo=bar}[5m])) by (baz), 0.001)
 	if grouping == "" {
@@ -274,7 +219,7 @@ func fetchRateRange(api v1.API, metricName string, labels string, grouping strin
 	return fetchRange(api, query, q.Range)
 }
 
-func fetchHistogramRange(api v1.API, metricName string, labels string, grouping string, q *MetricsQuery) Histogram {
+func fetchHistogramRange(api v1.API, metricName, labels, grouping string, q *BaseMetricsQuery) Histogram {
 	histogram := make(Histogram)
 
 	// Note: the p8s queries are not run in parallel here, but they are at the caller's place.
@@ -289,6 +234,7 @@ func fetchHistogramRange(api v1.API, metricName string, labels string, grouping 
 		query := fmt.Sprintf(
 			"round(sum(rate(%s_sum%s[%s]))%s / sum(rate(%s_count%s[%s]))%s, 0.001)", metricName, labels, q.RateInterval, groupingAvg,
 			metricName, labels, q.RateInterval, groupingAvg)
+		log.Infof("Query: %s\n", query)
 		histogram["avg"] = fetchRange(api, query, q.Range)
 	}
 
@@ -301,6 +247,7 @@ func fetchHistogramRange(api v1.API, metricName string, labels string, grouping 
 		query := fmt.Sprintf(
 			"round(histogram_quantile(%s, sum(rate(%s_bucket%s[%s])) by (le%s)), 0.001)", quantile, metricName, labels, q.RateInterval, groupingQuantile)
 		histogram[quantile] = fetchRange(api, query, q.Range)
+		log.Infof("Query: %s\n", query)
 	}
 
 	return histogram

--- a/prometheus/metrics_definitions.go
+++ b/prometheus/metrics_definitions.go
@@ -1,48 +1,53 @@
 package prometheus
 
-type kialiMetric struct {
-	name           string
-	istioName      string
-	isHisto        bool
-	useErrorLabels bool
+type IstioMetric struct {
+	KialiName      string
+	IstioName      string
+	IsHisto        bool
+	UseErrorLabels bool
 }
 
-var (
-	kialiMetrics = []kialiMetric{
-		kialiMetric{
-			name:      "request_count",
-			istioName: "istio_requests_total",
-			isHisto:   false},
-		kialiMetric{
-			name:           "request_error_count",
-			istioName:      "istio_requests_total",
-			isHisto:        false,
-			useErrorLabels: true},
-		kialiMetric{
-			name:      "request_size",
-			istioName: "istio_request_bytes",
-			isHisto:   true},
-		kialiMetric{
-			name:      "request_duration",
-			istioName: "istio_request_duration_seconds",
-			isHisto:   true},
-		kialiMetric{
-			name:      "response_size",
-			istioName: "istio_response_bytes",
-			isHisto:   true},
-		kialiMetric{
-			name:      "tcp_sent",
-			istioName: "istio_tcp_sent_bytes_total",
-			isHisto:   false},
-		kialiMetric{
-			name:      "tcp_received",
-			istioName: "istio_tcp_received_bytes_total",
-			isHisto:   false},
-	}
-)
+var IstioMetrics = []IstioMetric{
+	IstioMetric{
+		KialiName: "request_count",
+		IstioName: "istio_requests_total",
+		IsHisto:   false,
+	},
+	IstioMetric{
+		KialiName:      "request_error_count",
+		IstioName:      "istio_requests_total",
+		IsHisto:        false,
+		UseErrorLabels: true,
+	},
+	IstioMetric{
+		KialiName: "request_duration",
+		IstioName: "istio_request_duration_seconds",
+		IsHisto:   true,
+	},
+	IstioMetric{
+		KialiName: "request_size",
+		IstioName: "istio_request_bytes",
+		IsHisto:   true,
+	},
+	IstioMetric{
+		KialiName: "response_size",
+		IstioName: "istio_response_bytes",
+		IsHisto:   true,
+	},
+	IstioMetric{
+		KialiName: "tcp_received",
+		IstioName: "istio_tcp_received_bytes_total",
+		IsHisto:   false,
+	},
+	IstioMetric{
+		KialiName: "tcp_sent",
+		IstioName: "istio_tcp_sent_bytes_total",
+		IsHisto:   false,
+	},
+}
 
-func (in *kialiMetric) labelsToUse(labels, labelsError string) string {
-	if in.useErrorLabels {
+func (in *IstioMetric) labelsToUse(labels, labelsError string) string {
+	if in.UseErrorLabels {
 		return labelsError
 	}
 	return labels

--- a/prometheus/metrics_definitions.go
+++ b/prometheus/metrics_definitions.go
@@ -1,53 +1,53 @@
 package prometheus
 
-type IstioMetric struct {
-	KialiName      string
-	IstioName      string
-	IsHisto        bool
-	UseErrorLabels bool
+type istioMetric struct {
+	kialiName      string
+	istioName      string
+	isHisto        bool
+	useErrorLabels bool
 }
 
-var IstioMetrics = []IstioMetric{
-	IstioMetric{
-		KialiName: "request_count",
-		IstioName: "istio_requests_total",
-		IsHisto:   false,
+var istioMetrics = []istioMetric{
+	istioMetric{
+		kialiName: "request_count",
+		istioName: "istio_requests_total",
+		isHisto:   false,
 	},
-	IstioMetric{
-		KialiName:      "request_error_count",
-		IstioName:      "istio_requests_total",
-		IsHisto:        false,
-		UseErrorLabels: true,
+	istioMetric{
+		kialiName:      "request_error_count",
+		istioName:      "istio_requests_total",
+		isHisto:        false,
+		useErrorLabels: true,
 	},
-	IstioMetric{
-		KialiName: "request_duration",
-		IstioName: "istio_request_duration_seconds",
-		IsHisto:   true,
+	istioMetric{
+		kialiName: "request_duration",
+		istioName: "istio_request_duration_seconds",
+		isHisto:   true,
 	},
-	IstioMetric{
-		KialiName: "request_size",
-		IstioName: "istio_request_bytes",
-		IsHisto:   true,
+	istioMetric{
+		kialiName: "request_size",
+		istioName: "istio_request_bytes",
+		isHisto:   true,
 	},
-	IstioMetric{
-		KialiName: "response_size",
-		IstioName: "istio_response_bytes",
-		IsHisto:   true,
+	istioMetric{
+		kialiName: "response_size",
+		istioName: "istio_response_bytes",
+		isHisto:   true,
 	},
-	IstioMetric{
-		KialiName: "tcp_received",
-		IstioName: "istio_tcp_received_bytes_total",
-		IsHisto:   false,
+	istioMetric{
+		kialiName: "tcp_received",
+		istioName: "istio_tcp_received_bytes_total",
+		isHisto:   false,
 	},
-	IstioMetric{
-		KialiName: "tcp_sent",
-		IstioName: "istio_tcp_sent_bytes_total",
-		IsHisto:   false,
+	istioMetric{
+		kialiName: "tcp_sent",
+		istioName: "istio_tcp_sent_bytes_total",
+		isHisto:   false,
 	},
 }
 
-func (in *IstioMetric) labelsToUse(labels, labelsError string) string {
-	if in.UseErrorLabels {
+func (in *istioMetric) labelsToUse(labels, labelsError string) string {
+	if in.useErrorLabels {
 		return labelsError
 	}
 	return labels

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -185,7 +185,7 @@ func TestGetServiceMetrics(t *testing.T) {
 		return
 	}
 
-	q := prometheus.MetricsQuery{
+	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 		Service:   "productpage",
 	}
@@ -249,7 +249,7 @@ func TestGetAppMetrics(t *testing.T) {
 	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.4)
 	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.5)
 	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.6)
-	q := prometheus.MetricsQuery{
+	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
 	}
@@ -295,7 +295,7 @@ func TestGetFilteredAppMetrics(t *testing.T) {
 	}
 	mockRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m])), 0.001)", 1.5)
 	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	q := prometheus.MetricsQuery{
+	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
 	}
@@ -319,7 +319,7 @@ func TestGetAppMetricsInstantRates(t *testing.T) {
 		return
 	}
 	mockRange(api, "round(sum(irate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[1m])), 0.001)", 1.5)
-	q := prometheus.MetricsQuery{
+	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
 	}
@@ -370,7 +370,7 @@ func TestGetAppMetricsUnavailable(t *testing.T) {
 	// Mock everything to return empty data
 	mockEmptyRange(api, "round(sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m])), 0.001)")
 	mockEmptyHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]")
-	q := prometheus.MetricsQuery{
+	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
 	}
@@ -427,7 +427,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
 	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
 	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
-	q := prometheus.MetricsQuery{
+	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 	}
 	q.FillDefaults()

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -137,3 +137,8 @@ func (o *PromClientMock) FetchHistogramRange(metricName, labels, grouping string
 	args := o.Called(metricName, labels, grouping, q)
 	return args.Get(0).(prometheus.Histogram)
 }
+
+func (o *PromClientMock) GetMetrics(query *prometheus.IstioMetricsQuery) prometheus.Metrics {
+	args := o.Called(query)
+	return args.Get(0).(prometheus.Metrics)
+}

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -127,3 +127,13 @@ func (o *PromClientMock) GetDestinationServices(namespace string, namespaceCreat
 	args := o.Called(namespace, namespaceCreationTime, workloadname)
 	return args.Get(0).([]prometheus.Service), args.Error(1)
 }
+
+func (o *PromClientMock) FetchRateRange(metricName, labels, grouping string, q *prometheus.BaseMetricsQuery) *prometheus.Metric {
+	args := o.Called(metricName, labels, grouping, q)
+	return args.Get(0).(*prometheus.Metric)
+}
+
+func (o *PromClientMock) FetchHistogramRange(metricName, labels, grouping string, q *prometheus.BaseMetricsQuery) prometheus.Histogram {
+	args := o.Called(metricName, labels, grouping, q)
+	return args.Get(0).(prometheus.Histogram)
+}

--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -1,0 +1,87 @@
+package prometheus
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// BaseMetricsQuery holds common parameters for all kinds of queries
+type BaseMetricsQuery struct {
+	v1.Range
+	RateInterval string
+	RateFunc     string
+	Quantiles    []string
+	Avg          bool
+	ByLabels     []string
+}
+
+// FillDefaults fills the struct with default parameters
+func (q *BaseMetricsQuery) fillDefaults() {
+	q.End = time.Now()
+	q.Start = q.End.Add(-30 * time.Minute)
+	q.Step = 15 * time.Second
+	q.RateInterval = "1m"
+	q.RateFunc = "rate"
+	q.Avg = true
+}
+
+// IstioMetricsQuery holds query parameters for a typical metrics query
+type IstioMetricsQuery struct {
+	BaseMetricsQuery
+	Filters   []string
+	Namespace string
+	App       string
+	Workload  string
+	Service   string
+	Direction string // outbound | inbound
+	Reporter  string // source | destination, defaults to source if not provided
+}
+
+// FillDefaults fills the struct with default parameters
+func (q *IstioMetricsQuery) FillDefaults() {
+	q.BaseMetricsQuery.fillDefaults()
+	q.Reporter = "source"
+	q.Direction = "outbound"
+}
+
+// CustomMetricsQuery holds query parameters for a custom metrics query
+type CustomMetricsQuery struct {
+	BaseMetricsQuery
+	Namespace string
+	App       string
+	Version   string
+}
+
+// FillDefaults fills the struct with default parameters
+func (q *CustomMetricsQuery) FillDefaults() {
+	q.BaseMetricsQuery.fillDefaults()
+}
+
+// Metrics contains all simple metrics and histograms data
+type Metrics struct {
+	Metrics    map[string]*Metric   `json:"metrics"`
+	Histograms map[string]Histogram `json:"histograms"`
+}
+
+// Metric holds the Prometheus Matrix model, which contains one or more time series (depending on grouping)
+type Metric struct {
+	Matrix model.Matrix `json:"matrix"`
+	err    error
+}
+
+// Histogram contains Metric objects for several histogram-kind statistics
+type Histogram = map[string]*Metric
+
+// EnvoyServiceHealth is the number of healthy versus total membership (ie. replicas) inside envoy cluster for inbound and outbound traffic
+type EnvoyServiceHealth struct {
+	Inbound  EnvoyRatio `json:"inbound"`
+	Outbound EnvoyRatio `json:"outbound"`
+}
+
+// EnvoyRatio is the number of healthy members versus total members
+type EnvoyRatio struct {
+	Healthy int `json:"healthy"`
+	Total   int `json:"total"`
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -497,7 +497,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadMetrics,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/services/{service}/dashboard services serviceMetrics
+		// swagger:route GET /namespaces/{namespace}/services/{service}/dashboard services serviceDashboard
 		// ---
 		// Endpoint to fetch dashboard to be displayed, related to a single service
 		//
@@ -518,7 +518,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceDashboard,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/apps/{app}/dashboard apps appMetrics
+		// swagger:route GET /namespaces/{namespace}/apps/{app}/dashboard apps appDashboard
 		// ---
 		// Endpoint to fetch dashboard to be displayed, related to a single app
 		//
@@ -539,7 +539,7 @@ func NewRoutes() (r *Routes) {
 			handlers.AppDashboard,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/workloads/{workload}/dashboard workloads workloadMetrics
+		// swagger:route GET /namespaces/{namespace}/workloads/{workload}/dashboard workloads workloadDashboard
 		// ---
 		// Endpoint to fetch dashboard to be displayed, related to a single workload
 		//
@@ -560,7 +560,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadDashboard,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/apps/{app}/cstmetrics/{template} customDashboard
+		// swagger:route GET /namespaces/{namespace}/apps/{app}/cstmetrics/{template} apps customDashboard
 		// ---
 		// Endpoint to fetch custom dashboard to be displayed, based on the provided template
 		//

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -497,6 +497,27 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadMetrics,
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/apps/{app}/cstmetrics/{template} customMetrics
+		// ---
+		// Endpoint to fetch custom metrics to be displayed in a dashboard, based on the provided template
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      400: badRequestError
+		//      503: serviceUnavailableError
+		//      200: metricsResponse
+		//
+		{
+			"CustomMetrics",
+			"GET",
+			"/api/namespaces/{namespace}/apps/{app}/cstmetrics/{template}",
+			handlers.CustomMetrics,
+			true,
+		},
 		// swagger:route GET /namespaces/{namespace}/services/{service}/health services serviceHealth
 		// ---
 		// Get health associated to the given service

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -497,9 +497,9 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadMetrics,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/apps/{app}/cstmetrics/{template} customMetrics
+		// swagger:route GET /namespaces/{namespace}/services/{service}/dashboard services serviceMetrics
 		// ---
-		// Endpoint to fetch custom metrics to be displayed in a dashboard, based on the provided template
+		// Endpoint to fetch dashboard to be displayed, related to a single service
 		//
 		//     Produces:
 		//     - application/json
@@ -509,13 +509,76 @@ func NewRoutes() (r *Routes) {
 		// responses:
 		//      400: badRequestError
 		//      503: serviceUnavailableError
-		//      200: metricsResponse
+		//      200: dashboardResponse
 		//
 		{
-			"CustomMetrics",
+			"ServiceDashboard",
 			"GET",
-			"/api/namespaces/{namespace}/apps/{app}/cstmetrics/{template}",
-			handlers.CustomMetrics,
+			"/api/namespaces/{namespace}/services/{service}/dashboard",
+			handlers.ServiceDashboard,
+			true,
+		},
+		// swagger:route GET /namespaces/{namespace}/apps/{app}/dashboard apps appMetrics
+		// ---
+		// Endpoint to fetch dashboard to be displayed, related to a single app
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      400: badRequestError
+		//      503: serviceUnavailableError
+		//      200: dashboardResponse
+		//
+		{
+			"AppDashboard",
+			"GET",
+			"/api/namespaces/{namespace}/apps/{app}/dashboard",
+			handlers.AppDashboard,
+			true,
+		},
+		// swagger:route GET /namespaces/{namespace}/workloads/{workload}/dashboard workloads workloadMetrics
+		// ---
+		// Endpoint to fetch dashboard to be displayed, related to a single workload
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      400: badRequestError
+		//      503: serviceUnavailableError
+		//      200: dashboardResponse
+		//
+		{
+			"WorkloadDashboard",
+			"GET",
+			"/api/namespaces/{namespace}/workloads/{workload}/dashboard",
+			handlers.WorkloadDashboard,
+			true,
+		},
+		// swagger:route GET /namespaces/{namespace}/apps/{app}/cstmetrics/{template} customDashboard
+		// ---
+		// Endpoint to fetch custom dashboard to be displayed, based on the provided template
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      400: badRequestError
+		//      503: serviceUnavailableError
+		//      200: dashboardResponse
+		//
+		{
+			"CustomDashboard",
+			"GET",
+			"/api/namespaces/{namespace}/apps/{app}/cstdashboard/{template}",
+			handlers.CustomDashboard,
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/services/{service}/health services serviceHealth

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -560,7 +560,7 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadDashboard,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/apps/{app}/cstmetrics/{template} apps customDashboard
+		// swagger:route GET /namespaces/{namespace}/apps/{app}/customdashboard/{template} apps customDashboard
 		// ---
 		// Endpoint to fetch custom dashboard to be displayed, based on the provided template
 		//
@@ -577,7 +577,7 @@ func NewRoutes() (r *Routes) {
 		{
 			"CustomDashboard",
 			"GET",
-			"/api/namespaces/{namespace}/apps/{app}/cstdashboard/{template}",
+			"/api/namespaces/{namespace}/apps/{app}/customdashboard/{template}",
 			handlers.CustomDashboard,
 			true,
 		},

--- a/swagger.json
+++ b/swagger.json
@@ -492,6 +492,119 @@
         }
       }
     },
+    "/namespaces/{namespace}/apps/{app}/cstmetrics/{template}": {
+      "get": {
+        "description": "Endpoint to fetch custom metrics to be displayed in a dashboard, based on the provided template",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "customMetrics",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The app name (label value).",
+            "name": "app",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The dashboard template name.",
+            "name": "template",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "true",
+            "x-go-name": "Name",
+            "description": "Flag for fetching histogram average. Default is true.",
+            "name": "avg",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
+            "name": "byLabels[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration of the query period, in seconds.",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
+            "name": "quantiles[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation.",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Step between [graph] datapoints, in seconds.",
+            "name": "step",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Filters metrics by the specified version.",
+            "name": "version",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/metricsResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "503": {
+            "$ref": "#/responses/serviceUnavailableError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/apps/{app}/health": {
       "get": {
         "description": "Get health associated to the given app",

--- a/swagger.json
+++ b/swagger.json
@@ -492,7 +492,7 @@
         }
       }
     },
-    "/namespaces/{namespace}/apps/{app}/cstmetrics/{template}": {
+    "/namespaces/{namespace}/apps/{app}/customdashboard/{template}": {
       "get": {
         "description": "Endpoint to fetch custom dashboard to be displayed, based on the provided template",
         "produces": [

--- a/swagger.json
+++ b/swagger.json
@@ -494,7 +494,7 @@
     },
     "/namespaces/{namespace}/apps/{app}/cstmetrics/{template}": {
       "get": {
-        "description": "Endpoint to fetch custom metrics to be displayed in a dashboard, based on the provided template",
+        "description": "Endpoint to fetch custom dashboard to be displayed, based on the provided template",
         "produces": [
           "application/json"
         ],
@@ -502,7 +502,10 @@
           "http",
           "https"
         ],
-        "operationId": "customMetrics",
+        "tags": [
+          "apps"
+        ],
+        "operationId": "customDashboard",
         "parameters": [
           {
             "type": "string",
@@ -594,7 +597,124 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/metricsResponse"
+            "$ref": "#/responses/dashboardResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "503": {
+            "$ref": "#/responses/serviceUnavailableError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/apps/{app}/dashboard": {
+      "get": {
+        "description": "Endpoint to fetch dashboard to be displayed, related to a single app",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "apps"
+        ],
+        "operationId": "appDashboard",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The app name (label value).",
+            "name": "app",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "true",
+            "x-go-name": "Name",
+            "description": "Flag for fetching histogram average. Default is true.",
+            "name": "avg",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
+            "name": "byLabels[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "outbound",
+            "x-go-name": "Name",
+            "description": "Traffic direction: 'inbound' or 'outbound'.",
+            "name": "direction",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration of the query period, in seconds.",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
+            "name": "quantiles[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation.",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "source",
+            "x-go-name": "Name",
+            "description": "Istio telemetry reporter: 'source' or 'destination'.",
+            "name": "reporter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Step between [graph] datapoints, in seconds.",
+            "name": "step",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/dashboardResponse"
           },
           "400": {
             "$ref": "#/responses/badRequestError"
@@ -1454,6 +1574,123 @@
         }
       }
     },
+    "/namespaces/{namespace}/services/{service}/dashboard": {
+      "get": {
+        "description": "Endpoint to fetch dashboard to be displayed, related to a single service",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "services"
+        ],
+        "operationId": "serviceDashboard",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The service name.",
+            "name": "service",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "true",
+            "x-go-name": "Name",
+            "description": "Flag for fetching histogram average. Default is true.",
+            "name": "avg",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
+            "name": "byLabels[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "outbound",
+            "x-go-name": "Name",
+            "description": "Traffic direction: 'inbound' or 'outbound'.",
+            "name": "direction",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration of the query period, in seconds.",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
+            "name": "quantiles[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation.",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "source",
+            "x-go-name": "Name",
+            "description": "Istio telemetry reporter: 'source' or 'destination'.",
+            "name": "reporter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Step between [graph] datapoints, in seconds.",
+            "name": "step",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/dashboardResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "503": {
+            "$ref": "#/responses/serviceUnavailableError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/services/{service}/graph": {
       "get": {
         "produces": [
@@ -1856,6 +2093,123 @@
         }
       }
     },
+    "/namespaces/{namespace}/workloads/{workload}/dashboard": {
+      "get": {
+        "description": "Endpoint to fetch dashboard to be displayed, related to a single workload",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "workloads"
+        ],
+        "operationId": "workloadDashboard",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace id.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The workload name.",
+            "name": "workload",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "true",
+            "x-go-name": "Name",
+            "description": "Flag for fetching histogram average. Default is true.",
+            "name": "avg",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
+            "name": "byLabels[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "outbound",
+            "x-go-name": "Name",
+            "description": "Traffic direction: 'inbound' or 'outbound'.",
+            "name": "direction",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1800",
+            "x-go-name": "Name",
+            "description": "Duration of the query period, in seconds.",
+            "name": "duration",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "[]",
+            "x-go-name": "Name",
+            "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
+            "name": "quantiles[]",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "rate",
+            "x-go-name": "Name",
+            "description": "Prometheus function used to calculate rate: 'rate' or 'irate'.",
+            "name": "rateFunc",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "1m",
+            "x-go-name": "Name",
+            "description": "Interval used for rate and histogram calculation.",
+            "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "source",
+            "x-go-name": "Name",
+            "description": "Istio telemetry reporter: 'source' or 'destination'.",
+            "name": "reporter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "15",
+            "x-go-name": "Name",
+            "description": "Step between [graph] datapoints, in seconds.",
+            "name": "step",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/dashboardResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "503": {
+            "$ref": "#/responses/serviceUnavailableError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/workloads/{workload}/graph": {
       "get": {
         "produces": [
@@ -2218,6 +2572,21 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
+    "Aggregation": {
+      "description": "Aggregation is the model representing label's allowed aggregation, transformed from aggregation in MonitoringDashboard k8s resource",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "x-go-name": "DisplayName"
+        },
+        "label": {
+          "type": "string",
+          "x-go-name": "Label"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
     "App": {
       "type": "object",
       "required": [
@@ -2327,6 +2696,32 @@
       "description": "CauseType is a machine readable value providing more detail about what\noccurred in a status response. An operation may have multiple causes for a\nstatus (whether Failure or Success).",
       "type": "string",
       "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
+    },
+    "Chart": {
+      "description": "Chart is the model representing a custom chart, transformed from charts in MonitoringDashboard k8s resource",
+      "type": "object",
+      "properties": {
+        "counterRate": {
+          "$ref": "#/definitions/Metric"
+        },
+        "histogram": {
+          "$ref": "#/definitions/Histogram"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "spans": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Spans"
+        },
+        "unit": {
+          "type": "string",
+          "x-go-name": "Unit"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
     },
     "Config": {
       "type": "object",
@@ -2830,6 +3225,31 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/prometheus"
+    },
+    "MonitoringDashboard": {
+      "description": "MonitoringDashboard is the model representing custom monitoring dashboard, transformed from MonitoringDashboard k8s resource",
+      "type": "object",
+      "properties": {
+        "aggregations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Aggregation"
+          },
+          "x-go-name": "Aggregations"
+        },
+        "charts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Chart"
+          },
+          "x-go-name": "Charts"
+        },
+        "title": {
+          "type": "string",
+          "x-go-name": "Title"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
     },
     "NameIstioValidation": {
       "description": "List of validations grouped by object name",
@@ -4313,6 +4733,12 @@
         }
       }
     },
+    "dashboardResponse": {
+      "description": "Dashboard response model",
+      "schema": {
+        "$ref": "#/definitions/MonitoringDashboard"
+      }
+    },
     "grafanaInfoResponse": {
       "description": "Return all the descriptor data related to Grafana",
       "schema": {
@@ -4364,7 +4790,7 @@
       }
     },
     "metricsResponse": {
-      "description": "Listing all the information related to a service",
+      "description": "Metrics response model",
       "schema": {
         "$ref": "#/definitions/Metrics"
       }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-1974

* First commit:
  - Load custom dashboards from CRD
  - Expose via new route & handler

* Second commit:
  - Introduce a new hard-coded Istio dashboard that reuses the dashboard model to build Inbound & Outbound Istio metrics dashboard. The goal is to have the exact same Inbound & Outbound Metrics pages as before, but using new model.
  - Create new routes & handlers for these dashboards (for workload, app and service)

Note that these changes should not break anything in the UI. "Old" metrics endpoints are still valid and can still be consumed as before. Graph side panel will continue to use the old _metrics_ routes.
