### PR TITLE
KIALI-2082 Add Policy support to IstioConfig

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -339,6 +339,9 @@ func (in *IstioConfigService) UpdateIstioConfigDetail(api, namespace, resourceTy
 	case QuotaSpecBindings:
 		istioConfigDetail.QuotaSpecBinding = &models.QuotaSpecBinding{}
 		istioConfigDetail.QuotaSpecBinding.Parse(result)
+	case Policies:
+		istioConfigDetail.Policy = &models.Policy{}
+		istioConfigDetail.Policy.Parse(result)
 	default:
 		err = fmt.Errorf("Object type not found: %v", resourceType)
 	}

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -199,7 +199,7 @@ func (in *IstioConfigService) GetIstioConfigDetails(namespace, objectType, objec
 	istioConfigDetail := models.IstioConfigDetails{}
 	istioConfigDetail.Namespace = models.Namespace{Name: namespace}
 	istioConfigDetail.ObjectType = objectType
-	var gw, vs, dr, se, qs, qb, r, a, t kubernetes.IstioObject
+	var gw, vs, dr, se, qs, qb, r, a, t, pc kubernetes.IstioObject
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -257,6 +257,11 @@ func (in *IstioConfigService) GetIstioConfigDetails(namespace, objectType, objec
 		if qb, err = in.k8s.GetQuotaSpecBinding(namespace, object); err == nil {
 			istioConfigDetail.QuotaSpecBinding = &models.QuotaSpecBinding{}
 			istioConfigDetail.QuotaSpecBinding.Parse(qb)
+		}
+	case Policies:
+		if pc, err = in.k8s.GetPolicy(namespace, object); err == nil {
+			istioConfigDetail.Policy = &models.Policy{}
+			istioConfigDetail.Policy.Parse(pc)
 		}
 	default:
 		err = fmt.Errorf("Object type not found: %v", objectType)

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -42,6 +42,7 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(0, len(istioconfigList.Templates))
 	assert.Equal(0, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
 	assert.Nil(err)
 
 	criteria.IncludeGateways = true
@@ -57,6 +58,7 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(0, len(istioconfigList.Templates))
 	assert.Equal(0, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
 	assert.Nil(err)
 
 	criteria.IncludeVirtualServices = true
@@ -72,6 +74,7 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(0, len(istioconfigList.Templates))
 	assert.Equal(0, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
 	assert.Nil(err)
 
 	criteria.IncludeDestinationRules = true
@@ -87,6 +90,7 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(0, len(istioconfigList.Templates))
 	assert.Equal(0, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
 	assert.Nil(err)
 
 	criteria.IncludeServiceEntries = true
@@ -102,6 +106,7 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(0, len(istioconfigList.Templates))
 	assert.Equal(0, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
 	assert.Nil(err)
 
 	criteria.IncludeRules = true
@@ -117,6 +122,7 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(0, len(istioconfigList.Templates))
 	assert.Equal(0, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
 	assert.Nil(err)
 
 	criteria.IncludeAdapters = true
@@ -132,6 +138,7 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(0, len(istioconfigList.Templates))
 	assert.Equal(0, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
 	assert.Nil(err)
 
 	criteria.IncludeTemplates = true
@@ -147,6 +154,7 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(1, len(istioconfigList.Templates))
 	assert.Equal(0, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
 	assert.Nil(err)
 
 	criteria.IncludeQuotaSpecs = true
@@ -162,6 +170,7 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(1, len(istioconfigList.Templates))
 	assert.Equal(1, len(istioconfigList.QuotaSpecs))
 	assert.Equal(0, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
 	assert.Nil(err)
 
 	criteria.IncludeQuotaSpecBindings = true
@@ -177,6 +186,23 @@ func TestGetIstioConfigList(t *testing.T) {
 	assert.Equal(1, len(istioconfigList.Templates))
 	assert.Equal(1, len(istioconfigList.QuotaSpecs))
 	assert.Equal(1, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(0, len(istioconfigList.Policies))
+	assert.Nil(err)
+
+	criteria.IncludePolicies = true
+
+	istioconfigList, err = configService.GetIstioConfigList(criteria)
+
+	assert.Equal(2, len(istioconfigList.Gateways))
+	assert.Equal(2, len(istioconfigList.VirtualServices.Items))
+	assert.Equal(2, len(istioconfigList.DestinationRules.Items))
+	assert.Equal(1, len(istioconfigList.ServiceEntries))
+	assert.Equal(1, len(istioconfigList.Rules))
+	assert.Equal(1, len(istioconfigList.Adapters))
+	assert.Equal(1, len(istioconfigList.Templates))
+	assert.Equal(1, len(istioconfigList.QuotaSpecs))
+	assert.Equal(1, len(istioconfigList.QuotaSpecBindings))
+	assert.Equal(1, len(istioconfigList.Policies))
 	assert.Nil(err)
 }
 
@@ -230,6 +256,7 @@ func mockGetIstioConfigList() IstioConfigService {
 	k8s.On("GetTemplates", mock.AnythingOfType("string")).Return(fakeGetTemplates(), nil)
 	k8s.On("GetQuotaSpecs", mock.AnythingOfType("string")).Return(fakeGetQuotaSpecs(), nil)
 	k8s.On("GetQuotaSpecBindings", mock.AnythingOfType("string")).Return(fakeGetQuotaSpecBindings(), nil)
+	k8s.On("GetPolicies", mock.AnythingOfType("string")).Return(fakeGetPolicies(), nil)
 
 	return IstioConfigService{k8s: k8s}
 }
@@ -457,6 +484,40 @@ func fakeGetQuotaSpecBindings() []kubernetes.IstioObject {
 		},
 	}
 	return []kubernetes.IstioObject{&quotaSpec}
+}
+
+func fakeGetPolicies() []kubernetes.IstioObject {
+	policy := kubernetes.GenericIstioObject{}
+	policy.Name = "request-count"
+	policy.Spec = map[string]interface{}{
+		"targets": []interface{}{
+			map[string]interface{}{
+				"name": "target",
+				"port": []interface{}{
+					map[string]interface{}{
+						"number": 8080,
+						"name":   "tomcat",
+					},
+				},
+			},
+			map[string]interface{}{
+				"name": "target",
+				"port": []interface{}{
+					map[string]interface{}{
+						"number": 80,
+						"name":   "nginx",
+					},
+				},
+			},
+		},
+		"peers": []interface{}{
+			map[string]interface{}{
+				"mode": "STRICT",
+			},
+		},
+	}
+	return []kubernetes.IstioObject{&policy}
+
 }
 
 func fakeGetSelfSubjectAccessReview() []*auth_v1.SelfSubjectAccessReview {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -135,6 +135,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		// Validations on QuotaSpecs are not yet in place
 	case QuotaSpecBindings:
 		// Validations on QuotaSpecBindings are not yet in place
+	case Policies:
+		// Validations on Policies are not yet in place
 	default:
 		err = fmt.Errorf("Object type not found: %v", objectType)
 	}

--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -74,6 +74,15 @@ rules:
   - list
   - patch
   - watch
+- apiGroups: ["authentication.istio.io"]
+  resources:
+  - policies
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups: ["monitoring.kiali.io"]
   resources:
   - monitoringdashboards

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -74,6 +74,15 @@ rules:
   - list
   - patch
   - watch
+- apiGroups: ["authentication.istio.io"]
+  resources:
+  - policies
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups: ["apps.openshift.io"]
   resources:
   - deploymentconfigs

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -99,6 +99,7 @@ func parseCriteria(namespace string, objects string) business.IstioConfigCriteri
 	criteria.IncludeTemplates = defaultInclude
 	criteria.IncludeQuotaSpecs = defaultInclude
 	criteria.IncludeQuotaSpecBindings = defaultInclude
+	criteria.IncludePolicies = defaultInclude
 
 	if defaultInclude {
 		return criteria
@@ -131,6 +132,9 @@ func parseCriteria(namespace string, objects string) business.IstioConfigCriteri
 	}
 	if checkType(types, business.QuotaSpecBindings) {
 		criteria.IncludeQuotaSpecBindings = true
+	}
+	if checkType(types, business.Policies) {
+		criteria.IncludePolicies = true
 	}
 	return criteria
 }

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -71,6 +71,7 @@ type IstioClientInterface interface {
 	GetStatefulSets(namespace string) ([]v1beta2.StatefulSet, error)
 	GetTemplate(namespace, templateType, templateName string) (IstioObject, error)
 	GetTemplates(namespace string) ([]IstioObject, error)
+	GetPolicies(namespace string) ([]IstioObject, error)
 	GetVirtualService(namespace string, virtualservice string) (IstioObject, error)
 	GetVirtualServices(namespace string, serviceName string) ([]IstioObject, error)
 	IsOpenShift() bool
@@ -82,9 +83,10 @@ type IstioClientInterface interface {
 // It hides the way it queries each API
 type IstioClient struct {
 	IstioClientInterface
-	k8s                *kube.Clientset
-	istioConfigApi     *rest.RESTClient
-	istioNetworkingApi *rest.RESTClient
+	k8s                    *kube.Clientset
+	istioConfigApi         *rest.RESTClient
+	istioNetworkingApi     *rest.RESTClient
+	istioAuthenticationApi *rest.RESTClient
 	// isOpenShift private variable will check if kiali is deployed under an OpenShift cluster or not
 	// It is represented as a pointer to include the initialization phase.
 	// See kubernetes_service.go#IsOpenShift() for more details.
@@ -200,8 +202,14 @@ func NewClientFromConfig(config *rest.Config) (*IstioClient, error) {
 				scheme.AddKnownTypeWithName(configGroupVersion.WithKind(tp.objectKind), &GenericIstioObject{})
 				scheme.AddKnownTypeWithName(configGroupVersion.WithKind(tp.collectionKind), &GenericIstioObjectList{})
 			}
+			// Register authentication types
+			for _, at := range authenticationTypes {
+				scheme.AddKnownTypeWithName(authenticationGroupVersion.WithKind(at.objectKind), &GenericIstioObject{})
+				scheme.AddKnownTypeWithName(authenticationGroupVersion.WithKind(at.collectionKind), &GenericIstioObjectList{})
+			}
 			meta_v1.AddToGroupVersion(scheme, configGroupVersion)
 			meta_v1.AddToGroupVersion(scheme, networkingGroupVersion)
+			meta_v1.AddToGroupVersion(scheme, authenticationGroupVersion)
 			return nil
 		})
 
@@ -221,8 +229,14 @@ func NewClientFromConfig(config *rest.Config) (*IstioClient, error) {
 		return nil, err
 	}
 
+	istioAuthenticationAPI, err := newClientForAPI(config, authenticationGroupVersion, types)
+	if err != nil {
+		return nil, err
+	}
+
 	client.istioConfigApi = istioConfigAPI
 	client.istioNetworkingApi = istioNetworkingAPI
+	client.istioAuthenticationApi = istioAuthenticationAPI
 	return &client, nil
 }
 

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -71,6 +71,7 @@ type IstioClientInterface interface {
 	GetStatefulSets(namespace string) ([]v1beta2.StatefulSet, error)
 	GetTemplate(namespace, templateType, templateName string) (IstioObject, error)
 	GetTemplates(namespace string) ([]IstioObject, error)
+	GetPolicy(namespace string, policyName string) (IstioObject, error)
 	GetPolicies(namespace string) ([]IstioObject, error)
 	GetVirtualService(namespace string, virtualservice string) (IstioObject, error)
 	GetVirtualServices(namespace string, serviceName string) ([]IstioObject, error)

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -287,6 +287,20 @@ func (in *IstioClient) GetPolicies(namespace string) ([]IstioObject, error) {
 	return policies, nil
 }
 
+func (in *IstioClient) GetPolicy(namespace string, policyName string) (IstioObject, error) {
+	result, err := in.istioAuthenticationApi.Get().Namespace(namespace).Resource(policies).SubResource(policyName).Do().Get()
+	if err != nil {
+		return nil, err
+	}
+
+	policy, ok := result.(*GenericIstioObject)
+	if !ok {
+		return nil, fmt.Errorf("%s doesn't return a Policy object", namespace)
+	}
+
+	return policy.DeepCopyIstioObject(), nil
+}
+
 // UpdateIstioObject updates an Istio object from either config api or networking api
 func (in *IstioClient) UpdateIstioObject(api, namespace, resourceType, name, jsonPatch string) (IstioObject, error) {
 	log.Infof("UpdateIstioObject input: %s / %s / %s / %s", api, namespace, resourceType, name)

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -268,6 +268,25 @@ func (in *IstioClient) GetQuotaSpecBinding(namespace string, quotaSpecBindingNam
 	return quotaSpecBinding.DeepCopyIstioObject(), nil
 }
 
+func (in *IstioClient) GetPolicies(namespace string) ([]IstioObject, error) {
+	result, err := in.istioAuthenticationApi.Get().Namespace(namespace).Resource(policies).Do().Get()
+	if err != nil {
+		return nil, err
+	}
+
+	policyList, ok := result.(*GenericIstioObjectList)
+	if !ok {
+		return nil, fmt.Errorf("%s doesn't return a PolicyList list", namespace)
+	}
+
+	policies := make([]IstioObject, 0)
+	for _, ps := range policyList.GetItems() {
+		policies = append(policies, ps.DeepCopyIstioObject())
+	}
+
+	return policies, nil
+}
+
 // UpdateIstioObject updates an Istio object from either config api or networking api
 func (in *IstioClient) UpdateIstioObject(api, namespace, resourceType, name, jsonPatch string) (IstioObject, error) {
 	log.Infof("UpdateIstioObject input: %s / %s / %s / %s", api, namespace, resourceType, name)

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -54,8 +54,10 @@ func (in *IstioClient) DeleteIstioObject(api, namespace, resourceType, name stri
 	var err error
 	if api == configGroupVersion.Group {
 		_, err = in.istioConfigApi.Delete().Namespace(namespace).Resource(resourceType).Name(name).Do().Get()
-	} else {
+	} else if api == networkingGroupVersion.Group {
 		_, err = in.istioNetworkingApi.Delete().Namespace(namespace).Resource(resourceType).Name(name).Do().Get()
+	} else {
+		_, err = in.istioAuthenticationApi.Delete().Namespace(namespace).Resource(resourceType).Name(name).Do().Get()
 	}
 	return err
 }
@@ -309,8 +311,10 @@ func (in *IstioClient) UpdateIstioObject(api, namespace, resourceType, name, jso
 	bytePatch := []byte(jsonPatch)
 	if api == configGroupVersion.Group {
 		result, err = in.istioConfigApi.Patch(types.MergePatchType).Namespace(namespace).Resource(resourceType).SubResource(name).Body(bytePatch).Do().Get()
-	} else {
+	} else if api == networkingGroupVersion.Group {
 		result, err = in.istioNetworkingApi.Patch(types.MergePatchType).Namespace(namespace).Resource(resourceType).SubResource(name).Body(bytePatch).Do().Get()
+	} else {
+		result, err = in.istioAuthenticationApi.Patch(types.MergePatchType).Namespace(namespace).Resource(resourceType).SubResource(name).Body(bytePatch).Do().Get()
 	}
 	if err != nil {
 		return nil, err

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -235,6 +235,11 @@ func (o *K8SClientMock) GetPolicies(namespace string) ([]kubernetes.IstioObject,
 	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
 }
 
+func (o *K8SClientMock) GetPolicy(namespace string, policyName string) (kubernetes.IstioObject, error) {
+	args := o.Called(namespace)
+	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
+}
+
 func (o *K8SClientMock) IsOpenShift() bool {
 	args := o.Called()
 	return args.Get(0).(bool)

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -230,6 +230,11 @@ func (o *K8SClientMock) GetVirtualService(namespace string, virtualservice strin
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
+func (o *K8SClientMock) GetPolicies(namespace string) ([]kubernetes.IstioObject, error) {
+	args := o.Called(namespace)
+	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
+}
+
 func (o *K8SClientMock) IsOpenShift() bool {
 	args := o.Called()
 	return args.Get(0).(bool)

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -38,6 +38,12 @@ const (
 	quotaspecbindingType     = "QuotaSpecBinding"
 	quotaspecbindingTypeList = "QuotaSpecBindingList"
 
+	// Policies
+
+	policies       = "policies"
+	policyType     = "Policy"
+	policyTypeList = "PolicyList"
+
 	// Config - Rules
 
 	rules        = "rules"
@@ -163,6 +169,12 @@ var (
 	}
 	apiNetworkingVersion = networkingGroupVersion.Group + "/" + networkingGroupVersion.Version
 
+	authenticationGroupVersion = schema.GroupVersion{
+		Group:   "authentication.istio.io",
+		Version: "v1alpha1",
+	}
+	apiAuthenticationVersion = authenticationGroupVersion.Group + "/" + authenticationGroupVersion.Version
+
 	networkingTypes = []struct {
 		objectKind     string
 		collectionKind string
@@ -201,6 +213,16 @@ var (
 		{
 			objectKind:     quotaspecbindingType,
 			collectionKind: quotaspecbindingTypeList,
+		},
+	}
+
+	authenticationTypes = []struct {
+		objectKind     string
+		collectionKind string
+	}{
+		{
+			objectKind:     policyType,
+			collectionKind: policyTypeList,
 		},
 	}
 

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -19,6 +19,7 @@ type IstioConfigList struct {
 	Templates         IstioTemplates    `json:"templates"`
 	QuotaSpecs        QuotaSpecs        `json:"quotaSpecs"`
 	QuotaSpecBindings QuotaSpecBindings `json:"quotaSpecBindings"`
+	Policies          Policies          `json:"policies"`
 	IstioValidations  IstioValidations  `json:"validations"`
 }
 

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -35,6 +35,7 @@ type IstioConfigDetails struct {
 	Template         *IstioTemplate      `json:"template"`
 	QuotaSpec        *QuotaSpec          `json:"quotaSpec"`
 	QuotaSpecBinding *QuotaSpecBinding   `json:"quotaSpecBinding"`
+	Policy           *Policy             `json:"policy"`
 	Permissions      ResourcePermissions `json:"permissions"`
 	IstioValidation  *IstioValidation    `json:"validation"`
 }

--- a/models/policy.go
+++ b/models/policy.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+type Policies []Policy
+type Policy struct {
+	Metadata meta_v1.ObjectMeta `json:"metadata"`
+	Spec     struct {
+		Targets          interface{} `json:"targets"`
+		Peers            interface{} `json:"peers"`
+		PeerIsOptional   interface{} `json:"peerIsOptional"`
+		Origins          interface{} `json:"origins"`
+		OriginIsOptional interface{} `json:"originIsOptional"`
+		PrincipalBinding interface{} `json:"principalBinding"`
+	} `json:"spec"`
+}
+
+func (ps *Policies) Parse(policies []kubernetes.IstioObject) {
+	for _, qs := range policies {
+		policy := Policy{}
+		policy.Parse(qs)
+		*ps = append(*ps, policy)
+	}
+}
+
+func (p *Policy) Parse(policy kubernetes.IstioObject) {
+	p.Metadata = policy.GetObjectMeta()
+	p.Spec.Targets = policy.GetSpec()["targets"]
+	p.Spec.Peers = policy.GetSpec()["peers"]
+	p.Spec.PeerIsOptional = policy.GetSpec()["peersIsOptional"]
+	p.Spec.Origins = policy.GetSpec()["origins"]
+	p.Spec.OriginIsOptional = policy.GetSpec()["originIsOptinal"]
+	p.Spec.PrincipalBinding = policy.GetSpec()["principalBinding"]
+}

--- a/swagger.json
+++ b/swagger.json
@@ -2918,6 +2918,9 @@
         "permissions": {
           "$ref": "#/definitions/ResourcePermissions"
         },
+        "policy": {
+          "$ref": "#/definitions/Policy"
+        },
         "quotaSpec": {
           "$ref": "#/definitions/QuotaSpec"
         },
@@ -2961,6 +2964,9 @@
         },
         "namespace": {
           "$ref": "#/definitions/namespace"
+        },
+        "policies": {
+          "$ref": "#/definitions/Policies"
         },
         "quotaSpecBindings": {
           "$ref": "#/definitions/QuotaSpecBindings"
@@ -3434,6 +3440,52 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/Pod"
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "Policies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Policy"
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "Policy": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/ObjectMeta"
+        },
+        "spec": {
+          "type": "object",
+          "properties": {
+            "originIsOptional": {
+              "type": "object",
+              "x-go-name": "OriginIsOptional"
+            },
+            "origins": {
+              "type": "object",
+              "x-go-name": "Origins"
+            },
+            "peerIsOptional": {
+              "type": "object",
+              "x-go-name": "PeerIsOptional"
+            },
+            "peers": {
+              "type": "object",
+              "x-go-name": "Peers"
+            },
+            "principalBinding": {
+              "type": "object",
+              "x-go-name": "PrincipalBinding"
+            },
+            "targets": {
+              "type": "object",
+              "x-go-name": "Targets"
+            }
+          },
+          "x-go-name": "Spec"
+        }
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },


### PR DESCRIPTION
** Describe the change **
Users now can manage Policy Istio Objects within IstioConfig section. Users can Update/Delete those policies too.

![screen recording 8](https://user-images.githubusercontent.com/613814/51475513-d059a280-1d82-11e9-951c-787dd6f1a91e.gif)


** Issue reference **
https://issues.jboss.org/browse/KIALI-2082

** Backwards incompatible? **
Yes.
