### PR TITLE
KIALI-2457 Add validation to Destination Rule enabling Mesh-wide mTLS for clients

### DIFF
--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -6,12 +6,23 @@ import (
 	"github.com/kiali/kiali/models"
 )
 
+const DestinationRuleCheckerType = "destinationrule"
+
 type DestinationRulesChecker struct {
 	DestinationRules []kubernetes.IstioObject
 	MTLSDetails      kubernetes.MTLSDetails
 }
 
 func (in DestinationRulesChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	validations = validations.MergeValidations(in.runIndividualChecks())
+	validations = validations.MergeValidations(in.runGroupChecks())
+
+	return validations
+}
+
+func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	enabledDRCheckers := []GroupChecker{
@@ -24,4 +35,37 @@ func (in DestinationRulesChecker) Check() models.IstioValidations {
 	}
 
 	return validations
+}
+
+func (in DestinationRulesChecker) runIndividualChecks() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, destinationRule := range in.DestinationRules {
+		validations.MergeValidations(in.runChecks(destinationRule))
+	}
+
+	return validations
+}
+
+func (in DestinationRulesChecker) runChecks(destinationRule kubernetes.IstioObject) models.IstioValidations {
+	destinationRuleName := destinationRule.GetObjectMeta().Name
+	key := models.IstioValidationKey{Name: destinationRuleName, ObjectType: DestinationRuleCheckerType}
+	rrValidation := &models.IstioValidation{
+		Name:       destinationRuleName,
+		ObjectType: DestinationRuleCheckerType,
+		Valid:      true,
+		Checks:     []*models.IstioCheck{},
+	}
+
+	enabledCheckers := []Checker{
+		destinationrules.MeshWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
+	}
+
+	for _, checker := range enabledCheckers {
+		checks, validChecker := checker.Check()
+		rrValidation.Checks = append(rrValidation.Checks, checks...)
+		rrValidation.Valid = rrValidation.Valid && validChecker
+	}
+
+	return models.IstioValidations{key: rrValidation}
 }

--- a/business/checkers/destinationrules/meshwide_mtls_checker.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker.go
@@ -1,0 +1,32 @@
+package destinationrules
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type MeshWideMTLSChecker struct {
+	DestinationRule kubernetes.IstioObject
+	MTLSDetails     kubernetes.MTLSDetails
+}
+
+func (m MeshWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	// if DestinationRule doesn't enable mTLS, stop validation with any check
+	if !kubernetes.DestinationRuleHasMeshWideMTLSEnabled(m.DestinationRule) {
+		return validations, true
+	}
+
+	// otherwise, check among MeshPolicies for a rule enabling mesh-wide mTLS
+	for _, mp := range m.MTLSDetails.MeshPolicies {
+		if kubernetes.MeshPolicyHasMTLSEnabled(mp) {
+			return validations, true
+		}
+	}
+
+	check := models.Build("destinationrules.mtls.meshpolicymissing", "spec/trafficPolicy/tls/mode")
+	validations = append(validations, &check)
+
+	return validations, false
+}

--- a/business/checkers/destinationrules/meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker_test.go
@@ -1,0 +1,134 @@
+package destinationrules
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// Context: DestinationRule enables mesh-wide mTLS
+// Context: There is one MeshPolicy not enabling mTLS
+// It returns a validation
+func TestMTLSMeshWideDREnabledWithMeshPolicyDisabled(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE")),
+		},
+	}
+
+	testReturnsAValidation(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule enables mesh-wide mTLS
+// Context: There is one MeshPolicy enabling mTLS
+// It doesn't return any validation
+func TestMTLSMeshWideDREnabledWithMeshPolicy(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule enables namespace-wide mTLS
+// Context: There is one MeshPolicy enabling mTLS
+// It doesn't return any validation
+func TestMTLSNamespaceWideDREnabledWithMeshPolicy(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.istio-system.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule enables namespace-wide mTLS
+// Context: There is one MeshPolicy not enabling mTLS
+// It doesn't return any validation
+func TestMTLSNamespaceWideDREnabledWithMeshPolicyDisabled(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.istio-system.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule not enabling mTLS
+// Context: There is one MeshPolicy enabling mTLS
+// It doesn't return any validation
+func TestMTLSDRDisabledWithMeshPolicy(t *testing.T) {
+	destinationRule := data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.istio-system.svc.cluster.local")
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule not enabling mTLS
+// Context: There is one MeshPolicy not enabling mTLS
+// It doesn't return any validation
+func TestMTLSDRDisabledWithMeshPolicyDisabled(t *testing.T) {
+	destinationRule := data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.istio-system.svc.cluster.local")
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+func testReturnsAValidation(t *testing.T, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
+	assert := assert.New(t)
+
+	validations, valid := MeshWideMTLSChecker{
+		DestinationRule: destinationRule,
+		MTLSDetails:     mTLSDetails,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	assert.False(valid)
+
+	validation := validations[0]
+	assert.NotNil(validation)
+	assert.Equal(models.ErrorSeverity, validation.Severity)
+	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
+	assert.Equal(models.CheckMessage("destinationrules.mtls.meshpolicymissing"), validation.Message)
+}
+
+func testNoValidationsFound(t *testing.T, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
+	assert := assert.New(t)
+
+	validations, valid := MeshWideMTLSChecker{
+		DestinationRule: destinationRule,
+		MTLSDetails:     mTLSDetails,
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}

--- a/business/checkers/meshpolicies/mtls_checker_test.go
+++ b/business/checkers/meshpolicies/mtls_checker_test.go
@@ -16,7 +16,7 @@ import (
 // Context: MeshPolicy enables mTLS
 // Context: There is one Destination Rule enabling mTLS mesh-wide
 // It doesn't return any validation
-func TestMeshPolicymTLSDisabled(t *testing.T) {
+func TestMeshPolicymTLSEnabled(t *testing.T) {
 	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT"))
 	mTLSDetails := kubernetes.MTLSDetails{
 		DestinationRules: []kubernetes.IstioObject{

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -91,6 +91,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "mTLS settings of a non-local Destination Rule are overridden",
 		Severity: WarningSeverity,
 	},
+	"destinationrules.mtls.meshpolicymissing": {
+		Message:  "MeshPolicy enabling mTLS is missing",
+		Severity: ErrorSeverity,
+	},
 	"gateways.multimatch": {
 		Message:  "More than one Gateway for the same host port combination",
 		Severity: WarningSeverity,


### PR DESCRIPTION
** Describe the change **

Add validation to any DR enabling mesh-wide mTLS when there isn't any MeshPolicy enabling mTLS.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2457

** Screenshot **
![screenshot of kiali console 59](https://user-images.githubusercontent.com/613814/53729420-7e259a00-3e75-11e9-9a9e-84a81c3ac3ed.png)
