### PR TITLE
fix some things I noticed while testing KIALI-2644

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,7 @@ GRAFANA_URL="${GRAFANA_URL}"  \
 VERBOSE_MODE="${VERBOSE_MODE}" \
 KIALI_USERNAME="admin" \
 KIALI_PASSPHRASE="admin" \
+AUTH_STRATEGY="${AUTH_STRATEGY}" \
 deploy/kubernetes/deploy-kiali-to-kubernetes.sh
 
 ## k8s-undeploy: Undeploy docker image in Kubernetes namespace.

--- a/deploy/kubernetes/deploy-kiali-to-kubernetes.sh
+++ b/deploy/kubernetes/deploy-kiali-to-kubernetes.sh
@@ -280,7 +280,7 @@ if [ "${AUTH_STRATEGY}" == "login" ]; then
     exit 1
   fi
 else
-  echo "Using strategy [${AUTH_STRATEGY}] - a secret is not needed so one will not be created."
+  echo "Using strategy [${AUTH_STRATEGY}] - a secret is not needed so none will be created."
 fi
 
 for yaml in configmap serviceaccount clusterrole clusterrolebinding deployment service ingress crds

--- a/deploy/openshift/deploy-kiali-to-openshift.sh
+++ b/deploy/openshift/deploy-kiali-to-openshift.sh
@@ -283,7 +283,7 @@ if [ "${AUTH_STRATEGY}" == "login" ]; then
     exit 1
   fi
 else
-  echo "Using strategy [${AUTH_STRATEGY}] - a secret is not needed so one will not be created."
+  echo "Using strategy [${AUTH_STRATEGY}] - a secret is not needed so none will be created."
 fi
 
 for yaml in configmap serviceaccount clusterrole clusterrolebinding deployment service route ingress crds


### PR DESCRIPTION
-- the Makefile didn't pass through the strategy for the k8s-deploy target - this fixes that
-- the install scripts now echo a message when the secret creation is skipped so its obvious what is going on
-- get the scripts to look more identical (trying to keep these more or less in sync with each other, minus differences required between k8s and OS)
