### PR TITLE
KIALI-2723 [operator] be able to configure the service's type

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -13,6 +13,7 @@ CREDENTIALS_PASSPHRASE ?= admin
 IMAGE_VERSION ?= dev
 NAMESPACE ?= istio-system
 VERBOSE_MODE ?= 3
+SERVICE_TYPE ?= NodePort
 
 # Find the client executable (either istiooc or oc or kubectl)
 OC ?= $(shell which istiooc 2>/dev/null || which oc 2>/dev/null || which kubectl 2>/dev/null || echo "MISSING-OC/KUBECTL-FROM-PATH")
@@ -102,6 +103,7 @@ AUTH_STRATEGY="${AUTH_STRATEGY}" \
 IMAGE_VERSION=${IMAGE_VERSION} \
 NAMESPACE="${NAMESPACE}" \
 VERBOSE_MODE="${VERBOSE_MODE}" \
+SERVICE_TYPE="${SERVICE_TYPE}" \
 envsubst | ${OC} apply -n ${OPERATOR_NAMESPACE} -f -
 
 ## kiali-delete: Remove a Kiali CR from the cluster, informing the Kiali operator to uninstall Kiali.

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -46,6 +46,10 @@ spec:
 #  ---
 #  deployment:
 #
+# Determines which Kiali image to download and install.
+#    ---
+#    image_name: "kiali/kiali"
+#
 # The Kubernetes pull policy for the Kiali deployment.
 # This is overridden to be "Always" if image_version is set to "latest".
 #    ---
@@ -59,10 +63,6 @@ spec:
 #    ---
 #    image_version: "lastrelease"
 #
-# Determines which Kiali image to download and install.
-#    ---
-#    image_name: "kiali/kiali"
-#
 # The namespace into which Kiali is to be installed.
 #    ---
 #    namespace: "istio-system"
@@ -72,6 +72,11 @@ spec:
 # Only used when auth_strategy is "login".
 #    ---
 #    secret_name: "kiali"
+#
+# The Kiali service type. Kubernetes determines what values are valid.
+# Common values are "NodePort", "ClusterIP", and "LoadBalancer".
+#    ---
+#    service_type: "NodePort"
 #
 # Determines which priority levels of log messages Kiali will output.
 # Typical values are "3" for INFO and higher priority, "4" for DEBUG and higher priority.

--- a/operator/deploy/kiali/kiali_cr_dev.yaml
+++ b/operator/deploy/kiali/kiali_cr_dev.yaml
@@ -8,4 +8,5 @@ spec:
   deployment:
     image_version: $IMAGE_VERSION
     namespace: $NAMESPACE
+    service_type: $SERVICE_TYPE
     verbose_mode: $VERBOSE_MODE

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -28,6 +28,7 @@ kiali_defaults:
     image_version: "lastrelease"
     namespace: "istio-system"
     secret_name: "kiali"
+    service_type: "NodePort"
     verbose_mode: "3"
     version_label: ""
     view_only_mode: false

--- a/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
 spec:
-  type: NodePort
+  type: {{ kiali_vars.deployment.service_type }}
   ports:
   - name: tcp
     protocol: TCP

--- a/operator/roles/kiali-deploy/templates/openshift/service.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/service.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
 spec:
-  type: NodePort
+  type: {{ kiali_vars.deployment.service_type }}
   ports:
   - name: tcp
     protocol: TCP


### PR DESCRIPTION
This is so users can indicate if service type should be ClusterIP or LoadBalancer. Default is NodePort.

This is now in the Kiali CR's deployment section. For developers, you can pass this into the operator's make target with the SERVICE_TYPE env var:

```
cd operator
SERVICE_TYPE=ClusterIP make kiali-create
```

The top level Makefile's k8s-deploy (and the openshift-deploy) delegate to this operator Makefile, so this works:

`SERVICE_TYPE=ClusterIP make k8s-delpoy`


See issue #621 