### PR TITLE
KIALI-2436 Verify ServiceEntry port format

### DIFF
--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -24,7 +24,7 @@ func (g GatewayChecker) Check() models.IstioValidations {
 	for _, nssGw := range g.GatewaysPerNamespace {
 		for _, gw := range nssGw {
 			if gw.GetObjectMeta().Namespace == g.Namespace {
-				validations.MergeValidations(runSingleChecks(gw))
+				validations.MergeValidations(g.runSingleChecks(gw))
 			}
 		}
 	}
@@ -32,7 +32,7 @@ func (g GatewayChecker) Check() models.IstioValidations {
 	return validations
 }
 
-func runSingleChecks(gw kubernetes.IstioObject) models.IstioValidations {
+func (g GatewayChecker) runSingleChecks(gw kubernetes.IstioObject) models.IstioValidations {
 	validations := models.IstioValidations{}
 	checks, valid := gateways.PortChecker{
 		Gateway: gw,

--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -1,0 +1,41 @@
+package checkers
+
+import (
+	"github.com/kiali/kiali/business/checkers/serviceentries"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+const ServiceEntryCheckerType = "serviceentry"
+
+type ServiceEntryChecker struct {
+	ServiceEntries []kubernetes.IstioObject
+}
+
+func (s ServiceEntryChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, se := range s.ServiceEntries {
+		validations.MergeValidations(s.runSingleChecks(se))
+	}
+
+	return validations
+}
+
+func (s ServiceEntryChecker) runSingleChecks(se kubernetes.IstioObject) models.IstioValidations {
+	validations := models.IstioValidations{}
+	checks, valid := serviceentries.PortChecker{
+		ServiceEntry: se,
+	}.Check()
+
+	if !valid {
+		key := models.IstioValidationKey{ObjectType: ServiceEntryCheckerType, Name: se.GetObjectMeta().Name}
+		validations[key] = &models.IstioValidation{
+			Name:       key.Name,
+			ObjectType: key.ObjectType,
+			Checks:     checks,
+			Valid:      valid,
+		}
+	}
+	return validations
+}

--- a/business/checkers/serviceentries/port_checker.go
+++ b/business/checkers/serviceentries/port_checker.go
@@ -1,0 +1,32 @@
+package serviceentries
+
+import (
+	"fmt"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type PortChecker struct {
+	ServiceEntry kubernetes.IstioObject
+}
+
+func (p PortChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	if portsSpec, found := p.ServiceEntry.GetSpec()["ports"]; found {
+		if ports, ok := portsSpec.([]interface{}); ok {
+			for portIndex, port := range ports {
+				if portDef, ok := port.(map[string]interface{}); ok {
+					if !kubernetes.ValidatePort(portDef) {
+						validation := models.Build("port.name.mismatch",
+							fmt.Sprintf("spec/ports[%d]/name", portIndex))
+						validations = append(validations, &validation)
+					}
+				}
+			}
+		}
+	}
+
+	return validations, len(validations) == 0
+}

--- a/business/checkers/serviceentries/port_checker_test.go
+++ b/business/checkers/serviceentries/port_checker_test.go
@@ -1,0 +1,47 @@
+package serviceentries
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidPortDefinition(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	se := data.AddPortDefinitionToServiceEntry(
+		data.CreateEmptyPortDefinition(80, "http", "HTTP"),
+		data.CreateEmptyMeshExternalServiceEntry("valid-se", "test", []string{"localhost"}),
+	)
+
+	pc := PortChecker{ServiceEntry: se}
+	validations, valid := pc.Check()
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestInvalidPortDefinition(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	se := data.AddPortDefinitionToServiceEntry(
+		data.CreateEmptyPortDefinition(80, "example-http", "HTTP"),
+		data.CreateEmptyMeshExternalServiceEntry("notvalid-se", "test", []string{"localhost"}),
+	)
+
+	pc := PortChecker{ServiceEntry: se}
+	validations, valid := pc.Check()
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal(models.ErrorSeverity, validations[0].Severity)
+	assert.Equal(models.CheckMessage("port.name.mismatch"), validations[0].Message)
+	assert.Equal("spec/ports[0]/name", validations[0].Path)
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/config"
@@ -81,6 +81,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails},
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace},
 		checkers.MeshPolicyChecker{MeshPolicies: mtlsDetails.MeshPolicies, MTLSDetails: mtlsDetails},
+		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
 	}
 }
 
@@ -126,7 +127,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		mtlsChecker := checkers.MeshPolicyChecker{MeshPolicies: mtlsDetails.MeshPolicies, MTLSDetails: mtlsDetails}
 		objectCheckers = []ObjectChecker{mtlsChecker}
 	case ServiceEntries:
-		// Validations on ServiceEntries are not yet in place
+		serviceEntryChecker := checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries}
+		objectCheckers = []ObjectChecker{serviceEntryChecker}
 	case Rules:
 		// Validations on Istio Rules are not yet in place
 	case Templates:

--- a/tests/data/gateway_data.go
+++ b/tests/data/gateway_data.go
@@ -42,11 +42,7 @@ func CreateServer(hosts []string, port uint32, portName, protocolName string) ma
 		hostSlice = append(hostSlice, h)
 	}
 	return map[string]interface{}{
-		"port": map[string]interface{}{
-			"number":   port,
-			"name":     portName,
-			"protocol": protocolName,
-		},
+		"port":  CreateEmptyPortDefinition(port, portName, protocolName),
 		"hosts": hostSlice,
 	}
 }

--- a/tests/data/service_entry_data.go
+++ b/tests/data/service_entry_data.go
@@ -1,0 +1,62 @@
+package data
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateExternalServiceEntry() kubernetes.IstioObject {
+	return (&kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "external-svc-wikipedia",
+			Namespace: "wikipedia",
+		},
+		Spec: map[string]interface{}{
+			"hosts": []interface{}{
+				"wikipedia.org",
+			},
+			"location": "MESH_EXTERNAL",
+			"ports": []interface{}{
+				map[string]interface{}{
+					"number":   uint64(80),
+					"name":     "http-example",
+					"protocol": "HTTP",
+				},
+			},
+			"resolution": "DNS",
+		},
+	}).DeepCopyIstioObject()
+}
+
+func CreateEmptyMeshExternalServiceEntry(name, namespace string, hosts []string) kubernetes.IstioObject {
+	return (&kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: map[string]interface{}{
+			"hosts":      hosts,
+			"location":   "MESH_EXTERNAL",
+			"resolution": "DNS",
+		},
+	}).DeepCopyIstioObject()
+}
+
+func AddPortDefinitionToServiceEntry(portDef map[string]interface{}, se kubernetes.IstioObject) kubernetes.IstioObject {
+	if portsSpec, found := se.GetSpec()["ports"]; found {
+		if portsSlice, ok := portsSpec.([]interface{}); ok {
+			portsSlice = append(portsSlice, portDef)
+		}
+	} else {
+		se.GetSpec()["ports"] = []interface{}{portDef}
+	}
+	return se
+}
+
+func CreateEmptyPortDefinition(port uint32, portName, protocolName string) map[string]interface{} {
+	return map[string]interface{}{
+		"number":   port,
+		"name":     portName,
+		"protocol": protocolName,
+	}
+}

--- a/tests/data/virtual_service_data.go
+++ b/tests/data/virtual_service_data.go
@@ -78,26 +78,3 @@ func CreateVirtualServiceWithServiceEntryTarget() kubernetes.IstioObject {
 	}
 	return vs
 }
-
-func CreateExternalServiceEntry() kubernetes.IstioObject {
-	return (&kubernetes.GenericIstioObject{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      "external-svc-wikipedia",
-			Namespace: "wikipedia",
-		},
-		Spec: map[string]interface{}{
-			"hosts": []interface{}{
-				"wikipedia.org",
-			},
-			"location": "MESH_EXTERNAL",
-			"ports": []interface{}{
-				map[string]interface{}{
-					"number":   uint64(80),
-					"name":     "example-http",
-					"protocol": "HTTP",
-				},
-			},
-			"resolution": "DNS",
-		},
-	}).DeepCopyIstioObject()
-}


### PR DESCRIPTION
** Describe the change **

ServiceEntries require the same port name checking as Gateways. This PR enables checks for ServiceEntries as well as uses the same validation code as Gateways.

** Issue reference **

KIALI-2436

** Documentation **

Part of another JIRA (KIALI-2451)