### PR TITLE
 KIALI-2638 Add Handlers and Instances to IstioConfig

### DIFF
--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -45,13 +45,19 @@ rules:
   - watch
 - apiGroups: ["config.istio.io"]
   resources:
+  - adapters
   - apikeys
+  - bypasses
   - authorizations
   - checknothings
   - circonuses
+  - cloudwatches
   - deniers
+  - dogstatsds
+  - edges
   - fluentds
   - handlers
+  - instances
   - kubernetesenvs
   - kuberneteses
   - listcheckers
@@ -59,20 +65,23 @@ rules:
   - logentries
   - memquotas
   - metrics
+  - noops
   - opas
   - prometheuses
   - quotas
   - quotaspecbindings
   - quotaspecs
   - rbacs
+  - redisquotas
   - reportnothings
   - rules
-  - servicecontrolreports
-  - servicecontrols
+  - signalfxs
   - solarwindses
   - stackdrivers
   - statsds
   - stdios
+  - tracespans
+  - zipkins
   verbs:
   - create
   - delete
@@ -170,13 +179,19 @@ rules:
   - watch
 - apiGroups: ["config.istio.io"]
   resources:
+  - adapters
   - apikeys
+  - bypasses
   - authorizations
   - checknothings
   - circonuses
+  - cloudwatches
   - deniers
+  - dogstatsds
+  - edges
   - fluentds
   - handlers
+  - instances
   - kubernetesenvs
   - kuberneteses
   - listcheckers
@@ -184,20 +199,23 @@ rules:
   - logentries
   - memquotas
   - metrics
+  - noops
   - opas
   - prometheuses
   - quotas
   - quotaspecbindings
   - quotaspecs
   - rbacs
+  - redisquotas
   - reportnothings
   - rules
-  - servicecontrolreports
-  - servicecontrols
+  - signalfxs
   - solarwindses
   - stackdrivers
   - statsds
   - stdios
+  - tracespans
+  - zipkins
   verbs:
   - get
   - list

--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -80,6 +80,7 @@ rules:
   - stackdrivers
   - statsds
   - stdios
+  - templates
   - tracespans
   - zipkins
   verbs:
@@ -214,6 +215,7 @@ rules:
   - stackdrivers
   - statsds
   - stdios
+  - templates
   - tracespans
   - zipkins
   verbs:

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -81,6 +81,7 @@ rules:
   - stackdrivers
   - statsds
   - stdios
+  - templates
   - tracespans
   - zipkins
   verbs:
@@ -228,6 +229,7 @@ rules:
   - stackdrivers
   - statsds
   - stdios
+  - templates
   - tracespans
   - zipkins
   verbs:

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -46,13 +46,19 @@ rules:
   - watch
 - apiGroups: ["config.istio.io"]
   resources:
+  - adapters
   - apikeys
+  - bypasses
   - authorizations
   - checknothings
   - circonuses
+  - cloudwatches
   - deniers
+  - dogstatsds
+  - edges
   - fluentds
   - handlers
+  - instances
   - kubernetesenvs
   - kuberneteses
   - listcheckers
@@ -60,20 +66,23 @@ rules:
   - logentries
   - memquotas
   - metrics
+  - noops
   - opas
   - prometheuses
   - quotas
   - quotaspecbindings
   - quotaspecs
   - rbacs
+  - redisquotas
   - reportnothings
   - rules
-  - servicecontrolreports
-  - servicecontrols
+  - signalfxs
   - solarwindses
   - stackdrivers
   - statsds
   - stdios
+  - tracespans
+  - zipkins
   verbs:
   - create
   - delete
@@ -184,13 +193,19 @@ rules:
   - watch
 - apiGroups: ["config.istio.io"]
   resources:
+  - adapters
   - apikeys
+  - bypasses
   - authorizations
   - checknothings
   - circonuses
+  - cloudwatches
   - deniers
+  - dogstatsds
+  - edges
   - fluentds
   - handlers
+  - instances
   - kubernetesenvs
   - kuberneteses
   - listcheckers
@@ -198,20 +213,23 @@ rules:
   - logentries
   - memquotas
   - metrics
+  - noops
   - opas
   - prometheuses
   - quotas
   - quotaspecbindings
   - quotaspecs
   - rbacs
+  - redisquotas
   - reportnothings
   - rules
-  - servicecontrolreports
-  - servicecontrols
+  - signalfxs
   - solarwindses
   - stackdrivers
   - statsds
   - stdios
+  - tracespans
+  - zipkins
   verbs:
   - get
   - list

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -217,6 +217,10 @@ const (
 	reportnothingType     = "reportnothing"
 	reportnothingTypeList = "reportnothingList"
 
+	templates        = "templates"
+	templateType     = "template"
+	templateTypeList = "templateList"
+
 	tracespans        = "tracespans"
 	tracespanType     = "tracespan"
 	tracespanTypeList = "tracespanList"
@@ -447,6 +451,10 @@ var (
 			collectionKind: reportnothingTypeList,
 		},
 		{
+			objectKind:     templateType,
+			collectionKind: templateTypeList,
+		},
+		{
 			objectKind:     tracespanType,
 			collectionKind: tracespanTypeList,
 		},
@@ -514,6 +522,7 @@ var (
 		metricType:        metrics,
 		quotaType:         quotas,
 		reportnothingType: reportnothings,
+		templateType:      templates,
 		tracespanType:     tracespans,
 	}
 
@@ -565,6 +574,7 @@ var (
 		metrics:        metricType,
 		quotas:         quotaType,
 		reportnothings: reportnothingType,
+		templates:      templateType,
 		tracespans:     tracespanType,
 
 		// Policies

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -79,18 +79,33 @@ const (
 
 	// Config - Adapters
 
+	adapters        = "adapters"
+	adapterType     = "adapter"
+	adapterTypeList = "adapterList"
+
+	bypasses       = "bypasses"
+	bypassType     = "bypass"
+	bypassTypeList = "bypassList"
+
 	circonuses       = "circonuses"
 	circonusType     = "circonus"
 	circonusTypeList = "circonusList"
+
+	cloudwatches       = "cloudwatches"
+	cloudwatchType     = "cloudwatch"
+	cloudwatchTypeList = "cloudwatchList"
 
 	deniers        = "deniers"
 	denierType     = "denier"
 	denierTypeList = "denierList"
 
+	dogstatsds        = "dogstatsds"
+	dogstatsdType     = "dogstatsd"
+	dogstatsdTypeList = "dogstatsdList"
+
 	fluentds        = "fluentds"
 	fluentdType     = "fluentd"
 	fluentdTypeList = "fluentdList"
-	fluentdLabel    = "fluentd"
 
 	handlers        = "handlers"
 	handlerType     = "handler"
@@ -108,6 +123,10 @@ const (
 	memquotaType     = "memquota"
 	memquotaTypeList = "memquotaList"
 
+	noops        = "noops"
+	noopType     = "noop"
+	noopTypeList = "noopList"
+
 	opas        = "opas"
 	opaType     = "opa"
 	opaTypeList = "opaList"
@@ -120,9 +139,17 @@ const (
 	rbacType     = "rbac"
 	rbacTypeList = "rbacList"
 
+	redisquotas        = "redisquotas"
+	redisquotaType     = "redisquota"
+	redisquotaTypeList = "redisquotaList"
+
 	servicecontrols        = "servicecontrols"
 	servicecontrolType     = "servicecontrol"
 	servicecontrolTypeList = "servicecontrolList"
+
+	signalfxs        = "signalfxs"
+	signalfxType     = "signalfx"
+	signalfxTypeList = "signalfxList"
 
 	solarwindses       = "solarwindses"
 	solarwindsType     = "solarwinds"
@@ -140,6 +167,10 @@ const (
 	stdioType     = "stdio"
 	stdioTypeList = "stdioList"
 
+	zipkins        = "zipkins"
+	zipkinType     = "zipkin"
+	zipkinTypeList = "zipkinList"
+
 	// Config - Templates
 
 	apikeys        = "apikeys"
@@ -153,6 +184,14 @@ const (
 	checknothings        = "checknothings"
 	checknothingType     = "checknothing"
 	checknothingTypeList = "checknothingList"
+
+	edges        = "edges"
+	edgeType     = "edge"
+	edgeTypeList = "edgeList"
+
+	instances        = "instances"
+	instanceType     = "instance"
+	instanceTypeList = "instanceList"
 
 	kuberneteses       = "kuberneteses"
 	kubernetesType     = "kubernetes"
@@ -178,9 +217,9 @@ const (
 	reportnothingType     = "reportnothing"
 	reportnothingTypeList = "reportnothingList"
 
-	servicecontrolreports        = "servicecontrolreports"
-	servicecontrolreportType     = "servicecontrolreport"
-	servicecontrolreportTypeList = "servicecontrolreportList"
+	tracespans        = "tracespans"
+	tracespanType     = "tracespan"
+	tracespanTypeList = "tracespanList"
 )
 
 var (
@@ -270,12 +309,28 @@ var (
 		collectionKind string
 	}{
 		{
+			objectKind:     adapterType,
+			collectionKind: adapterTypeList,
+		},
+		{
+			objectKind:     bypassType,
+			collectionKind: bypassTypeList,
+		},
+		{
 			objectKind:     circonusType,
 			collectionKind: circonusTypeList,
 		},
 		{
+			objectKind:     cloudwatchType,
+			collectionKind: cloudwatchTypeList,
+		},
+		{
 			objectKind:     denierType,
 			collectionKind: denierTypeList,
+		},
+		{
+			objectKind:     dogstatsdType,
+			collectionKind: dogstatsdTypeList,
 		},
 		{
 			objectKind:     fluentdType,
@@ -298,6 +353,10 @@ var (
 			collectionKind: memquotaTypeList,
 		},
 		{
+			objectKind:     noopType,
+			collectionKind: noopTypeList,
+		},
+		{
 			objectKind:     opaType,
 			collectionKind: opaTypeList,
 		},
@@ -310,8 +369,12 @@ var (
 			collectionKind: rbacTypeList,
 		},
 		{
-			objectKind:     servicecontrolType,
-			collectionKind: servicecontrolTypeList,
+			objectKind:     redisquotaType,
+			collectionKind: redisquotaTypeList,
+		},
+		{
+			objectKind:     signalfxType,
+			collectionKind: signalfxTypeList,
 		},
 		{
 			objectKind:     solarwindsType,
@@ -328,6 +391,10 @@ var (
 		{
 			objectKind:     stdioType,
 			collectionKind: stdioTypeList,
+		},
+		{
+			objectKind:     zipkinType,
+			collectionKind: zipkinTypeList,
 		},
 	}
 
@@ -348,8 +415,16 @@ var (
 			collectionKind: checknothingTypeList,
 		},
 		{
+			objectKind:     edgeType,
+			collectionKind: edgeTypeList,
+		},
+		{
 			objectKind:     kubernetesType,
 			collectionKind: kubernetesTypeList,
+		},
+		{
+			objectKind:     instanceType,
+			collectionKind: instanceTypeList,
 		},
 		{
 			objectKind:     listEntryType,
@@ -372,8 +447,8 @@ var (
 			collectionKind: reportnothingTypeList,
 		},
 		{
-			objectKind:     servicecontrolreportType,
-			collectionKind: servicecontrolreportTypeList,
+			objectKind:     tracespanType,
+			collectionKind: tracespanTypeList,
 		},
 	}
 
@@ -403,34 +478,43 @@ var (
 	// Used for fetch istio actions details, so only applied to handlers (adapters) and instances (templates) types
 	// It should be one entry per adapter/template
 	adapterPlurals = map[string]string{
-		circonusType:       circonuses,
-		denierType:         deniers,
-		fluentdType:        fluentds,
-		handlerType:        handlers,
-		kubernetesenvType:  kubernetesenvs,
-		listcheckerType:    listcheckers,
-		memquotaType:       memquotas,
-		opaType:            opas,
-		prometheusType:     prometheuses,
-		rbacType:           rbacs,
-		servicecontrolType: servicecontrols,
-		solarwindsType:     solarwindses,
-		stackdriverType:    stackdrivers,
-		statsdType:         statsds,
-		stdioType:          stdios,
+		adapterType:       adapters,
+		bypassType:        bypasses,
+		circonusType:      circonuses,
+		cloudwatchType:    cloudwatches,
+		denierType:        deniers,
+		dogstatsdType:     dogstatsds,
+		fluentdType:       fluentds,
+		handlerType:       handlers,
+		kubernetesenvType: kubernetesenvs,
+		listcheckerType:   listcheckers,
+		memquotaType:      memquotas,
+		noopType:          noops,
+		opaType:           opas,
+		prometheusType:    prometheuses,
+		rbacType:          rbacs,
+		redisquotaType:    redisquotas,
+		signalfxType:      signalfxs,
+		solarwindsType:    solarwindses,
+		stackdriverType:   stackdrivers,
+		statsdType:        statsds,
+		stdioType:         stdios,
+		zipkinType:        zipkins,
 	}
 
 	templatePlurals = map[string]string{
-		apikeyType:               apikeys,
-		authorizationType:        authorizations,
-		checknothingType:         checknothings,
-		kubernetesType:           kuberneteses,
-		listEntryType:            listEntries,
-		logentryType:             logentries,
-		metricType:               metrics,
-		quotaType:                quotas,
-		reportnothingType:        reportnothings,
-		servicecontrolreportType: servicecontrolreports,
+		apikeyType:        apikeys,
+		authorizationType: authorizations,
+		checknothingType:  checknothings,
+		edgeType:          edges,
+		instanceType:      instances,
+		kubernetesType:    kuberneteses,
+		listEntryType:     listEntries,
+		logentryType:      logentries,
+		metricType:        metrics,
+		quotaType:         quotas,
+		reportnothingType: reportnothings,
+		tracespanType:     tracespans,
 	}
 
 	PluralType = map[string]string{
@@ -446,33 +530,42 @@ var (
 		quotaspecbindings: quotaspecbindingType,
 
 		// Adapters
-		circonuses:      circonusType,
-		deniers:         denierType,
-		fluentds:        fluentdType,
-		handlers:        handlerType,
-		kubernetesenvs:  kubernetesenvType,
-		listcheckers:    listcheckerType,
-		memquotas:       memquotaType,
-		opas:            opaType,
-		prometheuses:    prometheusType,
-		rbacs:           rbacType,
-		servicecontrols: servicecontrolType,
-		solarwindses:    solarwindsType,
-		stackdrivers:    stackdriverType,
-		statsds:         statsdType,
-		stdios:          stdioType,
+		adapters:       adapterType,
+		bypasses:       bypassType,
+		circonuses:     circonusType,
+		cloudwatches:   cloudwatchType,
+		deniers:        denierType,
+		dogstatsds:     dogstatsdType,
+		fluentds:       fluentdType,
+		handlers:       handlerType,
+		kubernetesenvs: kubernetesenvType,
+		listcheckers:   listcheckerType,
+		memquotas:      memquotaType,
+		noops:          noopType,
+		opas:           opaType,
+		prometheuses:   prometheusType,
+		rbacs:          rbacType,
+		redisquotas:    redisquotaType,
+		signalfxs:      signalfxType,
+		solarwindses:   solarwindsType,
+		stackdrivers:   stackdriverType,
+		statsds:        statsdType,
+		stdios:         stdioType,
+		zipkins:        zipkinType,
 
 		// Templates
-		apikeys:               apikeyType,
-		authorizations:        authorizationType,
-		checknothings:         checknothingType,
-		kuberneteses:          kubernetesType,
-		listEntries:           listEntryType,
-		logentries:            logentryType,
-		metrics:               metricType,
-		quotas:                quotaType,
-		reportnothings:        reportnothingType,
-		servicecontrolreports: servicecontrolreportType,
+		apikeys:        apikeyType,
+		authorizations: authorizationType,
+		checknothings:  checknothingType,
+		edges:          edgeType,
+		instances:      instanceType,
+		kuberneteses:   kubernetesType,
+		listEntries:    listEntryType,
+		logentries:     logentryType,
+		metrics:        metricType,
+		quotas:         quotaType,
+		reportnothings: reportnothingType,
+		tracespans:     tracespanType,
 
 		// Policies
 		policies:     policyType,


### PR DESCRIPTION
** Describe the change **

Update adapters/templates code to support old CRD way to install/configure adapters (with one CRD per item) or new way with generic "adapter"/"template"/"handler"/"instances" way.

Note, that Istio 1.1 maintains old way, in Istio 1.2 the old CRD will be removed and that will highly simplify the logic as no need to fetch specific CRD code.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2638

** Backwards incompatible? **

Yes, this modifies clusterrole.yaml as usual an it needs updates in upstream and downstream.

cc @gbaufake @jmazzitelli 

Note, this is a preliminar step towards 3scale integration, so now Kiali can proper list and edit external adapters code:

![image](https://user-images.githubusercontent.com/1662329/55420079-7b05f280-5576-11e9-8b4a-0401f6f9669a.png)

