### PR TITLE
KIALI-2093 - Verify rules for both sending+receiving are enabled

### DIFF
--- a/business/checkers/mesh_policies_checker.go
+++ b/business/checkers/mesh_policies_checker.go
@@ -23,7 +23,7 @@ func (m MeshPolicyChecker) Check() models.IstioValidations {
 	return validations
 }
 
-// runChecks runs all the individual checks for a single virtual service and appends the result into validations.
+// runChecks runs all the individual checks for a single mesh policy and appends the result into validations.
 func (m MeshPolicyChecker) runChecks(meshPolicy kubernetes.IstioObject) models.IstioValidations {
 	meshPolicyName := meshPolicy.GetObjectMeta().Name
 	key := models.IstioValidationKey{Name: meshPolicyName, ObjectType: MeshPolicyCheckerType}

--- a/business/checkers/mesh_policies_checker.go
+++ b/business/checkers/mesh_policies_checker.go
@@ -1,0 +1,48 @@
+package checkers
+
+import (
+	"github.com/kiali/kiali/business/checkers/meshpolicies"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+const MeshPolicyCheckerType = "meshpolicy"
+
+type MeshPolicyChecker struct {
+	MeshPolicies []kubernetes.IstioObject
+	MTLSDetails  kubernetes.MTLSDetails
+}
+
+func (m MeshPolicyChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, meshPolicy := range m.MeshPolicies {
+		validations.MergeValidations(m.runChecks(meshPolicy))
+	}
+
+	return validations
+}
+
+// runChecks runs all the individual checks for a single virtual service and appends the result into validations.
+func (m MeshPolicyChecker) runChecks(meshPolicy kubernetes.IstioObject) models.IstioValidations {
+	meshPolicyName := meshPolicy.GetObjectMeta().Name
+	key := models.IstioValidationKey{Name: meshPolicyName, ObjectType: MeshPolicyCheckerType}
+	rrValidation := &models.IstioValidation{
+		Name:       meshPolicyName,
+		ObjectType: MeshPolicyCheckerType,
+		Valid:      true,
+		Checks:     []*models.IstioCheck{},
+	}
+
+	enabledCheckers := []Checker{
+		meshpolicies.MtlsChecker{MeshPolicy: meshPolicy, MTLSDetails: m.MTLSDetails},
+	}
+
+	for _, checker := range enabledCheckers {
+		checks, validChecker := checker.Check()
+		rrValidation.Checks = append(rrValidation.Checks, checks...)
+		rrValidation.Valid = rrValidation.Valid && validChecker
+	}
+
+	return models.IstioValidations{key: rrValidation}
+}

--- a/business/checkers/meshpolicies/mtls_checker.go
+++ b/business/checkers/meshpolicies/mtls_checker.go
@@ -1,0 +1,43 @@
+package meshpolicies
+
+import (
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+const MeshPolicyCheckerType = "meshpolicy"
+
+type MtlsChecker struct {
+	MeshPolicy  kubernetes.IstioObject
+	MTLSDetails kubernetes.MTLSDetails
+}
+
+func (t MtlsChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	// if MeshPolicy doesn't enables mTLS, stop validation with any check.
+	if !business.MeshPolicyHasMTLSEnabled(t.MeshPolicy) {
+		return validations
+	}
+
+	// otherwise, check among Destination Rules for a rule enabling mTLS mesh-wide.
+	for _, dr := range t.MTLSDetails.DestinationRules {
+		if business.DestinationRuleHasMeshWideMTLSEnabled(dr) {
+			return validations
+		}
+	}
+
+	check := models.Build("meshpolicies.mtls.destinationrulemissing", "")
+	key := models.BuildKey(MeshPolicyCheckerType, t.MeshPolicy.GetObjectMeta().Name)
+	validations[key] = &models.IstioValidation{
+		Name:       t.MeshPolicy.GetObjectMeta().Name,
+		ObjectType: MeshPolicyCheckerType,
+		Valid:      false,
+		Checks: []*models.IstioCheck{
+			&check,
+		},
+	}
+
+	return validations
+}

--- a/business/checkers/meshpolicies/mtls_checker_test.go
+++ b/business/checkers/meshpolicies/mtls_checker_test.go
@@ -128,35 +128,30 @@ func TestMeshPolicymTLSDisabledDestinationRuleMissing(t *testing.T) {
 func testValidationAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
 	assert := assert.New(t)
 
-	validations := MtlsChecker{
+	validations, valid := MtlsChecker{
 		MeshPolicy:  meshPolicy,
 		MTLSDetails: mTLSDetails,
 	}.Check()
 
 	assert.NotEmpty(validations)
 	assert.Equal(1, len(validations))
+	assert.False(valid)
 
-	validation, ok := validations[models.BuildKey(MeshPolicyCheckerType, "default")]
-	assert.True(ok)
-	assert.False(validation.Valid)
-
-	assert.NotEmpty(validation.Checks)
-	assert.Equal(models.ErrorSeverity, validation.Checks[0].Severity)
-	assert.Equal("", validation.Checks[0].Path)
-	assert.Equal(models.CheckMessage("meshpolicies.mtls.destinationrulemissing"), validation.Checks[0].Message)
+	validation := validations[0]
+	assert.NotNil(validation)
+	assert.Equal(models.ErrorSeverity, validation.Severity)
+	assert.Equal("spec/peers/mtls", validation.Path)
+	assert.Equal(models.CheckMessage("meshpolicies.mtls.destinationrulemissing"), validation.Message)
 }
 
 func testValidationsNotAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
 	assert := assert.New(t)
 
-	validations := MtlsChecker{
+	validations, valid := MtlsChecker{
 		MeshPolicy:  meshPolicy,
 		MTLSDetails: mTLSDetails,
 	}.Check()
 
 	assert.Empty(validations)
-	validation, ok := validations[models.BuildKey(MeshPolicyCheckerType, "default")]
-
-	assert.False(ok)
-	assert.Nil(validation)
+	assert.True(valid)
 }

--- a/business/checkers/meshpolicies/mtls_checker_test.go
+++ b/business/checkers/meshpolicies/mtls_checker_test.go
@@ -1,0 +1,162 @@
+package meshpolicies
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+// Describe the validation of a MeshPolicy that enables mTLS. The validation is risen when there isn't any
+// Destination Rule enabling clients start mTLS connections.
+
+// Context: MeshPolicy enables mTLS
+// Context: There is one Destination Rule enabling mTLS mesh-wide
+// It doesn't return any validation
+func TestMeshPolicymTLSDisabled(t *testing.T) {
+	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("default", "default", "*.local")),
+		},
+	}
+
+	testValidationsNotAdded(t, meshPolicy, mTLSDetails)
+}
+
+// Context: MeshPolicy enables mTLS
+// Context: There is one Destination Rule enabling mTLS namespace-wide
+// It returns a validation
+func TestMeshPolicyEnabledDRNamespaceWide(t *testing.T) {
+	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+		},
+	}
+
+	testValidationAdded(t, meshPolicy, mTLSDetails)
+}
+
+// Context: MeshPolicy enables mTLS
+// Context: There is one Destination Rule not enabling any kind of mTLS
+// It returns a validation
+func TestMeshPolicyEnabledDRmTLSDisabled(t *testing.T) {
+	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.CreateEmptyDestinationRule("bar", "default", "*.bar.svc.cluster.local"),
+		},
+	}
+
+	testValidationAdded(t, meshPolicy, mTLSDetails)
+}
+
+// Context: MeshPolicy enables mTLS
+// Context: There isn't any Destination Rule
+// It returns a validation
+func TestMeshPolicymTLSEnabledDestinationRuleMissing(t *testing.T) {
+	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{},
+	}
+
+	testValidationAdded(t, meshPolicy, mTLSDetails)
+}
+
+// Context: MeshPolicy doesn't enable mTLS
+// Context: There is one Destination Rule enabling mTLS mesh-wide
+// It doesn't return any validation
+func TestMeshPolicymTLSDisabledDestinationRulePresent(t *testing.T) {
+	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("default", "default", "*.local")),
+		},
+	}
+
+	testValidationsNotAdded(t, meshPolicy, mTLSDetails)
+}
+
+// Context: MeshPolicy doesn't enable mTLS
+// Context: There is one Destination Rule enabling mTLS namespace-wide
+// It doesn't return any validation
+func TestMeshPolicyDisabledDRNamespaceWide(t *testing.T) {
+	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+		},
+	}
+
+	testValidationsNotAdded(t, meshPolicy, mTLSDetails)
+}
+
+// Context: MeshPolicy doesn't enable mTLS
+// Context: There is one Destination Rule not enabling any kind of mTLS
+// It doesn't return any validation
+func TestMeshPolicyDisabledDRmTLSDisabled(t *testing.T) {
+	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.CreateEmptyDestinationRule("bar", "default", "*.bar.svc.cluster.local"),
+		},
+	}
+
+	testValidationsNotAdded(t, meshPolicy, mTLSDetails)
+}
+
+// Context: MeshPolicy doesn't enable mTLS
+// Context: There isn't any Destination Rule
+// It doesn't return a validation
+func TestMeshPolicymTLSDisabledDestinationRuleMissing(t *testing.T) {
+	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{},
+	}
+
+	testValidationsNotAdded(t, meshPolicy, mTLSDetails)
+}
+
+func testValidationAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
+	assert := assert.New(t)
+
+	validations := MtlsChecker{
+		MeshPolicy:  meshPolicy,
+		MTLSDetails: mTLSDetails,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+
+	validation, ok := validations[models.BuildKey(MeshPolicyCheckerType, "default")]
+	assert.True(ok)
+	assert.False(validation.Valid)
+
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.ErrorSeverity, validation.Checks[0].Severity)
+	assert.Equal("", validation.Checks[0].Path)
+	assert.Equal(models.CheckMessage("meshpolicies.mtls.destinationrulemissing"), validation.Checks[0].Message)
+}
+
+func testValidationsNotAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
+	assert := assert.New(t)
+
+	validations := MtlsChecker{
+		MeshPolicy:  meshPolicy,
+		MTLSDetails: mTLSDetails,
+	}.Check()
+
+	assert.Empty(validations)
+	validation, ok := validations[models.BuildKey(MeshPolicyCheckerType, "default")]
+
+	assert.False(ok)
+	assert.Nil(validation)
+}

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -607,50 +607,12 @@ func (in *IstioConfigService) hasMeshPolicyEnabled(namespaces []string) (bool, e
 	}
 
 	for _, mp := range mps {
-		if MeshPolicyHasMTLSEnabled(mp) {
+		if kubernetes.MeshPolicyHasMTLSEnabled(mp) {
 			return true, nil
 		}
 	}
 
 	return false, nil
-}
-
-func MeshPolicyHasMTLSEnabled(mp kubernetes.IstioObject) bool {
-
-	// It is mandatory to have default as a name
-	if meshMeta := mp.GetObjectMeta(); meshMeta.Name != "default" {
-		return false
-	}
-
-	// It is no globally enabled when has targets
-	targets, targetPresent := mp.GetSpec()["targets"]
-	specificTarget := targetPresent && len(targets.([]interface{})) > 0
-	if specificTarget {
-		return false
-	}
-
-	// It is globally enabled when a peer has mtls enabled
-	peers, peersPresent := mp.GetSpec()["peers"]
-	if !peersPresent {
-		return false
-	}
-
-	for _, peer := range peers.([]interface{}) {
-		peerMap := peer.(map[string]interface{})
-		if mtls, present := peerMap["mtls"]; present {
-			if mtlsMap, ok := mtls.(map[string]interface{}); ok {
-				// mTLS enabled in case there is an empty map or mode is STRICT
-				if mode, found := mtlsMap["mode"]; !found || mode == "STRICT" {
-					return true
-				}
-			} else {
-				// mTLS enabled in case mtls object is empty
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 func (in *IstioConfigService) hasDestinationRuleEnabled(namespaces []string) (bool, error) {
@@ -660,39 +622,12 @@ func (in *IstioConfigService) hasDestinationRuleEnabled(namespaces []string) (bo
 	}
 
 	for _, dr := range drs {
-		if DestinationRuleHasMeshWideMTLSEnabled(dr) {
+		if kubernetes.DestinationRuleHasMeshWideMTLSEnabled(dr) {
 			return true, nil
 		}
 	}
 
 	return false, nil
-}
-
-func DestinationRuleHasMeshWideMTLSEnabled(dr kubernetes.IstioObject) bool {
-	// Following the suggested procedure to enable mesh-wide mTLS, host might be '*.local':
-	// https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutual-tls
-	host, hostPresent := dr.GetSpec()["host"]
-	if !hostPresent || host != "*.local" {
-		return false
-	}
-
-	if trafficPolicy, trafficPresent := dr.GetSpec()["trafficPolicy"]; trafficPresent {
-		if trafficCasted, ok := trafficPolicy.(map[string]interface{}); ok {
-			if tls, found := trafficCasted["tls"]; found {
-				if tlsCasted, ok := tls.(map[string]interface{}); ok {
-					if mode, found := tlsCasted["mode"]; found {
-						if modeCasted, ok := mode.(string); ok {
-							if modeCasted == "ISTIO_MUTUAL" {
-								return true
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	return false
 }
 
 func (in *IstioConfigService) getAllDestinationRules(namespaces []string) ([]kubernetes.IstioObject, error) {

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -80,6 +80,7 @@ func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().DestinationRules, nil)
 	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails(), nil)
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return(fakeCombinedServices([]string{""}), nil)
+	k8s.On("GetMeshPolicies", mock.AnythingOfType("string")).Return(fakeMeshPolicies(), nil)
 
 	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil)}
 }

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -140,7 +140,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"meshpolicies.mtls.destinationrulemissing": {
-		Message:  "Mesh-wide Destination Rule missing enabling mTLS",
+		Message:  "Mesh-wide Destination Rule enabling mTLS missing",
 		Severity: ErrorSeverity,
 	},
 }

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -138,6 +138,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "Subset not found",
 		Severity: WarningSeverity,
 	},
+	"meshpolicies.mtls.destinationrulemissing": {
+		Message:  "Mesh-wide Destination Rule missing enabling mTLS",
+		Severity: ErrorSeverity,
+	},
 }
 
 func Build(checkId string, path string) IstioCheck {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -71,6 +71,7 @@ var ObjectTypeSingular = map[string]string{
 	"rules":             "rule",
 	"quotaspecs":        "quotaspec",
 	"quotaspecbindings": "quotaspecbinding",
+	"meshpolicies":      "meshpolicy",
 }
 
 var checkDescriptors = map[string]IstioCheck{

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -140,7 +140,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"meshpolicies.mtls.destinationrulemissing": {
-		Message:  "Mesh-wide Destination Rule enabling mTLS missing",
+		Message:  "Mesh-wide Destination Rule enabling mTLS is missing",
 		Severity: ErrorSeverity,
 	},
 }

--- a/tests/data/mesh_policy_data.go
+++ b/tests/data/mesh_policy_data.go
@@ -18,6 +18,16 @@ func CreateEmptyMeshPolicy(name string, peers []interface{}) kubernetes.IstioObj
 	}).DeepCopyIstioObject()
 }
 
+func CreateMTLSPeers(mode string) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"mtls": map[string]interface{}{
+				"mode": mode,
+			},
+		},
+	}
+}
+
 func AddTargetsToMeshPolicy(targets []interface{}, mp kubernetes.IstioObject) kubernetes.IstioObject {
 	mp.GetSpec()["targets"] = targets
 	return mp


### PR DESCRIPTION
** Describe the change **

Adding a validation checking for a missing Destination Rule enabling mTLS mesh-wide when a MeshPolicy is present.

![screenshot of kiali console 54](https://user-images.githubusercontent.com/613814/53568423-414e6000-3b62-11e9-9f6f-951441b06dd8.png)

** Issue reference **
https://issues.jboss.org/browse/KIALI-2093

** Documentation **
https://github.com/kiali/kiali.io/pull/104