### PR TITLE
[hack] adds mirroring to bookinfo reviews

### DIFF
--- a/hack/istio/bookinfo-reviews-mirroring.yaml
+++ b/hack/istio/bookinfo-reviews-mirroring.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-mirroring-vs
+spec:
+  hosts:
+    - reviews
+  http:
+    - route:
+      - destination:
+          host: reviews
+          subset: reviews-mirroring-dr-v1
+        weight: 100
+      mirror:
+        host: reviews
+        subset: reviews-mirroring-dr-v2
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-mirroring-dr
+spec:
+  host: reviews
+  subsets:
+    - name: reviews-mirroring-dr-v1
+      labels:
+        version: v1
+    - name: reviews-mirroring-dr-v2
+      labels:
+        version: v2


### PR DESCRIPTION
oc apply this yaml to your bookinfo demo and see mirroring in action (look at traffic going from productpage to reviews).