### PR TITLE
KIALI-2610 Remove unused data from Services and Workload details endpoints

### DIFF
--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes/kubetest"
-	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
 )
 
@@ -337,58 +336,6 @@ func TestGetWorkloadFromDeployment(t *testing.T) {
 	assert.Equal("Deployment", workload.Type)
 	assert.Equal(true, workload.AppLabel)
 	assert.Equal(true, workload.VersionLabel)
-}
-
-func TestGetWorkloadDestinationServices(t *testing.T) {
-	assert := assert.New(t)
-	conf := config.NewConfig()
-	config.Set(conf)
-
-	destServices := []prometheus.Service{
-		{
-			Namespace:   "bookinfo",
-			ServiceName: "reviews",
-			App:         "reviews"},
-		{
-			Namespace:   "bookinfo",
-			ServiceName: "details",
-			App:         "details"},
-	}
-
-	// Setup mocks
-	notfound := fmt.Errorf("not found")
-	k8s := new(kubetest.K8SClientMock)
-	prom := new(prometheustest.PromClientMock)
-
-	k8s.On("IsOpenShift").Return(false)
-	k8s.On("GetDeployment", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&FakeDepSyncedWithRS()[0], nil)
-	k8s.On("GetDeploymentConfig", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&osappsv1.DeploymentConfig{}, notfound)
-	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1beta2.ReplicaSet{}, nil)
-	k8s.On("GetReplicationControllers", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.ReplicationController{}, nil)
-	k8s.On("GetStatefulSet", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&v1beta2.StatefulSet{}, notfound)
-	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsSyncedWithDeployments(), nil)
-	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
-	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
-	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return([]v1.Service{}, nil)
-	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(kubetest.FakeNamespace("bookinfo"), nil)
-	prom.On("GetDestinationServices", mock.AnythingOfType("string"), mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(destServices, nil)
-
-	svc := setupWorkloadService(k8s, prom)
-
-	workload, _ := svc.GetWorkload("bookinfo", "details-v1", true)
-
-	assert.Equal(2, len(workload.DestinationServices))
-	if len(workload.DestinationServices) < 2 {
-		return
-	}
-
-	destService := workload.DestinationServices[0]
-	assert.Equal("reviews", destService.Name)
-	assert.Equal("bookinfo", destService.Namespace)
-
-	destService = workload.DestinationServices[1]
-	assert.Equal("details", destService.Name)
-	assert.Equal("bookinfo", destService.Namespace)
 }
 
 func TestGetWorkloadFromPods(t *testing.T) {

--- a/models/service.go
+++ b/models/service.go
@@ -27,16 +27,16 @@ type ServiceList struct {
 }
 
 type ServiceDetails struct {
-	Service          Service                     `json:"service"`
-	IstioSidecar     bool                        `json:"istioSidecar"`
-	Endpoints        Endpoints                   `json:"endpoints"`
-	VirtualServices  VirtualServices             `json:"virtualServices"`
-	DestinationRules DestinationRules            `json:"destinationRules"`
-	Workloads        WorkloadOverviews           `json:"workloads"`
-	Health           ServiceHealth               `json:"health"`
-	Validations      IstioValidations            `json:"validations"`
-	ErrorTraces      int                         `json:"errorTraces"`
-	NamespaceMTLS    MTLSStatus                  `json:"namespaceMTLS"`
+	Service          Service           `json:"service"`
+	IstioSidecar     bool              `json:"istioSidecar"`
+	Endpoints        Endpoints         `json:"endpoints"`
+	VirtualServices  VirtualServices   `json:"virtualServices"`
+	DestinationRules DestinationRules  `json:"destinationRules"`
+	Workloads        WorkloadOverviews `json:"workloads"`
+	Health           ServiceHealth     `json:"health"`
+	Validations      IstioValidations  `json:"validations"`
+	ErrorTraces      int               `json:"errorTraces"`
+	NamespaceMTLS    MTLSStatus        `json:"namespaceMTLS"`
 }
 
 type Services []*Service

--- a/models/service.go
+++ b/models/service.go
@@ -1,10 +1,9 @@
 package models
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/prometheus"
 )
 
 type ServiceOverview struct {
@@ -33,7 +32,6 @@ type ServiceDetails struct {
 	Endpoints        Endpoints                   `json:"endpoints"`
 	VirtualServices  VirtualServices             `json:"virtualServices"`
 	DestinationRules DestinationRules            `json:"destinationRules"`
-	Dependencies     map[string][]SourceWorkload `json:"dependencies"`
 	Workloads        WorkloadOverviews           `json:"workloads"`
 	Health           ServiceHealth               `json:"health"`
 	Validations      IstioValidations            `json:"validations"`
@@ -51,12 +49,6 @@ type Service struct {
 	Type            string            `json:"type"`
 	Ip              string            `json:"ip"`
 	Ports           Ports             `json:"ports"`
-}
-
-// SourceWorkload holds workload identifiers used for service dependencies
-type SourceWorkload struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
 }
 
 func (ss *Services) Parse(services []v1.Service) {
@@ -110,17 +102,4 @@ func (s *ServiceDetails) SetDestinationRules(dr []kubernetes.IstioObject, canCre
 
 func (s *ServiceDetails) SetErrorTraces(errorTraces int) {
 	s.ErrorTraces = errorTraces
-}
-
-func (s *ServiceDetails) SetSourceWorkloads(sw map[string][]prometheus.Workload) {
-	// Transform dependencies for UI
-	s.Dependencies = make(map[string][]SourceWorkload)
-	for version, workloads := range sw {
-		for _, workload := range workloads {
-			s.Dependencies[version] = append(s.Dependencies[version], SourceWorkload{
-				Name:      workload.Workload,
-				Namespace: workload.Namespace,
-			})
-		}
-	}
 }

--- a/models/service_test.go
+++ b/models/service_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/prometheus"
 )
 
 func TestServiceDetailParsing(t *testing.T) {
@@ -23,7 +22,6 @@ func TestServiceDetailParsing(t *testing.T) {
 	service.SetPods(fakePods())
 	service.SetVirtualServices(fakeVirtualServices(), false, false, false)
 	service.SetDestinationRules(fakeDestinationRules(), false, false, false)
-	service.SetSourceWorkloads(fakeSourceWorkloads())
 
 	// Kubernetes Details
 
@@ -144,11 +142,6 @@ func TestServiceDetailParsing(t *testing.T) {
 			},
 		},
 	}, service.DestinationRules.Items[1].Spec.Subsets)
-
-	assert.Equal(service.Dependencies, map[string][]SourceWorkload{
-		"v1": {SourceWorkload{Name: "unknown", Namespace: "ns"}, SourceWorkload{Name: "products-v1", Namespace: "ns"}, SourceWorkload{Name: "reviews-v2", Namespace: "ns"}},
-		"v2": {SourceWorkload{Name: "catalog-v1", Namespace: "ns"}, SourceWorkload{Name: "shares-v2", Namespace: "ns"}},
-	})
 }
 
 func TestServiceParse(t *testing.T) {
@@ -385,13 +378,4 @@ func fakeDestinationRules() []kubernetes.IstioObject {
 	}
 
 	return []kubernetes.IstioObject{&destinationRule1, &destinationRule2}
-}
-
-func fakeSourceWorkloads() map[string][]prometheus.Workload {
-	return map[string][]prometheus.Workload{
-		"v1": {{App: "unknown", Version: "unknown", Namespace: "ns", Workload: "unknown"},
-			{App: "products", Version: "v1", Namespace: "ns", Workload: "products-v1"},
-			{App: "reviews", Version: "v2", Namespace: "ns", Workload: "reviews-v2"}},
-		"v2": {{App: "catalog", Version: "v1", Namespace: "ns", Workload: "catalog-v1"},
-			{App: "shares", Version: "v2", Namespace: "ns", Workload: "shares-v2"}}}
 }

--- a/models/workload.go
+++ b/models/workload.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/prometheus"
 )
 
 type WorkloadList struct {
@@ -96,16 +95,8 @@ type Workload struct {
 	// Services that match workload selector
 	Services Services `json:"services"`
 
-	DestinationServices []DestinationService `json:"destinationServices"`
-
 	// Runtimes and associated dashboards
 	Runtimes []Runtime `json:"runtimes"`
-}
-
-// DestinationService holds service identifiers used for workload dependencies
-type DestinationService struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
 }
 
 type Workloads []*Workload
@@ -368,14 +359,4 @@ func (workload *Workload) SetPods(pods []v1.Pod) {
 
 func (workload *Workload) SetServices(svcs []v1.Service) {
 	workload.Services.Parse(svcs)
-}
-
-func (workload *Workload) SetDestinationServices(dss []prometheus.Service) {
-	workload.DestinationServices = make([]DestinationService, 0, len(dss))
-	for _, service := range dss {
-		workload.DestinationServices = append(workload.DestinationServices, DestinationService{
-			Name:      service.ServiceName,
-			Namespace: service.Namespace,
-		})
-	}
 }

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -119,65 +119,6 @@ func TestGetSourceWorkloads(t *testing.T) {
 	assert.Equal(t, "v2", sources["v2"][0].Version)
 }
 
-func TestGetDestinationServices(t *testing.T) {
-	rqCustReviews := model.Metric{
-		"__name__":                      "istio_requests_total",
-		"destination_app":               "reviews",
-		"destination_service":           "reviews.bookinfo.svc.cluster.local",
-		"destination_service_name":      "reviews",
-		"destination_service_namespace": "bookinfo"}
-
-	rqCustDetails := model.Metric{
-		"__name__":                      "istio_requests_total",
-		"destination_app":               "details",
-		"destination_service":           "details.bookinfo.svc.cluster.local",
-		"destination_service_name":      "details",
-		"destination_service_namespace": "bookinfo"}
-
-	vector := model.Vector{
-		&model.Sample{
-			Metric: rqCustReviews,
-			Value:  4},
-		&model.Sample{
-			Metric: rqCustDetails,
-			Value:  4},
-	}
-
-	client, api, err := setupMocked()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	mockQuery(api, "sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"productpage-v1\",source_workload_namespace=\"bookinfo\"}[50s])) by (destination_service_namespace, destination_service_name, destination_service)", &vector)
-	clock := util.ClockMock{Time: time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC)}
-	util.Clock = clock
-
-	destinations, err := client.GetDestinationServices("bookinfo", clock.Time.Add(-time.Second*50), "productpage-v1")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	assert := assert.New(t)
-
-	assert.Equal(2, len(destinations), "Map should have 2 keys (versions)")
-
-	if len(destinations) < 2 {
-		return
-	}
-
-	svc := destinations[0]
-	assert.Equal("reviews", svc.App)
-	assert.Equal("reviews", svc.ServiceName)
-	assert.Equal("bookinfo", svc.Namespace)
-
-	svc = destinations[1]
-	assert.Equal("details", svc.App)
-	assert.Equal("details", svc.ServiceName)
-	assert.Equal("bookinfo", svc.Namespace)
-}
-
 func round(q string) string {
 	return fmt.Sprintf("round(%s, 0.001000) > 0.001000 or %s", q, q)
 }

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -173,16 +173,6 @@ func (o *PromClientMock) GetWorkloadRequestRates(namespace, workload, ratesInter
 	return args.Get(0).(model.Vector), args.Get(1).(model.Vector), args.Error(2)
 }
 
-func (o *PromClientMock) GetSourceWorkloads(namespace string, namespaceCreationTime time.Time, servicename string) (map[string][]prometheus.Workload, error) {
-	args := o.Called(namespace, namespaceCreationTime, servicename)
-	return args.Get(0).(map[string][]prometheus.Workload), args.Error(1)
-}
-
-func (o *PromClientMock) GetDestinationServices(namespace string, namespaceCreationTime time.Time, workloadname string) ([]prometheus.Service, error) {
-	args := o.Called(namespace, namespaceCreationTime, workloadname)
-	return args.Get(0).([]prometheus.Service), args.Error(1)
-}
-
 func (o *PromClientMock) FetchRange(metricName, labels, grouping, aggregator string, q *prometheus.BaseMetricsQuery) *prometheus.Metric {
 	args := o.Called(metricName, labels, grouping, aggregator, q)
 	return args.Get(0).(*prometheus.Metric)

--- a/swagger.json
+++ b/swagger.json
@@ -2970,21 +2970,6 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
-    "DestinationService": {
-      "description": "DestinationService holds service identifiers used for workload dependencies",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "namespace": {
-          "type": "string",
-          "x-go-name": "Namespace"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/models"
-    },
     "EdgeData": {
       "type": "object",
       "properties": {
@@ -4206,16 +4191,6 @@
     "ServiceDetails": {
       "type": "object",
       "properties": {
-        "dependencies": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/SourceWorkload"
-            }
-          },
-          "x-go-name": "Dependencies"
-        },
         "destinationRules": {
           "$ref": "#/definitions/destinationRules"
         },
@@ -4438,21 +4413,6 @@
     },
     "SeverityLevel": {
       "type": "string",
-      "x-go-package": "github.com/kiali/kiali/models"
-    },
-    "SourceWorkload": {
-      "description": "SourceWorkload holds workload identifiers used for service dependencies",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "namespace": {
-          "type": "string",
-          "x-go-name": "Namespace"
-        }
-      },
       "x-go-package": "github.com/kiali/kiali/models"
     },
     "Status": {
@@ -4687,13 +4647,6 @@
           "type": "string",
           "x-go-name": "CreatedAt",
           "example": "2018-07-31T12:24:17Z"
-        },
-        "destinationServices": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/DestinationService"
-          },
-          "x-go-name": "DestinationServices"
         },
         "istioSidecar": {
           "description": "Define if Pods related to this Workload has an IstioSidecar deployed",


### PR DESCRIPTION
This is code cleanup.

The destinationServices attribute of the WorkloadDetails endpoint and the dependencies attribute of the ServiceDetails endpont are no longer used in the front-end. Thus, removing this data from the JSON and also removing all involved code.

This is, probably, non-backwards compatible for the front-end side, since there will be missing JSON properties. 