### PR TITLE
Change perf info to Debugf

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -172,7 +172,7 @@ func NewClient() (*IstioClient, error) {
 // It returns an error on any problem.
 func NewClientFromConfig(config *rest.Config) (*IstioClient, error) {
 	client := IstioClient{}
-	log.Infof("Rest perf config QPS: %f Burst: %d", config.QPS, config.Burst)
+	log.Debugf("Rest perf config QPS: %f Burst: %d", config.QPS, config.Burst)
 
 	k8s, err := kube.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
** Describe the change **

Minor.
The Perf debug was intended when using caches and reusing clients.
There are some use cases that are not very clear why it can be the cliend re-used but meanwhile we work on that, this Infof is not necessary.
Moving to Debugf instead.