### PR TITLE
KIALI-2434 Check the portname form

### DIFF
--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -6,12 +6,46 @@ import (
 	"github.com/kiali/kiali/models"
 )
 
+const GatewayCheckerType = "gateway"
+
 type GatewayChecker struct {
 	GatewaysPerNamespace [][]kubernetes.IstioObject
+	Namespace            string
 }
 
+// Check runs checks for the all namespaces actions as well as for the single namespace validations
 func (g GatewayChecker) Check() models.IstioValidations {
-	return gateways.MultiMatchChecker{
+	// Multinamespace checkers
+	validations := gateways.MultiMatchChecker{
 		GatewaysPerNamespace: g.GatewaysPerNamespace,
 	}.Check()
+
+	// Single namespace
+	for _, nssGw := range g.GatewaysPerNamespace {
+		for _, gw := range nssGw {
+			if gw.GetObjectMeta().Namespace == g.Namespace {
+				validations.MergeValidations(runSingleChecks(gw))
+			}
+		}
+	}
+
+	return validations
+}
+
+func runSingleChecks(gw kubernetes.IstioObject) models.IstioValidations {
+	validations := models.IstioValidations{}
+	checks, valid := gateways.PortChecker{
+		Gateway: gw,
+	}.Check()
+
+	if !valid {
+		key := models.IstioValidationKey{ObjectType: GatewayCheckerType, Name: gw.GetObjectMeta().Name}
+		validations[key] = &models.IstioValidation{
+			Name:       key.Name,
+			ObjectType: key.ObjectType,
+			Checks:     checks,
+			Valid:      valid,
+		}
+	}
+	return validations
 }

--- a/business/checkers/gateways/port_checker.go
+++ b/business/checkers/gateways/port_checker.go
@@ -1,0 +1,34 @@
+package gateways
+
+import (
+	"fmt"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type PortChecker struct {
+	Gateway kubernetes.IstioObject
+}
+
+func (p PortChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	if serversSpec, found := p.Gateway.GetSpec()["servers"]; found {
+		if servers, ok := serversSpec.([]interface{}); ok {
+			for serverIndex, server := range servers {
+				if serverDef, ok := server.(map[string]interface{}); ok {
+					if portDef, found := serverDef["port"]; found {
+						if !kubernetes.ValidatePort(portDef) {
+							validation := models.Build("port.name.mismatch",
+								fmt.Sprintf("spec/servers[%d]/port/name", serverIndex))
+							validations = append(validations, &validation)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return validations, len(validations) == 0
+}

--- a/business/checkers/gateways/port_checker_test.go
+++ b/business/checkers/gateways/port_checker_test.go
@@ -1,0 +1,45 @@
+package gateways
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidPortDefinition(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gw := data.AddServerToGateway(
+		data.CreateServer([]string{"localhost"}, uint32(80), "http", "http"),
+		data.CreateEmptyGateway("valid-gw", "test", map[string]string{"istio": "ingressgateway"}),
+	)
+	pc := PortChecker{Gateway: gw}
+	validations, valid := pc.Check()
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestInvalidPortDefinition(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gw := data.AddServerToGateway(
+		data.CreateServer([]string{"localhost"}, uint32(80), "http", "http2"),
+		data.CreateEmptyGateway("notvalid-gw", "test", map[string]string{"istio": "ingressgateway"}),
+	)
+	pc := PortChecker{Gateway: gw}
+	validations, valid := pc.Check()
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal(models.ErrorSeverity, validations[0].Severity)
+	assert.Equal(models.CheckMessage("port.name.mismatch"), validations[0].Message)
+	assert.Equal("spec/servers[0]/port/name", validations[0].Path)
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -78,7 +78,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.VirtualServiceChecker{Namespace: namespace, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices},
 		checkers.NoServiceChecker{Namespace: namespace, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace},
 		checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails},
-		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace},
+		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace},
 	}
 }
 
@@ -110,7 +110,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	switch objectType {
 	case Gateways:
 		objectCheckers = []ObjectChecker{
-			checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace},
+			checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace},
 		}
 	case VirtualServices:
 		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -11,6 +12,8 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 )
+
+var portNameMatcher = regexp.MustCompile("^[\\-].*")
 
 // GetIstioDetails returns Istio details for a given namespace,
 // on this version it collects the VirtualServices and DestinationRules defined for a namespace.
@@ -502,6 +505,53 @@ func mapPortToVirtualServiceProtocol(proto string) string {
 	default:
 		return "tcp"
 	}
+}
+
+// ValidaPort parses the Istio Port definition and validates the naming scheme
+func ValidatePort(portDef interface{}) bool {
+	return matchPortNameRule(parsePort(portDef))
+}
+
+func parsePort(portDef interface{}) (string, string) {
+	var name, proto string
+	if port, ok := portDef.(map[string]interface{}); ok {
+		if portNameDef, found := port["name"]; found {
+			if portName, ok := portNameDef.(string); ok {
+				name = portName
+			}
+		}
+		if protocolDef, found := port["protocol"]; found {
+			if protocol, ok := protocolDef.(string); ok {
+				proto = protocol
+			}
+		}
+	}
+
+	return name, proto
+}
+
+func matchPortNameRule(portName, protocol string) bool {
+	protocol = strings.ToLower(protocol)
+	// Check that portName begins with the protocol
+
+	if protocol == "tcp" || protocol == "udp" {
+		// TCP and UDP protocols do not care about the name
+		return true
+	}
+
+	if !strings.HasPrefix(portName, protocol) {
+		return false
+	}
+
+	// If longer than protocol, then it must adhere to <protocol>[-suffix]
+	// and if there's -, then there must be a suffix ..
+	if len(portName) > len(protocol) {
+		restPortName := portName[len(protocol):]
+		return portNameMatcher.MatchString(restPortName)
+	}
+
+	// Case portName == protocolName
+	return true
 }
 
 // GatewayNames extracts the gateway names for easier matching

--- a/kubernetes/istio_details_service_test.go
+++ b/kubernetes/istio_details_service_test.go
@@ -40,3 +40,37 @@ func TestFQDNHostname(t *testing.T) {
 	assert.False(t, FilterByHost("ratings.foo.svc", "reviews", "bookinfo"))
 	assert.False(t, FilterByHost("ratings.foo.svc.cluster.local", "reviews", "bookinfo"))
 }
+
+func TestExactProtocolNameMatcher(t *testing.T) {
+	// http, http2, grpc, mongo, or redis
+	assert.True(t, matchPortNameRule("http", "http"))
+	assert.True(t, matchPortNameRule("http", "HTTP"))
+	assert.True(t, matchPortNameRule("grpc", "grpc"))
+	assert.True(t, matchPortNameRule("http2", "http2"))
+}
+
+func TestTCPAndUDPMatcher(t *testing.T) {
+	assert.True(t, matchPortNameRule("tcp", "TCP"))
+	assert.True(t, matchPortNameRule("tcp", "tcp"))
+	assert.True(t, matchPortNameRule("udp", "UDP"))
+	assert.True(t, matchPortNameRule("udp", "udp"))
+
+	assert.True(t, matchPortNameRule("tcp-any", "UDP"))
+	assert.True(t, matchPortNameRule("udp-any", "TCP"))
+
+	assert.True(t, matchPortNameRule("doesnotmatter", "UDP"))
+	assert.True(t, matchPortNameRule("everythingisvalid", "TCP"))
+}
+
+func TestValidProtocolNameMatcher(t *testing.T) {
+	assert.True(t, matchPortNameRule("http-name", "http"))
+	assert.True(t, matchPortNameRule("http2-name", "http2"))
+}
+
+func TestInvalidProtocolNameMatcher(t *testing.T) {
+	assert.False(t, matchPortNameRule("http2-name", "http"))
+	assert.False(t, matchPortNameRule("http-name", "http2"))
+
+	assert.False(t, matchPortNameRule("httpname", "http"))
+	assert.False(t, matchPortNameRule("name", "http"))
+}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -94,6 +94,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "More than one Gateway for the same host port combination",
 		Severity: WarningSeverity,
 	},
+	"port.name.mismatch": {
+		Message:  "Port name must follow <protocol>[-suffix] form",
+		Severity: ErrorSeverity,
+	},
 	"virtualservices.nogateway": {
 		Message:  "VirtualService is pointing to a non-existent gateway",
 		Severity: ErrorSeverity,


### PR DESCRIPTION
** Describe the change **

Adds validation to the portname for gateways as it must match the Istio rules for the routing to work correctly

https://istio.io/docs/setup/kubernetes/spec-requirements/

** Issue reference **

KIALI-2434
