### PR TITLE
KIALI-1987 Add a new env var to tag the kiali installation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -262,6 +262,13 @@ auth:
   strategy: VALUE
 ----
 
+|`INSTALLATION_TAG`
+|Tag used to identify that particular instnce/installation of the kiali server.
+[source,yaml]
+----
+installation_tag: VALUE
+----
+
 |`IDENTITY_CERT_FILE`
 |Certificate file used to identify the file server. If set, you must go over https to retrieve content from the file server.
 [source,yaml]

--- a/README.adoc
+++ b/README.adoc
@@ -262,7 +262,7 @@ auth:
   strategy: VALUE
 ----
 
-|`INSTALLATION_TAG`
+|`KIALI_INSTALLATION_TAG`
 |Tag used to identify that particular instnce/installation of the kiali server.
 [source,yaml]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -263,7 +263,7 @@ auth:
 ----
 
 |`KIALI_INSTALLATION_TAG`
-|Tag used to identify that particular instnce/installation of the kiali server.
+|Tag used to identify a particular instance/installation of the kiali server (Default: kiali)
 [source,yaml]
 ----
 installation_tag: VALUE

--- a/README.adoc
+++ b/README.adoc
@@ -263,7 +263,7 @@ auth:
 ----
 
 |`KIALI_INSTALLATION_TAG`
-|Tag used to identify a particular instance/installation of the kiali server (Default: kiali)
+|Tag used to identify a particular instance/installation of the kiali server
 [source,yaml]
 ----
 installation_tag: VALUE

--- a/config/config.go
+++ b/config/config.go
@@ -202,7 +202,7 @@ type Config struct {
 func NewConfig() (c *Config) {
 	c = new(Config)
 
-	c.InstallationTag = getDefaultString(EnvInstallationTag, "Kiali")
+	c.InstallationTag = getDefaultString(EnvInstallationTag, "")
 
 	c.Identity.CertFile = getDefaultString(EnvIdentityCertFile, "")
 	c.Identity.PrivateKeyFile = getDefaultString(EnvIdentityPrivateKeyFile, "")

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ import (
 // Environment vars can define some default values.
 // NOTE: If you add a new variable, don't forget to update README.adoc
 const (
+	EnvInstallationTag = "KIALI_INSTALLATION_TAG"
+
 	EnvIdentityCertFile       = "IDENTITY_CERT_FILE"
 	EnvIdentityPrivateKeyFile = "IDENTITY_PRIVATE_KEY_FILE"
 
@@ -189,6 +191,7 @@ type Config struct {
 	ExternalServices ExternalServices  `yaml:"external_services,omitempty"`
 	LoginToken       LoginToken        `yaml:"login_token,omitempty"`
 	IstioNamespace   string            `yaml:"istio_namespace,omitempty"`
+	InstallationTag  string            `yaml:"installation_tag,omitempty"`
 	IstioLabels      IstioLabels       `yaml:"istio_labels,omitempty"`
 	KubernetesConfig KubernetesConfig  `yaml:"kubernetes_config,omitempty"`
 	API              ApiConfig         `yaml:"api,omitempty"`
@@ -198,6 +201,8 @@ type Config struct {
 // NewConfig creates a default Config struct
 func NewConfig() (c *Config) {
 	c = new(Config)
+
+	c.InstallationTag = getDefaultString(EnvInstallationTag, "Kiali")
 
 	c.Identity.CertFile = getDefaultString(EnvIdentityCertFile, "")
 	c.Identity.PrivateKeyFile = getDefaultString(EnvIdentityPrivateKeyFile, "")

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -27,9 +27,10 @@ type PrometheusConfig struct {
 // PublicConfig is a subset of Kiali configuration that can be exposed to clients to
 // help them interact with the system.
 type PublicConfig struct {
-	IstioNamespace string             `json:"istioNamespace,omitempty"`
-	IstioLabels    config.IstioLabels `json:"istioLabels,omitempty"`
-	Prometheus     PrometheusConfig   `json:"prometheus,omitempty"`
+	InstallationTag string             `json:"installationTag,omitempty"`
+	IstioNamespace  string             `json:"istioNamespace,omitempty"`
+	IstioLabels     config.IstioLabels `json:"istioLabels,omitempty"`
+	Prometheus      PrometheusConfig   `json:"prometheus,omitempty"`
 }
 
 // Config is a REST http.HandlerFunc serving up the Kiali configuration made public to clients.
@@ -41,8 +42,9 @@ func Config(w http.ResponseWriter, r *http.Request) {
 	promConfig := getPrometheusConfig()
 	config := config.Get()
 	publicConfig := PublicConfig{
-		IstioNamespace: config.IstioNamespace,
-		IstioLabels:    config.IstioLabels,
+		InstallationTag: config.InstallationTag,
+		IstioNamespace:  config.IstioNamespace,
+		IstioLabels:     config.IstioLabels,
 		Prometheus: PrometheusConfig{
 			GlobalScrapeInterval: promConfig.GlobalScrapeInterval,
 			StorageTsdbRetention: promConfig.StorageTsdbRetention,


### PR DESCRIPTION
**Describe the change**
When running multiple clusters it can be so confusing which one kiali is looking at. This PR adds a new config variable that can be used to identify a kiali installation.
UI PR - [#1079](https://github.com/kiali/kiali-ui/pull/1079)
**Issue reference**
[JIRA KIALI-1987](https://issues.jboss.org/browse/KIALI-1987)
**Backwards incompatible?**
No
**Documentation**
Yes
