### PR TITLE
KIALI-1975 Runtime monitoring: list available runtimes for app and workload

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
 )
@@ -17,23 +18,43 @@ type DashboardsService struct {
 	mon  kubernetes.KialiMonitoringInterface
 }
 
+// Memoize titles
+var dashboardTitles = make(map[string]string)
+
+func dashboardKey(namespace, name string) string {
+	// @ is forbidden charatecter in k8s resource name, so safe to use here
+	return name + "@" + namespace
+}
+
 // NewDashboardsService initializes this business service
 func NewDashboardsService(mon kubernetes.KialiMonitoringInterface, prom prometheus.ClientInterface) DashboardsService {
 	return DashboardsService{prom: prom, mon: mon}
 }
 
-// GetDashboard returns a dashboard filled-in with target data
-func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, template string) (*models.MonitoringDashboard, error) {
+func (in *DashboardsService) loadDashboardResource(namespace, template string) (*kubernetes.MonitoringDashboard, error) {
 	// There is an override mechanism with dashboards: default dashboards can be provided in Kiali namespace,
 	// and can be overriden in app namespace.
 	// So we look for the one in app namespace first, and only if not found fallback to the one in istio-system.
-	dashboard, err := in.mon.GetDashboard(params.Namespace, template)
+	dashboard, err := in.mon.GetDashboard(namespace, template)
 	if err != nil {
 		cfg := config.Get()
 		dashboard, err = in.mon.GetDashboard(cfg.IstioNamespace, template)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// Update cached titles as soon as we reload a dashboard, to keep it decently up-to-date
+	dashboardTitles[dashboardKey(namespace, template)] = dashboard.Spec.Title
+
+	return dashboard, nil
+}
+
+// GetDashboard returns a dashboard filled-in with target data
+func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, template string) (*models.MonitoringDashboard, error) {
+	dashboard, err := in.loadDashboardResource(params.Namespace, template)
+	if err != nil {
+		return nil, err
 	}
 
 	labels := fmt.Sprintf(`{namespace="%s",app="%s"`, params.Namespace, params.App)
@@ -147,4 +168,31 @@ func (in *DashboardsService) GetIstioDashboard(params prometheus.IstioMetricsQue
 	}
 
 	return &dashboard, nil
+}
+
+func (in *DashboardsService) getDashboardTitle(namespace, template string) string {
+	key := dashboardKey(namespace, template)
+	if title, ok := dashboardTitles[key]; ok {
+		return title
+	}
+	dashboard, err := in.loadDashboardResource(namespace, template)
+	if err != nil {
+		log.Errorf("Cannot get dashboard %s in namespace %s", template, namespace)
+		return ""
+	}
+	return dashboard.Spec.Title
+}
+
+func (in *DashboardsService) getTitlesFromTemplates(namespace string, templatesNames map[string]string) []models.DashboardRef {
+	dashboards := []models.DashboardRef{}
+	for _, tpl := range templatesNames {
+		title := in.getDashboardTitle(namespace, tpl)
+		if title != "" {
+			dashboards = append(dashboards, models.DashboardRef{
+				Template: tpl,
+				Title:    title,
+			})
+		}
+	}
+	return dashboards
 }

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -31,7 +31,7 @@ func NewDashboardsService(mon kubernetes.KialiMonitoringInterface, prom promethe
 	return DashboardsService{prom: prom, mon: mon}
 }
 
-func (in *DashboardsService) loadDashboardResource(namespace, template string) (*kubernetes.MonitoringDashboard, error) {
+func (in *DashboardsService) loadDashboardResourceUpdatingCache(namespace, template string) (*kubernetes.MonitoringDashboard, error) {
 	// There is an override mechanism with dashboards: default dashboards can be provided in Kiali namespace,
 	// and can be overriden in app namespace.
 	// So we look for the one in app namespace first, and only if not found fallback to the one in istio-system.
@@ -52,7 +52,7 @@ func (in *DashboardsService) loadDashboardResource(namespace, template string) (
 
 // GetDashboard returns a dashboard filled-in with target data
 func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, template string) (*models.MonitoringDashboard, error) {
-	dashboard, err := in.loadDashboardResource(params.Namespace, template)
+	dashboard, err := in.loadDashboardResourceUpdatingCache(params.Namespace, template)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (in *DashboardsService) getDashboardTitle(namespace, template string) strin
 	if title, ok := dashboardTitles[key]; ok {
 		return title
 	}
-	dashboard, err := in.loadDashboardResource(namespace, template)
+	dashboard, err := in.loadDashboardResourceUpdatingCache(namespace, template)
 	if err != nil {
 		log.Errorf("Cannot get dashboard %s in namespace %s", template, namespace)
 		return ""

--- a/business/layer.go
+++ b/business/layer.go
@@ -53,7 +53,7 @@ func NewWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	temporaryLayer.IstioConfig = IstioConfigService{k8s: k8s}
 	temporaryLayer.Workload = WorkloadService{k8s: k8s, prom: prom, businessLayer: temporaryLayer}
 	temporaryLayer.Validations = IstioValidationsService{k8s: k8s, ws: temporaryLayer.Workload}
-	temporaryLayer.App = AppService{k8s: k8s}
+	temporaryLayer.App = AppService{prom: prom, k8s: k8s}
 	temporaryLayer.Namespace = NewNamespaceService(k8s)
 	temporaryLayer.k8s = k8s
 	return temporaryLayer

--- a/models/app.go
+++ b/models/app.go
@@ -54,4 +54,7 @@ type App struct {
 	// List of service names linked with an application
 	// required: true
 	ServiceNames []string `json:"serviceNames"`
+
+	// Custom dashboard ids and titles
+	CustomDashboards []DashboardRef `json:"customDashboards"`
 }

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -86,3 +86,9 @@ func PrepareIstioDashboard(direction, local, remote string) MonitoringDashboard 
 		Aggregations: buildIstioAggregations(local, remote),
 	}
 }
+
+// DashboardRef holds template name and title for a custom dashboard
+type DashboardRef struct {
+	Template string `json:"template"`
+	Title    string `json:"title"`
+}

--- a/models/pod.go
+++ b/models/pod.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"strings"
 
 	"k8s.io/api/core/v1"
 
@@ -22,6 +23,7 @@ type Pod struct {
 	Status              string            `json:"status"`
 	AppLabel            bool              `json:"appLabel"`
 	VersionLabel        bool              `json:"versionLabel"`
+	CustomDashboards    []string          `json:"-"` // not used in the UI but needed to build app and workload models
 }
 
 // Reference holds some information on the pod creator
@@ -88,6 +90,10 @@ func (pod *Pod) Parse(p *v1.Pod) {
 				pod.IstioContainers = append(pod.IstioContainers, &container)
 			}
 		}
+	}
+	// Check for custom dashboards annotation
+	if rawDashboards, ok := p.Annotations["kiali.io/dashboards"]; ok {
+		pod.CustomDashboards = strings.Split(strings.TrimSpace(rawDashboards), ",")
 	}
 	pod.Status = string(p.Status.Phase)
 	_, pod.AppLabel = p.Labels[conf.IstioLabels.AppLabelName]

--- a/models/pod.go
+++ b/models/pod.go
@@ -23,7 +23,7 @@ type Pod struct {
 	Status              string            `json:"status"`
 	AppLabel            bool              `json:"appLabel"`
 	VersionLabel        bool              `json:"versionLabel"`
-	CustomDashboards    []string          `json:"-"` // not used in the UI but needed to build app and workload models
+	CustomDashboards    []string          `json:"customDashboards"`
 }
 
 // Reference holds some information on the pod creator

--- a/models/workload.go
+++ b/models/workload.go
@@ -97,6 +97,9 @@ type Workload struct {
 	Services Services `json:"services"`
 
 	DestinationServices []DestinationService `json:"destinationServices"`
+
+	// Custom dashboard ids and titles
+	CustomDashboards []DashboardRef `json:"customDashboards"`
 }
 
 // DestinationService holds service identifiers used for workload dependencies

--- a/swagger.json
+++ b/swagger.json
@@ -2596,6 +2596,14 @@
         "serviceNames"
       ],
       "properties": {
+        "customDashboards": {
+          "description": "Custom dashboard ids and titles",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DashboardRef"
+          },
+          "x-go-name": "CustomDashboards"
+        },
         "name": {
           "description": "Name of the application",
           "type": "string",
@@ -2752,6 +2760,21 @@
         "name": {
           "type": "string",
           "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "DashboardRef": {
+      "description": "DashboardRef holds template name and title for a custom dashboard",
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "x-go-name": "Template"
+        },
+        "title": {
+          "type": "string",
+          "x-go-name": "Title"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -4200,6 +4223,14 @@
           "type": "string",
           "x-go-name": "CreatedAt",
           "example": "2018-07-31T12:24:17Z"
+        },
+        "customDashboards": {
+          "description": "Custom dashboard ids and titles",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DashboardRef"
+          },
+          "x-go-name": "CustomDashboards"
         },
         "destinationServices": {
           "type": "array",

--- a/swagger.json
+++ b/swagger.json
@@ -3573,6 +3573,13 @@
           },
           "x-go-name": "CreatedBy"
         },
+        "customDashboards": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "CustomDashboards"
+        },
         "istioContainers": {
           "type": "array",
           "items": {


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-1975

- Add CustomDashboards in app & workload details
- Get dashboards by parsing annotation kiali.io/dashboards on pods
- Memoize title to avoid reloading resource to often
