### PR TITLE
KIALI-2185 Validations: Allow VS to have empty weights in case actual…

### DIFF
--- a/business/checkers/virtual_services/route_checker.go
+++ b/business/checkers/virtual_services/route_checker.go
@@ -95,13 +95,12 @@ func (route RouteChecker) checkRoutesFor(kind string) ([]*models.IstioCheck, boo
 			path := fmt.Sprintf("spec/%s[%d]/route", kind, routeIdx)
 			validation := buildValidation("Weight sum should be 100", "error", path)
 			validations = append(validations, &validation)
-		}
-
-		if weightCount > 0 && weightCount != destinationWeights.Len() {
-			valid = false
-			path := fmt.Sprintf("spec/%s[%d]/route", kind, routeIdx)
-			validation := buildValidation("All routes should have weight", "error", path)
-			validations = append(validations, &validation)
+			if weightCount != destinationWeights.Len() {
+				valid = false
+				path := fmt.Sprintf("spec/%s[%d]/route", kind, routeIdx)
+				validation := buildValidation("All routes should have weight", "error", path)
+				validations = append(validations, &validation)
+			}
 		}
 	}
 


### PR DESCRIPTION
KIALI-2185 Validations: Allow VS to have empty weights in case actual weight sum is already 100
Discussion - https://github.com/kiali/kiali/issues/754

Update http route weight validation to allow 0 weight scenarios such as below - 

```
    http:
      route:
      - destination:
          host: ratings.default.svc.cluster.local
          subset: subset1
        weight: 100
      - destination:
          host: ratings.default.svc.cluster.local
          subset: subset2
```
