### PR TITLE
KIALI-1671 Refactor validations

### DIFF
--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -27,9 +27,9 @@ func TestGetNamespaceValidations(t *testing.T) {
 	vs := mockCombinedValidationService(fakeCombinedIstioDetails(),
 		[]string{"details", "product", "customer"}, fakePods())
 
-	validations, _ := vs.GetNamespaceValidations("test")
+	validations, _ := vs.GetValidations("test", "")
 	assert.NotEmpty(validations)
-	assert.True(validations["test"][models.IstioValidationKey{"virtualservice", "product-vs"}].Valid)
+	assert.True(validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}].Valid)
 }
 
 func TestGetIstioObjectValidations(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -31,7 +31,7 @@ type AppVersionParam struct {
 	Name string `json:"version"`
 }
 
-// swagger:parameters istioConfigList serviceValidations namespaceValidations objectValidations workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard
+// swagger:parameters istioConfigList  workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard
 type NamespaceParam struct {
 	// The namespace id.
 	//
@@ -40,7 +40,7 @@ type NamespaceParam struct {
 	Name string `json:"namespace"`
 }
 
-// swagger:parameters objectValidations istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype
+// swagger:parameters istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype
 type ObjectNameParam struct {
 	// The Istio object name.
 	//
@@ -49,7 +49,7 @@ type ObjectNameParam struct {
 	Name string `json:"object"`
 }
 
-// swagger:parameters objectValidations istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype
+// swagger:parameters istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype
 type ObjectTypeParam struct {
 	// The Istio object type.
 	//
@@ -68,7 +68,7 @@ type ObjectSubtypeParam struct {
 	Name string `json:"object_subtype"`
 }
 
-// swagger:parameters serviceValidations serviceDetails serviceMetrics graphService serviceDashboard
+// swagger:parameters serviceDetails serviceMetrics graphService serviceDashboard
 type ServiceParam struct {
 	// The service name.
 	//
@@ -398,20 +398,6 @@ type IstioConfigResponse struct {
 	Body models.IstioConfigList
 }
 
-// Listing all istio validations for object in the namespace
-// swagger:response namespaceValidationsResponse
-type NamespaceValidationResponse struct {
-	// in:body
-	Body NamespaceValidations
-}
-
-// Listing all istio validations for object in the namespace
-// swagger:response typeValidationsResponse
-type ServiceValidationResponse struct {
-	// in:body
-	Body TypedIstioValidations
-}
-
 // Listing all services in the namespace
 // swagger:response serviceListResponse
 type ServiceListResponse struct {
@@ -527,10 +513,6 @@ type JaegerInfoResponse struct {
 //////////////////
 // SWAGGER MODELS
 //////////////////
-
-// List of validations grouped by namespace
-// swagger:model
-type NamespaceValidations map[string]TypedIstioValidations
 
 // List of validations grouped by object type
 // swagger:model

--- a/hack/cluster-openshift.sh
+++ b/hack/cluster-openshift.sh
@@ -545,6 +545,13 @@ if [ "$_CMD" = "up" ]; then
       ${MAISTRA_ISTIO_OC_COMMAND} delete all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,virtualservices,destinationrules --selector=app=elasticsearch -n istio-system
   fi
 
+  if [ "${REMOVE_JAEGER}" == "true" ]; then
+      echo "Removing Jaeger from cluster..."
+      ${MAISTRA_ISTIO_OC_COMMAND} delete all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,virtualservices,destinationrules --selector=app=jaeger -n istio-system
+      echo "Removing Elasticsearch from cluster..."
+      ${MAISTRA_ISTIO_OC_COMMAND} delete all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,virtualservices,destinationrules --selector=app=elasticsearch -n istio-system
+  fi
+
 elif [ "$_CMD" = "down" ];then
 
   echo "Will shutdown the OpenShift cluster"

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/log"
@@ -34,30 +33,6 @@ func NamespaceList(w http.ResponseWriter, r *http.Request) {
 // services in the namespace
 func NamespaceMetrics(w http.ResponseWriter, r *http.Request) {
 	getNamespaceMetrics(w, r, defaultPromClientSupplier, defaultK8SClientSupplier)
-}
-
-// NamespaceIstioValidations is the API handler to get istio validations of a given namespace
-func NamespaceIstioValidations(w http.ResponseWriter, r *http.Request) {
-	// Get business layer
-	business, err := business.Get()
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
-
-	vars := mux.Vars(r)
-	namespace := vars["namespace"]
-
-	istioValidations, err := business.Validations.GetNamespaceValidations(namespace)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			RespondWithError(w, http.StatusNotFound, err.Error())
-		} else {
-			RespondWithError(w, http.StatusInternalServerError, "Error checking istio object consistency: "+err.Error())
-		}
-		return
-	}
-	RespondWithJSON(w, http.StatusOK, istioValidations)
 }
 
 // getServiceMetrics (mock-friendly version)

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -19,6 +19,7 @@ type IstioConfigList struct {
 	Templates         IstioTemplates    `json:"templates"`
 	QuotaSpecs        QuotaSpecs        `json:"quotaSpecs"`
 	QuotaSpecBindings QuotaSpecBindings `json:"quotaSpecBindings"`
+	IstioValidations  IstioValidations  `json:"validations"`
 }
 
 type IstioConfigDetails struct {
@@ -34,6 +35,7 @@ type IstioConfigDetails struct {
 	QuotaSpec        *QuotaSpec          `json:"quotaSpec"`
 	QuotaSpecBinding *QuotaSpecBinding   `json:"quotaSpecBinding"`
 	Permissions      ResourcePermissions `json:"permissions"`
+	IstioValidation  *IstioValidation    `json:"validation"`
 }
 
 // ResourcePermissions holds permission flags for an object type

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -81,6 +81,22 @@ func (iv IstioValidations) FilterByKey(objectType, name string) IstioValidations
 	return fiv
 }
 
+// FilterByTypes takes an input as ObjectTypes, transforms to singular types and filters the validations
+func (iv IstioValidations) FilterByTypes(objectTypes []string) IstioValidations {
+	types := make(map[string]bool, len(objectTypes))
+	for _, objectType := range objectTypes {
+		types[ObjectTypeSingular[objectType]] = true
+	}
+	fiv := IstioValidations{}
+	for k, v := range iv {
+		if _, found := types[k.ObjectType]; found {
+			fiv[k] = v
+		}
+	}
+
+	return fiv
+}
+
 func (iv IstioValidations) MergeValidations(validations IstioValidations) IstioValidations {
 	for key, validation := range validations {
 		v, ok := iv[key]

--- a/models/service.go
+++ b/models/service.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/prometheus"
@@ -36,6 +36,7 @@ type ServiceDetails struct {
 	Dependencies     map[string][]SourceWorkload `json:"dependencies"`
 	Workloads        WorkloadOverviews           `json:"workloads"`
 	Health           ServiceHealth               `json:"health"`
+	Validations      IstioValidations            `json:"validations"`
 }
 
 type Services []*Service

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -146,37 +146,6 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigDetails,
 			true,
 		},
-		//
-		// NOTE: Order of routes is important when two patterns may match
-		// On this case, this endpoint will have priority
-		// 	GET /namespaces/{namespace}/istio/{object_type}/{object}/istio_validations config objectValidations
-		//  vs
-		//  GET /namespaces/{namespace}/istio/{object_type}/{object_subtype}/{object}
-		//
-		// TODO This is going to be refactored in KIALI-1671 so this workaround is temporal for KIALI-1947
-		//
-		// swagger:route GET /namespaces/{namespace}/istio/{object_type}/{object}/istio_validations config objectValidations
-		// ---
-		// Endpoint to get the list of istio object validations for a service
-		//
-		//     Produces:
-		//     - application/json
-		//
-		//     Schemes: http, https
-		//
-		// responses:
-		//      400: badRequestError
-		//      404: notFoundError
-		//      500: internalError
-		//      200: typeValidationsResponse
-		//
-		{
-			"IstioConfigValidations",
-			"GET",
-			"/api/namespaces/{namespace}/istio/{object_type}/{object}/istio_validations",
-			handlers.IstioConfigValidations,
-			true,
-		},
 		// swagger:route GET /namespaces/{namespace}/istio/{object_type}/{object_subtype}/{object} config istioConfigDetailsSubtype
 		// ---
 		// Endpoint to get the Istio Config of an Istio object used for templates and adapters that is necessary to define a subtype
@@ -644,22 +613,6 @@ func NewRoutes() (r *Routes) {
 			handlers.WorkloadHealth,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/services/{service}/istio_validations services serviceValidations
-		// ---
-		// Endpoint to get the list of istio object validations for a service
-		//
-		// responses:
-		//      500: internalError
-		//      404: notFoundError
-		//      200: typeValidationsResponse
-		//
-		{
-			"ServiceValidations",
-			"GET",
-			"/api/namespaces/{namespace}/services/{service}/istio_validations",
-			handlers.ServiceIstioValidations,
-			true,
-		},
 		// swagger:route GET /namespaces/{namespace}/metrics namespaces namespaceMetrics
 		// ---
 		// Endpoint to fetch metrics to be displayed, related to a namespace
@@ -700,27 +653,6 @@ func NewRoutes() (r *Routes) {
 			"GET",
 			"/api/namespaces/{namespace}/health",
 			handlers.NamespaceHealth,
-			true,
-		},
-		// swagger:route GET /namespaces/{namespace}/istio_validations namespaces namespaceValidations
-		// ---
-		// Endpoint to get the list of istio object validations for a namespace
-		//
-		//     Produces:
-		//     - application/json
-		//
-		//     Schemes: http, https
-		//
-		// responses:
-		//      500: internalError
-		//      404: notFoundError
-		//      200: namespaceValidationsResponse
-		//
-		{
-			"NamespaceValidations",
-			"GET",
-			"/api/namespaces/{namespace}/istio_validations",
-			handlers.NamespaceIstioValidations,
 			true,
 		},
 		// swagger:route GET /namespaces/graph graphs graphNamespaces

--- a/swagger.json
+++ b/swagger.json
@@ -1364,100 +1364,6 @@
         }
       }
     },
-    "/namespaces/{namespace}/istio/{object_type}/{object}/istio_validations": {
-      "get": {
-        "description": "Endpoint to get the list of istio object validations for a service",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "config"
-        ],
-        "operationId": "objectValidations",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The namespace id.",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The Istio object name.",
-            "name": "object",
-            "in": "path",
-            "required": true
-          },
-          {
-            "pattern": "^(gateways|virtualservices|destinationrules|serviceentries|rules|quotaspecs|quotaspecbindings)$",
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The Istio object type.",
-            "name": "object_type",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/typeValidationsResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          }
-        }
-      }
-    },
-    "/namespaces/{namespace}/istio_validations": {
-      "get": {
-        "description": "Endpoint to get the list of istio object validations for a namespace",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "namespaces"
-        ],
-        "operationId": "namespaceValidations",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The namespace id.",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/namespaceValidationsResponse"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          }
-        }
-      }
-    },
     "/namespaces/{namespace}/metrics": {
       "get": {
         "description": "Endpoint to fetch metrics to be displayed, related to a namespace",
@@ -1834,44 +1740,6 @@
         "responses": {
           "200": {
             "$ref": "#/responses/serviceHealthResponse"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          }
-        }
-      }
-    },
-    "/namespaces/{namespace}/services/{service}/istio_validations": {
-      "get": {
-        "description": "Endpoint to get the list of istio object validations for a service",
-        "tags": [
-          "services"
-        ],
-        "operationId": "serviceValidations",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The namespace id.",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "The service name.",
-            "name": "service",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/typeValidationsResponse"
           },
           "404": {
             "$ref": "#/responses/notFoundError"
@@ -3065,6 +2933,9 @@
         "template": {
           "$ref": "#/definitions/istioTemplate"
         },
+        "validation": {
+          "$ref": "#/definitions/IstioValidation"
+        },
         "virtualService": {
           "$ref": "#/definitions/virtualService"
         }
@@ -3105,6 +2976,9 @@
         },
         "templates": {
           "$ref": "#/definitions/istioTemplates"
+        },
+        "validations": {
+          "$ref": "#/definitions/IstioValidations"
         },
         "virtualServices": {
           "$ref": "#/definitions/virtualServices"
@@ -3148,6 +3022,10 @@
           "example": false
         }
       },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "IstioValidations": {
+      "title": "IstioValidations represents a set of IstioValidation grouped by IstioValidationKey.",
       "x-go-package": "github.com/kiali/kiali/models"
     },
     "JaegerInfo": {
@@ -3225,14 +3103,6 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
-    "NameIstioValidation": {
-      "description": "List of validations grouped by object name",
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/IstioValidation"
-      },
-      "x-go-package": "github.com/kiali/kiali"
-    },
     "NamespaceAppHealth": {
       "description": "NamespaceAppHealth is an alias of map of app name x health",
       "type": "object",
@@ -3240,14 +3110,6 @@
         "$ref": "#/definitions/AppHealth"
       },
       "x-go-package": "github.com/kiali/kiali/models"
-    },
-    "NamespaceValidations": {
-      "description": "List of validations grouped by namespace",
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/TypedIstioValidations"
-      },
-      "x-go-package": "github.com/kiali/kiali"
     },
     "NodeData": {
       "type": "object",
@@ -3813,6 +3675,9 @@
         "service": {
           "$ref": "#/definitions/Service"
         },
+        "validations": {
+          "$ref": "#/definitions/IstioValidations"
+        },
         "virtualServices": {
           "$ref": "#/definitions/virtualServices"
         },
@@ -4129,14 +3994,6 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/config"
-    },
-    "TypedIstioValidations": {
-      "description": "List of validations grouped by object type",
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/NameIstioValidation"
-      },
-      "x-go-package": "github.com/kiali/kiali"
     },
     "UID": {
       "description": "UID is a type that holds unique ID values, including UUIDs.  Because we\ndon't ONLY use UUIDs, this is an alias to string.  Being a type captures\nintent and helps make sure that UIDs and names do not get conflated.",
@@ -4796,12 +4653,6 @@
         }
       }
     },
-    "namespaceValidationsResponse": {
-      "description": "Listing all istio validations for object in the namespace",
-      "schema": {
-        "$ref": "#/definitions/NamespaceValidations"
-      }
-    },
     "noContent": {
       "description": "NoContent: the response is empty",
       "schema": {
@@ -4910,12 +4761,6 @@
       "description": "HTTP status code 200 and tokenGenerated model in data",
       "schema": {
         "$ref": "#/definitions/TokenGenerated"
-      }
-    },
-    "typeValidationsResponse": {
-      "description": "Listing all istio validations for object in the namespace",
-      "schema": {
-        "$ref": "#/definitions/TypedIstioValidations"
       }
     },
     "workloadDetails": {

--- a/tests/e2e/tests/test_api_methods.py
+++ b/tests/e2e/tests/test_api_methods.py
@@ -9,9 +9,9 @@ def before_all_tests(kiali_client):
     swagger = kiali_client.swagger_parser.swagger
     swagger_method_list= []
     tested_method_list = ['Root','jaegerInfo', 'grafanaInfo', 'getStatus', 'getConfig', 'GetToken',
-                          'namespaceList', 'namespaceMetrics','namespaceHealth','namespaceValidations',
+                          'namespaceList', 'namespaceMetrics','namespaceHealth',
                           'istioConfigList', 'istioConfigDetails', 'objectValidations', ''
-                          'serviceList', 'serviceDetails', 'serviceMetrics', 'serviceHealth', 'serviceValidations',
+                          'serviceList', 'serviceDetails', 'serviceMetrics', 'serviceHealth',
                           'appHealth', 'appList', 'appDetails', 'appMetrics',
                           'workloadList', 'workloadDetails', 'workloadHealth', 'workloadMetrics',
                           'graphNamespaces', 'graphService', 'graphWorkload', 'graphApp', 'graphAppVersion', 'istioConfigDetailsSubtype',
@@ -87,23 +87,12 @@ def test_namespace_health(kiali_client):
     evaluate_response(kiali_client, method_name='namespaceHealth', path={'namespace': 'istio-system'})
 
 
-def test_namespace_validations(kiali_client):
-    evaluate_response(kiali_client, method_name='namespaceValidations', path={'namespace': 'istio-system'})
-
-
 def test_istio_config_list(kiali_client):
     evaluate_response(kiali_client, method_name='istioConfigList', path={'namespace': 'istio-system'})
 
 
 def test_istio_config_details(kiali_client):
     evaluate_response(kiali_client, method_name='istioConfigDetails', path={'namespace': 'istio-system', 'object_type': 'rules', 'object': 'promtcp'})
-
-
-def test_object_validations(kiali_client):
-    evaluate_response(kiali_client, method_name='objectValidations', path={'namespace': 'bookinfo', 'object_type': 'service', 'object': 'productpage'}, status_code_expected=400)
-    evaluate_response(kiali_client, method_name='objectValidations', path={'namespace': 'istio-system', 'object_type': 'rules', 'object': 'promtcp'})
-
-
 
 def test_istio_config_details_subtype(kiali_client):
     evaluate_response(kiali_client, method_name='istioConfigDetailsSubtype', path={'namespace': 'istio-system', 'object_type': 'templates', 'object_subtype': 'metrics', 'object': 'tcpbytereceived'} )
@@ -122,10 +111,6 @@ def test_service_metrics(kiali_client):
 
 def test_service_health(kiali_client):
     evaluate_response(kiali_client, method_name='serviceHealth', path={'namespace': 'istio-system', 'service': 'kiali'})
-
-
-def test_service_validations(kiali_client):
-    evaluate_response(kiali_client, method_name='serviceValidations', path={'namespace': 'istio-system', 'service': 'kiali'})
 
 
 def test_app_list(kiali_client):

--- a/tests/e2e/tests/test_kiali_istio_endpoint.py
+++ b/tests/e2e/tests/test_kiali_istio_endpoint.py
@@ -37,5 +37,5 @@ def test_istio_object_istio_validations(kiali_client):
 
     assert istio_validations != None
     assert istio_validations.get('validation') != None
-    assert OBJECT in istio_validations.get('validation')
-
+    assert OBJECT in istio_validations.get('validation').get('name')
+    assert OBJECT_TYPE in istio_validations.get('validation').get('objectType')

--- a/tests/e2e/tests/test_kiali_istio_endpoint.py
+++ b/tests/e2e/tests/test_kiali_istio_endpoint.py
@@ -15,10 +15,10 @@ def test_istio_config_list(kiali_client):
 
 def test_istio_namespace_validations_endpoint(kiali_client):
     bookinfo_namespace = conftest.get_bookinfo_namespace()
-    istio_validations = kiali_client.request(method_name='namespaceValidations', path={'namespace': bookinfo_namespace}).json()
+    istio_validations = kiali_client.request(method_name='istioConfigList', path={'namespace': bookinfo_namespace}, params={'validate': 'true'}).json()
 
     assert istio_validations != None
-    assert bookinfo_namespace in istio_validations
+    assert "validations" in istio_validations
 
 def test_istio_object_type(kiali_client):
     bookinfo_namespace = conftest.get_bookinfo_namespace()
@@ -32,9 +32,10 @@ def test_istio_object_type(kiali_client):
 def test_istio_object_istio_validations(kiali_client):
     bookinfo_namespace = conftest.get_bookinfo_namespace()
 
-    istio_validations = kiali_client.request(method_name='objectValidations',
-                            path={'namespace': bookinfo_namespace, 'object_type': OBJECT_TYPE, 'object': OBJECT}).json()
+    istio_validations = kiali_client.request(method_name='istioConfigDetails',
+                            path={'namespace': bookinfo_namespace, 'object_type': OBJECT_TYPE, 'object': OBJECT}, params={'validate': 'true'}).json()
+
     assert istio_validations != None
-    assert istio_validations.get('virtualservice') != None
-    assert OBJECT in istio_validations.get('virtualservice')
+    assert istio_validations.get('validation') != None
+    assert OBJECT in istio_validations.get('validation')
 

--- a/tests/e2e/tests/test_kiali_service_endpoint.py
+++ b/tests/e2e/tests/test_kiali_service_endpoint.py
@@ -188,6 +188,7 @@ def __test_service_health_endpoint(kiali_client):
 def test_service_validations_endpoint(kiali_client):
     bookinfo_namespace = conftest.get_bookinfo_namespace()
 
-    service_validations = kiali_client.request(method_name='serviceValidations', path={'namespace': bookinfo_namespace, 'service':SERVICE_TO_VALIDATE}).json()
+    service_validations = kiali_client.request(method_name='serviceDetails', path={'namespace': bookinfo_namespace, 'service':SERVICE_TO_VALIDATE}, params={'validate': 'true'}).json()
     assert service_validations != None
-    assert service_validations.get('gateway') != None
+    assert service_validations.get('validations') != None
+    assert service_validations.get('validations').get('gateway') != None


### PR DESCRIPTION
Requires kiali-UI PR 892 to be merged at the same time.

This change will remove the validation endpoints and refactor them to the requested items. This requires changes to the UI part, which are not completed yet. 

Here for comments. I also changed the "istio_validations" to "validate" parameter in the REST-interface as it in my opinion fit the change better.