### PR TITLE
KIALI-2327 Add linters to lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,11 +316,12 @@ gometalinter-install:
 
 ## lint. Runs gometalinter
 lint:
-	gometalinter --disable-all  --enable=vet --enable=vetshadow --enable=varcheck --enable=structcheck \
-	--enable=ineffassign --enable=unconvert --enable=goimports --enable=gosimple --enable=staticcheck --tests  --vendor ./...
+	gometalinter --disable-all  --enable=vet --enable=varcheck --enable=structcheck \
+	--enable=ineffassign --enable=unconvert --enable=goimports \
+	--tests  --vendor --deadline=60s ./...
 
 ## lint-all. Runs gometalinter with items from good to have list but does not run during travis
 lint-all:
 	gometalinter --disable-all --enable=vet --enable=vetshadow --enable=varcheck --enable=structcheck \
-	--enable=ineffassign --enable=unconvert --enable=goimports --enable=gosimple --enable=staticcheck \
-	--enable=nakedret --tests  --vendor ./...
+	--enable=ineffassign --enable=unconvert --enable=goimports --enable=staticcheck \
+	--tests  --vendor --deadline=60s ./...

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,8 @@ gometalinter-install:
 
 ## lint. Runs gometalinter
 lint:
-	gometalinter --disable-all  --enable=vet --enable=vetshadow --enable=varcheck --tests  --vendor ./...
+	gometalinter --disable-all  --enable=vet --enable=vetshadow --enable=varcheck --enable=structcheck \
+	--enable=ineffassign --tests  --vendor ./...
 
 ## lint-all. Runs gometalinter with items from good to have list but does not run during travis
 lint-all:

--- a/Makefile
+++ b/Makefile
@@ -317,10 +317,10 @@ gometalinter-install:
 ## lint. Runs gometalinter
 lint:
 	gometalinter --disable-all  --enable=vet --enable=vetshadow --enable=varcheck --enable=structcheck \
-	--enable=ineffassign --enable=unconvert --enable=goimports --tests  --vendor ./...
+	--enable=ineffassign --enable=unconvert --enable=goimports --enable=gosimple --enable=staticcheck --tests  --vendor ./...
 
 ## lint-all. Runs gometalinter with items from good to have list but does not run during travis
 lint-all:
 	gometalinter --disable-all --enable=vet --enable=vetshadow --enable=varcheck --enable=structcheck \
-	--enable=ineffassign --enable=unconvert --enable=goimports -enable=gosimple --enable=staticcheck \
+	--enable=ineffassign --enable=unconvert --enable=goimports --enable=gosimple --enable=staticcheck \
 	--enable=nakedret --tests  --vendor ./...

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ gometalinter-install:
 
 ## lint. Runs gometalinter
 lint:
-	gometalinter --disable-all  --enable=vet --tests  --vendor ./...
+	gometalinter --disable-all  --enable=vet --enable=vetshadow --enable=varcheck --tests  --vendor ./...
 
 ## lint-all. Runs gometalinter with items from good to have list but does not run during travis
 lint-all:

--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ gometalinter-install:
 ## lint. Runs gometalinter
 lint:
 	gometalinter --disable-all  --enable=vet --enable=vetshadow --enable=varcheck --enable=structcheck \
-	--enable=ineffassign --tests  --vendor ./...
+	--enable=ineffassign --enable=unconvert --enable=goimports --tests  --vendor ./...
 
 ## lint-all. Runs gometalinter with items from good to have list but does not run during travis
 lint-all:

--- a/business/apps.go
+++ b/business/apps.go
@@ -21,27 +21,6 @@ type AppService struct {
 	k8s  kubernetes.IstioClientInterface
 }
 
-// Temporal map of Workloads group by app label
-type appsWorkload map[string][]*models.Workload
-
-// Helper method to build a map of workloads for a given labelSelector
-func (in *AppService) fetchWorkloadsPerApp(namespace, labelSelector string) (appsWorkload, error) {
-	cfg := config.Get()
-
-	ws, err := fetchWorkloads(in.k8s, namespace, labelSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	apps := make(appsWorkload)
-	for _, w := range ws {
-		if appLabel, ok := w.Labels[cfg.IstioLabels.AppLabelName]; ok {
-			apps[appLabel] = append(apps[appLabel], w)
-		}
-	}
-	return apps, nil
-}
-
 // GetAppList is the API handler to fetch the list of applications in a given namespace
 func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
 	var err error

--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -1,8 +1,8 @@
 package business
 
 import (
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes/kubetest"
+	"testing"
+
 	osappsv1 "github.com/openshift/api/apps/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -11,7 +11,9 @@ import (
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
-	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
 func setupAppService(k8s *kubetest.K8SClientMock) AppService {

--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -19,7 +19,7 @@ func TestMissingGateway(t *testing.T) {
 	virtualService := data.AddGatewaysToVirtualService([]string{"my-gateway", "mesh"}, data.CreateVirtualService())
 	checker := NoGatewayChecker{
 		VirtualService: virtualService,
-		GatewayNames:   make(map[string]struct{}, 0),
+		GatewayNames:   make(map[string]struct{}),
 	}
 
 	validations, valid := checker.Check()

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -30,11 +30,11 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 
 	// Ensure the service or namespace exists.. do we need to block with this?
 	if service != "" {
-		if _, err := in.k8s.GetService(namespace, service); err != nil {
+		if _, err = in.k8s.GetService(namespace, service); err != nil {
 			return nil, err
 		}
 	} else {
-		if _, err := in.k8s.GetNamespace(namespace); err != nil {
+		if _, err = in.k8s.GetNamespace(namespace); err != nil {
 			return nil, err
 		}
 	}

--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/kiali/kiali/log"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
 )
 
 type Trace struct {
@@ -49,7 +49,7 @@ func getErrorTracesFromJaeger(namespace string, service string) (errorTraces int
 			q.Set("end", fmt.Sprintf("%d", t))
 			q.Set("tags", "{\"error\":\"true\"}")
 			u.RawQuery = q.Encode()
-			timeout := time.Duration(1000 * time.Millisecond)
+			timeout := 1000 * time.Millisecond
 			client := http.Client{
 				Timeout: timeout,
 			}
@@ -65,7 +65,7 @@ func getErrorTracesFromJaeger(namespace string, service string) (errorTraces int
 					return -1, err
 				}
 				var traces RequestTrace
-				if errMarshal := json.Unmarshal([]byte(body), &traces); errMarshal != nil {
+				if errMarshal := json.Unmarshal(body, &traces); errMarshal != nil {
 					log.Errorf("Error Unmarshal Jaeger Response fetching Error Traces: %s", errRead)
 					err = errMarshal
 					return -1, err
@@ -85,7 +85,7 @@ func GetServices() (services JaegerServices, err error) {
 		log.Errorf("Error parse Jaeger URL fetching Services: %s", err)
 		return services, err
 	}
-	timeout := time.Duration(1000 * time.Millisecond)
+	timeout := 1000 * time.Millisecond
 	client := http.Client{
 		Timeout: timeout,
 	}
@@ -100,20 +100,11 @@ func GetServices() (services JaegerServices, err error) {
 			err = errRead
 			return services, err
 		}
-		if errMarshal := json.Unmarshal([]byte(body), &services); errMarshal != nil {
+		if errMarshal := json.Unmarshal(body, &services); errMarshal != nil {
 			log.Errorf("Error Unmarshal Jaeger Response fetching Services: %s", errRead)
 			err = errMarshal
 			return services, err
 		}
 	}
 	return services, err
-}
-
-func contains(a []string, x string) bool {
-	for _, n := range a {
-		if x == n {
-			return true
-		}
-	}
-	return false
 }

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -1,12 +1,13 @@
 package business
 
 import (
+	"time"
+
 	osappsv1 "github.com/openshift/api/apps/v1"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/apps/v1beta2"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 
 	"github.com/kiali/kiali/config"
 )

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -2,7 +2,6 @@ package business
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
 	"testing"
 
 	osappsv1 "github.com/openshift/api/apps/v1"
@@ -12,6 +11,7 @@ import (
 	"k8s.io/api/apps/v1beta2"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
+	"k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes/kubetest"

--- a/config/config.go
+++ b/config/config.go
@@ -233,7 +233,7 @@ func NewConfig() (c *Config) {
 	c.KubernetesConfig.Burst = getDefaultInt(EnvKubernetesBurst, 200)
 	c.KubernetesConfig.QPS = getDefaultFloat32(EnvKubernetesQPS, 175)
 	c.KubernetesConfig.CacheEnabled = getDefaultBool(EnvKubernetesCacheEnabled, false)
-	c.KubernetesConfig.CacheDuration = getDefaultInt64(EnvKubernetesCacheDuration, time.Duration(5*time.Minute).Nanoseconds())
+	c.KubernetesConfig.CacheDuration = getDefaultInt64(EnvKubernetesCacheDuration, (5 * time.Minute).Nanoseconds())
 
 	trimmedExclusionPatterns := []string{}
 	for _, entry := range c.API.Namespaces.Exclude {

--- a/config/security/config_security_test.go
+++ b/config/security/config_security_test.go
@@ -5,9 +5,7 @@ import (
 )
 
 func TestValidateCredentials(t *testing.T) {
-	var creds *Credentials
-
-	creds = &Credentials{}
+	creds := &Credentials{}
 	if err := creds.ValidateCredentials(); err != nil {
 		t.Errorf("Empty credentials should be valid: %v", err)
 	}

--- a/graph/appender/dead_node_test.go
+++ b/graph/appender/dead_node_test.go
@@ -134,7 +134,7 @@ func TestDeadNode(t *testing.T) {
 
 	assert.Equal(9, len(trafficMap))
 
-	unknownNode, found = trafficMap[unknownId]
+	_, found = trafficMap[unknownId]
 	assert.Equal(false, found)
 
 	ingressNode, found = trafficMap[ingressId]
@@ -211,43 +211,43 @@ func testTrafficMap() map[string]*graph.Node {
 	trafficMap[n9.ID] = &n9
 	trafficMap[n10.ID] = &n10
 
-	e := n0.AddEdge(&n1)
-	e = n00.AddEdge(&n1)
+	n0.AddEdge(&n1)
+	e := n00.AddEdge(&n1)
 	e.Metadata["http"] = 0.8
 
-	e = n0.AddEdge(&n2)
+	n0.AddEdge(&n2)
 	e = n00.AddEdge(&n2)
 	e.Metadata["http"] = 0.8
 
-	e = n0.AddEdge(&n3)
+	n0.AddEdge(&n3)
 	e = n00.AddEdge(&n3)
 	e.Metadata["http"] = 0.8
 
-	e = n0.AddEdge(&n4)
+	n0.AddEdge(&n4)
 	e = n00.AddEdge(&n4)
 	e.Metadata["http"] = 0.0
 
-	e = n0.AddEdge(&n5)
+	n0.AddEdge(&n5)
 	e = n00.AddEdge(&n5)
 	e.Metadata["http"] = 0.8
 
-	e = n0.AddEdge(&n6)
+	n0.AddEdge(&n6)
 	e = n00.AddEdge(&n6)
 	e.Metadata["http"] = 0.0
 
-	e = n0.AddEdge(&n7)
+	n0.AddEdge(&n7)
 	e = n00.AddEdge(&n7)
 	e.Metadata["tcp"] = 74.1
 
-	e = n0.AddEdge(&n8)
+	n0.AddEdge(&n8)
 	e = n00.AddEdge(&n8)
 	e.Metadata["tcp"] = 74.1
 
-	e = n0.AddEdge(&n9)
+	n0.AddEdge(&n9)
 	e = n00.AddEdge(&n9)
 	e.Metadata["http"] = 0.8
 
-	e = n0.AddEdge(&n10)
+	n0.AddEdge(&n10)
 	e = n00.AddEdge(&n10)
 	e.Metadata["http"] = 0.8
 

--- a/graph/appender/istio_details.go
+++ b/graph/appender/istio_details.go
@@ -71,7 +71,7 @@ NODES:
 			}
 		case !versionOk && (n.NodeType == graph.NodeTypeApp):
 			if destServices, ok := n.Metadata["destServices"]; ok {
-				for serviceName, _ := range destServices.(map[string]bool) {
+				for serviceName := range destServices.(map[string]bool) {
 					for _, destinationRule := range istioCfg.DestinationRules.Items {
 						if destinationRule.HasCircuitBreaker(namespace, serviceName, "") {
 							n.Metadata["hasCB"] = true
@@ -82,7 +82,7 @@ NODES:
 			}
 		case versionOk:
 			if destServices, ok := n.Metadata["destServices"]; ok {
-				for serviceName, _ := range destServices.(map[string]bool) {
+				for serviceName := range destServices.(map[string]bool) {
 					for _, destinationRule := range istioCfg.DestinationRules.Items {
 						if destinationRule.HasCircuitBreaker(namespace, serviceName, n.Version) {
 							n.Metadata["hasCB"] = true

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -185,19 +185,3 @@ func addToMetadataValue(md map[string]interface{}, k string, v float64) {
 		md[k] = v
 	}
 }
-
-func averageMetadataValue(md map[string]interface{}, k string, v float64) {
-	total := v
-	count := 1.0
-	kTotal := k + "_total"
-	kCount := k + "_count"
-	if prevTotal, ok := md[kTotal]; ok {
-		total += prevTotal.(float64)
-	}
-	if prevCount, ok := md[kCount]; ok {
-		count += prevCount.(float64)
-	}
-	md[kTotal] = total
-	md[kCount] = count
-	md[k] = total / count
-}

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -98,7 +98,7 @@ func addToMetadataGrpc(val float64, code string, sourceMetadata, destMetadata, e
 
 	// Istio telemetry may use HTTP codes for gRPC, so if it quacks like a duck...
 	isHttpCode := len(code) == 3
-	isErr := false
+	var isErr bool
 	if isHttpCode {
 		isErr = strings.HasPrefix(code, "4") || strings.HasPrefix(code, "5")
 	} else {

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -73,8 +73,8 @@ func getPrometheusConfig() PrometheusConfig {
 		var config PrometheusPartialConfig
 		if checkErr(yaml.Unmarshal([]byte(configResult.YAML), &config), "Failed to unmarshal Prometheus configuration") {
 			scrapeIntervalString := config.Global.Scrape_interval
-			scrapeInterval, err := time.ParseDuration(scrapeIntervalString)
-			if checkErr(err, fmt.Sprintf("Invalid global scrape interval [%s]", scrapeIntervalString)) {
+			scrapeInterval, err2 := time.ParseDuration(scrapeIntervalString)
+			if checkErr(err2, fmt.Sprintf("Invalid global scrape interval [%s]", scrapeIntervalString)) {
 				promConfig.GlobalScrapeInterval = int64(scrapeInterval.Seconds())
 			}
 		}
@@ -83,8 +83,8 @@ func getPrometheusConfig() PrometheusConfig {
 	flags, err := client.GetFlags()
 	if checkErr(err, "Failed to fetch Prometheus flags") {
 		if retentionString, ok := flags["storage.tsdb.retention"]; ok {
-			retention, err := time.ParseDuration(retentionString)
-			if checkErr(err, fmt.Sprintf("Invalid storage.tsdb.retention [%s]", retentionString)) {
+			retention, err2 := time.ParseDuration(retentionString)
+			if checkErr(err2, fmt.Sprintf("Invalid storage.tsdb.retention [%s]", retentionString)) {
 				promConfig.StorageTsdbRetention = int64(retention.Seconds())
 			}
 		}

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -923,16 +923,16 @@ func handlePanic(w http.ResponseWriter) {
 	code := http.StatusInternalServerError
 	if r := recover(); r != nil {
 		var message string
-		switch r.(type) {
+		switch r := r.(type) {
 		case string:
-			message = r.(string)
+			message = r
 		case error:
-			message = r.(error).Error()
+			message = r.Error()
 		case func() string:
-			message = r.(func() string)()
+			message = r()
 		case graph.Response:
-			message = r.(graph.Response).Message
-			code = r.(graph.Response).Code
+			message = r.Message
+			code = r.Code
 		default:
 			message = fmt.Sprintf("%v", r)
 		}

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -240,7 +240,6 @@ func IstioConfigDelete(w http.ResponseWriter, r *http.Request) {
 		audit(r, "DELETE on Namespace: "+namespace+" Type: "+objectType+" Subtype: "+objectSubtype+" Name: "+object)
 		RespondWithCode(w, http.StatusOK)
 	}
-	return
 }
 
 func IstioConfigUpdate(w http.ResponseWriter, r *http.Request) {

--- a/handlers/istio_config_test.go
+++ b/handlers/istio_config_test.go
@@ -1,8 +1,9 @@
 package handlers
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseListParams(t *testing.T) {

--- a/kiali.go
+++ b/kiali.go
@@ -18,7 +18,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/kiali/kiali/business"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus/internalmetrics"

--- a/kubernetes/istio_rules_service.go
+++ b/kubernetes/istio_rules_service.go
@@ -91,9 +91,7 @@ func (in *IstioClient) getAdaptersTemplates(namespace string, itemType string, p
 	for i := 0; i < len(pluralsMap); i++ {
 		adapterTemplate := <-resultsChan
 		if adapterTemplate.err == nil {
-			for _, istioObject := range adapterTemplate.results {
-				results = append(results, istioObject)
-			}
+			results = append(results, adapterTemplate.results...)
 		} else {
 			log.Warningf("Querying %s got an error: %s", itemType, adapterTemplate.err)
 		}

--- a/kubernetes/istio_rules_service.go
+++ b/kubernetes/istio_rules_service.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+
 	"github.com/kiali/kiali/log"
 )
 

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -484,7 +484,6 @@ type MTLSDetails struct {
 }
 
 type istioResponse struct {
-	result  IstioObject
 	results []IstioObject
 	err     error
 }

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -73,7 +73,6 @@ const (
 	fluentds        = "fluentds"
 	fluentdType     = "fluentd"
 	fluentdTypeList = "fluentdList"
-	fluentdLabel    = "fluentd"
 
 	handlers        = "handlers"
 	handlerType     = "handler"

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -1,10 +1,10 @@
 package models
 
 import (
-	"k8s.io/api/core/v1"
 	"time"
 
 	osv1 "github.com/openshift/api/project/v1"
+	"k8s.io/api/core/v1"
 )
 
 // A Namespace provide a scope for names

--- a/models/pod.go
+++ b/models/pod.go
@@ -51,10 +51,8 @@ func (pods *Pods) Parse(list []v1.Pod) {
 	}
 }
 
-// Below types are used for unmarshalling json
-type createdBy struct {
-	Reference Reference `json:"reference"`
-}
+// Below type is used for unmarshalling json
+
 type sideCarStatus struct {
 	Containers     []string `json:"containers"`
 	InitContainers []string `json:"initContainers"`

--- a/prometheus/internalmetrics/internal_metrics_test.go
+++ b/prometheus/internalmetrics/internal_metrics_test.go
@@ -29,7 +29,7 @@ func TestSuccessOrFailureMetric(t *testing.T) {
 
 	// simulate a failure - our failure counter metric should increment to 1
 	doSomeWork(true)
-	metrics, err = registry.Gather()
+	metrics, _ = registry.Gather()
 	if len(metrics) != 2 {
 		t.Errorf("Should have metrics now")
 	}
@@ -49,7 +49,7 @@ func TestSuccessOrFailureMetric(t *testing.T) {
 
 	// simulate a success
 	doSomeWork(false)
-	metrics, err = registry.Gather()
+	metrics, _ = registry.Gather()
 
 	for _, m := range metrics {
 		if m.GetName() == "kiali_go_function_failures_total" {

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -80,7 +80,7 @@ func fetchAllMetrics(api v1.API, q *IstioMetricsQuery, labels, labelsError, grou
 		definition istioMetric
 	}
 	maxResults := len(istioMetrics)
-	results := make([]*resultHolder, maxResults, maxResults)
+	results := make([]*resultHolder, maxResults)
 
 	for i, istioMetric := range istioMetrics {
 		// if filters is empty, fetch all anyway

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -3,7 +3,6 @@ package prometheus
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -13,10 +12,6 @@ import (
 
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
-)
-
-var (
-	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 )
 
 func getMetrics(api v1.API, q *IstioMetricsQuery) Metrics {
@@ -172,18 +167,6 @@ func fetchHistogramRange(api v1.API, metricName, labels, grouping string, q *Bas
 	return histogram
 }
 
-func fetchTimestamp(api v1.API, query string, t time.Time) (model.Vector, error) {
-	result, err := api.Query(context.Background(), query, t)
-	if err != nil {
-		return nil, err
-	}
-	switch result.Type() {
-	case model.ValVector:
-		return result.(model.Vector), nil
-	}
-	return nil, fmt.Errorf("Invalid query, vector expected: %s", query)
-}
-
 func fetchRange(api v1.API, query string, bounds v1.Range) *Metric {
 	result, err := api.QueryRange(context.Background(), query, bounds)
 	if err != nil {
@@ -194,11 +177,6 @@ func fetchRange(api v1.API, query string, bounds v1.Range) *Metric {
 		return &Metric{Matrix: result.(model.Matrix)}
 	}
 	return &Metric{err: fmt.Errorf("Invalid query, matrix expected: %s", query)}
-}
-
-func replaceInvalidCharacters(metricName string) string {
-	// See https://github.com/prometheus/prometheus/blob/master/util/strutil/strconv.go#L43
-	return invalidLabelCharRE.ReplaceAllString(metricName, "_")
 }
 
 // getAllRequestRates retrieves traffic rates for requests entering, internal to, or exiting the namespace.

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -448,7 +448,7 @@ func TestGetAllRequestRates(t *testing.T) {
 	}
 	mockQueryWithTime(api, `rate(istio_requests_total{source_workload_namespace="ns"}[5m])`, queryTime, &vectorQ2)
 
-	rates, err := client.GetAllRequestRates("ns", "5m", queryTime)
+	rates, _ := client.GetAllRequestRates("ns", "5m", queryTime)
 	assert.Equal(t, 2, rates.Len())
 	assert.Equal(t, vectorQ1[0], rates[0])
 	assert.Equal(t, vectorQ2[0], rates[1])
@@ -480,7 +480,7 @@ func TestGetAllRequestRatesIstioSystem(t *testing.T) {
 	}
 	mockQueryWithTime(api, `rate(istio_requests_total{source_workload_namespace="istio-system"}[5m])`, queryTime, &vectorQ2)
 
-	rates, err := client.GetAllRequestRates("istio-system", "5m", queryTime)
+	rates, _ := client.GetAllRequestRates("istio-system", "5m", queryTime)
 	assert.Equal(t, 2, rates.Len())
 	assert.Equal(t, vectorQ1[0], rates[0])
 	assert.Equal(t, vectorQ2[0], rates[1])
@@ -504,7 +504,7 @@ func TestGetNamespaceServicesRequestRates(t *testing.T) {
 	}
 	mockQueryWithTime(api, `rate(istio_requests_total{destination_service_namespace="ns"}[5m])`, queryTime, &vectorQ1)
 
-	rates, err := client.GetNamespaceServicesRequestRates("ns", "5m", queryTime)
+	rates, _ := client.GetNamespaceServicesRequestRates("ns", "5m", queryTime)
 	assert.Equal(t, 1, rates.Len())
 	assert.Equal(t, vectorQ1[0], rates[0])
 }
@@ -519,7 +519,7 @@ func TestConfig(t *testing.T) {
 		YAML: `{"status":"success","data":{"yaml":"global:\n  scrape_interval: 15s\n"}}`,
 	})
 
-	config, err := client.GetConfiguration()
+	config, _ := client.GetConfiguration()
 	assert.Contains(t, config.YAML, "scrape_interval")
 }
 
@@ -531,7 +531,7 @@ func TestFlags(t *testing.T) {
 	}
 	mockFlags(api, pv1.FlagsResult{"storage.tsdb.retention": "6h"})
 
-	flags, err := client.GetFlags()
+	flags, _ := client.GetFlags()
 	assert.Equal(t, flags["storage.tsdb.retention"], "6h")
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -24,7 +24,6 @@ import (
 const (
 	authorizedUsername = "theUser"
 	authorizedPassword = "thePassword"
-	authorizedToken    = "theToken"
 )
 
 const (
@@ -133,7 +132,8 @@ func TestSecureComm(t *testing.T) {
 	}
 
 	// this makes sure the Prometheus metrics endpoint can start (we made an API call above; there should be metrics)
-	if s, err := getRequestResults(t, httpClient, metricsURL, basicCredentials); err != nil {
+	var s string
+	if s, err = getRequestResults(t, httpClient, metricsURL, basicCredentials); err != nil {
 		t.Fatalf("Failed: Basic Auth Metrics URL: %v", err)
 	} else {
 		// makes sure we did get the metrics endpoint

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -199,7 +199,7 @@ func generateStaticFile(t *testing.T, filename string, content string) {
 		t.Fatalf("Cannot create file [%v]: %v", filename, err)
 	}
 	defer file.Close()
-	fmt.Fprintf(file, content)
+	fmt.Fprint(file, content)
 }
 
 func generateCertificate(t *testing.T, certPath string, keyPath string, host string) error {

--- a/status/versions.go
+++ b/status/versions.go
@@ -26,10 +26,10 @@ var (
 	//   redhat@redhat-pulp.abc.xyz.redhat.com:8888/openshift-istio-tech-preview-0.1.0-1-3a136c90ec5e308f236e0d7ebb5c4c5e405217f4-Custom
 	// Example Istio snapshot version is:
 	//   root@f72e3d3ef3c2-docker.io/istio-release-1.0-20180927-21-10-cbe9c05c470ec1924f7bcf02334b183e7e6175cb-Clean
-	maistraProductVersionExpr = regexp.MustCompile("maistra-([0-9]+\\.[0-9]+\\.[0-9]+)")
-	maistraProjectVersionExpr = regexp.MustCompile("openshift-istio.*-([0-9]+\\.[0-9]+\\.[0-9]+)")
-	istioVersionExpr          = regexp.MustCompile("([0-9]+\\.[0-9]+\\.[0-9]+)")
-	istioSnapshotVersionExpr  = regexp.MustCompile("istio-release-([0-9]+\\.[0-9]+)(-[0-9]{8})")
+	maistraProductVersionExpr = regexp.MustCompile(`maistra-([0-9]+\.[0-9]+\.[0-9]+)`)
+	maistraProjectVersionExpr = regexp.MustCompile(`openshift-istio.*-([0-9]+\.[0-9]+\.[0-9]+)`)
+	istioVersionExpr          = regexp.MustCompile(`([0-9]+\.[0-9]+\.[0-9]+)`)
+	istioSnapshotVersionExpr  = regexp.MustCompile(`istio-release-([0-9]+\.[0-9]+)(-[0-9]{8})`)
 )
 
 func getVersions() {

--- a/util/intutil/convert.go
+++ b/util/intutil/convert.go
@@ -3,18 +3,14 @@ package intutil
 import "errors"
 
 func Convert(subject interface{}) (int, error) {
-	var result int
-
-	switch subject.(type) {
+	switch s := subject.(type) {
 	case uint64:
-		result = int(subject.(uint64))
+		return int(s), nil
 	case int64:
-		result = int(subject.(int64))
+		return int(s), nil
 	case int:
-		result = subject.(int)
+		return s, nil
 	default:
 		return 0, errors.New("It is not a numeric input")
 	}
-
-	return result, nil
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-2327

Note: some linters take almost 30s to execute on my machine... let's see how it goes with travis, but we may want to disable the slow ones.

Execution times on my machine:
```
DEBUG: [Feb 20 10:41:57.032] [ineffassign.8]: ineffassign linter took 146.876602ms
DEBUG: [Feb 20 10:41:59.429] [goimports.3]: goimports linter took 2.555698363s
DEBUG: [Feb 20 10:42:00.908] [vetshadow.6]: vetshadow linter took 4.027178064s
DEBUG: [Feb 20 10:42:00.957] [vet.1]: vet linter took 4.093894523s
DEBUG: [Feb 20 10:42:12.971] [varcheck.7]: varcheck linter took 16.088711282s
DEBUG: [Feb 20 10:42:13.345] [unconvert.9]: unconvert linter took 16.312805446s
DEBUG: [Feb 20 10:42:13.789] [structcheck.2]: structcheck linter took 16.924005641s
DEBUG: [Feb 20 10:42:20.365] [gosimple.4]: gosimple linter took 23.487195524s
DEBUG: [Feb 20 10:42:26.537] [staticcheck.5]: staticcheck linter took 29.659554083s
```