### PR TITLE
KIALI-2403 looks like the latest Istio 1.1 changed istio-pilot port. We need thi…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -224,7 +224,7 @@ func NewConfig() (c *Config) {
 	// Istio Configuration
 	c.ExternalServices.Istio.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))
 	c.ExternalServices.Istio.IstioSidecarAnnotation = strings.TrimSpace(getDefaultString(EnvIstioSidecarAnnotation, "sidecar.istio.io/status"))
-	c.ExternalServices.Istio.UrlServiceVersion = strings.TrimSpace(getDefaultString(EnvIstioUrlServiceVersion, "http://istio-pilot:9093/version"))
+	c.ExternalServices.Istio.UrlServiceVersion = strings.TrimSpace(getDefaultString(EnvIstioUrlServiceVersion, "http://istio-pilot:8080/version"))
 
 	// Token-based authentication Configuration
 	c.LoginToken.SigningKey = []byte(strings.TrimSpace(getDefaultString(EnvLoginTokenSigningKey, "kiali")))


### PR DESCRIPTION
 We need this to get the version string of Istio. This bad URL causes the about box to break and api/status to fail
