### PR TITLE
KIALI-2557 Ensure prometheus durations are parsed with prom utility

### DIFF
--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/prometheus/common/model"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
@@ -75,7 +76,7 @@ func NewOptions(r *http.Request) Options {
 
 	// query params
 	params := r.URL.Query()
-	var duration time.Duration
+	var duration model.Duration
 	var includeIstio bool
 	var injectServiceNodes bool
 	var queryTime int64
@@ -89,10 +90,10 @@ func NewOptions(r *http.Request) Options {
 	vendor := params.Get("vendor")
 
 	if durationString == "" {
-		duration, _ = time.ParseDuration(defaultDuration)
+		duration, _ = model.ParseDuration(defaultDuration)
 	} else {
 		var durationErr error
-		duration, durationErr = time.ParseDuration(durationString)
+		duration, durationErr = model.ParseDuration(durationString)
 		if durationErr != nil {
 			graph.BadRequest(fmt.Sprintf("Invalid duration [%s]", durationString))
 		}
@@ -177,7 +178,7 @@ func NewOptions(r *http.Request) Options {
 		if creationTime, found := accessibleNamespaces[namespaceToken]; found {
 			namespaceMap[namespaceToken] = graph.NamespaceInfo{
 				Name:     namespaceToken,
-				Duration: resolveNamespaceDuration(creationTime, duration, queryTime),
+				Duration: resolveNamespaceDuration(creationTime, time.Duration(duration), queryTime),
 			}
 		} else {
 			graph.Forbidden(fmt.Sprintf("Requested namespace [%s] is not accessible.", namespaceToken))
@@ -203,7 +204,7 @@ func NewOptions(r *http.Request) Options {
 			Workload:  workload,
 		},
 		VendorOptions: VendorOptions{
-			Duration:  duration,
+			Duration:  time.Duration(duration),
 			GraphType: graphType,
 			GroupBy:   groupBy,
 			QueryTime: queryTime,

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/prometheus/common/model"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/kiali/kiali/config"
@@ -73,9 +74,9 @@ func getPrometheusConfig() PrometheusConfig {
 		var config PrometheusPartialConfig
 		if checkErr(yaml.Unmarshal([]byte(configResult.YAML), &config), "Failed to unmarshal Prometheus configuration") {
 			scrapeIntervalString := config.Global.Scrape_interval
-			scrapeInterval, err := time.ParseDuration(scrapeIntervalString)
+			scrapeInterval, err := model.ParseDuration(scrapeIntervalString)
 			if checkErr(err, fmt.Sprintf("Invalid global scrape interval [%s]", scrapeIntervalString)) {
-				promConfig.GlobalScrapeInterval = int64(scrapeInterval.Seconds())
+				promConfig.GlobalScrapeInterval = int64(time.Duration(scrapeInterval).Seconds())
 			}
 		}
 	}
@@ -83,9 +84,9 @@ func getPrometheusConfig() PrometheusConfig {
 	flags, err := client.GetFlags()
 	if checkErr(err, "Failed to fetch Prometheus flags") {
 		if retentionString, ok := flags["storage.tsdb.retention"]; ok {
-			retention, err := time.ParseDuration(retentionString)
+			retention, err := model.ParseDuration(retentionString)
 			if checkErr(err, fmt.Sprintf("Invalid storage.tsdb.retention [%s]", retentionString)) {
-				promConfig.StorageTsdbRetention = int64(retention.Seconds())
+				promConfig.StorageTsdbRetention = int64(time.Duration(retention).Seconds())
 			}
 		}
 	}


### PR DESCRIPTION
Use Prometheus' model.ParseDuration as opposed to time.ParseDuration when
parsing a duration relevant to Prometheus.  Prom durations support a larger
set of period suffixes, like 'd' for days.

I tried this out manually by redeploying prom with 1d.  I saw the failure before the fix, and then success with the fix.
