### PR TITLE
push kiali image to both docker and quay. operator just goes to quay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ GO_VERSION_KIALI = 1.8.3
 CONTAINER_NAME ?= kiali/kiali
 CONTAINER_VERSION ?= dev
 
+# These two vars allow Jenkins to override values.
 DOCKER_NAME ?= ${CONTAINER_NAME}
 QUAY_NAME ?= quay.io/${CONTAINER_NAME}
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION ?= v0.19.0-SNAPSHOT
 COMMIT_HASH ?= $(shell git rev-parse HEAD)
 
 # Indicates which version of the UI console is to be embedded
-# in the docker image. If "local" the CONSOLE_LOCAL_DIR is
+# in the container image. If "local" the CONSOLE_LOCAL_DIR is
 # where the UI project has been git cloned and has its
 # content built in its build/ subdirectory.
 # WARNING: If you have previously run the 'docker' target but
@@ -25,10 +25,12 @@ VERSION_LABEL ?= ${VERSION}
 # The minimum Go version that must be used to build the app.
 GO_VERSION_KIALI = 1.8.3
 
-# Identifies the docker image that will be built and deployed.
-DOCKER_NAME ?= kiali/kiali
-DOCKER_VERSION ?= dev
-DOCKER_TAG = ${DOCKER_NAME}:${DOCKER_VERSION}
+# Identifies the container image that will be built and deployed.
+CONTAINER_NAME ?= kiali/kiali
+CONTAINER_VERSION ?= dev
+CONTAINER_TAG = ${CONTAINER_NAME}:${CONTAINER_VERSION}
+DOCKER_TAG = ${CONTAINER_TAG}
+QUAY_TAG = quay.io/${CONTAINER_TAG}
 
 # Declares the namespace where the objects are to be deployed.
 # For OpenShift, this is the name of the project.
@@ -179,22 +181,23 @@ swagger-travis: swagger-validate
 
 .prepare-docker-image-files:
 	@CONSOLE_VERSION=${CONSOLE_VERSION} CONSOLE_LOCAL_DIR=${CONSOLE_LOCAL_DIR} deploy/get-console.sh
-	@echo Preparing docker image files...
+	@echo Preparing container image files...
 	@mkdir -p _output/docker
 	@cp -r deploy/docker/* _output/docker
 	@cp ${GOPATH}/bin/kiali _output/docker
 
-## docker-build-kiali: Build Kiali docker image into local docker daemon. Runs `docker build` internally
+## docker-build-kiali: Build Kiali container image into local docker daemon.
 docker-build-kiali: .prepare-docker-image-files
-	@echo Building docker image for Kiali into local docker daemon...
+	@echo Building container image for Kiali into local docker daemon...
 	docker build -t ${DOCKER_TAG} _output/docker
+	docker tag ${DOCKER_TAG} ${QUAY_TAG}
 
-## docker-build-operator: Build Kiali operator docker image into local docker daemon. Runs `docker build` internally
+## docker-build-operator: Build Kiali operator container image into local docker daemon.
 docker-build-operator:
-	@echo Building docker image for Kiali operator into local docker daemon...
-	OPERATOR_IMAGE_VERSION=${DOCKER_VERSION} $(MAKE) -C operator operator-build
+	@echo Building container image for Kiali operator into local docker daemon...
+	OPERATOR_IMAGE_VERSION=${CONTAINER_VERSION} $(MAKE) -C operator operator-build
 
-## docker-build: Build Kiali and Kiali operator docker images into local docker daemon.
+## docker-build: Build Kiali and Kiali operator container images into local docker daemon.
 docker-build: docker-build-kiali docker-build-operator
 
 .prepare-minikube:
@@ -208,26 +211,29 @@ docker-build: docker-build-kiali docker-build-operator
 		echo "/etc/hosts should have kiali so you can access the ingress"; \
 	fi
 
-## minikube-docker: Build docker image into minikube docker daemon. Runs `docker build` internally
+## minikube-docker: Build container image into minikube docker daemon.
 minikube-docker: .prepare-minikube .prepare-docker-image-files
-	@echo Building docker image into minikube docker daemon...
+	@echo Building container image into minikube docker daemon...
 	@eval $$(minikube docker-env) ; \
 	docker build -t ${DOCKER_TAG} _output/docker
-	OPERATOR_IMAGE_VERSION=${DOCKER_VERSION} $(MAKE) -C operator operator-build
+	docker tag ${DOCKER_TAG} ${QUAY_TAG}
+	OPERATOR_IMAGE_VERSION=${CONTAINER_VERSION} $(MAKE) -C operator operator-build
 
-docker-push-operator:
-	OPERATOR_IMAGE_VERSION=${DOCKER_VERSION} $(MAKE) -C operator operator-push
+container-push-operator:
+	OPERATOR_IMAGE_VERSION=${CONTAINER_VERSION} $(MAKE) -C operator operator-push
 
-docker-push-kiali:
-	@echo Pushing current docker image to ${DOCKER_TAG}
+container-push-kiali:
+	@echo Pushing current image to ${QUAY_TAG}
+	docker push ${QUAY_TAG}
+	@echo Pushing current image to ${DOCKER_TAG}
 	docker push ${DOCKER_TAG}
 
-## docker-push: Pushing current docker images to ${DOCKER_TAG}. Runs `docker push` internally
-docker-push: docker-push-kiali
+## container-push: Pushes current container images to remote container repos.
+container-push: container-push-kiali container-push-operator
 
 ## operator-create: Delgates to the operator-create target of the operator Makefile
 operator-create: docker-build-operator
-	OPERATOR_IMAGE_VERSION=${DOCKER_VERSION} $(MAKE) -C operator operator-create
+	OPERATOR_IMAGE_VERSION=${CONTAINER_VERSION} $(MAKE) -C operator operator-create
 
 .ensure-oc-exists:
 	@$(eval OC ?= $(shell which istiooc 2>/dev/null || which oc 2>/dev/null || which kubectl))
@@ -241,11 +247,11 @@ operator-create: docker-build-operator
 
 ## openshift-deploy: Delgates to the kiali-create target of the operator Makefile
 openshift-deploy: openshift-undeploy
-	IMAGE_VERSION=${DOCKER_VERSION} $(MAKE) -C operator kiali-create
+	IMAGE_VERSION=${CONTAINER_VERSION} $(MAKE) -C operator kiali-create
 
 ## openshift-undeploy: Delgates to the kiali-delete target of the operator Makefile
 openshift-undeploy: .ensure-operator-is-running
-	IMAGE_VERSION=${DOCKER_VERSION} $(MAKE) -C operator kiali-delete
+	IMAGE_VERSION=${CONTAINER_VERSION} $(MAKE) -C operator kiali-delete
 
 ## k8s-deploy: Delgates to the kiali-create target of the operator Makefile
 k8s-deploy: openshift-deploy

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,12 @@ GO_VERSION_KIALI = 1.8.3
 # Identifies the container image that will be built and deployed.
 CONTAINER_NAME ?= kiali/kiali
 CONTAINER_VERSION ?= dev
-CONTAINER_TAG = ${CONTAINER_NAME}:${CONTAINER_VERSION}
-DOCKER_TAG = ${CONTAINER_TAG}
-QUAY_TAG = quay.io/${CONTAINER_TAG}
+
+DOCKER_NAME ?= ${CONTAINER_NAME}
+QUAY_NAME ?= quay.io/${CONTAINER_NAME}
+
+DOCKER_TAG = ${DOCKER_NAME}:${CONTAINER_VERSION}
+QUAY_TAG = ${QUAY_NAME}:${CONTAINER_VERSION}
 
 # Declares the namespace where the objects are to be deployed.
 # For OpenShift, this is the name of the project.

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -36,6 +36,11 @@ properties([
       trim: true,
       description: 'The name of the Quay repository to push the release'),
     string(
+      name: 'QUAY_OPERATOR_NAME',
+      defaultValue: 'quay.io/kiali/kiali-operator',
+      trim: true,
+      description: 'The name of the Quay repository to push the operator release'),
+    string(
       name: 'BACKEND_PULL_URI',
       defaultValue: 'https://api.github.com/repos/kiali/kiali/pulls',
       trim: true,

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -31,6 +31,11 @@ properties([
       trim: true,
       description: 'The name of the Docker repository to push the release'),
     string(
+      name: 'QUAY_NAME',
+      defaultValue: 'quay.io/kiali/kiali',
+      trim: true,
+      description: 'The name of the Quay repository to push the release'),
+    string(
       name: 'BACKEND_PULL_URI',
       defaultValue: 'https://api.github.com/repos/kiali/kiali/pulls',
       trim: true,
@@ -65,6 +70,7 @@ node('kiali-build') {
   def (backendMakefile, uiMakefile) = ['deploy/jenkins-ci/Makefile', 'Makefile.jenkins']
   def buildUi = params.SKIP_UI_RELEASE != "y"
   def dockerTag = ""
+  def quayTag = ""
 
   try {
     cleanWs()
@@ -149,10 +155,11 @@ node('kiali-build') {
         }
       }
 
-      stage('Release Kiali to DockerHub') {
-        withCredentials([usernamePassword(credentialsId: 'kiali-docker', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USER')]) {
+      stage('Release Kiali to Container Repositories') {
+        withCredentials([usernamePassword(credentialsId: 'kiali-docker', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USER'), usernamePassword(credentialsId: 'kiali-quay', passwordVariable: 'QUAY_PASSWORD', usernameVariable: 'QUAY_USER')]) {
           sh "make -f ${backendMakefile} -C ${backendDir} backend-push-docker"
           dockerTag = sh(returnStdout: true, script: "sed -rn 's/^VERSION \\?= v(.*)/v\\1/p' ${backendDir}/Makefile").trim()
+          quayTag = sh(returnStdout: true, script: "sed -rn 's/^VERSION \\?= v(.*)/v\\1/p' ${backendDir}/Makefile").trim()
         }
       }
 
@@ -173,7 +180,9 @@ node('kiali-build') {
              parameters: [
                [$class: 'StringParameterValue', value: 'minor', name: 'RELEASE_TYPE'],
                [$class: 'StringParameterValue', value: "${params.DOCKER_NAME}", name: 'DOCKER_NAME'],
+               [$class: 'StringParameterValue', value: "${params.QUAY_NAME}", name: 'QUAY_NAME'],
                [$class: 'StringParameterValue', value: dockerTag, name: 'DOCKER_TAG']
+               [$class: 'StringParameterValue', value: quayTag, name: 'QUAY_TAG']
              ], wait: false
            )
        }

--- a/deploy/jenkins-ci/Makefile
+++ b/deploy/jenkins-ci/Makefile
@@ -144,6 +144,7 @@ endif
 	CONTAINER_VERSION="$(VERSION_TAG)" \
 	  CONSOLE_VERSION="$(CONSOLE_VERSION)" \
 	  CONSOLE_LOCAL_DIR="$(CONSOLE_LOCAL_DIR)" \
+	  OPERATOR_IMAGE_NAME="$(QUAY_OPERATOR_NAME)" \
 	  make docker-build docker-push
 ifneq ($(IS_SNAPSHOT),y)
    # docker.io
@@ -157,6 +158,7 @@ ifneq ($(IS_SNAPSHOT),y)
 endif
 	docker rmi "$(DOCKER_NAME):$(VERSION_TAG)"
 	docker rmi "$(QUAY_NAME):$(VERSION_TAG)"
+	docker rmi "$(QUAY_OPERATOR_NAME):$(VERSION_TAG)"
 
 backend-push-version-tag:
 ifeq ($(PUSH_GITHUB_TAG),y)

--- a/deploy/jenkins-ci/Makefile
+++ b/deploy/jenkins-ci/Makefile
@@ -65,7 +65,8 @@ BUILD_TAG ?= prepare-next-version
 BUMP_BRANCH_ID ?= $(BUILD_TAG)
 
 DOCKER_NAME ?= docker.io/kiali/kiali
-
+QUAY_NAME ?= quay.io/kiali/kiali
+QUAY_OPERATOR_NAME ?= quay.io/kiali/kiali-operator
 
 ifeq ($(RELEASE_TYPE_IS_SNAPSHOT_OR_EDGE),y)
   IS_SNAPSHOT ?= y
@@ -134,16 +135,28 @@ ifdef DOCKER_PASSWORD
 	@docker login -u "$(DOCKER_USER)" -p "$(DOCKER_PASSWORD)" docker.io
 endif
 endif
-	DOCKER_VERSION="$(VERSION_TAG)" \
+ifdef QUAY_USER
+ifdef QUAY_PASSWORD
+	@echo "Logging in to Quay.io..."
+	@docker login -u "$(QUAY_USER)" -p "$(QUAY_PASSWORD)" quay.io
+endif
+endif
+	CONTAINER_VERSION="$(VERSION_TAG)" \
 	  CONSOLE_VERSION="$(CONSOLE_VERSION)" \
 	  CONSOLE_LOCAL_DIR="$(CONSOLE_LOCAL_DIR)" \
 	  make docker-build docker-push
 ifneq ($(IS_SNAPSHOT),y)
+   # docker.io
 	docker tag "$(DOCKER_NAME):$(VERSION_TAG)" "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"
 	docker push "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"
 	docker rmi "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"
+   # quay.io
+	docker tag "$(QUAY_NAME):$(VERSION_TAG)" "$(QUAY_NAME):v$(BACKEND_VERSION_BRANCH)"
+	docker push "$(QUAY_NAME):v$(BACKEND_VERSION_BRANCH)"
+	docker rmi "$(QUAY_NAME):v$(BACKEND_VERSION_BRANCH)"
 endif
 	docker rmi "$(DOCKER_NAME):$(VERSION_TAG)"
+	docker rmi "$(QUAY_NAME):$(VERSION_TAG)"
 
 backend-push-version-tag:
 ifeq ($(PUSH_GITHUB_TAG),y)


### PR DESCRIPTION
@israel-hdez please look this over and see if it makes sense/works.

The one part I'm not sure about is:

```
withCredentials([usernamePassword(credentialsId: 'kiali-docker', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USER'), usernamePassword(credentialsId: 'kiali-quay', passwordVariable: 'QUAY_PASSWORD', usernameVariable: 'QUAY_USER')]) {
          sh "make -f ${backendMakefile} -C ${backendDir} backend-push-docker"
          dockerTag = sh(returnStdout: true, script: "sed -rn 's/^VERSION \\?= v(.*)/v\\1/p' ${backendDir}/Makefile").trim()
          quayTag = sh(returnStdout: true, script: "sed -rn 's/^VERSION \\?= v(.*)/v\\1/p' ${backendDir}/Makefile").trim()
```

Not sure what these dockerTag (and now quayTag) are used for.