### PR TITLE
KIALI-2262 Make ServiceEntry validation work even without any services

### DIFF
--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -19,13 +19,7 @@ func (virtualService NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
 	routeProtocols := []string{"http", "tcp", "tls"}
-	for _, serviceName := range virtualService.ServiceNames {
-		if valid = kubernetes.FilterByRoute(virtualService.VirtualService.GetSpec(), routeProtocols, serviceName, virtualService.Namespace, virtualService.ServiceEntryHosts); valid {
-			break
-		}
-	}
-
-	if !valid {
+	if valid = kubernetes.FilterByRoute(virtualService.VirtualService.GetSpec(), routeProtocols, virtualService.ServiceNames, virtualService.Namespace, virtualService.ServiceEntryHosts); !valid {
 		for _, protocol := range routeProtocols {
 			if _, ok := virtualService.VirtualService.GetSpec()[protocol]; ok {
 				validation := models.BuildCheck("DestinationWeight on route doesn't have a valid service (host not found)", "error", fmt.Sprintf("spec/%s", protocol))

--- a/business/checkers/virtual_services/no_host_checker_test.go
+++ b/business/checkers/virtual_services/no_host_checker_test.go
@@ -14,7 +14,7 @@ func TestValidHost(t *testing.T) {
 	assert := assert.New(t)
 
 	validations, valid := NoHostChecker{
-		Namespace:      "test-namespace",
+		Namespace:      "test",
 		ServiceNames:   []string{"reviews", "other"},
 		VirtualService: data.CreateVirtualService(),
 	}.Check()
@@ -32,7 +32,7 @@ func TestNoValidHost(t *testing.T) {
 	virtualService := data.CreateVirtualService()
 
 	validations, valid := NoHostChecker{
-		Namespace:      "test-namespace",
+		Namespace:      "test",
 		ServiceNames:   []string{"details", "other"},
 		VirtualService: virtualService,
 	}.Check()
@@ -49,7 +49,7 @@ func TestNoValidHost(t *testing.T) {
 	delete(virtualService.GetSpec(), "http")
 
 	validations, valid = NoHostChecker{
-		Namespace:      "test-namespace",
+		Namespace:      "test",
 		ServiceNames:   []string{"details", "other"},
 		VirtualService: virtualService,
 	}.Check()
@@ -63,7 +63,7 @@ func TestNoValidHost(t *testing.T) {
 	delete(virtualService.GetSpec(), "tcp")
 
 	validations, valid = NoHostChecker{
-		Namespace:      "test-namespace",
+		Namespace:      "test",
 		ServiceNames:   []string{"details", "other"},
 		VirtualService: virtualService,
 	}.Check()
@@ -84,8 +84,8 @@ func TestValidServiceEntryHost(t *testing.T) {
 	virtualService := data.CreateVirtualServiceWithServiceEntryTarget()
 
 	validations, valid := NoHostChecker{
-		Namespace:      "test-namespace",
-		ServiceNames:   []string{"my-wiki-rule"},
+		Namespace:      "wikipedia",
+		ServiceNames:   []string{},
 		VirtualService: virtualService,
 	}.Check()
 
@@ -96,9 +96,29 @@ func TestValidServiceEntryHost(t *testing.T) {
 	serviceEntry := data.CreateExternalServiceEntry()
 
 	validations, valid = NoHostChecker{
-		Namespace:         "test-namespace",
-		ServiceNames:      []string{"my-wiki-rule"},
+		Namespace:         "wikipedia",
+		ServiceNames:      []string{},
 		VirtualService:    virtualService,
+		ServiceEntryHosts: kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{serviceEntry}),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestGoogleApisServiceExample(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	vs := data.CreateGoogleApisExampleVirtualService()
+	serviceEntry := data.CreateGoogleApisExampleExternalServiceEntry()
+
+	validations, valid := NoHostChecker{
+		Namespace:         "bookinfo",
+		ServiceNames:      []string{},
+		VirtualService:    vs,
 		ServiceEntryHosts: kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{serviceEntry}),
 	}.Check()
 

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -77,7 +77,7 @@ func (in *IstioClient) GetVirtualServices(namespace string, serviceName string) 
 	for _, virtualService := range virtualServiceList.GetItems() {
 		appendVirtualService := serviceName == ""
 		routeProtocols := []string{"http", "tcp"}
-		if !appendVirtualService && FilterByRoute(virtualService.GetSpec(), routeProtocols, serviceName, namespace, nil) {
+		if !appendVirtualService && FilterByRoute(virtualService.GetSpec(), routeProtocols, []string{serviceName}, namespace, nil) {
 			appendVirtualService = true
 		}
 		if appendVirtualService {
@@ -314,7 +314,7 @@ func FilterByHost(host, serviceName, namespace string) bool {
 	return false
 }
 
-func FilterByRoute(spec map[string]interface{}, protocols []string, service string, namespace string, serviceEntries map[string]struct{}) bool {
+func FilterByRoute(spec map[string]interface{}, protocols []string, serviceNames []string, namespace string, serviceEntries map[string]struct{}) bool {
 	if len(protocols) == 0 {
 		return false
 	}
@@ -331,8 +331,10 @@ func FilterByRoute(spec map[string]interface{}, protocols []string, service stri
 											if mDestinationW, ok := destinationW.(map[string]interface{}); ok {
 												if host, ok := mDestinationW["host"]; ok {
 													if sHost, ok := host.(string); ok {
-														if FilterByHost(sHost, service, namespace) {
-															return true
+														for _, service := range serviceNames {
+															if FilterByHost(sHost, service, namespace) {
+																return true
+															}
 														}
 														if serviceEntries != nil {
 															// We have ServiceEntry to check

--- a/tests/data/virtual_service_data.go
+++ b/tests/data/virtual_service_data.go
@@ -99,3 +99,62 @@ func CreateExternalServiceEntry() kubernetes.IstioObject {
 		},
 	}).DeepCopyIstioObject()
 }
+
+// CreateGoogleApisExampleExternalServiceEntry to test KIALI-2262
+func CreateGoogleApisExampleExternalServiceEntry() kubernetes.IstioObject {
+	return (&kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "google",
+			Namespace: "bookinfo",
+		},
+		Spec: map[string]interface{}{
+			"hosts": []interface{}{
+				"www.googleapis.com",
+			},
+			"location": "MESH_EXTERNAL",
+			"ports": map[string]interface{}{
+				"number":   uint64(443),
+				"name":     "https",
+				"protocol": "HTTPS",
+			},
+			"resolution": "DNS",
+		},
+	}).DeepCopyIstioObject()
+}
+
+func CreateGoogleApisExampleVirtualService() kubernetes.IstioObject {
+	vs := CreateEmptyVirtualService("google", "bookinfo", []string{"www.googleapis.com"})
+	vs.GetSpec()["tls"] = []interface{}{
+		map[string]interface{}{
+			"route": []interface{}{
+				map[string]interface{}{
+					"destination": map[string]interface{}{
+						"host": "www.googleapis.com",
+						"port": map[string]interface{}{
+							"number": uint64(443),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return vs
+	/*
+		vs.SetSpec(map[string]interface{}{
+			"hosts": []interface{}{
+				"www.googleapis.com",
+			},
+			"tls": map[string]interface{}{
+				"route": []interface{}{
+					"destination": map[string]interface{}{
+						"host": "www.googleapis.com",
+						"port": map[string]interface{}{
+							"number": uint64(443)
+						}
+					}
+				}
+			},
+		})
+	*/
+}


### PR DESCRIPTION
** Describe the change **

Previous validator for ServiceEntries required that some services exists, otherwise the path was never triggered. If there are no v1.Services, this would fail and the host would get flagged invalid.

** Issue reference **

KIALI-2262

@simonpasquier 