### PR TITLE
Discover Jaeger and Grafana URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -539,6 +539,15 @@ external_services:
     service: VALUE
 ----
 
+|`JAEGER_SERVICE_NAMESPACE`
+|The Kubernetes namespace that holds the Jaeger service. (default is `istio-system`)
+[source,yaml]
+----
+external_services:
+  jaeger:
+    service_namespace: VALUE
+----
+
 |`JAEGER_URL`
 |The URL to the Jaeger service. When not set, Kiali throw an error when the user try request to Jaeger (/api/jaeger).
 [source,yaml]

--- a/config/config.go
+++ b/config/config.go
@@ -53,8 +53,9 @@ const (
 	EnvGrafanaUsername                 = "GRAFANA_USERNAME"
 	EnvGrafanaPassword                 = "GRAFANA_PASSWORD"
 
-	EnvJaegerURL     = "JAEGER_URL"
-	EnvJaegerService = "JAEGER_SERVICE"
+	EnvJaegerURL              = "JAEGER_URL"
+	EnvJaegerService          = "JAEGER_SERVICE"
+	EnvJaegerServiceNamespace = "JAEGER_SERVICE_NAMESPACE"
 
 	EnvLoginTokenSigningKey        = "LOGIN_TOKEN_SIGNING_KEY"
 	EnvLoginTokenExpirationSeconds = "LOGIN_TOKEN_EXPIRATION_SECONDS"
@@ -128,8 +129,9 @@ type GrafanaConfig struct {
 
 // JaegerConfig describes configuration used for jaeger links
 type JaegerConfig struct {
-	URL     string `yaml:"url"`
-	Service string `yaml:"service"`
+	URL              string `yaml:"url"`
+	Service          string `yaml:"service"`
+	ServiceNamespace string `yaml:"service_namespace"`
 }
 
 // IstioConfig describes configuration used for istio links
@@ -250,6 +252,7 @@ func NewConfig() (c *Config) {
 
 	// Jaeger Configuration
 	c.ExternalServices.Jaeger.URL = strings.TrimSpace(getDefaultString(EnvJaegerURL, ""))
+	c.ExternalServices.Jaeger.ServiceNamespace = strings.TrimSpace(getDefaultString(EnvJaegerServiceNamespace, "istio-system"))
 	c.ExternalServices.Jaeger.Service = strings.TrimSpace(getDefaultString(EnvJaegerService, "jaeger-query"))
 
 	// Istio Configuration

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -12,7 +12,7 @@ import (
 	auth_v1 "k8s.io/api/authorization/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -25,6 +25,7 @@ import (
 
 	osappsv1 "github.com/openshift/api/apps/v1"
 	osv1 "github.com/openshift/api/project/v1"
+	osroutesv1 "github.com/openshift/api/route/v1"
 )
 
 var (
@@ -64,6 +65,7 @@ type IstioClientInterface interface {
 	GetQuotaSpecBindings(namespace string) ([]IstioObject, error)
 	GetReplicationControllers(namespace string) ([]v1.ReplicationController, error)
 	GetReplicaSets(namespace string) ([]v1beta2.ReplicaSet, error)
+	GetRoute(namespace string, service string) (*osroutesv1.Route, error)
 	GetSelfSubjectAccessReview(namespace, api, resourceType string, verbs []string) ([]*auth_v1.SelfSubjectAccessReview, error)
 	GetService(namespace string, serviceName string) (*v1.Service, error)
 	GetServices(namespace string, selectorLabels map[string]string) ([]v1.Service, error)

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -14,6 +14,7 @@ import (
 
 	osappsv1 "github.com/openshift/api/apps/v1"
 	osv1 "github.com/openshift/api/project/v1"
+	osroutesv1 "github.com/openshift/api/route/v1"
 )
 
 // GetNamespace fetches and returns the specified namespace definition
@@ -105,6 +106,17 @@ func (in *IstioClient) GetServices(namespace string, selectorLabels map[string]s
 		}
 	}
 	return services, nil
+}
+
+// GetRoute returns the external URL endpoint of a specific service.
+// It returns an error on any problem.
+func (in *IstioClient) GetRoute(namespace, service string) (*osroutesv1.Route, error) {
+	result := &osroutesv1.Route{}
+	err := in.k8s.RESTClient().Get().Prefix("apis", "route.openshift.io", "v1").Namespace(namespace).Resource("routes").SubResource(service).Do().Into(result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // GetDeployment returns the definition of a specific deployment.

--- a/status/discover.go
+++ b/status/discover.go
@@ -1,0 +1,62 @@
+package status
+
+import (
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"io/ioutil"
+)
+
+// The Kiali ServiceAccount token.
+var saToken string
+
+var clientFactory kubernetes.ClientFactory
+
+func DiscoverJaeger() (url string, err error) {
+	if config.Get().ExternalServices.Jaeger.URL != "" {
+		return config.Get().ExternalServices.Jaeger.URL, nil
+	}
+	return discoverUrlService(config.Get().ExternalServices.Jaeger.ServiceNamespace, config.Get().ExternalServices.Jaeger.Service)
+}
+
+func DiscoverGrafana() (url string, err error) {
+	if config.Get().ExternalServices.Grafana.URL != "" {
+		return config.Get().ExternalServices.Grafana.URL, nil
+	}
+	return discoverUrlService(config.Get().ExternalServices.Grafana.ServiceNamespace, config.Get().ExternalServices.Grafana.Service)
+}
+
+func discoverUrlService(ns string, service string) (url string, err error) {
+
+	if saToken == "" {
+		token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+		if err != nil {
+			return "", err
+		}
+		saToken = string(token)
+	}
+
+	if clientFactory == nil {
+		userClientFactory, err := kubernetes.GetClientFactory()
+		if err != nil {
+			return "", err
+		}
+		clientFactory = userClientFactory
+	}
+
+	client, err := clientFactory.GetClient(saToken)
+	if err != nil {
+		return "", err
+	}
+	route, err := client.GetRoute(ns, service)
+	if err != nil {
+		return "", err
+	}
+
+	host := route.Spec.Host
+
+	if route.Spec.TLS != nil {
+		return "https://" + host, nil
+	} else {
+		return "http://" + host, nil
+	}
+}

--- a/status/versions.go
+++ b/status/versions.go
@@ -187,7 +187,7 @@ type p8sResponseVersion struct {
 func jaegerVersion() (*ExternalServiceInfo, error) {
 	product := ExternalServiceInfo{}
 	product.Name = "Jaeger"
-	product.Url = config.Get().ExternalServices.Jaeger.URL
+	product.Url, _ = DiscoverJaeger()
 
 	return &product, nil
 }
@@ -195,7 +195,7 @@ func jaegerVersion() (*ExternalServiceInfo, error) {
 func grafanaVersion() (*ExternalServiceInfo, error) {
 	product := ExternalServiceInfo{}
 	product.Name = "Grafana"
-	product.Url = config.Get().ExternalServices.Grafana.URL
+	product.Url, _ = DiscoverGrafana()
 
 	return &product, nil
 }


### PR DESCRIPTION
AutoDiscover Jaeger and Grafana URL,

Openshift API provide the data that we need in https//127.0.0.1:8443/apis/route.openshift.io/v1/namespaces/istio-system/routes/jaeger-query

```json
{
  "kind": "Route",
  "apiVersion": "route.openshift.io/v1",
  "metadata": {
    "name": "jaeger-query",
    "namespace": "istio-system",
    "selfLink": "/apis/route.openshift.io/v1/namespaces/istio-system/routes/jaeger-query",
    "uid": "17acdd79-3454-11e9-bdca-54e1ad6bad86",
    "resourceVersion": "8016",
    "creationTimestamp": "2019-02-19T14:38:59Z",
    "labels": {
      "app": "jaeger-query",
      "jaeger-infra": "query-service"
    },
    "annotations": {
      "openshift.io/host.generated": "true"
    }
  },
  "spec": {
    "host": "jaeger-query-istio-system.127.0.0.1.nip.io",
    "to": {
      "kind": "Service",
      "name": "jaeger-query",
      "weight": 100
    },
    "port": {
      "targetPort": "jaeger-query"
    },
    "tls": {
      "termination": "edge"
    },
    "wildcardPolicy": "None"
  },
  "status": {
    "ingress": [
      {
        "host": "jaeger-query-istio-system.127.0.0.1.nip.io",
        "routerName": "router",
        "conditions": [
          {
            "type": "Admitted",
            "status": "True",
            "lastTransitionTime": "2019-02-19T14:38:59Z"
          }
        ],
        "wildcardPolicy": "None"
      }
    ]
  }
}
```