### PR TITLE
KIALI-2237 Runtime metrics: allow raw metrics

### DIFF
--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -55,8 +55,8 @@ func TestGetDashboard(t *testing.T) {
 	assert.Equal("My chart 1", dashboard.Charts[0].Name)
 	assert.Equal("My chart 2", dashboard.Charts[1].Name)
 	assert.Nil(dashboard.Charts[0].Histogram)
-	assert.Nil(dashboard.Charts[1].CounterRate)
-	assert.Equal(model.SampleValue(10), dashboard.Charts[0].CounterRate.Matrix[0].Values[0].Value)
+	assert.Nil(dashboard.Charts[1].Metric)
+	assert.Equal(model.SampleValue(10), dashboard.Charts[0].Metric.Matrix[0].Values[0].Value)
 	assert.Equal(model.SampleValue(11), dashboard.Charts[1].Histogram["avg"].Matrix[0].Values[0].Value)
 }
 
@@ -119,10 +119,10 @@ func TestGetIstioDashboard(t *testing.T) {
 	assert.Equal("Request duration", dashboard.Charts[1].Name)
 	assert.Equal("TCP sent", dashboard.Charts[5].Name)
 	assert.Nil(dashboard.Charts[0].Histogram)
-	assert.Nil(dashboard.Charts[1].CounterRate)
-	assert.Equal(model.SampleValue(10), dashboard.Charts[0].CounterRate.Matrix[0].Values[0].Value)
+	assert.Nil(dashboard.Charts[1].Metric)
+	assert.Equal(model.SampleValue(10), dashboard.Charts[0].Metric.Matrix[0].Values[0].Value)
 	assert.Equal(model.SampleValue(20), dashboard.Charts[1].Histogram["avg"].Matrix[0].Values[0].Value)
-	assert.Equal(model.SampleValue(13), dashboard.Charts[5].CounterRate.Matrix[0].Values[0].Value)
+	assert.Equal(model.SampleValue(13), dashboard.Charts[5].Metric.Matrix[0].Values[0].Value)
 }
 
 func fakeCounter(value int) *prometheus.Metric {
@@ -152,7 +152,7 @@ func fakeDashboard(id string) *kubernetes.MonitoringDashboard {
 					Unit:       "s",
 					Spans:      6,
 					MetricName: "my_metric_1",
-					MetricType: "counter",
+					DataType:   "rate",
 					Aggregations: []kubernetes.MonitoringDashboardAggregation{
 						kubernetes.MonitoringDashboardAggregation{
 							DisplayName: "Agg 1",
@@ -165,7 +165,7 @@ func fakeDashboard(id string) *kubernetes.MonitoringDashboard {
 					Unit:       "s",
 					Spans:      6,
 					MetricName: "my_metric_2",
-					MetricType: "histogram",
+					DataType:   "histogram",
 					Aggregations: []kubernetes.MonitoringDashboardAggregation{
 						kubernetes.MonitoringDashboardAggregation{
 							DisplayName: "Agg 2",

--- a/deploy/dashboards/vertx.yaml
+++ b/deploy/dashboards/vertx.yaml
@@ -9,7 +9,7 @@ spec:
       unit: "s"
       spans: 6
       metricName: "vertx_http_server_responseTime_seconds"
-      metricType: "histogram"
+      dataType: "histogram"
       aggregations:
         - label: "path"
           displayName: "Path"
@@ -17,7 +17,7 @@ spec:
       unit: "s"
       spans: 6
       metricName: "vertx_http_client_responseTime_seconds"
-      metricType: "histogram"
+      dataType: "histogram"
       aggregations:
         - label: "path"
           displayName: "Path"
@@ -25,7 +25,7 @@ spec:
       unit: "ops"
       spans: 6
       metricName: "vertx_http_server_requestCount_total"
-      metricType: "counter"
+      dataType: "rate"
       aggregations:
         - label: "code"
           displayName: "Error code"

--- a/kubernetes/kiali_monitoring_types.go
+++ b/kubernetes/kiali_monitoring_types.go
@@ -5,9 +5,11 @@ import (
 )
 
 const (
-	// Counter constant for MetricType
-	Counter = "counter"
-	// Histogram constant for MetricType
+	// Raw constant for DataType
+	Raw = "raw"
+	// Rate constant for DataType
+	Rate = "rate"
+	// Histogram constant for DataType
 	Histogram = "histogram"
 )
 
@@ -30,7 +32,7 @@ type MonitoringDashboardChart struct {
 	Unit         string
 	Spans        int
 	MetricName   string
-	MetricType   string // MetricType is either "counter" or "histogram"
+	DataType     string // MetricType is either "raw", "rate" or "histogram"
 	Aggregations []MonitoringDashboardAggregation
 }
 

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -17,11 +17,11 @@ type MonitoringDashboard struct {
 
 // Chart is the model representing a custom chart, transformed from charts in MonitoringDashboard k8s resource
 type Chart struct {
-	Name        string               `json:"name"`
-	Unit        string               `json:"unit"`
-	Spans       int                  `json:"spans"`
-	CounterRate *prometheus.Metric   `json:"counterRate"`
-	Histogram   prometheus.Histogram `json:"histogram"`
+	Name      string               `json:"name"`
+	Unit      string               `json:"unit"`
+	Spans     int                  `json:"spans"`
+	Metric    *prometheus.Metric   `json:"metric"`
+	Histogram prometheus.Histogram `json:"histogram"`
 }
 
 // ConvertChart converts a k8s chart (from MonitoringDashboard k8s resource) into this models chart

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -138,6 +138,11 @@ func (o *PromClientMock) GetDestinationServices(namespace string, namespaceCreat
 	return args.Get(0).([]prometheus.Service), args.Error(1)
 }
 
+func (o *PromClientMock) FetchRange(metricName, labels, grouping string, q *prometheus.BaseMetricsQuery) *prometheus.Metric {
+	args := o.Called(metricName, labels, grouping, q)
+	return args.Get(0).(*prometheus.Metric)
+}
+
 func (o *PromClientMock) FetchRateRange(metricName, labels, grouping string, q *prometheus.BaseMetricsQuery) *prometheus.Metric {
 	args := o.Called(metricName, labels, grouping, q)
 	return args.Get(0).(*prometheus.Metric)

--- a/swagger.json
+++ b/swagger.json
@@ -2702,11 +2702,11 @@
       "description": "Chart is the model representing a custom chart, transformed from charts in MonitoringDashboard k8s resource",
       "type": "object",
       "properties": {
-        "counterRate": {
-          "$ref": "#/definitions/Metric"
-        },
         "histogram": {
           "$ref": "#/definitions/Histogram"
+        },
+        "metric": {
+          "$ref": "#/definitions/Metric"
         },
         "name": {
           "type": "string",


### PR DESCRIPTION
Use "raw" data type to fetch gauges and counters (without rate)
In CRD, MetricType renamed to DataType and can now hold either raw, rate or histogram

JIRA: https://issues.jboss.org/browse/KIALI-2237

Frontend PR: https://github.com/kiali/kiali-ui/pull/932