### PR TITLE
KIALI-2405 Spring Boot dashboards

### DIFF
--- a/deploy/dashboards/springboot-jvm.yaml
+++ b/deploy/dashboards/springboot-jvm.yaml
@@ -1,0 +1,80 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: springboot-jvm
+  labels:
+    runtime: SpringBoot
+spec:
+  title: JVM Metrics
+  charts:
+    - name: "Total live threads"
+      unit: ""
+      spans: 4
+      metricName: "jvm_threads_live"
+      dataType: "raw"
+    - name: "Daemon threads"
+      unit: ""
+      spans: 4
+      metricName: "jvm_threads_daemon"
+      dataType: "raw"
+    - name: "Loaded classes"
+      unit: ""
+      spans: 4
+      metricName: "jvm_classes_loaded"
+      dataType: "raw"
+
+    - name: "Memory used"
+      unit: "B"
+      spans: 4
+      metricName: "jvm_memory_used_bytes"
+      dataType: "raw"
+      aggregations:
+        - label: "area"
+          displayName: "Area"
+        - label: "id"
+          displayName: "Space"
+    - name: "Memory commited"
+      unit: "B"
+      spans: 4
+      metricName: "jvm_memory_committed_bytes"
+      dataType: "raw"
+      aggregations:
+        - label: "area"
+          displayName: "Area"
+        - label: "id"
+          displayName: "Space"
+    - name: "Memory max"
+      unit: "B"
+      spans: 4
+      metricName: "jvm_memory_max_bytes"
+      dataType: "raw"
+      aggregations:
+        - label: "area"
+          displayName: "Area"
+        - label: "id"
+          displayName: "Space"
+
+    - name: "Pool buffer memory used"
+      unit: "B"
+      spans: 4
+      metricName: "jvm_buffer_memory_used_bytes"
+      dataType: "raw"
+      aggregations:
+        - label: "id"
+          displayName: "Pool"
+    - name: "Pool buffer capacity"
+      unit: "B"
+      spans: 4
+      metricName: "jvm_buffer_total_capacity_bytes"
+      dataType: "raw"
+      aggregations:
+        - label: "id"
+          displayName: "Pool"
+    - name: "Pool buffer count"
+      unit: "B"
+      spans: 4
+      metricName: "jvm_buffer_count"
+      dataType: "raw"
+      aggregations:
+        - label: "id"
+          displayName: "Pool"

--- a/deploy/dashboards/springboot-tomcat.yaml
+++ b/deploy/dashboards/springboot-tomcat.yaml
@@ -1,0 +1,58 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: springboot-tomcat
+  labels:
+    runtime: SpringBoot
+spec:
+  title: Tomcat Metrics
+  charts:
+    - name: "Sessions created"
+      unit: ""
+      spans: 4
+      metricName: "tomcat_sessions_created_total"
+      dataType: "raw"
+    - name: "Active sessions"
+      unit: ""
+      spans: 4
+      metricName: "tomcat_sessions_active_current"
+      dataType: "raw"
+    - name: "Sessions rejected"
+      unit: ""
+      spans: 4
+      metricName: "tomcat_sessions_rejected_total"
+      dataType: "raw"
+
+    - name: "Bytes sent"
+      unit: "bps"
+      spans: 6
+      metricName: "tomcat_global_sent_bytes_total"
+      dataType: "rate"
+      aggregations:
+        - label: "name"
+          displayName: "Name"
+    - name: "Bytes received"
+      unit: "bps"
+      spans: 6
+      metricName: "tomcat_global_received_bytes_total"
+      dataType: "rate"
+      aggregations:
+        - label: "name"
+          displayName: "Name"
+
+    - name: "Global errors"
+      unit: ""
+      spans: 6
+      metricName: "tomcat_global_error_total"
+      dataType: "raw"
+      aggregations:
+        - label: "name"
+          displayName: "Name"
+    - name: "Servlet errors"
+      unit: ""
+      spans: 6
+      metricName: "tomcat_servlet_error_total"
+      dataType: "raw"
+      aggregations:
+        - label: "name"
+          displayName: "Name"

--- a/deploy/kubernetes/deploy-kiali-to-kubernetes.sh
+++ b/deploy/kubernetes/deploy-kiali-to-kubernetes.sh
@@ -238,7 +238,7 @@ done
 # Deploy Kiali MonitoringDashboards to Kubernetes
 # Note for undeploy script: dashboards are implicitly undeployed when the related CRD is removed
 echo "Deploying Kiali dashboards to Kubernetes namespace ${NAMESPACE}"
-for dashboard in nodejs thorntail vertx-client vertx-eventbus vertx-pool vertx-server
+for dashboard in nodejs thorntail vertx-client vertx-eventbus vertx-pool vertx-server springboot-jvm springboot-tomcat
 do
   yaml_path="${YAML_DIR}/../dashboards/${dashboard}.yaml"
   if [ -f "${yaml_path}" ]; then

--- a/deploy/openshift/deploy-kiali-to-openshift.sh
+++ b/deploy/openshift/deploy-kiali-to-openshift.sh
@@ -246,7 +246,7 @@ PROTOCOL="$(if [[ $(oc get routes -n ${NAMESPACE} kiali -o jsonpath=\"{.spec.tls
 # Deploy Kiali MonitoringDashboards to OpenShift
 # Note for undeploy script: dashboards are implicitly undeployed when the related CRD is removed
 echo "Deploying Kiali dashboards to OpenShift project ${NAMESPACE}"
-for dashboard in nodejs thorntail vertx-client vertx-eventbus vertx-pool vertx-server
+for dashboard in nodejs thorntail vertx-client vertx-eventbus vertx-pool vertx-server springboot-jvm springboot-tomcat
 do
   yaml_path="${YAML_DIR}/../dashboards/${dashboard}.yaml"
   if [ -f "${yaml_path}" ]; then


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-2405

Tomcat dashboard (tomcat is springboot default's webserver)
![tomcat](https://i.imgur.com/stqsnoZ.png)

JVM metrics
![jvm](https://i.imgur.com/xJYwowG.png)

For testing, you can use the new bookinfo-runtimes : https://github.com/jotak/bookinfo-runtimes
- run the `deploy-all.sh` script
- install the new dashboards from this PR (either directly or redeploy kiali)
- if you don't run the latest istio, you have to update once again prometheus config map (see `bookinfo-runtimes` readme)