### PR TITLE
KIALI-2562 Return a validation success also for each enabled type

### DIFF
--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -38,14 +38,12 @@ func (g GatewayChecker) runSingleChecks(gw kubernetes.IstioObject) models.IstioV
 		Gateway: gw,
 	}.Check()
 
-	if !valid {
-		key := models.IstioValidationKey{ObjectType: GatewayCheckerType, Name: gw.GetObjectMeta().Name}
-		validations[key] = &models.IstioValidation{
-			Name:       key.Name,
-			ObjectType: key.ObjectType,
-			Checks:     checks,
-			Valid:      valid,
-		}
+	key := models.IstioValidationKey{ObjectType: GatewayCheckerType, Name: gw.GetObjectMeta().Name}
+	validations[key] = &models.IstioValidation{
+		Name:       key.Name,
+		ObjectType: key.ObjectType,
+		Checks:     checks,
+		Valid:      valid,
 	}
 	return validations
 }

--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -28,14 +28,12 @@ func (s ServiceEntryChecker) runSingleChecks(se kubernetes.IstioObject) models.I
 		ServiceEntry: se,
 	}.Check()
 
-	if !valid {
-		key := models.IstioValidationKey{ObjectType: ServiceEntryCheckerType, Name: se.GetObjectMeta().Name}
-		validations[key] = &models.IstioValidation{
-			Name:       key.Name,
-			ObjectType: key.ObjectType,
-			Checks:     checks,
-			Valid:      valid,
-		}
+	key := models.IstioValidationKey{ObjectType: ServiceEntryCheckerType, Name: se.GetObjectMeta().Name}
+	validations[key] = &models.IstioValidation{
+		Name:       key.Name,
+		ObjectType: key.ObjectType,
+		Checks:     checks,
+		Valid:      valid,
 	}
 	return validations
 }


### PR DESCRIPTION
** Describe the change **

ServiceEntries and Gateways returned validation results only in case of errors, not when there's success. This adds positive results also and fixes the UI's view of "valid/false" for these object types.

** Issue reference **

KIALI-2562
