### PR TITLE
KIALI-2644 Add in ability to specify the login type during install

### DIFF
--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -16,6 +16,8 @@ data:
         url: ${JAEGER_URL}
       grafana:
         url: ${GRAFANA_URL}
+    auth:
+      strategy: ${AUTH_STRATEGY}
     identity:
       cert_file: /kiali-cert/cert-chain.pem
       private_key_file: /kiali-cert/key.pem


### PR DESCRIPTION
** Describe the change **

When installing using OpenShift and there is no AUTH_STRATEGY specified it will ask if they want to use the login or OAuth option.

It will also check if the AUTH_STRATEGY is 'login' before asking for login credentials to be added (a username and password are only needed if the auth strategy is login. So there is no need to ask if we are not using 'login').

It also fixes a bug where if you run the install multiple times it will not update the Kiali installation. For instance, we could update the configmap or secret but since the deployment is not updated the Kiali pod wont get redeployed. Now we explicitly delete the Kiali deployment before doing the install.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2644

