### PR TITLE
KIALI-2303 - do not abort the kiali pod startup when the secret is missing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -183,6 +183,13 @@ func NewConfig() (c *Config) {
 		Username: getDefaultString(EnvServerCredentialsUsername, ""),
 		Password: getDefaultString(EnvServerCredentialsPassword, ""),
 	}
+	// anonymous access is allowed if username and password were explicitly set to empty string
+	if c.Server.Credentials.Username == "" && c.Server.Credentials.Password == "" {
+		_, unameOK := os.LookupEnv(EnvServerCredentialsUsername)
+		_, pwordOK := os.LookupEnv(EnvServerCredentialsPassword)
+		c.Server.Credentials.Anonymous = unameOK && pwordOK
+	}
+
 	c.Server.WebRoot = strings.TrimSpace(getDefaultString(EnvWebRoot, "/"))
 	c.Server.StaticContentRootDirectory = strings.TrimSpace(getDefaultString(EnvServerStaticContentRootDirectory, "/opt/kiali/console"))
 	c.Server.CORSAllowAll = getDefaultBool(EnvServerCORSAllowAll, false)

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -44,11 +44,13 @@ spec:
             secretKeyRef:
               name: kiali
               key: username
+              optional: true
         - name: SERVER_CREDENTIALS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: kiali
               key: passphrase
+              optional: true
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"

--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -44,11 +44,13 @@ spec:
             secretKeyRef:
               name: kiali
               key: username
+              optional: true
         - name: SERVER_CREDENTIALS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: kiali
               key: passphrase
+              optional: true
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"

--- a/kiali.go
+++ b/kiali.go
@@ -144,6 +144,15 @@ func validateConfig() error {
 		return fmt.Errorf("web root must begin with a / and contain only alphanumerics: %v", path)
 	}
 
+	// log some messages to let the administrator know when credentials are configured certain ways
+	creds := config.Get().Server.Credentials
+	if creds.Anonymous {
+		log.Warningf("Kiali is configured for anonymous access - users will not be authenticated.")
+	} else if creds.Username == "" && creds.Password == "" {
+		// This won't cause Kiali to abort, but users won't be able to log in, so immediately log a warning
+		log.Warningf("Credentials are missing. Create a secret and restart Kiali. Please refer to the documentation for more details.")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
log some messages and let the user know a secret needs to be created