### PR TITLE
Fix subset host+port validation issue

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -20,7 +20,7 @@ const (
 )
 
 type Host struct {
-	Port            uint32
+	Port            int
 	Hostname        string
 	ServerIndex     int
 	HostIndex       int
@@ -82,12 +82,12 @@ func addError(validations models.IstioValidations, gatewayRuleName string, serve
 }
 
 func parsePortAndHostnames(serverDef map[string]interface{}) []Host {
-	var port uint32
+	var port int
 	if portDef, found := serverDef["port"]; found {
 		if ports, ok := portDef.(map[string]interface{}); ok {
 			if numberDef, found := ports["number"]; found {
-				if portNumber, ok := numberDef.(uint32); ok {
-					port = portNumber
+				if portNumber, ok := numberDef.(int64); ok {
+					port = int(portNumber)
 				}
 			}
 		}


### PR DESCRIPTION
Istio's type for port is uint32 only in documentation and internally, it exports it as int and turns to int64 in parsing

Thus, we now expect int64 and hope that Istio doesn't fix anything..