### PR TITLE
KIALI-2312 Security policy appender return 0 values also

### DIFF
--- a/graph/appender/security_policy.go
+++ b/graph/appender/security_policy.go
@@ -162,9 +162,7 @@ func applySecurityPolicy(trafficMap graph.TrafficMap, securityPolicyMap map[stri
 						other += rate
 					}
 				}
-				if percentMtls := mtls / (mtls + other) * 100; percentMtls > 0 {
-					e.Metadata["isMTLS"] = percentMtls
-				}
+				e.Metadata["isMTLS"] = mtls / (mtls + other) * 100
 			}
 		}
 	}


### PR DESCRIPTION
** Describe the change **
In the frontend we need to differentiate between non-loaded edges or edges with 0% of mtls traffic.
If we don't have that, then we see this effect in the graph when enabling security layer:

![Screen recording (12)](https://user-images.githubusercontent.com/613814/55399164-a541bb00-554a-11e9-815d-e0c8b43ced9e.gif)

After this change, the effect is the following:
![Screen recording (13)](https://user-images.githubusercontent.com/613814/55399264-ef2aa100-554a-11e9-91c7-b77ac337ec43.gif)

Front-end PR:
https://github.com/kiali/kiali-ui/pull/1089

** Issue reference **
https://issues.jboss.org/browse/KIALI-2312