### PR TITLE
KIALI-2497 Fix update of secret config

### DIFF
--- a/kiali.go
+++ b/kiali.go
@@ -148,8 +148,10 @@ func waitForSecret() {
 		}
 	}()
 	secret := <-foundSecretChan
-	config.Get().Server.Credentials.Username = secret.Username
-	config.Get().Server.Credentials.Passphrase = secret.Passphrase
+	cfg := config.Get()
+	cfg.Server.Credentials.Username = secret.Username
+	cfg.Server.Credentials.Passphrase = secret.Passphrase
+	config.Set(cfg)
 }
 
 func waitForTermination() {


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2497 (follow-up)

config.Get() is now returning a copy of the config. It cannot be updated anymore by setting fields directly.

To update the config, the full config must be get, then update the fields and, finally, re-set the config.
