### PR TITLE
KIALI-2544 remove unused edges

### DIFF
--- a/graph/appender/unused_node.go
+++ b/graph/appender/unused_node.go
@@ -40,17 +40,9 @@ func (a UnusedNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo 
 func (a UnusedNodeAppender) addUnusedNodes(trafficMap graph.TrafficMap, namespace string, workloads []models.WorkloadListItem) {
 	unusedTrafficMap := a.buildUnusedTrafficMap(trafficMap, namespace, workloads)
 
-	// If trafficMap is empty just populate it with the unused nodes and return
-	if len(trafficMap) == 0 {
-		for k, v := range unusedTrafficMap {
-			trafficMap[k] = v
-		}
-		return
-	}
-
 	// Integrate the unused nodes into the existing traffic map
-	for _, v := range unusedTrafficMap {
-		addUnusedNodeToTrafficMap(trafficMap, v)
+	for id, unusedNode := range unusedTrafficMap {
+		trafficMap[id] = unusedNode
 	}
 }
 
@@ -81,30 +73,4 @@ func (a UnusedNodeAppender) buildUnusedTrafficMap(trafficMap graph.TrafficMap, n
 		}
 	}
 	return unusedTrafficMap
-}
-
-func addUnusedNodeToTrafficMap(trafficMap graph.TrafficMap, unusedNode *graph.Node) {
-	// add unused node to traffic map
-	trafficMap[unusedNode.ID] = unusedNode
-
-	// Add a "sibling" edge to any node with an edge to the same app
-	for _, n := range trafficMap {
-		findAndAddSibling(n, unusedNode)
-	}
-}
-
-func findAndAddSibling(parent, unusedNode *graph.Node) {
-	if unusedNode.App == graph.Unknown {
-		return
-	}
-
-	found := false
-	for _, edge := range parent.Edges {
-		if found = edge.Dest.App == unusedNode.App; found {
-			break
-		}
-	}
-	if found {
-		parent.AddEdge(unusedNode)
-	}
 }

--- a/graph/appender/unused_node_test.go
+++ b/graph/appender/unused_node_test.go
@@ -151,7 +151,7 @@ func TestVersionWithNoTrafficScenario(t *testing.T) {
 	assert.Equal("v1", preference.Version)
 	assert.Equal(float64(0.8), e.Metadata["http"])
 	assert.Equal(nil, preference.Metadata["isUnused"])
-	assert.Equal(2, len(preference.Edges))
+	assert.Equal(1, len(preference.Edges))
 
 	e = preference.Edges[0]
 	recommendationV1 := e.Dest
@@ -160,13 +160,6 @@ func TestVersionWithNoTrafficScenario(t *testing.T) {
 	assert.Equal("v1", recommendationV1.Version)
 	assert.Equal(float64(0.8), e.Metadata["http"])
 	assert.Equal(nil, recommendationV1.Metadata["isUnused"])
-
-	e = preference.Edges[1]
-	recommendationV2 := e.Dest
-	assert.Equal("recommendation-v2", recommendationV2.Workload)
-	assert.Equal("recommendation", recommendationV2.App)
-	assert.Equal("v2", recommendationV2.Version)
-	assert.Equal(true, recommendationV2.Metadata["isUnused"])
 }
 
 func mockWorkloads() []models.WorkloadListItem {

--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -64,7 +64,6 @@ type EdgeData struct {
 	Traffic      ProtocolTraffic `json:"traffic,omitempty"`      // traffic rates for the edge protocol
 	ResponseTime string          `json:"responseTime,omitempty"` // in millis
 	IsMTLS       string          `json:"isMTLS,omitempty"`       // set to the percentage of traffic using a mutual TLS connection
-	IsUnused     bool            `json:"isUnused,omitempty"`     // true | false
 }
 
 type NodeWrapper struct {
@@ -282,9 +281,6 @@ func addEdgeTelemetry(e *graph.Edge, ed *EdgeData) {
 	if val, ok := e.Metadata["responseTime"]; ok {
 		responseTime := val.(float64)
 		ed.ResponseTime = fmt.Sprintf("%.0f", responseTime)
-	}
-	if val, ok := e.Source.Metadata["isUnused"]; ok {
-		ed.IsUnused = val.(bool)
 	}
 
 	// an edge represents traffic for at most one protocol

--- a/swagger.json
+++ b/swagger.json
@@ -2960,10 +2960,6 @@
           "type": "string",
           "x-go-name": "IsMTLS"
         },
-        "isUnused": {
-          "type": "boolean",
-          "x-go-name": "IsUnused"
-        },
         "responseTime": {
           "type": "string",
           "x-go-name": "ResponseTime"


### PR DESCRIPTION
The unused graph appender should limit itself to elements with true backing
definitions.  The edges generated by the appender are anticipated but don't
actually have any backing time series, and can be confusing or misleading.

It is not required for running but this PR goes with UI PR https://github.com/kiali/kiali-ui/pull/1066
