### PR TITLE
to support system tests / code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ format:
 			gofmt -w $$gofile; \
 	done
 
+## build-system-test: Building executable for system tests with code coverage enabled
+build-system-test:
+	@echo Building executable for system tests with code coverage enabled
+	go test -c -covermode=count -coverpkg ./...  -o ${GOPATH}/bin/kiali
+
 ## build-test: Run tests and installing test dependencies, excluding third party tests under vendor. Runs `go test -i` internally
 build-test:
 	@echo Building and installing test dependencies to help speed up test runs.

--- a/deploy/jenkins-ci/deploy-kiali-for-system-tests-code-coverage.sh
+++ b/deploy/jenkins-ci/deploy-kiali-for-system-tests-code-coverage.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+bash <(curl -L https://git.io/getLatestKialiOperator)
+
+echo -n "Waiting for Kiali to start"
+for run in {1..60}
+do
+  oc get pods -l app=kiali -n istio-system 2>/dev/null | grep "^kiali.*Running" > /dev/null && _STARTED=true && break
+  echo -n "."
+  sleep 5
+done
+echo
+
+if [ -z ${_STARTED} ]; then
+  echo "ERROR: Kiali is not running yet. Please make sure it was deployed successfully."
+  exit 1
+else
+  echo "Kiali is running - will now update for system tests/code coverage"
+fi
+
+oc patch deployment kiali -n istio-system --type=json -p='[{"op":"replace","path":"/spec/template/spec/containers/0/command", "value":["/opt/kiali/kiali", "-config", "/kiali-configuration/config.yaml", "-v", "4", "-systemTest", "-test.coverprofile", "/opt/kiali/console/coverage.cov"]}]'
+
+oc delete pods -n istio-system --selector=app=kiali
+
+echo "Kiali is running with system tests/code coverage enabled."

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+// This file is mandatory as otherwise the kiali binary for system tests is not generated correctly.
+import (
+   "flag"
+   "testing"
+)
+
+var systemTest *bool
+
+func init() {
+   systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
+}
+
+// Test started when the test binary is started. Only calls main.
+func TestSystem(t *testing.T) {
+   if *systemTest {
+      main()
+   }
+}


### PR DESCRIPTION
A possible replacement for PR #970 

I have not run the Makefile target or the main_test.go defined here - I simply found them in PR #970 and assumed Jenkins somehow uses them.

But the .sh script I did run with and that did work (even though the pod logged an error because kiali didn't have the systemTests option compiled in it - which I assume is what main_test.go provides)

This is just an example PR. QE can take it and use it, alter it, duplicate it and change it.. whatever is best. I just created this as an example of how we can do this without injecting this systemTest test all throughout the operator.