### PR TITLE
Kiali 2698 reduce server debug logging

### DIFF
--- a/graph/appender/response_time.go
+++ b/graph/appender/response_time.go
@@ -57,7 +57,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 		log.Warningf("Replacing invalid quantile [%.2f] with default [%.2f]", a.Quantile, DefaultQuantile)
 		quantile = DefaultQuantile
 	}
-	log.Debugf("Generating responseTime using quantile [%.2f]; namespace = %v", quantile, namespace)
+	log.Tracef("Generating responseTime using quantile [%.2f]; namespace = %v", quantile, namespace)
 	duration := a.Namespaces[namespace].Duration
 
 	// create map to quickly look up responseTime

--- a/graph/appender/security_policy.go
+++ b/graph/appender/security_policy.go
@@ -51,7 +51,7 @@ func (a SecurityPolicyAppender) AppendGraph(trafficMap graph.TrafficMap, globalI
 }
 
 func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespace string, client *prometheus.Client) {
-	log.Debugf("Resolving security policy for namespace = %v", namespace)
+	log.Tracef("Resolving security policy for namespace = %v", namespace)
 	duration := a.Namespaces[namespace].Duration
 
 	// query prometheus for mutual_tls info in two queries (use dest telemetry because it reports the security policy):

--- a/graph/appender/unused_node.go
+++ b/graph/appender/unused_node.go
@@ -64,7 +64,7 @@ func (a UnusedNodeAppender) buildUnusedTrafficMap(trafficMap graph.TrafficMap, n
 		id, nodeType := graph.Id("", "", namespace, w.Name, app, version, a.GraphType)
 		if _, found := trafficMap[id]; !found {
 			if _, found = unusedTrafficMap[id]; !found {
-				log.Debugf("Adding unused node for workload [%s] with labels [%v]", w.Name, labels)
+				log.Tracef("Adding unused node for workload [%s] with labels [%v]", w.Name, labels)
 				node := graph.NewNodeExplicit(id, namespace, w.Name, app, version, "", nodeType, a.GraphType)
 				// note: we don't know what the protocol really should be, http is most common, it's a dead edge anyway
 				node.Metadata = map[string]interface{}{"httpIn": 0.0, "httpOut": 0.0, "isUnused": true}

--- a/graph/appender/util.go
+++ b/graph/appender/util.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
-	"github.com/prometheus/client_golang/api/prometheus/v1"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
 
@@ -20,7 +20,7 @@ func promQuery(query string, queryTime time.Time, api v1.API, a Appender) model.
 
 	// wrap with a round() to be in line with metrics api
 	query = fmt.Sprintf("round(%s,0.001)", query)
-	log.Debugf("Appender query:\n%s&time=%v (now=%v, %v)\n", query, queryTime.Format(graph.TF), time.Now().Format(graph.TF), queryTime.Unix())
+	log.Tracef("Appender query:\n%s&time=%v (now=%v, %v)\n", query, queryTime.Format(graph.TF), time.Now().Format(graph.TF), queryTime.Unix())
 
 	promtimer := internalmetrics.GetPrometheusProcessingTimePrometheusTimer("Graph-Appender-" + a.Name())
 	value, err := api.Query(ctx, query, queryTime)

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -38,7 +38,7 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/prometheus/client_golang/api/prometheus/v1"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
 	"github.com/kiali/kiali/config"
@@ -90,12 +90,12 @@ func buildNamespacesTrafficMap(o options.Options, client *prometheus.Client, glo
 		graph.Error(fmt.Sprintf("Vendor [%s] not supported", o.Vendor))
 	}
 
-	log.Debugf("Build [%s] graph for [%v] namespaces [%s]", o.GraphType, len(o.Namespaces), o.Namespaces)
+	log.Tracef("Build [%s] graph for [%v] namespaces [%s]", o.GraphType, len(o.Namespaces), o.Namespaces)
 
 	trafficMap := graph.NewTrafficMap()
 
 	for _, namespace := range o.Namespaces {
-		log.Debugf("Build traffic map for namespace [%s]", namespace)
+		log.Tracef("Build traffic map for namespace [%s]", namespace)
 		namespaceTrafficMap := buildNamespaceTrafficMap(namespace.Name, o, client)
 		namespaceInfo := appender.NewNamespaceInfo(namespace.Name)
 		for _, a := range o.Appenders {
@@ -243,7 +243,7 @@ func reduceToServiceGraph(trafficMap graph.TrafficMap) graph.TrafficMap {
 					if e.Dest.NodeType == graph.NodeTypeService {
 						serviceEdges = append(serviceEdges, e)
 					} else {
-						log.Debugf("Service graph ignoring non-service root destination [%s]", e.Dest.Workload)
+						log.Tracef("Service graph ignoring non-service root destination [%s]", e.Dest.Workload)
 					}
 				}
 				n.Edges = serviceEdges
@@ -262,7 +262,7 @@ func reduceToServiceGraph(trafficMap graph.TrafficMap) graph.TrafficMap {
 			for _, serviceEdge := range workload.Edges {
 				// As above, ignore edges to non-service destinations
 				if serviceEdge.Dest.NodeType != graph.NodeTypeService {
-					log.Debugf("Service graph ignoring non-service destination [%s]", serviceEdge.Dest.Workload)
+					log.Tracef("Service graph ignoring non-service destination [%s]", serviceEdge.Dest.Workload)
 					continue
 				}
 				childService := serviceEdge.Dest
@@ -656,7 +656,7 @@ func graphNode(w http.ResponseWriter, r *http.Request, client *prometheus.Client
 
 	n := graph.NewNode(o.NodeOptions.Namespace, o.NodeOptions.Service, o.NodeOptions.Namespace, o.NodeOptions.Workload, o.NodeOptions.App, o.NodeOptions.Version, o.GraphType)
 
-	log.Debugf("Build graph for node [%+v]", n)
+	log.Tracef("Build graph for node [%+v]", n)
 
 	trafficMap := buildNodeTrafficMap(o.NodeOptions.Namespace, n, o, client)
 
@@ -914,7 +914,7 @@ func buildNodeTrafficMap(namespace string, n graph.Node, o options.Options, clie
 }
 
 func generateGraph(trafficMap graph.TrafficMap, w http.ResponseWriter, o options.Options) {
-	log.Debugf("Generating config for [%s] service graph...", o.Vendor)
+	log.Tracef("Generating config for [%s] service graph...", o.Vendor)
 
 	promtimer := internalmetrics.GetGraphMarshalTimePrometheusTimer(o.GetGraphKind(), o.GraphType, o.InjectServiceNodes)
 	defer promtimer.ObserveDuration()
@@ -927,7 +927,7 @@ func generateGraph(trafficMap graph.TrafficMap, w http.ResponseWriter, o options
 		graph.Error(fmt.Sprintf("Vendor [%s] not supported", o.Vendor))
 	}
 
-	log.Debugf("Done generating config for [%s] service graph.", o.Vendor)
+	log.Tracef("Done generating config for [%s] service graph.", o.Vendor)
 	RespondWithJSONIndent(w, http.StatusOK, vendorConfig)
 }
 
@@ -941,7 +941,7 @@ func promQuery(query string, queryTime time.Time, api v1.API) model.Vector {
 
 	// wrap with a round() to be in line with metrics api
 	query = fmt.Sprintf("round(%s,0.001)", query)
-	log.Debugf("Graph query:\n%s@time=%v (now=%v, %v)\n", query, queryTime.Format(graph.TF), time.Now().Format(graph.TF), queryTime.Unix())
+	log.Tracef("Graph query:\n%s@time=%v (now=%v, %v)\n", query, queryTime.Format(graph.TF), time.Now().Format(graph.TF), queryTime.Unix())
 
 	promtimer := internalmetrics.GetPrometheusProcessingTimePrometheusTimer("Graph-Generation")
 	value, err := api.Query(ctx, query, queryTime)

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -128,12 +128,11 @@ func extractBaseMetricsQueryParams(queryParams url.Values, q *prometheus.BaseMet
 		log.Debugf("[extractMetricsQueryParams] Interval set to: %v", q.RateInterval)
 	}
 	// If needed, adjust query start time (bound to namespace creation time)
-	log.Debugf("[extractMetricsQueryParams] Requested query start time: %v", q.Start)
 	intervalDuration := q.End.Sub(intervalStartTime)
 	allowedStart := namespaceInfo.CreationTimestamp.Add(intervalDuration)
 	if q.Start.Before(allowedStart) {
+		log.Debugf("[extractMetricsQueryParams] Requested query start time [%v] set to allowed time [%v]", q.Start, allowedStart)
 		q.Start = allowedStart
-		log.Debugf("[extractMetricsQueryParams] Query start time set to: %v", q.Start)
 
 		if q.Start.After(q.End) {
 			// This means that the query range does not fall in the range


### PR DESCRIPTION
Even debug logging can be voluminous due to the auto-refreshing aspects of the UI.  Make some change to protect against spamming logs.
