### PR TITLE
KIALI-2563 List RBAC resources only if cluster specifies those resources

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -145,6 +145,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		// Validations on Policies are not yet in place
 	case ClusterRbacConfigs:
 		// Validations on ClusterRbacConfigs are not yet in place
+	case RbacConfigs:
+		// Validations on RbacConfigs are not yet in place
 	case ServiceRoles:
 		// Validations on ServiceRoles are not yet in place
 	case ServiceRoleBindings:

--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -107,6 +107,7 @@ rules:
 - apiGroups: ["rbac.istio.io"]
   resources:
   - clusterrbacconfigs
+  - rbacconfigs
   - serviceroles
   - servicerolebindings
   verbs:
@@ -222,6 +223,7 @@ rules:
 - apiGroups: ["rbac.istio.io"]
   resources:
   - clusterrbacconfigs
+  - rbacconfigs
   - serviceroles
   - servicerolebindings
   verbs:

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -108,6 +108,7 @@ rules:
 - apiGroups: ["rbac.istio.io"]
   resources:
   - clusterrbacconfigs
+  - rbacconfigs
   - serviceroles
   - servicerolebindings
   verbs:
@@ -236,6 +237,7 @@ rules:
 - apiGroups: ["rbac.istio.io"]
   resources:
   - clusterrbacconfigs
+  - rbacconfigs
   - serviceroles
   - servicerolebindings
   verbs:

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -103,6 +103,7 @@ func parseCriteria(namespace string, objects string) business.IstioConfigCriteri
 	criteria.IncludePolicies = defaultInclude
 	criteria.IncludeMeshPolicies = defaultInclude
 	criteria.IncludeClusterRbacConfigs = defaultInclude
+	criteria.IncludeRbacConfigs = defaultInclude
 	criteria.IncludeServiceRoles = defaultInclude
 	criteria.IncludeServiceRoleBindings = defaultInclude
 
@@ -146,6 +147,9 @@ func parseCriteria(namespace string, objects string) business.IstioConfigCriteri
 	}
 	if checkType(types, business.ClusterRbacConfigs) {
 		criteria.IncludeClusterRbacConfigs = true
+	}
+	if checkType(types, business.RbacConfigs) {
+		criteria.IncludeRbacConfigs = true
 	}
 	if checkType(types, business.ServiceRoles) {
 		criteria.IncludeServiceRoles = true

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -78,6 +78,8 @@ type IstioClientInterface interface {
 	GetMeshPolicies(namespace string) ([]IstioObject, error)
 	GetClusterRbacConfig(namespace string, name string) (IstioObject, error)
 	GetClusterRbacConfigs(namespace string) ([]IstioObject, error)
+	GetRbacConfig(namespace string, name string) (IstioObject, error)
+	GetRbacConfigs(namespace string) ([]IstioObject, error)
 	GetServiceRole(namespace string, name string) (IstioObject, error)
 	GetServiceRoles(namespace string) ([]IstioObject, error)
 	GetServiceRoleBinding(namespace string, name string) (IstioObject, error)

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -102,6 +102,10 @@ type IstioClient struct {
 	// It is represented as a pointer to include the initialization phase.
 	// See kubernetes_service.go#IsOpenShift() for more details.
 	isOpenShift *bool
+	// rbacResources private variable will check which resources kiali has access to from rbac.istio.io group
+	// It is represented as a pointer to include the initialization phase.
+	// See istio_details_service.go#HasRbacResource() for more details.
+	rbacResources *map[string]bool
 	// Cache controller is a global cache for all k8s objects fetched by kiali in multiple namespaces.
 	// It doesn't support reduced permissions scenarios yet, don't forget to disabled on those use cases.
 	k8sCache  cacheController

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -571,6 +571,52 @@ func (in *IstioClient) GetClusterRbacConfig(namespace string, name string) (Isti
 	return c, nil
 }
 
+func (in *IstioClient) GetRbacConfigs(namespace string) ([]IstioObject, error) {
+	// In case RbacConfigs aren't present on Istio, return empty array.
+	if !in.hasRbacResource(rbacconfigs) {
+		return []IstioObject{}, nil
+	}
+
+	result, err := in.istioRbacApi.Get().Namespace(namespace).Resource(rbacconfigs).Do().Get()
+	if err != nil {
+		return nil, err
+	}
+	typeMeta := meta_v1.TypeMeta{
+		Kind:       PluralType[rbacconfigs],
+		APIVersion: ApiRbacVersion,
+	}
+	rbacConfigList, ok := result.(*GenericIstioObjectList)
+	if !ok {
+		return nil, fmt.Errorf("%s doesn't return a RbacConfigList list", namespace)
+	}
+
+	rbacConfigs := make([]IstioObject, 0)
+	for _, rc := range rbacConfigList.GetItems() {
+		r := rc.DeepCopyIstioObject()
+		r.SetTypeMeta(typeMeta)
+		rbacConfigs = append(rbacConfigs, r)
+	}
+	return rbacConfigs, nil
+}
+
+func (in *IstioClient) GetRbacConfig(namespace string, name string) (IstioObject, error) {
+	result, err := in.istioRbacApi.Get().Namespace(namespace).Resource(rbacconfigs).SubResource(name).Do().Get()
+	if err != nil {
+		return nil, err
+	}
+	typeMeta := meta_v1.TypeMeta{
+		Kind:       PluralType[rbacconfigs],
+		APIVersion: ApiRbacVersion,
+	}
+	rbacConfig, ok := result.(*GenericIstioObject)
+	if !ok {
+		return nil, fmt.Errorf("%s doesn't return a RbacConfig object", namespace)
+	}
+	r := rbacConfig.DeepCopyIstioObject()
+	r.SetTypeMeta(typeMeta)
+	return r, nil
+}
+
 func (in *IstioClient) GetServiceRoles(namespace string) ([]IstioObject, error) {
 	// In case ServiceRoles aren't present on Istio, return empty array.
 	if !in.hasRbacResource(serviceroles) {

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -139,6 +140,30 @@ func (in *IstioClient) UpdateIstioObject(api, namespace, resourceType, name, jso
 	}
 	istioObject.SetTypeMeta(typeMeta)
 	return istioObject, err
+}
+
+func (in *IstioClient) hasRbacResource(resource string) bool {
+	return in.getRbacResources()[resource]
+}
+
+func (in *IstioClient) getRbacResources() map[string]bool {
+	if in.rbacResources != nil {
+		return *in.rbacResources
+	}
+
+	rbacResources := map[string]bool{}
+	resourceListRaw, err := in.k8s.RESTClient().Get().AbsPath("/apis/rbac.istio.io/v1alpha1").Do().Raw()
+	if err == nil {
+		resourceList := meta_v1.APIResourceList{}
+		if errMarshall := json.Unmarshal(resourceListRaw, &resourceList); errMarshall == nil {
+			for _, resource := range resourceList.APIResources {
+				rbacResources[resource.Name] = true
+			}
+		}
+	}
+	in.rbacResources = &rbacResources
+
+	return *in.rbacResources
 }
 
 // GetVirtualServices return all VirtualServices for a given namespace.
@@ -501,6 +526,11 @@ func (in *IstioClient) GetMeshPolicy(namespace string, policyName string) (Istio
 }
 
 func (in *IstioClient) GetClusterRbacConfigs(namespace string) ([]IstioObject, error) {
+	// In case ClusterRbacConfigs aren't present on Istio, return empty array.
+	if !in.hasRbacResource(clusterrbacconfigs) {
+		return []IstioObject{}, nil
+	}
+
 	result, err := in.istioRbacApi.Get().Namespace(namespace).Resource(clusterrbacconfigs).Do().Get()
 	if err != nil {
 		return nil, err
@@ -542,6 +572,11 @@ func (in *IstioClient) GetClusterRbacConfig(namespace string, name string) (Isti
 }
 
 func (in *IstioClient) GetServiceRoles(namespace string) ([]IstioObject, error) {
+	// In case ServiceRoles aren't present on Istio, return empty array.
+	if !in.hasRbacResource(serviceroles) {
+		return []IstioObject{}, nil
+	}
+
 	result, err := in.istioRbacApi.Get().Namespace(namespace).Resource(serviceroles).Do().Get()
 	if err != nil {
 		return nil, err
@@ -583,6 +618,11 @@ func (in *IstioClient) GetServiceRole(namespace string, name string) (IstioObjec
 }
 
 func (in *IstioClient) GetServiceRoleBindings(namespace string) ([]IstioObject, error) {
+	// In case ServiceRoleBindings aren't present on Istio, return empty array.
+	if !in.hasRbacResource(servicerolebindings) {
+		return []IstioObject{}, nil
+	}
+
 	result, err := in.istioRbacApi.Get().Namespace(namespace).Resource(servicerolebindings).Do().Get()
 	if err != nil {
 		return nil, err

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -307,6 +307,16 @@ func (o *K8SClientMock) GetClusterRbacConfig(namespace string, policyName string
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
+func (o *K8SClientMock) GetRbacConfigs(namespace string) ([]kubernetes.IstioObject, error) {
+	args := o.Called(namespace)
+	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
+}
+
+func (o *K8SClientMock) GetRbacConfig(namespace string, policyName string) (kubernetes.IstioObject, error) {
+	args := o.Called(namespace)
+	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
+}
+
 func (o *K8SClientMock) GetServiceRoles(namespace string) ([]kubernetes.IstioObject, error) {
 	args := o.Called(namespace)
 	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -59,6 +59,10 @@ const (
 	clusterrbacconfigType     = "ClusterRbacConfig"
 	clusterrbacconfigTypeList = "ClusterRbacConfigList"
 
+	rbacconfigs        = "rbacconfigs"
+	rbacconfigType     = "RbacConfig"
+	rbacconfigTypeList = "RbacConfigList"
+
 	serviceroles        = "serviceroles"
 	serviceroleType     = "ServiceRole"
 	serviceroleTypeList = "ServiceRoleList"
@@ -382,6 +386,10 @@ var (
 			collectionKind: clusterrbacconfigTypeList,
 		},
 		{
+			objectKind:     rbacconfigType,
+			collectionKind: rbacconfigTypeList,
+		},
+		{
 			objectKind:     serviceroleType,
 			collectionKind: serviceroleTypeList,
 		},
@@ -472,6 +480,7 @@ var (
 
 		// Rbac
 		clusterrbacconfigs:  clusterrbacconfigType,
+		rbacconfigs:         rbacconfigType,
 		serviceroles:        serviceroleType,
 		servicerolebindings: servicerolebindingType,
 	}

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -22,6 +22,7 @@ type IstioConfigList struct {
 	Policies            Policies            `json:"policies"`
 	MeshPolicies        MeshPolicies        `json:"meshPolicies"`
 	ClusterRbacConfigs  ClusterRbacConfigs  `json:"clusterRbacConfigs"`
+	RbacConfigs         RbacConfigs         `json:"rbacConfigs"`
 	ServiceRoles        ServiceRoles        `json:"serviceRoles"`
 	ServiceRoleBindings ServiceRoleBindings `json:"serviceRoleBindings"`
 	IstioValidations    IstioValidations    `json:"validations"`
@@ -42,6 +43,7 @@ type IstioConfigDetails struct {
 	Policy             *Policy             `json:"policy"`
 	MeshPolicy         *MeshPolicy         `json:"meshPolicy"`
 	ClusterRbacConfig  *ClusterRbacConfig  `json:"clusterRbacConfig"`
+	RbacConfig         *RbacConfig         `json:"rbacConfig"`
 	ServiceRole        *ServiceRole        `json:"serviceRole"`
 	ServiceRoleBinding *ServiceRoleBinding `json:"serviceRoleBinding"`
 	Permissions        ResourcePermissions `json:"permissions"`

--- a/models/rbac_config.go
+++ b/models/rbac_config.go
@@ -1,0 +1,34 @@
+package models
+
+import (
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+type RbacConfigs []RbacConfig
+type RbacConfig struct {
+	meta_v1.TypeMeta
+	Metadata meta_v1.ObjectMeta `json:"metadata"`
+	Spec     struct {
+		Mode      interface{} `json:"mode"`
+		Inclusion interface{} `json:"inclusion"`
+		Exclusion interface{} `json:"exclusion"`
+	} `json:"spec"`
+}
+
+func (rcs *RbacConfigs) Parse(rbacConfigs []kubernetes.IstioObject) {
+	for _, rc := range rbacConfigs {
+		rbacConfig := RbacConfig{}
+		rbacConfig.Parse(rc)
+		*rcs = append(*rcs, rbacConfig)
+	}
+}
+
+func (rc *RbacConfig) Parse(rbacConfig kubernetes.IstioObject) {
+	rc.TypeMeta = rbacConfig.GetTypeMeta()
+	rc.Metadata = rbacConfig.GetObjectMeta()
+	rc.Spec.Mode = rbacConfig.GetSpec()["mode"]
+	rc.Spec.Inclusion = rbacConfig.GetSpec()["inclusion"]
+	rc.Spec.Exclusion = rbacConfig.GetSpec()["exclusion"]
+}

--- a/swagger.json
+++ b/swagger.json
@@ -3235,6 +3235,9 @@
         "quotaSpecBinding": {
           "$ref": "#/definitions/QuotaSpecBinding"
         },
+        "rbacConfig": {
+          "$ref": "#/definitions/RbacConfig"
+        },
         "rule": {
           "$ref": "#/definitions/istioRule"
         },
@@ -3293,6 +3296,9 @@
         },
         "quotaSpecs": {
           "$ref": "#/definitions/QuotaSpecs"
+        },
+        "rbacConfigs": {
+          "$ref": "#/definitions/RbacConfigs"
         },
         "rules": {
           "$ref": "#/definitions/istioRules"
@@ -3982,6 +3988,50 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/QuotaSpec"
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "RbacConfig": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "metadata": {
+          "$ref": "#/definitions/ObjectMeta"
+        },
+        "spec": {
+          "type": "object",
+          "properties": {
+            "exclusion": {
+              "type": "object",
+              "x-go-name": "Exclusion"
+            },
+            "inclusion": {
+              "type": "object",
+              "x-go-name": "Inclusion"
+            },
+            "mode": {
+              "type": "object",
+              "x-go-name": "Mode"
+            }
+          },
+          "x-go-name": "Spec"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "RbacConfigs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RbacConfig"
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },


### PR DESCRIPTION
** Describe the change **
List only resources that are available in Istio into IstioConfig.
In case the cluster doesn't have that resource available, it returns an empty array.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2563


