### PR TITLE
KIALI-2362 Allow different operators than "sum" for raw metrics

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -62,11 +62,11 @@ func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, 
 			defer wg.Done()
 			filledCharts[idx] = models.ConvertChart(chart)
 			if chart.DataType == kubernetes.Raw {
-				aggOp := params.RawAggregationOperator
-				if chart.AggregationOperator != "" {
-					aggOp = chart.AggregationOperator
+				aggregator := params.RawDataAggregator
+				if chart.Aggregator != "" {
+					aggregator = chart.Aggregator
 				}
-				filledCharts[idx].Metric = in.prom.FetchRange(chart.MetricName, labels, grouping, aggOp, &params.BaseMetricsQuery)
+				filledCharts[idx].Metric = in.prom.FetchRange(chart.MetricName, labels, grouping, aggregator, &params.BaseMetricsQuery)
 			} else if chart.DataType == kubernetes.Rate {
 				filledCharts[idx].Metric = in.prom.FetchRateRange(chart.MetricName, labels, grouping, &params.BaseMetricsQuery)
 			} else {

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -62,7 +62,11 @@ func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, 
 			defer wg.Done()
 			filledCharts[idx] = models.ConvertChart(chart)
 			if chart.DataType == kubernetes.Raw {
-				filledCharts[idx].Metric = in.prom.FetchRange(chart.MetricName, labels, grouping, &params.BaseMetricsQuery)
+				aggOp := params.RawAggregationOperator
+				if chart.AggregationOperator != "" {
+					aggOp = chart.AggregationOperator
+				}
+				filledCharts[idx].Metric = in.prom.FetchRange(chart.MetricName, labels, grouping, aggOp, &params.BaseMetricsQuery)
 			} else if chart.DataType == kubernetes.Rate {
 				filledCharts[idx].Metric = in.prom.FetchRateRange(chart.MetricName, labels, grouping, &params.BaseMetricsQuery)
 			} else {

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -45,6 +45,10 @@ func extractCustomMetricsQueryParams(r *http.Request, q *prometheus.CustomMetric
 	q.FillDefaults()
 	queryParams := r.URL.Query()
 	q.Version = queryParams.Get("version")
+	op := queryParams.Get("rawAggregationOperator")
+	if op != "" {
+		q.RawAggregationOperator = queryParams.Get("rawAggregationOperator")
+	}
 	return extractBaseMetricsQueryParams(queryParams, &q.BaseMetricsQuery, namespaceInfo)
 }
 

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -45,9 +45,11 @@ func extractCustomMetricsQueryParams(r *http.Request, q *prometheus.CustomMetric
 	q.FillDefaults()
 	queryParams := r.URL.Query()
 	q.Version = queryParams.Get("version")
-	op := queryParams.Get("rawAggregationOperator")
-	if op != "" {
-		q.RawAggregationOperator = queryParams.Get("rawAggregationOperator")
+	op := queryParams.Get("rawDataAggregator")
+	// Explicit white-listing operators to prevent any kind of injection
+	// For a list of operators, see https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
+	if op == "sum" || op == "min" || op == "max" || op == "avg" || op == "stddev" || op == "stdvar" {
+		q.RawDataAggregator = op
 	}
 	return extractBaseMetricsQueryParams(queryParams, &q.BaseMetricsQuery, namespaceInfo)
 }

--- a/kubernetes/kiali_monitoring_types.go
+++ b/kubernetes/kiali_monitoring_types.go
@@ -29,12 +29,13 @@ type MonitoringDashboardSpec struct {
 }
 
 type MonitoringDashboardChart struct {
-	Name         string
-	Unit         string
-	Spans        int
-	MetricName   string
-	DataType     string // MetricType is either "raw", "rate" or "histogram"
-	Aggregations []MonitoringDashboardAggregation
+	Name                string
+	Unit                string
+	Spans               int
+	MetricName          string
+	DataType            string // MetricType is either "raw", "rate" or "histogram"
+	AggregationOperator string // AggregationOperator can be set for raw data. Ex: "sum", "avg". See https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
+	Aggregations        []MonitoringDashboardAggregation
 }
 
 type MonitoringDashboardAggregation struct {

--- a/kubernetes/kiali_monitoring_types.go
+++ b/kubernetes/kiali_monitoring_types.go
@@ -29,13 +29,13 @@ type MonitoringDashboardSpec struct {
 }
 
 type MonitoringDashboardChart struct {
-	Name                string
-	Unit                string
-	Spans               int
-	MetricName          string
-	DataType            string // MetricType is either "raw", "rate" or "histogram"
-	AggregationOperator string // AggregationOperator can be set for raw data. Ex: "sum", "avg". See https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
-	Aggregations        []MonitoringDashboardAggregation
+	Name         string
+	Unit         string
+	Spans        int
+	MetricName   string
+	DataType     string // MetricType is either "raw", "rate" or "histogram"
+	Aggregator   string // Aggregator can be set for raw data. Ex: "sum", "avg". See https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
+	Aggregations []MonitoringDashboardAggregation
 }
 
 type MonitoringDashboardAggregation struct {

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -25,7 +25,7 @@ type ClientInterface interface {
 	GetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 	GetSourceWorkloads(namespace string, namespaceCreationTime time.Time, servicename string) (map[string][]Workload, error)
 	GetDestinationServices(namespace string, namespaceCreationTime time.Time, workloadname string) ([]Service, error)
-	FetchRange(metricName, labels, grouping string, q *BaseMetricsQuery) *Metric
+	FetchRange(metricName, labels, grouping, aggOp string, q *BaseMetricsQuery) *Metric
 	FetchRateRange(metricName, labels, grouping string, q *BaseMetricsQuery) *Metric
 	FetchHistogramRange(metricName, labels, grouping string, q *BaseMetricsQuery) Histogram
 	GetMetrics(query *IstioMetricsQuery) Metrics
@@ -205,8 +205,8 @@ func (in *Client) GetWorkloadRequestRates(namespace, workload, ratesInterval str
 }
 
 // FetchRange fetches a simple metric (gauge or counter) in given range
-func (in *Client) FetchRange(metricName, labels, grouping string, q *BaseMetricsQuery) *Metric {
-	query := fmt.Sprintf("sum(%s%s)", metricName, labels)
+func (in *Client) FetchRange(metricName, labels, grouping, aggOp string, q *BaseMetricsQuery) *Metric {
+	query := fmt.Sprintf("%s(%s%s)", aggOp, metricName, labels)
 	if grouping != "" {
 		query += fmt.Sprintf(" by (%s)", grouping)
 	}

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -25,7 +25,7 @@ type ClientInterface interface {
 	GetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 	GetSourceWorkloads(namespace string, namespaceCreationTime time.Time, servicename string) (map[string][]Workload, error)
 	GetDestinationServices(namespace string, namespaceCreationTime time.Time, workloadname string) ([]Service, error)
-	FetchRange(metricName, labels, grouping, aggOp string, q *BaseMetricsQuery) *Metric
+	FetchRange(metricName, labels, grouping, aggregator string, q *BaseMetricsQuery) *Metric
 	FetchRateRange(metricName, labels, grouping string, q *BaseMetricsQuery) *Metric
 	FetchHistogramRange(metricName, labels, grouping string, q *BaseMetricsQuery) Histogram
 	GetMetrics(query *IstioMetricsQuery) Metrics
@@ -205,8 +205,8 @@ func (in *Client) GetWorkloadRequestRates(namespace, workload, ratesInterval str
 }
 
 // FetchRange fetches a simple metric (gauge or counter) in given range
-func (in *Client) FetchRange(metricName, labels, grouping, aggOp string, q *BaseMetricsQuery) *Metric {
-	query := fmt.Sprintf("%s(%s%s)", aggOp, metricName, labels)
+func (in *Client) FetchRange(metricName, labels, grouping, aggregator string, q *BaseMetricsQuery) *Metric {
+	query := fmt.Sprintf("%s(%s%s)", aggregator, metricName, labels)
 	if grouping != "" {
 		query += fmt.Sprintf(" by (%s)", grouping)
 	}

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -138,8 +138,8 @@ func (o *PromClientMock) GetDestinationServices(namespace string, namespaceCreat
 	return args.Get(0).([]prometheus.Service), args.Error(1)
 }
 
-func (o *PromClientMock) FetchRange(metricName, labels, grouping, aggOp string, q *prometheus.BaseMetricsQuery) *prometheus.Metric {
-	args := o.Called(metricName, labels, grouping, aggOp, q)
+func (o *PromClientMock) FetchRange(metricName, labels, grouping, aggregator string, q *prometheus.BaseMetricsQuery) *prometheus.Metric {
+	args := o.Called(metricName, labels, grouping, aggregator, q)
 	return args.Get(0).(*prometheus.Metric)
 }
 

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -138,8 +138,8 @@ func (o *PromClientMock) GetDestinationServices(namespace string, namespaceCreat
 	return args.Get(0).([]prometheus.Service), args.Error(1)
 }
 
-func (o *PromClientMock) FetchRange(metricName, labels, grouping string, q *prometheus.BaseMetricsQuery) *prometheus.Metric {
-	args := o.Called(metricName, labels, grouping, q)
+func (o *PromClientMock) FetchRange(metricName, labels, grouping, aggOp string, q *prometheus.BaseMetricsQuery) *prometheus.Metric {
+	args := o.Called(metricName, labels, grouping, aggOp, q)
 	return args.Get(0).(*prometheus.Metric)
 }
 

--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -50,14 +50,16 @@ func (q *IstioMetricsQuery) FillDefaults() {
 // CustomMetricsQuery holds query parameters for a custom metrics query
 type CustomMetricsQuery struct {
 	BaseMetricsQuery
-	Namespace string
-	App       string
-	Version   string
+	Namespace              string
+	App                    string
+	Version                string
+	RawAggregationOperator string
 }
 
 // FillDefaults fills the struct with default parameters
 func (q *CustomMetricsQuery) FillDefaults() {
 	q.BaseMetricsQuery.fillDefaults()
+	q.RawAggregationOperator = "sum"
 }
 
 // Metrics contains all simple metrics and histograms data

--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -50,16 +50,16 @@ func (q *IstioMetricsQuery) FillDefaults() {
 // CustomMetricsQuery holds query parameters for a custom metrics query
 type CustomMetricsQuery struct {
 	BaseMetricsQuery
-	Namespace              string
-	App                    string
-	Version                string
-	RawAggregationOperator string
+	Namespace         string
+	App               string
+	Version           string
+	RawDataAggregator string
 }
 
 // FillDefaults fills the struct with default parameters
 func (q *CustomMetricsQuery) FillDefaults() {
 	q.BaseMetricsQuery.fillDefaults()
-	q.RawAggregationOperator = "sum"
+	q.RawDataAggregator = "sum"
 }
 
 // Metrics contains all simple metrics and histograms data


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-2362

This allows to:
- Hard-define the operator to use in the dashboard definition
- Or let the client (UI) decide which to use, if no hard definition


Frontend: https://github.com/kiali/kiali-ui/pull/985