### PR TITLE
KIALI-2185 Reducing validation severity to warning for DestinationWeights

### DIFF
--- a/business/checkers/virtual_services/route_checker.go
+++ b/business/checkers/virtual_services/route_checker.go
@@ -98,7 +98,7 @@ func (route RouteChecker) checkRoutesFor(kind string) ([]*models.IstioCheck, boo
 			if weightCount != destinationWeights.Len() {
 				valid = false
 				path := fmt.Sprintf("spec/%s[%d]/route", kind, routeIdx)
-				validation := buildValidation("All routes should have weight", "error", path)
+				validation := buildValidation("All routes should have weight", "warning", path)
 				validations = append(validations, &validation)
 			}
 		}


### PR DESCRIPTION
** Describe the change **
Continuation of #758.
Adding one test for the scenario described right there.
Also reducing severity from error to warning for "All routes should have weights" since it isn't an mandatory requirement to make istio works.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2185

** Backwards incompatible? **
yes

** Documentation **

Documentation PR: https://github.com/kiali/kiali.io/pull/93

** Screen captures **

![screenshot of kiali console 21](https://user-images.githubusercontent.com/613814/51558265-4cd1ab80-1e7f-11e9-897b-567e8869ba96.png)
![screenshot of kiali console 22](https://user-images.githubusercontent.com/613814/51558348-8a363900-1e7f-11e9-8824-dfa1bf3fd6a4.png)
![screenshot of kiali console 19](https://user-images.githubusercontent.com/613814/51558261-4a6f5180-1e7f-11e9-85af-42c5b45dd123.png)
![screenshot of kiali console 20](https://user-images.githubusercontent.com/613814/51558262-4ba07e80-1e7f-11e9-869a-fbd6f1d5fe3d.png)
