### PR TITLE
Upgrade requirement defined by operator-sdk prerequisites go version v1.10+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-- 1.9.4
+- 1.11
 
 notifications:
   irc:

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ gometalinter-install:
 
 ## lint: Runs gometalinter
 lint:
-	gometalinter --disable-all  --enable=vet --tests  --vendor ./...
+	gometalinter --debug --disable-all  --enable=vet --tests  --vendor ./...
 
 ## lint-all: Runs gometalinter with items from good to have list but does not run during travis
 lint-all:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CONSOLE_LOCAL_DIR ?= ../../../../../kiali-ui
 VERSION_LABEL ?= ${VERSION}
 
 # The minimum Go version that must be used to build the app.
-GO_VERSION_KIALI = 1.8.3
+GO_VERSION_KIALI = 1.10.1
 
 # Identifies the container image that will be built and deployed.
 CONTAINER_NAME ?= kiali/kiali


### PR DESCRIPTION
For install the operator-sdk we need go in version 1.10+ , the output errors in makefile have not sense and the solution is upgrade the go version.

https://github.com/operator-framework/operator-sdk

cc @jmazzitelli 