### PR TITLE
KIALI-2457 Tidying up validations - Failed - more golang background needed

### DIFF
--- a/business/checkers/checker.go
+++ b/business/checkers/checker.go
@@ -8,7 +8,7 @@ import (
 type ObjectChecker interface {
 	GetType() string
 	GetGroupCheckers() []GroupChecker
-	GetIndividualCheckers() []IndividualChecker
+	GetIndividualCheckers(object kubernetes.IstioObject) []IndividualChecker
 	GetObjects() []kubernetes.IstioObject
 	Check() models.IstioValidations
 }

--- a/business/checkers/checker.go
+++ b/business/checkers/checker.go
@@ -1,11 +1,87 @@
 package checkers
 
-import "github.com/kiali/kiali/models"
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
 
-type Checker interface {
+type IndividualChecker interface {
 	Check() ([]*models.IstioCheck, bool)
 }
 
 type GroupChecker interface {
 	Check() models.IstioValidations
+}
+
+type ObjectCheck struct{}
+
+func (oc ObjectCheck) GetType() string {
+	return "Type not defined"
+}
+
+func (oc ObjectCheck) GetGroupCheckers() []GroupChecker {
+	return []GroupChecker{}
+}
+
+func (oc ObjectCheck) GetIndividualCheckers(object kubernetes.IstioObject) []IndividualChecker {
+	return []IndividualChecker{}
+}
+
+func (oc ObjectCheck) GetObjects() []kubernetes.IstioObject {
+	return []kubernetes.IstioObject{}
+}
+
+// An Object Checker runs all checkers for an specific object type (i.e.: pod, route rule,...)
+// It runs two kinds of checkers:
+// 1. Individual checks: validating individual objects.
+// 2. Group checks: validating behaviour between objects.
+func (oc ObjectCheck) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	validations = validations.MergeValidations(oc.runIndividualChecks())
+	validations = validations.MergeValidations(oc.runGroupChecks())
+
+	return validations
+}
+
+// runGroupChecks runs group checks for all objects passed
+func (oc ObjectCheck) runGroupChecks() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, checker := range oc.GetGroupCheckers() {
+		validations = validations.MergeValidations(checker.Check())
+	}
+
+	return validations
+}
+
+// Runs individual checks for each object in oc.GetObjects
+func (oc ObjectCheck) runIndividualChecks() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, object := range oc.GetObjects() {
+		validations.MergeValidations(oc.runChecks(object))
+	}
+
+	return validations
+}
+
+// runChecks runs all the individual checks for a single object and appends the result into validations.
+func (oc ObjectCheck) runChecks(object kubernetes.IstioObject) models.IstioValidations {
+	objectName := object.GetObjectMeta().Name
+	key := models.IstioValidationKey{Name: objectName, ObjectType: oc.GetType()}
+	rrValidation := &models.IstioValidation{
+		Name:       objectName,
+		ObjectType: oc.GetType(),
+		Valid:      true,
+		Checks:     []*models.IstioCheck{},
+	}
+
+	for _, checker := range oc.GetIndividualCheckers(object) {
+		checks, validChecker := checker.Check()
+		rrValidation.Checks = append(rrValidation.Checks, checks...)
+		rrValidation.Valid = rrValidation.Valid && validChecker
+	}
+
+	return models.IstioValidations{key: rrValidation}
 }

--- a/business/checkers/checker.go
+++ b/business/checkers/checker.go
@@ -5,6 +5,14 @@ import (
 	"github.com/kiali/kiali/models"
 )
 
+type ObjectChecker interface {
+	GetType() string
+	GetGroupCheckers() []GroupChecker
+	GetIndividualCheckers() []IndividualChecker
+	GetObjects() []kubernetes.IstioObject
+	Check() models.IstioValidations
+}
+
 type IndividualChecker interface {
 	Check() ([]*models.IstioCheck, bool)
 }

--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -3,69 +3,31 @@ package checkers
 import (
 	"github.com/kiali/kiali/business/checkers/destinationrules"
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/models"
 )
 
-const DestinationRuleCheckerType = "destinationrule"
-
 type DestinationRulesChecker struct {
+	ObjectCheck
 	DestinationRules []kubernetes.IstioObject
 	MTLSDetails      kubernetes.MTLSDetails
 }
 
-func (in DestinationRulesChecker) Check() models.IstioValidations {
-	validations := models.IstioValidations{}
-
-	validations = validations.MergeValidations(in.runIndividualChecks())
-	validations = validations.MergeValidations(in.runGroupChecks())
-
-	return validations
+func (in DestinationRulesChecker) GetType() string {
+	return "destinationrule"
 }
 
-func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
-	validations := models.IstioValidations{}
+func (in DestinationRulesChecker) GetObjects() []kubernetes.IstioObject {
+	return in.DestinationRules
+}
 
-	enabledDRCheckers := []GroupChecker{
+func (in DestinationRulesChecker) GetGroupCheckers() []GroupChecker {
+	return []GroupChecker{
 		destinationrules.MultiMatchChecker{DestinationRules: in.DestinationRules},
 		destinationrules.TrafficPolicyChecker{DestinationRules: in.DestinationRules, MTLSDetails: in.MTLSDetails},
 	}
-
-	for _, checker := range enabledDRCheckers {
-		validations = validations.MergeValidations(checker.Check())
-	}
-
-	return validations
 }
 
-func (in DestinationRulesChecker) runIndividualChecks() models.IstioValidations {
-	validations := models.IstioValidations{}
-
-	for _, destinationRule := range in.DestinationRules {
-		validations.MergeValidations(in.runChecks(destinationRule))
-	}
-
-	return validations
-}
-
-func (in DestinationRulesChecker) runChecks(destinationRule kubernetes.IstioObject) models.IstioValidations {
-	destinationRuleName := destinationRule.GetObjectMeta().Name
-	key := models.IstioValidationKey{Name: destinationRuleName, ObjectType: DestinationRuleCheckerType}
-	rrValidation := &models.IstioValidation{
-		Name:       destinationRuleName,
-		ObjectType: DestinationRuleCheckerType,
-		Valid:      true,
-		Checks:     []*models.IstioCheck{},
-	}
-
-	enabledCheckers := []Checker{
+func (in DestinationRulesChecker) GetIndividualCheckers(destinationRule kubernetes.IstioObject) []IndividualChecker {
+	return []IndividualChecker{
 		destinationrules.MeshWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
 	}
-
-	for _, checker := range enabledCheckers {
-		checks, validChecker := checker.Check()
-		rrValidation.Checks = append(rrValidation.Checks, checks...)
-		rrValidation.Valid = rrValidation.Valid && validChecker
-	}
-
-	return models.IstioValidations{key: rrValidation}
 }

--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -6,12 +6,23 @@ import (
 	"github.com/kiali/kiali/models"
 )
 
+const DestinationRuleCheckerType = "destinationrule"
+
 type DestinationRulesChecker struct {
 	DestinationRules []kubernetes.IstioObject
 	MTLSDetails      kubernetes.MTLSDetails
 }
 
 func (in DestinationRulesChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	validations = validations.MergeValidations(in.runIndividualChecks())
+	validations = validations.MergeValidations(in.runGroupChecks())
+
+	return validations
+}
+
+func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	enabledDRCheckers := []GroupChecker{
@@ -24,4 +35,37 @@ func (in DestinationRulesChecker) Check() models.IstioValidations {
 	}
 
 	return validations
+}
+
+func (in DestinationRulesChecker) runIndividualChecks() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, destinationRule := range in.DestinationRules {
+		validations.MergeValidations(in.runChecks(destinationRule))
+	}
+
+	return validations
+}
+
+func (in DestinationRulesChecker) runChecks(destinationRule kubernetes.IstioObject) models.IstioValidations {
+	destinationRuleName := destinationRule.GetObjectMeta().Name
+	key := models.IstioValidationKey{Name: destinationRuleName, ObjectType: DestinationRuleCheckerType}
+	rrValidation := &models.IstioValidation{
+		Name:       destinationRuleName,
+		ObjectType: DestinationRuleCheckerType,
+		Valid:      true,
+		Checks:     []*models.IstioCheck{},
+	}
+
+	enabledCheckers := []Checker{
+		destinationrules.MeshWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
+	}
+
+	for _, checker := range enabledCheckers {
+		checks, validChecker := checker.Check()
+		rrValidation.Checks = append(rrValidation.Checks, checks...)
+		rrValidation.Valid = rrValidation.Valid && validChecker
+	}
+
+	return models.IstioValidations{key: rrValidation}
 }

--- a/business/checkers/destinationrules/meshwide_mtls_checker.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker.go
@@ -1,0 +1,32 @@
+package destinationrules
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type MeshWideMTLSChecker struct {
+	DestinationRule kubernetes.IstioObject
+	MTLSDetails     kubernetes.MTLSDetails
+}
+
+func (m MeshWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	// if DestinationRule doesn't enable mTLS, stop validation with any check
+	if !kubernetes.DestinationRuleHasMeshWideMTLSEnabled(m.DestinationRule) {
+		return validations, true
+	}
+
+	// otherwise, check among MeshPolicies for a rule enabling mesh-wide mTLS
+	for _, mp := range m.MTLSDetails.MeshPolicies {
+		if kubernetes.MeshPolicyHasMTLSEnabled(mp) {
+			return validations, true
+		}
+	}
+
+	check := models.Build("destinationrules.mtls.meshpolicymissing", "spec/trafficPolicy/tls/mode")
+	validations = append(validations, &check)
+
+	return validations, false
+}

--- a/business/checkers/destinationrules/meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker_test.go
@@ -1,0 +1,134 @@
+package destinationrules
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// Context: DestinationRule enables mesh-wide mTLS
+// Context: There is one MeshPolicy not enabling mTLS
+// It returns a validation
+func TestMTLSMeshWideDREnabledWithMeshPolicyDisabled(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE")),
+		},
+	}
+
+	testReturnsAValidation(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule enables mesh-wide mTLS
+// Context: There is one MeshPolicy enabling mTLS
+// It doesn't return any validation
+func TestMTLSMeshWideDREnabledWithMeshPolicy(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule enables namespace-wide mTLS
+// Context: There is one MeshPolicy enabling mTLS
+// It doesn't return any validation
+func TestMTLSNamespaceWideDREnabledWithMeshPolicy(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.istio-system.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule enables namespace-wide mTLS
+// Context: There is one MeshPolicy not enabling mTLS
+// It doesn't return any validation
+func TestMTLSNamespaceWideDREnabledWithMeshPolicyDisabled(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.istio-system.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule not enabling mTLS
+// Context: There is one MeshPolicy enabling mTLS
+// It doesn't return any validation
+func TestMTLSDRDisabledWithMeshPolicy(t *testing.T) {
+	destinationRule := data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.istio-system.svc.cluster.local")
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule not enabling mTLS
+// Context: There is one MeshPolicy not enabling mTLS
+// It doesn't return any validation
+func TestMTLSDRDisabledWithMeshPolicyDisabled(t *testing.T) {
+	destinationRule := data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.istio-system.svc.cluster.local")
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE")),
+		},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+func testReturnsAValidation(t *testing.T, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
+	assert := assert.New(t)
+
+	validations, valid := MeshWideMTLSChecker{
+		DestinationRule: destinationRule,
+		MTLSDetails:     mTLSDetails,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	assert.False(valid)
+
+	validation := validations[0]
+	assert.NotNil(validation)
+	assert.Equal(models.ErrorSeverity, validation.Severity)
+	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
+	assert.Equal(models.CheckMessage("destinationrules.mtls.meshpolicymissing"), validation.Message)
+}
+
+func testNoValidationsFound(t *testing.T, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
+	assert := assert.New(t)
+
+	validations, valid := MeshWideMTLSChecker{
+		DestinationRule: destinationRule,
+		MTLSDetails:     mTLSDetails,
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}

--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -28,6 +28,15 @@ func (g GatewayChecker) GetIndividualCheckers(object kubernetes.IstioObject) []I
 	}
 }
 
+func (oc GatewayChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	validations = validations.MergeValidations(oc.runIndividualChecks())
+	validations = validations.MergeValidations(oc.runGroupChecks())
+
+	return validations
+}
+
 func (g GatewayChecker) runIndividualChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 

--- a/business/checkers/mesh_policies_checker.go
+++ b/business/checkers/mesh_policies_checker.go
@@ -3,46 +3,24 @@ package checkers
 import (
 	"github.com/kiali/kiali/business/checkers/meshpolicies"
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/models"
 )
 
-const MeshPolicyCheckerType = "meshpolicy"
-
 type MeshPolicyChecker struct {
+	ObjectCheck
 	MeshPolicies []kubernetes.IstioObject
 	MTLSDetails  kubernetes.MTLSDetails
 }
 
-func (m MeshPolicyChecker) Check() models.IstioValidations {
-	validations := models.IstioValidations{}
-
-	for _, meshPolicy := range m.MeshPolicies {
-		validations.MergeValidations(m.runChecks(meshPolicy))
-	}
-
-	return validations
+func (in MeshPolicyChecker) GetType() string {
+	return "meshpolicy"
 }
 
-// runChecks runs all the individual checks for a single mesh policy and appends the result into validations.
-func (m MeshPolicyChecker) runChecks(meshPolicy kubernetes.IstioObject) models.IstioValidations {
-	meshPolicyName := meshPolicy.GetObjectMeta().Name
-	key := models.IstioValidationKey{Name: meshPolicyName, ObjectType: MeshPolicyCheckerType}
-	rrValidation := &models.IstioValidation{
-		Name:       meshPolicyName,
-		ObjectType: MeshPolicyCheckerType,
-		Valid:      true,
-		Checks:     []*models.IstioCheck{},
-	}
+func (in MeshPolicyChecker) GetObjects() []kubernetes.IstioObject {
+	return in.MeshPolicies
+}
 
-	enabledCheckers := []Checker{
-		meshpolicies.MtlsChecker{MeshPolicy: meshPolicy, MTLSDetails: m.MTLSDetails},
+func (in MeshPolicyChecker) GetIndividualCheckers(meshPolicy kubernetes.IstioObject) []IndividualChecker {
+	return []IndividualChecker{
+		meshpolicies.MtlsChecker{MeshPolicy: meshPolicy, MTLSDetails: in.MTLSDetails},
 	}
-
-	for _, checker := range enabledCheckers {
-		checks, validChecker := checker.Check()
-		rrValidation.Checks = append(rrValidation.Checks, checks...)
-		rrValidation.Valid = rrValidation.Valid && validChecker
-	}
-
-	return models.IstioValidations{key: rrValidation}
 }

--- a/business/checkers/meshpolicies/mtls_checker_test.go
+++ b/business/checkers/meshpolicies/mtls_checker_test.go
@@ -16,7 +16,7 @@ import (
 // Context: MeshPolicy enables mTLS
 // Context: There is one Destination Rule enabling mTLS mesh-wide
 // It doesn't return any validation
-func TestMeshPolicymTLSDisabled(t *testing.T) {
+func TestMeshPolicymTLSEnabled(t *testing.T) {
 	meshPolicy := data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT"))
 	mTLSDetails := kubernetes.MTLSDetails{
 		DestinationRules: []kubernetes.IstioObject{

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -10,6 +10,7 @@ import (
 )
 
 type NoServiceChecker struct {
+	ObjectCheck
 	Namespace            string
 	IstioDetails         *kubernetes.IstioDetails
 	Services             []v1.Service

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -3,78 +3,32 @@ package checkers
 import (
 	"github.com/kiali/kiali/business/checkers/virtual_services"
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/models"
 )
 
-const VirtualCheckerType = "virtualservice"
-
 type VirtualServiceChecker struct {
+	ObjectCheck
 	Namespace        string
 	DestinationRules []kubernetes.IstioObject
 	VirtualServices  []kubernetes.IstioObject
 }
 
-// An Object Checker runs all checkers for an specific object type (i.e.: pod, route rule,...)
-// It run two kinds of checkers:
-// 1. Individual checks: validating individual objects.
-// 2. Group checks: validating behaviour between configurations.
-func (in VirtualServiceChecker) Check() models.IstioValidations {
-	validations := models.IstioValidations{}
-
-	validations = validations.MergeValidations(in.runIndividualChecks())
-	validations = validations.MergeValidations(in.runGroupChecks())
-
-	return validations
+func (in VirtualServiceChecker) GetType() string {
+	return "virtualservice"
 }
 
-// Runs individual checks for each virtual service
-func (in VirtualServiceChecker) runIndividualChecks() models.IstioValidations {
-	validations := models.IstioValidations{}
-
-	for _, virtualService := range in.VirtualServices {
-		validations.MergeValidations(in.runChecks(virtualService))
-	}
-
-	return validations
+func (in VirtualServiceChecker) GetObjects() []kubernetes.IstioObject {
+	return in.VirtualServices
 }
 
-// runGroupChecks runs group checks for all virtual services
-func (in VirtualServiceChecker) runGroupChecks() models.IstioValidations {
-	validations := models.IstioValidations{}
-
-	enabledCheckers := []GroupChecker{
+func (in VirtualServiceChecker) GetGroupCheckers() []GroupChecker {
+	return []GroupChecker{
 		virtual_services.SingleHostChecker{Namespace: in.Namespace, VirtualServices: in.VirtualServices},
 	}
-
-	for _, checker := range enabledCheckers {
-		validations = validations.MergeValidations(checker.Check())
-	}
-
-	return validations
 }
 
-// runChecks runs all the individual checks for a single virtual service and appends the result into validations.
-func (in VirtualServiceChecker) runChecks(virtualService kubernetes.IstioObject) models.IstioValidations {
-	virtualServiceName := virtualService.GetObjectMeta().Name
-	key := models.IstioValidationKey{Name: virtualServiceName, ObjectType: VirtualCheckerType}
-	rrValidation := &models.IstioValidation{
-		Name:       virtualServiceName,
-		ObjectType: VirtualCheckerType,
-		Valid:      true,
-		// Explicitly create an empty array as 0-values do not appear in json
-		Checks: []*models.IstioCheck{},
-	}
-
-	enabledCheckers := []Checker{
+func (in VirtualServiceChecker) GetIndividualCheckers(virtualService kubernetes.IstioObject) []IndividualChecker {
+	return []IndividualChecker{
 		virtual_services.RouteChecker{Route: virtualService},
 		virtual_services.SubsetPresenceChecker{Namespace: in.Namespace, DestinationRules: in.DestinationRules, VirtualService: virtualService},
 	}
-
-	for _, checker := range enabledCheckers {
-		checks, validChecker := checker.Check()
-		rrValidation.Checks = append(rrValidation.Checks, checks...)
-		rrValidation.Valid = rrValidation.Valid && validChecker
-	}
-
-	return models.IstioValidations{key: rrValidation}
 }

--- a/business/checkers/virtual_service_checker_test.go
+++ b/business/checkers/virtual_service_checker_test.go
@@ -19,7 +19,7 @@ func prepareTestForVirtualService(istioObject kubernetes.IstioObject) models.Ist
 		data.CreateTestDestinationRule("test", "reviewsrule", "reviews"),
 	}
 
-	virtualServiceChecker := VirtualServiceChecker{"bookinfo", destinationList, istioObjects}
+	virtualServiceChecker := VirtualServiceChecker{Namespace: "bookinfo", DestinationRules: destinationList, VirtualServices: istioObjects}
 
 	return virtualServiceChecker.Check()
 }
@@ -82,8 +82,8 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 		data.CreateTestDestinationRule("test", "reviewsrule1", "reviews"),
 	}
 
-	virtualServiceChecker := VirtualServiceChecker{"bookinfo",
-		destinationList, fakeVirtualServiceMultipleIstioObjects()}
+	virtualServiceChecker := VirtualServiceChecker{Namespace: "bookinfo",
+		DestinationRules: destinationList, VirtualServices: fakeVirtualServiceMultipleIstioObjects()}
 
 	validations := virtualServiceChecker.Check()
 	assert.NotEmpty(validations)

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -18,10 +18,6 @@ type IstioValidationsService struct {
 	businessLayer *Layer
 }
 
-type ObjectChecker interface {
-	Check() models.IstioValidations
-}
-
 // GetValidations returns an IstioValidations object with all the checks found when running
 // all the enabled checkers. If service is "" then the whole namespace is validated.
 func (in *IstioValidationsService) GetValidations(namespace, service string) (models.IstioValidations, error) {
@@ -75,7 +71,7 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 }
 
 func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioDetails kubernetes.IstioDetails, services []v1.Service, workloads models.WorkloadList, gatewaysPerNamespace [][]kubernetes.IstioObject, mtlsDetails kubernetes.MTLSDetails) []ObjectChecker {
-	return []ObjectChecker{
+	return []checkers.ObjectChecker{
 		checkers.VirtualServiceChecker{Namespace: namespace, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices},
 		checkers.NoServiceChecker{Namespace: namespace, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace},
 		checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails},

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -91,6 +91,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "mTLS settings of a non-local Destination Rule are overridden",
 		Severity: WarningSeverity,
 	},
+	"destinationrules.mtls.meshpolicymissing": {
+		Message:  "MeshPolicy enabling mTLS is missing",
+		Severity: ErrorSeverity,
+	},
 	"gateways.multimatch": {
 		Message:  "More than one Gateway for the same host port combination",
 		Severity: WarningSeverity,


### PR DESCRIPTION
** Describe the change **

Such a failure. I still have in my mind the inheritance mechanism from Ruby and Java.
I tried to specify some common methods on the parents, some other methods on the children and in some other cases, override some methods in children that are already specified on parent.

The thing is, GoLang doesn't offer inheritance itself, it just let embed structs. So the embedded struct doesn't know anything about the struct embedding it. Then, when a child call a method defined in the parent and this last one calls to another method overrode in the child, the call goes to the parent instead of the child.

This makes that the embedded structs are more likely self-contained. Methods defined in that embedded method can't rely on the embeddee struct, so they can only use data/methods specified in its struct.

