### PR TITLE
KIALI-2689 Support OAuth logout in OpenShift 4

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/version"
 	kube "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -89,6 +90,7 @@ type IstioClientInterface interface {
 	GetServiceRoles(namespace string) ([]IstioObject, error)
 	GetServiceRoleBinding(namespace string, name string) (IstioObject, error)
 	GetServiceRoleBindings(namespace string) ([]IstioObject, error)
+	GetServerVersion() (*version.Info, error)
 	GetVirtualService(namespace string, virtualservice string) (IstioObject, error)
 	GetVirtualServices(namespace string, serviceName string) ([]IstioObject, error)
 	IsOpenShift() bool

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -14,6 +14,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -26,6 +27,11 @@ func (in *IstioClient) GetNamespace(namespace string) (*core_v1.Namespace, error
 	}
 
 	return ns, nil
+}
+
+// GetServerVersion fetches and returns information about the version Kubernetes that is running
+func (in *IstioClient) GetServerVersion() (*version.Info, error) {
+	return in.k8s.Discovery().ServerVersion()
 }
 
 // GetNamespaces returns a list of all namespaces of the cluster.

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -12,6 +12,8 @@ import (
 	batch_apps_v1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/rest"
 
 	"github.com/kiali/kiali/kubernetes"
 )
@@ -20,7 +22,8 @@ import (
 
 type K8SClientFactoryMock struct {
 	mock.Mock
-	k8s kubernetes.IstioClientInterface
+	baseIstioConfig *rest.Config
+	k8s             kubernetes.IstioClientInterface
 }
 
 // Constructor
@@ -352,6 +355,11 @@ func (o *K8SClientMock) GetAuthorizationDetails(namespace string) (*kubernetes.R
 func (o *K8SClientMock) IsOpenShift() bool {
 	args := o.Called()
 	return args.Get(0).(bool)
+}
+
+func (o *K8SClientMock) GetServerVersion() (*version.Info, error) {
+	args := o.Called()
+	return args.Get(0).(*version.Info), args.Error(1)
 }
 
 func (o *K8SClientMock) Stop() {


### PR DESCRIPTION
** Describe the change **

Adds in additional logout information needed when running on OpenShift 4. On OpenShift 4 we need to go to a logout page and include a specific redirect url to be used. On OpenShift 3 this not needed.

It will also delete the OpenShift token in the k8s backend so that it is marked as being invalid by OpenShift.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2689

** Backwards incompatible? **

Yes, it will continue to work the same with OpenShift 3 and OpenShift 4. It will not affect what is happening when running in Kubernetes.