### PR TITLE
Fix main Makefile target invocation that was renamed

### DIFF
--- a/deploy/jenkins-ci/Makefile
+++ b/deploy/jenkins-ci/Makefile
@@ -145,7 +145,7 @@ endif
 	  CONSOLE_VERSION="$(CONSOLE_VERSION)" \
 	  CONSOLE_LOCAL_DIR="$(CONSOLE_LOCAL_DIR)" \
 	  OPERATOR_IMAGE_NAME="$(QUAY_OPERATOR_NAME)" \
-	  make docker-build docker-push
+	  make docker-build container-push
 ifneq ($(IS_SNAPSHOT),y)
    # docker.io
 	docker tag "$(DOCKER_NAME):$(VERSION_TAG)" "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"


### PR DESCRIPTION
In main makefile, `docker-push` was renamed to `container-push`.
Fixing this in Jenkins Makefile.