### PR TITLE
Minor change: allow trailing "/" in grafana url,

### DIFF
--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -132,7 +133,10 @@ func getDashboardPath(url string, searchPattern string, credentials string, dash
 }
 
 func findDashboard(url, searchPattern string, credentials string) ([]byte, int, error) {
-	req, err := http.NewRequest(http.MethodGet, url+"/api/search?query="+searchPattern, nil)
+	if !strings.HasSuffix(url, "/") {
+		url = url + "/"
+	}
+	req, err := http.NewRequest(http.MethodGet, url+"api/search?query="+searchPattern, nil)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -152,7 +152,7 @@ func fetchHistogramRange(api v1.API, metricName, labels, grouping string, q *Bas
 		query := fmt.Sprintf("sum(rate(%s_sum%s[%s]))%s / sum(rate(%s_count%s[%s]))%s",
 			metricName, labels, q.RateInterval, groupingAvg, metricName, labels, q.RateInterval, groupingAvg)
 		query = roundSignificant(query, 0.001)
-		log.Infof("Query: %s\n", query)
+		log.Debugf("Query: %s\n", query)
 		histogram["avg"] = fetchRange(api, query, q.Range)
 	}
 
@@ -166,7 +166,7 @@ func fetchHistogramRange(api v1.API, metricName, labels, grouping string, q *Bas
 			quantile, metricName, labels, q.RateInterval, groupingQuantile)
 		query = roundSignificant(query, 0.001)
 		histogram[quantile] = fetchRange(api, query, q.Range)
-		log.Infof("Query: %s\n", query)
+		log.Debugf("Query: %s\n", query)
 	}
 
 	return histogram


### PR DESCRIPTION
... and change log.Info to log.Debug in metrics calls


This allows the user to set URL in config as "http://grafana-server" or "http://grafana-server/"