### PR TITLE
KIALI-2561 Ask browser to not use cache

### DIFF
--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -278,6 +278,8 @@ func NewAuthenticationHandler() (AuthenticationHandler, error) {
 
 func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+
 		statusCode := http.StatusOK
 		conf := config.Get()
 
@@ -314,6 +316,7 @@ func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {
 
 func (aHandler AuthenticationHandler) HandleUnauthenticated(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 		context := context.WithValue(r.Context(), "token", "")
 		next.ServeHTTP(w, r.WithContext(context))
 	})


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2561

Background:
- When user was already logged in, front-end was wrongly displaying the login page even if user was already logged in. This was causing a confusing experience, because any random credentials could be entered and, then, the user was being able to access the main console. Also, just refreshing with F5 caused the main console to render.
- On other less critical case, the contrary was also happening: while user was not yet logged in, front-end was displaying the main console but before any data was loaded, the UI switched immediately to the login page.

This is caused because the UI makes a request to the /api/auth/info endpoint to check if there is an active session. Browser was storing in cache the response of this endpoint on the first load of Kiali. On subsequent page loads, browser was using the cached response and the UI was determining an incorrect logged in status of the user. It could even determine an incorrect authentication strategy.

Currently, front-end is assuming that all requests hit the back-end. That was not happening always. This commit makes a change to ask the browser to not use its cache so that the front-end assumption becomes true.

Ultimately, the browser will choose. If browser keeps using cache, front-end changes will be needed.
