### PR TITLE
KIALI-2148 Adding mTLS status into status endpoint

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -9,6 +9,7 @@ import (
 
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
@@ -544,7 +545,7 @@ func (in *IstioConfigService) hasMeshPolicyEnabled() (bool, error) {
 }
 
 func (in *IstioConfigService) hasDestinationRuleEnabled() (bool, error) {
-	dr, err := in.k8s.GetDestinationRule("default", "default")
+	dr, err := in.k8s.GetDestinationRule(config.Get().IstioNamespace, "default")
 	if err != nil {
 		if errors2.IsNotFound(err) {
 			return false, nil

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -484,7 +484,7 @@ func getPermissions(k8s kubernetes.IstioClientInterface, namespace, objectType, 
 }
 
 func (in *IstioConfigService) MeshWidemTLSStatus(namespaces []string) (string, error) {
-	mpp, mpErr := in.hasMeshPolicyEnabled()
+	mpp, mpErr := in.hasMeshPolicyEnabled(namespaces)
 	if mpErr != nil {
 		return "", mpErr
 	}
@@ -503,8 +503,14 @@ func (in *IstioConfigService) MeshWidemTLSStatus(namespaces []string) (string, e
 	return MeshmTLSNotEnabled, nil
 }
 
-func (in *IstioConfigService) hasMeshPolicyEnabled() (bool, error) {
-	mps, err := in.k8s.GetMeshPolicies()
+func (in *IstioConfigService) hasMeshPolicyEnabled(namespaces []string) (bool, error) {
+	if len(namespaces) < 1 {
+		return false, fmt.Errorf("Can't find MeshPolicies without a namespace")
+	}
+
+	// MeshPolicies are not namespaced. So any namespace user has access to
+	// will work to retrieve all the MeshPolicies.
+	mps, err := in.k8s.GetMeshPolicies(namespaces[0])
 	if err != nil {
 		return false, err
 	}

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -892,10 +892,10 @@ func TestDestinationRuleEnabled(t *testing.T) {
 	assert := assert.New(t)
 
 	dr := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("default", "default", "*.local"))
+		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "default", "default").Return(dr, nil)
+	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
 	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled()
@@ -908,10 +908,10 @@ func TestDRWildcardLocalHost(t *testing.T) {
 	assert := assert.New(t)
 
 	dr := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("default", "default", "sleep.foo.svc.cluster.local"))
+		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "default", "default").Return(dr, nil)
+	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
 	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled()
@@ -930,10 +930,10 @@ func TestDRNotMutualTLSMode(t *testing.T) {
 	}
 
 	dr := data.AddTrafficPolicyToDestinationRule(trafficPolicy,
-		data.CreateEmptyDestinationRule("default", "default", "*.local"))
+		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "default", "default").Return(dr, nil)
+	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
 	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled()
@@ -946,10 +946,10 @@ func TestMeshStatusEnabled(t *testing.T) {
 	assert := assert.New(t)
 
 	dr := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("default", "default", "*.local"))
+		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "default", "default").Return(dr, nil)
+	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
 	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
@@ -963,10 +963,10 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 	assert := assert.New(t)
 
 	dr := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("default", "default", "sleep.foo.svc.cluster.local"))
+		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "default", "default").Return(dr, nil)
+	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
 	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
@@ -980,10 +980,10 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 	assert := assert.New(t)
 
 	dr := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("default", "default", "sleep.foo.svc.cluster.local"))
+		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "default", "default").Return(dr, nil)
+	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
 	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("wrong-name"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -895,7 +895,7 @@ func TestDestinationRuleEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetDestinationRules", "test", "").Return([]kubernetes.IstioObject{dr}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
 	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled([]string{"test"})
@@ -911,7 +911,7 @@ func TestDRWildcardLocalHost(t *testing.T) {
 		data.CreateEmptyDestinationRule("myproject", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetDestinationRules", "test", "").Return([]kubernetes.IstioObject{dr}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
 	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled([]string{"test"})
@@ -933,7 +933,7 @@ func TestDRNotMutualTLSMode(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetDestinationRules", "test", "").Return([]kubernetes.IstioObject{dr}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
 	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled([]string{"test"})
@@ -949,7 +949,7 @@ func TestMeshStatusEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetDestinationRules", "test", "").Return([]kubernetes.IstioObject{dr}, nil)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
@@ -966,7 +966,7 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetDestinationRules", "test", "").Return([]kubernetes.IstioObject{dr}, nil)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
@@ -983,7 +983,7 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetDestinationRules", "test", "").Return([]kubernetes.IstioObject{dr}, nil)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLS("wrong-name"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -809,10 +809,10 @@ func TestCorrectMeshPolicy(t *testing.T) {
 	assert := assert.New(t)
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
+	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	meshPolicyEnabled, err := (istioConfigService).hasMeshPolicyEnabled()
+	meshPolicyEnabled, err := (istioConfigService).hasMeshPolicyEnabled([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(true, meshPolicyEnabled)
@@ -822,10 +822,10 @@ func TestPolicyWithWrongName(t *testing.T) {
 	assert := assert.New(t)
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("wrong-name"), nil)
+	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLS("wrong-name"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	isGloballyEnabled, err := (istioConfigService).hasMeshPolicyEnabled()
+	isGloballyEnabled, err := (istioConfigService).hasMeshPolicyEnabled([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(false, isGloballyEnabled)
@@ -847,10 +847,10 @@ func TestWithoutMeshPolicy(t *testing.T) {
 	assert := assert.New(t)
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetMeshPolicies").Return([]kubernetes.IstioObject{}, nil)
+	k8s.On("GetMeshPolicies", "test").Return([]kubernetes.IstioObject{}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	meshPolicyEnabled, err := (istioConfigService).hasMeshPolicyEnabled()
+	meshPolicyEnabled, err := (istioConfigService).hasMeshPolicyEnabled([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(false, meshPolicyEnabled)
@@ -860,10 +860,10 @@ func TestMeshPolicyWithTargets(t *testing.T) {
 	assert := assert.New(t)
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLSSpecificTarget(), nil)
+	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLSSpecificTarget(), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	meshPolicyEnabled, err := (istioConfigService).hasMeshPolicyEnabled()
+	meshPolicyEnabled, err := (istioConfigService).hasMeshPolicyEnabled([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(false, meshPolicyEnabled)
@@ -895,10 +895,10 @@ func TestDestinationRuleEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled()
+	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(true, drEnabled)
@@ -911,10 +911,10 @@ func TestDRWildcardLocalHost(t *testing.T) {
 		data.CreateEmptyDestinationRule("myproject", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled()
+	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(false, drEnabled)
@@ -933,10 +933,10 @@ func TestDRNotMutualTLSMode(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled()
+	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(false, drEnabled)
@@ -949,11 +949,11 @@ func TestMeshStatusEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
-	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
+	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	status, err := (istioConfigService).MeshWidemTLSStatus()
+	status, err := (istioConfigService).MeshWidemTLSStatus([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(MeshmTLSEnabled, status)
@@ -966,11 +966,11 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
-	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
+	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	status, err := (istioConfigService).MeshWidemTLSStatus()
+	status, err := (istioConfigService).MeshWidemTLSStatus([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(MeshmTLSPartiallyEnabled, status)
@@ -983,11 +983,11 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
-	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("wrong-name"), nil)
+	k8s.On("GetAllDestinationRules", []string{"test"}).Return([]kubernetes.IstioObject{dr}, nil)
+	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLS("wrong-name"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
-	status, err := (istioConfigService).MeshWidemTLSStatus()
+	status, err := (istioConfigService).MeshWidemTLSStatus([]string{"test"})
 
 	assert.NoError(err)
 	assert.Equal(MeshmTLSNotEnabled, status)

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -895,7 +895,7 @@ func TestDestinationRuleEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
+	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
 	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled()
@@ -908,10 +908,10 @@ func TestDRWildcardLocalHost(t *testing.T) {
 	assert := assert.New(t)
 
 	dr := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
+		data.CreateEmptyDestinationRule("myproject", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
+	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
 	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled()
@@ -933,7 +933,7 @@ func TestDRNotMutualTLSMode(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
+	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
 	drEnabled, err := (istioConfigService).hasDestinationRuleEnabled()
@@ -949,7 +949,7 @@ func TestMeshStatusEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
+	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
 	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
@@ -966,7 +966,7 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
+	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
 	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("default"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}
@@ -983,7 +983,7 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
 
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetDestinationRule", "istio-system", "default").Return(dr, nil)
+	k8s.On("GetAllDestinationRules").Return([]kubernetes.IstioObject{dr}, nil)
 	k8s.On("GetMeshPolicies").Return(fakeMeshPolicyEnablingMTLS("wrong-name"), nil)
 
 	istioConfigService := IstioConfigService{k8s: k8s}

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -49,12 +49,12 @@ func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
 			namespaces = models.CastProjectCollection(projects)
 		}
 	} else {
-		services, err := in.k8s.GetNamespaces()
+		nss, err := in.k8s.GetNamespaces()
 		if err != nil {
 			return nil, err
 		}
 
-		namespaces = models.CastNamespaceCollection(services)
+		namespaces = models.CastNamespaceCollection(nss)
 	}
 
 	result := namespaces

--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -96,6 +96,7 @@ rules:
 - apiGroups: ["authentication.istio.io"]
   resources:
   - policies
+  - meshpolicies
   verbs:
   - create
   - delete

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -96,6 +96,7 @@ rules:
 - apiGroups: ["authentication.istio.io"]
   resources:
   - policies
+  - meshpolicies
   verbs:
   - create
   - delete

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -45,7 +45,6 @@ type IstioClientInterface interface {
 	GetDeploymentConfigs(namespace string) ([]osappsv1.DeploymentConfig, error)
 	GetDestinationRule(namespace string, destinationrule string) (IstioObject, error)
 	GetDestinationRules(namespace string, serviceName string) ([]IstioObject, error)
-	GetAllDestinationRules(namespace []string) ([]IstioObject, error)
 	GetEndpoints(namespace string, serviceName string) (*v1.Endpoints, error)
 	GetGateway(namespace string, gateway string) (IstioObject, error)
 	GetGateways(namespace string) ([]IstioObject, error)

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -52,6 +52,7 @@ type IstioClientInterface interface {
 	GetIstioRule(namespace string, istiorule string) (IstioObject, error)
 	GetIstioRules(namespace string) ([]IstioObject, error)
 	GetJobs(namespace string) ([]batch_v1.Job, error)
+	GetMeshPolicies() ([]IstioObject, error)
 	GetNamespace(namespace string) (*v1.Namespace, error)
 	GetNamespaces() ([]v1.Namespace, error)
 	GetPods(namespace, labelSelector string) ([]v1.Pod, error)

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -45,6 +45,7 @@ type IstioClientInterface interface {
 	GetDeploymentConfigs(namespace string) ([]osappsv1.DeploymentConfig, error)
 	GetDestinationRule(namespace string, destinationrule string) (IstioObject, error)
 	GetDestinationRules(namespace string, serviceName string) ([]IstioObject, error)
+	GetAllDestinationRules() ([]IstioObject, error)
 	GetEndpoints(namespace string, serviceName string) (*v1.Endpoints, error)
 	GetGateway(namespace string, gateway string) (IstioObject, error)
 	GetGateways(namespace string) ([]IstioObject, error)

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -45,7 +45,7 @@ type IstioClientInterface interface {
 	GetDeploymentConfigs(namespace string) ([]osappsv1.DeploymentConfig, error)
 	GetDestinationRule(namespace string, destinationrule string) (IstioObject, error)
 	GetDestinationRules(namespace string, serviceName string) ([]IstioObject, error)
-	GetAllDestinationRules() ([]IstioObject, error)
+	GetAllDestinationRules(namespace []string) ([]IstioObject, error)
 	GetEndpoints(namespace string, serviceName string) (*v1.Endpoints, error)
 	GetGateway(namespace string, gateway string) (IstioObject, error)
 	GetGateways(namespace string) ([]IstioObject, error)

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -53,7 +53,7 @@ type IstioClientInterface interface {
 	GetIstioRule(namespace string, istiorule string) (IstioObject, error)
 	GetIstioRules(namespace string) ([]IstioObject, error)
 	GetJobs(namespace string) ([]batch_v1.Job, error)
-	GetMeshPolicies() ([]IstioObject, error)
+	GetMeshPolicies(namespace string) ([]IstioObject, error)
 	GetNamespace(namespace string) (*v1.Namespace, error)
 	GetNamespaces() ([]v1.Namespace, error)
 	GetPods(namespace, labelSelector string) ([]v1.Pod, error)

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -370,8 +370,10 @@ func (in *IstioClient) GetPolicy(namespace string, policyName string) (IstioObje
 	return policy.DeepCopyIstioObject(), nil
 }
 
-func (in *IstioClient) GetMeshPolicies() ([]IstioObject, error) {
-	result, err := in.istioAuthenticationApi.Get().Resource(meshPolicies).Do().Get()
+func (in *IstioClient) GetMeshPolicies(namespace string) ([]IstioObject, error) {
+	// MeshPolicies are not namespaced. However, API returns all the instances even asking for one specific namespace.
+	// Due to soft-multitenancy, the call performed is namespaced to avoid triggering an error for cluster-wide access.
+	result, err := in.istioAuthenticationApi.Get().Namespace(namespace).Resource(meshPolicies).Do().Get()
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -219,6 +219,25 @@ func (in *IstioClient) GetDestinationRules(namespace string, serviceName string)
 	return destinationRules, nil
 }
 
+func (in *IstioClient) GetAllDestinationRules() ([]IstioObject, error) {
+	result, err := in.istioNetworkingApi.Get().Resource(destinationRules).Do().Get()
+	if err != nil {
+		return nil, err
+	}
+
+	destinationRuleList, ok := result.(*GenericIstioObjectList)
+	if !ok {
+		return nil, fmt.Errorf("It doesn't return a DestinationRule list")
+	}
+
+	destinationRules := make([]IstioObject, 0)
+	for _, dr := range destinationRuleList.GetItems() {
+		destinationRules = append(destinationRules, dr.DeepCopyIstioObject())
+	}
+
+	return destinationRules, nil
+}
+
 func (in *IstioClient) GetDestinationRule(namespace string, destinationrule string) (IstioObject, error) {
 	result, err := in.istioNetworkingApi.Get().Namespace(namespace).Resource(destinationRules).SubResource(destinationrule).Do().Get()
 	if err != nil {

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -328,6 +328,25 @@ func (in *IstioClient) GetPolicy(namespace string, policyName string) (IstioObje
 	return policy.DeepCopyIstioObject(), nil
 }
 
+func (in *IstioClient) GetMeshPolicies() ([]IstioObject, error) {
+	result, err := in.istioAuthenticationApi.Get().Resource(meshPolicies).Do().Get()
+	if err != nil {
+		return nil, err
+	}
+
+	policyList, ok := result.(*GenericIstioObjectList)
+	if !ok {
+		return nil, fmt.Errorf("it doesn't return a PolicyList list")
+	}
+
+	policies := make([]IstioObject, 0)
+	for _, ps := range policyList.GetItems() {
+		policies = append(policies, ps.DeepCopyIstioObject())
+	}
+
+	return policies, nil
+}
+
 // UpdateIstioObject updates an Istio object from either config api or networking api
 func (in *IstioClient) UpdateIstioObject(api, namespace, resourceType, name, jsonPatch string) (IstioObject, error) {
 	log.Debugf("UpdateIstioObject input: %s / %s / %s / %s", api, namespace, resourceType, name)

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -85,11 +85,6 @@ func (o *K8SClientMock) GetDestinationRule(namespace string, destinationrule str
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
-func (o *K8SClientMock) GetAllDestinationRules(namespaces []string) ([]kubernetes.IstioObject, error) {
-	args := o.Called(namespaces)
-	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
-}
-
 func (o *K8SClientMock) GetEndpoints(namespace string, serviceName string) (*v1.Endpoints, error) {
 	args := o.Called(namespace, serviceName)
 	return args.Get(0).(*v1.Endpoints), args.Error(1)

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -85,8 +85,8 @@ func (o *K8SClientMock) GetDestinationRule(namespace string, destinationrule str
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
-func (o *K8SClientMock) GetAllDestinationRules() ([]kubernetes.IstioObject, error) {
-	args := o.Called()
+func (o *K8SClientMock) GetAllDestinationRules(namespaces []string) ([]kubernetes.IstioObject, error) {
+	args := o.Called(namespaces)
 	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
 }
 
@@ -245,8 +245,8 @@ func (o *K8SClientMock) GetPolicy(namespace string, policyName string) (kubernet
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
-func (o *K8SClientMock) GetMeshPolicies() ([]kubernetes.IstioObject, error) {
-	args := o.Called()
+func (o *K8SClientMock) GetMeshPolicies(namespace string) ([]kubernetes.IstioObject, error) {
+	args := o.Called(namespace)
 	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
 }
 

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -245,6 +245,11 @@ func (o *K8SClientMock) GetPolicy(namespace string, policyName string) (kubernet
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
+func (o *K8SClientMock) GetMeshPolicies() ([]kubernetes.IstioObject, error) {
+	args := o.Called()
+	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
+}
+
 func (o *K8SClientMock) IsOpenShift() bool {
 	args := o.Called()
 	return args.Get(0).(bool)

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -200,11 +200,6 @@ func (o *K8SClientMock) GetServiceEntry(namespace string, serviceEntryName strin
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
-func (o *K8SClientMock) GetServicePods(namespace string, serviceName string, serviceVersion string) (*v1.PodList, error) {
-	args := o.Called(namespace, serviceName, serviceVersion)
-	return args.Get(0).(*v1.PodList), args.Error(1)
-}
-
 func (o *K8SClientMock) GetStatefulSet(namespace string, statefulsetName string) (*v1beta2.StatefulSet, error) {
 	args := o.Called(namespace, statefulsetName)
 	return args.Get(0).(*v1beta2.StatefulSet), args.Error(1)

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -85,6 +85,11 @@ func (o *K8SClientMock) GetDestinationRule(namespace string, destinationrule str
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
+func (o *K8SClientMock) GetAllDestinationRules() ([]kubernetes.IstioObject, error) {
+	args := o.Called()
+	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
+}
+
 func (o *K8SClientMock) GetEndpoints(namespace string, serviceName string) (*v1.Endpoints, error) {
 	args := o.Called(namespace, serviceName)
 	return args.Get(0).(*v1.Endpoints), args.Error(1)

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -44,6 +44,12 @@ const (
 	policyType     = "Policy"
 	policyTypeList = "PolicyList"
 
+	//MeshPolicies
+
+	meshPolicies       = "meshpolicies"
+	meshPolicyType     = "MeshPolicy"
+	meshPolicyTypeList = "MeshPolicyList"
+
 	// Config - Rules
 
 	rules        = "rules"
@@ -223,6 +229,10 @@ var (
 		{
 			objectKind:     policyType,
 			collectionKind: policyTypeList,
+		},
+		{
+			objectKind:     meshPolicyType,
+			collectionKind: meshPolicyTypeList,
 		},
 	}
 

--- a/status/mtls_status.go
+++ b/status/mtls_status.go
@@ -4,11 +4,6 @@ import (
 	"github.com/kiali/kiali/business"
 )
 
-const (
-	GloballyEnabled    = "GLOBALLY_ENABLED"
-	NotGloballyEnabled = "NOT_GLOBALLY_ENABLED"
-)
-
 func (si *StatusInfo) getmTLSStatus() {
 	// Get business layer
 	business, err := business.Get()
@@ -17,15 +12,10 @@ func (si *StatusInfo) getmTLSStatus() {
 		return
 	}
 
-	isGlobalmTLSEnabled, err := business.IstioConfig.IsMTLSGloballyEnabled()
+	globalmTLSStatus, err := business.IstioConfig.MeshWidemTLSStatus()
 	if err != nil {
 		Put(ClusterMTLS, "error")
 	}
 
-	status := NotGloballyEnabled
-	if isGlobalmTLSEnabled {
-		status = GloballyEnabled
-	}
-
-	Put(ClusterMTLS, status)
+	Put(ClusterMTLS, globalmTLSStatus)
 }

--- a/status/mtls_status.go
+++ b/status/mtls_status.go
@@ -12,9 +12,21 @@ func (si *StatusInfo) getmTLSStatus() {
 		return
 	}
 
-	globalmTLSStatus, err := business.IstioConfig.MeshWidemTLSStatus()
+	namespaces, err := business.Namespace.GetNamespaces()
 	if err != nil {
 		Put(ClusterMTLS, "error")
+		return
+	}
+
+	nsNames := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		nsNames = append(nsNames, ns.Name)
+	}
+
+	globalmTLSStatus, err := business.IstioConfig.MeshWidemTLSStatus(nsNames)
+	if err != nil {
+		Put(ClusterMTLS, "error")
+		return
 	}
 
 	Put(ClusterMTLS, globalmTLSStatus)

--- a/status/mtls_status.go
+++ b/status/mtls_status.go
@@ -1,0 +1,31 @@
+package status
+
+import (
+	"github.com/kiali/kiali/business"
+)
+
+const (
+	GloballyEnabled    = "GLOBALLY_ENABLED"
+	NotGloballyEnabled = "NOT_GLOBALLY_ENABLED"
+)
+
+func (si *StatusInfo) getmTLSStatus() {
+	// Get business layer
+	business, err := business.Get()
+	if err != nil {
+		Put(ClusterMTLS, "error")
+		return
+	}
+
+	isGlobalmTLSEnabled, err := business.IstioConfig.IsMTLSGloballyEnabled()
+	if err != nil {
+		Put(ClusterMTLS, "error")
+	}
+
+	status := NotGloballyEnabled
+	if isGlobalmTLSEnabled {
+		status = GloballyEnabled
+	}
+
+	Put(ClusterMTLS, status)
+}

--- a/status/status.go
+++ b/status/status.go
@@ -7,6 +7,7 @@ const (
 	CoreVersion    = name + " core version"
 	CoreCommitHash = name + " core commit hash"
 	State          = name + " state"
+	ClusterMTLS    = "Istio mTLS"
 	StateRunning   = "running"
 )
 
@@ -75,6 +76,7 @@ func Put(name, value string) (previous string, hasPrevious bool) {
 func Get() (status StatusInfo) {
 	info.ExternalServices = []ExternalServiceInfo{}
 	info.WarningMessages = []string{}
+	info.getmTLSStatus()
 	getVersions()
 	return info
 }

--- a/tests/data/mesh_policy_data.go
+++ b/tests/data/mesh_policy_data.go
@@ -1,0 +1,24 @@
+package data
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateEmptyMeshPolicy(name string, peers []interface{}) kubernetes.IstioObject {
+	return (&kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:        name,
+			ClusterName: "svc.cluster.local",
+		},
+		Spec: map[string]interface{}{
+			"peers": peers,
+		},
+	}).DeepCopyIstioObject()
+}
+
+func AddTargetsToMeshPolicy(targets []interface{}, mp kubernetes.IstioObject) kubernetes.IstioObject {
+	mp.GetSpec()["targets"] = targets
+	return mp
+}


### PR DESCRIPTION
** Describe the change **

We need to show whether or not mTLS is globally enabled or not. This PR adds that status in `/api/status` endpoint.

The idea is that the ui takes it and prints a padlock into the masthead.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2148

** Backwards incompatible? **
yep.

![screenshot of https___kiali-istio-system 192 168 42 226 nip io_api_status](https://user-images.githubusercontent.com/613814/51981502-90d23b00-2493-11e9-8e08-10a5e06a0928.png)

![screenshot of https___kiali-istio-system 192 168 42 226 nip io_api_status 1](https://user-images.githubusercontent.com/613814/51981505-929bfe80-2493-11e9-90ea-e0ec1482bbc5.png)

![screenshot of https___kiali-istio-system 192 168 42 226 nip io_api_status 2](https://user-images.githubusercontent.com/613814/51981506-9465c200-2493-11e9-9414-3d5a8b976ae4.png)
