### PR TITLE
KIALI-2094 Destination Rule validation when TLS not mentioned and non-local DR present

### DIFF
--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -8,6 +8,7 @@ import (
 
 type DestinationRulesChecker struct {
 	DestinationRules []kubernetes.IstioObject
+	MTLSDetails      kubernetes.MTLSDetails
 }
 
 func (in DestinationRulesChecker) Check() models.IstioValidations {
@@ -15,6 +16,7 @@ func (in DestinationRulesChecker) Check() models.IstioValidations {
 
 	enabledDRCheckers := []GroupChecker{
 		destinationrules.MultiMatchChecker{DestinationRules: in.DestinationRules},
+		destinationrules.TrafficPolicyChecker{DestinationRules: in.DestinationRules, MTLSDetails: in.MTLSDetails},
 	}
 
 	for _, checker := range enabledDRCheckers {

--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -76,10 +76,10 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 }
 
 func enablesNonLocalmTLSForService(dr kubernetes.IstioObject, service string) bool {
-	return service == "*" && enablesNonLocalmTLS(dr)
+	return service == "*" && enablesmTLS(dr)
 }
 
-func enablesNonLocalmTLS(dr kubernetes.IstioObject) bool {
+func enablesmTLS(dr kubernetes.IstioObject) bool {
 	if trafficPolicy, trafficPresent := dr.GetSpec()["trafficPolicy"]; trafficPresent {
 		if trafficCasted, ok := trafficPolicy.(map[string]interface{}); ok {
 			if tls, found := trafficCasted["tls"]; found {

--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -38,7 +38,7 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 				fqdn := FormatHostnameForPrefixSearch(dHost, dr.GetObjectMeta().Namespace, dr.GetObjectMeta().ClusterName)
 
 				// Skip DR validation if it enables mTLS either namespace or mesh-wide
-				if enablesNonLocalmTLSForService(dr, fqdn.Service) {
+				if isNonLocalmTLSForServiceEnabled(dr, fqdn.Service) {
 					continue
 				}
 
@@ -75,11 +75,11 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 	return validations
 }
 
-func enablesNonLocalmTLSForService(dr kubernetes.IstioObject, service string) bool {
-	return service == "*" && enablesmTLS(dr)
+func isNonLocalmTLSForServiceEnabled(dr kubernetes.IstioObject, service string) bool {
+	return service == "*" && ismTLSEnabled(dr)
 }
 
-func enablesmTLS(dr kubernetes.IstioObject) bool {
+func ismTLSEnabled(dr kubernetes.IstioObject) bool {
 	if trafficPolicy, trafficPresent := dr.GetSpec()["trafficPolicy"]; trafficPresent {
 		if trafficCasted, ok := trafficPolicy.(map[string]interface{}); ok {
 			if tls, found := trafficCasted["tls"]; found {

--- a/business/checkers/destinationrules/traffic_policy_checker.go
+++ b/business/checkers/destinationrules/traffic_policy_checker.go
@@ -1,1 +1,60 @@
 package destinationrules
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type TrafficPolicyChecker struct {
+	DestinationRules []kubernetes.IstioObject
+}
+
+func (t TrafficPolicyChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	// When mTLS is not enabled, there is no validation to be added.
+	if !t.hasEnablingmTLSDR() {
+		return validations
+	}
+
+	// Check whether DRs override mTLS.
+	for _, dr := range t.DestinationRules {
+		if !enablesNonLocalmTLS(dr) {
+			check := models.Build("destinationrules.trafficpolicy.meshmtls", "spec")
+			key := models.BuildKey(DestinationRulesCheckerType, dr.GetObjectMeta().Name)
+			validation := buildDestinationRuleValidation(dr, check, true)
+
+			if _, exists := validations[key]; !exists {
+				validations.MergeValidations(models.IstioValidations{key: validation})
+			}
+		}
+	}
+
+	return validations
+}
+
+func (t TrafficPolicyChecker) hasEnablingmTLSDR() bool {
+	enablesTLS := false
+
+	for _, dr := range t.DestinationRules {
+		enablesTLS = enablesNonLocalmTLS(dr)
+		if enablesTLS {
+			break
+		}
+	}
+
+	return enablesTLS
+}
+
+func buildDestinationRuleValidation(dr kubernetes.IstioObject, checks models.IstioCheck, valid bool) *models.IstioValidation {
+	validation := &models.IstioValidation{
+		Name:       dr.GetObjectMeta().Name,
+		ObjectType: DestinationRulesCheckerType,
+		Valid:      valid,
+		Checks: []*models.IstioCheck{
+			&checks,
+		},
+	}
+
+	return validation
+}

--- a/business/checkers/destinationrules/traffic_policy_checker.go
+++ b/business/checkers/destinationrules/traffic_policy_checker.go
@@ -1,0 +1,1 @@
+package destinationrules

--- a/business/checkers/destinationrules/traffic_policy_checker.go
+++ b/business/checkers/destinationrules/traffic_policy_checker.go
@@ -7,6 +7,7 @@ import (
 
 type TrafficPolicyChecker struct {
 	DestinationRules []kubernetes.IstioObject
+	MTLSDetails      kubernetes.MTLSDetails
 }
 
 func (t TrafficPolicyChecker) Check() models.IstioValidations {
@@ -19,8 +20,8 @@ func (t TrafficPolicyChecker) Check() models.IstioValidations {
 
 	// Check whether DRs override mTLS.
 	for _, dr := range t.DestinationRules {
-		if !enablesNonLocalmTLS(dr) {
-			check := models.Build("destinationrules.trafficpolicy.meshmtls", "spec")
+		if !hasTrafficPolicy(dr) || !hasmTLSSettings(dr) {
+			check := models.Build("destinationrules.trafficpolicy.notlssettings", "spec/trafficPolicy")
 			key := models.BuildKey(DestinationRulesCheckerType, dr.GetObjectMeta().Name)
 			validation := buildDestinationRuleValidation(dr, check, true)
 
@@ -36,14 +37,55 @@ func (t TrafficPolicyChecker) Check() models.IstioValidations {
 func (t TrafficPolicyChecker) hasEnablingmTLSDR() bool {
 	enablesTLS := false
 
-	for _, dr := range t.DestinationRules {
-		enablesTLS = enablesNonLocalmTLS(dr)
+	for _, dr := range t.MTLSDetails.DestinationRules {
+		enablesTLS = enablesmTLS(dr)
 		if enablesTLS {
 			break
 		}
 	}
 
 	return enablesTLS
+}
+
+func hasTrafficPolicy(dr kubernetes.IstioObject) bool {
+	_, trafficPresent := dr.GetSpec()["trafficPolicy"]
+	return trafficPresent
+}
+
+func hasmTLSSettings(dr kubernetes.IstioObject) bool {
+	return enablesAnyTLS(dr) || enablesPortTLS(dr)
+}
+
+// enablesPortTLS returns true when there is one port that specifies any TLS settings
+func enablesPortTLS(dr kubernetes.IstioObject) bool {
+	if trafficPolicy, trafficPresent := dr.GetSpec()["trafficPolicy"]; trafficPresent {
+		if trafficCasted, ok := trafficPolicy.(map[string]interface{}); ok {
+			if portsSettings, found := trafficCasted["portLevelSettings"]; found {
+				if portsSettingsCasted, ok := portsSettings.([]interface{}); ok {
+					for _, portSettings := range portsSettingsCasted {
+						if portSettingsCasted, ok := portSettings.(map[string]interface{}); ok {
+							if _, found := portSettingsCasted["tls"]; found {
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// enablesAnyTLS returns true when there is a trafficPolicy specifying any tls mode
+func enablesAnyTLS(dr kubernetes.IstioObject) bool {
+	if trafficPolicy, trafficPresent := dr.GetSpec()["trafficPolicy"]; trafficPresent {
+		if trafficCasted, ok := trafficPolicy.(map[string]interface{}); ok {
+			if _, found := trafficCasted["tls"]; found {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func buildDestinationRuleValidation(dr kubernetes.IstioObject, checks models.IstioCheck, valid bool) *models.IstioValidation {

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -1,0 +1,31 @@
+package destinationrules
+
+import "testing"
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule doesn't specify trafficPolicy
+// It returns a validation
+func TestMTLSMeshWideEnabledDRWithoutTrafficPolicy(t *testing.T) {
+
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule does specify trafficPolicy
+// It doesn't return any validation
+func TestMTLSMeshWideEnabledDRWithTrafficPolicy(t *testing.T) {
+
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule doesn't specify trafficPolicy
+// It returns a validation
+func TestNamespacemTLSEnabledDRWithoutTrafficPolicy(t *testing.T) {
+
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule does specify trafficPolicy
+// It doesn't return any validation
+func TestNamespacemTLSEnabledDRWithTrafficPolicy(t *testing.T) {
+
+}

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -1,31 +1,184 @@
 package destinationrules
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
 
 // Context: MeshPolicy Enabling mTLS
 // Context: DestinationRule doesn't specify trafficPolicy
 // It returns a validation
 func TestMTLSMeshWideEnabledDRWithoutTrafficPolicy(t *testing.T) {
+	assert := assert.New(t)
 
+	destinationRules := []kubernetes.IstioObject{
+		// Mesh-wide DR enabling mTLS communication
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+		// Subject DR that doesn't specify any trafficPolicy
+		data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews"),
+	}
+
+	validations := TrafficPolicyChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+
+	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+	assert.True(ok)
+	assert.True(validation.Valid)
+
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.meshmtls"), validation.Checks[0].Message)
 }
 
 // Context: MeshPolicy Enabling mTLS
-// Context: DestinationRule does specify trafficPolicy
+// Context: DestinationRule doesn't specify mTLS options
+// It returns a validation
+func TestMTLSMeshWideEnabledDRWithoutmTLSOptions(t *testing.T) {
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		// Mesh-wide DR enabling mTLS communication
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	validations := TrafficPolicyChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+
+	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+	assert.True(ok)
+	assert.True(validation.Valid)
+
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.meshmtls"), validation.Checks[0].Message)
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule does specify trafficPolicy and mTLS options
 // It doesn't return any validation
 func TestMTLSMeshWideEnabledDRWithTrafficPolicy(t *testing.T) {
+	assert := assert.New(t)
 
+	destinationRules := []kubernetes.IstioObject{
+		// Mesh-wide DR enabling mTLS communication
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+		// Subject DR that specify TrafficPolicy
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	validations := TrafficPolicyChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.Empty(validations)
+	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+
+	assert.False(ok)
+	assert.Nil(validation)
 }
 
 // Context: Namespace-wide mTLS enabled
 // Context: DestinationRule doesn't specify trafficPolicy
 // It returns a validation
 func TestNamespacemTLSEnabledDRWithoutTrafficPolicy(t *testing.T) {
+	assert := assert.New(t)
 
+	destinationRules := []kubernetes.IstioObject{
+		// Namespace-wide DR enabling mTLS communication
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+		// Subject DR that doesn't specify any trafficPolicy
+		data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews"),
+	}
+
+	validations := TrafficPolicyChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+
+	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+	assert.True(ok)
+	assert.True(validation.Valid)
+
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.meshmtls"), validation.Checks[0].Message)
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule doesn't specify mTLS options
+// It returns a validation
+func TestNamespacemTLSEnabledDRWithoutmTLSOptions(t *testing.T) {
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		// Namespace-wide DR enabling mTLS communication
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	validations := TrafficPolicyChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+
+	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+	assert.True(ok)
+	assert.True(validation.Valid)
+
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.meshmtls"), validation.Checks[0].Message)
 }
 
 // Context: Namespace-wide mTLS enabled
 // Context: DestinationRule does specify trafficPolicy
 // It doesn't return any validation
 func TestNamespacemTLSEnabledDRWithTrafficPolicy(t *testing.T) {
+	assert := assert.New(t)
 
+	destinationRules := []kubernetes.IstioObject{
+		// Namespace-wide DR enabling mTLS communication
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+		// Subject DR that specify trafficPolicy and mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	validations := TrafficPolicyChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.Empty(validations)
+	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+	assert.False(ok)
+	assert.Nil(validation)
 }

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -14,136 +14,174 @@ import (
 // Context: DestinationRule doesn't specify trafficPolicy
 // It returns a validation
 func TestMTLSMeshWideEnabledDRWithoutTrafficPolicy(t *testing.T) {
-	assert := assert.New(t)
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("istio-system", "default", "*.local")),
+		},
+	}
 
 	destinationRules := []kubernetes.IstioObject{
-		// Mesh-wide DR enabling mTLS communication
-		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-			data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
 		// Subject DR that doesn't specify any trafficPolicy
 		data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews"),
 	}
 
-	validations := TrafficPolicyChecker{
-		DestinationRules: destinationRules,
-	}.Check()
-
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
-
-	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
-	assert.True(ok)
-	assert.True(validation.Valid)
-
-	assert.NotEmpty(validation.Checks)
-	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.meshmtls"), validation.Checks[0].Message)
+	testValidationAdded(t, destinationRules, mTLSDetails)
 }
 
 // Context: MeshPolicy Enabling mTLS
 // Context: DestinationRule doesn't specify mTLS options
 // It returns a validation
 func TestMTLSMeshWideEnabledDRWithoutmTLSOptions(t *testing.T) {
-	assert := assert.New(t)
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+		},
+	}
 
 	destinationRules := []kubernetes.IstioObject{
-		// Mesh-wide DR enabling mTLS communication
-		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-			data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
 		// Subject DR that specify trafficPolicy but no mTLS options
 		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
 			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 	}
 
-	validations := TrafficPolicyChecker{
-		DestinationRules: destinationRules,
-	}.Check()
+	testValidationAdded(t, destinationRules, mTLSDetails)
+}
 
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule doesn't specify port-level mTLS options
+// It returns a validation
+func TestMTLSMeshWideEnabledDRWithoutPortLevelmTLSOptions(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+		},
+	}
 
-	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
-	assert.True(ok)
-	assert.True(validation.Valid)
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreatePortLevelTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
 
-	assert.NotEmpty(validation.Checks)
-	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.meshmtls"), validation.Checks[0].Message)
+	testValidationAdded(t, destinationRules, mTLSDetails)
 }
 
 // Context: MeshPolicy Enabling mTLS
 // Context: DestinationRule does specify trafficPolicy and mTLS options
 // It doesn't return any validation
 func TestMTLSMeshWideEnabledDRWithTrafficPolicy(t *testing.T) {
-	assert := assert.New(t)
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+		},
+	}
 
 	destinationRules := []kubernetes.IstioObject{
-		// Mesh-wide DR enabling mTLS communication
-		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-			data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
 		// Subject DR that specify TrafficPolicy
 		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 	}
 
-	validations := TrafficPolicyChecker{
-		DestinationRules: destinationRules,
-	}.Check()
+	testValidationsNotAdded(t, destinationRules, mTLSDetails)
+}
 
-	assert.Empty(validations)
-	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule does specify trafficPolicy and TLS options
+// It doesn't return any validation
+func TestMTLSMeshWideEnabledDRWithPortLevelTLSTrafficPolicy(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+		},
+	}
 
-	assert.False(ok)
-	assert.Nil(validation)
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify TrafficPolicy
+		data.AddTrafficPolicyToDestinationRule(data.CreateTLSPortLevelTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	testValidationsNotAdded(t, destinationRules, mTLSDetails)
 }
 
 // Context: Namespace-wide mTLS enabled
 // Context: DestinationRule doesn't specify trafficPolicy
 // It returns a validation
 func TestNamespacemTLSEnabledDRWithoutTrafficPolicy(t *testing.T) {
-	assert := assert.New(t)
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+		},
+	}
 
 	destinationRules := []kubernetes.IstioObject{
-		// Namespace-wide DR enabling mTLS communication
-		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-			data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
 		// Subject DR that doesn't specify any trafficPolicy
 		data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews"),
 	}
 
-	validations := TrafficPolicyChecker{
-		DestinationRules: destinationRules,
-	}.Check()
-
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
-
-	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
-	assert.True(ok)
-	assert.True(validation.Valid)
-
-	assert.NotEmpty(validation.Checks)
-	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.meshmtls"), validation.Checks[0].Message)
+	testValidationAdded(t, destinationRules, mTLSDetails)
 }
 
 // Context: Namespace-wide mTLS enabled
 // Context: DestinationRule doesn't specify mTLS options
 // It returns a validation
 func TestNamespacemTLSEnabledDRWithoutmTLSOptions(t *testing.T) {
-	assert := assert.New(t)
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+		},
+	}
 
 	destinationRules := []kubernetes.IstioObject{
-		// Namespace-wide DR enabling mTLS communication
-		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-			data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
 		// Subject DR that specify trafficPolicy but no mTLS options
 		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
 			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 	}
 
+	testValidationAdded(t, destinationRules, mTLSDetails)
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule does specify trafficPolicy
+// It doesn't return any validation
+func TestNamespacemTLSEnabledDRWithTrafficPolicy(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy and mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	testValidationsNotAdded(t, destinationRules, mTLSDetails)
+}
+
+func testValidationAdded(t *testing.T, destinationRules []kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
+	assert := assert.New(t)
+
 	validations := TrafficPolicyChecker{
 		DestinationRules: destinationRules,
+		MTLSDetails:      mTLSDetails,
 	}.Check()
 
 	assert.NotEmpty(validations)
@@ -155,30 +193,21 @@ func TestNamespacemTLSEnabledDRWithoutmTLSOptions(t *testing.T) {
 
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.meshmtls"), validation.Checks[0].Message)
+	assert.Equal("spec/trafficPolicy", validation.Checks[0].Path)
+	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.notlssettings"), validation.Checks[0].Message)
 }
 
-// Context: Namespace-wide mTLS enabled
-// Context: DestinationRule does specify trafficPolicy
-// It doesn't return any validation
-func TestNamespacemTLSEnabledDRWithTrafficPolicy(t *testing.T) {
+func testValidationsNotAdded(t *testing.T, destinationRules []kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
 	assert := assert.New(t)
-
-	destinationRules := []kubernetes.IstioObject{
-		// Namespace-wide DR enabling mTLS communication
-		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-			data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
-		// Subject DR that specify trafficPolicy and mTLS options
-		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
-	}
 
 	validations := TrafficPolicyChecker{
 		DestinationRules: destinationRules,
+		MTLSDetails:      mTLSDetails,
 	}.Check()
 
 	assert.Empty(validations)
 	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+
 	assert.False(ok)
 	assert.Nil(validation)
 }

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -19,6 +19,8 @@ func TestMTLSMeshWideEnabledDRWithoutTrafficPolicy(t *testing.T) {
 			// Mesh-wide DR enabling mTLS communication
 			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 				data.CreateEmptyDestinationRule("istio-system", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 		},
 	}
 
@@ -39,6 +41,8 @@ func TestMTLSMeshWideEnabledDRWithoutmTLSOptions(t *testing.T) {
 			// Mesh-wide DR enabling mTLS communication
 			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 		},
 	}
 
@@ -60,6 +64,8 @@ func TestMTLSMeshWideEnabledDRWithoutPortLevelmTLSOptions(t *testing.T) {
 			// Mesh-wide DR enabling mTLS communication
 			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 		},
 	}
 
@@ -81,6 +87,8 @@ func TestMTLSMeshWideEnabledDRWithTrafficPolicy(t *testing.T) {
 			// Mesh-wide DR enabling mTLS communication
 			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 		},
 	}
 
@@ -102,6 +110,8 @@ func TestMTLSMeshWideEnabledDRWithPortLevelTLSTrafficPolicy(t *testing.T) {
 			// Mesh-wide DR enabling mTLS communication
 			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 		},
 	}
 
@@ -123,6 +133,8 @@ func TestNamespacemTLSEnabledDRWithoutTrafficPolicy(t *testing.T) {
 			// Namespace-wide DR enabling mTLS communication
 			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 		},
 	}
 
@@ -143,6 +155,8 @@ func TestNamespacemTLSEnabledDRWithoutmTLSOptions(t *testing.T) {
 			// Namespace-wide DR enabling mTLS communication
 			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 		},
 	}
 
@@ -164,6 +178,8 @@ func TestNamespacemTLSEnabledDRWithTrafficPolicy(t *testing.T) {
 			// Namespace-wide DR enabling mTLS communication
 			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
 		},
 	}
 

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -89,6 +89,7 @@ func mockCombinedValidationService(istioObjects *kubernetes.IstioDetails, servic
 	k8s.On("GetServiceEntries", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().ServiceEntries, nil)
 	k8s.On("GetGateways", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().Gateways, nil)
 	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(kubetest.FakeNamespace("test"), nil)
+	k8s.On("GetMeshPolicies", mock.AnythingOfType("string")).Return(fakeMeshPolicies(), nil)
 
 	k8s.On("GetGateways", "test", mock.AnythingOfType("string")).Return(getGateway("first"), nil)
 	k8s.On("GetGateways", "test2", mock.AnythingOfType("string")).Return(getGateway("second"), nil)
@@ -120,14 +121,21 @@ func getGateway(name string) []kubernetes.IstioObject {
 		}))}
 }
 
+func fakeMeshPolicies() []kubernetes.IstioObject {
+	return []kubernetes.IstioObject{
+		data.CreateEmptyMeshPolicy("default", nil),
+		data.CreateEmptyMeshPolicy("test", nil),
+	}
+}
+
 func fakeNamespaces() []v1.Namespace {
 	return []v1.Namespace{
-		v1.Namespace{
+		{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: "test",
 			},
 		},
-		v1.Namespace{
+		{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: "test2",
 			},
@@ -155,7 +163,7 @@ func fakeCombinedServices(services []string) []v1.Service {
 func fakePods() *v1.PodList {
 	return &v1.PodList{
 		Items: []v1.Pod{
-			v1.Pod{
+			{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "reviews-12345-hello",
 					Labels: map[string]string{
@@ -164,7 +172,7 @@ func fakePods() *v1.PodList {
 					},
 				},
 			},
-			v1.Pod{
+			{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "reviews-54321-hello",
 					Labels: map[string]string{

--- a/business/layer.go
+++ b/business/layer.go
@@ -52,7 +52,7 @@ func NewWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	temporaryLayer.Svc = SvcService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.IstioConfig = IstioConfigService{k8s: k8s}
 	temporaryLayer.Workload = WorkloadService{k8s: k8s, prom: prom, businessLayer: temporaryLayer}
-	temporaryLayer.Validations = IstioValidationsService{k8s: k8s, ws: temporaryLayer.Workload}
+	temporaryLayer.Validations = IstioValidationsService{k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.App = AppService{prom: prom, k8s: k8s}
 	temporaryLayer.Namespace = NewNamespaceService(k8s)
 	temporaryLayer.k8s = k8s

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -474,6 +474,12 @@ type IstioDetails struct {
 	Gateways         []IstioObject `json:"gateways"`
 }
 
+// MTLSDetails is a wrapper to group all Istio objects related to non-local mTLS configurations
+type MTLSDetails struct {
+	DestinationRules []IstioObject `json:"destinationrules"`
+	MeshPolicies     []IstioObject `json:"meshpolicies"`
+}
+
 type istioResponse struct {
 	result  IstioObject
 	results []IstioObject

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -86,8 +86,8 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "This subset's labels are not found from any matching host",
 		Severity: ErrorSeverity,
 	},
-	"destinationrules.trafficpolicy.meshmtls": {
-		Message:  "This DestinationRule disables mTLS specified by another mesh-wide DestinationRule.",
+	"destinationrules.trafficpolicy.notlssettings": {
+		Message:  "mTLS settings of a non-local Destination Rule are overridden",
 		Severity: WarningSeverity,
 	},
 	"gateways.multimatch": {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -86,6 +86,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "This subset's labels are not found from any matching host",
 		Severity: ErrorSeverity,
 	},
+	"destinationrules.trafficpolicy.meshmtls": {
+		Message:  "This DestinationRule disables mTLS specified by another mesh-wide DestinationRule.",
+		Severity: WarningSeverity,
+	},
 	"gateways.multimatch": {
 		Message:  "More than one Gateway for the same host port combination",
 		Severity: WarningSeverity,
@@ -136,6 +140,10 @@ func Build(checkId string, path string) IstioCheck {
 	check := checkDescriptors[checkId]
 	check.Path = path
 	return check
+}
+
+func BuildKey(objectType, name string) IstioValidationKey {
+	return IstioValidationKey{ObjectType: objectType, Name: name}
 }
 
 func CheckMessage(checkId string) string {

--- a/tests/data/destination_rules_data.go
+++ b/tests/data/destination_rules_data.go
@@ -58,3 +58,11 @@ func CreateMTLSTrafficPolicyForDestinationRules() map[string]interface{} {
 		},
 	}
 }
+
+func CreateLoadBalancerTrafficPolicyForDestinationRules() map[string]interface{} {
+	return map[string]interface{}{
+		"loadBalancer": map[string]interface{}{
+			"simple": "ROUND_ROBIN",
+		},
+	}
+}

--- a/tests/data/destination_rules_data.go
+++ b/tests/data/destination_rules_data.go
@@ -66,3 +66,33 @@ func CreateLoadBalancerTrafficPolicyForDestinationRules() map[string]interface{}
 		},
 	}
 }
+
+func CreatePortLevelTrafficPolicyForDestinationRules() map[string]interface{} {
+	return map[string]interface{}{
+		"portLevelSettings": []interface{}{
+			map[string]interface{}{
+				"port": map[string]interface{}{
+					"number": 9080,
+				},
+				"loadBalancer": map[string]interface{}{
+					"simple": "ROUND_ROBIN",
+				},
+			},
+		},
+	}
+}
+
+func CreateTLSPortLevelTrafficPolicyForDestinationRules() map[string]interface{} {
+	return map[string]interface{}{
+		"portLevelSettings": []interface{}{
+			map[string]interface{}{
+				"port": map[string]interface{}{
+					"number": 9080,
+				},
+				"tls": map[string]interface{}{
+					"mode": "SIMPLE",
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
** Describe the change **
This PR adds a warning into IstioConfig section whenever a Destination Rule doesn't specify any tls and there is one Destination Rule setting up a non-local TLS rule.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2094

** Backwards incompatible? **
yes

** screenshots **

With warnings:

No trafficPolicy mentioned:
![screenshot of kiali console 38](https://user-images.githubusercontent.com/613814/52726501-995a6380-2fb3-11e9-992e-dddbdcebe1ec.png)

No TLS references in trafficPolicy level:
![screenshot of kiali console 39](https://user-images.githubusercontent.com/613814/52726741-12f25180-2fb4-11e9-8b62-77ca31a665a5.png)

No TLS references in Port Level
![screenshot of kiali console 34](https://user-images.githubusercontent.com/613814/52726256-251fc000-2fb3-11e9-9b8a-510d5266376e.png)


Without warning scenarios:
There are no warnings when you have TLS settings in either trafficPolicy or port level.

![screenshot of kiali console 37](https://user-images.githubusercontent.com/613814/52726263-294bdd80-2fb3-11e9-9a0f-55e8d8be7b56.png)
![screenshot of kiali console 36](https://user-images.githubusercontent.com/613814/52726261-27821a00-2fb3-11e9-8af3-751f2f46f83d.png)
![screenshot of kiali console 33](https://user-images.githubusercontent.com/613814/52726251-2355fc80-2fb3-11e9-8811-a2ae7152fbc3.png)
![screenshot of kiali console 35](https://user-images.githubusercontent.com/613814/52726260-2650ed00-2fb3-11e9-9a7c-8ae877a349a5.png)

All the yamls tested are compressed in here: [kiali-2094.zip](https://github.com/kiali/kiali/files/2861244/kiali-2094.zip)