### PR TITLE
Add yaml to hack folder to enable mesh-wide mTLS

### DIFF
--- a/hack/istio/istio-mtls-meshwide.yaml
+++ b/hack/istio/istio-mtls-meshwide.yaml
@@ -1,0 +1,24 @@
+##########
+# This enables mTLS at service mesh level.
+# The MeshPolicy allows all the services to receive traffic in mTLS mode.
+# The DestinationRule allows all the entities to start communications in mTLS mode.
+##########
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+spec:
+  peers:
+  - mtls: {}
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL


### PR DESCRIPTION
** Describe the change **
Adding a hack yaml which enables meshwide mTLS to the whole Istio installation.
