### PR TITLE
KIALI-2546 Runtimes metrics discovery 

### DIFF
--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -14,10 +14,13 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/prometheus/prometheustest"
 )
 
 func setupAppService(k8s *kubetest.K8SClientMock) AppService {
-	return AppService{k8s: k8s}
+	prom := new(prometheustest.PromClientMock)
+	prom.MockEmptyMetricsDiscovery()
+	return AppService{k8s: k8s, prom: prom}
 }
 
 func TestGetAppListFromDeployments(t *testing.T) {

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -153,9 +153,10 @@ func (in *DashboardsService) GetDashboard(params prometheus.CustomMetricsQuery, 
 	}
 
 	aggLabels := models.ConvertAggregations(dashboard.Spec)
-	labels := fmt.Sprintf(`{namespace="%s",app="%s"`, params.Namespace, params.App)
+	cfg := config.Get()
+	labels := fmt.Sprintf(`{namespace="%s",%s="%s"`, params.Namespace, cfg.IstioLabels.AppLabelName, params.App)
 	if params.Version != "" {
-		labels += fmt.Sprintf(`,version="%s"`, params.Version)
+		labels += fmt.Sprintf(`,%s="%s"`, cfg.IstioLabels.VersionLabelName, params.Version)
 	} else {
 		// For app-based dashboards, we automatically add a possible aggregation/grouping over versions
 		versionsAgg := models.Aggregation{
@@ -347,9 +348,10 @@ func (in *DashboardsService) buildRuntimesList(namespace string, templatesNames 
 }
 
 func (in *DashboardsService) fetchMetricNames(namespace, app, version string) []string {
-	labels := fmt.Sprintf(`{namespace="%s",app="%s"`, namespace, app)
+	cfg := config.Get()
+	labels := fmt.Sprintf(`{namespace="%s",%s="%s"`, namespace, cfg.IstioLabels.AppLabelName, app)
 	if version != "" {
-		labels += fmt.Sprintf(`,version="%s"`, version)
+		labels += fmt.Sprintf(`,%s="%s"`, cfg.IstioLabels.VersionLabelName, version)
 	}
 	labels += "}"
 	metrics, err := in.prom.GetMetricsForLabels([]string{labels})

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -2,6 +2,7 @@ package business
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -11,32 +12,90 @@ import (
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 // DashboardsService deals with fetching dashboards from k8s client
 type DashboardsService struct {
-	prom prometheus.ClientInterface
-	mon  kubernetes.KialiMonitoringInterface
+	prom      prometheus.ClientInterface
+	k8sClient kubernetes.KialiMonitoringInterface
 }
 
 // NewDashboardsService initializes this business service
-func NewDashboardsService(mon kubernetes.KialiMonitoringInterface, prom prometheus.ClientInterface) DashboardsService {
-	return DashboardsService{prom: prom, mon: mon}
+func NewDashboardsService(k8sClient kubernetes.KialiMonitoringInterface, prom prometheus.ClientInterface) DashboardsService {
+	return DashboardsService{prom: prom, k8sClient: k8sClient}
 }
 
-func (in *DashboardsService) loadDashboardResource(namespace, template string) (*v1alpha1.MonitoringDashboard, error) {
+func (in *DashboardsService) k8s() (kubernetes.KialiMonitoringInterface, error) {
+	// Lazy init
+	if in.k8sClient == nil {
+		client, err := kubernetes.NewKialiMonitoringClient()
+		if err != nil {
+			return nil, fmt.Errorf("Cannot initialize Kiali Monitoring Client: %v", err)
+		}
+		in.k8sClient = client
+	}
+	return in.k8sClient, nil
+}
+
+// k8sGetDashboard wraps KialiMonitoringInterface.GetDashboard with client creation & error handling
+func (in *DashboardsService) k8sGetDashboard(namespace, template string) (*v1alpha1.MonitoringDashboard, error) {
+	client, err := in.k8s()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetDashboard(namespace, template)
+}
+
+// k8sGetDashboards wraps KialiMonitoringInterface.GetDashboards with client creation & error handling
+func (in *DashboardsService) k8sGetDashboards(namespace string) ([]v1alpha1.MonitoringDashboard, error) {
+	client, err := in.k8s()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetDashboards(namespace)
+}
+
+func (in *DashboardsService) loadRawDashboardResource(namespace, template string) (*v1alpha1.MonitoringDashboard, error) {
 	// There is an override mechanism with dashboards: default dashboards can be provided in Kiali namespace,
 	// and can be overriden in app namespace.
 	// So we look for the one in app namespace first, and only if not found fallback to the one in istio-system.
-	dashboard, err := in.mon.GetDashboard(namespace, template)
+	dashboard, err := in.k8sGetDashboard(namespace, template)
 	if err != nil {
 		cfg := config.Get()
-		dashboard, err = in.mon.GetDashboard(cfg.IstioNamespace, template)
+		dashboard, err = in.k8sGetDashboard(cfg.IstioNamespace, template)
 		if err != nil {
 			return nil, err
 		}
 	}
 	return dashboard, err
+}
+
+func (in *DashboardsService) loadRawDashboardResources(namespace string) (map[string]v1alpha1.MonitoringDashboard, error) {
+	all := make(map[string]v1alpha1.MonitoringDashboard)
+
+	// From Kiali namespace
+	cfg := config.Get()
+	dashboards, err := in.k8sGetDashboards(cfg.IstioNamespace)
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range dashboards {
+		all[d.Name] = d
+	}
+
+	// From specific namespace
+	if namespace != cfg.IstioNamespace {
+		dashboards, err = in.k8sGetDashboards(namespace)
+		if err != nil {
+			return nil, err
+		}
+		for _, d := range dashboards {
+			all[d.Name] = d
+		}
+	}
+
+	return all, nil
 }
 
 func (in *DashboardsService) loadAndResolveDashboardResource(namespace, template string, loaded map[string]bool) (*v1alpha1.MonitoringDashboard, error) {
@@ -45,7 +104,7 @@ func (in *DashboardsService) loadAndResolveDashboardResource(namespace, template
 		return nil, fmt.Errorf("Cannot load dashboard %s due to circular dependency detected. Already loaded dependencies: %v", template, loaded)
 	}
 	loaded[template] = true
-	dashboard, err := in.loadDashboardResource(namespace, template)
+	dashboard, err := in.loadRawDashboardResource(namespace, template)
 	if err != nil {
 		return nil, err
 	}
@@ -220,6 +279,45 @@ func (in *DashboardsService) GetIstioDashboard(params prometheus.IstioMetricsQue
 	return &dashboard, nil
 }
 
+// GetCustomDashboardRefs finds all dashboard IDs and Titles associated to this app and add them to the model
+func (in *DashboardsService) GetCustomDashboardRefs(namespace, app, version string, pods models.Pods) []models.Runtime {
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "DashboardsService", "GetCustomDashboardRefs")
+	defer promtimer.ObserveNow(&err)
+
+	uniqueRefsList := getUniqueRuntimes(pods)
+	if len(uniqueRefsList) > 0 {
+		return in.buildRuntimesList(namespace, uniqueRefsList)
+	}
+	if app != "" {
+		// Discovery only works with proper "app" labelling
+		return in.discoverRuntimesList(namespace, app, version)
+	}
+	return []models.Runtime{}
+}
+
+func getUniqueRuntimes(pods models.Pods) []string {
+	// Get uniqueness from plain list rather than map to preserve ordering; anyway, very low amount of objects is expected
+	uniqueRefs := []string{}
+	for _, pod := range pods {
+		for _, ref := range pod.RuntimesAnnotation {
+			if ref != "" {
+				exists := false
+				for _, existingRef := range uniqueRefs {
+					if ref == existingRef {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					uniqueRefs = append(uniqueRefs, ref)
+				}
+			}
+		}
+	}
+	return uniqueRefs
+}
+
 func (in *DashboardsService) buildRuntimesList(namespace string, templatesNames []string) []models.Runtime {
 	dashboards := make([]*v1alpha1.MonitoringDashboard, len(templatesNames))
 	wg := sync.WaitGroup{}
@@ -227,7 +325,7 @@ func (in *DashboardsService) buildRuntimesList(namespace string, templatesNames 
 	for idx, template := range templatesNames {
 		go func(i int, tpl string) {
 			defer wg.Done()
-			dashboard, err := in.loadDashboardResource(namespace, tpl)
+			dashboard, err := in.loadRawDashboardResource(namespace, tpl)
 			if err != nil {
 				log.Errorf("Cannot get dashboard %s in namespace %s. Error was: %v", tpl, namespace, err)
 			} else {
@@ -243,26 +341,98 @@ func (in *DashboardsService) buildRuntimesList(namespace string, templatesNames 
 		if dashboard == nil {
 			continue
 		}
-		runtime := dashboard.Spec.Runtime
-		ref := models.DashboardRef{
-			Template: dashboard.Name,
-			Title:    dashboard.Spec.Title,
-		}
-		found := false
-		for i := range runtimes {
-			rtObj := &runtimes[i]
-			if rtObj.Name == runtime {
-				rtObj.DashboardRefs = append(rtObj.DashboardRefs, ref)
-				found = true
-				break
+		runtimes = addDashboardToRuntimes(dashboard, runtimes)
+	}
+	return runtimes
+}
+
+func (in *DashboardsService) fetchMetricNames(namespace, app, version string) []string {
+	labels := fmt.Sprintf(`{namespace="%s",app="%s"`, namespace, app)
+	if version != "" {
+		labels += fmt.Sprintf(`,version="%s"`, version)
+	}
+	labels += "}"
+	metrics, err := in.prom.GetMetricsForLabels([]string{labels})
+	if err != nil {
+		log.Errorf("Runtimes discovery failed, cannot load metrics for labels: %s. Error was: %v", labels, err)
+	}
+	return metrics
+}
+
+func (in *DashboardsService) discoverRuntimesList(namespace, app, version string) []models.Runtime {
+	var metrics []string
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		metrics = in.fetchMetricNames(namespace, app, version)
+	}()
+
+	allDashboards, err := in.loadRawDashboardResources(namespace)
+	if err != nil {
+		log.Errorf("Runtimes discovery failed, cannot load dashboards in namespace %s. Error was: %v", namespace, err)
+		return []models.Runtime{}
+	}
+
+	wg.Wait()
+	return runDiscoveryMatcher(metrics, allDashboards)
+}
+
+func runDiscoveryMatcher(metrics []string, allDashboards map[string]v1alpha1.MonitoringDashboard) []models.Runtime {
+	// In all dashboards, finds the ones that match the metrics set
+	// We must exclude from the results included dashboards when both the including and the included dashboards are matching
+	runtimesMap := make(map[string]*v1alpha1.MonitoringDashboard)
+	for _, d := range allDashboards {
+		dashboard := d // sticky reference
+		matchReference := strings.TrimSpace(dashboard.Spec.DiscoverOn)
+		if matchReference != "" {
+			for _, metric := range metrics {
+				if matchReference == strings.TrimSpace(metric) {
+					if _, exists := runtimesMap[dashboard.Name]; !exists {
+						runtimesMap[dashboard.Name] = &dashboard
+					}
+					// Mark included dashboards as already found
+					// and set them "nil" to not show them as standalone dashboards even if they match
+					for _, item := range dashboard.Spec.Items {
+						if item.Include != "" {
+							runtimesMap[item.Include] = nil
+						}
+					}
+					break
+				}
 			}
 		}
-		if !found {
-			runtimes = append(runtimes, models.Runtime{
-				Name:          runtime,
-				DashboardRefs: []models.DashboardRef{ref},
-			})
+	}
+	runtimes := []models.Runtime{}
+	for _, dashboard := range runtimesMap {
+		if dashboard != nil {
+			runtimes = addDashboardToRuntimes(dashboard, runtimes)
 		}
+	}
+	sort.Slice(runtimes, func(i, j int) bool { return runtimes[i].Name < runtimes[j].Name })
+	return runtimes
+}
+
+func addDashboardToRuntimes(dashboard *v1alpha1.MonitoringDashboard, runtimes []models.Runtime) []models.Runtime {
+	runtime := dashboard.Spec.Runtime
+	ref := models.DashboardRef{
+		Template: dashboard.Name,
+		Title:    dashboard.Spec.Title,
+	}
+	found := false
+	for i := range runtimes {
+		rtObj := &runtimes[i]
+		if rtObj.Name == runtime {
+			rtObj.DashboardRefs = append(rtObj.DashboardRefs, ref)
+			found = true
+			break
+		}
+	}
+	if !found {
+		runtimes = append(runtimes, models.Runtime{
+			Name:          runtime,
+			DashboardRefs: []models.DashboardRef{ref},
+		})
 	}
 	return runtimes
 }

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -28,6 +28,14 @@ func (o *k8sKialiMonitoringClientMock) GetDashboard(namespace string, name strin
 	return args.Get(0).(*v1alpha1.MonitoringDashboard), nil
 }
 
+func (o *k8sKialiMonitoringClientMock) GetDashboards(namespace string) ([]v1alpha1.MonitoringDashboard, error) {
+	args := o.Called(namespace)
+	if args.Error(1) != nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]v1alpha1.MonitoringDashboard), nil
+}
+
 func TestGetDashboard(t *testing.T) {
 	assert := assert.New(t)
 
@@ -37,7 +45,7 @@ func TestGetDashboard(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 	service := NewDashboardsService(k8s, prom)
-	k8s.On("GetDashboard", "my-namespace", "dashboard1").Return(fakeDashboard(), nil)
+	k8s.On("GetDashboard", "my-namespace", "dashboard1").Return(fakeDashboard("1"), nil)
 
 	expectedLabels := "{namespace=\"my-namespace\",app=\"my-app\"}"
 	query := prometheus.CustomMetricsQuery{
@@ -45,8 +53,8 @@ func TestGetDashboard(t *testing.T) {
 		App:       "my-app",
 	}
 	query.FillDefaults()
-	prom.On("FetchRateRange", "my_metric_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter(10))
-	prom.On("FetchHistogramRange", "my_metric_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram(11))
+	prom.On("FetchRateRange", "my_metric_1_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter(10))
+	prom.On("FetchHistogramRange", "my_metric_1_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram(11))
 
 	dashboard, err := service.GetDashboard(query, "dashboard1")
 
@@ -55,8 +63,8 @@ func TestGetDashboard(t *testing.T) {
 	assert.Equal("Dashboard 1", dashboard.Title)
 	assert.Len(dashboard.Aggregations, 3)
 	assert.Len(dashboard.Charts, 2)
-	assert.Equal("My chart 1", dashboard.Charts[0].Name)
-	assert.Equal("My chart 2", dashboard.Charts[1].Name)
+	assert.Equal("My chart 1_1", dashboard.Charts[0].Name)
+	assert.Equal("My chart 1_2", dashboard.Charts[1].Name)
 	assert.Nil(dashboard.Charts[0].Histogram)
 	assert.Nil(dashboard.Charts[1].Metric)
 	assert.Equal(model.SampleValue(10), dashboard.Charts[0].Metric.Matrix[0].Values[0].Value)
@@ -73,7 +81,7 @@ func TestGetDashboardFromKialiNamespace(t *testing.T) {
 	config.Set(conf)
 	service := NewDashboardsService(k8s, prom)
 	k8s.On("GetDashboard", "my-namespace", "dashboard1").Return(nil, errors.New("denied"))
-	k8s.On("GetDashboard", "istio-system", "dashboard1").Return(fakeDashboard(), nil)
+	k8s.On("GetDashboard", "istio-system", "dashboard1").Return(fakeDashboard("1"), nil)
 
 	expectedLabels := "{namespace=\"my-namespace\",app=\"my-app\"}"
 	query := prometheus.CustomMetricsQuery{
@@ -81,8 +89,8 @@ func TestGetDashboardFromKialiNamespace(t *testing.T) {
 		App:       "my-app",
 	}
 	query.FillDefaults()
-	prom.On("FetchRateRange", "my_metric_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter(10))
-	prom.On("FetchHistogramRange", "my_metric_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram(11))
+	prom.On("FetchRateRange", "my_metric_1_1", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeCounter(10))
+	prom.On("FetchHistogramRange", "my_metric_1_2", expectedLabels, "", &query.BaseMetricsQuery).Return(fakeHistogram(11))
 
 	dashboard, err := service.GetDashboard(query, "dashboard1")
 
@@ -131,23 +139,8 @@ func TestGetIstioDashboard(t *testing.T) {
 func TestGetComposedDashboard(t *testing.T) {
 	assert := assert.New(t)
 
-	composed := v1alpha1.MonitoringDashboard{
-		Spec: v1alpha1.MonitoringDashboardSpec{
-			Title: "Dashboard 2",
-			Items: []v1alpha1.MonitoringDashboardItem{
-				v1alpha1.MonitoringDashboardItem{
-					Chart: v1alpha1.MonitoringDashboardChart{
-						Name:       "My chart 2 - 1",
-						MetricName: "my_metric_2_1",
-						DataType:   "rate",
-					},
-				},
-				v1alpha1.MonitoringDashboardItem{
-					Include: "dashboard1",
-				},
-			},
-		},
-	}
+	composed := fakeDashboard("2")
+	composed.Spec.Items = append(composed.Spec.Items, v1alpha1.MonitoringDashboardItem{Include: "dashboard1"})
 
 	// Setup mocks
 	k8s := new(k8sKialiMonitoringClientMock)
@@ -155,71 +148,50 @@ func TestGetComposedDashboard(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 	service := NewDashboardsService(k8s, prom)
-	k8s.On("GetDashboard", "my-namespace", "dashboard1").Return(fakeDashboard(), nil)
-	k8s.On("GetDashboard", "my-namespace", "dashboard2").Return(&composed, nil)
+	k8s.On("GetDashboard", "my-namespace", "dashboard1").Return(fakeDashboard("1"), nil)
+	k8s.On("GetDashboard", "my-namespace", "dashboard2").Return(composed, nil)
+
+	d, err := service.loadAndResolveDashboardResource("my-namespace", "dashboard2", map[string]bool{})
+	assert.Nil(err)
+	k8s.AssertNumberOfCalls(t, "GetDashboard", 2)
+	assert.Equal("Dashboard 2", d.Spec.Title)
+	assert.Len(d.Spec.Items, 4)
+	assert.Equal("My chart 2_1", d.Spec.Items[0].Chart.Name)
+	assert.Equal("My chart 2_2", d.Spec.Items[1].Chart.Name)
+	assert.Equal("My chart 1_1", d.Spec.Items[2].Chart.Name)
+	assert.Equal("My chart 1_2", d.Spec.Items[3].Chart.Name)
+}
+
+func TestGetComposedDashboardSingleChart(t *testing.T) {
+	assert := assert.New(t)
+
+	composed := fakeDashboard("2")
+	composed.Spec.Items = append(composed.Spec.Items, v1alpha1.MonitoringDashboardItem{Include: "dashboard1$My chart 1_2"})
+
+	// Setup mocks
+	k8s := new(k8sKialiMonitoringClientMock)
+	prom := new(prometheustest.PromClientMock)
+	conf := config.NewConfig()
+	config.Set(conf)
+	service := NewDashboardsService(k8s, prom)
+	k8s.On("GetDashboard", "my-namespace", "dashboard1").Return(fakeDashboard("1"), nil)
+	k8s.On("GetDashboard", "my-namespace", "dashboard2").Return(composed, nil)
 
 	d, err := service.loadAndResolveDashboardResource("my-namespace", "dashboard2", map[string]bool{})
 	assert.Nil(err)
 	k8s.AssertNumberOfCalls(t, "GetDashboard", 2)
 	assert.Equal("Dashboard 2", d.Spec.Title)
 	assert.Len(d.Spec.Items, 3)
-	assert.Equal("My chart 2 - 1", d.Spec.Items[0].Chart.Name)
-	assert.Equal("My chart 1", d.Spec.Items[1].Chart.Name)
-	assert.Equal("My chart 2", d.Spec.Items[2].Chart.Name)
-}
-
-func TestGetComposedDashboardSingleChart(t *testing.T) {
-	assert := assert.New(t)
-
-	composed := v1alpha1.MonitoringDashboard{
-		Spec: v1alpha1.MonitoringDashboardSpec{
-			Title: "Dashboard 2",
-			Items: []v1alpha1.MonitoringDashboardItem{
-				v1alpha1.MonitoringDashboardItem{
-					Chart: v1alpha1.MonitoringDashboardChart{
-						Name:       "My chart 2 - 1",
-						MetricName: "my_metric_2_1",
-						DataType:   "rate",
-					},
-				},
-				v1alpha1.MonitoringDashboardItem{
-					Include: "dashboard1$My chart 2",
-				},
-			},
-		},
-	}
-
-	// Setup mocks
-	k8s := new(k8sKialiMonitoringClientMock)
-	prom := new(prometheustest.PromClientMock)
-	conf := config.NewConfig()
-	config.Set(conf)
-	service := NewDashboardsService(k8s, prom)
-	k8s.On("GetDashboard", "my-namespace", "dashboard1").Return(fakeDashboard(), nil)
-	k8s.On("GetDashboard", "my-namespace", "dashboard2").Return(&composed, nil)
-
-	d, err := service.loadAndResolveDashboardResource("my-namespace", "dashboard2", map[string]bool{})
-	assert.Nil(err)
-	k8s.AssertNumberOfCalls(t, "GetDashboard", 2)
-	assert.Equal("Dashboard 2", d.Spec.Title)
-	assert.Len(d.Spec.Items, 2)
-	assert.Equal("My chart 2 - 1", d.Spec.Items[0].Chart.Name)
-	assert.Equal("My chart 2", d.Spec.Items[1].Chart.Name)
+	assert.Equal("My chart 2_1", d.Spec.Items[0].Chart.Name)
+	assert.Equal("My chart 2_2", d.Spec.Items[1].Chart.Name)
+	assert.Equal("My chart 1_2", d.Spec.Items[2].Chart.Name)
 }
 
 func TestCircularDependency(t *testing.T) {
 	assert := assert.New(t)
 
-	composed := v1alpha1.MonitoringDashboard{
-		Spec: v1alpha1.MonitoringDashboardSpec{
-			Title: "Dashboard 2",
-			Items: []v1alpha1.MonitoringDashboardItem{
-				v1alpha1.MonitoringDashboardItem{
-					Include: "dashboard2",
-				},
-			},
-		},
-	}
+	composed := fakeDashboard("2")
+	composed.Spec.Items = append(composed.Spec.Items, v1alpha1.MonitoringDashboardItem{Include: "dashboard2"})
 
 	// Setup mocks
 	k8s := new(k8sKialiMonitoringClientMock)
@@ -227,11 +199,70 @@ func TestCircularDependency(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 	service := NewDashboardsService(k8s, prom)
-	k8s.On("GetDashboard", "my-namespace", "dashboard2").Return(&composed, nil)
+	k8s.On("GetDashboard", "my-namespace", "dashboard2").Return(composed, nil)
 
 	_, err := service.loadAndResolveDashboardResource("my-namespace", "dashboard2", map[string]bool{})
 	assert.Contains(err.Error(), "circular dependency detected")
 	k8s.AssertNumberOfCalls(t, "GetDashboard", 1)
+}
+
+func TestDiscoveryMatcher(t *testing.T) {
+	assert := assert.New(t)
+
+	d1 := fakeDashboard("1")
+	d2 := fakeDashboard("2")
+	d3 := fakeDashboard("3")
+
+	dashboards := make(map[string]v1alpha1.MonitoringDashboard)
+	dashboards[d1.Name] = *d1
+	dashboards[d2.Name] = *d2
+	dashboards[d3.Name] = *d3
+
+	metrics := []string{
+		"my_metric_1_1",
+		"my_metric_1_2",
+		"my_metric_1_3",
+		"my_metric_2_1",
+	}
+
+	runtimes := runDiscoveryMatcher(metrics, dashboards)
+
+	assert.Len(runtimes, 2)
+	assert.Equal("Runtime 1", runtimes[0].Name)
+	assert.Len(runtimes[0].DashboardRefs, 1)
+	assert.Equal("dashboard1", runtimes[0].DashboardRefs[0].Template)
+	assert.Equal("Runtime 2", runtimes[1].Name)
+	assert.Len(runtimes[1].DashboardRefs, 1)
+	assert.Equal("dashboard2", runtimes[1].DashboardRefs[0].Template)
+}
+
+func TestDiscoveryMatcherWithComposition(t *testing.T) {
+	assert := assert.New(t)
+
+	d1 := fakeDashboard("1")
+	d2 := fakeDashboard("2")
+	d2.Spec.Items = append(d2.Spec.Items, v1alpha1.MonitoringDashboardItem{Include: d1.Name})
+	d3 := fakeDashboard("3")
+
+	dashboards := make(map[string]v1alpha1.MonitoringDashboard)
+	dashboards[d1.Name] = *d1
+	dashboards[d2.Name] = *d2
+	dashboards[d3.Name] = *d3
+
+	metrics := []string{
+		"my_metric_1_1",
+		"my_metric_1_2",
+		"my_metric_1_3",
+		"my_metric_2_1",
+	}
+
+	runtimes := runDiscoveryMatcher(metrics, dashboards)
+
+	// Only top-level runtime must appear
+	assert.Len(runtimes, 1)
+	assert.Equal("Runtime 2", runtimes[0].Name)
+	assert.Len(runtimes[0].DashboardRefs, 1)
+	assert.Equal("dashboard2", runtimes[0].DashboardRefs[0].Template)
 }
 
 func fakeCounter(value int) *prometheus.Metric {
@@ -251,19 +282,21 @@ func fakeHistogram(avg int) prometheus.Histogram {
 	}
 }
 
-func fakeDashboard() *v1alpha1.MonitoringDashboard {
+func fakeDashboard(id string) *v1alpha1.MonitoringDashboard {
 	return &v1alpha1.MonitoringDashboard{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "dashboard1",
+			Name: "dashboard" + id,
 		},
 		Spec: v1alpha1.MonitoringDashboardSpec{
-			Title: "Dashboard 1",
+			Title:      "Dashboard " + id,
+			Runtime:    "Runtime " + id,
+			DiscoverOn: "my_metric_" + id + "_1",
 			Items: []v1alpha1.MonitoringDashboardItem{
 				v1alpha1.MonitoringDashboardItem{
-					Chart: kmock.FakeChart("1", "rate"),
+					Chart: kmock.FakeChart(id+"_1", "rate"),
 				},
 				v1alpha1.MonitoringDashboardItem{
-					Chart: kmock.FakeChart("2", "histogram"),
+					Chart: kmock.FakeChart(id+"_2", "histogram"),
 				},
 			},
 		},

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -66,7 +66,7 @@ func mockWorkLoadService(k8s *kubetest.K8SClientMock) WorkloadService {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakePods().Items, nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 	return svc
 }
 

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -2,8 +2,9 @@ package business
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
 	"testing"
+
+	"k8s.io/api/core/v1"
 
 	osappsv1 "github.com/openshift/api/apps/v1"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,9 @@ import (
 	"github.com/kiali/kiali/prometheus/prometheustest"
 )
 
-func setupWorkloadService(k8s *kubetest.K8SClientMock, prom *prometheustest.PromClientMock) WorkloadService {
+func setupWorkloadService(k8s *kubetest.K8SClientMock) WorkloadService {
+	prom := new(prometheustest.PromClientMock)
+	prom.MockEmptyMetricsDiscovery()
 	return WorkloadService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom)}
 }
 
@@ -39,7 +42,7 @@ func TestGetWorkloadListFromDeployments(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -78,7 +81,7 @@ func TestGetWorkloadListFromReplicaSets(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -117,7 +120,7 @@ func TestGetWorkloadListFromReplicationControllers(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -156,7 +159,7 @@ func TestGetWorkloadListFromDeploymentConfigs(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -195,7 +198,7 @@ func TestGetWorkloadListFromStatefulSets(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -234,7 +237,7 @@ func TestGetWorkloadListFromDepRCPod(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsSyncedWithDeployments(), nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -265,7 +268,7 @@ func TestGetWorkloadListFromPod(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsNoController(), nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -296,7 +299,7 @@ func TestGetWorkloadListFromPods(t *testing.T) {
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsFromDaemonSet(), nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads
@@ -328,7 +331,7 @@ func TestGetWorkloadFromDeployment(t *testing.T) {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workload, _ := svc.GetWorkload("Namespace", "details-v1", false)
 
@@ -355,7 +358,7 @@ func TestGetWorkloadFromPods(t *testing.T) {
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsFromDaemonSet(), nil)
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workload, _ := svc.GetWorkload("Namespace", "daemon-controller", false)
 
@@ -375,7 +378,7 @@ func TestGetPods(t *testing.T) {
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsSyncedWithDeployments(), nil)
 	k8s.On("IsOpenShift").Return(false)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	pods, _ := svc.GetPods("Namespace", "app=httpbin")
 
@@ -405,7 +408,7 @@ func TestDuplicatedControllers(t *testing.T) {
 	k8s.On("GetDeploymentConfig", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&osappsv1.DeploymentConfig{}, notfound)
 	k8s.On("GetStatefulSet", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&FakeDuplicatedStatefulSets()[0], nil)
 
-	svc := setupWorkloadService(k8s, nil)
+	svc := setupWorkloadService(k8s)
 
 	workloadList, _ := svc.GetWorkloadList("Namespace")
 	workloads := workloadList.Workloads

--- a/deploy/dashboards/go.yaml
+++ b/deploy/dashboards/go.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   title: Go Metrics
   runtime: Go
+  discoverOn: "go_info"
   items:
   - chart:
       name: "Threads"

--- a/deploy/dashboards/micrometer-1.0.6-jvm-pool.yaml
+++ b/deploy/dashboards/micrometer-1.0.6-jvm-pool.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: JVM
   title: JVM Pool Metrics
+  discoverOn: "jvm_buffer_total_capacity_bytes"
   items:
   - chart:
       name: "Pool buffer memory used"

--- a/deploy/dashboards/micrometer-1.0.6-jvm.yaml
+++ b/deploy/dashboards/micrometer-1.0.6-jvm.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: JVM
   title: JVM Metrics
+  discoverOn: "jvm_threads_live"
   items:
   - chart:
       name: "Total live threads"

--- a/deploy/dashboards/micrometer-1.1-jvm.yaml
+++ b/deploy/dashboards/micrometer-1.1-jvm.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: JVM
   title: JVM Metrics
+  discoverOn: "jvm_threads_live_threads"
   items:
   - chart:
       name: "Memory used"

--- a/deploy/dashboards/microprofile-1.1.yaml
+++ b/deploy/dashboards/microprofile-1.1.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   title: MicroProfile Metrics
   runtime: MicroProfile
+  discoverOn: "base:thread_count"
   items:
   - chart:
       name: "Current loaded classes"

--- a/deploy/dashboards/microprofile-x.y.yaml
+++ b/deploy/dashboards/microprofile-x.y.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   title: MicroProfile Metrics
   runtime: MicroProfile
+  discoverOn: "base:gc_complete_scavenger_count"
   items:
   - chart:
       name: "Young GC time"

--- a/deploy/dashboards/nodejs.yaml
+++ b/deploy/dashboards/nodejs.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Node.js
   title: Node.js Metrics
+  discoverOn: "nodejs_active_handles_total"
   items:
   - chart:
       name: "Active handles"

--- a/deploy/dashboards/thorntail.yaml
+++ b/deploy/dashboards/thorntail.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Thorntail
   title: Thorntail Metrics
+  discoverOn: "vendor:loaded_modules"
   items:
   - include: "microprofile-1.1"
   - chart:

--- a/deploy/dashboards/tomcat.yaml
+++ b/deploy/dashboards/tomcat.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Tomcat
   title: Tomcat Metrics
+  discoverOn: "tomcat_sessions_created_total"
   items:
   - chart:
       name: "Sessions created"

--- a/deploy/dashboards/vertx-client.yaml
+++ b/deploy/dashboards/vertx-client.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Vert.x
   title: Vert.x Client Metrics
+  discoverOn: "vertx_http_client_connections"
   items:
   - chart:
       name: "Client response time"

--- a/deploy/dashboards/vertx-eventbus.yaml
+++ b/deploy/dashboards/vertx-eventbus.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Vert.x
   title: Vert.x Eventbus Metrics
+  discoverOn: "vertx_eventbus_handlers"
   items:
   - chart:
       name: "Event bus handlers"

--- a/deploy/dashboards/vertx-pool.yaml
+++ b/deploy/dashboards/vertx-pool.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Vert.x
   title: Vert.x Pools Metrics
+  discoverOn: "vertx_pool_ratio"
   items:
   - chart:
       name: "Usage duration"

--- a/deploy/dashboards/vertx-server.yaml
+++ b/deploy/dashboards/vertx-server.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Vert.x
   title: Vert.x Server Metrics
+  discoverOn: "vertx_http_server_connections"
   items:
   - chart:
       name: "Server response time"

--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -132,6 +132,7 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -255,3 +256,4 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+  - list

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -145,6 +145,7 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+  - list
 ---
 apiVersion: v1
 kind: ClusterRole
@@ -281,3 +282,4 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+  - list

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -174,6 +174,7 @@ func setupAppListEndpoint() (*httptest.Server, *kubetest.K8SClientMock, *prometh
 	config.Set(config.NewConfig())
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
+	prom.MockEmptyMetricsDiscovery()
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	business.SetWithBackends(mockClientFactory, prom)

--- a/kubernetes/kiali_monitoring/v1alpha1/kiali_monitoring_types.go
+++ b/kubernetes/kiali_monitoring/v1alpha1/kiali_monitoring_types.go
@@ -26,10 +26,17 @@ type MonitoringDashboard struct {
 	Spec               MonitoringDashboardSpec `json:"spec"`
 }
 
+type MonitoringDashboardsList struct {
+	meta_v1.TypeMeta `json:",inline"`
+	meta_v1.ListMeta `json:"metadata"`
+	Items            []MonitoringDashboard `json:"items"`
+}
+
 type MonitoringDashboardSpec struct {
-	Title   string                    `json:"title"`
-	Runtime string                    `json:"runtime"`
-	Items   []MonitoringDashboardItem `json:"items"`
+	Title      string                    `json:"title"`
+	Runtime    string                    `json:"runtime"`
+	DiscoverOn string                    `json:"discoverOn"`
+	Items      []MonitoringDashboardItem `json:"items"`
 }
 
 type MonitoringDashboardItem struct {
@@ -74,6 +81,35 @@ func (in *MonitoringDashboard) DeepCopy() *MonitoringDashboard {
 }
 
 func (in *MonitoringDashboard) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *MonitoringDashboardsList) DeepCopyInto(out *MonitoringDashboardsList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	out.ListMeta = in.ListMeta
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]MonitoringDashboard, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *MonitoringDashboardsList) DeepCopy() *MonitoringDashboardsList {
+	if in == nil {
+		return nil
+	}
+	out := new(MonitoringDashboardsList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *MonitoringDashboardsList) DeepCopyObject() runtime.Object {
 	if c := in.DeepCopy(); c != nil {
 		return c
 	}

--- a/kubernetes/kiali_monitoring_client.go
+++ b/kubernetes/kiali_monitoring_client.go
@@ -10,6 +10,7 @@ import (
 // KialiMonitoringInterface for mocks (only mocked function are necessary here)
 type KialiMonitoringInterface interface {
 	GetDashboard(namespace string, name string) (*v1alpha1.MonitoringDashboard, error)
+	GetDashboards(namespace string) ([]v1alpha1.MonitoringDashboard, error)
 }
 
 // KialiMonitoringClient is the client struct for Kiali Monitoring API over Kubernetes
@@ -54,4 +55,14 @@ func (in *KialiMonitoringClient) GetDashboard(namespace, name string) (*v1alpha1
 		return nil, err
 	}
 	return &result, err
+}
+
+// GetDashboards returns all MonitoringDashboards from the given namespace
+func (in *KialiMonitoringClient) GetDashboards(namespace string) ([]v1alpha1.MonitoringDashboard, error) {
+	result := v1alpha1.MonitoringDashboardsList{}
+	err := in.client.Get().Namespace(namespace).Resource("monitoringdashboards").Do().Into(&result)
+	if err != nil {
+		return nil, err
+	}
+	return result.Items, nil
 }

--- a/operator/roles/kiali/templates/dashboards/go.yaml
+++ b/operator/roles/kiali/templates/dashboards/go.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   title: Go Metrics
   runtime: Go
+  discoverOn: "go_info"
   items:
   - chart:
       name: "Threads"

--- a/operator/roles/kiali/templates/dashboards/micrometer-1.0.6-jvm-pool.yaml
+++ b/operator/roles/kiali/templates/dashboards/micrometer-1.0.6-jvm-pool.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: JVM
   title: JVM Pool Metrics
+  discoverOn: "jvm_buffer_total_capacity_bytes"
   items:
   - chart:
       name: "Pool buffer memory used"

--- a/operator/roles/kiali/templates/dashboards/micrometer-1.0.6-jvm.yaml
+++ b/operator/roles/kiali/templates/dashboards/micrometer-1.0.6-jvm.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: JVM
   title: JVM Metrics
+  discoverOn: "jvm_threads_live"
   items:
   - chart:
       name: "Total live threads"

--- a/operator/roles/kiali/templates/dashboards/micrometer-1.1-jvm.yaml
+++ b/operator/roles/kiali/templates/dashboards/micrometer-1.1-jvm.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: JVM
   title: JVM Metrics
+  discoverOn: "jvm_threads_live_threads"
   items:
   - chart:
       name: "Memory used"

--- a/operator/roles/kiali/templates/dashboards/microprofile-1.1.yaml
+++ b/operator/roles/kiali/templates/dashboards/microprofile-1.1.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   title: MicroProfile Metrics
   runtime: MicroProfile
+  discoverOn: "base:thread_count"
   items:
   - chart:
       name: "Current loaded classes"

--- a/operator/roles/kiali/templates/dashboards/microprofile-x.y.yaml
+++ b/operator/roles/kiali/templates/dashboards/microprofile-x.y.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   title: MicroProfile Metrics
   runtime: MicroProfile
+  discoverOn: "base:gc_complete_scavenger_count"
   items:
   - chart:
       name: "Young GC time"

--- a/operator/roles/kiali/templates/dashboards/nodejs.yaml
+++ b/operator/roles/kiali/templates/dashboards/nodejs.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Node.js
   title: Node.js Metrics
+  discoverOn: "nodejs_active_handles_total"
   items:
   - chart:
       name: "Active handles"

--- a/operator/roles/kiali/templates/dashboards/thorntail.yaml
+++ b/operator/roles/kiali/templates/dashboards/thorntail.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Thorntail
   title: Thorntail Metrics
+  discoverOn: "vendor:loaded_modules"
   items:
   - include: "microprofile-1.1"
   - chart:

--- a/operator/roles/kiali/templates/dashboards/tomcat.yaml
+++ b/operator/roles/kiali/templates/dashboards/tomcat.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Tomcat
   title: Tomcat Metrics
+  discoverOn: "tomcat_sessions_created_total"
   items:
   - chart:
       name: "Sessions created"

--- a/operator/roles/kiali/templates/dashboards/vertx-client.yaml
+++ b/operator/roles/kiali/templates/dashboards/vertx-client.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Vert.x
   title: Vert.x Client Metrics
+  discoverOn: "vertx_http_client_connections"
   items:
   - chart:
       name: "Client response time"

--- a/operator/roles/kiali/templates/dashboards/vertx-eventbus.yaml
+++ b/operator/roles/kiali/templates/dashboards/vertx-eventbus.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Vert.x
   title: Vert.x Eventbus Metrics
+  discoverOn: "vertx_eventbus_handlers"
   items:
   - chart:
       name: "Event bus handlers"

--- a/operator/roles/kiali/templates/dashboards/vertx-pool.yaml
+++ b/operator/roles/kiali/templates/dashboards/vertx-pool.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Vert.x
   title: Vert.x Pools Metrics
+  discoverOn: "vertx_pool_ratio"
   items:
   - chart:
       name: "Usage duration"

--- a/operator/roles/kiali/templates/dashboards/vertx-server.yaml
+++ b/operator/roles/kiali/templates/dashboards/vertx-server.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   runtime: Vert.x
   title: Vert.x Server Metrics
+  discoverOn: "vertx_http_server_connections"
   items:
   - chart:
       name: "Server response time"

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -26,6 +26,7 @@ type ClientInterface interface {
 	GetNamespaceServicesRequestRates(namespace, ratesInterval string, queryTime time.Time) (model.Vector, error)
 	GetServiceRequestRates(namespace, service, ratesInterval string, queryTime time.Time) (model.Vector, error)
 	GetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
+	GetMetricsForLabels(labels []string) ([]string, error)
 }
 
 // Client for Prometheus API.
@@ -139,4 +140,22 @@ func (in *Client) GetFlags() (v1.FlagsResult, error) {
 		return nil, err
 	}
 	return flags, nil
+}
+
+// GetMetricsForLabels returns a list of metrics existing for the provided labels set
+func (in *Client) GetMetricsForLabels(labels []string) ([]string, error) {
+	// Arbitrarily set time range. Meaning that discovery works with metrics produced within last hour
+	end := time.Now()
+	start := end.Add(-time.Hour)
+	results, err := in.api.Series(context.Background(), labels, start, end)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, labelSet := range results {
+		if name, ok := labelSet["__name__"]; ok {
+			names = append(names, string(name))
+		}
+	}
+	return names, nil
 }

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -138,6 +138,11 @@ func (o *PromClientMock) MockWorkloadRequestRates(namespace, wkld string, in, ou
 	o.On("GetWorkloadRequestRates", namespace, wkld, mock.AnythingOfType("string"), mock.AnythingOfType("time.Time")).Return(in, out, nil)
 }
 
+// MockEmptyMetricsDiscovery mocks GetMetricsForLabels (for runtimes metrics discovery) as being empty
+func (o *PromClientMock) MockEmptyMetricsDiscovery() {
+	o.On("GetMetricsForLabels", mock.AnythingOfType("[]string")).Return([]string{}, nil)
+}
+
 func (o *PromClientMock) GetAllRequestRates(namespace, ratesInterval string, queryTime time.Time) (model.Vector, error) {
 	args := o.Called(namespace, ratesInterval, queryTime)
 	return args.Get(0).(model.Vector), args.Error(1)
@@ -191,4 +196,9 @@ func (o *PromClientMock) FetchHistogramRange(metricName, labels, grouping string
 func (o *PromClientMock) GetMetrics(query *prometheus.IstioMetricsQuery) prometheus.Metrics {
 	args := o.Called(query)
 	return args.Get(0).(prometheus.Metrics)
+}
+
+func (o *PromClientMock) GetMetricsForLabels(labels []string) ([]string, error) {
+	args := o.Called(labels)
+	return args.Get(0).([]string), args.Error(1)
 }


### PR DESCRIPTION
This is enabling auto-discovery of dashboards, removing the need for pods annotations.

Pods annotations mechanism is not removed however: it can still be useful for dashboards where we are unable to provide a distinctive criteria for discovery, or also to speed up details display (annotation processing is much faster than discovery).


Some performance consideration, measuring the loading time of Workload Details page:
- (1) Before this PR, with no explicit runtimes dashboard: avg ~= 13ms
- (2) Before this PR, with explicit runtimes dashboards: avg ~= 20ms
- (3) After this PR, with explicit runtimes dashboards: avg ~= 20ms (no change, as expected)
- (4) After this PR, with no explicit dashboard / auto-discovery: avg ~= 180ms
[EDIT] / (4-bis) got better figures by adding goroutines, (4) now has avg ~= 75ms

![pic](https://i.imgur.com/p2CE2bj.png)

With (4-bis):
![pic2](https://i.imgur.com/lcZz8mv.png)

This peak due to discovery was kinda expected, see description in https://issues.jboss.org/browse/KIALI-2546 ; suggestion is to cache dashboards.

Note however that the increased latency *only* affects the Workloads / App details page, (not list pages), which makes it less critical as there's no scaling issue (we only show workload details one by one).