### PR TITLE
KIALI-2671: Update endpoints for OpenShift 4

### DIFF
--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -20,6 +20,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments
@@ -168,6 +173,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments


### PR DESCRIPTION
** Describe the change **

Some of the endpoints we were using have now changed in OpenShift 4. This updates to use the newer endpoints.

They updates also work in OpenShift 3, so it should still continue to work for using currently on OpenShift 3. This change doesn't affect people running on kubernetes.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2671