### PR TITLE
KIALI-2147 Change DR validations to support mesh/ns-wide mTLS enabled

### DIFF
--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -96,6 +96,50 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 
 }
 
+func TestMultiHostMatchingMeshWideMTLSDestinationRule(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateTestDestinationRule("test", "rule2", "*.local")),
+	}
+
+	validations := MultiMatchChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.Empty(validations)
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "rule2"}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
+func TestMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateTestDestinationRule("test", "rule2", "*.test.svc.cluster.local")),
+	}
+
+	validations := MultiMatchChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.Empty(validations)
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "rule2"}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
 func TestMultiHostMatchDifferentSubsets(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -63,6 +63,13 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 
 func (n NoDestinationChecker) hasMatchingWorkload(service string, labels map[string]string) bool {
 	appLabel := config.Get().IstioLabels.AppLabelName
+
+	// Check wildcard hosts
+	if service == "*" {
+		return true
+	}
+
+	// Check workloads
 	for _, wl := range n.WorkloadList.Workloads {
 		if service == wl.Labels[appLabel] {
 			valid := true
@@ -83,6 +90,12 @@ func (n NoDestinationChecker) hasMatchingWorkload(service string, labels map[str
 
 func (n NoDestinationChecker) hasMatchingService(service string) bool {
 	appLabel := config.Get().IstioLabels.AppLabelName
+
+	// Check wildcard hosts
+	if service == "*" {
+		return true
+	}
+
 	// Check Workloads
 	for _, wl := range n.WorkloadList.Workloads {
 		if service == wl.Labels[appLabel] {

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -16,6 +16,7 @@ func appVersionLabel(app, version string) map[string]string {
 		"version": version,
 	}
 }
+
 func TestValidHost(t *testing.T) {
 	assert := assert.New(t)
 
@@ -26,6 +27,42 @@ func TestValidHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
 		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestValidWildcardHost(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := NoDestinationChecker{
+		Namespace: "test-namespace",
+		WorkloadList: data.CreateWorkloadList("test-namespace",
+			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
+			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
+		),
+		DestinationRule: data.CreateTestDestinationRule("test-namespace",
+			"name", "*.test-namespace.svc.cluster.local"),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestValidMeshWideHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	validations, valid := NoDestinationChecker{
+		Namespace: "test-namespace",
+		WorkloadList: data.CreateWorkloadList("test-namespace",
+			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
+			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
+		),
+		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "*.local"),
 	}.Check()
 
 	assert.True(valid)

--- a/tests/data/destination_rules_data.go
+++ b/tests/data/destination_rules_data.go
@@ -45,3 +45,16 @@ func AddSubsetToDestinationRule(subset map[string]interface{}, dr kubernetes.Ist
 	}
 	return dr
 }
+
+func AddTrafficPolicyToDestinationRule(trafficPolicy map[string]interface{}, dr kubernetes.IstioObject) kubernetes.IstioObject {
+	dr.GetSpec()["trafficPolicy"] = trafficPolicy
+	return dr
+}
+
+func CreateMTLSTrafficPolicyForDestinationRules() map[string]interface{} {
+	return map[string]interface{}{
+		"tls": map[string]interface{}{
+			"mode": "ISTIO_MUTUAL",
+		},
+	}
+}


### PR DESCRIPTION
** Describe the change **
Destination Rules validations now takes into account the mTLS enablers (DR + MeshPolicy combo).

** Issue reference **
https://issues.jboss.org/browse/KIALI-2147

** Backwards incompatible? **
yep.
