### PR TITLE
KIALI-577 Server-side REST support for getting pod details and pod logs

### DIFF
--- a/business/test_util.go
+++ b/business/test_util.go
@@ -6,10 +6,11 @@ import (
 	osappsv1 "github.com/openshift/api/apps/v1"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/apps/v1beta2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
@@ -574,6 +575,44 @@ func FakePodsSyncedWithDeployments() []v1.Pod {
 				},
 			},
 		},
+	}
+}
+
+func FakePodSyncedWithDeployments() *v1.Pod {
+	conf := config.NewConfig()
+	config.Set(conf)
+	appLabel := conf.IstioLabels.AppLabelName
+	versionLabel := conf.IstioLabels.VersionLabelName
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	controller := true
+	return &v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:              "details-v1-3618568057-dnkjp",
+			CreationTimestamp: meta_v1.NewTime(t1),
+			Labels:            map[string]string{appLabel: "httpbin", versionLabel: "v1"},
+			OwnerReferences: []meta_v1.OwnerReference{meta_v1.OwnerReference{
+				Controller: &controller,
+				Kind:       "ReplicaSet",
+				Name:       "details-v1-3618568057",
+			}},
+			Annotations: kubetest.FakeIstioAnnotations(),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				v1.Container{Name: "details", Image: "whatever"},
+				v1.Container{Name: "istio-proxy", Image: "docker.io/istio/proxy:0.7.1"},
+			},
+			InitContainers: []v1.Container{
+				v1.Container{Name: "istio-init", Image: "docker.io/istio/proxy_init:0.7.1"},
+				v1.Container{Name: "enable-core-dump", Image: "alpine"},
+			},
+		},
+	}
+}
+
+func FakePodLogsSyncedWithDeployments() *kubernetes.PodLogs {
+	return &kubernetes.PodLogs{
+		Logs: "Fake Log Entry 1\nFake Log Entry 2",
 	}
 }
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/api/apps/v1beta2"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/kubernetes"
@@ -88,6 +88,24 @@ func (in *WorkloadService) GetPods(namespace string, labelSelector string) (mode
 	pods := models.Pods{}
 	pods.Parse(ps)
 	return pods, nil
+}
+
+func (in *WorkloadService) GetPod(namespace, name string) (*models.Pod, error) {
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "WorkloadService", "GetPod")
+	defer promtimer.ObserveNow(&err)
+
+	p, err := in.k8s.GetPod(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	pod := models.Pod{}
+	pod.Parse(p)
+	return &pod, nil
+}
+
+func (in *WorkloadService) GetPodLogs(namespace, name string, opts *v1.PodLogOptions) (*kubernetes.PodLogs, error) {
+	return in.k8s.GetPodLogs(namespace, name, opts)
 }
 
 func fetchWorkloads(k8s kubernetes.IstioClientInterface, namespace string, labelSelector string) (models.Workloads, error) {

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -2,7 +2,6 @@ package business
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
 	"testing"
 
 	osappsv1 "github.com/openshift/api/apps/v1"
@@ -12,8 +11,10 @@ import (
 	"k8s.io/api/apps/v1beta2"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/prometheus/prometheustest"
 )
@@ -38,6 +39,8 @@ func TestGetWorkloadListFromDeployments(t *testing.T) {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
+	k8s.On("GetPod", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(v1.Pod{}, nil)
+	k8s.On("GetPodLogs", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.Anything).Return(&kubernetes.PodLogs{}, nil)
 
 	svc := setupWorkloadService(k8s, nil)
 
@@ -77,6 +80,8 @@ func TestGetWorkloadListFromReplicaSets(t *testing.T) {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]v1.Pod{}, nil)
+	k8s.On("GetPod", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(v1.Pod{}, nil)
+	k8s.On("GetPodLogs", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.Anything).Return(&kubernetes.PodLogs{}, nil)
 
 	svc := setupWorkloadService(k8s, nil)
 
@@ -383,6 +388,40 @@ func TestGetPods(t *testing.T) {
 	assert.Equal("details-v1-3618568057-dnkjp", pods[0].Name)
 }
 
+func TestGetPod(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Setup mocks
+	k8s := new(kubetest.K8SClientMock)
+	k8s.On("GetPod", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodSyncedWithDeployments(), nil)
+	k8s.On("IsOpenShift").Return(false)
+
+	svc := setupWorkloadService(k8s, nil)
+
+	pod, _ := svc.GetPod("Namespace", "details-v1-3618568057-dnkjp")
+
+	assert.Equal("details-v1-3618568057-dnkjp", pod.Name)
+}
+
+func TestGetPodLogs(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Setup mocks
+	k8s := new(kubetest.K8SClientMock)
+	k8s.On("GetPodLogs", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.Anything).Return(FakePodLogsSyncedWithDeployments(), nil)
+	k8s.On("IsOpenShift").Return(false)
+
+	svc := setupWorkloadService(k8s, nil)
+
+	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &v1.PodLogOptions{Container: "details"})
+
+	assert.Equal("Fake Log Entry 1\nFake Log Entry 2", podLogs.Logs)
+}
+
 func TestDuplicatedControllers(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()
@@ -399,6 +438,8 @@ func TestDuplicatedControllers(t *testing.T) {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodsSyncedWithDuplicated(), nil)
+	k8s.On("GetPod", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakePodSyncedWithDeployments(), nil)
+	k8s.On("GetPodLogs", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.Anything).Return(FakePodLogsSyncedWithDeployments(), nil)
 
 	notfound := fmt.Errorf("not found")
 	k8s.On("GetDeployment", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&FakeDuplicatedDeployments()[0], nil)

--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
   - namespaces
   - nodes
   - pods
+  - pods/log
   - services
   - replicationcontrollers
   verbs:
@@ -138,6 +139,7 @@ rules:
   - namespaces
   - nodes
   - pods
+  - pods/log
   - services
   - replicationcontrollers
   verbs:

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
   - namespaces
   - nodes
   - pods
+  - pods/log
   - services
   - replicationcontrollers
   - routes
@@ -151,6 +152,7 @@ rules:
   - namespaces
   - nodes
   - pods
+  - pods/log
   - services
   - replicationcontrollers
   - routes

--- a/doc.go
+++ b/doc.go
@@ -31,9 +31,18 @@ type AppVersionParam struct {
 	Name string `json:"version"`
 }
 
+// swagger:parameters podLogs
+type ContainerParam struct {
+	// The pod container name. Optional for single-container pod. Otherwise required.
+	//
+	// in: query
+	// required: false
+	Name string `json:"container"`
+}
+
 // swagger:parameters istioConfigList  workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard istioConfigCreate istioConfigCreateSubtype namespaceTls
 type NamespaceParam struct {
-	// The namespace id.
+	// The namespace name.
 	//
 	// in: path
 	// required: true
@@ -68,6 +77,15 @@ type ObjectSubtypeParam struct {
 	Name string `json:"object_subtype"`
 }
 
+// swagger:parameters podDetails podLogs
+type PodParam struct {
+	// The pod name.
+	//
+	// in: path
+	// required: true
+	Name string `json:"pod"`
+}
+
 // swagger:parameters serviceDetails serviceMetrics graphService serviceDashboard
 type ServiceParam struct {
 	// The service name.
@@ -75,6 +93,15 @@ type ServiceParam struct {
 	// in: path
 	// required: true
 	Name string `json:"service"`
+}
+
+// swagger:parameters podLogs
+type SinceTimeParam struct {
+	// The start time for fetching logs. UNIX time in seconds. Default is all logs.
+	//
+	// in: query
+	// required: false
+	Name string `json:"sinceTime"`
 }
 
 // swagger:parameters customDashboard

--- a/doc.go
+++ b/doc.go
@@ -40,7 +40,7 @@ type ContainerParam struct {
 	Name string `json:"container"`
 }
 
-// swagger:parameters istioConfigList  workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard istioConfigCreate istioConfigCreateSubtype namespaceTls
+// swagger:parameters istioConfigList  workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard istioConfigCreate istioConfigCreateSubtype namespaceTls podDetails podLogs
 type NamespaceParam struct {
 	// The namespace name.
 	//

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -1,10 +1,15 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/prometheus"
@@ -113,4 +118,72 @@ func WorkloadDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	RespondWithJSON(w, http.StatusOK, dashboard)
+}
+
+// PodDetails is the API handler to fetch all details to be displayed, related to a single pod
+func PodDetails(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	// Get business layer
+	business, err := getBusiness(r)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Pods initialization error: "+err.Error())
+		return
+	}
+	namespace := vars["namespace"]
+	pod := vars["pod"]
+
+	// Fetch and build pod
+	podDetails, err := business.Workload.GetPod(namespace, pod)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			RespondWithError(w, http.StatusNotFound, err.Error())
+		} else {
+			RespondWithError(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, podDetails)
+}
+
+func PodLogs(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	queryParams := r.URL.Query()
+
+	// Get business layer
+	business, err := getBusiness(r)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Pod Logs initialization error: "+err.Error())
+		return
+	}
+	namespace := vars["namespace"]
+	pod := vars["pod"]
+
+	// Get log options
+	podLogOptions := v1.PodLogOptions{Timestamps: true}
+	if container := queryParams.Get("container"); container != "" {
+		podLogOptions.Container = container
+	}
+	if sinceTime := queryParams.Get("sinceTime"); sinceTime != "" {
+		if numTime, err := strconv.ParseInt(sinceTime, 10, 64); err == nil {
+			podLogOptions.SinceTime = &meta_v1.Time{time.Unix(numTime, 0)}
+		} else {
+			RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("Invalid sinceTime [%s]: %v", sinceTime, err))
+			return
+		}
+	}
+
+	// Fetch pod logs
+	podLogs, err := business.Workload.GetPodLogs(namespace, pod, &podLogOptions)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			RespondWithError(w, http.StatusNotFound, err.Error())
+		} else {
+			RespondWithError(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, podLogs)
 }

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -32,6 +32,10 @@ var (
 	emptyGetOptions  = meta_v1.GetOptions{}
 )
 
+type PodLogs struct {
+	Logs string
+}
+
 // IstioClientInterface for mocks (only mocked function are necessary here)
 type IstioClientInterface interface {
 	CreateIstioObject(api, namespace, resourceType, json string) (IstioObject, error)
@@ -55,6 +59,8 @@ type IstioClientInterface interface {
 	GetJobs(namespace string) ([]batch_v1.Job, error)
 	GetNamespace(namespace string) (*v1.Namespace, error)
 	GetNamespaces() ([]v1.Namespace, error)
+	GetPod(namespace, name string) (*v1.Pod, error)
+	GetPodLogs(namespace, name string, opts *v1.PodLogOptions) (*PodLogs, error)
 	GetPods(namespace, labelSelector string) ([]v1.Pod, error)
 	GetProject(project string) (*osv1.Project, error)
 	GetProjects() ([]osv1.Project, error)

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -33,7 +33,7 @@ var (
 )
 
 type PodLogs struct {
-	Logs string
+	Logs string `json:"logs,omitempty"`
 }
 
 // IstioClientInterface for mocks (only mocked function are necessary here)

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -245,22 +245,22 @@ func (in *IstioClient) GetPods(namespace, labelSelector string) ([]v1.Pod, error
 // It returns an error on any problem.
 func (in *IstioClient) GetPod(namespace, name string) (*v1.Pod, error) {
 	if in.k8sCache != nil {
-		pods, err := in.k8sCache.GetPods(namespace)
-		if err != nil {
-			return &v1.Pod{}, err
-		}
-		for _, pod := range pods {
-			if name == pod.Name {
-				return &pod, nil
+		if pods, err := in.k8sCache.GetPods(namespace); err != nil {
+			return nil, err
+		} else {
+			for _, pod := range pods {
+				if name == pod.Name {
+					return &pod, nil
+				}
 			}
+			return nil, NewNotFound(name, "core/v1", "Pod")
 		}
-		return &v1.Pod{}, nil
 	}
 
-	if pod, err := in.k8s.CoreV1().Pods(namespace).Get(name, emptyGetOptions); err == nil {
-		return pod, nil
+	if pod, err := in.k8s.CoreV1().Pods(namespace).Get(name, emptyGetOptions); err != nil {
+		return nil, err
 	} else {
-		return &v1.Pod{}, err
+		return pod, nil
 	}
 }
 

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -1,16 +1,19 @@
 package kubernetes
 
 import (
+	"bytes"
+
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/apps/v1beta2"
 	auth_v1 "k8s.io/api/authorization/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	osappsv1 "github.com/openshift/api/apps/v1"
 	osv1 "github.com/openshift/api/project/v1"
@@ -236,6 +239,45 @@ func (in *IstioClient) GetPods(namespace, labelSelector string) ([]v1.Pod, error
 	} else {
 		return []v1.Pod{}, err
 	}
+}
+
+// GetPod returns the pod definitions for a given pod name.
+// It returns an error on any problem.
+func (in *IstioClient) GetPod(namespace, name string) (*v1.Pod, error) {
+	if in.k8sCache != nil {
+		pods, err := in.k8sCache.GetPods(namespace)
+		if err != nil {
+			return &v1.Pod{}, err
+		}
+		for _, pod := range pods {
+			if name == pod.Name {
+				return &pod, nil
+			}
+		}
+		return &v1.Pod{}, nil
+	}
+
+	if pod, err := in.k8s.CoreV1().Pods(namespace).Get(name, emptyGetOptions); err == nil {
+		return pod, nil
+	} else {
+		return &v1.Pod{}, err
+	}
+}
+
+// GetPod returns the pod definitions for a given pod name.
+// It returns an error on any problem.
+func (in *IstioClient) GetPodLogs(namespace, name string, opts *v1.PodLogOptions) (*PodLogs, error) {
+	req := in.k8s.CoreV1().RESTClient().Get().Namespace(namespace).Name(name).Resource("pods").SubResource("log").VersionedParams(opts, scheme.ParameterCodec)
+
+	readCloser, err := req.Stream()
+	if err != nil {
+		return nil, err
+	}
+
+	defer readCloser.Close()
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(readCloser)
+	return &PodLogs{Logs: buf.String()}, nil
 }
 
 func (in *IstioClient) GetCronJobs(namespace string) ([]batch_v1beta1.CronJob, error) {

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -182,6 +182,16 @@ func (o *K8SClientMock) GetPods(namespace, labelSelector string) ([]v1.Pod, erro
 	return args.Get(0).([]v1.Pod), args.Error(1)
 }
 
+func (o *K8SClientMock) GetPod(namespace, name string) (*v1.Pod, error) {
+	args := o.Called(namespace, name)
+	return args.Get(0).(*v1.Pod), args.Error(1)
+}
+
+func (o *K8SClientMock) GetPodLogs(namespace, name string, opts *v1.PodLogOptions) (*kubernetes.PodLogs, error) {
+	args := o.Called(namespace, name, opts)
+	return args.Get(0).(*kubernetes.PodLogs), args.Error(1)
+}
+
 func (o *K8SClientMock) GetProject(project string) (*osv1.Project, error) {
 	args := o.Called(project)
 	return args.Get(0).(*osv1.Project), args.Error(1)

--- a/models/pod.go
+++ b/models/pod.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/config"
 )
@@ -18,6 +18,7 @@ type Pod struct {
 	Labels              map[string]string `json:"labels"`
 	CreatedAt           string            `json:"createdAt"`
 	CreatedBy           []Reference       `json:"createdBy"`
+	Containers          []*ContainerInfo  `json:"containers"`
 	IstioContainers     []*ContainerInfo  `json:"istioContainers"`
 	IstioInitContainers []*ContainerInfo  `json:"istioInitContainers"`
 	Status              string            `json:"status"`
@@ -60,7 +61,7 @@ type sideCarStatus struct {
 	InitContainers []string `json:"initContainers"`
 }
 
-// ParseDeployment extracts desired information from k8s Pod info
+// ParsePod extracts desired information from k8s Pod info
 func (pod *Pod) Parse(p *v1.Pod) {
 	pod.Name = p.Name
 	pod.Labels = p.Labels
@@ -72,7 +73,8 @@ func (pod *Pod) Parse(p *v1.Pod) {
 		})
 	}
 	conf := config.Get()
-	// ParseDeployment some annotations
+	// ParsePod some annotations
+	istioContainerNames := map[string]bool{}
 	if jSon, ok := p.Annotations[conf.ExternalServices.Istio.IstioSidecarAnnotation]; ok {
 		var scs sideCarStatus
 		err := json.Unmarshal([]byte(jSon), &scs)
@@ -82,14 +84,26 @@ func (pod *Pod) Parse(p *v1.Pod) {
 					Name:  name,
 					Image: lookupImage(name, p.Spec.InitContainers)}
 				pod.IstioInitContainers = append(pod.IstioInitContainers, &container)
+				istioContainerNames[name] = true
 			}
 			for _, name := range scs.Containers {
 				container := ContainerInfo{
 					Name:  name,
 					Image: lookupImage(name, p.Spec.Containers)}
 				pod.IstioContainers = append(pod.IstioContainers, &container)
+				istioContainerNames[name] = true
 			}
 		}
+	}
+	for _, c := range p.Spec.Containers {
+		if istioContainerNames[c.Name] {
+			continue
+		}
+		container := ContainerInfo{
+			Name:  c.Name,
+			Image: c.Image,
+		}
+		pod.Containers = append(pod.Containers, &container)
 	}
 	// Check for custom dashboards annotation
 	if rawRuntimes, ok := p.Annotations["kiali.io/runtimes"]; ok {

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -945,6 +945,48 @@ func NewRoutes() (r *Routes) {
 			handlers.GetJaegerInfo,
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/pods/{pod} pods podDetails
+		// ---
+		// Endpoint to get pod details
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      500: internalError
+		//      404: notFoundError
+		//      200: workloadDetails
+		//
+		{
+			"PodDetails",
+			"GET",
+			"/api/namespaces/{namespace}/pods/{pod}",
+			handlers.PodDetails,
+			true,
+		},
+		// swagger:route GET /namespaces/{namespace}/pods/{pod}/logs pods podLogs
+		// ---
+		// Endpoint to get pod logs
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      500: internalError
+		//      404: notFoundError
+		//      200: workloadDetails
+		//
+		{
+			"PodLogs",
+			"GET",
+			"/api/namespaces/{namespace}/pods/{pod}/logs",
+			handlers.PodLogs,
+			true,
+		},
 	}
 
 	return

--- a/swagger.json
+++ b/swagger.json
@@ -1652,6 +1652,14 @@
           {
             "type": "string",
             "x-go-name": "Name",
+            "description": "The namespace name.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
             "description": "The pod name.",
             "name": "pod",
             "in": "path",
@@ -1692,6 +1700,14 @@
             "description": "The pod container name. Optional for single-container pod. Otherwise required.",
             "name": "container",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace name.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
           },
           {
             "type": "string",

--- a/swagger.json
+++ b/swagger.json
@@ -340,7 +340,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -449,7 +449,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -542,7 +542,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -584,7 +584,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -629,7 +629,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -745,7 +745,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -930,7 +930,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1123,7 +1123,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1157,7 +1157,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1206,7 +1206,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1263,7 +1263,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1326,7 +1326,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1386,7 +1386,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1451,7 +1451,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1506,7 +1506,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1558,7 +1558,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1615,7 +1615,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1630,6 +1630,94 @@
           },
           "503": {
             "$ref": "#/responses/serviceUnavailableError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/pods/{pod}": {
+      "get": {
+        "description": "Endpoint to get pod details",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "pods"
+        ],
+        "operationId": "podDetails",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The pod name.",
+            "name": "pod",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/workloadDetails"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/namespaces/{namespace}/pods/{pod}/logs": {
+      "get": {
+        "description": "Endpoint to get pod logs",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "pods"
+        ],
+        "operationId": "podLogs",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The pod container name. Optional for single-container pod. Otherwise required.",
+            "name": "container",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The pod name.",
+            "name": "pod",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The start time for fetching logs. UNIX time in seconds. Default is all logs.",
+            "name": "sinceTime",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/workloadDetails"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
           }
         }
       }
@@ -1652,7 +1740,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1686,7 +1774,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1731,7 +1819,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -1856,7 +1944,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -2009,7 +2097,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -2149,7 +2237,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -2186,7 +2274,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -2220,7 +2308,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -2265,7 +2353,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -2390,7 +2478,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -2551,7 +2639,7 @@
           {
             "type": "string",
             "x-go-name": "Name",
-            "description": "The namespace id.",
+            "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
             "required": true
@@ -3748,6 +3836,13 @@
         "appLabel": {
           "type": "boolean",
           "x-go-name": "AppLabel"
+        },
+        "containers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContainerInfo"
+          },
+          "x-go-name": "Containers"
         },
         "createdAt": {
           "type": "string",


### PR DESCRIPTION
Starting with a draft PR for this potential feature for dislaying pod logs via the Kiali console.  This is the initial server-side support, adding REST API endpoints for both Pod details and Pod logs.

@jotak If you'd like to take a look or give it a try please do so.  @jmazzitelli , @mwringe, Also take a look if you'd like to test/review/provide feedback.  I'll add you all as reviewers but feel free to take your name off if you're not interested in the draft PR.

*** REQUIRES UI PR: https://github.com/kiali/kiali-ui/pull/1101

** TODO create an upstream PR to change the helm chart for pods/log permission addition

