### PR TITLE
KIALI-2371 Accept FQDN format for gateway name in VS

### DIFF
--- a/business/checkers/virtual_services/no_gateway_checker.go
+++ b/business/checkers/virtual_services/no_gateway_checker.go
@@ -16,7 +16,7 @@ type NoGatewayChecker struct {
 func (s NoGatewayChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
-	valid, index := kubernetes.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.GatewayNames)
+	valid, index := kubernetes.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.GatewayNames, s.VirtualService.GetObjectMeta().Namespace)
 	if !valid {
 		path := "spec/gateways[" + strconv.Itoa(index) + "]"
 		validation := models.Build("virtualservices.nogateway", path)

--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -3,6 +3,7 @@ package virtual_services
 import (
 	"testing"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -29,6 +30,25 @@ func TestFoundGateway(t *testing.T) {
 	assert := assert.New(t)
 
 	virtualService := data.AddGatewaysToVirtualService([]string{"my-gateway", "mesh"}, data.CreateVirtualService())
+	gatewayNames := kubernetes.GatewayNames([]kubernetes.IstioObject{data.CreateEmptyGateway("my-gateway", make(map[string]string))})
+
+	checker := NoGatewayChecker{
+		VirtualService: virtualService,
+		GatewayNames:   gatewayNames,
+	}
+
+	validations, valid := checker.Check()
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestFQDNFoundGateway(t *testing.T) {
+	assert := assert.New(t)
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	virtualService := data.AddGatewaysToVirtualService([]string{"my-gateway.test.svc.cluster.local", "mesh"}, data.CreateVirtualService())
 	gatewayNames := kubernetes.GatewayNames([]kubernetes.IstioObject{data.CreateEmptyGateway("my-gateway", make(map[string]string))})
 
 	checker := NoGatewayChecker{

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -502,14 +502,20 @@ func GatewayNames(gateways []IstioObject) map[string]struct{} {
 }
 
 // ValidateVirtualServiceGateways checks all VirtualService gateways (except mesh, which is reserved word) and checks that they're found from the given list of gatewayNames. Also return index of missing gatways to show clearer error path in editor
-func ValidateVirtualServiceGateways(spec map[string]interface{}, gatewayNames map[string]struct{}) (bool, int) {
+func ValidateVirtualServiceGateways(spec map[string]interface{}, gatewayNames map[string]struct{}, namespace string) (bool, int) {
 	if gatewaysSpec, found := spec["gateways"]; found {
 		if gateways, ok := gatewaysSpec.([]interface{}); ok {
 			for index, g := range gateways {
 				if gate, ok := g.(string); ok {
-					if _, found := gatewayNames[gate]; !found && gate != "mesh" {
-						return false, index
+					if gate == "mesh" {
+						return true, -1
 					}
+					for gw := range gatewayNames {
+						if found := FilterByHost(gate, gw, namespace); found {
+							return true, -1
+						}
+					}
+					return false, index
 				}
 			}
 		}


### PR DESCRIPTION
** Describe the change **

gateways section in the VirtualService definition has a list of gateways, which we assume to be in a service-name only format. This patch allows the FQDN format to be used as well (Istio documentation does not mention which format is correct).

** Issue reference **

KIALI-2371
