### PR TITLE
KIALI-2497 Add secretMissing flag to /api/auth/info endpoint

### DIFF
--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -27,6 +27,7 @@ type AuthInfo struct {
 	Strategy              string      `json:"strategy"`
 	AuthorizationEndpoint string      `json:"authorizationEndpoint,omitempty"`
 	SessionInfo           sessionInfo `json:"sessionInfo"`
+	SecretMissing         bool        `json:"secretMissing,omitempty"`
 }
 
 type sessionInfo struct {
@@ -360,6 +361,10 @@ func AuthenticationInfo(w http.ResponseWriter, r *http.Request) {
 		}
 
 		response.AuthorizationEndpoint = metadata.AuthorizationEndpoint
+	case config.AuthStrategyLogin:
+		if conf.Server.Credentials.Username == "" && conf.Server.Credentials.Passphrase == "" {
+			response.SecretMissing = true
+		}
 	}
 
 	token := getTokenStringFromRequest(r)


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2497

The endpoint will set the flag if the secret is missing when auth_strategy is the regular login method.
This will allow the front-end to show a warning or an error to the user.

Related front-end PR: https://github.com/kiali/kiali-ui/pull/1105