### PR TITLE
KIALI-2551 Adding ns-wide mtls validations

### DIFF
--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -59,6 +59,7 @@ func (in DestinationRulesChecker) runChecks(destinationRule kubernetes.IstioObje
 
 	enabledCheckers := []Checker{
 		destinationrules.MeshWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
+		destinationrules.NamespaceWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -60,6 +60,7 @@ func (in DestinationRulesChecker) runChecks(destinationRule kubernetes.IstioObje
 	enabledCheckers := []Checker{
 		destinationrules.MeshWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
 		destinationrules.NamespaceWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
+		destinationrules.DisabledNamespaceWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go
+++ b/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go
@@ -1,0 +1,50 @@
+package destinationrules
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type DisabledNamespaceWideMTLSChecker struct {
+	DestinationRule kubernetes.IstioObject
+	MTLSDetails     kubernetes.MTLSDetails
+}
+
+// Check if a the Policy is allows non-mtls traffic when DestinationRule explicitly disables mTLS ns-wide
+func (m DisabledNamespaceWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	// Stop validation without any check if DestinationRule doesn't explicitly disables mTLS
+	if enabled, mode := kubernetes.DestinationRuleHasNamespaceWideMTLSEnabled(m.DestinationRule.GetObjectMeta().Namespace, m.DestinationRule); enabled || mode != "DISABLED" {
+		return validations, true
+	}
+
+	// otherwise, check among Policies for a rule enabling mTLS
+	for _, mp := range m.MTLSDetails.Policies {
+		enabled, status := kubernetes.PolicyHasMTLSEnabled(mp)
+
+		// If Policy has mTLS enabled in the namespace
+		// traffic going through DestinationRule won't work
+		if enabled {
+			check := models.Build("destinationrules.mtls.policymtlsenabled", "spec/trafficPolicy/tls/mode")
+			return append(validations, &check), false
+		}
+
+		// If Policy is disabling mTLS,
+		// traffic going through DestinationRule will work
+		if status == "DISABLED" {
+			return validations, true
+		}
+
+	}
+
+	// In case any Policy enables mTLS, check among MeshPolicies for a rule enabling it
+	for _, mp := range m.MTLSDetails.MeshPolicies {
+		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
+			check := models.Build("destinationrules.mtls.meshpolicymtlsenabled", "spec/trafficPolicy/tls/mode")
+			return append(validations, &check), false
+		}
+	}
+
+	return validations, true
+}

--- a/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go
+++ b/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go
@@ -14,33 +14,24 @@ type DisabledNamespaceWideMTLSChecker struct {
 func (m DisabledNamespaceWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
-	// Stop validation without any check if DestinationRule doesn't explicitly disables mTLS
-	if enabled, mode := kubernetes.DestinationRuleHasNamespaceWideMTLSEnabled(m.DestinationRule.GetObjectMeta().Namespace, m.DestinationRule); enabled || mode != "DISABLED" {
+	// Stop validation if DestinationRule doesn't explicitly disables mTLS
+	if _, mode := kubernetes.DestinationRuleHasNamespaceWideMTLSEnabled(m.DestinationRule.GetObjectMeta().Namespace, m.DestinationRule); mode != "DISABLE" {
 		return validations, true
 	}
 
 	// otherwise, check among Policies for a rule enabling mTLS
 	for _, mp := range m.MTLSDetails.Policies {
-		enabled, status := kubernetes.PolicyHasMTLSEnabled(mp)
-
 		// If Policy has mTLS enabled in the namespace
 		// traffic going through DestinationRule won't work
-		if enabled {
+		if strictMode := kubernetes.PolicyHasStrictMTLS(mp); strictMode {
 			check := models.Build("destinationrules.mtls.policymtlsenabled", "spec/trafficPolicy/tls/mode")
 			return append(validations, &check), false
 		}
-
-		// If Policy is disabling mTLS,
-		// traffic going through DestinationRule will work
-		if status == "DISABLED" {
-			return validations, true
-		}
-
 	}
 
 	// In case any Policy enables mTLS, check among MeshPolicies for a rule enabling it
 	for _, mp := range m.MTLSDetails.MeshPolicies {
-		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
+		if strictMode := kubernetes.PolicyHasStrictMTLS(mp); strictMode {
 			check := models.Build("destinationrules.mtls.meshpolicymtlsenabled", "spec/trafficPolicy/tls/mode")
 			return append(validations, &check), false
 		}

--- a/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
@@ -1,0 +1,139 @@
+package destinationrules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+// Context: DestinationRule ns-wide disabling mTLS connections
+// Context: Policy ns-wide in permissive mode
+// It doesn't return any validation
+func TestDRNSWideDisablingTLSPolicyPermissive(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		Policies: []kubernetes.IstioObject{
+			data.CreateEmptyPolicy("default", "bookinfo", data.CreateMTLSPeers("PERMISSIVE")),
+		},
+	}
+
+	testNoDisabledMtlsValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule ns-wide disabling mTLS connections
+// Context: Policy ns-wide in strict mode
+// It returns a policymtlsenabled validation
+func TestDRNSWideDisablingTLSPolicyStrict(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		Policies: []kubernetes.IstioObject{
+			data.CreateEmptyPolicy("default", "bookinfo", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testDisabledMtlsValidationsFound(t, "destinationrules.mtls.policymtlsenabled", destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule ns-wide disabling mTLS connections
+// Context: Doesn't have Policy ns-wide defining TLS settings
+// Context: Does have a MeshPolicy in strict mode
+// It returns a meshpolicymtlsenabled validation
+func TestDRNSWideDisablingTLSMeshPolicyStrict(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testDisabledMtlsValidationsFound(t, "destinationrules.mtls.meshpolicymtlsenabled", destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule ns-wide disabling mTLS connections
+// Context: Doesn't have Policy ns-wide defining TLS settings
+// Context: Does have a MeshPolicy in permissive mode
+// It doesn't return any validation
+func TestDRNSWideDisablingTLSMeshPolicyPermissive(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE")),
+		},
+	}
+
+	testNoDisabledMtlsValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule ns-wide disabling mTLS connections
+// Context: Doesn't have Policy ns-wide defining TLS settings
+// Context: Doesn't have a MeshPolicy defining TLS settings
+// It doesn't return any validation
+func TestDRNSWideDisablingTLSWithoutPolicy(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{}
+
+	testNoDisabledMtlsValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: There isn't any ns-wide DestinationRule defining mTLS connections
+// It doesn't return any validation
+func TestDRNonTLSRelated(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "dr-mtls", "*.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{}
+
+	testNoDisabledMtlsValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+func testNoDisabledMtlsValidationsFound(t *testing.T, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
+	assert := assert.New(t)
+
+	validations, valid := DisabledNamespaceWideMTLSChecker{
+		DestinationRule: destinationRule,
+		MTLSDetails:     mTLSDetails,
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+func testDisabledMtlsValidationsFound(t *testing.T, validationId string, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
+	assert := assert.New(t)
+
+	validations, valid := DisabledNamespaceWideMTLSChecker{
+		DestinationRule: destinationRule,
+		MTLSDetails:     mTLSDetails,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	assert.False(valid)
+
+	validation := validations[0]
+	assert.NotNil(validation)
+	assert.Equal(models.ErrorSeverity, validation.Severity)
+	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
+	assert.Equal(models.CheckMessage(validationId), validation.Message)
+}

--- a/business/checkers/destinationrules/meshwide_mtls_checker.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker.go
@@ -20,7 +20,7 @@ func (m MeshWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 
 	// otherwise, check among MeshPolicies for a rule enabling mesh-wide mTLS
 	for _, mp := range m.MTLSDetails.MeshPolicies {
-		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
+		if strictMode := kubernetes.PolicyHasStrictMTLS(mp); strictMode {
 			return validations, true
 		}
 	}

--- a/business/checkers/destinationrules/namespacewide_mtls_checker.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker.go
@@ -20,14 +20,14 @@ func (m NamespaceWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 
 	// otherwise, check among Policies for a rule enabling ns-wide mTLS
 	for _, mp := range m.MTLSDetails.Policies {
-		if enabled, mode := kubernetes.PolicyHasMTLSEnabled(mp); enabled || mode != "" {
+		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
 			return validations, true
 		}
 	}
 
 	// In case any Policy enables mTLS, check among MeshPolicies for a rule enabling it
 	for _, mp := range m.MTLSDetails.MeshPolicies {
-		if enabled, mode := kubernetes.PolicyHasMTLSEnabled(mp); enabled || mode != "" {
+		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
 			return validations, true
 		}
 	}

--- a/business/checkers/destinationrules/namespacewide_mtls_checker.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker.go
@@ -1,0 +1,32 @@
+package destinationrules
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type NamespaceWideMTLSChecker struct {
+	DestinationRule kubernetes.IstioObject
+	MTLSDetails     kubernetes.MTLSDetails
+}
+
+func (m NamespaceWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	// if DestinationRule doesn't enable mTLS, stop validation with any check
+	if enabled, _ := kubernetes.DestinationRuleHasNamespaceWideMTLSEnabled(m.DestinationRule.GetObjectMeta().Namespace, m.DestinationRule); !enabled {
+		return validations, true
+	}
+
+	// otherwise, check among MeshPolicies for a rule enabling mesh-wide mTLS
+	for _, mp := range m.MTLSDetails.Policies {
+		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
+			return validations, true
+		}
+	}
+
+	check := models.Build("destinationrules.mtls.nspolicymissing", "spec/trafficPolicy/tls/mode")
+	validations = append(validations, &check)
+
+	return validations, false
+}

--- a/business/checkers/destinationrules/namespacewide_mtls_checker.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker.go
@@ -18,9 +18,16 @@ func (m NamespaceWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 		return validations, true
 	}
 
-	// otherwise, check among MeshPolicies for a rule enabling ns-wide mTLS
+	// otherwise, check among Policies for a rule enabling ns-wide mTLS
 	for _, mp := range m.MTLSDetails.Policies {
-		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
+		if enabled, mode := kubernetes.PolicyHasMTLSEnabled(mp); enabled || mode != "" {
+			return validations, true
+		}
+	}
+
+	// In case any Policy enables mTLS, check among MeshPolicies for a rule enabling it
+	for _, mp := range m.MTLSDetails.MeshPolicies {
+		if enabled, mode := kubernetes.PolicyHasMTLSEnabled(mp); enabled || mode != "" {
 			return validations, true
 		}
 	}

--- a/business/checkers/destinationrules/namespacewide_mtls_checker.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker.go
@@ -18,7 +18,7 @@ func (m NamespaceWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 		return validations, true
 	}
 
-	// otherwise, check among MeshPolicies for a rule enabling mesh-wide mTLS
+	// otherwise, check among MeshPolicies for a rule enabling ns-wide mTLS
 	for _, mp := range m.MTLSDetails.Policies {
 		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
 			return validations, true

--- a/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
@@ -1,0 +1,68 @@
+package destinationrules
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+)
+
+// Context: DestinationRule enables namespace-wide mTLS
+// Context: There is one Policy not enabling mTLS
+// It returns a validation
+func TestMTLSNshWideDREnabledWithNsPolicyPermissive(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "dr-mtls", "*.bookinfo.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		Policies: []kubernetes.IstioObject{
+			data.CreateEmptyPolicy("default", "bookinfo", data.CreateMTLSPeers("PERMISSIVE")),
+		},
+	}
+
+	validations, valid := NamespaceWideMTLSChecker{
+		DestinationRule: destinationRule,
+		MTLSDetails:     mTlsDetails,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	assert.False(valid)
+
+	validation := validations[0]
+	assert.NotNil(validation)
+	assert.Equal(models.ErrorSeverity, validation.Severity)
+	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
+	assert.Equal(models.CheckMessage("destinationrules.mtls.nspolicymissing"), validation.Message)
+}
+
+// Context: DestinationRule enables namespace-wide mTLS
+// Context: There is one Policy enabling mTLS
+// It doesn't return any validation
+func TestMTLSNsWideDREnabledWithPolicy(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "dr-mtls", "*.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		Policies: []kubernetes.IstioObject{
+			data.CreateEmptyPolicy("default", "bookinfo", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	assert := assert.New(t)
+
+	validations, valid := NamespaceWideMTLSChecker{
+		DestinationRule: destinationRule,
+		MTLSDetails:     mTlsDetails,
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}

--- a/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
@@ -3,11 +3,12 @@ package destinationrules
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 // Context: DestinationRule enables namespace-wide mTLS

--- a/business/checkers/mesh_policies_checker.go
+++ b/business/checkers/mesh_policies_checker.go
@@ -35,7 +35,7 @@ func (m MeshPolicyChecker) runChecks(meshPolicy kubernetes.IstioObject) models.I
 	}
 
 	enabledCheckers := []Checker{
-		meshpolicies.MtlsChecker{MeshPolicy: meshPolicy, MTLSDetails: m.MTLSDetails},
+		meshpolicies.MeshMtlsChecker{MeshPolicy: meshPolicy, MTLSDetails: m.MTLSDetails},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/meshpolicies/mesh_mtls_checker.go
+++ b/business/checkers/meshpolicies/mesh_mtls_checker.go
@@ -13,8 +13,8 @@ type MeshMtlsChecker struct {
 func (t MeshMtlsChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
-	// if MeshPolicy doesn't enables mTLS, stop validation with any check.
-	if enabled, _ := kubernetes.PolicyHasMTLSEnabled(t.MeshPolicy); !enabled {
+	// if MeshPolicy doesn't have mtls in strict mode, stop validation with any check.
+	if strictMode := kubernetes.PolicyHasStrictMTLS(t.MeshPolicy); !strictMode {
 		return validations, true
 	}
 

--- a/business/checkers/meshpolicies/mesh_mtls_checker.go
+++ b/business/checkers/meshpolicies/mesh_mtls_checker.go
@@ -5,14 +5,12 @@ import (
 	"github.com/kiali/kiali/models"
 )
 
-const MeshPolicyCheckerType = "meshpolicy"
-
-type MtlsChecker struct {
+type MeshMtlsChecker struct {
 	MeshPolicy  kubernetes.IstioObject
 	MTLSDetails kubernetes.MTLSDetails
 }
 
-func (t MtlsChecker) Check() ([]*models.IstioCheck, bool) {
+func (t MeshMtlsChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
 	// if MeshPolicy doesn't enables mTLS, stop validation with any check.

--- a/business/checkers/meshpolicies/mesh_mtls_checker_test.go
+++ b/business/checkers/meshpolicies/mesh_mtls_checker_test.go
@@ -128,7 +128,7 @@ func TestMeshPolicymTLSDisabledDestinationRuleMissing(t *testing.T) {
 func testValidationAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
 	assert := assert.New(t)
 
-	validations, valid := MtlsChecker{
+	validations, valid := MeshMtlsChecker{
 		MeshPolicy:  meshPolicy,
 		MTLSDetails: mTLSDetails,
 	}.Check()
@@ -147,7 +147,7 @@ func testValidationAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDe
 func testValidationsNotAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
 	assert := assert.New(t)
 
-	validations, valid := MtlsChecker{
+	validations, valid := MeshMtlsChecker{
 		MeshPolicy:  meshPolicy,
 		MTLSDetails: mTLSDetails,
 	}.Check()

--- a/business/checkers/policies/namespace_mtls_checker.go
+++ b/business/checkers/policies/namespace_mtls_checker.go
@@ -1,0 +1,32 @@
+package policies
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type NamespaceMtlsChecker struct {
+	Policy      kubernetes.IstioObject
+	MTLSDetails kubernetes.MTLSDetails
+}
+
+func (t NamespaceMtlsChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	// if Policy doesn't enables mTLS, stop validation with any check.
+	if enabled, _ := kubernetes.PolicyHasMTLSEnabled(t.Policy); !enabled {
+		return validations, true
+	}
+
+	// otherwise, check among Destination Rules for a rule enabling mTLS namespace-wide.
+	for _, dr := range t.MTLSDetails.DestinationRules {
+		if enabled, _ := kubernetes.DestinationRuleHasNamespaceWideMTLSEnabled(t.Policy.GetObjectMeta().Namespace, dr); enabled {
+			return validations, true
+		}
+	}
+
+	check := models.Build("policies.mtls.destinationrulemissing", "spec/peers/mtls")
+	validations = append(validations, &check)
+
+	return validations, false
+}

--- a/business/checkers/policies/namespace_mtls_checker.go
+++ b/business/checkers/policies/namespace_mtls_checker.go
@@ -19,9 +19,15 @@ func (t NamespaceMtlsChecker) Check() ([]*models.IstioCheck, bool) {
 		return validations, true
 	}
 
-	// otherwise, check among Destination Rules for a rule enabling mTLS namespace-wide.
+	// otherwise, check among Destination Rules for a rule enabling mTLS namespace-wide or mesh-wide.
 	for _, dr := range t.MTLSDetails.DestinationRules {
+		// Check if there is a Destination Rule enabling ns-wide mTLS
 		if enabled, _ := kubernetes.DestinationRuleHasNamespaceWideMTLSEnabled(t.Policy.GetObjectMeta().Namespace, dr); enabled {
+			return validations, true
+		}
+
+		// Check if there is a Destination Rule enabling mesh-wide mTLS in second position
+		if enabled, _ := kubernetes.DestinationRuleHasMeshWideMTLSEnabled(dr); enabled {
 			return validations, true
 		}
 	}

--- a/business/checkers/policies/namespace_mtls_checker.go
+++ b/business/checkers/policies/namespace_mtls_checker.go
@@ -15,7 +15,7 @@ func (t NamespaceMtlsChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
 	// if Policy doesn't enables mTLS, stop validation with any check.
-	if enabled, _ := kubernetes.PolicyHasMTLSEnabled(t.Policy); !enabled {
+	if strictMode := kubernetes.PolicyHasStrictMTLS(t.Policy); !strictMode {
 		return validations, true
 	}
 

--- a/business/checkers/policies/namespace_mtls_checker.go
+++ b/business/checkers/policies/namespace_mtls_checker.go
@@ -10,6 +10,7 @@ type NamespaceMtlsChecker struct {
 	MTLSDetails kubernetes.MTLSDetails
 }
 
+// Checks if a Policy enabling namespace-wide has a Destination Rule enabling mTLS too
 func (t NamespaceMtlsChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 

--- a/business/checkers/policies/namespace_mtls_checker_test.go
+++ b/business/checkers/policies/namespace_mtls_checker_test.go
@@ -1,0 +1,69 @@
+package policies
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+// Describe the validation of a Policy that enables mTLS for one namespace. The validation is risen when there isn't any
+// Destination Rule enabling clients start mTLS connections.
+
+// Context: Policy enables mTLS for a namespace
+// Context: There is one Destination Rule not enabling mTLS
+// It returns a validation
+func TestPolicymTLSEnabled(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	policy := data.CreateEmptyPolicy("default", "bar", data.CreateMTLSPeers("STRICT"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.CreateEmptyDestinationRule("bar", "default", "*.bar.svc.cluster.local"),
+		},
+	}
+
+	validations, valid := NamespaceMtlsChecker{
+		Policy:      policy,
+		MTLSDetails: mTLSDetails,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	assert.False(valid)
+
+	validation := validations[0]
+	assert.NotNil(validation)
+	assert.Equal(models.ErrorSeverity, validation.Severity)
+	assert.Equal("spec/peers/mtls", validation.Path)
+	assert.Equal(models.CheckMessage("policies.mtls.destinationrulemissing"), validation.Message)
+}
+
+// Context: Policy enables mTLS for a namespace
+// Context: There is one Destination Rule enabling mTLS for the namespace
+// It returns doesn't return any validation
+func TestPolicyEnabledDRmTLSEnabled(t *testing.T) {
+	assert := assert.New(t)
+
+	policy := data.CreateEmptyPolicy("default", "bar", data.CreateMTLSPeers("STRICT"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bar", "default", "*.bar.svc.cluster.local")),
+		},
+	}
+
+	validations, valid := NamespaceMtlsChecker{
+		Policy:      policy,
+		MTLSDetails: mTLSDetails,
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}

--- a/business/checkers/policies/namespace_mtls_checker_test.go
+++ b/business/checkers/policies/namespace_mtls_checker_test.go
@@ -67,3 +67,28 @@ func TestPolicyEnabledDRmTLSEnabled(t *testing.T) {
 	assert.Empty(validations)
 	assert.True(valid)
 }
+
+// Context: Policy enables mTLS for a namespace
+// Context: There is one Destination Rule enabling mTLS for the namespace
+// Context: There is one Destination Rule enabling mTLS for the whole service-mesh
+// It returns doesn't return any validation
+func TestPolicyEnabledDRmTLSMeshWideEnabled(t *testing.T) {
+	assert := assert.New(t)
+
+	policy := data.CreateEmptyPolicy("default", "bar", data.CreateMTLSPeers("STRICT"))
+
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bar", "default", "*.local")),
+		},
+	}
+
+	validations, valid := NamespaceMtlsChecker{
+		Policy:      policy,
+		MTLSDetails: mTLSDetails,
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}

--- a/business/checkers/policies/namespace_mtls_checker_test.go
+++ b/business/checkers/policies/namespace_mtls_checker_test.go
@@ -92,3 +92,27 @@ func TestPolicyEnabledDRmTLSMeshWideEnabled(t *testing.T) {
 	assert.Empty(validations)
 	assert.True(valid)
 }
+
+// Context: Policy enables mTLS in PERMISSIVE mode
+// Context: Any Destination Rule.
+// It doesn't return any validation
+func TestPolicyPermissive(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	policy := data.CreateEmptyPolicy("default", "bar", data.CreateMTLSPeers("PERMISSIVE"))
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			data.CreateEmptyDestinationRule("bar", "default", "*.bar.svc.cluster.local"),
+		},
+	}
+
+	validations, valid := NamespaceMtlsChecker{
+		Policy:      policy,
+		MTLSDetails: mTLSDetails,
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}

--- a/business/checkers/policies_checker.go
+++ b/business/checkers/policies_checker.go
@@ -1,0 +1,48 @@
+package checkers
+
+import (
+	"github.com/kiali/kiali/business/checkers/policies"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+const PolicyCheckerType = "policy"
+
+type PolicyChecker struct {
+	Policies    []kubernetes.IstioObject
+	MTLSDetails kubernetes.MTLSDetails
+}
+
+func (m PolicyChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, policy := range m.Policies {
+		validations.MergeValidations(m.runChecks(policy))
+	}
+
+	return validations
+}
+
+// runChecks runs all the individual checks for a single mesh policy and appends the result into validations.
+func (m PolicyChecker) runChecks(policy kubernetes.IstioObject) models.IstioValidations {
+	policyName := policy.GetObjectMeta().Name
+	key := models.IstioValidationKey{Name: policyName, ObjectType: PolicyCheckerType}
+	rrValidation := &models.IstioValidation{
+		Name:       policyName,
+		ObjectType: PolicyCheckerType,
+		Valid:      true,
+		Checks:     []*models.IstioCheck{},
+	}
+
+	enabledCheckers := []Checker{
+		policies.NamespaceMtlsChecker{Policy: policy, MTLSDetails: m.MTLSDetails},
+	}
+
+	for _, checker := range enabledCheckers {
+		checks, validChecker := checker.Check()
+		rrValidation.Checks = append(rrValidation.Checks, checks...)
+		rrValidation.Valid = rrValidation.Valid && validChecker
+	}
+
+	return models.IstioValidations{key: rrValidation}
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -83,6 +83,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails},
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace},
 		checkers.MeshPolicyChecker{MeshPolicies: mtlsDetails.MeshPolicies, MTLSDetails: mtlsDetails},
+		checkers.PolicyChecker{Policies: mtlsDetails.Policies, MTLSDetails: mtlsDetails},
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
 		checkers.ServiceRoleBindChecker{RBACDetails: rbacDetails},
 	}
@@ -129,8 +130,11 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		destinationRulesChecker := checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails}
 		objectCheckers = []ObjectChecker{noServiceChecker, destinationRulesChecker}
 	case MeshPolicies:
-		mtlsChecker := checkers.MeshPolicyChecker{MeshPolicies: mtlsDetails.MeshPolicies, MTLSDetails: mtlsDetails}
-		objectCheckers = []ObjectChecker{mtlsChecker}
+		meshPoliciesChecker := checkers.MeshPolicyChecker{MeshPolicies: mtlsDetails.MeshPolicies, MTLSDetails: mtlsDetails}
+		objectCheckers = []ObjectChecker{meshPoliciesChecker}
+	case Policies:
+		policiesChecker := checkers.PolicyChecker{Policies: mtlsDetails.Policies, MTLSDetails: mtlsDetails}
+		objectCheckers = []ObjectChecker{policiesChecker}
 	case ServiceEntries:
 		serviceEntryChecker := checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries}
 		objectCheckers = []ObjectChecker{serviceEntryChecker}
@@ -146,8 +150,6 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		// Validations on QuotaSpecs are not yet in place
 	case QuotaSpecBindings:
 		// Validations on QuotaSpecBindings are not yet in place
-	case Policies:
-		// Validations on Policies are not yet in place
 	case ClusterRbacConfigs:
 		// Validations on ClusterRbacConfigs are not yet in place
 	case RbacConfigs:

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -81,6 +81,7 @@ func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails(), nil)
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return(fakeCombinedServices([]string{""}), nil)
 	k8s.On("GetMeshPolicies", mock.AnythingOfType("string")).Return(fakeMeshPolicies(), nil)
+	k8s.On("GetPolicies", mock.AnythingOfType("string")).Return(fakePolicies(), nil)
 	k8s.On("GetAuthorizationDetails", mock.AnythingOfType("string")).Return(&kubernetes.RBACDetails{}, nil)
 
 	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil)}
@@ -97,6 +98,7 @@ func mockCombinedValidationService(istioObjects *kubernetes.IstioDetails, servic
 	k8s.On("GetGateways", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().Gateways, nil)
 	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(kubetest.FakeNamespace("test"), nil)
 	k8s.On("GetMeshPolicies", mock.AnythingOfType("string")).Return(fakeMeshPolicies(), nil)
+	k8s.On("GetPolicies", mock.AnythingOfType("string")).Return(fakePolicies(), nil)
 	k8s.On("IsOpenShift").Return(false)
 
 	k8s.On("GetGateways", "test", mock.AnythingOfType("string")).Return(getGateway("first"), nil)
@@ -135,6 +137,13 @@ func fakeMeshPolicies() []kubernetes.IstioObject {
 	return []kubernetes.IstioObject{
 		data.CreateEmptyMeshPolicy("default", nil),
 		data.CreateEmptyMeshPolicy("test", nil),
+	}
+}
+
+func fakePolicies() []kubernetes.IstioObject {
+	return []kubernetes.IstioObject{
+		data.CreateEmptyPolicy("default", "bookinfo", nil),
+		data.CreateEmptyPolicy("test", "foo", nil),
 	}
 }
 

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -950,6 +950,11 @@ func ValidateVirtualServiceGateways(spec map[string]interface{}, gatewayNames ma
 	return true, -1
 }
 
+func PolicyHasStrictMTLS(policy IstioObject) bool {
+	_, mode := PolicyHasMTLSEnabled(policy)
+	return mode == "STRICT"
+}
+
 func PolicyHasMTLSEnabled(policy IstioObject) (bool, string) {
 	// It is mandatory to have default as a name
 	if policyMeta := policy.GetObjectMeta(); policyMeta.Name != "default" {
@@ -973,21 +978,13 @@ func PolicyHasMTLSEnabled(policy IstioObject) (bool, string) {
 		peerMap := peer.(map[string]interface{})
 		if mtls, present := peerMap["mtls"]; present {
 			if mtlsMap, ok := mtls.(map[string]interface{}); ok {
-				// mTLS enabled in case there is an empty map or mode is STRICT
 				if mode, found := mtlsMap["mode"]; found {
-					if mode == "STRICT" {
-						return true, "ENABLED"
-					} else {
-						return false, "DISABLED"
-					}
-				} else {
-					// STRICT mode when mtls object is empty
-					return true, "ENABLED"
+					return true, mode.(string)
 				}
-			} else {
-				// STRICT mode when mtls object is empty
-				return true, "ENABLED"
 			}
+
+			// STRICT mode when mtls object is empty
+			return true, "STRICT"
 		}
 	}
 
@@ -1019,11 +1016,7 @@ func DestinationRuleHasMTLSEnabledForHost(expectedHost string, destinationRule I
 				if tlsCasted, ok := tls.(map[string]interface{}); ok {
 					if mode, found := tlsCasted["mode"]; found {
 						if modeCasted, ok := mode.(string); ok {
-							if modeCasted == "ISTIO_MUTUAL" {
-								return true, "ENABLED"
-							} else {
-								return false, "DISABLED"
-							}
+							return modeCasted == "ISTIO_MUTUAL", modeCasted
 						}
 					}
 				}

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -978,8 +978,12 @@ func PolicyHasMTLSEnabled(policy IstioObject) (bool, string) {
 		peerMap := peer.(map[string]interface{})
 		if mtls, present := peerMap["mtls"]; present {
 			if mtlsMap, ok := mtls.(map[string]interface{}); ok {
-				if mode, found := mtlsMap["mode"]; found {
-					return true, mode.(string)
+				if modeItf, found := mtlsMap["mode"]; found {
+					if mode, ok := modeItf.(string); ok {
+						return true, mode
+					} else {
+						return false, ""
+					}
 				}
 			}
 

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -536,6 +536,7 @@ type IstioDetails struct {
 type MTLSDetails struct {
 	DestinationRules []IstioObject `json:"destinationrules"`
 	MeshPolicies     []IstioObject `json:"meshpolicies"`
+	Policies         []IstioObject `json:"policies"`
 }
 
 // RBACDetails is a wrapper for objects related to Istio RBAC (Role Based Access Control)

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -72,6 +72,7 @@ var ObjectTypeSingular = map[string]string{
 	"quotaspecs":          "quotaspec",
 	"quotaspecbindings":   "quotaspecbinding",
 	"meshpolicies":        "meshpolicy",
+	"policies":            "policy",
 	"serviceroles":        "servicerole",
 	"servicerolebindings": "servicerolebinding",
 	"clusterrbacconfigs":  "clusterrbacconfig",
@@ -99,7 +100,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: ErrorSeverity,
 	},
 	"destinationrules.mtls.nspolicymissing": {
-		Message:  "Policy enabling mTLS for this namespace is missing",
+		Message:  "Policy enabling namespace-wide mTLS is missing",
 		Severity: ErrorSeverity,
 	},
 	"gateways.multimatch": {
@@ -164,6 +165,10 @@ var checkDescriptors = map[string]IstioCheck{
 	},
 	"servicerolebinding.invalid.role": {
 		Message:  "ServiceRole does not exists in this namespace",
+		Severity: ErrorSeverity,
+	},
+	"policies.mtls.destinationrulemissing": {
+		Message:  "Destination Rule enabling namespace-wide mTLS is missing",
 		Severity: ErrorSeverity,
 	},
 }

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -103,6 +103,14 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "Policy enabling namespace-wide mTLS is missing",
 		Severity: ErrorSeverity,
 	},
+	"destinationrules.mtls.policymtlsenabled": {
+		Message:  "Policy with TLS strict mode found, it should be permissive",
+		Severity: ErrorSeverity,
+	},
+	"destinationrules.mtls.meshpolicymtlsenabled": {
+		Message:  "MeshPolicy enabling mTLS found, permissive policy is needed",
+		Severity: ErrorSeverity,
+	},
 	"gateways.multimatch": {
 		Message:  "More than one Gateway for the same host port combination",
 		Severity: WarningSeverity,

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -98,6 +98,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "MeshPolicy enabling mTLS is missing",
 		Severity: ErrorSeverity,
 	},
+	"destinationrules.mtls.nspolicymissing": {
+		Message:  "Policy enabling mTLS for this namespace is missing",
+		Severity: ErrorSeverity,
+	},
 	"gateways.multimatch": {
 		Message:  "More than one Gateway for the same host port combination",
 		Severity: WarningSeverity,


### PR DESCRIPTION
** Describe the change **

* Adding validations for enabling ns-wide mTLS scenarios (Destination Rules and Policies)
* Adding validations for disabling ns-wide mTLS scenarios (Destination Rules and Policies)

** Issue reference **
https://issues.jboss.org/browse/KIALI-2551

** Backwards incompatible? **
yes.

** Testing files **
[test-files.zip](https://github.com/kiali/kiali/files/2991563/2551.zip)
It contains three scripts that runs the scenarios covered by each one of the checkers introduced in this PR.




