### PR TITLE
KIALI-2458 Grant Kiali permission to access routes

### DIFF
--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -15,12 +15,6 @@ rules:
   - pods
   - services
   - replicationcontrollers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: ["route.openshift.io"]
-  resources:
   - routes
   verbs:
   - get


### PR DESCRIPTION
** Describe the change **

Grants the Kiali service account permission to access routes.

This was incorrectly setup in a previous PR but it was not applied correctly. This fixes the problem.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2458

