### PR TITLE
add gometalinter but dont lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,13 @@ env:
 # See: https://github.com/golang/dep/blob/master/docs/FAQ.md#should-i-commit-my-vendor-directory
 install:
  - make swagger-install
+ - make gometalinter-install
 #- make dep-install
 #- make dep-update
 
 script:
   - if [ ! -z "$(gofmt -l ${GO_FILES})" ]; then echo "These files need to be formatted:" "$(gofmt -l ${GO_FILES})";echo "Diff files:"; gofmt -d ${GO_FILES}; exit 1; fi # Gofmt Linter
+  - make lint
   - make clean build test-race
   - make swagger-travis
 

--- a/Makefile
+++ b/Makefile
@@ -296,3 +296,12 @@ k8s-undeploy: .k8s-validate
 k8s-reload-image: .k8s-validate
 	@echo Refreshing image in Kubernetes namespace ${NAMESPACE}
 	${KUBECTL} delete pod --selector=app=kiali -n ${NAMESPACE}
+
+## gometalinter-install. Installs gometalinter
+gometalinter-install:
+	go get -u github.com/alecthomas/gometalinter
+	gometalinter --install
+
+## lint. Runs gometalinter
+lint:
+	gometalinter --disable-all --tests  --vendor ./...


### PR DESCRIPTION
** Describe the change **
This adds a make task to install gometalinter and also adds it to the travis run but does not enforce anything, it just passes no matter what.

** Issue reference **
https://github.com/kiali/kiali/issues/722


** Backwards incompatible? **

- [x] Is your change introducing backwards incompatible changes?

