### PR TITLE
KIALI-2668 Fixing validations around both ns-wide and mesh-wide mtls

### DIFF
--- a/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
@@ -31,6 +31,29 @@ func TestDRNSWideDisablingTLSPolicyPermissive(t *testing.T) {
 }
 
 // Context: DestinationRule ns-wide disabling mTLS connections
+// Context: Policy ns-wide in permissive mode
+// Context: Does have a MeshPolicy in strict mode
+// It doesn't return any validation
+func TestDRNSWideDisablingTLSPolicyPermissiveMeshStrict(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		Policies: []kubernetes.IstioObject{
+			data.CreateEmptyPolicy("default", "bookinfo", data.CreateMTLSPeers("PERMISSIVE")),
+		},
+		MeshPolicies: []kubernetes.IstioObject{
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+		},
+	}
+
+	testNoDisabledMtlsValidationsFound(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule ns-wide disabling mTLS connections
 // Context: Policy ns-wide in strict mode
 // It returns a policymtlsenabled validation
 func TestDRNSWideDisablingTLSPolicyStrict(t *testing.T) {

--- a/business/checkers/destinationrules/meshwide_mtls_checker.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker.go
@@ -20,7 +20,7 @@ func (m MeshWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 
 	// otherwise, check among MeshPolicies for a rule enabling mesh-wide mTLS
 	for _, mp := range m.MTLSDetails.MeshPolicies {
-		if strictMode := kubernetes.PolicyHasStrictMTLS(mp); strictMode {
+		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
 			return validations, true
 		}
 	}

--- a/business/checkers/destinationrules/meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker_test.go
@@ -9,8 +9,22 @@ import (
 )
 
 // Context: DestinationRule enables mesh-wide mTLS
-// Context: There is one MeshPolicy not enabling mTLS
-// It returns a validation
+// Context: There is no MeshPolicy
+// It doesn't return any validation
+func TestMTLSMeshWideDREnabledWithNoMeshPolicy(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		MeshPolicies: []kubernetes.IstioObject{},
+	}
+
+	testReturnsAValidation(t, destinationRule, mTlsDetails)
+}
+
+// Context: DestinationRule enables mesh-wide mTLS
+// Context: There is one MeshPolicy in PERMISSIVE mode
+// It doesn't return any validation
 func TestMTLSMeshWideDREnabledWithMeshPolicyDisabled(t *testing.T) {
 	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.local"))
@@ -21,11 +35,11 @@ func TestMTLSMeshWideDREnabledWithMeshPolicyDisabled(t *testing.T) {
 		},
 	}
 
-	testReturnsAValidation(t, destinationRule, mTlsDetails)
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
 }
 
 // Context: DestinationRule enables mesh-wide mTLS
-// Context: There is one MeshPolicy enabling mTLS
+// Context: There is one MeshPolicy enabling mTLS in STRICT mode
 // It doesn't return any validation
 func TestMTLSMeshWideDREnabledWithMeshPolicy(t *testing.T) {
 	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
@@ -41,7 +55,7 @@ func TestMTLSMeshWideDREnabledWithMeshPolicy(t *testing.T) {
 }
 
 // Context: DestinationRule enables namespace-wide mTLS
-// Context: There is one MeshPolicy enabling mTLS
+// Context: There is one MeshPolicy enabling mTLS in STRICT mode
 // It doesn't return any validation
 func TestMTLSNamespaceWideDREnabledWithMeshPolicy(t *testing.T) {
 	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
@@ -57,7 +71,7 @@ func TestMTLSNamespaceWideDREnabledWithMeshPolicy(t *testing.T) {
 }
 
 // Context: DestinationRule enables namespace-wide mTLS
-// Context: There is one MeshPolicy not enabling mTLS
+// Context: There is one MeshPolicy enabling mTLS in PERMISSIVE mode
 // It doesn't return any validation
 func TestMTLSNamespaceWideDREnabledWithMeshPolicyDisabled(t *testing.T) {
 	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
@@ -65,7 +79,7 @@ func TestMTLSNamespaceWideDREnabledWithMeshPolicyDisabled(t *testing.T) {
 
 	mTlsDetails := kubernetes.MTLSDetails{
 		MeshPolicies: []kubernetes.IstioObject{
-			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("STRICT")),
+			data.CreateEmptyMeshPolicy("default", data.CreateMTLSPeers("PERMISSIVE")),
 		},
 	}
 


### PR DESCRIPTION
** Describe the change **

Scenarios fixed:

Scenario 1. 
MeshPolicy that uses PERMISSIVE mode + DestinationRule enabling mTLS traffic.
Problem: DR rule shows validation error: 'MeshPolicy enabling mTLS is missing'.
Expected: No validations shown for that DR.
Explanation: Permissive mode allows all kinds of traffic, mTLS included.

Scenario 2.
MeshPolicy in STRICT mode + DestinationRule enabling mTLS mesh-wide (classic scenario)
Policy ns-level in PERMISSIVE mode + DR disabling mTLS ns-wide.
Problem: DR rule shows validation error: MeshPolicy in strict mode has found, should be permissive.
Expected: No validations shown for that DR.
Explanation: ns-level Policy in PERMISSIVE mode allows disabled mtls connections.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2668

