### PR TITLE
Ignore VSCode directories for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ _output
 # IntelliJ
 .idea/
 
+# VSCode
+.vscode/
+
 # The vendor directory is to be committed to the git repo
 #vendor/
 


### PR DESCRIPTION
** Describe the change **

Adds .vscode/ to .gitignore to prevent those directories from appearing in the git status / add / commits / etc. These appear when for example using pipenv to run our e2e tests with Python and the VSCode has different settings to defaults (per project).