### PR TITLE
KIALI-2187 use the downloader var rather than hardcoding curl

### DIFF
--- a/deploy/kubernetes/deploy-kiali-to-kubernetes.sh
+++ b/deploy/kubernetes/deploy-kiali-to-kubernetes.sh
@@ -92,13 +92,13 @@ fi
 # Note that you could ask for "latest" - that would pick up the current image built from master.
 if [ "${IMAGE_VERSION}" == "lastrelease" ]; then
   get_downloader
-  version_we_want=$(${downloader} https://api.github.com/repos/kiali/kiali/releases/latest 2> /dev/null |\
+  kiali_version_we_want=$(${downloader} https://api.github.com/repos/kiali/kiali/releases/latest 2> /dev/null |\
     grep  "tag_name" | \
     sed -e 's/.*://' -e 's/ *"//' -e 's/",//')
-  echo "Will use the last Kiali release: $version_we_want"
-  IMAGE_VERSION=${version_we_want}
+  echo "Will use the last Kiali release: $kiali_version_we_want"
+  IMAGE_VERSION=${kiali_version_we_want}
   if [ "${VERSION_LABEL}" == "lastrelease" ]; then
-    VERSION_LABEL=${version_we_want}
+    VERSION_LABEL=${kiali_version_we_want}
   fi
 else
   if [ "${IMAGE_VERSION}" == "latest" ]; then

--- a/deploy/openshift/deploy-kiali-to-openshift.sh
+++ b/deploy/openshift/deploy-kiali-to-openshift.sh
@@ -92,13 +92,13 @@ fi
 # Note that you could ask for "latest" - that would pick up the current image built from master.
 if [ "${IMAGE_VERSION}" == "lastrelease" ]; then
   get_downloader
-  version_we_want=$(${downloader} https://api.github.com/repos/kiali/kiali/releases/latest 2> /dev/null |\
+  kiali_version_we_want=$(${downloader} https://api.github.com/repos/kiali/kiali/releases/latest 2> /dev/null |\
     grep  "tag_name" | \
     sed -e 's/.*://' -e 's/ *"//' -e 's/",//')
-  echo "Will use the last Kiali release: $version_we_want"
-  IMAGE_VERSION=${version_we_want}
+  echo "Will use the last Kiali release: $kiali_version_we_want"
+  IMAGE_VERSION=${kiali_version_we_want}
   if [ "${VERSION_LABEL}" == "lastrelease" ]; then
-    VERSION_LABEL=${version_we_want}
+    VERSION_LABEL=${kiali_version_we_want}
   fi
 else
   if [ "${IMAGE_VERSION}" == "latest" ]; then


### PR DESCRIPTION
** Describe the change **

In the deploy scripts for both openshift and k8s, the use of curl was explicit when downloading the github json which is used to determine the latest release. They should be using the `$downloader` var since some systems don't have curl, but do have wget. We want to support both.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2187

** Backwards incompatible? **

yes
