### PR TITLE
KIALI-2419 Subset name can be nil if Galley is not acting

### DIFF
--- a/business/checkers/virtual_services/subset_presence_checker.go
+++ b/business/checkers/virtual_services/subset_presence_checker.go
@@ -122,11 +122,13 @@ func hasSubsetDefined(destinationRule kubernetes.IstioObject, subsetTarget strin
 		if dSubsets, ok := subsets.([]interface{}); ok {
 			for _, subset := range dSubsets {
 				if innerSubset, ok := subset.(map[string]interface{}); ok {
-					subsetName := innerSubset["name"].(string)
-					if subsetName == subsetTarget {
-						if labels, ok := innerSubset["labels"]; ok {
-							if _, ok := labels.(map[string]interface{}); ok {
-								return true
+					if sSubsetName := innerSubset["name"]; ok {
+						subsetName := sSubsetName.(string)
+						if subsetName == subsetTarget {
+							if labels, ok := innerSubset["labels"]; ok {
+								if _, ok := labels.(map[string]interface{}); ok {
+									return true
+								}
 							}
 						}
 					}


### PR DESCRIPTION
** Describe the change **

In theory, when Gallely is working, the VS/DR should be well formed, but if not, there can be a boggus resource which need extra check for nil values.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2419