### PR TITLE
KIALI-2648 - New Auth Openshift Test Case

### DIFF
--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -15,8 +15,8 @@ CIRCUIT_BREAKER_FILE = ASSETS_PATH + '/bookinfo-reviews-all-cb.yaml'
 VIRTUAL_SERVICE_FILE = ASSETS_PATH + '/bookinfo-ratings-delay.yaml'
 WORKLOADS_FILE = ASSETS_PATH  + '/bookinfo-workloads.yaml'
 
-CURRENT_CONFIGMAP_FILE = CONFIG_PATH + '/current_kiali_configmap.yaml'
-NEW_CONFIG_MAP_FILE = CONFIG_PATH + '/new_kiali_configmap.yaml'
+CURRENT_CONFIGMAP_FILE = './current_kiali_configmap.yaml'
+NEW_CONFIG_MAP_FILE = './new_kiali_configmap.yaml'
 
 @pytest.fixture(scope='session')
 def kiali_client():
@@ -77,3 +77,9 @@ def get_kiali_clusterrole_file(file_type):
     yaml_content = urlopen(file).read()
 
     return next(yaml.safe_load_all(yaml_content))
+
+def get_kiali_hostname():
+    return __get_environment_config__(ENV_FILE).get('kiali_hostname')
+
+def get_kiali_swagger_address():
+    return __get_environment_config__(ENV_FILE).get('kiali_swagger_address')

--- a/tests/e2e/tests/test_kiali_configmap.py
+++ b/tests/e2e/tests/test_kiali_configmap.py
@@ -1,7 +1,10 @@
 import pytest
 import tests.conftest as conftest
-from utils.command_exec import command_exec
+import time
+from subprocess import PIPE, Popen
 from kiali import KialiClient
+from utils.command_exec import command_exec
+from utils.timeout import timeout
 
 
 STRATEGY_LOGIN = 'login'
@@ -26,7 +29,44 @@ def test_auth_anonymous():
         # Return Auth strategy back to 'login'
         create_configmap_and_wait_for_kiali(conftest.CURRENT_CONFIGMAP_FILE)
 
-def test_change_web_root(kiali_client):
+def test_auth_openshift():
+
+    kiali_hostname = conftest.get_kiali_hostname()
+    cookie_file = "./tmp_cookie_file"
+
+    try:
+        assert change_configmap_with_new_value(element_name='strategy:', list=STRATEGY_LIST,
+            new_value=STRATEGY_OPENSHIFT, current_configmap_file=conftest.CURRENT_CONFIGMAP_FILE,
+            new_configmap_file=conftest.NEW_CONFIG_MAP_FILE)
+
+        # Create token cookie file
+        cmd = "curl -v -k POST -c {} -d 'access_token='$(oc whoami -t)'&expires_in=86400&scope=user%3Afull&token_type=Bearer' https://{}/api/authenticate".format(cookie_file,  kiali_hostname)
+        with timeout(seconds=120, error_message='Timed out waiting getting token'):
+            while True:
+                stdout, stderr = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE).communicate()
+                if 'username' in stdout.decode():
+                    break
+
+                time.sleep(2)
+
+        # Make the API request using token cookie
+        cmd = "curl -v -k -b {} https://{}/api/namespaces".format(cookie_file, kiali_hostname)
+        with timeout(seconds=120, error_message='Timed out waiting getting token'):
+            while True:
+                stdout, stderr = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE).communicate()
+                if "istio-system" in stdout.decode():
+                    break
+
+                time.sleep(2)
+
+        cmd = "rm -f {}".format(cookie_file)
+        Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE).communicate()
+
+    finally:
+        # Return Auth strategy back to 'login'
+         create_configmap_and_wait_for_kiali(conftest.CURRENT_CONFIGMAP_FILE)
+
+def __test_change_web_root(kiali_client):
     new_web_root_value = '/e2e'
 
     try:
@@ -34,8 +74,13 @@ def test_change_web_root(kiali_client):
             new_value=new_web_root_value, current_configmap_file=conftest.CURRENT_CONFIGMAP_FILE,
             new_configmap_file=conftest.NEW_CONFIG_MAP_FILE)
 
-        assert kiali_client.request(plain_url="e2e/api/namespaces", path=None, params=None)
+        with timeout(seconds=180, error_message='Timed out waiting for API call'):
+            while True:
+                response = kiali_client.request(plain_url=new_web_root_value + "/api/namespaces", path=None, params=None)
+                if response.status_code == 200:
+                    break
 
+                time.sleep(2)
     finally:
         # Return web_root back to '/'
         create_configmap_and_wait_for_kiali(conftest.CURRENT_CONFIGMAP_FILE)
@@ -43,16 +88,19 @@ def test_change_web_root(kiali_client):
 ##
 
 def do_auth_strategy_test(auth_type):
-    config = conftest.__get_environment_config__(conftest.ENV_FILE)
-    swagger = config.get('kiali_swagger_address')
-    hostname = config.get('kiali_hostname')
+    swagger = conftest.get_kiali_swagger_address()
+    hostname = conftest.get_kiali_hostname()
 
     if AUTH_NOAUTH in auth_type:
-        kiali_client = KialiClient(hostname=hostname, auth_type=AUTH_NOAUTH, verify=False, swagger_address=swagger)
-        response = kiali_client.request(method_name='namespaceList', path=None, params=None)
 
-        # Make API call - expected to pass with no authentication
-        assert response.status_code == 200, "Unexpected status code \'response.status_code\'"
+        with timeout(seconds=180, error_message='Timed out waiting for API call to complete'):
+            while True:
+                kiali_client = KialiClient(hostname=hostname, auth_type=AUTH_NOAUTH, verify=False, swagger_address=swagger)
+                response = kiali_client.request(method_name='namespaceList', path=None, params=None)
+                if response.status_code == 200:
+                    break
+
+                time.sleep(2)
     else:
         assert False, "To Do"
 


### PR DESCRIPTION
Add Auth Strategy 'openshift' test case
Deprecate web-root test case (web-root now must be changed in the Kiali deployment)