### PR TITLE
KIALI-1186 Use oauth token when contacting the k8s master

### DIFF
--- a/graph/appender/dead_node.go
+++ b/graph/appender/dead_node.go
@@ -1,7 +1,6 @@
 package appender
 
 import (
-	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -27,11 +26,6 @@ func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *G
 		return
 	}
 
-	var err error
-	if globalInfo.Business == nil {
-		globalInfo.Business, err = business.Get()
-		graph.CheckError(err)
-	}
 	if namespaceInfo.WorkloadList == nil {
 		workloadList, err := globalInfo.Business.Workload.GetWorkloadList(namespaceInfo.Namespace)
 		graph.CheckError(err)

--- a/graph/appender/dead_node_test.go
+++ b/graph/appender/dead_node_test.go
@@ -99,7 +99,7 @@ func setupWorkloads() *business.Layer {
 	k8s.On("GetStatefulSets", mock.AnythingOfType("string")).Return([]v1beta2.StatefulSet{}, nil)
 	config.Set(config.NewConfig())
 
-	businessLayer := business.SetWithBackends(k8s, nil)
+	businessLayer := business.NewWithBackends(k8s, nil)
 	return businessLayer
 }
 

--- a/graph/appender/istio_details.go
+++ b/graph/appender/istio_details.go
@@ -27,12 +27,6 @@ func (a IstioAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *Glob
 		return
 	}
 
-	if globalInfo.Business == nil {
-		var err error
-		globalInfo.Business, err = business.Get()
-		graph.CheckError(err)
-	}
-
 	addBadging(trafficMap, globalInfo, namespaceInfo)
 	addLabels(trafficMap, globalInfo)
 }

--- a/graph/appender/istio_details_test.go
+++ b/graph/appender/istio_details_test.go
@@ -62,7 +62,7 @@ func TestCBAll(t *testing.T) {
 	k8s.On("GetService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&coreV1.Service{}, nil)
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{}, nil)
 
-	businessLayer := business.SetWithBackends(k8s, nil)
+	businessLayer := business.NewWithBackends(k8s, nil)
 	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId := setupTrafficMap()
 
 	assert.Equal(5, len(trafficMap))
@@ -126,7 +126,7 @@ func TestCBSubset(t *testing.T) {
 	k8s.On("GetService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&coreV1.Service{}, nil)
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{}, nil)
 
-	businessLayer := business.SetWithBackends(k8s, nil)
+	businessLayer := business.NewWithBackends(k8s, nil)
 	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId := setupTrafficMap()
 
 	assert.Equal(5, len(trafficMap))
@@ -186,7 +186,7 @@ func TestVS(t *testing.T) {
 		vService.DeepCopyIstioObject(),
 	}, nil)
 
-	businessLayer := business.SetWithBackends(k8s, nil)
+	businessLayer := business.NewWithBackends(k8s, nil)
 	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId := setupTrafficMap()
 
 	assert.Equal(5, len(trafficMap))

--- a/graph/appender/service_entry.go
+++ b/graph/appender/service_entry.go
@@ -28,12 +28,6 @@ func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInf
 		return
 	}
 
-	var err error
-	if globalInfo.Business == nil {
-		globalInfo.Business, err = business.Get()
-		graph.CheckError(err)
-	}
-
 	a.applyServiceEntries(trafficMap, globalInfo, namespaceInfo)
 }
 

--- a/graph/appender/service_entry_test.go
+++ b/graph/appender/service_entry_test.go
@@ -38,7 +38,7 @@ func setupServiceEntries() *business.Layer {
 	k8s.On("GetServiceEntries", mock.AnythingOfType("string")).Return([]kubernetes.IstioObject{&externalServiceEntry, &internalServiceEntry, &defaultServiceEntry}, nil)
 	config.Set(config.NewConfig())
 
-	businessLayer := business.SetWithBackends(k8s, nil)
+	businessLayer := business.NewWithBackends(k8s, nil)
 	return businessLayer
 }
 

--- a/graph/appender/sidecars_check.go
+++ b/graph/appender/sidecars_check.go
@@ -1,7 +1,6 @@
 package appender
 
 import (
-	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 )
@@ -24,11 +23,6 @@ func (a SidecarsCheckAppender) AppendGraph(trafficMap graph.TrafficMap, globalIn
 		return
 	}
 
-	if globalInfo.Business == nil {
-		var err error
-		globalInfo.Business, err = business.Get()
-		graph.CheckError(err)
-	}
 	if namespaceInfo.WorkloadList == nil {
 		workloadList, err := globalInfo.Business.Workload.GetWorkloadList(namespaceInfo.Namespace)
 		graph.CheckError(err)

--- a/graph/appender/sidecars_check_test.go
+++ b/graph/appender/sidecars_check_test.go
@@ -229,6 +229,6 @@ func setupSidecarsCheckWorkloads(deployments []v1beta1.Deployment, pods []v1.Pod
 	k8s.On("GetStatefulSets", mock.AnythingOfType("string")).Return([]v1beta2.StatefulSet{}, nil)
 	config.Set(config.NewConfig())
 
-	businessLayer := business.SetWithBackends(k8s, nil)
+	businessLayer := business.NewWithBackends(k8s, nil)
 	return businessLayer
 }

--- a/graph/appender/unused_node.go
+++ b/graph/appender/unused_node.go
@@ -1,7 +1,6 @@
 package appender
 
 import (
-	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
@@ -29,11 +28,6 @@ func (a UnusedNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo 
 		return
 	}
 
-	if globalInfo.Business == nil {
-		var err error
-		globalInfo.Business, err = business.Get()
-		graph.CheckError(err)
-	}
 	if namespaceInfo.WorkloadList == nil {
 		workloadList, err := globalInfo.Business.Workload.GetWorkloadList(namespaceInfo.Namespace)
 		graph.CheckError(err)

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -17,7 +17,7 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Apps initialization error: "+err.Error())
 		return
@@ -38,7 +38,7 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 func AppDetails(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -62,16 +62,16 @@ func AppDetails(w http.ResponseWriter, r *http.Request) {
 
 // AppMetrics is the API handler to fetch metrics to be displayed, related to an app-label grouping
 func AppMetrics(w http.ResponseWriter, r *http.Request) {
-	getAppMetrics(w, r, defaultPromClientSupplier, defaultK8SClientSupplier)
+	getAppMetrics(w, r, defaultPromClientSupplier)
 }
 
 // getAppMetrics (mock-friendly version)
-func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, k8sSupplier k8sClientSupplier) {
+func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier) {
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	app := vars["app"]
 
-	prom, _, namespaceInfo := initClientsForMetrics(w, promSupplier, k8sSupplier, namespace)
+	prom, namespaceInfo := initClientsForMetrics(w, r, promSupplier, namespace)
 	if prom == nil {
 		// any returned value nil means error & response already written
 		return
@@ -95,7 +95,7 @@ func CustomDashboard(w http.ResponseWriter, r *http.Request) {
 	app := vars["app"]
 	template := vars["template"]
 
-	prom, _, namespaceInfo := initClientsForMetrics(w, defaultPromClientSupplier, defaultK8SClientSupplier, namespace)
+	prom, namespaceInfo := initClientsForMetrics(w, r, defaultPromClientSupplier, namespace)
 	if prom == nil {
 		// any returned value nil means error & response already written
 		return
@@ -135,7 +135,7 @@ func AppDashboard(w http.ResponseWriter, r *http.Request) {
 	namespace := vars["namespace"]
 	app := vars["app"]
 
-	prom, _, namespaceInfo := initClientsForMetrics(w, defaultPromClientSupplier, defaultK8SClientSupplier, namespace)
+	prom, namespaceInfo := initClientsForMetrics(w, r, defaultPromClientSupplier, namespace)
 	if prom == nil {
 		// any returned value nil means error & response already written
 		return

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -25,7 +25,7 @@ func TestGetGrafanaInfoDisabled(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Grafana.DisplayLink = false
 	config.Set(conf)
-	info, code, err := getGrafanaInfo(func(_, _ string) (*v1.ServiceSpec, error) {
+	info, code, err := getGrafanaInfo("", func(_, _, _ string) (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
 			ClusterIP: "fromservice",
 			Ports: []v1.ServicePort{
@@ -40,7 +40,7 @@ func TestGetGrafanaInfoFromConfig(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Grafana.URL = "http://fromconfig:3001"
 	config.Set(conf)
-	info, code, err := getGrafanaInfo(func(_, _ string) (*v1.ServiceSpec, error) {
+	info, code, err := getGrafanaInfo("", func(_, _, _ string) (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
 			ExternalIPs: []string{"fromservice"},
 			Ports: []v1.ServicePort{
@@ -55,7 +55,7 @@ func TestGetGrafanaInfoFromConfig(t *testing.T) {
 func TestGetGrafanaInfoNoExternalIP(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
-	_, code, err := getGrafanaInfo(func(_, _ string) (*v1.ServiceSpec, error) {
+	_, code, err := getGrafanaInfo("", func(_, _, _ string) (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
 			ExternalIPs: []string{},
 			Ports: []v1.ServicePort{
@@ -69,7 +69,7 @@ func TestGetGrafanaInfoGetError(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Grafana.URL = "http://fromconfig:3001"
 	config.Set(conf)
-	_, code, err := getGrafanaInfo(func(_, _ string) (*v1.ServiceSpec, error) {
+	_, code, err := getGrafanaInfo("", func(_, _, _ string) (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
 			ExternalIPs: []string{"fromservice"},
 			Ports: []v1.ServicePort{
@@ -83,7 +83,7 @@ func TestGetGrafanaInfoInvalidDashboard(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Grafana.URL = "http://fromconfig:3001"
 	config.Set(conf)
-	_, code, err := getGrafanaInfo(func(_, _ string) (*v1.ServiceSpec, error) {
+	_, code, err := getGrafanaInfo("", func(_, _, _ string) (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
 			ExternalIPs: []string{"fromservice"},
 			Ports: []v1.ServicePort{

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -67,7 +68,9 @@ func setupMocked() (*prometheus.Client, *prometheustest.PromAPIMock, *kubetest.K
 	}
 	client.Inject(api)
 
-	business.SetWithBackends(k8s, nil)
+	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
+	business.SetWithBackends(mockClientFactory, nil)
+
 	return client, api, k8s, nil
 }
 
@@ -465,7 +468,8 @@ func TestAppGraph(t *testing.T) {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client)
+			context := context.WithValue(r.Context(), "token", "test")
+			fut(w, r.WithContext(context), client)
 		}))
 
 	ts := httptest.NewServer(mr)
@@ -499,7 +503,8 @@ func TestVersionedAppGraph(t *testing.T) {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client)
+			context := context.WithValue(r.Context(), "token", "test")
+			fut(w, r.WithContext(context), client)
 		}))
 
 	ts := httptest.NewServer(mr)
@@ -533,7 +538,8 @@ func TestServiceGraph(t *testing.T) {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client)
+			context := context.WithValue(r.Context(), "token", "test")
+			fut(w, r.WithContext(context), client)
 		}))
 
 	ts := httptest.NewServer(mr)
@@ -567,7 +573,8 @@ func TestWorkloadGraph(t *testing.T) {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client)
+			context := context.WithValue(r.Context(), "token", "test")
+			fut(w, r.WithContext(context), client)
 		}))
 
 	ts := httptest.NewServer(mr)
@@ -792,7 +799,8 @@ func TestAppNodeGraph(t *testing.T) {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/applications/{app}/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client)
+			context := context.WithValue(r.Context(), "token", "test")
+			fut(w, r.WithContext(context), client)
 		}))
 
 	ts := httptest.NewServer(mr)
@@ -1017,7 +1025,8 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/applications/{app}/versions/{version}/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client)
+			context := context.WithValue(r.Context(), "token", "test")
+			fut(w, r.WithContext(context), client)
 		}))
 
 	ts := httptest.NewServer(mr)
@@ -1242,7 +1251,8 @@ func TestWorkloadNodeGraph(t *testing.T) {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/workloads/{workload}/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client)
+			context := context.WithValue(r.Context(), "token", "test")
+			fut(w, r.WithContext(context), client)
 		}))
 
 	ts := httptest.NewServer(mr)
@@ -1318,7 +1328,8 @@ func TestServiceNodeGraph(t *testing.T) {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/services/{service}/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client)
+			context := context.WithValue(r.Context(), "token", "test")
+			fut(w, r.WithContext(context), client)
 		}))
 
 	ts := httptest.NewServer(mr)
@@ -1452,7 +1463,8 @@ func TestComplexGraph(t *testing.T) {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/graph", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fut(w, r, client)
+			context := context.WithValue(r.Context(), "token", "test")
+			fut(w, r.WithContext(context), client)
 		}))
 
 	ts := httptest.NewServer(mr)

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -17,7 +17,7 @@ const defaultHealthRateInterval = "10m"
 // NamespaceHealth is the API handler to get app-based health of every services in the given namespace
 func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -64,7 +64,7 @@ func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 
 // AppHealth is the API handler to get health of a single app
 func AppHealth(w http.ResponseWriter, r *http.Request) {
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -84,7 +84,7 @@ func AppHealth(w http.ResponseWriter, r *http.Request) {
 
 // WorkloadHealth is the API handler to get health of a single workload
 func WorkloadHealth(w http.ResponseWriter, r *http.Request) {
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -105,7 +105,7 @@ func WorkloadHealth(w http.ResponseWriter, r *http.Request) {
 
 // ServiceHealth is the API handler to get health of a single service
 func ServiceHealth(w http.ResponseWriter, r *http.Request) {
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -55,11 +56,19 @@ func TestNamespaceAppHealth(t *testing.T) {
 func setupNamespaceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
-	business.SetWithBackends(k8s, prom)
+
+	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
+	business.SetWithBackends(mockClientFactory, prom)
+
 	setupMockData(k8s)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/health", NamespaceHealth)
+
+	mr.HandleFunc("/api/namespaces/{namespace}/health", http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			context := context.WithValue(r.Context(), "token", "test")
+			NamespaceHealth(w, r.WithContext(context))
+		}))
 
 	ts := httptest.NewServer(mr)
 	return ts, k8s, prom
@@ -97,11 +106,19 @@ func TestAppHealth(t *testing.T) {
 func setupAppHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
-	business.SetWithBackends(k8s, prom)
+
+	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
+	business.SetWithBackends(mockClientFactory, prom)
+
 	setupMockData(k8s)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/apps/{app}/health", AppHealth)
+
+	mr.HandleFunc("/api/namespaces/{namespace}/apps/{app}/health", http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			context := context.WithValue(r.Context(), "token", "test")
+			AppHealth(w, r.WithContext(context))
+		}))
 
 	ts := httptest.NewServer(mr)
 	return ts, k8s, prom
@@ -133,11 +150,19 @@ func TestServiceHealth(t *testing.T) {
 func setupServiceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
-	business.SetWithBackends(k8s, prom)
+
+	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
+	business.SetWithBackends(mockClientFactory, prom)
+
 	setupMockData(k8s)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/services/{service}/health", ServiceHealth)
+
+	mr.HandleFunc("/api/namespaces/{namespace}/services/{service}/health", http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			context := context.WithValue(r.Context(), "token", "test")
+			ServiceHealth(w, r.WithContext(context))
+		}))
 
 	ts := httptest.NewServer(mr)
 	return ts, k8s, prom

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -36,7 +36,7 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 	criteria := parseCriteria(namespace, objects)
 
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -175,7 +175,7 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -235,7 +235,7 @@ func IstioConfigDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -269,7 +269,7 @@ func IstioConfigUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -311,7 +311,7 @@ func IstioConfigCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus"
 )
 
 func NamespaceList(w http.ResponseWriter, r *http.Request) {
+	business, err := getBusiness(r)
 
-	business, err := business.Get()
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
@@ -32,15 +31,15 @@ func NamespaceList(w http.ResponseWriter, r *http.Request) {
 // NamespaceMetrics is the API handler to fetch metrics to be displayed, related to all
 // services in the namespace
 func NamespaceMetrics(w http.ResponseWriter, r *http.Request) {
-	getNamespaceMetrics(w, r, defaultPromClientSupplier, defaultK8SClientSupplier)
+	getNamespaceMetrics(w, r, defaultPromClientSupplier)
 }
 
 // getServiceMetrics (mock-friendly version)
-func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, k8sSupplier k8sClientSupplier) {
+func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier) {
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 
-	prom, _, namespaceInfo := initClientsForMetrics(w, promSupplier, k8sSupplier, namespace)
+	prom, namespaceInfo := initClientsForMetrics(w, r, promSupplier, namespace)
 	if prom == nil {
 		// any returned value nil means error & response already written
 		return

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -16,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
@@ -144,10 +144,9 @@ func setupNamespaceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheust
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/metrics", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			getNamespaceMetrics(w, r, func() (*prometheus.Client, error) {
+			context := context.WithValue(r.Context(), "token", "test")
+			getNamespaceMetrics(w, r.WithContext(context), func() (*prometheus.Client, error) {
 				return client, nil
-			}, func() (kubernetes.IstioClientInterface, error) {
-				return k8s, nil
 			})
 		}))
 

--- a/handlers/root.go
+++ b/handlers/root.go
@@ -11,5 +11,15 @@ func Root(w http.ResponseWriter, r *http.Request) {
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
-	RespondWithJSONIndent(w, http.StatusOK, status.Get())
+
+	tokenContext := r.Context().Value("token")
+	if tokenContext != nil {
+		if token, ok := tokenContext.(string); ok {
+			RespondWithJSONIndent(w, http.StatusOK, status.Get(token))
+		} else {
+			RespondWithJSONIndent(w, http.StatusInternalServerError, "Token is not of type string")
+		}
+	} else {
+		RespondWithJSONIndent(w, http.StatusInternalServerError, "Token missing in request context")
+	}
 }

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -18,7 +18,7 @@ func ServiceList(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -37,16 +37,16 @@ func ServiceList(w http.ResponseWriter, r *http.Request) {
 
 // ServiceMetrics is the API handler to fetch metrics to be displayed, related to a single service
 func ServiceMetrics(w http.ResponseWriter, r *http.Request) {
-	getServiceMetrics(w, r, defaultPromClientSupplier, defaultK8SClientSupplier)
+	getServiceMetrics(w, r, defaultPromClientSupplier)
 }
 
 // getServiceMetrics (mock-friendly version)
-func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, k8sSupplier k8sClientSupplier) {
+func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier) {
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	service := vars["service"]
 
-	prom, _, namespaceInfo := initClientsForMetrics(w, promSupplier, k8sSupplier, namespace)
+	prom, namespaceInfo := initClientsForMetrics(w, r, promSupplier, namespace)
 	if prom == nil {
 		// any returned value nil means error & response already written
 		return
@@ -66,7 +66,7 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 // ServiceDetails is the API handler to fetch full details of an specific service
 func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -136,7 +136,7 @@ func ServiceDashboard(w http.ResponseWriter, r *http.Request) {
 	namespace := vars["namespace"]
 	service := vars["service"]
 
-	prom, _, namespaceInfo := initClientsForMetrics(w, defaultPromClientSupplier, defaultK8SClientSupplier, namespace)
+	prom, namespaceInfo := initClientsForMetrics(w, r, defaultPromClientSupplier, namespace)
 	if prom == nil {
 		// any returned value nil means error & response already written
 		return

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -15,7 +15,7 @@ func WorkloadList(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Workloads initialization error: "+err.Error())
 		return
@@ -37,7 +37,7 @@ func WorkloadDetails(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
 	// Get business layer
-	business, err := business.Get()
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Workloads initialization error: "+err.Error())
 		return
@@ -61,16 +61,16 @@ func WorkloadDetails(w http.ResponseWriter, r *http.Request) {
 
 // WorkloadMetrics is the API handler to fetch metrics to be displayed, related to a single workload
 func WorkloadMetrics(w http.ResponseWriter, r *http.Request) {
-	getWorkloadMetrics(w, r, defaultPromClientSupplier, defaultK8SClientSupplier)
+	getWorkloadMetrics(w, r, defaultPromClientSupplier)
 }
 
 // getWorkloadMetrics (mock-friendly version)
-func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, k8sSupplier k8sClientSupplier) {
+func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier) {
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	workload := vars["workload"]
 
-	prom, _, namespaceInfo := initClientsForMetrics(w, promSupplier, k8sSupplier, namespace)
+	prom, namespaceInfo := initClientsForMetrics(w, r, promSupplier, namespace)
 	if prom == nil {
 		// any returned value nil means error & response already written
 		return
@@ -93,7 +93,7 @@ func WorkloadDashboard(w http.ResponseWriter, r *http.Request) {
 	namespace := vars["namespace"]
 	workload := vars["workload"]
 
-	prom, _, namespaceInfo := initClientsForMetrics(w, defaultPromClientSupplier, defaultK8SClientSupplier, namespace)
+	prom, namespaceInfo := initClientsForMetrics(w, r, defaultPromClientSupplier, namespace)
 	if prom == nil {
 		// any returned value nil means error & response already written
 		return

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -108,6 +108,17 @@ type IstioClient struct {
 	stopCache chan struct{}
 }
 
+// ClientFactory interface for the clientFactory object
+type ClientFactory interface {
+	NewClient(token string) (IstioClientInterface, error)
+}
+
+// clientFactory used to generate per users clients
+type clientFactory struct {
+	ClientFactory
+	baseIstioConfig *rest.Config
+}
+
 // GetK8sApi returns the clientset referencing all K8s rest clients
 func (client *IstioClient) GetK8sApi() *kube.Clientset {
 	return client.k8s
@@ -154,13 +165,33 @@ func ConfigClient() (*rest.Config, error) {
 	}, nil
 }
 
-// NewClient creates a new client to the Kubernetes and Istio APIs.
-func NewClient() (*IstioClient, error) {
-	config, err := ConfigClient()
+// NewClientFactory create a new ClientFactory that can be used to generate per user clients
+func NewClientFactory() (ClientFactory, error) {
 
+	// Get the normal configuration
+	config, err := ConfigClient()
 	if err != nil {
 		return nil, err
 	}
+
+	// Create a new config based on what was gathered above but don't specify the bearer token to use
+	istioConfig := rest.Config{
+		Host:            config.Host,
+		TLSClientConfig: config.TLSClientConfig,
+		QPS:             config.QPS,
+		Burst:           config.Burst,
+	}
+
+	return &clientFactory{
+		baseIstioConfig: &istioConfig,
+	}, nil
+}
+
+// NewClient creates a new IstioClientInterface based on a users k8s token
+func (uc *clientFactory) NewClient(token string) (IstioClientInterface, error) {
+	config := uc.baseIstioConfig
+
+	config.BearerToken = token
 
 	return NewClientFromConfig(config)
 }

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -15,7 +15,30 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/kubernetes"
+	"k8s.io/client-go/rest"
 )
+
+//// Mock for the K8SClientFactory
+
+type K8SClientFactoryMock struct {
+	mock.Mock
+	baseIstioConfig *rest.Config
+	k8s             kubernetes.IstioClientInterface
+}
+
+// Constructor
+func NewK8SClientFactoryMock(k8s kubernetes.IstioClientInterface) *K8SClientFactoryMock {
+	k8sClientFactory := new(K8SClientFactoryMock)
+	k8sClientFactory.k8s = k8s
+	return k8sClientFactory
+}
+
+// Business Methods
+func (o *K8SClientFactoryMock) NewClient(token string) (kubernetes.IstioClientInterface, error) {
+	return o.k8s, nil
+}
+
+/////
 
 type K8SClientMock struct {
 	mock.Mock

--- a/routing/router.go
+++ b/routing/router.go
@@ -35,11 +35,12 @@ func NewRouter() *mux.Router {
 
 	// Build our API server routes and install them.
 	apiRoutes := NewRoutes()
+	authenticationHandler, _ := handlers.NewAuthenticationHandler()
 	for _, route := range apiRoutes.Routes {
-		var handlerFunction http.Handler = route.HandlerFunc
+		var handlerFunction http.Handler = authenticationHandler.HandleUnauthenticated(route.HandlerFunc)
 		handlerFunction = metricHandler(handlerFunction, route)
 		if route.Authenticated {
-			handlerFunction = handlers.AuthenticationHandler(handlerFunction)
+			handlerFunction = authenticationHandler.Handle(route.HandlerFunc)
 		}
 		appRouter.
 			Methods(route.Method).

--- a/server/server.go
+++ b/server/server.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/routing"
@@ -59,12 +58,6 @@ func (s *Server) Start() {
 // Stop the HTTP server
 func (s *Server) Stop() {
 	log.Infof("Server endpoint will stop at [%v]", s.httpServer.Addr)
-	layer, err := business.Get()
-	if err != nil {
-		log.Errorf("Error stopping business layer: %s", err)
-	} else {
-		layer.Stop()
-	}
 	s.httpServer.Close()
 }
 

--- a/status/mtls_status.go
+++ b/status/mtls_status.go
@@ -4,9 +4,9 @@ import (
 	"github.com/kiali/kiali/business"
 )
 
-func (si *StatusInfo) getmTLSStatus() {
+func (si *StatusInfo) getmTLSStatus(token string) {
 	// Get business layer
-	business, err := business.Get()
+	business, err := business.Get(token)
 	if err != nil {
 		Put(ClusterMTLS, "error")
 		return

--- a/status/status.go
+++ b/status/status.go
@@ -73,10 +73,10 @@ func Put(name, value string) (previous string, hasPrevious bool) {
 }
 
 // Get returns a copy of the current status info.
-func Get() (status StatusInfo) {
+func Get(token string) (status StatusInfo) {
 	info.ExternalServices = []ExternalServiceInfo{}
 	info.WarningMessages = []string{}
-	info.getmTLSStatus()
+	info.getmTLSStatus(token)
 	getVersions()
 	return info
 }


### PR DESCRIPTION
**Describe the change**

If we are using the Oauth login mechanism for OpenShift, we will now use this token when contacting the k8s master. This means the permissions the user has in the OpenShift cluster will affect what they can access in Kiali.

If a user is not using the Oauth login mechanism, then we use the service accounts token when contacting the k8s master.

This basically brings us up to the 'mulitenancy' support that we want to have with OpenShift.

**Issue reference**

https://issues.jboss.org/browse/KIALI-1186

**Documentation**

We do need documentation to be updated. Will submit a PR for docs once this PR has been reviewed.

**Known Issues**

There are a few issues I have seen so far:

1) if you are in the graph seeing one namespace and then later login with a user that doesn't have access to the namespace you are shown an error.
2) if your user doesn't have access to the kiali-system namespace you will get an error about not being able to generate the grafana links.

These are also issues that we have if you were running with reduced permissions. I would rather fix those in a separate jira and keep this one more focused on the task we are trying to do here.

User who are logging into Kiali may not have all the permissions that the `kiali` role grants, so we might experience some issues with access denied problems (and will need to work towards making them work better). The easier way to get around this is to grant the user the `kiali` role for that namespace (`oc adm policy add-role-to-user kiali ${USER} -n ${NAMESPACE}`)


**Other Considerations**
We should also see how this affects performance. Before we were reusing the k8s client across all connections and now we are creating new ones per user requests. Its unknown at this point how much of a performace hit this will cause.

**How to test**
1) build Kiali like you would if you were using oauth authentication 
ie `AUTH_STRATEGY=openshift make openshift-deploy`

2) log into openshift using a user account. You should only be displayed data that you have access to. If you want to grant a user access to another namespace, you can grant them the `kiali` role:
`oc adm policy add-role-to-user kiali ${USER} -n ${NAMESPACE}`