### PR TITLE
KIALI-2506 Cache K8S clients between requests

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -31,7 +31,7 @@ func GetUnauthenticated() (*Layer, error) {
 func Get(token string) (*Layer, error) {
 	// Use an existing client factory if it exists, otherwise create and use in the future
 	if clientFactory == nil {
-		userClient, err := kubernetes.NewClientFactory()
+		userClient, err := kubernetes.GetClientFactory()
 		if err != nil {
 			return nil, err
 		}
@@ -39,7 +39,7 @@ func Get(token string) (*Layer, error) {
 	}
 
 	// Creates a new k8s client based on the current users token
-	k8s, err := clientFactory.NewClient(token)
+	k8s, err := clientFactory.GetClient(token)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -22,14 +22,14 @@ var clientFactory kubernetes.ClientFactory
 
 func getService(token string, namespace string, service string) (*v1.ServiceSpec, error) {
 	if clientFactory == nil {
-		userClientFactory, err := kubernetes.NewClientFactory()
+		userClientFactory, err := kubernetes.GetClientFactory()
 		if err != nil {
 			return nil, err
 		}
 		clientFactory = userClientFactory
 	}
 
-	client, err := clientFactory.NewClient(token)
+	client, err := clientFactory.GetClient(token)
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -1,0 +1,137 @@
+package kubernetes
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
+)
+
+var factory *clientFactory
+
+// Mutex for when modifying the stored clients
+var mutex = &sync.RWMutex{}
+
+const expirationTime = time.Minute * 15
+
+// ClientFactory interface for the clientFactory object
+type ClientFactory interface {
+	GetClient(token string) (IstioClientInterface, error)
+}
+
+// clientFactory used to generate per users clients
+type clientFactory struct {
+	ClientFactory
+	baseIstioConfig *rest.Config
+	clientEntries   map[string]*clientEntry
+}
+
+// clientEntry stored the client and its created timestamp
+type clientEntry struct {
+	client  IstioClientInterface
+	created time.Time
+}
+
+// GetClientFactory returns the client factory. Creates a new one if necessary
+func GetClientFactory() (ClientFactory, error) {
+	if factory == nil {
+		// Get the normal configuration
+		config, err := ConfigClient()
+		if err != nil {
+			return nil, err
+		}
+
+		// Create a new config based on what was gathered above but don't specify the bearer token to use
+		istioConfig := rest.Config{
+			Host:            config.Host,
+			TLSClientConfig: config.TLSClientConfig,
+			QPS:             config.QPS,
+			Burst:           config.Burst,
+		}
+
+		return getClientFactory(&istioConfig, expirationTime)
+
+	}
+	return factory, nil
+}
+
+// newClientFactory allows for specifying the config and expiry duration
+// Mock friendly for testing purposes
+func getClientFactory(istioConfig *rest.Config, expiry time.Duration) (*clientFactory, error) {
+	mutex.Lock()
+	if factory == nil {
+		clientEntriesMap := make(map[string]*clientEntry)
+
+		factory = &clientFactory{
+			baseIstioConfig: istioConfig,
+			clientEntries:   clientEntriesMap,
+		}
+
+		go watchClients(clientEntriesMap, expiry)
+	}
+	mutex.Unlock()
+	return factory, nil
+}
+
+// NewClient creates a new IstioClientInterface based on a users k8s token
+func (cf *clientFactory) newClient(token string) (IstioClientInterface, error) {
+	config := cf.baseIstioConfig
+
+	config.BearerToken = token
+
+	return NewClientFromConfig(config)
+}
+
+// GetClient returns a client for the specified token. Creating one if necessary.
+func (cf *clientFactory) GetClient(token string) (IstioClientInterface, error) {
+	clientEntry, err := cf.getClientEntry(token)
+	if err != nil {
+		return nil, err
+	}
+	return clientEntry.client, nil
+}
+
+// getClientEntry returns a clientEntry for the specified token. Creating one if necessary.
+func (cf *clientFactory) getClientEntry(token string) (*clientEntry, error) {
+	mutex.RLock()
+	cEntry, ok := cf.clientEntries[token]
+	mutex.RUnlock()
+	if ok {
+		return cEntry, nil
+	} else {
+		client, err := cf.newClient(token)
+		if err != nil {
+			log.Errorf("Error fetching the Kubernetes client: %v", err)
+			return nil, err
+		}
+
+		cEntry := clientEntry{
+			client:  client,
+			created: time.Now(),
+		}
+
+		mutex.Lock()
+		cf.clientEntries[token] = &cEntry
+		mutex.Unlock()
+		internalmetrics.SetKubernetesClients(len(cf.clientEntries))
+		return &cEntry, nil
+	}
+}
+
+// watchClients loops over clients and removes ones which are too old
+func watchClients(clientEntries map[string]*clientEntry, expiry time.Duration) {
+	for {
+		time.Sleep(expiry)
+		mutex.Lock()
+		for token, clientEntry := range clientEntries {
+			if time.Since(clientEntry.created) > expiry {
+				delete(clientEntries, token)
+			}
+		}
+		internalmetrics.SetKubernetesClients(len(clientEntries))
+		mutex.Unlock()
+	}
+}

--- a/kubernetes/client_factory_test.go
+++ b/kubernetes/client_factory_test.go
@@ -1,0 +1,69 @@
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+)
+
+// TestClientExpiry Verify that clients expire
+func TestClientExpiry(t *testing.T) {
+	istioConfig := rest.Config{}
+	clientFactory, _ := getClientFactory(&istioConfig, time.Millisecond*100)
+
+	clientEntries := clientFactory.clientEntries
+	// Make sure we are starting off with an empty set of clients
+	mutex.RLock()
+	assert.Equal(t, 0, len(clientEntries))
+	mutex.RUnlock()
+
+	mutex.Lock()
+	// Create a single initial test client
+	clientEntries["foo"] = &clientEntry{
+		created: time.Now(),
+	}
+	mutex.Unlock()
+
+	// Verify we have the client
+	mutex.RLock()
+	assert.Equal(t, 1, len(clientEntries))
+	_, found := clientEntries["foo"]
+	mutex.RUnlock()
+	assert.True(t, found)
+
+	// Sleep for a bit and add another client
+	time.Sleep(time.Millisecond * 25)
+	mutex.Lock()
+	clientEntries["bar"] = &clientEntry{
+		created: time.Now(),
+	}
+	mutex.Unlock()
+
+	// Verify we have both the foo and bar clients
+	mutex.RLock()
+	assert.Equal(t, 2, len(clientEntries))
+	_, found = clientEntries["foo"]
+	assert.True(t, found)
+	_, found = clientEntries["bar"]
+	assert.True(t, found)
+	mutex.RUnlock()
+
+	// Wait for foo to be expired
+	time.Sleep(time.Millisecond * 100)
+	// Verify the client has been removed
+	mutex.RLock()
+	assert.Equal(t, 1, len(clientEntries))
+	_, found = clientEntries["foo"]
+	assert.False(t, found)
+	_, found = clientEntries["bar"]
+	assert.True(t, found)
+	mutex.RUnlock()
+
+	// Wait for bar to be expired
+	time.Sleep(time.Millisecond * 125)
+	mutex.RLock()
+	assert.Equal(t, 0, len(clientEntries))
+	mutex.RUnlock()
+}

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -34,7 +34,7 @@ func NewK8SClientFactoryMock(k8s kubernetes.IstioClientInterface) *K8SClientFact
 }
 
 // Business Methods
-func (o *K8SClientFactoryMock) NewClient(token string) (kubernetes.IstioClientInterface, error) {
+func (o *K8SClientFactoryMock) GetClient(token string) (kubernetes.IstioClientInterface, error) {
 	return o.k8s, nil
 }
 

--- a/prometheus/internalmetrics/internal_metrics.go
+++ b/prometheus/internalmetrics/internal_metrics.go
@@ -33,6 +33,7 @@ type MetricsType struct {
 	PrometheusProcessingTime *prometheus.HistogramVec
 	GoFunctionProcessingTime *prometheus.HistogramVec
 	GoFunctionFailures       *prometheus.CounterVec
+	KubernetesClients        *prometheus.GaugeVec
 }
 
 // Metrics contains all of Kiali's own internal metrics.
@@ -95,6 +96,13 @@ var Metrics = MetricsType{
 		},
 		[]string{labelPackage, labelType, labelFunction},
 	),
+	KubernetesClients: prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kiali_kubernetes_clients",
+			Help: "The number of Kubernetes clients in use.",
+		},
+		[]string{},
+	),
 }
 
 // SuccessOrFailureMetricType let's you capture metrics for both successes and failures,
@@ -151,6 +159,7 @@ func RegisterInternalMetrics() {
 		Metrics.PrometheusProcessingTime,
 		Metrics.GoFunctionProcessingTime,
 		Metrics.GoFunctionFailures,
+		Metrics.KubernetesClients,
 	)
 }
 
@@ -266,4 +275,9 @@ func GetGoFunctionMetric(goPkg string, goType string, goFunc string) SuccessOrFa
 			labelFunction: goFunc,
 		}),
 	}
+}
+
+// SetKubernetesClients sets the kubernetes client count
+func SetKubernetesClients(clientCount int) {
+	Metrics.KubernetesClients.With(prometheus.Labels{}).Set(float64(clientCount))
 }


### PR DESCRIPTION
** Describe the change **

Instead of creating a new k8s client on each request, we store in memory the clients. If a client is not used in 15 minutes, it is deleted. This is done for performance reasons.

A new metric ('kiali_kubernetes_clients') tracks how many clients are in use at any given time.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2506
