### PR TITLE
Update Maistra yaml file in hack script

### DIFF
--- a/hack/cluster-openshift.sh
+++ b/hack/cluster-openshift.sh
@@ -48,7 +48,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 DEFAULT_MAISTRA_ISTIO_OC_DOWNLOAD_VERSION="v3.11.0+maistra-0.9.0"
 
 # The default installation custom resource used to define what to install
-DEFAULT_MAISTRA_INSTALL_YAML="https://raw.githubusercontent.com/Maistra/openshift-ansible/maistra-0.9/istio/cr-minimal.yaml"
+DEFAULT_MAISTRA_INSTALL_YAML="https://raw.githubusercontent.com/Maistra/openshift-ansible/maistra-0.9/istio/istio-installation-minimal.yaml"
 
 # set the default openshift address here so that it can be used for the usage text
 #


### PR DESCRIPTION
Maistra 0.9.0 has renamed yaml files used by cluster-openshift.sh to install Istio:

https://github.com/Maistra/openshift-ansible/tree/maistra-0.9/istio

