### PR TITLE
KIALI-2425 Fix ServiceEntry parsing for validation

### DIFF
--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kiali/kiali/business/checkers/destinationrules"
 	"github.com/kiali/kiali/business/checkers/virtual_services"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	v1 "k8s.io/api/core/v1"
 )
@@ -23,6 +24,8 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 		return validations
 	}
 
+	log.Infof("ServiceEntries: %v\n", in.IstioDetails.ServiceEntries)
+
 	serviceNames := getServiceNames(in.Services)
 	serviceHosts := kubernetes.ServiceEntryHostnames(in.IstioDetails.ServiceEntries)
 	gatewayNames := kubernetes.GatewayNames(in.GatewaysPerNamespace)
@@ -38,7 +41,7 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 	return validations
 }
 
-func runVirtualServiceCheck(virtualService kubernetes.IstioObject, namespace string, serviceNames []string, serviceHosts map[string]struct{}) models.IstioValidations {
+func runVirtualServiceCheck(virtualService kubernetes.IstioObject, namespace string, serviceNames []string, serviceHosts map[string][]string) models.IstioValidations {
 	result, valid := virtual_services.NoHostChecker{
 		Namespace:         namespace,
 		ServiceNames:      serviceNames,
@@ -76,7 +79,7 @@ func runGatewayCheck(virtualService kubernetes.IstioObject, gatewayNames map[str
 	return vsvalidations
 }
 
-func runDestinationRuleCheck(destinationRule kubernetes.IstioObject, namespace string, workloads models.WorkloadList, serviceNames []string, serviceHosts map[string]struct{}) models.IstioValidations {
+func runDestinationRuleCheck(destinationRule kubernetes.IstioObject, namespace string, workloads models.WorkloadList, serviceNames []string, serviceHosts map[string][]string) models.IstioValidations {
 	result, valid := destinationrules.NoDestinationChecker{
 		Namespace:       namespace,
 		WorkloadList:    workloads,

--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -12,7 +12,7 @@ type NoHostChecker struct {
 	Namespace         string
 	ServiceNames      []string
 	VirtualService    kubernetes.IstioObject
-	ServiceEntryHosts map[string]struct{}
+	ServiceEntryHosts map[string][]string
 }
 
 func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
@@ -62,10 +62,12 @@ func (n NoHostChecker) checkDestination(destination interface{}, protocol string
 								return true
 							}
 						}
-						if n.ServiceEntryHosts != nil {
+						if protocols, found := n.ServiceEntryHosts[sHost]; found {
 							// We have ServiceEntry to check
-							if _, found := n.ServiceEntryHosts[strings.ToLower(protocol)+sHost]; found {
-								return true
+							for _, prot := range protocols {
+								if prot == strings.ToLower(protocol) {
+									return true
+								}
 							}
 						}
 					}

--- a/tests/data/virtual_service_data.go
+++ b/tests/data/virtual_service_data.go
@@ -90,10 +90,12 @@ func CreateExternalServiceEntry() kubernetes.IstioObject {
 				"wikipedia.org",
 			},
 			"location": "MESH_EXTERNAL",
-			"ports": map[string]interface{}{
-				"number":   uint64(80),
-				"name":     "example-http",
-				"protocol": "HTTP",
+			"ports": []interface{}{
+				map[string]interface{}{
+					"number":   uint64(80),
+					"name":     "example-http",
+					"protocol": "HTTP",
+				},
 			},
 			"resolution": "DNS",
 		},


### PR DESCRIPTION
** Describe the change **

Changes the type checking to match []interface{} first for hosts to match correctly the type. Also, changed the parsed datatype internally to make it easier to call for different purposes (such as when no protocol is known).

** Issue reference **

KIALI-2425

