### PR TITLE
KIALI-2556 Fix node type of unknown destination

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -145,7 +145,7 @@ func Id(serviceNamespace, service, workloadNamespace, workload, app, version, gr
 	// Every other field is unknown. Allow one unknown service per namespace to help reflect these
 	// bad destinations in the graph,  it may help diagnose a problem.
 	if Unknown == workload && Unknown == app && Unknown == service {
-		return fmt.Sprintf("svc_%s_unknown", namespace), NodeTypeService
+		return fmt.Sprintf("svc_%s_unknown", namespace), NodeTypeUnknown
 	}
 
 	workloadOk := IsOK(workload)


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2556

This prevents the UI from creating links to service pages for the "unknown" node when this node is a destination.

