### PR TITLE
KIALI-2155 Update the graph VS detection

### DIFF
--- a/models/virtual_service.go
+++ b/models/virtual_service.go
@@ -59,12 +59,15 @@ func (vService *VirtualService) IsValidHost(namespace string, serviceName string
 	if serviceName == "" {
 		return false
 	}
-	if hosts, ok := vService.Spec.Hosts.([]interface{}); ok {
-		for _, host := range hosts {
-			if kubernetes.FilterByHost(host.(string), serviceName, namespace) {
-				return true
-			}
-		}
+
+	protocolNames := []string{"http", "tcp"}
+	protocols := map[string]interface{}{
+		"http": vService.Spec.Http,
+		"tcp":  vService.Spec.Tcp,
+	}
+
+	if kubernetes.FilterByRoute(protocols, protocolNames, serviceName, namespace, nil) {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
The way we were determining if a service in a graph had its traffic affected by a virtual service was wrong. We were assuming that the virtual service 'host' value would correspond to the hostname of the service, when it can be any valid hostname.

This change brings how the graph does its VS detection in line with how the service detail pages does things (which does correctly detect the virtual services).

** Issue reference **

https://issues.jboss.org/browse/KIALI-2155

** Backwards incompatible? **

This will change how VS badges are detected in the graph. They will now be in line with how the details page does things.

Meshes should now have their VS badge applied where appropriate to indicate that the traffic could have been modified by a VS.
