### PR TITLE
KIALI-2390 Allow VirtualService gateway check to validate all namespaces

### DIFF
--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -23,7 +23,7 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 
 	if host, ok := n.DestinationRule.GetSpec()["host"]; ok {
 		if dHost, ok := host.(string); ok {
-			fqdn := FormatHostnameForPrefixSearch(dHost, n.DestinationRule.GetObjectMeta().Namespace, n.DestinationRule.GetObjectMeta().ClusterName)
+			fqdn := kubernetes.ParseHost(dHost, n.DestinationRule.GetObjectMeta().Namespace, n.DestinationRule.GetObjectMeta().ClusterName)
 			if !n.hasMatchingService(fqdn.Service) {
 				validation := models.Build("destinationrules.nodest.matchingworkload", "spec/host")
 				validations = append(validations, &validation)

--- a/business/checkers/destinationrules/traffic_policy_checker.go
+++ b/business/checkers/destinationrules/traffic_policy_checker.go
@@ -38,7 +38,7 @@ func (t TrafficPolicyChecker) isNonLocalmTLSEnabled() bool {
 	for _, dr := range t.MTLSDetails.DestinationRules {
 		if host, ok := dr.GetSpec()["host"]; ok {
 			if dHost, ok := host.(string); ok {
-				fqdn := FormatHostnameForPrefixSearch(dHost, dr.GetObjectMeta().Namespace, dr.GetObjectMeta().ClusterName)
+				fqdn := kubernetes.ParseHost(dHost, dr.GetObjectMeta().Namespace, dr.GetObjectMeta().ClusterName)
 				if isNonLocalmTLSForServiceEnabled(dr, fqdn.Service) {
 					return true
 				}

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -17,7 +17,7 @@ func TestCorrectGateways(t *testing.T) {
 	assert := assert.New(t)
 
 	gwObject := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
-		data.CreateEmptyGateway("validgateway", map[string]string{
+		data.CreateEmptyGateway("validgateway", "test", map[string]string{
 			"app": "real",
 		}))
 
@@ -39,13 +39,13 @@ func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 	assert := assert.New(t)
 
 	gwObject := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
-		data.CreateEmptyGateway("validgateway", map[string]string{
+		data.CreateEmptyGateway("validgateway", "test", map[string]string{
 			"app": "real",
 		}))
 
 	// Another namespace
 	gwObject2 := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
-		data.CreateEmptyGateway("stillvalid", map[string]string{
+		data.CreateEmptyGateway("stillvalid", "test", map[string]string{
 			"app": "someother",
 		}))
 
@@ -69,19 +69,19 @@ func TestWildCardMatchingHost(t *testing.T) {
 	assert := assert.New(t)
 
 	gwObject := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
-		data.CreateEmptyGateway("validgateway", map[string]string{
+		data.CreateEmptyGateway("validgateway", "test", map[string]string{
 			"app": "real",
 		}))
 
 	// Another namespace
 	gwObject2 := data.AddServerToGateway(data.CreateServer([]string{"*"}, 80, "http", "http"),
-		data.CreateEmptyGateway("stillvalid", map[string]string{
+		data.CreateEmptyGateway("stillvalid", "test", map[string]string{
 			"app": "someother",
 		}))
 
 	// Another namespace
 	gwObject3 := data.AddServerToGateway(data.CreateServer([]string{"*.justhost.com"}, 80, "http", "http"),
-		data.CreateEmptyGateway("keepsvalid", map[string]string{
+		data.CreateEmptyGateway("keepsvalid", "test", map[string]string{
 			"app": "someother",
 		}))
 
@@ -106,13 +106,13 @@ func TestTwoWildCardsMatching(t *testing.T) {
 	assert := assert.New(t)
 
 	gwObject := data.AddServerToGateway(data.CreateServer([]string{"*"}, 80, "http", "http"),
-		data.CreateEmptyGateway("validgateway", map[string]string{
+		data.CreateEmptyGateway("validgateway", "test", map[string]string{
 			"app": "real",
 		}))
 
 	// Another namespace
 	gwObject2 := data.AddServerToGateway(data.CreateServer([]string{"*"}, 80, "http", "http"),
-		data.CreateEmptyGateway("stillvalid", map[string]string{
+		data.CreateEmptyGateway("stillvalid", "test", map[string]string{
 			"app": "someother",
 		}))
 

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -9,10 +9,11 @@ import (
 )
 
 type NoServiceChecker struct {
-	Namespace    string
-	IstioDetails *kubernetes.IstioDetails
-	Services     []v1.Service
-	WorkloadList models.WorkloadList
+	Namespace            string
+	IstioDetails         *kubernetes.IstioDetails
+	Services             []v1.Service
+	WorkloadList         models.WorkloadList
+	GatewaysPerNamespace [][]kubernetes.IstioObject
 }
 
 func (in NoServiceChecker) Check() models.IstioValidations {
@@ -24,7 +25,7 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 
 	serviceNames := getServiceNames(in.Services)
 	serviceHosts := kubernetes.ServiceEntryHostnames(in.IstioDetails.ServiceEntries)
-	gatewayNames := kubernetes.GatewayNames(in.IstioDetails.Gateways)
+	gatewayNames := kubernetes.GatewayNames(in.GatewaysPerNamespace)
 
 	for _, virtualService := range in.IstioDetails.VirtualServices {
 		validations.MergeValidations(runVirtualServiceCheck(virtualService, in.Namespace, serviceNames, serviceHosts))

--- a/business/checkers/virtual_services/no_gateway_checker.go
+++ b/business/checkers/virtual_services/no_gateway_checker.go
@@ -16,7 +16,7 @@ type NoGatewayChecker struct {
 func (s NoGatewayChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
-	valid, index := kubernetes.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.GatewayNames, s.VirtualService.GetObjectMeta().Namespace)
+	valid, index := kubernetes.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.GatewayNames, s.VirtualService.GetObjectMeta().Namespace, s.VirtualService.GetObjectMeta().ClusterName)
 	if !valid {
 		path := "spec/gateways[" + strconv.Itoa(index) + "]"
 		validation := models.Build("virtualservices.nogateway", path)

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -262,7 +262,7 @@ func mockGetIstioConfigList() IstioConfigService {
 }
 
 func fakeGetGateways() []kubernetes.IstioObject {
-	gw1 := data.CreateEmptyGateway("gw-1", map[string]string{
+	gw1 := data.CreateEmptyGateway("gw-1", "test", map[string]string{
 		"app": "my-gateway1-controller",
 	})
 
@@ -283,7 +283,7 @@ func fakeGetGateways() []kubernetes.IstioObject {
 		},
 	}
 
-	gw2 := data.CreateEmptyGateway("gw-2", map[string]string{
+	gw2 := data.CreateEmptyGateway("gw-2", "test", map[string]string{
 		"app": "my-gateway2-controller",
 	})
 

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/api/apps/v1beta2"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
@@ -77,6 +77,9 @@ func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 	k8s.On("GetGateways", "test2", mock.AnythingOfType("string")).Return(getGateway("second"), nil)
 	k8s.On("GetNamespaces").Return(fakeNamespaces(), nil)
 	mockWorkLoadService(k8s)
+	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().DestinationRules, nil)
+	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails(), nil)
+	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return(fakeCombinedServices([]string{""}), nil)
 
 	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil)}
 }
@@ -120,7 +123,7 @@ func fakeCombinedIstioDetails() *kubernetes.IstioDetails {
 
 func getGateway(name string) []kubernetes.IstioObject {
 	return []kubernetes.IstioObject{data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
-		data.CreateEmptyGateway(name, map[string]string{
+		data.CreateEmptyGateway(name, "test", map[string]string{
 			"app": "real",
 		}))}
 }

--- a/tests/data/gateway_data.go
+++ b/tests/data/gateway_data.go
@@ -1,18 +1,21 @@
 package data
 
 import (
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func CreateEmptyGateway(name string, selector map[string]string) kubernetes.IstioObject {
+func CreateEmptyGateway(name, namespace string, selector map[string]string) kubernetes.IstioObject {
 	iSelector := make(map[string]interface{}, len(selector))
 	for k, v := range selector {
 		iSelector[k] = v
 	}
 	gateway := kubernetes.GenericIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: name,
+			Name:        name,
+			Namespace:   namespace,
+			ClusterName: config.Get().ExternalServices.Istio.IstioIdentityDomain,
 		},
 		Spec: map[string]interface{}{
 			"selector": iSelector,


### PR DESCRIPTION
** Describe the change **

If FQDN format is used for the given gateway host, check against all namespaces and their gateways for a match. We already check all namespaces for gateway existing, so doing it for the VirtualServices makes sense also.

Also, added Host type to the kubernetes/types.go since this format is used in multiple places. Might be worth doing all internal checks with FQDN in the future (but this PR only adds that to few places).

** Issue reference **

KIALI-2390, issue #767 

** Backwards incompatible? **

Yes
