### PR TITLE
KIALI-2442 Map kind and apiVersion attributes

### DIFF
--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -137,6 +137,7 @@ func (in *IstioClient) UpdateIstioObject(api, namespace, resourceType, name, jso
 	if !ok {
 		return nil, fmt.Errorf("%s/%s doesn't return an IstioObject object", namespace, name)
 	}
+	istioObject.SetTypeMeta(typeMeta)
 	return istioObject, err
 }
 

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -56,15 +57,24 @@ func (in *IstioClient) CreateIstioObject(api, namespace, resourceType, json stri
 	var result runtime.Object
 	var err error
 
+	typeMeta := meta_v1.TypeMeta{
+		Kind: "",
+		APIVersion: "",
+	}
+	typeMeta.Kind = PluralType[resourceType]
 	byteJson := []byte(json)
 	if api == ConfigGroupVersion.Group {
 		result, err = in.istioConfigApi.Post().Namespace(namespace).Resource(resourceType).Body(byteJson).Do().Get()
+		typeMeta.APIVersion = ApiConfigVersion
 	} else if api == NetworkingGroupVersion.Group {
 		result, err = in.istioNetworkingApi.Post().Namespace(namespace).Resource(resourceType).Body(byteJson).Do().Get()
+		typeMeta.APIVersion = ApiNetworkingVersion
 	} else if api == AuthenticationGroupVersion.Group {
 		result, err = in.istioAuthenticationApi.Post().Namespace(namespace).Resource(resourceType).Body(byteJson).Do().Get()
+		typeMeta.APIVersion = ApiAuthenticationVersion
 	} else {
 		result, err = in.istioRbacApi.Post().Namespace(namespace).Resource(resourceType).Body(byteJson).Do().Get()
+		typeMeta.APIVersion = ApiRbacVersion
 	}
 
 	if err != nil {
@@ -75,6 +85,7 @@ func (in *IstioClient) CreateIstioObject(api, namespace, resourceType, json stri
 	if !ok {
 		return nil, fmt.Errorf("%s/%s doesn't return an IstioObject object", namespace, resourceType)
 	}
+	istioObject.SetTypeMeta(typeMeta)
 	return istioObject, err
 }
 
@@ -99,15 +110,25 @@ func (in *IstioClient) UpdateIstioObject(api, namespace, resourceType, name, jso
 	log.Debugf("UpdateIstioObject input: %s / %s / %s / %s", api, namespace, resourceType, name)
 	var result runtime.Object
 	var err error
+
+	typeMeta := meta_v1.TypeMeta{
+		Kind: "",
+		APIVersion: "",
+	}
+	typeMeta.Kind = PluralType[resourceType]
 	bytePatch := []byte(jsonPatch)
 	if api == ConfigGroupVersion.Group {
 		result, err = in.istioConfigApi.Patch(types.MergePatchType).Namespace(namespace).Resource(resourceType).SubResource(name).Body(bytePatch).Do().Get()
+		typeMeta.APIVersion = ApiConfigVersion
 	} else if api == NetworkingGroupVersion.Group {
 		result, err = in.istioNetworkingApi.Patch(types.MergePatchType).Namespace(namespace).Resource(resourceType).SubResource(name).Body(bytePatch).Do().Get()
+		typeMeta.APIVersion = ApiNetworkingVersion
 	} else if api == AuthenticationGroupVersion.Group {
 		result, err = in.istioAuthenticationApi.Patch(types.MergePatchType).Namespace(namespace).Resource(resourceType).SubResource(name).Body(bytePatch).Do().Get()
+		typeMeta.APIVersion = ApiAuthenticationVersion
 	} else {
 		result, err = in.istioRbacApi.Patch(types.MergePatchType).Namespace(namespace).Resource(resourceType).SubResource(name).Body(bytePatch).Do().Get()
+		typeMeta.APIVersion = ApiRbacVersion
 	}
 	if err != nil {
 		return nil, err
@@ -131,7 +152,10 @@ func (in *IstioClient) GetVirtualServices(namespace string, serviceName string) 
 	if !ok {
 		return nil, fmt.Errorf("%s/%s doesn't return a VirtualService list", namespace, serviceName)
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[virtualServices],
+		APIVersion: ApiNetworkingVersion,
+	}
 	virtualServices := make([]IstioObject, 0)
 	for _, virtualService := range virtualServiceList.GetItems() {
 		appendVirtualService := serviceName == ""
@@ -140,7 +164,9 @@ func (in *IstioClient) GetVirtualServices(namespace string, serviceName string) 
 			appendVirtualService = true
 		}
 		if appendVirtualService {
-			virtualServices = append(virtualServices, virtualService.DeepCopyIstioObject())
+			vs := virtualService.DeepCopyIstioObject()
+			vs.SetTypeMeta(typeMeta)
+			virtualServices = append(virtualServices, vs)
 		}
 	}
 	return virtualServices, nil
@@ -151,12 +177,17 @@ func (in *IstioClient) GetVirtualService(namespace string, virtualservice string
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[virtualServices],
+		APIVersion: ApiNetworkingVersion,
+	}
 	virtualService, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s/%s doesn't return a VirtualService object", namespace, virtualservice)
 	}
-	return virtualService.DeepCopyIstioObject(), nil
+	vs := virtualService.DeepCopyIstioObject()
+	vs.SetTypeMeta(typeMeta)
+	return vs, nil
 }
 
 // GetGateways return all Gateways for a given namespace.
@@ -170,10 +201,15 @@ func (in *IstioClient) GetGateways(namespace string) ([]IstioObject, error) {
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a Gateway list", namespace)
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[gateways],
+		APIVersion: ApiNetworkingVersion,
+	}
 	gateways := make([]IstioObject, 0)
 	for _, gateway := range gatewayList.GetItems() {
-		gateways = append(gateways, gateway.DeepCopyIstioObject())
+		gw := gateway.DeepCopyIstioObject()
+		gw.SetTypeMeta(typeMeta)
+		gateways = append(gateways, gw)
 	}
 	return gateways, nil
 }
@@ -183,12 +219,17 @@ func (in *IstioClient) GetGateway(namespace string, gateway string) (IstioObject
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[gateways],
+		APIVersion: ApiNetworkingVersion,
+	}
 	gatewayObject, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s/%s doesn't return a Gateway object", namespace, gateway)
 	}
-	return gatewayObject.DeepCopyIstioObject(), nil
+	gw := gatewayObject.DeepCopyIstioObject()
+	gw.SetTypeMeta(typeMeta)
+	return gw, nil
 }
 
 // GetServiceEntries return all ServiceEntry objects for a given namespace.
@@ -198,6 +239,10 @@ func (in *IstioClient) GetServiceEntries(namespace string) ([]IstioObject, error
 	if err != nil {
 		return nil, err
 	}
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[serviceentries],
+		APIVersion: ApiNetworkingVersion,
+	}
 	serviceEntriesList, ok := result.(*GenericIstioObjectList)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a ServiceEntry list", namespace)
@@ -205,7 +250,9 @@ func (in *IstioClient) GetServiceEntries(namespace string) ([]IstioObject, error
 
 	serviceEntries := make([]IstioObject, 0)
 	for _, serviceEntry := range serviceEntriesList.GetItems() {
-		serviceEntries = append(serviceEntries, serviceEntry.DeepCopyIstioObject())
+		se := serviceEntry.DeepCopyIstioObject()
+		se.SetTypeMeta(typeMeta)
+		serviceEntries = append(serviceEntries, se)
 	}
 	return serviceEntries, nil
 }
@@ -215,12 +262,17 @@ func (in *IstioClient) GetServiceEntry(namespace string, serviceEntryName string
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[serviceentries],
+		APIVersion: ApiNetworkingVersion,
+	}
 	serviceEntry, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s/%v doesn't return a ServiceEntry object", namespace, serviceEntry)
 	}
-	return serviceEntry.DeepCopyIstioObject(), nil
+	se := serviceEntry.DeepCopyIstioObject()
+	se.SetTypeMeta(typeMeta)
+	return se, nil
 }
 
 // GetDestinationRules returns all DestinationRules for a given namespace.
@@ -230,6 +282,10 @@ func (in *IstioClient) GetDestinationRules(namespace string, serviceName string)
 	result, err := in.istioNetworkingApi.Get().Namespace(namespace).Resource(destinationRules).Do().Get()
 	if err != nil {
 		return nil, err
+	}
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[destinationRules],
+		APIVersion: ApiNetworkingVersion,
 	}
 	destinationRuleList, ok := result.(*GenericIstioObjectList)
 	if !ok {
@@ -245,7 +301,9 @@ func (in *IstioClient) GetDestinationRules(namespace string, serviceName string)
 			}
 		}
 		if appendDestinationRule {
-			destinationRules = append(destinationRules, destinationRule.DeepCopyIstioObject())
+			dr := destinationRule.DeepCopyIstioObject()
+			dr.SetTypeMeta(typeMeta)
+			destinationRules = append(destinationRules, dr)
 		}
 	}
 	return destinationRules, nil
@@ -256,11 +314,17 @@ func (in *IstioClient) GetDestinationRule(namespace string, destinationrule stri
 	if err != nil {
 		return nil, err
 	}
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[destinationRules],
+		APIVersion: ApiNetworkingVersion,
+	}
 	destinationRule, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s/%s doesn't return a DestinationRule object", namespace, destinationrule)
 	}
-	return destinationRule.DeepCopyIstioObject(), nil
+	dr := destinationRule.DeepCopyIstioObject()
+	dr.SetTypeMeta(typeMeta)
+	return dr, nil
 }
 
 // GetQuotaSpecs returns all QuotaSpecs objects for a given namespace.
@@ -270,6 +334,10 @@ func (in *IstioClient) GetQuotaSpecs(namespace string) ([]IstioObject, error) {
 	if err != nil {
 		return nil, err
 	}
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[quotaspecs],
+		APIVersion: ApiConfigVersion,
+	}
 	quotaSpecList, ok := result.(*GenericIstioObjectList)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a QuotaSpecList list", namespace)
@@ -277,7 +345,9 @@ func (in *IstioClient) GetQuotaSpecs(namespace string) ([]IstioObject, error) {
 
 	quotaSpecs := make([]IstioObject, 0)
 	for _, qs := range quotaSpecList.GetItems() {
-		quotaSpecs = append(quotaSpecs, qs.DeepCopyIstioObject())
+		q := qs.DeepCopyIstioObject()
+		q.SetTypeMeta(typeMeta)
+		quotaSpecs = append(quotaSpecs, q)
 	}
 	return quotaSpecs, nil
 }
@@ -287,12 +357,17 @@ func (in *IstioClient) GetQuotaSpec(namespace string, quotaSpecName string) (Ist
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[quotaspecs],
+		APIVersion: ApiConfigVersion,
+	}
 	quotaSpec, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s/%s doesn't return a QuotaSpec object", namespace, quotaSpecName)
 	}
-	return quotaSpec.DeepCopyIstioObject(), nil
+	qs := quotaSpec.DeepCopyIstioObject()
+	qs.SetTypeMeta(typeMeta)
+	return qs, nil
 }
 
 // GetQuotaSpecBindings returns all QuotaSpecBindings objects for a given namespace.
@@ -302,6 +377,10 @@ func (in *IstioClient) GetQuotaSpecBindings(namespace string) ([]IstioObject, er
 	if err != nil {
 		return nil, err
 	}
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[quotaspecbindings],
+		APIVersion: ApiConfigVersion,
+	}
 	quotaSpecBindingList, ok := result.(*GenericIstioObjectList)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a QuotaSpecBindingList list", namespace)
@@ -309,7 +388,9 @@ func (in *IstioClient) GetQuotaSpecBindings(namespace string) ([]IstioObject, er
 
 	quotaSpecBindings := make([]IstioObject, 0)
 	for _, qs := range quotaSpecBindingList.GetItems() {
-		quotaSpecBindings = append(quotaSpecBindings, qs.DeepCopyIstioObject())
+		q := qs.DeepCopyIstioObject()
+		q.SetTypeMeta(typeMeta)
+		quotaSpecBindings = append(quotaSpecBindings, q)
 	}
 	return quotaSpecBindings, nil
 }
@@ -319,12 +400,17 @@ func (in *IstioClient) GetQuotaSpecBinding(namespace string, quotaSpecBindingNam
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[quotaspecbindings],
+		APIVersion: ApiConfigVersion,
+	}
 	quotaSpecBinding, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s/%s doesn't return a QuotaSpecBinding object", namespace, quotaSpecBindingName)
 	}
-	return quotaSpecBinding.DeepCopyIstioObject(), nil
+	qs := quotaSpecBinding.DeepCopyIstioObject()
+	qs.SetTypeMeta(typeMeta)
+	return qs, nil
 }
 
 func (in *IstioClient) GetPolicies(namespace string) ([]IstioObject, error) {
@@ -332,7 +418,10 @@ func (in *IstioClient) GetPolicies(namespace string) ([]IstioObject, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[policies],
+		APIVersion: ApiAuthenticationVersion,
+	}
 	policyList, ok := result.(*GenericIstioObjectList)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a PolicyList list", namespace)
@@ -340,7 +429,9 @@ func (in *IstioClient) GetPolicies(namespace string) ([]IstioObject, error) {
 
 	policies := make([]IstioObject, 0)
 	for _, ps := range policyList.GetItems() {
-		policies = append(policies, ps.DeepCopyIstioObject())
+		p := ps.DeepCopyIstioObject()
+		p.SetTypeMeta(typeMeta)
+		policies = append(policies, p)
 	}
 
 	return policies, nil
@@ -351,13 +442,17 @@ func (in *IstioClient) GetPolicy(namespace string, policyName string) (IstioObje
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[policies],
+		APIVersion: ApiAuthenticationVersion,
+	}
 	policy, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a Policy object", namespace)
 	}
-
-	return policy.DeepCopyIstioObject(), nil
+	p := policy.DeepCopyIstioObject()
+	p.SetTypeMeta(typeMeta)
+	return p, nil
 }
 
 func (in *IstioClient) GetMeshPolicies(namespace string) ([]IstioObject, error) {
@@ -367,7 +462,10 @@ func (in *IstioClient) GetMeshPolicies(namespace string) ([]IstioObject, error) 
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[meshPolicies],
+		APIVersion: ApiAuthenticationVersion,
+	}
 	policyList, ok := result.(*GenericIstioObjectList)
 	if !ok {
 		return nil, fmt.Errorf("it doesn't return a PolicyList list")
@@ -375,7 +473,9 @@ func (in *IstioClient) GetMeshPolicies(namespace string) ([]IstioObject, error) 
 
 	policies := make([]IstioObject, 0)
 	for _, ps := range policyList.GetItems() {
-		policies = append(policies, ps.DeepCopyIstioObject())
+		p := ps.DeepCopyIstioObject()
+		p.SetTypeMeta(typeMeta)
+		policies = append(policies, p)
 	}
 
 	return policies, nil
@@ -386,13 +486,17 @@ func (in *IstioClient) GetMeshPolicy(namespace string, policyName string) (Istio
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[meshPolicies],
+		APIVersion: ApiAuthenticationVersion,
+	}
 	mp, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a MeshPolicy object", namespace)
 	}
-
-	return mp.DeepCopyIstioObject(), nil
+	p := mp.DeepCopyIstioObject()
+	p.SetTypeMeta(typeMeta)
+	return p, nil
 }
 
 func (in *IstioClient) GetClusterRbacConfigs(namespace string) ([]IstioObject, error) {
@@ -400,7 +504,10 @@ func (in *IstioClient) GetClusterRbacConfigs(namespace string) ([]IstioObject, e
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[clusterrbacconfigs],
+		APIVersion: ApiRbacVersion,
+	}
 	clusterRbacConfigList, ok := result.(*GenericIstioObjectList)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a RbacConfigList list", namespace)
@@ -408,9 +515,10 @@ func (in *IstioClient) GetClusterRbacConfigs(namespace string) ([]IstioObject, e
 
 	clusterRbacConfigs := make([]IstioObject, 0)
 	for _, crc := range clusterRbacConfigList.GetItems() {
-		clusterRbacConfigs = append(clusterRbacConfigs, crc.DeepCopyIstioObject())
+		c := crc.DeepCopyIstioObject()
+		c.SetTypeMeta(typeMeta)
+		clusterRbacConfigs = append(clusterRbacConfigs, c)
 	}
-
 	return clusterRbacConfigs, nil
 }
 
@@ -419,13 +527,17 @@ func (in *IstioClient) GetClusterRbacConfig(namespace string, name string) (Isti
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[clusterrbacconfigs],
+		APIVersion: ApiRbacVersion,
+	}
 	clusterRbacConfig, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a ClusterRbacConfig object", namespace)
 	}
-
-	return clusterRbacConfig.DeepCopyIstioObject(), nil
+	c := clusterRbacConfig.DeepCopyIstioObject()
+	c.SetTypeMeta(typeMeta)
+	return c, nil
 }
 
 func (in *IstioClient) GetServiceRoles(namespace string) ([]IstioObject, error) {
@@ -433,7 +545,10 @@ func (in *IstioClient) GetServiceRoles(namespace string) ([]IstioObject, error) 
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[serviceroles],
+		APIVersion: ApiRbacVersion,
+	}
 	serviceRoleList, ok := result.(*GenericIstioObjectList)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a ServiceRoleList list", namespace)
@@ -441,9 +556,10 @@ func (in *IstioClient) GetServiceRoles(namespace string) ([]IstioObject, error) 
 
 	serviceRoles := make([]IstioObject, 0)
 	for _, sr := range serviceRoleList.GetItems() {
-		serviceRoles = append(serviceRoles, sr.DeepCopyIstioObject())
+		s := sr.DeepCopyIstioObject()
+		s.SetTypeMeta(typeMeta)
+		serviceRoles = append(serviceRoles, s)
 	}
-
 	return serviceRoles, nil
 }
 
@@ -452,13 +568,17 @@ func (in *IstioClient) GetServiceRole(namespace string, name string) (IstioObjec
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[serviceroles],
+		APIVersion: ApiRbacVersion,
+	}
 	serviceRole, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a ServiceRole object", namespace)
 	}
-
-	return serviceRole.DeepCopyIstioObject(), nil
+	s := serviceRole.DeepCopyIstioObject()
+	s.SetTypeMeta(typeMeta)
+	return s, nil
 }
 
 func (in *IstioClient) GetServiceRoleBindings(namespace string) ([]IstioObject, error) {
@@ -466,7 +586,10 @@ func (in *IstioClient) GetServiceRoleBindings(namespace string) ([]IstioObject, 
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[servicerolebindings],
+		APIVersion: ApiRbacVersion,
+	}
 	serviceRoleBindingList, ok := result.(*GenericIstioObjectList)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a ServiceRoleBindingList list", namespace)
@@ -474,9 +597,10 @@ func (in *IstioClient) GetServiceRoleBindings(namespace string) ([]IstioObject, 
 
 	serviceRoleBindings := make([]IstioObject, 0)
 	for _, sr := range serviceRoleBindingList.GetItems() {
-		serviceRoleBindings = append(serviceRoleBindings, sr.DeepCopyIstioObject())
+		s := sr.DeepCopyIstioObject()
+		s.SetTypeMeta(typeMeta)
+		serviceRoleBindings = append(serviceRoleBindings, s)
 	}
-
 	return serviceRoleBindings, nil
 }
 
@@ -485,13 +609,17 @@ func (in *IstioClient) GetServiceRoleBinding(namespace string, name string) (Ist
 	if err != nil {
 		return nil, err
 	}
-
+	typeMeta := meta_v1.TypeMeta{
+		Kind: PluralType[servicerolebindings],
+		APIVersion: ApiRbacVersion,
+	}
 	serviceRoleBinding, ok := result.(*GenericIstioObject)
 	if !ok {
 		return nil, fmt.Errorf("%s doesn't return a ServiceRoleBinding object", namespace)
 	}
-
-	return serviceRoleBinding.DeepCopyIstioObject(), nil
+	s := serviceRoleBinding.DeepCopyIstioObject()
+	s.SetTypeMeta(typeMeta)
+	return s, nil
 }
 
 func FilterByHost(host, serviceName, namespace string) bool {

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -58,7 +58,7 @@ func (in *IstioClient) CreateIstioObject(api, namespace, resourceType, json stri
 	var err error
 
 	typeMeta := meta_v1.TypeMeta{
-		Kind: "",
+		Kind:       "",
 		APIVersion: "",
 	}
 	typeMeta.Kind = PluralType[resourceType]
@@ -112,7 +112,7 @@ func (in *IstioClient) UpdateIstioObject(api, namespace, resourceType, name, jso
 	var err error
 
 	typeMeta := meta_v1.TypeMeta{
-		Kind: "",
+		Kind:       "",
 		APIVersion: "",
 	}
 	typeMeta.Kind = PluralType[resourceType]
@@ -153,7 +153,7 @@ func (in *IstioClient) GetVirtualServices(namespace string, serviceName string) 
 		return nil, fmt.Errorf("%s/%s doesn't return a VirtualService list", namespace, serviceName)
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[virtualServices],
+		Kind:       PluralType[virtualServices],
 		APIVersion: ApiNetworkingVersion,
 	}
 	virtualServices := make([]IstioObject, 0)
@@ -178,7 +178,7 @@ func (in *IstioClient) GetVirtualService(namespace string, virtualservice string
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[virtualServices],
+		Kind:       PluralType[virtualServices],
 		APIVersion: ApiNetworkingVersion,
 	}
 	virtualService, ok := result.(*GenericIstioObject)
@@ -202,7 +202,7 @@ func (in *IstioClient) GetGateways(namespace string) ([]IstioObject, error) {
 		return nil, fmt.Errorf("%s doesn't return a Gateway list", namespace)
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[gateways],
+		Kind:       PluralType[gateways],
 		APIVersion: ApiNetworkingVersion,
 	}
 	gateways := make([]IstioObject, 0)
@@ -220,7 +220,7 @@ func (in *IstioClient) GetGateway(namespace string, gateway string) (IstioObject
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[gateways],
+		Kind:       PluralType[gateways],
 		APIVersion: ApiNetworkingVersion,
 	}
 	gatewayObject, ok := result.(*GenericIstioObject)
@@ -240,7 +240,7 @@ func (in *IstioClient) GetServiceEntries(namespace string) ([]IstioObject, error
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[serviceentries],
+		Kind:       PluralType[serviceentries],
 		APIVersion: ApiNetworkingVersion,
 	}
 	serviceEntriesList, ok := result.(*GenericIstioObjectList)
@@ -263,7 +263,7 @@ func (in *IstioClient) GetServiceEntry(namespace string, serviceEntryName string
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[serviceentries],
+		Kind:       PluralType[serviceentries],
 		APIVersion: ApiNetworkingVersion,
 	}
 	serviceEntry, ok := result.(*GenericIstioObject)
@@ -284,7 +284,7 @@ func (in *IstioClient) GetDestinationRules(namespace string, serviceName string)
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[destinationRules],
+		Kind:       PluralType[destinationRules],
 		APIVersion: ApiNetworkingVersion,
 	}
 	destinationRuleList, ok := result.(*GenericIstioObjectList)
@@ -315,7 +315,7 @@ func (in *IstioClient) GetDestinationRule(namespace string, destinationrule stri
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[destinationRules],
+		Kind:       PluralType[destinationRules],
 		APIVersion: ApiNetworkingVersion,
 	}
 	destinationRule, ok := result.(*GenericIstioObject)
@@ -335,7 +335,7 @@ func (in *IstioClient) GetQuotaSpecs(namespace string) ([]IstioObject, error) {
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[quotaspecs],
+		Kind:       PluralType[quotaspecs],
 		APIVersion: ApiConfigVersion,
 	}
 	quotaSpecList, ok := result.(*GenericIstioObjectList)
@@ -358,7 +358,7 @@ func (in *IstioClient) GetQuotaSpec(namespace string, quotaSpecName string) (Ist
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[quotaspecs],
+		Kind:       PluralType[quotaspecs],
 		APIVersion: ApiConfigVersion,
 	}
 	quotaSpec, ok := result.(*GenericIstioObject)
@@ -378,7 +378,7 @@ func (in *IstioClient) GetQuotaSpecBindings(namespace string) ([]IstioObject, er
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[quotaspecbindings],
+		Kind:       PluralType[quotaspecbindings],
 		APIVersion: ApiConfigVersion,
 	}
 	quotaSpecBindingList, ok := result.(*GenericIstioObjectList)
@@ -401,7 +401,7 @@ func (in *IstioClient) GetQuotaSpecBinding(namespace string, quotaSpecBindingNam
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[quotaspecbindings],
+		Kind:       PluralType[quotaspecbindings],
 		APIVersion: ApiConfigVersion,
 	}
 	quotaSpecBinding, ok := result.(*GenericIstioObject)
@@ -419,7 +419,7 @@ func (in *IstioClient) GetPolicies(namespace string) ([]IstioObject, error) {
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[policies],
+		Kind:       PluralType[policies],
 		APIVersion: ApiAuthenticationVersion,
 	}
 	policyList, ok := result.(*GenericIstioObjectList)
@@ -443,7 +443,7 @@ func (in *IstioClient) GetPolicy(namespace string, policyName string) (IstioObje
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[policies],
+		Kind:       PluralType[policies],
 		APIVersion: ApiAuthenticationVersion,
 	}
 	policy, ok := result.(*GenericIstioObject)
@@ -463,7 +463,7 @@ func (in *IstioClient) GetMeshPolicies(namespace string) ([]IstioObject, error) 
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[meshPolicies],
+		Kind:       PluralType[meshPolicies],
 		APIVersion: ApiAuthenticationVersion,
 	}
 	policyList, ok := result.(*GenericIstioObjectList)
@@ -487,7 +487,7 @@ func (in *IstioClient) GetMeshPolicy(namespace string, policyName string) (Istio
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[meshPolicies],
+		Kind:       PluralType[meshPolicies],
 		APIVersion: ApiAuthenticationVersion,
 	}
 	mp, ok := result.(*GenericIstioObject)
@@ -505,7 +505,7 @@ func (in *IstioClient) GetClusterRbacConfigs(namespace string) ([]IstioObject, e
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[clusterrbacconfigs],
+		Kind:       PluralType[clusterrbacconfigs],
 		APIVersion: ApiRbacVersion,
 	}
 	clusterRbacConfigList, ok := result.(*GenericIstioObjectList)
@@ -528,7 +528,7 @@ func (in *IstioClient) GetClusterRbacConfig(namespace string, name string) (Isti
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[clusterrbacconfigs],
+		Kind:       PluralType[clusterrbacconfigs],
 		APIVersion: ApiRbacVersion,
 	}
 	clusterRbacConfig, ok := result.(*GenericIstioObject)
@@ -546,7 +546,7 @@ func (in *IstioClient) GetServiceRoles(namespace string) ([]IstioObject, error) 
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[serviceroles],
+		Kind:       PluralType[serviceroles],
 		APIVersion: ApiRbacVersion,
 	}
 	serviceRoleList, ok := result.(*GenericIstioObjectList)
@@ -569,7 +569,7 @@ func (in *IstioClient) GetServiceRole(namespace string, name string) (IstioObjec
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[serviceroles],
+		Kind:       PluralType[serviceroles],
 		APIVersion: ApiRbacVersion,
 	}
 	serviceRole, ok := result.(*GenericIstioObject)
@@ -587,7 +587,7 @@ func (in *IstioClient) GetServiceRoleBindings(namespace string) ([]IstioObject, 
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[servicerolebindings],
+		Kind:       PluralType[servicerolebindings],
 		APIVersion: ApiRbacVersion,
 	}
 	serviceRoleBindingList, ok := result.(*GenericIstioObjectList)
@@ -610,7 +610,7 @@ func (in *IstioClient) GetServiceRoleBinding(namespace string, name string) (Ist
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[servicerolebindings],
+		Kind:       PluralType[servicerolebindings],
 		APIVersion: ApiRbacVersion,
 	}
 	serviceRoleBinding, ok := result.(*GenericIstioObject)

--- a/kubernetes/istio_rules_service.go
+++ b/kubernetes/istio_rules_service.go
@@ -15,7 +15,7 @@ func (in *IstioClient) GetIstioRules(namespace string) ([]IstioObject, error) {
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[rules],
+		Kind:       PluralType[rules],
 		APIVersion: ApiConfigVersion,
 	}
 	ruleList, ok := result.(*GenericIstioObjectList)
@@ -45,7 +45,7 @@ func (in *IstioClient) GetIstioRule(namespace string, istiorule string) (IstioOb
 		return nil, err
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[rules],
+		Kind:       PluralType[rules],
 		APIVersion: ApiConfigVersion,
 	}
 	mRule, ok := result.(*GenericIstioObject)
@@ -72,7 +72,7 @@ func (in *IstioClient) getAdaptersTemplates(namespace string, itemType string, p
 			results, err := in.istioConfigApi.Get().Namespace(namespace).Resource(plural).Do().Get()
 			istioObjects := istioResponse{}
 			typeMeta := meta_v1.TypeMeta{
-				Kind: PluralType[plural],
+				Kind:       PluralType[plural],
 				APIVersion: ApiConfigVersion,
 			}
 			resultList, ok := results.(*GenericIstioObjectList)
@@ -133,7 +133,7 @@ func (in *IstioClient) getAdapterTemplate(namespace string, itemType string, ite
 		return nil, fmt.Errorf("%s is not supported", itemSubtype)
 	}
 	typeMeta := meta_v1.TypeMeta{
-		Kind: PluralType[itemSubtype],
+		Kind:       PluralType[itemSubtype],
 		APIVersion: ApiConfigVersion,
 	}
 	result, err := in.istioConfigApi.Get().Namespace(namespace).Resource(itemSubtype).SubResource(itemName).Do().Get()

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -483,6 +483,8 @@ type IstioObject interface {
 	runtime.Object
 	GetSpec() map[string]interface{}
 	SetSpec(map[string]interface{})
+	GetTypeMeta() meta_v1.TypeMeta
+	SetTypeMeta(meta_v1.TypeMeta)
 	GetObjectMeta() meta_v1.ObjectMeta
 	SetObjectMeta(meta_v1.ObjectMeta)
 	DeepCopyIstioObject() IstioObject
@@ -555,6 +557,16 @@ func (in *GenericIstioObject) GetSpec() map[string]interface{} {
 // SetSpec for a wrapper
 func (in *GenericIstioObject) SetSpec(spec map[string]interface{}) {
 	in.Spec = spec
+}
+
+// GetTypeMeta from a wrapper
+func (in *GenericIstioObject) GetTypeMeta() meta_v1.TypeMeta {
+	return in.TypeMeta
+}
+
+// SetObjectMeta for a wrapper
+func (in *GenericIstioObject) SetTypeMeta(typemeta meta_v1.TypeMeta) {
+	in.TypeMeta = typemeta
 }
 
 // GetObjectMeta from a wrapper

--- a/models/cluster_rbac_config.go
+++ b/models/cluster_rbac_config.go
@@ -8,6 +8,7 @@ import (
 
 type ClusterRbacConfigs []ClusterRbacConfig
 type ClusterRbacConfig struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Mode      interface{} `json:"mode"`
@@ -25,6 +26,7 @@ func (rcs *ClusterRbacConfigs) Parse(clusterRbacConfigs []kubernetes.IstioObject
 }
 
 func (rc *ClusterRbacConfig) Parse(clusterRbacConfig kubernetes.IstioObject) {
+	rc.TypeMeta = clusterRbacConfig.GetTypeMeta()
 	rc.Metadata = clusterRbacConfig.GetObjectMeta()
 	rc.Spec.Mode = clusterRbacConfig.GetSpec()["mode"]
 	rc.Spec.Inclusion = clusterRbacConfig.GetSpec()["inclusion"]

--- a/models/destination_rule.go
+++ b/models/destination_rule.go
@@ -25,6 +25,7 @@ type DestinationRules struct {
 //
 // swagger:model destinationRule
 type DestinationRule struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Host          interface{} `json:"host"`
@@ -43,6 +44,7 @@ func (dRules *DestinationRules) Parse(destinationRules []kubernetes.IstioObject)
 }
 
 func (dRule *DestinationRule) Parse(destinationRule kubernetes.IstioObject) {
+	dRule.TypeMeta = destinationRule.GetTypeMeta()
 	dRule.Metadata = destinationRule.GetObjectMeta()
 	dRule.Spec.Host = destinationRule.GetSpec()["host"]
 	dRule.Spec.TrafficPolicy = destinationRule.GetSpec()["trafficPolicy"]

--- a/models/gateway.go
+++ b/models/gateway.go
@@ -8,6 +8,7 @@ import (
 
 type Gateways []Gateway
 type Gateway struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Servers  interface{} `json:"servers"`
@@ -24,6 +25,7 @@ func (gws *Gateways) Parse(gateways []kubernetes.IstioObject) {
 }
 
 func (gw *Gateway) Parse(gateway kubernetes.IstioObject) {
+	gw.TypeMeta = gateway.GetTypeMeta()
 	gw.Metadata = gateway.GetObjectMeta()
 	gw.Spec.Servers = gateway.GetSpec()["servers"]
 	gw.Spec.Selector = gateway.GetSpec()["selector"]

--- a/models/istio_rule.go
+++ b/models/istio_rule.go
@@ -26,6 +26,7 @@ type IstioRules []IstioRule
 //
 // swagger:model istioRule
 type IstioRule struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Match   interface{} `json:"match"`
@@ -48,6 +49,7 @@ type IstioAdapters []IstioAdapter
 //
 // swagger:model istioAdapter
 type IstioAdapter struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     interface{}        `json:"spec"`
 	Adapter  string             `json:"adapter"`
@@ -70,6 +72,7 @@ type IstioTemplates []IstioTemplate
 //
 // swagger:model istioTemplate
 type IstioTemplate struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     interface{}        `json:"spec"`
 	Template string             `json:"template"`
@@ -87,6 +90,7 @@ func CastIstioRulesCollection(rules []kubernetes.IstioObject) IstioRules {
 
 func CastIstioRule(rule kubernetes.IstioObject) IstioRule {
 	istioRule := IstioRule{}
+	istioRule.TypeMeta = rule.GetTypeMeta()
 	istioRule.Metadata = rule.GetObjectMeta()
 	istioRule.Spec.Match = rule.GetSpec()["match"]
 	istioRule.Spec.Actions = rule.GetSpec()["actions"]
@@ -103,6 +107,7 @@ func CastIstioAdaptersCollection(adapters []kubernetes.IstioObject) IstioAdapter
 
 func CastIstioAdapter(adapter kubernetes.IstioObject) IstioAdapter {
 	istioAdapter := IstioAdapter{}
+	istioAdapter.TypeMeta = adapter.GetTypeMeta()
 	istioAdapter.Metadata = adapter.GetObjectMeta()
 	istioAdapter.Spec = adapter.GetSpec()
 	istioAdapter.Adapter = adapter.GetObjectMeta().Labels["adapter"]
@@ -120,6 +125,7 @@ func CastIstioTemplatesCollection(templates []kubernetes.IstioObject) IstioTempl
 
 func CastIstioTemplate(template kubernetes.IstioObject) IstioTemplate {
 	istioTemplate := IstioTemplate{}
+	istioTemplate.TypeMeta = template.GetTypeMeta()
 	istioTemplate.Metadata = template.GetObjectMeta()
 	istioTemplate.Spec = template.GetSpec()
 	istioTemplate.Template = template.GetObjectMeta().Labels["template"]

--- a/models/mesh_policy.go
+++ b/models/mesh_policy.go
@@ -8,6 +8,7 @@ import (
 
 type MeshPolicies []MeshPolicy
 type MeshPolicy struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Targets          interface{} `json:"targets"`
@@ -28,6 +29,7 @@ func (mps *MeshPolicies) Parse(meshPolicies []kubernetes.IstioObject) {
 }
 
 func (mp *MeshPolicy) Parse(meshPolicy kubernetes.IstioObject) {
+	mp.TypeMeta = meshPolicy.GetTypeMeta()
 	mp.Metadata = meshPolicy.GetObjectMeta()
 	mp.Spec.Targets = meshPolicy.GetSpec()["targets"]
 	mp.Spec.Peers = meshPolicy.GetSpec()["peers"]

--- a/models/policy.go
+++ b/models/policy.go
@@ -8,6 +8,7 @@ import (
 
 type Policies []Policy
 type Policy struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Targets          interface{} `json:"targets"`
@@ -28,6 +29,7 @@ func (ps *Policies) Parse(policies []kubernetes.IstioObject) {
 }
 
 func (p *Policy) Parse(policy kubernetes.IstioObject) {
+	p.TypeMeta = policy.GetTypeMeta()
 	p.Metadata = policy.GetObjectMeta()
 	p.Spec.Targets = policy.GetSpec()["targets"]
 	p.Spec.Peers = policy.GetSpec()["peers"]

--- a/models/quota_spec.go
+++ b/models/quota_spec.go
@@ -8,6 +8,7 @@ import (
 
 type QuotaSpecs []QuotaSpec
 type QuotaSpec struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Rules interface{} `json:"rules"`
@@ -23,6 +24,7 @@ func (qss *QuotaSpecs) Parse(quotaSpecs []kubernetes.IstioObject) {
 }
 
 func (qs *QuotaSpec) Parse(quotaSpec kubernetes.IstioObject) {
+	qs.TypeMeta = quotaSpec.GetTypeMeta()
 	qs.Metadata = quotaSpec.GetObjectMeta()
 	qs.Spec.Rules = quotaSpec.GetSpec()["rules"]
 }

--- a/models/service_entry.go
+++ b/models/service_entry.go
@@ -8,6 +8,7 @@ import (
 
 type ServiceEntries []ServiceEntry
 type ServiceEntry struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Hosts      interface{} `json:"hosts"`
@@ -28,6 +29,7 @@ func (ses *ServiceEntries) Parse(serviceEntries []kubernetes.IstioObject) {
 }
 
 func (se *ServiceEntry) Parse(serviceEntry kubernetes.IstioObject) {
+	se.TypeMeta = serviceEntry.GetTypeMeta()
 	se.Metadata = serviceEntry.GetObjectMeta()
 	se.Spec.Hosts = serviceEntry.GetSpec()["hosts"]
 	se.Spec.Addresses = serviceEntry.GetSpec()["addresses"]

--- a/models/service_role.go
+++ b/models/service_role.go
@@ -8,6 +8,7 @@ import (
 
 type ServiceRoles []ServiceRole
 type ServiceRole struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Rules interface{} `json:"rules"`
@@ -23,6 +24,7 @@ func (srs *ServiceRoles) Parse(serviceRoles []kubernetes.IstioObject) {
 }
 
 func (sr *ServiceRole) Parse(serviceRole kubernetes.IstioObject) {
+	sr.TypeMeta = serviceRole.GetTypeMeta()
 	sr.Metadata = serviceRole.GetObjectMeta()
 	sr.Spec.Rules = serviceRole.GetSpec()["rules"]
 }

--- a/models/virtual_service.go
+++ b/models/virtual_service.go
@@ -24,6 +24,7 @@ type VirtualServices struct {
 //
 // swagger:model virtualService
 type VirtualService struct {
+	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Hosts    interface{} `json:"hosts"`
@@ -44,6 +45,7 @@ func (vServices *VirtualServices) Parse(virtualServices []kubernetes.IstioObject
 }
 
 func (vService *VirtualService) Parse(virtualService kubernetes.IstioObject) {
+	vService.TypeMeta = virtualService.GetTypeMeta()
 	vService.Metadata = virtualService.GetObjectMeta()
 	vService.Spec.Hosts = virtualService.GetSpec()["hosts"]
 	vService.Spec.Gateways = virtualService.GetSpec()["gateways"]

--- a/swagger.json
+++ b/swagger.json
@@ -2829,6 +2829,16 @@
     "ClusterRbacConfig": {
       "type": "object",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -3013,6 +3023,16 @@
     "Gateway": {
       "type": "object",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -3326,6 +3346,16 @@
     "MeshPolicy": {
       "type": "object",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -3741,6 +3771,16 @@
     "Policy": {
       "type": "object",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -3823,6 +3863,16 @@
     "QuotaSpec": {
       "type": "object",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -4081,6 +4131,16 @@
     "ServiceEntry": {
       "type": "object",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -4175,6 +4235,16 @@
     "ServiceRole": {
       "type": "object",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -4733,6 +4803,16 @@
       "type": "object",
       "title": "DestinationRule destinationRule",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -4821,6 +4901,16 @@
           "type": "string",
           "x-go-name": "Adapters"
         },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -4847,6 +4937,16 @@
       "type": "object",
       "title": "IstioRule istioRule",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -4883,6 +4983,16 @@
       "type": "object",
       "title": "IstioTemplate istioTemplate",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },
@@ -4935,6 +5045,16 @@
       "type": "object",
       "title": "VirtualService virtualService",
       "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "metadata": {
           "$ref": "#/definitions/ObjectMeta"
         },


### PR DESCRIPTION
It adds mapping for "kind" and "apiVersion" objects from the backend.
Note that these fields are not returned from the k8s API (those are empty), so it should be provided by kiali.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2442
