### PR TITLE
KIALI-565 Return graph duration in the JSON

### DIFF
--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -89,6 +89,7 @@ type Elements struct {
 
 type Config struct {
 	Timestamp int64    `json:"timestamp"`
+	Duration  int64    `json:"duration"`
 	GraphType string   `json:"graphType"`
 	Elements  Elements `json:"elements"`
 }
@@ -152,7 +153,8 @@ func NewConfig(trafficMap graph.TrafficMap, o options.VendorOptions) (result Con
 
 	elements := Elements{nodes, edges}
 	result = Config{
-		Timestamp: o.Timestamp,
+		Duration:  int64(o.Duration.Seconds()),
+		Timestamp: o.QueryTime,
 		GraphType: o.GraphType,
 		Elements:  elements,
 	}

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -46,20 +46,19 @@ type NodeOptions struct {
 
 // VendorOptions are those that are supplied to the vendor-specific generators.
 type VendorOptions struct {
+	Duration  time.Duration
 	GraphType string
 	GroupBy   string
-	Timestamp int64
+	QueryTime int64 // unix time in seconds
 }
 
 // Options are all supported graph generation options.
 type Options struct {
 	AccessibleNamespaces map[string]time.Time
 	Appenders            []appender.Appender
-	Duration             time.Duration
 	IncludeIstio         bool // include istio-system services. Ignored for istio-system ns. Default false.
 	InjectServiceNodes   bool // inject destination service nodes between source and destination nodes.
 	Namespaces           map[string]graph.NamespaceInfo
-	QueryTime            int64 // unix time in seconds
 	Vendor               string
 	NodeOptions
 	VendorOptions
@@ -179,11 +178,9 @@ func NewOptions(r *http.Request) Options {
 
 	options := Options{
 		AccessibleNamespaces: accessibleNamespaces,
-		Duration:             duration,
 		IncludeIstio:         includeIstio,
 		InjectServiceNodes:   injectServiceNodes,
 		Namespaces:           namespaceMap,
-		QueryTime:            queryTime,
 		Vendor:               vendor,
 		NodeOptions: NodeOptions{
 			App:       app,
@@ -193,9 +190,10 @@ func NewOptions(r *http.Request) Options {
 			Workload:  workload,
 		},
 		VendorOptions: VendorOptions{
+			Duration:  duration,
 			GraphType: graphType,
 			GroupBy:   groupBy,
-			Timestamp: queryTime,
+			QueryTime: queryTime,
 		},
 	}
 

--- a/handlers/testdata/test_app_graph.expected
+++ b/handlers/testdata/test_app_graph.expected
@@ -1,5 +1,6 @@
 {
   "timestamp": 1523364075,
+  "duration": 600,
   "graphType": "app",
   "elements": {
     "nodes": [

--- a/handlers/testdata/test_app_node_graph.expected
+++ b/handlers/testdata/test_app_node_graph.expected
@@ -1,5 +1,6 @@
 {
   "timestamp": 1523364075,
+  "duration": 600,
   "graphType": "versionedApp",
   "elements": {
     "nodes": [

--- a/handlers/testdata/test_complex_graph.expected
+++ b/handlers/testdata/test_complex_graph.expected
@@ -1,5 +1,6 @@
 {
   "timestamp": 1523364075,
+  "duration": 600,
   "graphType": "versionedApp",
   "elements": {
     "nodes": [

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -1,5 +1,6 @@
 {
   "timestamp": 1523364075,
+  "duration": 600,
   "graphType": "service",
   "elements": {
     "nodes": [

--- a/handlers/testdata/test_service_node_graph.expected
+++ b/handlers/testdata/test_service_node_graph.expected
@@ -1,5 +1,6 @@
 {
   "timestamp": 1523364075,
+  "duration": 600,
   "graphType": "workload",
   "elements": {
     "nodes": [

--- a/handlers/testdata/test_versioned_app_graph.expected
+++ b/handlers/testdata/test_versioned_app_graph.expected
@@ -1,5 +1,6 @@
 {
   "timestamp": 1523364075,
+  "duration": 600,
   "graphType": "versionedApp",
   "elements": {
     "nodes": [

--- a/handlers/testdata/test_versioned_app_node_graph.expected
+++ b/handlers/testdata/test_versioned_app_node_graph.expected
@@ -1,5 +1,6 @@
 {
   "timestamp": 1523364075,
+  "duration": 600,
   "graphType": "versionedApp",
   "elements": {
     "nodes": [

--- a/handlers/testdata/test_workload_graph.expected
+++ b/handlers/testdata/test_workload_graph.expected
@@ -1,5 +1,6 @@
 {
   "timestamp": 1523364075,
+  "duration": 600,
   "graphType": "workload",
   "elements": {
     "nodes": [

--- a/handlers/testdata/test_workload_node_graph.expected
+++ b/handlers/testdata/test_workload_node_graph.expected
@@ -1,5 +1,6 @@
 {
   "timestamp": 1523364075,
+  "duration": 600,
   "graphType": "workload",
   "elements": {
     "nodes": [

--- a/swagger.json
+++ b/swagger.json
@@ -2734,6 +2734,11 @@
     "Config": {
       "type": "object",
       "properties": {
+        "duration": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Duration"
+        },
         "elements": {
           "$ref": "#/definitions/Elements"
         },


### PR DESCRIPTION
This allows the client to parse out the exact time range the graph represents
