### PR TITLE
changes for the v0.18.1 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ GO_VERSION_KIALI = 1.8.3
 CONTAINER_NAME ?= kiali/kiali
 CONTAINER_VERSION ?= dev
 
+# These two vars allow Jenkins to override values.
 DOCKER_NAME ?= ${CONTAINER_NAME}
 QUAY_NAME ?= quay.io/${CONTAINER_NAME}
 

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ container-push-kiali:
 ## container-push: Pushes current container images to remote container repos.
 container-push: container-push-kiali container-push-operator
 
-## operator-create: Delgates to the operator-create target of the operator Makefile
+## operator-create: Delegates to the operator-create target of the operator Makefile
 operator-create: docker-build-operator
 	OPERATOR_IMAGE_VERSION=${CONTAINER_VERSION} $(MAKE) -C operator operator-create
 
@@ -249,18 +249,18 @@ operator-create: docker-build-operator
 	  echo "The Operator is not running. To start it, run: make operator-create"; exit 1; \
 	fi
 
-## openshift-deploy: Delgates to the kiali-create target of the operator Makefile
+## openshift-deploy: Delegates to the kiali-create target of the operator Makefile
 openshift-deploy: openshift-undeploy
 	IMAGE_VERSION=${CONTAINER_VERSION} $(MAKE) -C operator kiali-create
 
-## openshift-undeploy: Delgates to the kiali-delete target of the operator Makefile
+## openshift-undeploy: Delegates to the kiali-delete target of the operator Makefile
 openshift-undeploy: .ensure-operator-is-running
 	IMAGE_VERSION=${CONTAINER_VERSION} $(MAKE) -C operator kiali-delete
 
-## k8s-deploy: Delgates to the kiali-create target of the operator Makefile
+## k8s-deploy: Delegates to the kiali-create target of the operator Makefile
 k8s-deploy: openshift-deploy
 
-## k8s-undeploy: Delgates to the kiali-delete target of the operator Makefile
+## k8s-undeploy: Delegates to the kiali-delete target of the operator Makefile
 k8s-undeploy: openshift-undeploy
 
 ## openshift-reload-image: Refreshing image in Openshift project.

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,12 @@ GO_VERSION_KIALI = 1.8.3
 # Identifies the container image that will be built and deployed.
 CONTAINER_NAME ?= kiali/kiali
 CONTAINER_VERSION ?= dev
-CONTAINER_TAG = ${CONTAINER_NAME}:${CONTAINER_VERSION}
-DOCKER_TAG = ${CONTAINER_TAG}
-QUAY_TAG = quay.io/${CONTAINER_TAG}
+
+DOCKER_NAME ?= ${CONTAINER_NAME}
+QUAY_NAME ?= quay.io/${CONTAINER_NAME}
+
+DOCKER_TAG = ${DOCKER_NAME}:${CONTAINER_VERSION}
+QUAY_TAG = ${QUAY_NAME}:${CONTAINER_VERSION}
 
 # Declares the namespace where the objects are to be deployed.
 # For OpenShift, this is the name of the project.

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -36,6 +36,11 @@ properties([
       trim: true,
       description: 'The name of the Quay repository to push the release'),
     string(
+      name: 'QUAY_OPERATOR_NAME',
+      defaultValue: 'quay.io/kiali/kiali-operator',
+      trim: true,
+      description: 'The name of the Quay repository to push the operator release'),
+    string(
       name: 'BACKEND_PULL_URI',
       defaultValue: 'https://api.github.com/repos/kiali/kiali/pulls',
       trim: true,

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -186,7 +186,7 @@ node('kiali-build') {
                [$class: 'StringParameterValue', value: 'minor', name: 'RELEASE_TYPE'],
                [$class: 'StringParameterValue', value: "${params.DOCKER_NAME}", name: 'DOCKER_NAME'],
                [$class: 'StringParameterValue', value: "${params.QUAY_NAME}", name: 'QUAY_NAME'],
-               [$class: 'StringParameterValue', value: dockerTag, name: 'DOCKER_TAG']
+               [$class: 'StringParameterValue', value: dockerTag, name: 'DOCKER_TAG'],
                [$class: 'StringParameterValue', value: quayTag, name: 'QUAY_TAG']
              ], wait: false
            )

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -31,6 +31,11 @@ properties([
       trim: true,
       description: 'The name of the Docker repository to push the release'),
     string(
+      name: 'QUAY_NAME',
+      defaultValue: 'quay.io/kiali/kiali',
+      trim: true,
+      description: 'The name of the Quay repository to push the release'),
+    string(
       name: 'BACKEND_PULL_URI',
       defaultValue: 'https://api.github.com/repos/kiali/kiali/pulls',
       trim: true,
@@ -65,6 +70,7 @@ node('kiali-build') {
   def (backendMakefile, uiMakefile) = ['deploy/jenkins-ci/Makefile', 'Makefile.jenkins']
   def buildUi = params.SKIP_UI_RELEASE != "y"
   def dockerTag = ""
+  def quayTag = ""
 
   try {
     cleanWs()
@@ -149,10 +155,11 @@ node('kiali-build') {
         }
       }
 
-      stage('Release Kiali to DockerHub') {
-        withCredentials([usernamePassword(credentialsId: 'kiali-docker', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USER')]) {
+      stage('Release Kiali to Container Repositories') {
+        withCredentials([usernamePassword(credentialsId: 'kiali-docker', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USER'), usernamePassword(credentialsId: 'kiali-quay', passwordVariable: 'QUAY_PASSWORD', usernameVariable: 'QUAY_USER')]) {
           sh "make -f ${backendMakefile} -C ${backendDir} backend-push-docker"
           dockerTag = sh(returnStdout: true, script: "sed -rn 's/^VERSION \\?= v(.*)/v\\1/p' ${backendDir}/Makefile").trim()
+          quayTag = sh(returnStdout: true, script: "sed -rn 's/^VERSION \\?= v(.*)/v\\1/p' ${backendDir}/Makefile").trim()
         }
       }
 
@@ -173,7 +180,9 @@ node('kiali-build') {
              parameters: [
                [$class: 'StringParameterValue', value: 'minor', name: 'RELEASE_TYPE'],
                [$class: 'StringParameterValue', value: "${params.DOCKER_NAME}", name: 'DOCKER_NAME'],
+               [$class: 'StringParameterValue', value: "${params.QUAY_NAME}", name: 'QUAY_NAME'],
                [$class: 'StringParameterValue', value: dockerTag, name: 'DOCKER_TAG']
+               [$class: 'StringParameterValue', value: quayTag, name: 'QUAY_TAG']
              ], wait: false
            )
        }

--- a/deploy/jenkins-ci/Makefile
+++ b/deploy/jenkins-ci/Makefile
@@ -144,6 +144,7 @@ endif
 	CONTAINER_VERSION="$(VERSION_TAG)" \
 	  CONSOLE_VERSION="$(CONSOLE_VERSION)" \
 	  CONSOLE_LOCAL_DIR="$(CONSOLE_LOCAL_DIR)" \
+	  OPERATOR_IMAGE_NAME="$(QUAY_OPERATOR_NAME)" \
 	  make docker-build docker-push
 ifneq ($(IS_SNAPSHOT),y)
    # docker.io
@@ -157,6 +158,7 @@ ifneq ($(IS_SNAPSHOT),y)
 endif
 	docker rmi "$(DOCKER_NAME):$(VERSION_TAG)"
 	docker rmi "$(QUAY_NAME):$(VERSION_TAG)"
+	docker rmi "$(QUAY_OPERATOR_NAME):$(VERSION_TAG)"
 
 backend-push-version-tag:
 ifeq ($(PUSH_GITHUB_TAG),y)

--- a/deploy/jenkins-ci/Makefile
+++ b/deploy/jenkins-ci/Makefile
@@ -65,7 +65,8 @@ BUILD_TAG ?= prepare-next-version
 BUMP_BRANCH_ID ?= $(BUILD_TAG)
 
 DOCKER_NAME ?= docker.io/kiali/kiali
-
+QUAY_NAME ?= quay.io/kiali/kiali
+QUAY_OPERATOR_NAME ?= quay.io/kiali/kiali-operator
 
 ifeq ($(RELEASE_TYPE_IS_SNAPSHOT_OR_EDGE),y)
   IS_SNAPSHOT ?= y
@@ -134,16 +135,28 @@ ifdef DOCKER_PASSWORD
 	@docker login -u "$(DOCKER_USER)" -p "$(DOCKER_PASSWORD)" docker.io
 endif
 endif
-	DOCKER_VERSION="$(VERSION_TAG)" \
+ifdef QUAY_USER
+ifdef QUAY_PASSWORD
+	@echo "Logging in to Quay.io..."
+	@docker login -u "$(QUAY_USER)" -p "$(QUAY_PASSWORD)" quay.io
+endif
+endif
+	CONTAINER_VERSION="$(VERSION_TAG)" \
 	  CONSOLE_VERSION="$(CONSOLE_VERSION)" \
 	  CONSOLE_LOCAL_DIR="$(CONSOLE_LOCAL_DIR)" \
 	  make docker-build docker-push
 ifneq ($(IS_SNAPSHOT),y)
+   # docker.io
 	docker tag "$(DOCKER_NAME):$(VERSION_TAG)" "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"
 	docker push "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"
 	docker rmi "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"
+   # quay.io
+	docker tag "$(QUAY_NAME):$(VERSION_TAG)" "$(QUAY_NAME):v$(BACKEND_VERSION_BRANCH)"
+	docker push "$(QUAY_NAME):v$(BACKEND_VERSION_BRANCH)"
+	docker rmi "$(QUAY_NAME):v$(BACKEND_VERSION_BRANCH)"
 endif
 	docker rmi "$(DOCKER_NAME):$(VERSION_TAG)"
+	docker rmi "$(QUAY_NAME):$(VERSION_TAG)"
 
 backend-push-version-tag:
 ifeq ($(PUSH_GITHUB_TAG),y)

--- a/deploy/jenkins-ci/Makefile
+++ b/deploy/jenkins-ci/Makefile
@@ -145,7 +145,7 @@ endif
 	  CONSOLE_VERSION="$(CONSOLE_VERSION)" \
 	  CONSOLE_LOCAL_DIR="$(CONSOLE_LOCAL_DIR)" \
 	  OPERATOR_IMAGE_NAME="$(QUAY_OPERATOR_NAME)" \
-	  make docker-build docker-push
+	  make docker-build container-push
 ifneq ($(IS_SNAPSHOT),y)
    # docker.io
 	docker tag "$(DOCKER_NAME):$(VERSION_TAG)" "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -12,7 +12,7 @@ CREDENTIALS_USERNAME ?= admin
 CREDENTIALS_PASSPHRASE ?= admin
 IMAGE_VERSION ?= dev
 NAMESPACE ?= istio-system
-VERBOSE_MODE ?= 3
+VERBOSE_MODE ?= 4
 SERVICE_TYPE ?= NodePort
 
 # Find the client executable (either istiooc or oc or kubectl)

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -13,6 +13,7 @@ CREDENTIALS_PASSPHRASE ?= admin
 IMAGE_VERSION ?= dev
 NAMESPACE ?= istio-system
 VERBOSE_MODE ?= 3
+SERVICE_TYPE ?= NodePort
 
 # Find the client executable (either istiooc or oc or kubectl)
 OC ?= $(shell which istiooc 2>/dev/null || which oc 2>/dev/null || which kubectl 2>/dev/null || echo "MISSING-OC/KUBECTL-FROM-PATH")
@@ -102,6 +103,7 @@ AUTH_STRATEGY="${AUTH_STRATEGY}" \
 IMAGE_VERSION=${IMAGE_VERSION} \
 NAMESPACE="${NAMESPACE}" \
 VERBOSE_MODE="${VERBOSE_MODE}" \
+SERVICE_TYPE="${SERVICE_TYPE}" \
 envsubst | ${OC} apply -n ${OPERATOR_NAMESPACE} -f -
 
 ## kiali-delete: Remove a Kiali CR from the cluster, informing the Kiali operator to uninstall Kiali.

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.6.0
+FROM quay.io/operator-framework/ansible-operator:v0.7.0
 
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/

--- a/operator/deploy/deploy-kiali-operator.sh
+++ b/operator/deploy/deploy-kiali-operator.sh
@@ -316,7 +316,7 @@ if [ "${OPERATOR_INSTALL_KIALI}" != "true" ]; then
   echo "An example Kiali CR with all settings documented can be found here:"
   echo "  https://raw.githubusercontent.com/kiali/kiali/${_BRANCH}/operator/deploy/kiali/kiali_cr.yaml"
   echo "To install Kiali with all default settings, you can run:"
-  echo "  ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/kiali/kiali/${_BRANCH}/operator/deploy/kiali/kiali_cr.yaml"
+  echo "  ${CLIENT_EXE} apply -n ${OPERATOR_NAMESPACE} -f https://raw.githubusercontent.com/kiali/kiali/${_BRANCH}/operator/deploy/kiali/kiali_cr.yaml"
   echo "Do not forget to create a secret if you wish to use an auth strategy of 'login' (This is"
   echo "the default setting when installing in Kubernetes but not OpenShift)."
   echo "An example would be:"

--- a/operator/deploy/deploy-kiali-operator.sh
+++ b/operator/deploy/deploy-kiali-operator.sh
@@ -118,8 +118,8 @@
 #    Default: "lastrelease"
 #
 # ISTIO_NAMESPACE
-#    The namespace where Istio is installed.
-#    Default: "istio-system"
+#    The namespace where Istio is installed. If empty, assumes the value of NAMESPACE.
+#    Default: ""
 #
 # JAEGER_URL
 #    The Jaeger URL that Kiali will use when integrating with Jaeger.

--- a/operator/deploy/deploy-kiali-operator.sh
+++ b/operator/deploy/deploy-kiali-operator.sh
@@ -276,12 +276,14 @@ do
 done
 
 # Wait for the operator to start up so we can confirm it is OK.
-for run in {1..10}
+echo -n "Waiting for the operator to start."
+for run in {1..60}
 do
   ${CLIENT_EXE} get pods -l app=kiali-operator -n ${OPERATOR_NAMESPACE} 2>/dev/null | grep "^kiali-operator.*Running" > /dev/null && _OPERATOR_STARTED=true && break
-  echo "Waiting for the operator to start..."
-  sleep 6
+  echo -n "."
+  sleep 5
 done
+echo
 
 if [ -z ${_OPERATOR_STARTED} ]; then
   echo "ERROR: The Kiali Operator is not running yet. Please make sure it was deployed successfully."

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -46,6 +46,10 @@ spec:
 #  ---
 #  deployment:
 #
+# Determines which Kiali image to download and install.
+#    ---
+#    image_name: "kiali/kiali"
+#
 # The Kubernetes pull policy for the Kiali deployment.
 # This is overridden to be "Always" if image_version is set to "latest".
 #    ---
@@ -59,10 +63,6 @@ spec:
 #    ---
 #    image_version: "lastrelease"
 #
-# Determines which Kiali image to download and install.
-#    ---
-#    image_name: "kiali/kiali"
-#
 # The namespace into which Kiali is to be installed.
 #    ---
 #    namespace: "istio-system"
@@ -72,6 +72,11 @@ spec:
 # Only used when auth_strategy is "login".
 #    ---
 #    secret_name: "kiali"
+#
+# The Kiali service type. Kubernetes determines what values are valid.
+# Common values are "NodePort", "ClusterIP", and "LoadBalancer".
+#    ---
+#    service_type: "NodePort"
 #
 # Determines which priority levels of log messages Kiali will output.
 # Typical values are "3" for INFO and higher priority, "4" for DEBUG and higher priority.

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -24,9 +24,10 @@ spec:
 #  installation_tag: ""
 
 ##########
-# The namespace where Istio is installed.
+# The namespace where Istio is installed. If left empty, it is assumed to be the
+# same namespace as where Kiali is installed (i.e. deployment.namespace).
 #    ---
-#  istio_namespace: "istio-system"
+#  istio_namespace: ""
 
 ##########
 #  ---
@@ -41,6 +42,7 @@ spec:
 #      - "kube.*"
 #      - "openshift.*"
 #      - "ibm.*"
+#      - "kiali.*"
 
 ##########
 #  ---
@@ -104,7 +106,7 @@ spec:
 # Determines which priority levels of log messages Kiali will output.
 # Typical values are "3" for INFO and higher priority, "4" for DEBUG and higher priority.
 #    ---
-#    verbose_mode: "3"
+#    verbose_mode: "4"
 #
 # Kiali resources will be assigned a "version" label when they are deployed.
 # This determines what value those "version" labels will have.
@@ -132,7 +134,7 @@ spec:
 # password: Password to be used when making requests to Grafana. User only requires viewer permissions.
 # service: The Kubernetes service name for Grafana. Kiali uses this to connect within the cluster to Grafana.
 # service_dashboard_pattern: Search pattern for Grafana Service dashboard.
-# service_namespace: The Kubernetes namespace that holds the Grafana service.
+# service_namespace: The Kubernetes namespace that holds the Grafana service (if empty, assumes the same value as deployment.namespace)
 # url: The URL that Kiali uses when integrating with Grafana. This URL must be accessible to clients external to
 #      the cluster in order for the integration to work properly. If empty, an attempt to auto-discover it is made.
 # username: Username to be used when making requests to Grafana. User only requires viewer permissions.
@@ -147,7 +149,7 @@ spec:
 #      password: ""
 #      service: "grafana"
 #      service_dashboard_pattern: "Istio%20Service%20Dashboard"
-#      service_namespace: "istio-system"
+#      service_namespace: ""
 #      url: ""
 #      username: ""
 #      var_namespace: "var-namespace"
@@ -159,11 +161,12 @@ spec:
 # istio_identity_domain: The annotation used by Istio to identify domains.
 # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
 # url_service_version: The Istio service used to determine the Istio version.
+#                      If empty, assumes it is in the istio namespace at the URL "http://istio-pilot.<istio_namespace>:8080/version"
 #    ---
 #    istio:
 #      istio_identity_domain: "svc.cluster.local"
 #      istio_sidecar_annotation: "sidecar.istio.io/status"
-#      url_service_version: "http://istio-pilot:8080/version"
+#      url_service_version: ""
 #
 # **Jaeger-specific settings:
 # service: The Kubernetes service name for Jaeger. Kiali uses this to connect within the cluster to Jaeger.
@@ -177,11 +180,13 @@ spec:
 # **Prometheus-specific settings:
 # custom_metrics_url: The URL used to query the Prometheus Server for building the runtime metrics dashboards.
 #                     This URL must be accessible from the Kiali pod.
+#                     If empty, assumes it is in the istio namespace at the URL "http://prometheus.<istio_namespace>:9090"
 # url: The URL used to query the Prometheus Server. This URL must be accessible from the Kiali pod.
+#      If empty, assumes it is in the istio namespace at the URL "http://prometheus.<istio_namespace>:9090"
 #    ---
 #    prometheus:
-#      custom_metrics_url: "http://prometheus.istio-system:9090"
-#      url: "http://prometheus.istio-system:9090"
+#      custom_metrics_url: ""
+#      url: ""
 
 ##########
 #  ---

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -4,6 +4,20 @@ metadata:
   name: kiali
 spec:
 
+###################################################################
+# kiali_cr.yaml
+#
+# This is a fully documented Kiali custom resource yaml file.
+# It can be used to tell the Kiali Operator to install Kiali.
+#
+# This is actually an empty Kiali CR, however, it provides
+# documentation on all available settings.
+# In each documented section, you will see a "---" marker;
+# below that marker you will see the names of the settings along
+# with their default values. If the setting is not defined by
+# default, its name will be prefixed with "#".
+###################################################################
+
 ##########
 # Tag used to identify a particular instance/installation of the Kiali server.
 #    ---
@@ -45,6 +59,15 @@ spec:
 ##########
 #  ---
 #  deployment:
+#
+# Additional custom yaml to add to the service definition. This is used mainly to customize the service type.
+# For example, if the deployment.service_type is set to "LoadBalancer" and you want to set the loadBalancerIP,
+# you can do so here with: additional_service_yaml: { "loadBalancerIP": "78.11.24.19" }.
+# Another example would be if the deployment.service_type is set to "ExternalName" you will need to configure
+# the name via: additional_service_yaml: { "externalName": "my.kiali.example.com" }.
+# A final example would be if external IPs need to be set: additional_service_yaml: { "externalIPs": ["80.11.12.10"] }
+#    ---
+#    #additional_service_yaml:
 #
 # Determines which Kiali image to download and install.
 #    ---

--- a/operator/deploy/kiali/kiali_cr_dev.yaml
+++ b/operator/deploy/kiali/kiali_cr_dev.yaml
@@ -8,4 +8,5 @@ spec:
   deployment:
     image_version: $IMAGE_VERSION
     namespace: $NAMESPACE
+    service_type: $SERVICE_TYPE
     verbose_mode: $VERBOSE_MODE

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -9,7 +9,7 @@
 
 kiali_defaults:
   installation_tag: ""
-  istio_namespace: "istio-system"
+  istio_namespace: ""
 
   api:
     namespaces:
@@ -18,6 +18,7 @@ kiali_defaults:
       - "kube.*"
       - "openshift.*"
       - "ibm.*"
+      - "kiali.*"
 
   auth:
     strategy: ""
@@ -30,7 +31,7 @@ kiali_defaults:
     namespace: "istio-system"
     secret_name: "kiali"
     service_type: "NodePort"
-    verbose_mode: "3"
+    verbose_mode: "4"
     version_label: ""
     view_only_mode: false
 
@@ -41,7 +42,7 @@ kiali_defaults:
       password: ""
       service: "grafana"
       service_dashboard_pattern: "Istio%20Service%20Dashboard"
-      service_namespace: "istio-system"
+      service_namespace: ""
       url: ""
       username: ""
       var_namespace: "var-namespace"
@@ -51,13 +52,13 @@ kiali_defaults:
     istio:
       istio_identity_domain: "svc.cluster.local"
       istio_sidecar_annotation: "sidecar.istio.io/status"
-      url_service_version: "http://istio-pilot:8080/version"
+      url_service_version: ""
     jaeger:
       service: "jaeger-query"
       url: ""
     prometheus:
-      custom_metrics_url: "http://prometheus.istio-system:9090"
-      url: "http://prometheus.istio-system:9090"
+      custom_metrics_url: ""
+      url: ""
 
   identity:
     cert_file: ""

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -28,6 +28,7 @@ kiali_defaults:
     image_version: "lastrelease"
     namespace: "istio-system"
     secret_name: "kiali"
+    service_type: "NodePort"
     verbose_mode: "3"
     version_label: ""
     view_only_mode: false

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -23,6 +23,7 @@ kiali_defaults:
     strategy: ""
 
   deployment:
+    #additional_service_yaml:
     image_name: "kiali/kiali"
     image_pull_policy: "IfNotPresent"
     image_version: "lastrelease"

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -42,7 +42,7 @@
   - kiali_vars.server.web_root == ""
 - name: Make sure web root never ends with a slash
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'server': {'web_root': kiali_server.web_root | regex_replace('\\/$', '')}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'server': {'web_root': kiali_vars.server.web_root | regex_replace('\\/$', '')}}, recursive=True) }}"
   when:
   - kiali_vars.server.web_root != "/"
   - kiali_vars.server.web_root is match(".*/$")

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -35,6 +35,43 @@
     msg: "{{ msg.split('\n') }}"
   tags: test
 
+# We do not want to blindly default to istio-system for some namespaces. If the istio_namespace is not
+# provided, assume it is the same namespace where Kiali is being deployed. Set the other istio namespace
+# values accordingly.
+# We determine the default Istio namespace var first, and the rest will use it for their default as appropriate.
+
+- name: Set default istio namespace
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'istio_namespace': kiali_vars.deployment.namespace}, recursive=True) }}"
+  when:
+  - kiali_vars.istio_namespace == ""
+
+- name: Set default Grafana service namespace
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'service_namespace': kiali_vars.istio_namespace}}}, recursive=True) }}"
+  when:
+  - kiali_vars.external_services.grafana.service_namespace == ""
+
+- name: Set default Istio service that provides version info
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'istio': {'url_service_version': 'http://istio-pilot.' + kiali_vars.istio_namespace + ':8080/version'}}}, recursive=True) }}"
+  when:
+  - kiali_vars.external_services.istio.url_service_version == ""
+
+- name: Set default Prometheus URL
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'prometheus': {'url': 'http://prometheus.' + kiali_vars.istio_namespace + ':9090'}}}, recursive=True) }}"
+  when:
+  - kiali_vars.external_services.prometheus.url == ""
+
+- name: Set default Prometheus Custom Metrics URL
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'prometheus': {'custom_metrics_url': kiali_vars.external_services.prometheus.url}}}, recursive=True) }}"
+  when:
+  - kiali_vars.external_services.prometheus.custom_metrics_url == ""
+
+# Determine some more defaults.
+
 - name: Set default web root based on cluster type
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'server': {'web_root': '/' if is_openshift else '/kiali'}}, recursive=True) }}"

--- a/operator/roles/kiali-deploy/templates/kubernetes/clusterrolebinding.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
   name: {{ 'kiali-viewer' if kiali_vars.deployment.view_only_mode == True else 'kiali' }}
 subjects:
 - kind: ServiceAccount
-  name: kiali
+  name: kiali-service-account
   namespace: {{ kiali_vars.deployment.namespace }}

--- a/operator/roles/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         prometheus.io/port: "{{ kiali_vars.server.metrics_port }}"
         kiali.io/runtimes: go,kiali
     spec:
-      serviceAccount: kiali
+      serviceAccount: kiali-service-account
       containers:
       - image: {{ kiali_vars.deployment.image_name }}:{{ kiali_vars.deployment.image_version }}
         imagePullPolicy: {{ kiali_vars.deployment.image_pull_policy }}

--- a/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
@@ -15,3 +15,4 @@ spec:
   selector:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
+  {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
 spec:
-  type: NodePort
+  type: {{ kiali_vars.deployment.service_type }}
   ports:
   - name: tcp
     protocol: TCP

--- a/operator/roles/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kiali
+  name: kiali-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali

--- a/operator/roles/kiali-deploy/templates/openshift/clusterrolebinding.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
   name: {{ 'kiali-viewer' if kiali_vars.deployment.view_only_mode == True else 'kiali' }}
 subjects:
 - kind: ServiceAccount
-  name: kiali
+  name: kiali-service-account
   namespace: {{ kiali_vars.deployment.namespace }}

--- a/operator/roles/kiali-deploy/templates/openshift/deployment.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         maxAvailable: 1
       type: RollingUpdate
     spec:
-      serviceAccount: kiali
+      serviceAccount: kiali-service-account
       containers:
       - image: {{ kiali_vars.deployment.image_name }}:{{ kiali_vars.deployment.image_version }}
         imagePullPolicy: {{ kiali_vars.deployment.image_pull_policy }}

--- a/operator/roles/kiali-deploy/templates/openshift/service.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/service.yaml
@@ -17,3 +17,4 @@ spec:
   selector:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
+  {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/operator/roles/kiali-deploy/templates/openshift/service.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/service.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
 spec:
-  type: NodePort
+  type: {{ kiali_vars.deployment.service_type }}
   ports:
   - name: tcp
     protocol: TCP

--- a/operator/roles/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kiali
+  name: kiali-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali

--- a/operator/roles/kiali-remove/tasks/main.yml
+++ b/operator/roles/kiali-remove/tasks/main.yml
@@ -67,7 +67,7 @@
   - "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name='kiali', api_version='v1') }}"
   - "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='Service', resource_name='kiali', api_version='v1') }}"
   - "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='CustomResourceDefinition', resource_name='monitoringdashboards.monitoring.kiali.io', api_version='apiextensions.k8s.io/v1beta1') }}"
-  - "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name='kiali', api_version='v1') }}"
+  - "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name='kiali-service-account', api_version='v1') }}"
   - "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='ClusterRoleBinding', resource_name='kiali', api_version='v1beta1') }}"
   - "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
   - "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"


### PR DESCRIPTION
I see nothing in here that would require a new UI build. These really just affect server-side.

The point to this PR and v0.18.1 release is:
1) to get the operator to work on kubernetes
2) to get the operator to pass tests so we can get it into OperatorHub.io (which requires it to run on k8s)
