### PR TITLE
KIALI-2272 Improve protocol support

### DIFF
--- a/graph/appender/dead_node_test.go
+++ b/graph/appender/dead_node_test.go
@@ -213,43 +213,43 @@ func testTrafficMap() map[string]*graph.Node {
 
 	e := n0.AddEdge(&n1)
 	e = n00.AddEdge(&n1)
-	e.Metadata["httpIn"] = 0.8
+	e.Metadata["http"] = 0.8
 
 	e = n0.AddEdge(&n2)
 	e = n00.AddEdge(&n2)
-	e.Metadata["httpIn"] = 0.8
+	e.Metadata["http"] = 0.8
 
 	e = n0.AddEdge(&n3)
 	e = n00.AddEdge(&n3)
-	e.Metadata["httpIn"] = 0.8
+	e.Metadata["http"] = 0.8
 
 	e = n0.AddEdge(&n4)
 	e = n00.AddEdge(&n4)
-	e.Metadata["httpIn"] = 0.0
+	e.Metadata["http"] = 0.0
 
 	e = n0.AddEdge(&n5)
 	e = n00.AddEdge(&n5)
-	e.Metadata["httpIn"] = 0.8
+	e.Metadata["http"] = 0.8
 
 	e = n0.AddEdge(&n6)
 	e = n00.AddEdge(&n6)
-	e.Metadata["httpIn"] = 0.0
+	e.Metadata["http"] = 0.0
 
 	e = n0.AddEdge(&n7)
 	e = n00.AddEdge(&n7)
-	e.Metadata["tcpIn"] = 74.1
+	e.Metadata["tcp"] = 74.1
 
 	e = n0.AddEdge(&n8)
 	e = n00.AddEdge(&n8)
-	e.Metadata["tcpIn"] = 74.1
+	e.Metadata["tcp"] = 74.1
 
 	e = n0.AddEdge(&n9)
 	e = n00.AddEdge(&n9)
-	e.Metadata["httpIn"] = 0.8
+	e.Metadata["http"] = 0.8
 
 	e = n0.AddEdge(&n10)
 	e = n00.AddEdge(&n10)
-	e.Metadata["httpIn"] = 0.8
+	e.Metadata["http"] = 0.8
 
 	return trafficMap
 }

--- a/graph/appender/unused_node.go
+++ b/graph/appender/unused_node.go
@@ -80,6 +80,7 @@ func (a UnusedNodeAppender) buildUnusedTrafficMap(trafficMap graph.TrafficMap, n
 			if _, found = unusedTrafficMap[id]; !found {
 				log.Debugf("Adding unused node for workload [%s] with labels [%v]", w.Name, labels)
 				node := graph.NewNodeExplicit(id, namespace, w.Name, app, version, "", nodeType, a.GraphType)
+				// note: we don't konw what the protocol really should be, http is most common, it's a dead edge anyway
 				node.Metadata = map[string]interface{}{"httpIn": 0.0, "httpOut": 0.0, "isUnused": true}
 				unusedTrafficMap[id] = &node
 			}

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -1,0 +1,181 @@
+package graph
+
+import (
+	"strings"
+
+	"github.com/kiali/kiali/log"
+)
+
+type Rate struct {
+	Name         string
+	IsErr        bool
+	IsIn         bool
+	IsOut        bool
+	IsPercentErr bool
+	IsPercentReq bool
+	IsTotal      bool
+	Precision    int
+}
+
+type Protocol struct {
+	Name      string
+	EdgeRates []Rate
+	NodeRates []Rate
+	Unit      string
+	UnitShort string
+}
+
+/* TODO: For now, treat gRPC like HTTP, uncomment this when we want to treat gRPC explicitly
+var GRPC Protocol = Protocol{
+	Name: "grpc",
+	EdgeRates: []Rate{
+		Rate{Name: "grpc", IsTotal: true, Precision: 2},
+		Rate{Name: "grpcErr", IsErr: true, Precision: 2},
+		Rate{Name: "grpcPercentErr", IsPercentErr: true, Precision: 1},
+		Rate{Name: "grpcPercentReq", IsPercentReq: true, Precision: 1},
+	},
+	NodeRates: []Rate{
+		Rate{Name: "grpcIn", IsIn: true, Precision: 2},
+		Rate{Name: "grpcInErr", IsErr: true, Precision: 2},
+		Rate{Name: "grpcOut", IsOut: true, Precision: 2},
+	},
+	Unit:      "requests per second",
+	UnitShort: "rps",
+}
+*/
+var HTTP Protocol = Protocol{
+	Name: "http",
+	EdgeRates: []Rate{
+		Rate{Name: "http", IsTotal: true, Precision: 2},
+		Rate{Name: "http3xx", Precision: 2},
+		Rate{Name: "http4xx", IsErr: true, Precision: 2},
+		Rate{Name: "http5xx", IsErr: true, Precision: 2},
+		Rate{Name: "httpPercentErr", IsPercentErr: true, Precision: 1},
+		Rate{Name: "httpPercentReq", IsPercentReq: true, Precision: 1},
+	},
+	NodeRates: []Rate{
+		Rate{Name: "httpIn", IsIn: true, Precision: 2},
+		Rate{Name: "httpIn3xx", Precision: 2},
+		Rate{Name: "httpIn4xx", IsErr: true, Precision: 2},
+		Rate{Name: "httpIn5xx", IsErr: true, Precision: 2},
+		Rate{Name: "httpOut", IsOut: true, Precision: 2},
+	},
+	Unit:      "requests per second",
+	UnitShort: "rps",
+}
+var TCP Protocol = Protocol{
+	Name: "tcp",
+	EdgeRates: []Rate{
+		Rate{Name: "tcp", IsTotal: true, Precision: 2},
+	},
+	NodeRates: []Rate{
+		Rate{Name: "tcpIn", IsIn: true, Precision: 2},
+		Rate{Name: "tcpOut", IsOut: true, Precision: 2},
+	},
+	Unit:      "bytes per second",
+	UnitShort: "bps",
+}
+
+// TODO: For now, treat gRPC like HTTP, uncomment this when we want to treat gRPC explicitly
+// var Protocols []Protocol = []Protocol{GRPC, HTTP, TCP}
+var Protocols []Protocol = []Protocol{HTTP, TCP}
+
+func AddToMetadata(protocol string, val float64, code string, sourceMetadata, destMetadata, edgeMetadata map[string]interface{}) {
+	switch protocol {
+	case "grpc":
+		// TODO: For now, treat gRPC like HTTP, uncomment this (and remove the http line below it) when we want to treat gRPC explicitly
+		// addToMetadataGrpc(val, code, sourceMetadata, destMetadata, edgeMetadata)
+		addToMetadataHttp(val, code, sourceMetadata, destMetadata, edgeMetadata)
+	case "http":
+		addToMetadataHttp(val, code, sourceMetadata, destMetadata, edgeMetadata)
+	case "tcp":
+		addToMetadataTcp(val, code, sourceMetadata, destMetadata, edgeMetadata)
+	default:
+		log.Tracef("Ignore unhandled metadata protocol [%s]", protocol)
+	}
+}
+
+/* TODO: For now, treat gRPC like HTTP, uncomment this when we want to treat gRPC explicitly
+func addToMetadataGrpc(val float64, code string, sourceMetadata, destMetadata, edgeMetadata map[string]interface{}) {
+	addToMetadataValue(sourceMetadata, "grpcOut", val)
+	addToMetadataValue(destMetadata, "grpcIn", val)
+	addToMetadataValue(edgeMetadata, "grpc", val)
+
+	// Istio telemetry may use HTTP codes for gRPC, so if it quacks like a duck...
+	isHttpCode := len(code) == 3
+	isErr := false
+	if isHttpCode {
+		isErr = strings.HasPrefix(code, "4") || strings.HasPrefix(code, "5")
+	} else {
+		isErr = code != "0"
+	}
+	if isErr {
+		addToMetadataValue(destMetadata, "grpcInErr", val)
+		addToMetadataValue(edgeMetadata, "grpcErr", val)
+	}
+}
+*/
+
+func addToMetadataHttp(val float64, code string, sourceMetadata, destMetadata, edgeMetadata map[string]interface{}) {
+	addToMetadataValue(sourceMetadata, "httpOut", val)
+	addToMetadataValue(destMetadata, "httpIn", val)
+	addToMetadataValue(edgeMetadata, "http", val)
+
+	// note, we don't track 2xx because it's not used downstream and can be easily
+	// calculated: 2xx = (rate - 3xx - 4xx - 5xx)
+	switch {
+	case strings.HasPrefix(code, "3"):
+		addToMetadataValue(destMetadata, "httpIn3xx", val)
+		addToMetadataValue(edgeMetadata, "http3xx", val)
+	case strings.HasPrefix(code, "4"):
+		addToMetadataValue(destMetadata, "httpIn4xx", val)
+		addToMetadataValue(edgeMetadata, "http4xx", val)
+	case strings.HasPrefix(code, "5"):
+		addToMetadataValue(destMetadata, "httpIn5xx", val)
+		addToMetadataValue(edgeMetadata, "http5xx", val)
+	}
+}
+
+func addToMetadataTcp(val float64, code string, sourceMetadata, destMetadata, edgeMetadata map[string]interface{}) {
+	addToMetadataValue(sourceMetadata, "tcpOut", val)
+	addToMetadataValue(destMetadata, "tcpIn", val)
+	addToMetadataValue(edgeMetadata, "tcp", val)
+}
+
+func AddOutgoingEdgeToMetadata(sourceMetadata, edgeMetadata map[string]interface{}) {
+	/* TODO: For now, treat gRPC like HTTP, uncomment this when we want to treat gRPC explicitly
+	if val, valOk := edgeMetadata["grpc"]; valOk {
+		addToMetadataValue(sourceMetadata, "grpcOut", val.(float64))
+	}
+	*/
+	if val, valOk := edgeMetadata["http"]; valOk {
+		addToMetadataValue(sourceMetadata, "httpOut", val.(float64))
+	}
+	if val, valOk := edgeMetadata["tcp"]; valOk {
+		addToMetadataValue(sourceMetadata, "tcpOut", val.(float64))
+	}
+}
+
+func addToMetadataValue(md map[string]interface{}, k string, v float64) {
+	if curr, ok := md[k]; ok {
+		md[k] = curr.(float64) + v
+	} else {
+		md[k] = v
+	}
+}
+
+func averageMetadataValue(md map[string]interface{}, k string, v float64) {
+	total := v
+	count := 1.0
+	kTotal := k + "_total"
+	kCount := k + "_count"
+	if prevTotal, ok := md[kTotal]; ok {
+		total += prevTotal.(float64)
+	}
+	if prevCount, ok := md[kCount]; ok {
+		count += prevCount.(float64)
+	}
+	md[kTotal] = total
+	md[kCount] = count
+	md[k] = total / count
+}

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -88,7 +88,7 @@ func mockQuery(api *prometheustest.PromAPIMock, query string, ret *model.Vector)
 
 // mockNamespaceGraph provides the same single-namespace mocks to be used for different graph types
 func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_service_namespace="bookinfo",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":     "unknown",
 		"source_workload":               "unknown",
@@ -99,13 +99,14 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	v0 := model.Vector{
 		&model.Sample{
 			Metric: q0m0,
 			Value:  50}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":     "istio-system",
 		"source_workload":               "ingressgateway-unknown",
@@ -116,13 +117,14 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	v1 := model.Vector{
 		&model.Sample{
 			Metric: q1m0,
 			Value:  100}}
 
-	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q2m0 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
 		"source_workload":               "productpage-v1",
@@ -133,6 +135,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "reviews-v1",
 		"destination_app":               "reviews",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q2m1 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -144,6 +147,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "reviews-v2",
 		"destination_app":               "reviews",
 		"destination_version":           "v2",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q2m2 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -155,6 +159,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "reviews-v3",
 		"destination_app":               "reviews",
 		"destination_version":           "v3",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q2m3 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -166,6 +171,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "300"}
 	q2m4 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -177,6 +183,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "400"}
 	q2m5 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -188,6 +195,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "500"}
 	q2m6 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -199,6 +207,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q2m7 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -210,6 +219,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q2m8 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -221,6 +231,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "ratings-v1",
 		"destination_app":               "ratings",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q2m9 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -232,6 +243,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "ratings-v1",
 		"destination_app":               "ratings",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "500"}
 	q2m10 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -243,6 +255,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "reviews-v2",
 		"destination_app":               "reviews",
 		"destination_version":           "v2",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q2m11 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -254,6 +267,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "ratings-v1",
 		"destination_app":               "ratings",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q2m12 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -265,6 +279,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "ratings-v1",
 		"destination_app":               "ratings",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "500"}
 	q2m13 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -276,6 +291,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "reviews-v3",
 		"destination_app":               "reviews",
 		"destination_version":           "v3",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q2m14 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -287,6 +303,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_workload":          "pricing-v1",
 		"destination_app":               "pricing",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 
 	v2 := model.Vector{
@@ -537,7 +554,7 @@ func TestWorkloadGraph(t *testing.T) {
 }
 
 func TestAppNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":     "unknown",
 		"source_workload":               "unknown",
@@ -548,6 +565,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":     "istio-system",
@@ -559,6 +577,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -568,7 +587,7 @@ func TestAppNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
 		"source_workload":               "productpage-v1",
@@ -579,6 +598,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "reviews-v1",
 		"destination_app":               "reviews",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m1 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -590,6 +610,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "reviews-v2",
 		"destination_app":               "reviews",
 		"destination_version":           "v2",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m2 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -601,6 +622,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "reviews-v3",
 		"destination_app":               "reviews",
 		"destination_version":           "v3",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m3 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -612,6 +634,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "300"}
 	q1m4 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -623,6 +646,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "400"}
 	q1m5 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -634,6 +658,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "500"}
 	q1m6 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -645,6 +670,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m7 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -656,6 +682,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 
 	v1 := model.Vector{
@@ -741,7 +768,7 @@ func TestAppNodeGraph(t *testing.T) {
 }
 
 func TestVersionedAppNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage",destination_version="v1",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage",destination_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":     "unknown",
 		"source_workload":               "unknown",
@@ -752,6 +779,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":     "istio-system",
@@ -763,6 +791,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -772,7 +801,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",source_version="v1",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",source_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
 		"source_workload":               "productpage-v1",
@@ -783,6 +812,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "reviews-v1",
 		"destination_app":               "reviews",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m1 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -794,6 +824,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "reviews-v2",
 		"destination_app":               "reviews",
 		"destination_version":           "v2",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m2 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -805,6 +836,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "reviews-v3",
 		"destination_app":               "reviews",
 		"destination_version":           "v3",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m3 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -816,6 +848,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "300"}
 	q1m4 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -827,6 +860,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "400"}
 	q1m5 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -838,6 +872,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "500"}
 	q1m6 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -849,6 +884,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m7 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -860,6 +896,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 
 	v1 := model.Vector{
@@ -945,7 +982,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 }
 
 func TestWorkloadNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":     "unknown",
 		"source_workload":               "unknown",
@@ -956,6 +993,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":     "istio-system",
@@ -967,6 +1005,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -976,7 +1015,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
 		"source_workload":               "productpage-v1",
@@ -987,6 +1026,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "reviews-v1",
 		"destination_app":               "reviews",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m1 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -998,6 +1038,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "reviews-v2",
 		"destination_app":               "reviews",
 		"destination_version":           "v2",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m2 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -1009,6 +1050,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "reviews-v3",
 		"destination_app":               "reviews",
 		"destination_version":           "v3",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m3 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -1020,6 +1062,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "300"}
 	q1m4 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -1031,6 +1074,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "400"}
 	q1m5 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -1042,6 +1086,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "500"}
 	q1m6 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -1053,6 +1098,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "details-v1",
 		"destination_app":               "details",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	q1m7 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
@@ -1064,6 +1110,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 
 	v1 := model.Vector{
@@ -1149,10 +1196,10 @@ func TestWorkloadNodeGraph(t *testing.T) {
 }
 
 func TestServiceNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_service_namespace="bookinfo",destination_service_name="productpage",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_service_namespace="bookinfo",destination_service_name="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name="productpage",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":     "istio-system",
 		"source_workload":               "ingressgateway-unknown",
@@ -1163,6 +1210,7 @@ func TestServiceNodeGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	v1 := model.Vector{
 		&model.Sample{
@@ -1226,7 +1274,7 @@ func TestServiceNodeGraph(t *testing.T) {
 // - a "shared" node (internal in ns-1, outsider in ns-2)
 // note: this is still not particularly robust, not sure how to include appenders in unit tests given that they create their own new business/kube clients
 func TestComplexGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_service_namespace="bookinfo",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":     "unknown",
 		"source_workload":               "unknown",
@@ -1237,16 +1285,17 @@ func TestComplexGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	v0 := model.Vector{
 		&model.Sample{
 			Metric: q0m0,
 			Value:  50}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	v1 := model.Vector{}
 
-	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	v2 := model.Vector{}
 
 	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_workload_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)`
@@ -1258,7 +1307,7 @@ func TestComplexGraph(t *testing.T) {
 	q5 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version),0.001)`
 	v5 := model.Vector{}
 
-	q6 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_service_namespace="tutorial",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q6 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_service_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q6m0 := model.Metric{
 		"source_workload_namespace":     "unknown",
 		"source_workload":               "unknown",
@@ -1269,16 +1318,17 @@ func TestComplexGraph(t *testing.T) {
 		"destination_workload":          "customer-v1",
 		"destination_app":               "customer",
 		"destination_version":           "v1",
+		"request_protocol":              "grpc",
 		"response_code":                 "200"}
 	v6 := model.Vector{
 		&model.Sample{
 			Metric: q6m0,
 			Value:  50}}
 
-	q7 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q7 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	v7 := model.Vector{}
 
-	q8 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="tutorial",response_code=~"[2345][0-9][0-9]"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,response_code),0.001)`
+	q8 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version,request_protocol,response_code),0.001)`
 	q8m0 := model.Metric{
 		"source_workload_namespace":     "tutorial",
 		"source_workload":               "customer-v1",
@@ -1289,6 +1339,7 @@ func TestComplexGraph(t *testing.T) {
 		"destination_workload":          "productpage-v1",
 		"destination_app":               "productpage",
 		"destination_version":           "v1",
+		"request_protocol":              "http",
 		"response_code":                 "200"}
 	v8 := model.Vector{
 		&model.Sample{

--- a/handlers/testdata/test_app_graph.expected
+++ b/handlers/testdata/test_app_graph.expected
@@ -13,7 +13,14 @@
           "destServices": {
             "pricing": true
           },
-          "httpIn": "20.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isOutside": true
         }
@@ -27,10 +34,17 @@
           "destServices": {
             "details": true
           },
-          "httpIn": "80.00",
-          "httpIn3XX": "20.00",
-          "httpIn4XX": "20.00",
-          "httpIn5XX": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "80.00",
+                "httpIn3xx": "20.00",
+                "httpIn4xx": "20.00",
+                "httpIn5xx": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -42,9 +56,21 @@
           "destServices": {
             "productpage": true
           },
-          "httpIn": "170.00",
-          "httpOut": "160.00",
-          "tcpOut": "31.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "170.00",
+                "httpOut": "160.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -56,8 +82,15 @@
           "destServices": {
             "ratings": true
           },
-          "httpIn": "60.00",
-          "httpIn5XX": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "60.00",
+                "httpIn5xx": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -69,8 +102,15 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "100.00",
-          "httpOut": "120.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "100.00",
+                "httpOut": "120.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -82,7 +122,14 @@
           "destServices": {
             "tcp": true
           },
-          "tcpIn": "581.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "581.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -91,8 +138,20 @@
           "nodeType": "app",
           "namespace": "istio-system",
           "app": "ingressgateway",
-          "httpOut": "100.00",
-          "tcpOut": "150.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "150.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isOutside": true,
           "isRoot": true
@@ -106,8 +165,20 @@
           "workload": "unknown",
           "app": "unknown",
           "version": "unknown",
-          "httpOut": "50.00",
-          "tcpOut": "400.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "50.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "400.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isRoot": true
         }
@@ -119,7 +190,14 @@
           "id": "2c8bf7e7efb0982b18c76d507200a8b7",
           "source": "19950ddefadd370bf5434953c1944c80",
           "target": "2c22af42b0c750749399ed2838c56054",
-          "http": "100.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "100.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -127,7 +205,14 @@
           "id": "18fa6836a929941e8deabad5fa1cae62",
           "source": "19950ddefadd370bf5434953c1944c80",
           "target": "4ee8019fc0454770a401b89d427277bf",
-          "tcp": "150.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "150.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -135,8 +220,15 @@
           "id": "e9ffbf24e385c93dfa124d81e2ac33a7",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "2c22af42b0c750749399ed2838c56054",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -144,8 +236,15 @@
           "id": "ff5217a9064e30e4fb875256dab56037",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "37ddc91db761d432f3fff1943802cad7",
-          "http": "60.00",
-          "httpPercentReq": "37.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "60.00",
+                "httpPercentReq": "37.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -153,7 +252,14 @@
           "id": "16a0c4225bbdbd471e6e7b8fd438733d",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "4ee8019fc0454770a401b89d427277bf",
-          "tcp": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -161,12 +267,19 @@
           "id": "89fa162a49acca6ff974afd30aab2ff0",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "6cdb3cf3ee9a17772f13b295368e112a",
-          "http": "80.00",
-          "http3XX": "20.00",
-          "http4XX": "20.00",
-          "http5XX": "20.00",
-          "httpPercentErr": "50.0",
-          "httpPercentReq": "50.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "80.00",
+                "http3xx": "20.00",
+                "http4xx": "20.00",
+                "http5xx": "20.00",
+                "httpPercentErr": "50.0",
+                "httpPercentReq": "50.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -174,8 +287,15 @@
           "id": "4aaf7cb151db415f3ba4918be2296c38",
           "source": "37ddc91db761d432f3fff1943802cad7",
           "target": "37ddc91db761d432f3fff1943802cad7",
-          "http": "40.00",
-          "httpPercentReq": "33.3"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "40.00",
+                "httpPercentReq": "33.3"
+              }
+            }
+          ]
         }
       },
       {
@@ -183,8 +303,15 @@
           "id": "edb2cdfc2a757d260aa847d55e9eadde",
           "source": "37ddc91db761d432f3fff1943802cad7",
           "target": "66bce9783dc2dbb5fecb178b0108484e",
-          "http": "20.00",
-          "httpPercentReq": "16.7"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "16.7"
+              }
+            }
+          ]
         }
       },
       {
@@ -192,10 +319,17 @@
           "id": "a553e38605904d17c50ab1d0db84f113",
           "source": "37ddc91db761d432f3fff1943802cad7",
           "target": "c219903556c3afdb05eda7e610aba628",
-          "http": "60.00",
-          "http5XX": "20.00",
-          "httpPercentErr": "33.3",
-          "httpPercentReq": "50.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "60.00",
+                "http5xx": "20.00",
+                "httpPercentErr": "33.3",
+                "httpPercentReq": "50.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -203,7 +337,14 @@
           "id": "efe83e483ada36899c34ef66a7974d31",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "2c22af42b0c750749399ed2838c56054",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -211,7 +352,14 @@
           "id": "d4fc7bd6594937fa94402fcfcc9f3a95",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "4ee8019fc0454770a401b89d427277bf",
-          "tcp": "400.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "400.00"
+              }
+            }
+          ]
         }
       }
     ]

--- a/handlers/testdata/test_app_node_graph.expected
+++ b/handlers/testdata/test_app_node_graph.expected
@@ -24,10 +24,17 @@
           "destServices": {
             "details": true
           },
-          "httpIn": "80.00",
-          "httpIn3XX": "20.00",
-          "httpIn4XX": "20.00",
-          "httpIn5XX": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "80.00",
+                "httpIn3xx": "20.00",
+                "httpIn4xx": "20.00",
+                "httpIn5xx": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -41,9 +48,21 @@
           "destServices": {
             "productpage": true
           },
-          "httpIn": "170.00",
-          "httpOut": "160.00",
-          "tcpOut": "31.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "170.00",
+                "httpOut": "160.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -58,7 +77,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -73,7 +99,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -88,7 +121,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -102,7 +142,14 @@
           "destServices": {
             "tcp": true
           },
-          "tcpIn": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -113,7 +160,14 @@
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
           "version": "unknown",
-          "httpOut": "100.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isOutside": true,
           "isRoot": true
@@ -127,7 +181,14 @@
           "workload": "unknown",
           "app": "unknown",
           "version": "unknown",
-          "httpOut": "50.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "50.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isRoot": true
         }
@@ -139,7 +200,14 @@
           "id": "8088ca79aa13e423747334c532144c4f",
           "source": "933d90e5172f69af1baa035e8a8ad27c",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "100.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "100.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -147,7 +215,14 @@
           "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "tcp": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -155,12 +230,19 @@
           "id": "9f6a2ed75734d99002d37ac867190b9e",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "50113397f439f05f3280ad0772b9b307",
-          "http": "80.00",
-          "http3XX": "20.00",
-          "http4XX": "20.00",
-          "http5XX": "20.00",
-          "httpPercentErr": "50.0",
-          "httpPercentReq": "50.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "80.00",
+                "http3xx": "20.00",
+                "http4xx": "20.00",
+                "http5xx": "20.00",
+                "httpPercentErr": "50.0",
+                "httpPercentReq": "50.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -168,8 +250,15 @@
           "id": "0d38eb7edb4da38dac33b79a24c3c208",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -177,8 +266,15 @@
           "id": "4ab6875deb3c0cbec4c8f260841f3d24",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -186,8 +282,15 @@
           "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "acd188a125352509e86ce104323c5d4f",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -195,8 +298,15 @@
           "id": "d99fa824b2d85a2053f51fe3bd94ef60",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -204,7 +314,14 @@
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00"
+              }
+            }
+          ]
         }
       }
     ]

--- a/handlers/testdata/test_complex_graph.expected
+++ b/handlers/testdata/test_complex_graph.expected
@@ -15,7 +15,14 @@
           "destServices": {
             "productpage": true
           },
-          "httpIn": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -29,8 +36,15 @@
           "destServices": {
             "customer": true
           },
-          "httpIn": "50.00",
-          "httpOut": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "50.00",
+                "httpOut": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -41,7 +55,14 @@
           "workload": "unknown",
           "app": "unknown",
           "version": "unknown",
-          "httpOut": "50.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isRoot": true
         }
@@ -53,15 +74,30 @@
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00",
+                "httpPercentReq": "50.0"
+              }
+            }
+          ]
         }
       },
       {
         "data": {
-          "id": "7e12fa53b9413b80e96193555818be7e",
+          "id": "1f024523da856e5b5a549d4a64b26cd3",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "d75c918a12f72a1ea1797911cb9770f7",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -69,7 +105,14 @@
           "id": "de3e83491767bce819c83b9f9a75b497",
           "source": "d75c918a12f72a1ea1797911cb9770f7",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00"
+              }
+            }
+          ]
         }
       }
     ]

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -13,8 +13,15 @@
           "destServices": {
             "pricing": true
           },
-          "httpIn": "20.00",
-          "httpOut": "20.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00",
+                "httpOut": "20.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isOutside": true
         }
@@ -28,11 +35,18 @@
           "destServices": {
             "details": true
           },
-          "httpIn": "80.00",
-          "httpIn3XX": "20.00",
-          "httpIn4XX": "20.00",
-          "httpIn5XX": "20.00",
-          "httpOut": "80.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "80.00",
+                "httpIn3xx": "20.00",
+                "httpIn4xx": "20.00",
+                "httpIn5xx": "20.00",
+                "httpOut": "80.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -44,8 +58,15 @@
           "destServices": {
             "productpage": true
           },
-          "httpIn": "170.00",
-          "httpOut": "170.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "170.00",
+                "httpOut": "170.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -57,9 +78,16 @@
           "destServices": {
             "ratings": true
           },
-          "httpIn": "60.00",
-          "httpIn5XX": "20.00",
-          "httpOut": "60.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "60.00",
+                "httpIn5xx": "20.00",
+                "httpOut": "60.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -71,8 +99,15 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "100.00",
-          "httpOut": "100.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "100.00",
+                "httpOut": "100.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -84,8 +119,15 @@
           "destServices": {
             "tcp": true
           },
-          "tcpIn": "581.00",
-          "tcpOut": "581.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "581.00",
+                "tcpOut": "581.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -96,8 +138,20 @@
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
           "version": "unknown",
-          "httpOut": "100.00",
-          "tcpOut": "150.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "150.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isMisconfigured": "labels=[version]",
           "isOutside": true,
@@ -112,8 +166,20 @@
           "workload": "unknown",
           "app": "unknown",
           "version": "unknown",
-          "httpOut": "50.00",
-          "tcpOut": "400.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "50.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "400.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isRoot": true
         }
@@ -125,12 +191,19 @@
           "id": "619130e72e856618da923e25348f370f",
           "source": "42c017b34656a709d614f53967b05cc8",
           "target": "35533a08d948509abf8ae4d5d5647594",
-          "http": "80.00",
-          "http3XX": "20.00",
-          "http4XX": "20.00",
-          "http5XX": "20.00",
-          "httpPercentErr": "50.0",
-          "httpPercentReq": "50.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "80.00",
+                "http3xx": "20.00",
+                "http4xx": "20.00",
+                "http5xx": "20.00",
+                "httpPercentErr": "50.0",
+                "httpPercentReq": "50.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -138,8 +211,15 @@
           "id": "fafebffe3d83500a33fcdc0e268fabe4",
           "source": "42c017b34656a709d614f53967b05cc8",
           "target": "42c017b34656a709d614f53967b05cc8",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -147,7 +227,14 @@
           "id": "e4b85b504c8777f3882217b3791d4c60",
           "source": "42c017b34656a709d614f53967b05cc8",
           "target": "8a4a4ea447daf00b8a30169659086b5f",
-          "tcp": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -155,8 +242,15 @@
           "id": "1cf252f0a8d0ab09f9f5408ae22792f2",
           "source": "42c017b34656a709d614f53967b05cc8",
           "target": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "http": "60.00",
-          "httpPercentReq": "37.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "60.00",
+                "httpPercentReq": "37.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -164,7 +258,14 @@
           "id": "1f3288555e23c16338013c2413d5987b",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "42c017b34656a709d614f53967b05cc8",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -172,7 +273,14 @@
           "id": "8c1b4e5d28259bbb16fac3edeb229115",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "8a4a4ea447daf00b8a30169659086b5f",
-          "tcp": "400.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "400.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -180,7 +288,14 @@
           "id": "eed4f01258af80c8c8e2f07c548550f8",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "42c017b34656a709d614f53967b05cc8",
-          "http": "100.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "100.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -188,7 +303,14 @@
           "id": "dee0c874bb93f64c52f13ee82c5eee11",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "8a4a4ea447daf00b8a30169659086b5f",
-          "tcp": "150.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "150.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -196,8 +318,15 @@
           "id": "c8ee3a318ac7b96bd1800e9d500e3db5",
           "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
           "target": "715046fe06feb0ca6986fde2c2d18e22",
-          "http": "20.00",
-          "httpPercentReq": "28.6"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "28.6"
+              }
+            }
+          ]
         }
       },
       {
@@ -205,8 +334,15 @@
           "id": "1bec06d1f0bf0a55ec9501008f3d14d4",
           "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
           "target": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "http": "40.00",
-          "httpPercentReq": "80.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "40.00",
+                "httpPercentReq": "80.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -214,9 +350,16 @@
           "id": "c8c0d78efa927aaff53a1a275cdc5e5e",
           "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
           "target": "e96a4db610f877425f52a4b563e24c4c",
-          "http": "60.00",
-          "http5XX": "20.00",
-          "httpPercentErr": "33.3"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "60.00",
+                "http5xx": "20.00",
+                "httpPercentErr": "33.3"
+              }
+            }
+          ]
         }
       }
     ]

--- a/handlers/testdata/test_service_node_graph.expected
+++ b/handlers/testdata/test_service_node_graph.expected
@@ -15,8 +15,20 @@
           "destServices": {
             "productpage": true
           },
-          "httpIn": "100.00",
-          "tcpIn": "31.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "100.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -27,8 +39,20 @@
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
           "version": "unknown",
-          "httpOut": "100.00",
-          "tcpOut": "31.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "31.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isMisconfigured": "labels=[version]",
           "isOutside": true,
@@ -42,7 +66,14 @@
           "id": "347e210a97f5235b5a60b810ef1bfaa6",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "http": "100.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "100.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -50,7 +81,14 @@
           "id": "c3fa6dedc4a1b3d61a3bb48dcb46dafa",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "tcp": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "31.00"
+              }
+            }
+          ]
         }
       }
     ]

--- a/handlers/testdata/test_versioned_app_graph.expected
+++ b/handlers/testdata/test_versioned_app_graph.expected
@@ -15,7 +15,14 @@
           "destServices": {
             "pricing": true
           },
-          "httpIn": "20.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isOutside": true
         }
@@ -40,10 +47,17 @@
           "destServices": {
             "details": true
           },
-          "httpIn": "80.00",
-          "httpIn3XX": "20.00",
-          "httpIn4XX": "20.00",
-          "httpIn5XX": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "80.00",
+                "httpIn3xx": "20.00",
+                "httpIn4xx": "20.00",
+                "httpIn5xx": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -57,9 +71,21 @@
           "destServices": {
             "productpage": true
           },
-          "httpIn": "170.00",
-          "httpOut": "160.00",
-          "tcpOut": "31.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "170.00",
+                "httpOut": "160.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -73,8 +99,15 @@
           "destServices": {
             "ratings": true
           },
-          "httpIn": "60.00",
-          "httpIn5XX": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "60.00",
+                "httpIn5xx": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -89,7 +122,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -104,8 +144,15 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "40.00",
-          "httpOut": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "40.00",
+                "httpOut": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -120,8 +167,15 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "40.00",
-          "httpOut": "70.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "40.00",
+                "httpOut": "70.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -135,7 +189,14 @@
           "destServices": {
             "tcp": true
           },
-          "tcpIn": "581.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "581.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -146,8 +207,20 @@
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
           "version": "unknown",
-          "httpOut": "100.00",
-          "tcpOut": "150.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "150.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isOutside": true,
           "isRoot": true
@@ -161,8 +234,20 @@
           "workload": "unknown",
           "app": "unknown",
           "version": "unknown",
-          "httpOut": "50.00",
-          "tcpOut": "400.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "50.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "400.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isRoot": true
         }
@@ -174,10 +259,17 @@
           "id": "ddf45549de5e603dee9a0cd9c83f9cfb",
           "source": "5cb6f79f37cb95cf40ea6fb23779b0e6",
           "target": "08d6a5dd6e290fbc42e259053b86a762",
-          "http": "30.00",
-          "http5XX": "10.00",
-          "httpPercentErr": "33.3",
-          "httpPercentReq": "60.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "30.00",
+                "http5xx": "10.00",
+                "httpPercentErr": "33.3",
+                "httpPercentReq": "60.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -185,8 +277,15 @@
           "id": "e23d51a059f4d5e45ed6ae625f9b9a5f",
           "source": "5cb6f79f37cb95cf40ea6fb23779b0e6",
           "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "http": "20.00",
-          "httpPercentReq": "40.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "40.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -194,7 +293,14 @@
           "id": "9f5ad0240b6a9e430d3dc2bcb2b3daaa",
           "source": "933d90e5172f69af1baa035e8a8ad27c",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "tcp": "150.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "150.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -202,7 +308,14 @@
           "id": "8088ca79aa13e423747334c532144c4f",
           "source": "933d90e5172f69af1baa035e8a8ad27c",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "100.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "100.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -210,7 +323,14 @@
           "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "tcp": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -218,12 +338,19 @@
           "id": "9f6a2ed75734d99002d37ac867190b9e",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "50113397f439f05f3280ad0772b9b307",
-          "http": "80.00",
-          "http3XX": "20.00",
-          "http4XX": "20.00",
-          "http5XX": "20.00",
-          "httpPercentErr": "50.0",
-          "httpPercentReq": "50.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "80.00",
+                "http3xx": "20.00",
+                "http4xx": "20.00",
+                "http5xx": "20.00",
+                "httpPercentErr": "50.0",
+                "httpPercentReq": "50.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -231,8 +358,15 @@
           "id": "0d38eb7edb4da38dac33b79a24c3c208",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -240,8 +374,15 @@
           "id": "4ab6875deb3c0cbec4c8f260841f3d24",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -249,8 +390,15 @@
           "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "acd188a125352509e86ce104323c5d4f",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -258,8 +406,15 @@
           "id": "d99fa824b2d85a2053f51fe3bd94ef60",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -267,7 +422,14 @@
           "id": "d5054f4fd0140de3542ad2764d0f20bf",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "tcp": "400.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "400.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -275,7 +437,14 @@
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -283,10 +452,17 @@
           "id": "4fe76972070982cc0fe01b5d42836ca1",
           "source": "dd4c5162b7f38a52e7f984766f88d807",
           "target": "08d6a5dd6e290fbc42e259053b86a762",
-          "http": "30.00",
-          "http5XX": "10.00",
-          "httpPercentErr": "33.3",
-          "httpPercentReq": "42.9"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "30.00",
+                "http5xx": "10.00",
+                "httpPercentErr": "33.3",
+                "httpPercentReq": "42.9"
+              }
+            }
+          ]
         }
       },
       {
@@ -294,8 +470,15 @@
           "id": "5d3f0ce188557ed9741bda52cb245ff4",
           "source": "dd4c5162b7f38a52e7f984766f88d807",
           "target": "87100ff76f5122d56e8aa75d018b5d67",
-          "http": "20.00",
-          "httpPercentReq": "28.6"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "28.6"
+              }
+            }
+          ]
         }
       },
       {
@@ -303,8 +486,15 @@
           "id": "1959f1719d95c1a853a435a5807df1c3",
           "source": "dd4c5162b7f38a52e7f984766f88d807",
           "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "http": "20.00",
-          "httpPercentReq": "28.6"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "28.6"
+              }
+            }
+          ]
         }
       }
     ]

--- a/handlers/testdata/test_versioned_app_node_graph.expected
+++ b/handlers/testdata/test_versioned_app_node_graph.expected
@@ -24,10 +24,17 @@
           "destServices": {
             "details": true
           },
-          "httpIn": "80.00",
-          "httpIn3XX": "20.00",
-          "httpIn4XX": "20.00",
-          "httpIn5XX": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "80.00",
+                "httpIn3xx": "20.00",
+                "httpIn4xx": "20.00",
+                "httpIn5xx": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -41,9 +48,21 @@
           "destServices": {
             "productpage": true
           },
-          "httpIn": "170.00",
-          "httpOut": "160.00",
-          "tcpOut": "31.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "170.00",
+                "httpOut": "160.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -58,7 +77,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -73,7 +99,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -88,7 +121,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -102,7 +142,14 @@
           "destServices": {
             "tcp": true
           },
-          "tcpIn": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -113,7 +160,14 @@
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
           "version": "unknown",
-          "httpOut": "100.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isOutside": true,
           "isRoot": true
@@ -127,7 +181,14 @@
           "workload": "unknown",
           "app": "unknown",
           "version": "unknown",
-          "httpOut": "50.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "50.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isRoot": true
         }
@@ -139,7 +200,14 @@
           "id": "8088ca79aa13e423747334c532144c4f",
           "source": "933d90e5172f69af1baa035e8a8ad27c",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "100.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "100.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -147,7 +215,14 @@
           "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "tcp": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -155,12 +230,19 @@
           "id": "9f6a2ed75734d99002d37ac867190b9e",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "50113397f439f05f3280ad0772b9b307",
-          "http": "80.00",
-          "http3XX": "20.00",
-          "http4XX": "20.00",
-          "http5XX": "20.00",
-          "httpPercentErr": "50.0",
-          "httpPercentReq": "50.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "80.00",
+                "http3xx": "20.00",
+                "http4xx": "20.00",
+                "http5xx": "20.00",
+                "httpPercentErr": "50.0",
+                "httpPercentReq": "50.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -168,8 +250,15 @@
           "id": "0d38eb7edb4da38dac33b79a24c3c208",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -177,8 +266,15 @@
           "id": "4ab6875deb3c0cbec4c8f260841f3d24",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -186,8 +282,15 @@
           "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "acd188a125352509e86ce104323c5d4f",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -195,8 +298,15 @@
           "id": "d99fa824b2d85a2053f51fe3bd94ef60",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -204,7 +314,14 @@
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00"
+              }
+            }
+          ]
         }
       }
     ]

--- a/handlers/testdata/test_workload_graph.expected
+++ b/handlers/testdata/test_workload_graph.expected
@@ -15,7 +15,14 @@
           "destServices": {
             "pricing": true
           },
-          "httpIn": "20.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isOutside": true
         }
@@ -31,10 +38,17 @@
           "destServices": {
             "details": true
           },
-          "httpIn": "80.00",
-          "httpIn3XX": "20.00",
-          "httpIn4XX": "20.00",
-          "httpIn5XX": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "80.00",
+                "httpIn3xx": "20.00",
+                "httpIn4xx": "20.00",
+                "httpIn5xx": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -48,9 +62,21 @@
           "destServices": {
             "productpage": true
           },
-          "httpIn": "170.00",
-          "httpOut": "160.00",
-          "tcpOut": "31.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "170.00",
+                "httpOut": "160.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -64,8 +90,15 @@
           "destServices": {
             "ratings": true
           },
-          "httpIn": "60.00",
-          "httpIn5XX": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "60.00",
+                "httpIn5xx": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -79,7 +112,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -93,8 +133,15 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "40.00",
-          "httpOut": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "40.00",
+                "httpOut": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -108,8 +155,15 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "40.00",
-          "httpOut": "70.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "40.00",
+                "httpOut": "70.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -123,7 +177,14 @@
           "destServices": {
             "tcp": true
           },
-          "tcpIn": "581.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "581.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -134,8 +195,20 @@
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
           "version": "unknown",
-          "httpOut": "100.00",
-          "tcpOut": "150.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "150.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isMisconfigured": "labels=[version]",
           "isOutside": true,
@@ -150,8 +223,20 @@
           "workload": "unknown",
           "app": "unknown",
           "version": "unknown",
-          "httpOut": "50.00",
-          "tcpOut": "400.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "50.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "400.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isRoot": true
         }
@@ -163,8 +248,15 @@
           "id": "710c2bf1d8a5b3fc854451e7346e05f5",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -172,12 +264,19 @@
           "id": "df66cffc756bf9983dd453837e4e14a7",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "5cd385c1ee3309ae40828b5702ae57fb",
-          "http": "80.00",
-          "http3XX": "20.00",
-          "http4XX": "20.00",
-          "http5XX": "20.00",
-          "httpPercentErr": "50.0",
-          "httpPercentReq": "50.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "80.00",
+                "http3xx": "20.00",
+                "http4xx": "20.00",
+                "http5xx": "20.00",
+                "httpPercentErr": "50.0",
+                "httpPercentReq": "50.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -185,8 +284,15 @@
           "id": "1da31b81ccaf408abccbc57071458462",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "731126638001dfa2b6cbeb3b326b6678",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -194,7 +300,14 @@
           "id": "cc4b63704dba836d37dd97aacf75afee",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "tcp": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -202,8 +315,15 @@
           "id": "c2ab8814859ec0974c5efd597b5bb4fd",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "9e97011b2086f59a90626cfd5cf23fbf",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -211,8 +331,15 @@
           "id": "943e5cc1b00d97a8a344fe1efd941130",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "fc3e7c5bb695ef8ed8ab2c5f6ac4725b",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -220,8 +347,15 @@
           "id": "dfb27d138c8b9b95b699e910fdda93bf",
           "source": "731126638001dfa2b6cbeb3b326b6678",
           "target": "2075586d4defa2622017ea76b7c582c0",
-          "http": "20.00",
-          "httpPercentReq": "28.6"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "28.6"
+              }
+            }
+          ]
         }
       },
       {
@@ -229,10 +363,17 @@
           "id": "fa1db53921ef4a16b273c5260df63c2d",
           "source": "731126638001dfa2b6cbeb3b326b6678",
           "target": "5fd49fef66081810598406b0686500ae",
-          "http": "30.00",
-          "http5XX": "10.00",
-          "httpPercentErr": "33.3",
-          "httpPercentReq": "42.9"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "30.00",
+                "http5xx": "10.00",
+                "httpPercentErr": "33.3",
+                "httpPercentReq": "42.9"
+              }
+            }
+          ]
         }
       },
       {
@@ -240,8 +381,15 @@
           "id": "6822e986b101e54af3305af8d2d08051",
           "source": "731126638001dfa2b6cbeb3b326b6678",
           "target": "731126638001dfa2b6cbeb3b326b6678",
-          "http": "20.00",
-          "httpPercentReq": "28.6"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "28.6"
+              }
+            }
+          ]
         }
       },
       {
@@ -249,10 +397,17 @@
           "id": "0b356bd23faa1d1f26b3edeb4bbf0502",
           "source": "9e97011b2086f59a90626cfd5cf23fbf",
           "target": "5fd49fef66081810598406b0686500ae",
-          "http": "30.00",
-          "http5XX": "10.00",
-          "httpPercentErr": "33.3",
-          "httpPercentReq": "60.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "30.00",
+                "http5xx": "10.00",
+                "httpPercentErr": "33.3",
+                "httpPercentReq": "60.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -260,8 +415,15 @@
           "id": "0d137e50b408f6108b52a8db15f90472",
           "source": "9e97011b2086f59a90626cfd5cf23fbf",
           "target": "9e97011b2086f59a90626cfd5cf23fbf",
-          "http": "20.00",
-          "httpPercentReq": "40.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "40.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -269,7 +431,14 @@
           "id": "b38eaa93622c6c652c3daf15b31a476d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -277,7 +446,14 @@
           "id": "add44fff17f11c9c090f09d178d6090c",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "tcp": "400.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "400.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -285,7 +461,14 @@
           "id": "347e210a97f5235b5a60b810ef1bfaa6",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "http": "100.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "100.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -293,7 +476,14 @@
           "id": "5644333566484a57ab42a2567bd5d805",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "tcp": "150.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "150.00"
+              }
+            }
+          ]
         }
       }
     ]

--- a/handlers/testdata/test_workload_node_graph.expected
+++ b/handlers/testdata/test_workload_node_graph.expected
@@ -15,10 +15,17 @@
           "destServices": {
             "details": true
           },
-          "httpIn": "80.00",
-          "httpIn3XX": "20.00",
-          "httpIn4XX": "20.00",
-          "httpIn5XX": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "80.00",
+                "httpIn3xx": "20.00",
+                "httpIn4xx": "20.00",
+                "httpIn5xx": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -32,9 +39,21 @@
           "destServices": {
             "productpage": true
           },
-          "httpIn": "170.00",
-          "httpOut": "160.00",
-          "tcpOut": "31.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "170.00",
+                "httpOut": "160.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -48,7 +67,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -62,7 +88,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -76,7 +109,14 @@
           "destServices": {
             "reviews": true
           },
-          "httpIn": "20.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "20.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -90,7 +130,14 @@
           "destServices": {
             "tcp": true
           },
-          "tcpIn": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -100,7 +147,14 @@
           "namespace": "istio-system",
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
-          "httpOut": "100.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isOutside": true,
           "isRoot": true
@@ -114,7 +168,14 @@
           "workload": "unknown",
           "app": "unknown",
           "version": "unknown",
-          "httpOut": "50.00",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "50.00"
+              }
+            }
+          ],
           "isInaccessible": true,
           "isRoot": true
         }
@@ -126,8 +187,15 @@
           "id": "710c2bf1d8a5b3fc854451e7346e05f5",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -135,12 +203,19 @@
           "id": "df66cffc756bf9983dd453837e4e14a7",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "5cd385c1ee3309ae40828b5702ae57fb",
-          "http": "80.00",
-          "http3XX": "20.00",
-          "http4XX": "20.00",
-          "http5XX": "20.00",
-          "httpPercentErr": "50.0",
-          "httpPercentReq": "50.0"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "80.00",
+                "http3xx": "20.00",
+                "http4xx": "20.00",
+                "http5xx": "20.00",
+                "httpPercentErr": "50.0",
+                "httpPercentReq": "50.0"
+              }
+            }
+          ]
         }
       },
       {
@@ -148,8 +223,15 @@
           "id": "1da31b81ccaf408abccbc57071458462",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "731126638001dfa2b6cbeb3b326b6678",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -157,7 +239,14 @@
           "id": "cc4b63704dba836d37dd97aacf75afee",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "tcp": "31.00"
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcp": "31.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -165,8 +254,15 @@
           "id": "c2ab8814859ec0974c5efd597b5bb4fd",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "9e97011b2086f59a90626cfd5cf23fbf",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -174,8 +270,15 @@
           "id": "943e5cc1b00d97a8a344fe1efd941130",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "fc3e7c5bb695ef8ed8ab2c5f6ac4725b",
-          "http": "20.00",
-          "httpPercentReq": "12.5"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "20.00",
+                "httpPercentReq": "12.5"
+              }
+            }
+          ]
         }
       },
       {
@@ -183,7 +286,14 @@
           "id": "b38eaa93622c6c652c3daf15b31a476d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "http": "50.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "50.00"
+              }
+            }
+          ]
         }
       },
       {
@@ -191,7 +301,14 @@
           "id": "347e210a97f5235b5a60b810ef1bfaa6",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "http": "100.00"
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "http": "100.00"
+              }
+            }
+          ]
         }
       }
     ]

--- a/swagger.json
+++ b/swagger.json
@@ -2663,31 +2663,6 @@
     "EdgeData": {
       "type": "object",
       "properties": {
-        "http": {
-          "description": "App Fields (not required by Cytoscape)",
-          "type": "string",
-          "x-go-name": "Http"
-        },
-        "http3XX": {
-          "type": "string",
-          "x-go-name": "Http3xx"
-        },
-        "http4XX": {
-          "type": "string",
-          "x-go-name": "Http4xx"
-        },
-        "http5XX": {
-          "type": "string",
-          "x-go-name": "Http5xx"
-        },
-        "httpPercentErr": {
-          "type": "string",
-          "x-go-name": "HttpPercentErr"
-        },
-        "httpPercentReq": {
-          "type": "string",
-          "x-go-name": "HttpPercentReq"
-        },
         "id": {
           "description": "Cytoscape Fields",
           "type": "string",
@@ -2713,9 +2688,13 @@
           "type": "string",
           "x-go-name": "Target"
         },
-        "tcp": {
-          "type": "string",
-          "x-go-name": "Tcp"
+        "traffic": {
+          "description": "App Fields (not required by Cytoscape)",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProtocolTraffic"
+          },
+          "x-go-name": "Traffic"
         }
       },
       "x-go-package": "github.com/kiali/kiali/graph/cytoscape"
@@ -3137,26 +3116,6 @@
           "type": "boolean",
           "x-go-name": "HasVS"
         },
-        "httpIn": {
-          "type": "string",
-          "x-go-name": "HttpIn"
-        },
-        "httpIn3XX": {
-          "type": "string",
-          "x-go-name": "HttpIn3xx"
-        },
-        "httpIn4XX": {
-          "type": "string",
-          "x-go-name": "HttpIn4xx"
-        },
-        "httpIn5XX": {
-          "type": "string",
-          "x-go-name": "HttpIn5xx"
-        },
-        "httpOut": {
-          "type": "string",
-          "x-go-name": "HttpOut"
-        },
         "id": {
           "description": "Cytoscape Fields",
           "type": "string",
@@ -3211,13 +3170,12 @@
           "type": "string",
           "x-go-name": "Service"
         },
-        "tcpIn": {
-          "type": "string",
-          "x-go-name": "TcpIn"
-        },
-        "tcpOut": {
-          "type": "string",
-          "x-go-name": "TcpOut"
+        "traffic": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProtocolTraffic"
+          },
+          "x-go-name": "Traffic"
         },
         "version": {
           "type": "string",
@@ -3462,6 +3420,23 @@
         "$ref": "#/definitions/Port"
       },
       "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "ProtocolTraffic": {
+      "type": "object",
+      "properties": {
+        "protocol": {
+          "type": "string",
+          "x-go-name": "Protocol"
+        },
+        "rates": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Rates"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/graph/cytoscape"
     },
     "QuotaSpec": {
       "type": "object",


### PR DESCRIPTION
- Introduce generic JSON structure for reporting traffic rates
- Add new protocol.go to centralize protocol-specific logic
  - with the exception of protocol-specific queries (like for TCP)

THIS PR REQUIRES UI PR https://github.com/kiali/kiali-ui/pull/945 . When both are approved the DNM label can be removed and the two PRs should be merged in tandem.