### PR TITLE
KIALI-2325 Add a read only role for kiali

### DIFF
--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -130,106 +130,106 @@ metadata:
     app: kiali
     version: ${VERSION_LABEL}
 rules:
-  - apiGroups: [""]
-    resources:
-      - configmaps
-      - endpoints
-      - namespaces
-      - nodes
-      - pods
-      - services
-      - replicationcontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["extensions", "apps"]
-    resources:
-      - deployments
-      - statefulsets
-      - replicasets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["autoscaling"]
-    resources:
-      - horizontalpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["batch"]
-    resources:
-      - cronjobs
-      - jobs
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["config.istio.io"]
-    resources:
-      - apikeys
-      - authorizations
-      - checknothings
-      - circonuses
-      - deniers
-      - fluentds
-      - handlers
-      - kubernetesenvs
-      - kuberneteses
-      - listcheckers
-      - listentries
-      - logentries
-      - memquotas
-      - metrics
-      - opas
-      - prometheuses
-      - quotas
-      - quotaspecbindings
-      - quotaspecs
-      - rbacs
-      - reportnothings
-      - rules
-      - servicecontrolreports
-      - servicecontrols
-      - solarwindses
-      - stackdrivers
-      - statsds
-      - stdios
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["networking.istio.io"]
-    resources:
-      - destinationrules
-      - gateways
-      - serviceentries
-      - virtualservices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["authentication.istio.io"]
-    resources:
-      - policies
-      - meshpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["rbac.istio.io"]
-    resources:
-      - clusterrbacconfigs
-      - serviceroles
-      - servicerolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["monitoring.kiali.io"]
-    resources:
-      - monitoringdashboards
-    verbs:
-      - get
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - services
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - statefulsets
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["config.istio.io"]
+  resources:
+  - apikeys
+  - authorizations
+  - checknothings
+  - circonuses
+  - deniers
+  - fluentds
+  - handlers
+  - kubernetesenvs
+  - kuberneteses
+  - listcheckers
+  - listentries
+  - logentries
+  - memquotas
+  - metrics
+  - opas
+  - prometheuses
+  - quotas
+  - quotaspecbindings
+  - quotaspecs
+  - rbacs
+  - reportnothings
+  - rules
+  - servicecontrolreports
+  - servicecontrols
+  - solarwindses
+  - stackdrivers
+  - statsds
+  - stdios
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["networking.istio.io"]
+  resources:
+  - destinationrules
+  - gateways
+  - serviceentries
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["authentication.istio.io"]
+  resources:
+  - policies
+  - meshpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["rbac.istio.io"]
+  resources:
+  - clusterrbacconfigs
+  - serviceroles
+  - servicerolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get

--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -121,3 +121,115 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kiali-viewer
+  labels:
+    app: kiali
+    version: ${VERSION_LABEL}
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - namespaces
+      - nodes
+      - pods
+      - services
+      - replicationcontrollers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["extensions", "apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["config.istio.io"]
+    resources:
+      - apikeys
+      - authorizations
+      - checknothings
+      - circonuses
+      - deniers
+      - fluentds
+      - handlers
+      - kubernetesenvs
+      - kuberneteses
+      - listcheckers
+      - listentries
+      - logentries
+      - memquotas
+      - metrics
+      - opas
+      - prometheuses
+      - quotas
+      - quotaspecbindings
+      - quotaspecs
+      - rbacs
+      - reportnothings
+      - rules
+      - servicecontrolreports
+      - servicecontrols
+      - solarwindses
+      - stackdrivers
+      - statsds
+      - stdios
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["networking.istio.io"]
+    resources:
+      - destinationrules
+      - gateways
+      - serviceentries
+      - virtualservices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["authentication.istio.io"]
+    resources:
+      - policies
+      - meshpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["rbac.istio.io"]
+    resources:
+      - clusterrbacconfigs
+      - serviceroles
+      - servicerolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["monitoring.kiali.io"]
+    resources:
+      - monitoringdashboards
+    verbs:
+      - get

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -143,119 +143,119 @@ metadata:
     app: kiali
     version: ${VERSION_LABEL}
 rules:
-  - apiGroups: [""]
-    resources:
-      - configmaps
-      - endpoints
-      - namespaces
-      - nodes
-      - pods
-      - services
-      - replicationcontrollers
-      - routes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["extensions", "apps"]
-    resources:
-      - deployments
-      - statefulsets
-      - replicasets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["autoscaling"]
-    resources:
-      - horizontalpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["batch"]
-    resources:
-      - cronjobs
-      - jobs
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["config.istio.io"]
-    resources:
-      - apikeys
-      - authorizations
-      - checknothings
-      - circonuses
-      - deniers
-      - fluentds
-      - handlers
-      - kubernetesenvs
-      - kuberneteses
-      - listcheckers
-      - listentries
-      - logentries
-      - memquotas
-      - metrics
-      - opas
-      - prometheuses
-      - quotas
-      - quotaspecbindings
-      - quotaspecs
-      - rbacs
-      - reportnothings
-      - rules
-      - servicecontrolreports
-      - servicecontrols
-      - solarwindses
-      - stackdrivers
-      - statsds
-      - stdios
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["networking.istio.io"]
-    resources:
-      - destinationrules
-      - gateways
-      - serviceentries
-      - virtualservices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["authentication.istio.io"]
-    resources:
-      - policies
-      - meshpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["rbac.istio.io"]
-    resources:
-      - clusterrbacconfigs
-      - serviceroles
-      - servicerolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["apps.openshift.io"]
-    resources:
-      - deploymentconfigs
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups: ["project.openshift.io"]
-    resources:
-      - projects
-    verbs:
-      - get
-  - apiGroups: ["monitoring.kiali.io"]
-    resources:
-      - monitoringdashboards
-    verbs:
-      - get
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - services
+  - replicationcontrollers
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - statefulsets
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["config.istio.io"]
+  resources:
+  - apikeys
+  - authorizations
+  - checknothings
+  - circonuses
+  - deniers
+  - fluentds
+  - handlers
+  - kubernetesenvs
+  - kuberneteses
+  - listcheckers
+  - listentries
+  - logentries
+  - memquotas
+  - metrics
+  - opas
+  - prometheuses
+  - quotas
+  - quotaspecbindings
+  - quotaspecs
+  - rbacs
+  - reportnothings
+  - rules
+  - servicecontrolreports
+  - servicecontrols
+  - solarwindses
+  - stackdrivers
+  - statsds
+  - stdios
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["networking.istio.io"]
+  resources:
+  - destinationrules
+  - gateways
+  - serviceentries
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["authentication.istio.io"]
+  resources:
+  - policies
+  - meshpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["rbac.istio.io"]
+  resources:
+  - clusterrbacconfigs
+  - serviceroles
+  - servicerolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -134,3 +134,128 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+---
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: kiali-viewer
+  labels:
+    app: kiali
+    version: ${VERSION_LABEL}
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - namespaces
+      - nodes
+      - pods
+      - services
+      - replicationcontrollers
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["extensions", "apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["config.istio.io"]
+    resources:
+      - apikeys
+      - authorizations
+      - checknothings
+      - circonuses
+      - deniers
+      - fluentds
+      - handlers
+      - kubernetesenvs
+      - kuberneteses
+      - listcheckers
+      - listentries
+      - logentries
+      - memquotas
+      - metrics
+      - opas
+      - prometheuses
+      - quotas
+      - quotaspecbindings
+      - quotaspecs
+      - rbacs
+      - reportnothings
+      - rules
+      - servicecontrolreports
+      - servicecontrols
+      - solarwindses
+      - stackdrivers
+      - statsds
+      - stdios
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["networking.istio.io"]
+    resources:
+      - destinationrules
+      - gateways
+      - serviceentries
+      - virtualservices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["authentication.istio.io"]
+    resources:
+      - policies
+      - meshpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["rbac.istio.io"]
+    resources:
+      - clusterrbacconfigs
+      - serviceroles
+      - servicerolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["apps.openshift.io"]
+    resources:
+      - deploymentconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["project.openshift.io"]
+    resources:
+      - projects
+    verbs:
+      - get
+  - apiGroups: ["monitoring.kiali.io"]
+    resources:
+      - monitoringdashboards
+    verbs:
+      - get


### PR DESCRIPTION
This PRs adds an additional "kiali-viewer" role than can be used manually in restricted scenarios.
It doesn't modify any clusterrolebinding.


