### PR TITLE
KIALI-2188 Fix root path redirection loop

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -17,7 +17,7 @@ func NewRouter() *mux.Router {
 	webRoot := conf.Server.WebRoot
 	webRootWithSlash := webRoot + "/"
 
-	rootRouter := mux.NewRouter().StrictSlash(true)
+	rootRouter := mux.NewRouter().StrictSlash(false)
 	appRouter := rootRouter
 
 	// Due to PathPrefix matching behavoir on sub-routers
@@ -27,8 +27,10 @@ func NewRouter() *mux.Router {
 		rootRouter.HandleFunc(webRoot, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, webRootWithSlash, http.StatusFound)
 		})
-		appRouter = rootRouter.PathPrefix(conf.Server.WebRoot).Subrouter().StrictSlash(true)
+		appRouter = rootRouter.PathPrefix(conf.Server.WebRoot).Subrouter()
 	}
+
+	appRouter = appRouter.StrictSlash(true)
 
 	// Build our API server routes and install them.
 	apiRoutes := NewRoutes()


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2188

Because of the `StrictSlash(true)` on the root URL, the muxer was redirecting from `$webRoot/` -> to -> `$webRoot` (without trailing slash). However, there is a manual redirection in the opposite way when $webRoot is not '/' (custom context case). This was causing a redirection loop making impossible to access the UI using the root Kiali URL when custom context is configured.

The loop is removed by turning on "StrictSlash" after the manual redirection is configured.
