### PR TITLE
Fix json camelCase on istio labels

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -131,8 +131,8 @@ type LoginToken struct {
 
 // IstioLabels holds configuration about the labels required by Istio
 type IstioLabels struct {
-	AppLabelName     string `yaml:"app_label_name,omitempty"`
-	VersionLabelName string `yaml:"version_label_name,omitempty"`
+	AppLabelName     string `yaml:"app_label_name,omitempty" json:"appLabelName"`
+	VersionLabelName string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
 // Kubernetes client configuration


### PR DESCRIPTION
This struct is sent to the client for getting server config, so its fields need to be correctly written in json.

Frontend PR: https://github.com/kiali/kiali-ui/pull/997