### PR TITLE
KIALI-2009 change service account name to match maistra and upstream helm

### DIFF
--- a/deploy/kubernetes/clusterrolebinding.yaml
+++ b/deploy/kubernetes/clusterrolebinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: kiali
+  name: kiali-service-account
   namespace: ${NAMESPACE}

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app: kiali
         version: ${VERSION_LABEL}
     spec:
-      serviceAccount: kiali
+      serviceAccount: kiali-service-account
       containers:
       - image: ${IMAGE_NAME}:${IMAGE_VERSION}
         ${IMAGE_PULL_POLICY_TOKEN}

--- a/deploy/kubernetes/serviceaccount.yaml
+++ b/deploy/kubernetes/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kiali
+  name: kiali-service-account
   labels:
     app: kiali
     version: ${VERSION_LABEL}

--- a/deploy/openshift/clusterrolebinding.yaml
+++ b/deploy/openshift/clusterrolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: kiali
 subjects:
 - kind: ServiceAccount
-  name: kiali
+  name: kiali-service-account
   namespace: ${NAMESPACE}

--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         maxAvailable: 1
       type: RollingUpdate
     spec:
-      serviceAccount: kiali
+      serviceAccount: kiali-service-account
       containers:
       - image: ${IMAGE_NAME}:${IMAGE_VERSION}
         ${IMAGE_PULL_POLICY_TOKEN}

--- a/deploy/openshift/serviceaccount.yaml
+++ b/deploy/openshift/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kiali
+  name: kiali-service-account
   labels:
     app: kiali
     version: ${VERSION_LABEL}


### PR DESCRIPTION
We need this to remain consistent no matter how kiali is installed. This is important because citadel names the secrets with the name of the service account.