### PR TITLE
KIALI-2676 Don't panic when there are no endpoints for a given service

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -6,6 +6,7 @@ import (
 
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/business/checkers"
@@ -257,7 +258,7 @@ func (in *SvcService) getServiceDefinition(namespace, service string) (svc *core
 		defer wg.Done()
 		var err2 error
 		eps, err2 = in.k8s.GetEndpoints(namespace, service)
-		if err2 != nil {
+		if err2 != nil && !errors.IsNotFound(err2) {
 			log.Errorf("Error fetching Endpoints per namespace %s and service %s: %s", namespace, service, err2)
 			errChan <- err2
 		}

--- a/models/service.go
+++ b/models/service.go
@@ -50,6 +50,7 @@ type Service struct {
 	Type            string            `json:"type"`
 	Ip              string            `json:"ip"`
 	Ports           Ports             `json:"ports"`
+	ExternalName    string            `json:"externalName"`
 }
 
 func (ss *Services) Parse(services []core_v1.Service) {
@@ -71,6 +72,7 @@ func (s *Service) Parse(service *core_v1.Service) {
 		s.Labels = service.Labels
 		s.Type = string(service.Spec.Type)
 		s.Ip = service.Spec.ClusterIP
+		s.ExternalName = service.Spec.ExternalName
 		s.CreatedAt = formatTime(service.CreationTimestamp.Time)
 		s.ResourceVersion = service.ResourceVersion
 		(&s.Ports).Parse(service.Spec.Ports)

--- a/swagger.json
+++ b/swagger.json
@@ -4277,6 +4277,10 @@
           "type": "string",
           "x-go-name": "CreatedAt"
         },
+        "externalName": {
+          "type": "string",
+          "x-go-name": "ExternalName"
+        },
         "ip": {
           "type": "string",
           "x-go-name": "Ip"


### PR DESCRIPTION
** Describe the change **

Support ExternalName services. 
Knative creates both ClusterIP and ExternalName services. The last ones don't have endpoints attached to it. Therefore, the API returns a NotFound error.
Also, I found appropiate to add an extra field related to this scenario: ExternalName. It returns the hostname exposed in that Service (type of ExternalName).

PR showing this new field into Service Details page:  https://github.com/kiali/kiali-ui/pull/1134

** Issue reference **
https://issues.jboss.org/browse/KIALI-2676

** Backwards incompatible? **
yes.
