### PR TITLE
KIALI-2245 Add gRPC support

### DIFF
--- a/graph/appender/response_time_test.go
+++ b/graph/appender/response_time_test.go
@@ -13,10 +13,10 @@ import (
 func TestResponseTime(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter="destination",source_workload="unknown",destination_service_namespace="bookinfo",response_code=~"2[0-9]{2}"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)`
+	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter="destination",source_workload="unknown",destination_service_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo",response_code=~"2[0-9]{2}"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)`
+	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":     "istio-system",
 		"source_workload":               "ingressgateway-unknown",
@@ -32,7 +32,7 @@ func TestResponseTime(t *testing.T) {
 			Metric: q1m0,
 			Value:  0.010}}
 
-	q2 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter="source",source_workload_namespace="bookinfo",response_code=~"2[0-9]{2}"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)`
+	q2 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{reporter="source",source_workload_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload,destination_app,destination_version)),0.001)`
 	q2m0 := model.Metric{
 		"source_workload_namespace":     "bookinfo",
 		"source_workload":               "productpage-v1",

--- a/graph/appender/unused_node.go
+++ b/graph/appender/unused_node.go
@@ -80,7 +80,7 @@ func (a UnusedNodeAppender) buildUnusedTrafficMap(trafficMap graph.TrafficMap, n
 			if _, found = unusedTrafficMap[id]; !found {
 				log.Debugf("Adding unused node for workload [%s] with labels [%v]", w.Name, labels)
 				node := graph.NewNodeExplicit(id, namespace, w.Name, app, version, "", nodeType, a.GraphType)
-				// note: we don't konw what the protocol really should be, http is most common, it's a dead edge anyway
+				// note: we don't know what the protocol really should be, http is most common, it's a dead edge anyway
 				node.Metadata = map[string]interface{}{"httpIn": 0.0, "httpOut": 0.0, "isUnused": true}
 				unusedTrafficMap[id] = &node
 			}

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -25,7 +25,6 @@ type Protocol struct {
 	UnitShort string
 }
 
-/* TODO: For now, treat gRPC like HTTP, uncomment this when we want to treat gRPC explicitly
 var GRPC Protocol = Protocol{
 	Name: "grpc",
 	EdgeRates: []Rate{
@@ -42,7 +41,7 @@ var GRPC Protocol = Protocol{
 	Unit:      "requests per second",
 	UnitShort: "rps",
 }
-*/
+
 var HTTP Protocol = Protocol{
 	Name: "http",
 	EdgeRates: []Rate{
@@ -76,16 +75,12 @@ var TCP Protocol = Protocol{
 	UnitShort: "bps",
 }
 
-// TODO: For now, treat gRPC like HTTP, uncomment this when we want to treat gRPC explicitly
-// var Protocols []Protocol = []Protocol{GRPC, HTTP, TCP}
-var Protocols []Protocol = []Protocol{HTTP, TCP}
+var Protocols []Protocol = []Protocol{GRPC, HTTP, TCP}
 
 func AddToMetadata(protocol string, val float64, code string, sourceMetadata, destMetadata, edgeMetadata map[string]interface{}) {
 	switch protocol {
 	case "grpc":
-		// TODO: For now, treat gRPC like HTTP, uncomment this (and remove the http line below it) when we want to treat gRPC explicitly
-		// addToMetadataGrpc(val, code, sourceMetadata, destMetadata, edgeMetadata)
-		addToMetadataHttp(val, code, sourceMetadata, destMetadata, edgeMetadata)
+		addToMetadataGrpc(val, code, sourceMetadata, destMetadata, edgeMetadata)
 	case "http":
 		addToMetadataHttp(val, code, sourceMetadata, destMetadata, edgeMetadata)
 	case "tcp":
@@ -95,7 +90,6 @@ func AddToMetadata(protocol string, val float64, code string, sourceMetadata, de
 	}
 }
 
-/* TODO: For now, treat gRPC like HTTP, uncomment this when we want to treat gRPC explicitly
 func addToMetadataGrpc(val float64, code string, sourceMetadata, destMetadata, edgeMetadata map[string]interface{}) {
 	addToMetadataValue(sourceMetadata, "grpcOut", val)
 	addToMetadataValue(destMetadata, "grpcIn", val)
@@ -114,7 +108,6 @@ func addToMetadataGrpc(val float64, code string, sourceMetadata, destMetadata, e
 		addToMetadataValue(edgeMetadata, "grpcErr", val)
 	}
 }
-*/
 
 func addToMetadataHttp(val float64, code string, sourceMetadata, destMetadata, edgeMetadata map[string]interface{}) {
 	addToMetadataValue(sourceMetadata, "httpOut", val)
@@ -143,11 +136,9 @@ func addToMetadataTcp(val float64, code string, sourceMetadata, destMetadata, ed
 }
 
 func AddOutgoingEdgeToMetadata(sourceMetadata, edgeMetadata map[string]interface{}) {
-	/* TODO: For now, treat gRPC like HTTP, uncomment this when we want to treat gRPC explicitly
 	if val, valOk := edgeMetadata["grpc"]; valOk {
 		addToMetadataValue(sourceMetadata, "grpcOut", val.(float64))
 	}
-	*/
 	if val, valOk := edgeMetadata["http"]; valOk {
 		addToMetadataValue(sourceMetadata, "httpOut", val.(float64))
 	}

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -279,11 +279,10 @@ func addServiceGraphTraffic(target, source *graph.Edge) {
 	default:
 		graph.Error(fmt.Sprintf("Unexpected edge protocol [%v] for edge [%+v]", protocol, target))
 	}
-	// hande any appender-based edge data
-	// - responseTime is not a counter, set an average, not a total
-	if responseTime, ok := source.Metadata["responseTime"]; ok {
-		averageMetadataValue(target.Metadata, "responseTime", responseTime.(float64))
-	}
+
+	// handle any appender-based edge data (nothing currently)
+	// note: We used to average response times of the aggregated edges but realized that
+	// we can't average quantiles (kiali-2297).
 }
 
 func checkNodeType(expected string, n *graph.Node) {
@@ -298,22 +297,6 @@ func addToMetadataValue(md map[string]interface{}, k string, v float64) {
 	} else {
 		md[k] = v
 	}
-}
-
-func averageMetadataValue(md map[string]interface{}, k string, v float64) {
-	total := v
-	count := 1.0
-	kTotal := k + "_total"
-	kCount := k + "_count"
-	if prevTotal, ok := md[kTotal]; ok {
-		total += prevTotal.(float64)
-	}
-	if prevCount, ok := md[kCount]; ok {
-		count += prevCount.(float64)
-	}
-	md[kTotal] = total
-	md[kCount] = count
-	md[k] = total / count
 }
 
 // buildNamespaceTrafficMap returns a map of all namespace nodes (key=id).  All
@@ -363,9 +346,9 @@ func buildNamespaceTrafficMap(namespace string, o options.Options, client *prome
 	if o.IncludeIstio {
 		istioNamespace := config.Get().IstioNamespace
 
-		// 4) if the target namespace is istioNamespace re-query for traffic originating from a workload outside of the namespace
+		// 4) if the target namespace is istioNamespace re-query for traffic originating from outside (other than unknown, covered in query #1)
 		if namespace == istioNamespace {
-			query = fmt.Sprintf(`sum(rate(%s{reporter="destination",source_workload_namespace!="%s",destination_service_namespace="%s"} [%vs])) by (%s)`,
+			query = fmt.Sprintf(`sum(rate(%s{reporter="destination",source_workload!="unknown",source_workload_namespace!="%s",destination_service_namespace="%s"} [%vs])) by (%s)`,
 				requestsMetric,
 				namespace,
 				namespace,

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -261,24 +261,7 @@ func reduceToServiceGraph(trafficMap graph.TrafficMap) graph.TrafficMap {
 }
 
 func addServiceGraphTraffic(target, source *graph.Edge) {
-	protocol := target.Metadata["protocol"]
-	switch protocol {
-	case "http":
-		addToMetadataValue(target.Metadata, "http", source.Metadata["http"].(float64))
-		if val, ok := source.Metadata["http3xx"]; ok {
-			addToMetadataValue(target.Metadata, "http3xx", val.(float64))
-		}
-		if val, ok := source.Metadata["http4xx"]; ok {
-			addToMetadataValue(target.Metadata, "http4xx", val.(float64))
-		}
-		if val, ok := source.Metadata["http5xx"]; ok {
-			addToMetadataValue(target.Metadata, "http5xx", val.(float64))
-		}
-	case "tcp":
-		addToMetadataValue(target.Metadata, "tcp", source.Metadata["tcp"].(float64))
-	default:
-		graph.Error(fmt.Sprintf("Unexpected edge protocol [%v] for edge [%+v]", protocol, target))
-	}
+	graph.AddServiceGraphTraffic(target, source)
 
 	// handle any appender-based edge data (nothing currently)
 	// note: We used to average response times of the aggregated edges but realized that
@@ -288,14 +271,6 @@ func addServiceGraphTraffic(target, source *graph.Edge) {
 func checkNodeType(expected string, n *graph.Node) {
 	if expected != n.NodeType {
 		graph.Error(fmt.Sprintf("Expected nodeType [%s] for node [%+v]", expected, n))
-	}
-}
-
-func addToMetadataValue(md map[string]interface{}, k string, v float64) {
-	if curr, ok := md[k]; ok {
-		md[k] = curr.(float64) + v
-	} else {
-		md[k] = v
 	}
 }
 

--- a/handlers/testdata/test_app_graph.expected
+++ b/handlers/testdata/test_app_graph.expected
@@ -190,14 +190,13 @@
           "id": "2c8bf7e7efb0982b18c76d507200a8b7",
           "source": "19950ddefadd370bf5434953c1944c80",
           "target": "2c22af42b0c750749399ed2838c56054",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "100.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -205,14 +204,12 @@
           "id": "18fa6836a929941e8deabad5fa1cae62",
           "source": "19950ddefadd370bf5434953c1944c80",
           "target": "4ee8019fc0454770a401b89d427277bf",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "150.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "150.00"
             }
-          ]
+          }
         }
       },
       {
@@ -220,15 +217,13 @@
           "id": "e9ffbf24e385c93dfa124d81e2ac33a7",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "2c22af42b0c750749399ed2838c56054",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -236,15 +231,13 @@
           "id": "ff5217a9064e30e4fb875256dab56037",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "37ddc91db761d432f3fff1943802cad7",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "60.00",
-                "httpPercentReq": "37.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "60.00",
+              "httpPercentReq": "37.5"
             }
-          ]
+          }
         }
       },
       {
@@ -252,14 +245,12 @@
           "id": "16a0c4225bbdbd471e6e7b8fd438733d",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "4ee8019fc0454770a401b89d427277bf",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "31.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "31.00"
             }
-          ]
+          }
         }
       },
       {
@@ -267,19 +258,17 @@
           "id": "89fa162a49acca6ff974afd30aab2ff0",
           "source": "2c22af42b0c750749399ed2838c56054",
           "target": "6cdb3cf3ee9a17772f13b295368e112a",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "80.00",
-                "http3xx": "20.00",
-                "http4xx": "20.00",
-                "http5xx": "20.00",
-                "httpPercentErr": "50.0",
-                "httpPercentReq": "50.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "80.00",
+              "http3xx": "20.00",
+              "http4xx": "20.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "50.0",
+              "httpPercentReq": "50.0"
             }
-          ]
+          }
         }
       },
       {
@@ -287,15 +276,13 @@
           "id": "4aaf7cb151db415f3ba4918be2296c38",
           "source": "37ddc91db761d432f3fff1943802cad7",
           "target": "37ddc91db761d432f3fff1943802cad7",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "40.00",
-                "httpPercentReq": "33.3"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "40.00",
+              "httpPercentReq": "33.3"
             }
-          ]
+          }
         }
       },
       {
@@ -303,15 +290,13 @@
           "id": "edb2cdfc2a757d260aa847d55e9eadde",
           "source": "37ddc91db761d432f3fff1943802cad7",
           "target": "66bce9783dc2dbb5fecb178b0108484e",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "16.7"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "16.7"
             }
-          ]
+          }
         }
       },
       {
@@ -319,17 +304,15 @@
           "id": "a553e38605904d17c50ab1d0db84f113",
           "source": "37ddc91db761d432f3fff1943802cad7",
           "target": "c219903556c3afdb05eda7e610aba628",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "60.00",
-                "http5xx": "20.00",
-                "httpPercentErr": "33.3",
-                "httpPercentReq": "50.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "60.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "50.0"
             }
-          ]
+          }
         }
       },
       {
@@ -337,14 +320,13 @@
           "id": "efe83e483ada36899c34ef66a7974d31",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "2c22af42b0c750749399ed2838c56054",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -352,14 +334,12 @@
           "id": "d4fc7bd6594937fa94402fcfcc9f3a95",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "4ee8019fc0454770a401b89d427277bf",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "400.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "400.00"
             }
-          ]
+          }
         }
       }
     ]

--- a/handlers/testdata/test_app_node_graph.expected
+++ b/handlers/testdata/test_app_node_graph.expected
@@ -200,14 +200,13 @@
           "id": "8088ca79aa13e423747334c532144c4f",
           "source": "933d90e5172f69af1baa035e8a8ad27c",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "100.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -215,14 +214,12 @@
           "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "31.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "31.00"
             }
-          ]
+          }
         }
       },
       {
@@ -230,19 +227,17 @@
           "id": "9f6a2ed75734d99002d37ac867190b9e",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "50113397f439f05f3280ad0772b9b307",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "80.00",
-                "http3xx": "20.00",
-                "http4xx": "20.00",
-                "http5xx": "20.00",
-                "httpPercentErr": "50.0",
-                "httpPercentReq": "50.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "80.00",
+              "http3xx": "20.00",
+              "http4xx": "20.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "50.0",
+              "httpPercentReq": "50.0"
             }
-          ]
+          }
         }
       },
       {
@@ -250,15 +245,13 @@
           "id": "0d38eb7edb4da38dac33b79a24c3c208",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -266,15 +259,13 @@
           "id": "4ab6875deb3c0cbec4c8f260841f3d24",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -282,15 +273,13 @@
           "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "acd188a125352509e86ce104323c5d4f",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -298,15 +287,13 @@
           "id": "d99fa824b2d85a2053f51fe3bd94ef60",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -314,14 +301,13 @@
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       }
     ]

--- a/handlers/testdata/test_complex_graph.expected
+++ b/handlers/testdata/test_complex_graph.expected
@@ -38,9 +38,14 @@
           },
           "traffic": [
             {
+              "protocol": "grpc",
+              "rates": {
+                "grpcIn": "50.00"
+              }
+            },
+            {
               "protocol": "http",
               "rates": {
-                "httpIn": "50.00",
                 "httpOut": "50.00"
               }
             }
@@ -57,9 +62,15 @@
           "version": "unknown",
           "traffic": [
             {
+              "protocol": "grpc",
+              "rates": {
+                "grpcOut": "50.00"
+              }
+            },
+            {
               "protocol": "http",
               "rates": {
-                "httpOut": "100.00"
+                "httpOut": "50.00"
               }
             }
           ],
@@ -74,15 +85,13 @@
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00",
-                "httpPercentReq": "50.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -90,14 +99,13 @@
           "id": "1f024523da856e5b5a549d4a64b26cd3",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "d75c918a12f72a1ea1797911cb9770f7",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00"
-              }
+          "traffic": {
+            "protocol": "grpc",
+            "rates": {
+              "grpc": "50.00",
+              "grpcPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -105,14 +113,13 @@
           "id": "de3e83491767bce819c83b9f9a75b497",
           "source": "d75c918a12f72a1ea1797911cb9770f7",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       }
     ]

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -191,19 +191,17 @@
           "id": "619130e72e856618da923e25348f370f",
           "source": "42c017b34656a709d614f53967b05cc8",
           "target": "35533a08d948509abf8ae4d5d5647594",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "80.00",
-                "http3xx": "20.00",
-                "http4xx": "20.00",
-                "http5xx": "20.00",
-                "httpPercentErr": "50.0",
-                "httpPercentReq": "50.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "80.00",
+              "http3xx": "20.00",
+              "http4xx": "20.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "50.0",
+              "httpPercentReq": "50.0"
             }
-          ]
+          }
         }
       },
       {
@@ -211,15 +209,13 @@
           "id": "fafebffe3d83500a33fcdc0e268fabe4",
           "source": "42c017b34656a709d614f53967b05cc8",
           "target": "42c017b34656a709d614f53967b05cc8",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -227,14 +223,12 @@
           "id": "e4b85b504c8777f3882217b3791d4c60",
           "source": "42c017b34656a709d614f53967b05cc8",
           "target": "8a4a4ea447daf00b8a30169659086b5f",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "31.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "31.00"
             }
-          ]
+          }
         }
       },
       {
@@ -242,15 +236,13 @@
           "id": "1cf252f0a8d0ab09f9f5408ae22792f2",
           "source": "42c017b34656a709d614f53967b05cc8",
           "target": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "60.00",
-                "httpPercentReq": "37.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "60.00",
+              "httpPercentReq": "37.5"
             }
-          ]
+          }
         }
       },
       {
@@ -258,14 +250,13 @@
           "id": "1f3288555e23c16338013c2413d5987b",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "42c017b34656a709d614f53967b05cc8",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -273,14 +264,12 @@
           "id": "8c1b4e5d28259bbb16fac3edeb229115",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "8a4a4ea447daf00b8a30169659086b5f",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "400.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "400.00"
             }
-          ]
+          }
         }
       },
       {
@@ -288,14 +277,13 @@
           "id": "eed4f01258af80c8c8e2f07c548550f8",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "42c017b34656a709d614f53967b05cc8",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "100.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -303,14 +291,12 @@
           "id": "dee0c874bb93f64c52f13ee82c5eee11",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "8a4a4ea447daf00b8a30169659086b5f",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "150.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "150.00"
             }
-          ]
+          }
         }
       },
       {
@@ -318,15 +304,13 @@
           "id": "c8ee3a318ac7b96bd1800e9d500e3db5",
           "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
           "target": "715046fe06feb0ca6986fde2c2d18e22",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "28.6"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "28.6"
             }
-          ]
+          }
         }
       },
       {
@@ -334,15 +318,13 @@
           "id": "1bec06d1f0bf0a55ec9501008f3d14d4",
           "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
           "target": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "40.00",
-                "httpPercentReq": "80.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "40.00",
+              "httpPercentReq": "80.0"
             }
-          ]
+          }
         }
       },
       {
@@ -350,16 +332,15 @@
           "id": "c8c0d78efa927aaff53a1a275cdc5e5e",
           "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
           "target": "e96a4db610f877425f52a4b563e24c4c",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "60.00",
-                "http5xx": "20.00",
-                "httpPercentErr": "33.3"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "60.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "120.0"
             }
-          ]
+          }
         }
       }
     ]

--- a/handlers/testdata/test_service_node_graph.expected
+++ b/handlers/testdata/test_service_node_graph.expected
@@ -66,14 +66,13 @@
           "id": "347e210a97f5235b5a60b810ef1bfaa6",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "100.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -81,14 +80,12 @@
           "id": "c3fa6dedc4a1b3d61a3bb48dcb46dafa",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "31.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "31.00"
             }
-          ]
+          }
         }
       }
     ]

--- a/handlers/testdata/test_versioned_app_graph.expected
+++ b/handlers/testdata/test_versioned_app_graph.expected
@@ -259,17 +259,15 @@
           "id": "ddf45549de5e603dee9a0cd9c83f9cfb",
           "source": "5cb6f79f37cb95cf40ea6fb23779b0e6",
           "target": "08d6a5dd6e290fbc42e259053b86a762",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "30.00",
-                "http5xx": "10.00",
-                "httpPercentErr": "33.3",
-                "httpPercentReq": "60.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "30.00",
+              "http5xx": "10.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "60.0"
             }
-          ]
+          }
         }
       },
       {
@@ -277,15 +275,13 @@
           "id": "e23d51a059f4d5e45ed6ae625f9b9a5f",
           "source": "5cb6f79f37cb95cf40ea6fb23779b0e6",
           "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "40.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "40.0"
             }
-          ]
+          }
         }
       },
       {
@@ -293,14 +289,12 @@
           "id": "9f5ad0240b6a9e430d3dc2bcb2b3daaa",
           "source": "933d90e5172f69af1baa035e8a8ad27c",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "150.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "150.00"
             }
-          ]
+          }
         }
       },
       {
@@ -308,14 +302,13 @@
           "id": "8088ca79aa13e423747334c532144c4f",
           "source": "933d90e5172f69af1baa035e8a8ad27c",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "100.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -323,14 +316,12 @@
           "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "31.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "31.00"
             }
-          ]
+          }
         }
       },
       {
@@ -338,19 +329,17 @@
           "id": "9f6a2ed75734d99002d37ac867190b9e",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "50113397f439f05f3280ad0772b9b307",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "80.00",
-                "http3xx": "20.00",
-                "http4xx": "20.00",
-                "http5xx": "20.00",
-                "httpPercentErr": "50.0",
-                "httpPercentReq": "50.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "80.00",
+              "http3xx": "20.00",
+              "http4xx": "20.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "50.0",
+              "httpPercentReq": "50.0"
             }
-          ]
+          }
         }
       },
       {
@@ -358,15 +347,13 @@
           "id": "0d38eb7edb4da38dac33b79a24c3c208",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -374,15 +361,13 @@
           "id": "4ab6875deb3c0cbec4c8f260841f3d24",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -390,15 +375,13 @@
           "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "acd188a125352509e86ce104323c5d4f",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -406,15 +389,13 @@
           "id": "d99fa824b2d85a2053f51fe3bd94ef60",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -422,14 +403,12 @@
           "id": "d5054f4fd0140de3542ad2764d0f20bf",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "400.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "400.00"
             }
-          ]
+          }
         }
       },
       {
@@ -437,14 +416,13 @@
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -452,17 +430,15 @@
           "id": "4fe76972070982cc0fe01b5d42836ca1",
           "source": "dd4c5162b7f38a52e7f984766f88d807",
           "target": "08d6a5dd6e290fbc42e259053b86a762",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "30.00",
-                "http5xx": "10.00",
-                "httpPercentErr": "33.3",
-                "httpPercentReq": "42.9"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "30.00",
+              "http5xx": "10.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "42.9"
             }
-          ]
+          }
         }
       },
       {
@@ -470,15 +446,13 @@
           "id": "5d3f0ce188557ed9741bda52cb245ff4",
           "source": "dd4c5162b7f38a52e7f984766f88d807",
           "target": "87100ff76f5122d56e8aa75d018b5d67",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "28.6"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "28.6"
             }
-          ]
+          }
         }
       },
       {
@@ -486,15 +460,13 @@
           "id": "1959f1719d95c1a853a435a5807df1c3",
           "source": "dd4c5162b7f38a52e7f984766f88d807",
           "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "28.6"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "28.6"
             }
-          ]
+          }
         }
       }
     ]

--- a/handlers/testdata/test_versioned_app_node_graph.expected
+++ b/handlers/testdata/test_versioned_app_node_graph.expected
@@ -200,14 +200,13 @@
           "id": "8088ca79aa13e423747334c532144c4f",
           "source": "933d90e5172f69af1baa035e8a8ad27c",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "100.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -215,14 +214,12 @@
           "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "31.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "31.00"
             }
-          ]
+          }
         }
       },
       {
@@ -230,19 +227,17 @@
           "id": "9f6a2ed75734d99002d37ac867190b9e",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "50113397f439f05f3280ad0772b9b307",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "80.00",
-                "http3xx": "20.00",
-                "http4xx": "20.00",
-                "http5xx": "20.00",
-                "httpPercentErr": "50.0",
-                "httpPercentReq": "50.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "80.00",
+              "http3xx": "20.00",
+              "http4xx": "20.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "50.0",
+              "httpPercentReq": "50.0"
             }
-          ]
+          }
         }
       },
       {
@@ -250,15 +245,13 @@
           "id": "0d38eb7edb4da38dac33b79a24c3c208",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -266,15 +259,13 @@
           "id": "4ab6875deb3c0cbec4c8f260841f3d24",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -282,15 +273,13 @@
           "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "acd188a125352509e86ce104323c5d4f",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -298,15 +287,13 @@
           "id": "d99fa824b2d85a2053f51fe3bd94ef60",
           "source": "a1ffc0d6abdf480e17b214b85257e633",
           "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -314,14 +301,13 @@
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       }
     ]

--- a/handlers/testdata/test_workload_graph.expected
+++ b/handlers/testdata/test_workload_graph.expected
@@ -248,15 +248,13 @@
           "id": "710c2bf1d8a5b3fc854451e7346e05f5",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -264,19 +262,17 @@
           "id": "df66cffc756bf9983dd453837e4e14a7",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "5cd385c1ee3309ae40828b5702ae57fb",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "80.00",
-                "http3xx": "20.00",
-                "http4xx": "20.00",
-                "http5xx": "20.00",
-                "httpPercentErr": "50.0",
-                "httpPercentReq": "50.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "80.00",
+              "http3xx": "20.00",
+              "http4xx": "20.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "50.0",
+              "httpPercentReq": "50.0"
             }
-          ]
+          }
         }
       },
       {
@@ -284,15 +280,13 @@
           "id": "1da31b81ccaf408abccbc57071458462",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "731126638001dfa2b6cbeb3b326b6678",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -300,14 +294,12 @@
           "id": "cc4b63704dba836d37dd97aacf75afee",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "31.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "31.00"
             }
-          ]
+          }
         }
       },
       {
@@ -315,15 +307,13 @@
           "id": "c2ab8814859ec0974c5efd597b5bb4fd",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "9e97011b2086f59a90626cfd5cf23fbf",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -331,15 +321,13 @@
           "id": "943e5cc1b00d97a8a344fe1efd941130",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "fc3e7c5bb695ef8ed8ab2c5f6ac4725b",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -347,15 +335,13 @@
           "id": "dfb27d138c8b9b95b699e910fdda93bf",
           "source": "731126638001dfa2b6cbeb3b326b6678",
           "target": "2075586d4defa2622017ea76b7c582c0",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "28.6"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "28.6"
             }
-          ]
+          }
         }
       },
       {
@@ -363,17 +349,15 @@
           "id": "fa1db53921ef4a16b273c5260df63c2d",
           "source": "731126638001dfa2b6cbeb3b326b6678",
           "target": "5fd49fef66081810598406b0686500ae",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "30.00",
-                "http5xx": "10.00",
-                "httpPercentErr": "33.3",
-                "httpPercentReq": "42.9"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "30.00",
+              "http5xx": "10.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "42.9"
             }
-          ]
+          }
         }
       },
       {
@@ -381,15 +365,13 @@
           "id": "6822e986b101e54af3305af8d2d08051",
           "source": "731126638001dfa2b6cbeb3b326b6678",
           "target": "731126638001dfa2b6cbeb3b326b6678",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "28.6"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "28.6"
             }
-          ]
+          }
         }
       },
       {
@@ -397,17 +379,15 @@
           "id": "0b356bd23faa1d1f26b3edeb4bbf0502",
           "source": "9e97011b2086f59a90626cfd5cf23fbf",
           "target": "5fd49fef66081810598406b0686500ae",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "30.00",
-                "http5xx": "10.00",
-                "httpPercentErr": "33.3",
-                "httpPercentReq": "60.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "30.00",
+              "http5xx": "10.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "60.0"
             }
-          ]
+          }
         }
       },
       {
@@ -415,15 +395,13 @@
           "id": "0d137e50b408f6108b52a8db15f90472",
           "source": "9e97011b2086f59a90626cfd5cf23fbf",
           "target": "9e97011b2086f59a90626cfd5cf23fbf",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "40.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "40.0"
             }
-          ]
+          }
         }
       },
       {
@@ -431,14 +409,13 @@
           "id": "b38eaa93622c6c652c3daf15b31a476d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -446,14 +423,12 @@
           "id": "add44fff17f11c9c090f09d178d6090c",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "400.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "400.00"
             }
-          ]
+          }
         }
       },
       {
@@ -461,14 +436,13 @@
           "id": "347e210a97f5235b5a60b810ef1bfaa6",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "100.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -476,14 +450,12 @@
           "id": "5644333566484a57ab42a2567bd5d805",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "150.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "150.00"
             }
-          ]
+          }
         }
       }
     ]

--- a/handlers/testdata/test_workload_node_graph.expected
+++ b/handlers/testdata/test_workload_node_graph.expected
@@ -187,15 +187,13 @@
           "id": "710c2bf1d8a5b3fc854451e7346e05f5",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -203,19 +201,17 @@
           "id": "df66cffc756bf9983dd453837e4e14a7",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "5cd385c1ee3309ae40828b5702ae57fb",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "80.00",
-                "http3xx": "20.00",
-                "http4xx": "20.00",
-                "http5xx": "20.00",
-                "httpPercentErr": "50.0",
-                "httpPercentReq": "50.0"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "80.00",
+              "http3xx": "20.00",
+              "http4xx": "20.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "50.0",
+              "httpPercentReq": "50.0"
             }
-          ]
+          }
         }
       },
       {
@@ -223,15 +219,13 @@
           "id": "1da31b81ccaf408abccbc57071458462",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "731126638001dfa2b6cbeb3b326b6678",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -239,14 +233,12 @@
           "id": "cc4b63704dba836d37dd97aacf75afee",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "traffic": [
-            {
-              "protocol": "tcp",
-              "rates": {
-                "tcp": "31.00"
-              }
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "31.00"
             }
-          ]
+          }
         }
       },
       {
@@ -254,15 +246,13 @@
           "id": "c2ab8814859ec0974c5efd597b5bb4fd",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "9e97011b2086f59a90626cfd5cf23fbf",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -270,15 +260,13 @@
           "id": "943e5cc1b00d97a8a344fe1efd941130",
           "source": "240c2314cefc993c5d9479a5c349fbd2",
           "target": "fc3e7c5bb695ef8ed8ab2c5f6ac4725b",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "20.00",
-                "httpPercentReq": "12.5"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
             }
-          ]
+          }
         }
       },
       {
@@ -286,14 +274,13 @@
           "id": "b38eaa93622c6c652c3daf15b31a476d",
           "source": "b30b0078325bf2e1adb4d57c4c0c2665",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "50.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       },
       {
@@ -301,14 +288,13 @@
           "id": "347e210a97f5235b5a60b810ef1bfaa6",
           "source": "c72e12859eac1424516065e6a64c92e0",
           "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": [
-            {
-              "protocol": "http",
-              "rates": {
-                "http": "100.00"
-              }
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
             }
-          ]
+          }
         }
       }
     ]

--- a/swagger.json
+++ b/swagger.json
@@ -2843,12 +2843,7 @@
           "x-go-name": "Target"
         },
         "traffic": {
-          "description": "App Fields (not required by Cytoscape)",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ProtocolTraffic"
-          },
-          "x-go-name": "Traffic"
+          "$ref": "#/definitions/ProtocolTraffic"
         }
       },
       "x-go-package": "github.com/kiali/kiali/graph/cytoscape"


### PR DESCRIPTION
also:
    - no longer default %traffic to 100%, it's confusing. Default to 0 like everything else and report 100s.
    - change edge to a single traffic protocol, multiple protocols don't make sense.
    - allow ResponseTime to accept grpc success code (0)
    - Handle KIALI-2297 service edge response time issue
    - Handle KIALI-2296 100% label issue
    - Handle KIALI-2290 App box side panel issue
    - Fix bug with istio namespace unknown traffic rates being doubled

THIS PR REQUIRES UI PR https://github.com/kiali/kiali-ui/pull/957
