### PR TITLE
KIALI-2260 Improve validation rules for DR and VS

### DIFF
--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -50,8 +50,8 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
-	assert.Equal("This subset's labels are not found from any matching host", validations[0].Message)
-	assert.Equal("spec/subsets[0]", validations[0].Path)
+	assert.Equal("This host has no matching workloads", validations[0].Message)
+	assert.Equal("spec/host", validations[0].Path)
 }
 
 func TestNoMatchingSubset(t *testing.T) {

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -102,9 +102,9 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	productVs := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}]
 	assert.False(productVs.Valid)
 	assert.Equal(2, len(productVs.Checks))
-	assert.Equal("spec/http/destination[0]/host", productVs.Checks[0].Path)
+	assert.Equal("spec/http/route[0]/destination/host", productVs.Checks[0].Path)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", productVs.Checks[0].Message)
-	assert.Equal("spec/tcp/destination[0]/host", productVs.Checks[1].Path)
+	assert.Equal("spec/tcp/route[0]/destination/host", productVs.Checks[1].Path)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", productVs.Checks[1].Message)
 
 	validations = NoServiceChecker{

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
@@ -102,9 +102,9 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	productVs := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}]
 	assert.False(productVs.Valid)
 	assert.Equal(2, len(productVs.Checks))
-	assert.Equal("spec/http", productVs.Checks[0].Path)
+	assert.Equal("spec/http/destination[0]/host", productVs.Checks[0].Path)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", productVs.Checks[0].Message)
-	assert.Equal("spec/tcp", productVs.Checks[1].Path)
+	assert.Equal("spec/tcp/destination[0]/host", productVs.Checks[1].Path)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", productVs.Checks[1].Message)
 
 	validations = NoServiceChecker{

--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -2,6 +2,7 @@ package virtual_services
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -14,29 +15,62 @@ type NoHostChecker struct {
 	ServiceEntryHosts map[string]struct{}
 }
 
-func (virtualService NoHostChecker) Check() ([]*models.IstioCheck, bool) {
-	valid := false
+func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
 	routeProtocols := []string{"http", "tcp", "tls"}
-	for _, serviceName := range virtualService.ServiceNames {
-		if valid = kubernetes.FilterByRoute(virtualService.VirtualService.GetSpec(), routeProtocols, serviceName, virtualService.Namespace, virtualService.ServiceEntryHosts); valid {
-			break
-		}
-	}
-
-	if !valid {
-		for _, protocol := range routeProtocols {
-			if _, ok := virtualService.VirtualService.GetSpec()[protocol]; ok {
-				validation := models.BuildCheck("DestinationWeight on route doesn't have a valid service (host not found)", "error", fmt.Sprintf("spec/%s", protocol))
-				validations = append(validations, &validation)
+	countOfDefinedProtocols := 0
+	for _, protocol := range routeProtocols {
+		if prot, ok := n.VirtualService.GetSpec()[protocol]; ok {
+			countOfDefinedProtocols++
+			if aHttp, ok := prot.([]interface{}); ok {
+				for _, httpRoute := range aHttp {
+					if mHttpRoute, ok := httpRoute.(map[string]interface{}); ok {
+						if route, ok := mHttpRoute["route"]; ok {
+							if aDestinationWeight, ok := route.([]interface{}); ok {
+								for i, destination := range aDestinationWeight {
+									if !n.checkDestination(destination, protocol) {
+										validation := models.BuildCheck("DestinationWeight on route doesn't have a valid service (host not found)", "error", fmt.Sprintf("spec/%s/destination[%d]/host", protocol, i))
+										validations = append(validations, &validation)
+									}
+								}
+							}
+						}
+					}
+				}
 			}
 		}
-		if len(validations) == 0 {
-			validation := models.BuildCheck("VirtualService doesn't define any route protocol", "error", "")
-			validations = append(validations, &validation)
-		}
 	}
 
-	return validations, valid
+	if countOfDefinedProtocols < 1 {
+		validation := models.BuildCheck("VirtualService doesn't define any valid route protocol", "error", "")
+		validations = append(validations, &validation)
+	}
+
+	return validations, len(validations) == 0
+}
+
+func (n NoHostChecker) checkDestination(destination interface{}, protocol string) bool {
+	if mDestination, ok := destination.(map[string]interface{}); ok {
+		if destinationW, ok := mDestination["destination"]; ok {
+			if mDestinationW, ok := destinationW.(map[string]interface{}); ok {
+				if host, ok := mDestinationW["host"]; ok {
+					if sHost, ok := host.(string); ok {
+						for _, service := range n.ServiceNames {
+							if kubernetes.FilterByHost(sHost, service, n.Namespace) {
+								return true
+							}
+						}
+						if n.ServiceEntryHosts != nil {
+							// We have ServiceEntry to check
+							if _, found := n.ServiceEntryHosts[strings.ToLower(protocol)+sHost]; found {
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
 }

--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -30,7 +30,7 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 							if aDestinationWeight, ok := route.([]interface{}); ok {
 								for i, destination := range aDestinationWeight {
 									if !n.checkDestination(destination, protocol) {
-										validation := models.BuildCheck("DestinationWeight on route doesn't have a valid service (host not found)", "error", fmt.Sprintf("spec/%s/destination[%d]/host", protocol, i))
+										validation := models.BuildCheck("DestinationWeight on route doesn't have a valid service (host not found)", "error", fmt.Sprintf("spec/%s/route[%d]/destination/host", protocol, i))
 										validations = append(validations, &validation)
 									}
 								}

--- a/business/checkers/virtual_services/no_host_checker_test.go
+++ b/business/checkers/virtual_services/no_host_checker_test.go
@@ -41,10 +41,10 @@ func TestNoValidHost(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", validations[0].Message)
-	assert.Equal("spec/http", validations[0].Path)
+	assert.Equal("spec/http/destination[0]/host", validations[0].Path)
 	assert.Equal("error", validations[1].Severity)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", validations[1].Message)
-	assert.Equal("spec/tcp", validations[1].Path)
+	assert.Equal("spec/tcp/destination[0]/host", validations[1].Path)
 
 	delete(virtualService.GetSpec(), "http")
 
@@ -58,7 +58,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", validations[0].Message)
-	assert.Equal("spec/tcp", validations[0].Path)
+	assert.Equal("spec/tcp/destination[0]/host", validations[0].Path)
 
 	delete(virtualService.GetSpec(), "tcp")
 
@@ -71,7 +71,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
-	assert.Equal("VirtualService doesn't define any route protocol", validations[0].Message)
+	assert.Equal("VirtualService doesn't define any valid route protocol", validations[0].Message)
 	assert.Equal("", validations[0].Path)
 }
 

--- a/business/checkers/virtual_services/no_host_checker_test.go
+++ b/business/checkers/virtual_services/no_host_checker_test.go
@@ -41,10 +41,10 @@ func TestNoValidHost(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", validations[0].Message)
-	assert.Equal("spec/http/destination[0]/host", validations[0].Path)
+	assert.Equal("spec/http/route[0]/destination/host", validations[0].Path)
 	assert.Equal("error", validations[1].Severity)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", validations[1].Message)
-	assert.Equal("spec/tcp/destination[0]/host", validations[1].Path)
+	assert.Equal("spec/tcp/route[0]/destination/host", validations[1].Path)
 
 	delete(virtualService.GetSpec(), "http")
 
@@ -58,7 +58,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Equal("error", validations[0].Severity)
 	assert.Equal("DestinationWeight on route doesn't have a valid service (host not found)", validations[0].Message)
-	assert.Equal("spec/tcp/destination[0]/host", validations[0].Path)
+	assert.Equal("spec/tcp/route[0]/destination/host", validations[0].Path)
 
 	delete(virtualService.GetSpec(), "tcp")
 

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -356,51 +356,6 @@ func FilterByRoute(spec map[string]interface{}, protocols []string, service stri
 	return false
 }
 
-func FilterByRouteAndSubset(spec map[string]interface{}, protocols []string, service string, namespace string, subsets []string) bool {
-	if len(protocols) == 0 {
-		return false
-	}
-	for _, protocol := range protocols {
-		if prot, ok := spec[protocol]; ok {
-			if aHttp, ok := prot.([]interface{}); ok {
-				for _, httpRoute := range aHttp {
-					if mHttpRoute, ok := httpRoute.(map[string]interface{}); ok {
-						if route, ok := mHttpRoute["route"]; ok {
-							if aDestinationWeight, ok := route.([]interface{}); ok {
-								for _, destination := range aDestinationWeight {
-									if mDestination, ok := destination.(map[string]interface{}); ok {
-										if destinationW, ok := mDestination["destination"]; ok {
-											if mDestinationW, ok := destinationW.(map[string]interface{}); ok {
-												if host, ok := mDestinationW["host"]; ok {
-													if sHost, ok := host.(string); ok {
-														if FilterByHost(sHost, service, namespace) {
-															// Check service + name is found on a route
-															if subset, ok := mDestinationW["subset"]; ok {
-																if sSubset, ok := subset.(string); ok {
-																	for _, checkSubset := range subsets {
-																		if sSubset == checkSubset {
-																			return true
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
 // ServiceEntryHostnames returns a list of hostnames defined in the ServiceEntries Specs. Key in the resulting map is the protocol (in lowercase) + hostname
 // exported for test
 func ServiceEntryHostnames(serviceEntries []IstioObject) map[string]struct{} {


### PR DESCRIPTION
** Describe the change **

Currently the validation might show an error in the subset only for DRs, even when the host itself was the issue. Change the validation order to catch the host error first and stop checking the subsets if the host itself is invalid.

With VirtualServices, the host checking was happy if any destination had a valid host. Changed to check all the hosts for validity and make the path for those errors the host instead of the protocol. Also, remove code from kubernetes package as that wasn't used by anything.

** Issue reference **

KIALI-2260
