### PR TITLE
Remove unused NamespaceValidations and fix istioConfigDelete return value

### DIFF
--- a/handlers/base.go
+++ b/handlers/base.go
@@ -32,3 +32,7 @@ func RespondWithJSONIndent(w http.ResponseWriter, code int, payload interface{})
 func RespondWithError(w http.ResponseWriter, code int, message string) {
 	RespondWithJSON(w, code, map[string]string{"error": message})
 }
+
+func RespondWithCode(w http.ResponseWriter, code int) {
+	w.WriteHeader(code)
+}

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -232,7 +232,7 @@ func IstioConfigDelete(w http.ResponseWriter, r *http.Request) {
 			RespondWithError(w, http.StatusInternalServerError, err.Error())
 		}
 	} else {
-		RespondWithJSON(w, http.StatusOK, "Deleted")
+		RespondWithCode(w, http.StatusOK)
 	}
 	return
 }

--- a/models/istio_validation_test.go
+++ b/models/istio_validation_test.go
@@ -26,25 +26,3 @@ func TestIstioValidationsMarshal(t *testing.T) {
 	assert.Empty(err)
 	assert.Equal(string(b), `{"virtualservice":{"bar":{"name":"bar","objectType":"virtualservice","valid":false,"checks":null},"foo":{"name":"foo","objectType":"virtualservice","valid":true,"checks":null}}}`)
 }
-
-func TestNamespaceValidationsMarshall(t *testing.T) {
-	assert := assert.New(t)
-
-	validations := NamespaceValidations{
-		"bookinfo": IstioValidations{
-			IstioValidationKey{"virtualservice", "foo"}: &IstioValidation{
-				Name:       "foo",
-				ObjectType: "virtualservice",
-				Valid:      true,
-			},
-			IstioValidationKey{"virtualservice", "bar"}: &IstioValidation{
-				Name:       "bar",
-				ObjectType: "virtualservice",
-				Valid:      false,
-			},
-		},
-	}
-	b, err := json.Marshal(validations)
-	assert.Empty(err)
-	assert.Equal(string(b), `{"bookinfo":{"virtualservice":{"bar":{"name":"bar","objectType":"virtualservice","valid":false,"checks":null},"foo":{"name":"foo","objectType":"virtualservice","valid":true,"checks":null}}}}`)
-}


### PR DESCRIPTION
** Describe the change **

NamespaceValidations are no longer used, thus code should be removed. Also, IstioConfigDelete REST-call was returning payload, which isn't JSON. The documentation says it should return no payload and only "200" and thus this PR fixes that.
