### PR TITLE
issue 761 - macOS doesn't have readlink - do it another way

### DIFF
--- a/deploy/kubernetes/deploy-kiali-to-kubernetes.sh
+++ b/deploy/kubernetes/deploy-kiali-to-kubernetes.sh
@@ -106,7 +106,7 @@ get_downloader() {
 # It is assumed the yaml files are in the same location as this script.
 # Figure out where that is using a method that is valid for bash and sh.
 
-YAML_DIR=${YAML_DIR:-$(dirname $(readlink -f "$0"))}
+YAML_DIR=${YAML_DIR:-$(cd "$(dirname "$0")" && pwd -P)}
 
 # Now deploy all the Kiali components to kubernetes
 # If we are missing one or more of the yaml files, download them

--- a/deploy/openshift/deploy-kiali-to-openshift.sh
+++ b/deploy/openshift/deploy-kiali-to-openshift.sh
@@ -106,7 +106,7 @@ get_downloader() {
 # It is assumed the yaml files are in the same location as this script.
 # Figure out where that is using a method that is valid for bash and sh.
 
-YAML_DIR=${YAML_DIR:-$(dirname $(readlink -f "$0"))}
+YAML_DIR=${YAML_DIR:-$(cd "$(dirname "$0")" && pwd -P)}
 
 # Now deploy all the Kiali components to OpenShift
 # If we are missing one or more of the yaml files, download them


### PR DESCRIPTION
The install script uses readlink to see if the yaml files are on disk. Even though most people won't (and thus this failure doesn't make a difference other than an error message spit out) let's help out kiali devs that are on MacOS and want to use these install scripts.

Rather than use readlink, do it another way that is supported on linux and macos.