### PR TITLE
KIALI-2548 forward "/" requests to the real root context path

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -27,6 +27,12 @@ func NewRouter() *mux.Router {
 		rootRouter.HandleFunc(webRoot, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, webRootWithSlash, http.StatusFound)
 		})
+
+		// help the user out - if a request comes in for "/", redirect to our true webroot
+		rootRouter.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, webRootWithSlash, http.StatusFound)
+		})
+
 		appRouter = rootRouter.PathPrefix(conf.Server.WebRoot).Subrouter()
 	}
 


### PR DESCRIPTION
** Describe the change **

If the root context path is not "/", and a request comes in for "/", help the user out by forwarding to the true context root. This means a request to "/" will never result in a 404 - it will be forwarded to the true root context.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2548
