### PR TITLE
KIALI-2542 Status endpoint needs credentials to determinate mTLS status

### DIFF
--- a/routing/routes.go
+++ b/routing/routes.go
@@ -140,7 +140,7 @@ func NewRoutes() (r *Routes) {
 			"GET",
 			"/api/status",
 			handlers.Root,
-			false,
+			true,
 		},
 		// swagger:route GET /config getConfig
 		// ---


### PR DESCRIPTION
** Describe the change **
mTLS masthead icon stopped to work after changes on authentication

** Issue reference **
https://issues.jboss.org/browse/KIALI-2542

** Backwards incompatible? **
yes
