### PR TITLE
istio 1.1 needs to have crds installed explicitly

### DIFF
--- a/hack/istio/install-istio-kiali-via-helm.sh
+++ b/hack/istio/install-istio-kiali-via-helm.sh
@@ -331,9 +331,11 @@ fi
 if [ "${DELETE_ISTIO}" == "true" ]; then
   echo DELETING ISTIO!
   ${CLIENT_EXE} delete -f /tmp/istio.yaml
+  for i in ${ISTIO_DIR}/install/kubernetes/helm/istio-init/files/crd*yaml; do ${CLIENT_EXE} delete -f $i; done
   ${CLIENT_EXE} delete namespace ${NAMESPACE}
 else
   echo Installing Istio...
+  for i in ${ISTIO_DIR}/install/kubernetes/helm/istio-init/files/crd*yaml; do ${CLIENT_EXE} apply -f $i; done
   ${CLIENT_EXE} apply -f /tmp/istio.yaml
 fi
 


### PR DESCRIPTION
looks like istio 1.1 snapshot 5 now requires CRDs to be installed explicitly (before, helm did it for you): https://preliminary.istio.io/docs/setup/kubernetes/helm-install/#option-1-install-with-helm-via-helm-template

this fixes our hack script to do this. You can still use the hack script for earlier versions of istio, just ignore the error message about the crd directory not existing (didn't exist until 1.1-snapshot.5)