### PR TITLE
Enable code coverage for system tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ format:
 			gofmt -w $$gofile; \
 	done
 
+## build-system-test: Building executable for system tests with code coverage enabled
+build-system-test:
+	@echo Building executable for system tests with code coverage enabled
+	go test -c -covermode=count -coverpkg ./...  -o ${GOPATH}/bin/kiali
+
 ## build-test: Run tests and installing test dependencies, excluding third party tests under vendor. Runs `go test -i` internally
 build-test:
 	@echo Building and installing test dependencies to help speed up test runs.

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+// This file is mandatory as otherwise the kiali binary for system tests is not generated correctly.
+import (
+	"flag"
+	"testing"
+)
+
+var systemTest *bool
+
+func init() {
+	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
+}
+
+// Test started when the test binary is started. Only calls main.
+func TestSystem(t *testing.T) {
+	if *systemTest {
+		main()
+	}
+}


### PR DESCRIPTION
** Describe the change **

This commit adds possibility to build kiali which can produce code coverage report even for system tests which run against kiali deployed in OpenShift. Note this does not do anything for code coverage of unit tests.

