### PR TITLE
Fix operator role on monitoringdashboards

### DIFF
--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -218,3 +218,4 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+  - list

--- a/operator/roles/kiali-deploy/templates/kubernetes/clusterrole-viewer.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/clusterrole-viewer.yaml
@@ -122,3 +122,4 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+  - list

--- a/operator/roles/kiali-deploy/templates/kubernetes/clusterrole.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/clusterrole.yaml
@@ -134,3 +134,4 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+  - list

--- a/operator/roles/kiali-deploy/templates/openshift/clusterrole-viewer.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/clusterrole-viewer.yaml
@@ -139,3 +139,4 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+  - list

--- a/operator/roles/kiali-deploy/templates/openshift/clusterrole.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/clusterrole.yaml
@@ -151,3 +151,4 @@ rules:
   - monitoringdashboards
   verbs:
   - get
+  - list


### PR DESCRIPTION
The "list" role is missing in operator for monitoringdashboards.
It was necessary for dashboards auto-discovery