### PR TITLE
Add knative support to cluster-openshift.sh

### DIFF
--- a/hack/cluster-openshift.sh
+++ b/hack/cluster-openshift.sh
@@ -116,7 +116,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     -kn|--knative)
       KNATIVE_ENABLED="true"
-      shift;
+      shift;shift
       ;;
     -ke|--kiali-enabled)
       KIALI_ENABLED="$2"
@@ -182,6 +182,10 @@ Valid options:
       Default: ${DEFAULT_MAISTRA_INSTALL_YAML}
   -ke|--kiali-enabled (true|false)
       When set to true, Kiali will be installed in OpenShift.
+      Default: false
+      Used only for the 'up' command.
+  -kn|--knative (true|false)
+      When set to true, Knative will be installed in OpenShift.
       Default: false
       Used only for the 'up' command.
   -ku|--kiali-username <username>
@@ -603,8 +607,8 @@ if [ "$_CMD" = "up" ]; then
     echo "Knative is installed!"
 
     echo "Installing a sample application for knative..."
-    istiooc delete -n knative-examples -f ${SCRIPT_ROOT}/knative/service.yaml || true
-    istiooc apply -n knative-examples -f ${SCRIPT_ROOT}/knative/service.yaml
+    ${MAISTRA_ISTIO_OC_COMMAND} delete -n knative-examples -f ${SCRIPT_ROOT}/knative/service.yaml || true
+    ${MAISTRA_ISTIO_OC_COMMAND} apply -n knative-examples -f ${SCRIPT_ROOT}/knative/service.yaml
   fi
 
   if [ "${REMOVE_JAEGER}" == "true" ]; then

--- a/hack/cluster-openshift.sh
+++ b/hack/cluster-openshift.sh
@@ -604,7 +604,7 @@ if [ "$_CMD" = "up" ]; then
 
     echo "Installing a sample application for knative..."
     istiooc delete -n knative-examples -f ${SCRIPT_ROOT}/knative/service.yaml || true
-    istiooc apply -n knative-examples -f ${ROOT}/knative/service.yaml
+    istiooc apply -n knative-examples -f ${SCRIPT_ROOT}/knative/service.yaml
   fi
 
   if [ "${REMOVE_JAEGER}" == "true" ]; then

--- a/hack/cluster-openshift.sh
+++ b/hack/cluster-openshift.sh
@@ -115,7 +115,7 @@ while [[ $# -gt 0 ]]; do
       shift;shift
       ;;
     -kn|--knative)
-      KNATIVE_ENABLED="true"
+      KNATIVE_ENABLED="$2"
       shift;shift
       ;;
     -ke|--kiali-enabled)

--- a/hack/knative/config-domain.yaml
+++ b/hack/knative/config-domain.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-domain
+  namespace: knative-serving
+data:
+  knative.${DOMAIN}: ""

--- a/hack/knative/deploy-hello-world.sh
+++ b/hack/knative/deploy-hello-world.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+NAMESPACE=${NAMESPACE:-knative-examples}
+ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
+
+istiooc delete -n $NAMESPACE -f $ROOT/service.yaml || true
+istiooc apply -n $NAMESPACE -f $ROOT/service.yaml

--- a/hack/knative/deploy-hello-world.sh
+++ b/hack/knative/deploy-hello-world.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -e
-
-NAMESPACE=${NAMESPACE:-knative-examples}
-ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
-
-istiooc delete -n $NAMESPACE -f $ROOT/service.yaml || true
-istiooc apply -n $NAMESPACE -f $ROOT/service.yaml

--- a/hack/knative/service.yaml
+++ b/hack/knative/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: helloworld-go
+  istio-injection: enabled
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: gcr.io/knative-samples/helloworld-go
+            imagePullPolicy: IfNotPresent
+            env:
+            - name: TARGET
+              value: "Go Sample v1"


### PR DESCRIPTION
This patch enables support to installing knative on Openshift, as well as installing a sample application that can be used for testing.

### What does it do?

Running `hack/cluster-openshift.sh up -kn true` prepares the cluster, installs knative and deploys a simple application.

### How to check it works?

```bash
DOMAIN="$(oc get route -n istio-system istio-ingressgateway --output=custom-columns=ROUTE:.spec.host | grep -v ROUTE | sed 's/istio-ingressgateway-istio-system.//g')"
INGRESS_IP="$(oc get svc istio-ingressgateway --namespace istio-system --output 'jsonpath={.status.loadBalancer.ingress[0].ip}')"

curl -H "Host: helloworld-go.knative-examples.knative.${DOMAIN}" "http://${INGRESS_IP}"
```

The response should be `Hello Go Sample v1!`, and changing the variable on `hack/knative/service.yaml` should change the result.

### How to check the services?

```bash
oc project knative-examples
oc get ksvc -o yaml
```

### How does it look on Kiali?

See for yourself:

![](https://i.imgur.com/hwCiIgh.png)
![](https://i.imgur.com/2GSH610.png)
![](https://i.imgur.com/fPbp8Gs.png)
![](https://i.imgur.com/iBIcM3V.png)

The most glaring issue is that the services are generated with different names each time they are autoscaled, and go up and down as they are created. Everything else seems to be supported ok, in the sense that Kiali is not rejecting input or breaking.

No work has been done yet to support this kind of setup, but it's good that everything works even though Kiali has no concept of knative in it yet.