### PR TITLE
should not be using hardcoded strings - use constants

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,13 @@ const (
 	MaistraVersionSupported = ">= 0.1.0"
 )
 
+// The valid auth strategies
+const (
+	AuthStrategyOpenshift = "openshift"
+	AuthStrategyLogin     = "login"
+	AuthStrategyAnonymous = "anonymous"
+)
+
 // Global configuration for the application.
 var configuration *Config
 
@@ -254,7 +261,7 @@ func NewConfig() (c *Config) {
 	}
 	c.API.Namespaces.Exclude = trimmedExclusionPatterns
 
-	c.Auth.Strategy = getDefaultString(EnvAuthStrategy, "login")
+	c.Auth.Strategy = getDefaultString(EnvAuthStrategy, AuthStrategyLogin)
 
 	log.Infof("Using the '%v' authentication strategy", c.Auth.Strategy)
 

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -20,7 +20,7 @@ func AuthenticationHandler(next http.Handler) http.Handler {
 		conf := config.Get()
 
 		switch conf.Auth.Strategy {
-		case "openshift":
+		case config.AuthStrategyOpenshift:
 			business, err := business.Get()
 
 			if err != nil {
@@ -34,7 +34,7 @@ func AuthenticationHandler(next http.Handler) http.Handler {
 					statusCode = http.StatusUnauthorized
 				}
 			}
-		case "login":
+		case config.AuthStrategyLogin:
 			if strings.Contains(r.Header.Get("Authorization"), "Bearer") {
 				_, err := config.ValidateToken(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
 
@@ -48,7 +48,7 @@ func AuthenticationHandler(next http.Handler) http.Handler {
 					statusCode = http.StatusUnauthorized
 				}
 			}
-		case "anonymous":
+		case config.AuthStrategyAnonymous:
 			log.Trace("Access to the server endpoint is not secured with credentials - letting request come in")
 		}
 
@@ -79,7 +79,7 @@ func AuthenticationInfo(w http.ResponseWriter, r *http.Request) {
 	response.Strategy = conf.Auth.Strategy
 
 	switch conf.Auth.Strategy {
-	case "openshift":
+	case config.AuthStrategyOpenshift:
 		business, err := business.Get()
 
 		if err != nil {

--- a/handlers/oauth.go
+++ b/handlers/oauth.go
@@ -24,12 +24,12 @@ type UserResponse struct {
 	ExpiresOn string `json:"expiresOn"`
 }
 
-// Checks if the token is working correctly.
+// OauthCheck checks if the token is working correctly.
 // This endpoint is more strict than the one on business/openshift_oauth.go
 // because it is not going to be requested as often, so we can request some
 // more fine-grained permissions.
 func OauthCheck(w http.ResponseWriter, r *http.Request) {
-	if config.Get().Auth.Strategy != "openshift" {
+	if config.Get().Auth.Strategy != config.AuthStrategyOpenshift {
 		RespondWithJSONIndent(w, http.StatusInternalServerError, "Openshift OAuth is not enabled for this deployment")
 		return
 	}

--- a/kiali.go
+++ b/kiali.go
@@ -18,7 +18,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/kiali/kiali/business"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus/internalmetrics"


### PR DESCRIPTION
I was looking in this code and noticed we are using hardcoded strings throughout for the strategy names - these should be constant variables so we don't screw it up later with typos