### PR TITLE
KIALI-2291 Support requestProtocol query param in metrics options

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -255,6 +255,16 @@ type RateIntervalParam struct {
 }
 
 // swagger:parameters serviceMetrics appMetrics workloadMetrics appDashboard serviceDashboard workloadDashboard
+type RequestProtocolParam struct {
+	// Desired request protocol for the telemetry: For example, 'http' or 'grpc'.
+	//
+	// in: query
+	// required: false
+	// default: all protocols
+	Name string `json:"requestProtocol"`
+}
+
+// swagger:parameters serviceMetrics appMetrics workloadMetrics appDashboard serviceDashboard workloadDashboard
 type ReporterParam struct {
 	// Istio telemetry reporter: 'source' or 'destination'.
 	//

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -27,6 +27,10 @@ func extractIstioMetricsQueryParams(r *http.Request, q *prometheus.IstioMetricsQ
 		}
 		q.Direction = dir
 	}
+	requestProtocol := queryParams.Get("requestProtocol")
+	if requestProtocol != "" {
+		q.RequestProtocol = requestProtocol
+	}
 	reporter := queryParams.Get("reporter")
 	if reporter != "" {
 		if reporter != "source" && reporter != "destination" {

--- a/handlers/metrics_test.go
+++ b/handlers/metrics_test.go
@@ -25,6 +25,9 @@ func TestExtractMetricsQueryParams(t *testing.T) {
 	q.Add("byLabels[]", "response_code")
 	q.Add("filters[]", "request_count")
 	q.Add("filters[]", "request_size")
+	q.Add("reporter", "destination")
+	q.Add("direction", "outbound")
+	q.Add("requestProtocol", "http")
 	req.URL.RawQuery = q.Encode()
 
 	mq := prometheus.IstioMetricsQuery{Namespace: "ns"}
@@ -38,6 +41,9 @@ func TestExtractMetricsQueryParams(t *testing.T) {
 	assert.Equal(t, 10*time.Second, mq.Step)
 	assert.Equal(t, []string{"response_code"}, mq.ByLabels)
 	assert.Equal(t, []string{"request_count", "request_size"}, mq.Filters)
+	assert.Equal(t, "destination", mq.Reporter)
+	assert.Equal(t, "outbound", mq.Direction)
+	assert.Equal(t, "http", mq.RequestProtocol)
 
 	// Check that start date is normalized for step
 	// Interval [12:24:21, 12:41:01] should be converted to [12:24:20, 12:41:01]

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -48,6 +48,9 @@ func buildLabelStrings(q *IstioMetricsQuery) (string, string) {
 	if q.App != "" {
 		labels = append(labels, fmt.Sprintf(`%s_app="%s"`, ref, q.App))
 	}
+	if q.RequestProtocol != "" {
+		labels = append(labels, fmt.Sprintf(`request_protocol="%s"`, q.RequestProtocol))
+	}
 
 	full := "{" + strings.Join(labels, ",") + "}"
 

--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -30,13 +30,14 @@ func (q *BaseMetricsQuery) fillDefaults() {
 // IstioMetricsQuery holds query parameters for a typical metrics query
 type IstioMetricsQuery struct {
 	BaseMetricsQuery
-	Filters   []string
-	Namespace string
-	App       string
-	Workload  string
-	Service   string
-	Direction string // outbound | inbound
-	Reporter  string // source | destination, defaults to source if not provided
+	Filters         []string
+	Namespace       string
+	App             string
+	Workload        string
+	Service         string
+	Direction       string // outbound | inbound
+	RequestProtocol string // e.g. http | grpc
+	Reporter        string // source | destination, defaults to source if not provided
 }
 
 // FillDefaults fills the struct with default parameters

--- a/swagger.json
+++ b/swagger.json
@@ -697,6 +697,14 @@
           },
           {
             "type": "string",
+            "default": "all protocols",
+            "x-go-name": "Name",
+            "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
+            "name": "requestProtocol",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "default": "source",
             "x-go-name": "Name",
             "description": "Istio telemetry reporter: 'source' or 'destination'.",
@@ -878,6 +886,14 @@
             "x-go-name": "Name",
             "description": "Interval used for rate and histogram calculation.",
             "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "all protocols",
+            "x-go-name": "Name",
+            "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
+            "name": "requestProtocol",
             "in": "query"
           },
           {
@@ -1687,6 +1703,14 @@
           },
           {
             "type": "string",
+            "default": "all protocols",
+            "x-go-name": "Name",
+            "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
+            "name": "requestProtocol",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "default": "source",
             "x-go-name": "Name",
             "description": "Istio telemetry reporter: 'source' or 'destination'.",
@@ -1965,6 +1989,14 @@
           },
           {
             "type": "string",
+            "default": "all protocols",
+            "x-go-name": "Name",
+            "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
+            "name": "requestProtocol",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "default": "source",
             "x-go-name": "Name",
             "description": "Istio telemetry reporter: 'source' or 'destination'.",
@@ -2164,6 +2196,14 @@
             "x-go-name": "Name",
             "description": "Interval used for rate and histogram calculation.",
             "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "all protocols",
+            "x-go-name": "Name",
+            "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
+            "name": "requestProtocol",
             "in": "query"
           },
           {
@@ -2442,6 +2482,14 @@
             "x-go-name": "Name",
             "description": "Interval used for rate and histogram calculation.",
             "name": "rateInterval",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "all protocols",
+            "x-go-name": "Name",
+            "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
+            "name": "requestProtocol",
             "in": "query"
           },
           {


### PR DESCRIPTION
Add a new query parameter to the metrics API such that callers can restrict results to a specific protocol.