### PR TITLE
KIALI-2772 Add support for the new gateway annotation format

### DIFF
--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -1,7 +1,6 @@
 package virtual_services
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/kiali/kiali/config"
@@ -40,8 +39,6 @@ func TestFoundGateway(t *testing.T) {
 			data.CreateEmptyGateway("my-gateway", "test", make(map[string]string)),
 		},
 	})
-
-	fmt.Printf("GatewayNames: %v\n", gatewayNames)
 
 	checker := NoGatewayChecker{
 		VirtualService: virtualService,
@@ -84,6 +81,30 @@ func TestFQDNFoundOtherNamespaceGateway(t *testing.T) {
 
 	// virtualService is in "test" namespace
 	virtualService := data.AddGatewaysToVirtualService([]string{"my-gateway.istio-system.svc.cluster.local", "mesh"}, data.CreateVirtualService())
+	gatewayNames := kubernetes.GatewayNames([][]kubernetes.IstioObject{
+		[]kubernetes.IstioObject{
+			data.CreateEmptyGateway("my-gateway", "istio-system", make(map[string]string)),
+		},
+	})
+
+	checker := NoGatewayChecker{
+		VirtualService: virtualService,
+		GatewayNames:   gatewayNames,
+	}
+
+	validations, valid := checker.Check()
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestNewIstioGatewayNameFormat(t *testing.T) {
+	assert := assert.New(t)
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// virtualService is in "test" namespace
+	virtualService := data.AddGatewaysToVirtualService([]string{"istio-system/my-gateway"}, data.CreateVirtualService())
 	gatewayNames := kubernetes.GatewayNames([][]kubernetes.IstioObject{
 		[]kubernetes.IstioObject{
 			data.CreateEmptyGateway("my-gateway", "istio-system", make(map[string]string)),

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -941,6 +941,9 @@ func GatewayNames(gateways [][]IstioObject) map[string]struct{} {
 
 // ValidateVirtualServiceGateways checks all VirtualService gateways (except mesh, which is reserved word) and checks that they're found from the given list of gatewayNames. Also return index of missing gatways to show clearer error path in editor
 func ValidateVirtualServiceGateways(spec map[string]interface{}, gatewayNames map[string]struct{}, namespace, clusterName string) (bool, int) {
+	if clusterName == "" {
+		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
+	}
 	if gatewaysSpec, found := spec["gateways"]; found {
 		if gateways, ok := gatewaysSpec.([]interface{}); ok {
 			for index, g := range gateways {

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -948,7 +948,17 @@ func ValidateVirtualServiceGateways(spec map[string]interface{}, gatewayNames ma
 					if gate == "mesh" {
 						return true, -1
 					}
-					hostname := ParseHost(gate, namespace, clusterName).String()
+					var hostname string
+					if strings.Contains(gate, "/") {
+						parts := strings.Split(gate, "/")
+						hostname = Host{
+							Service:   parts[1],
+							Namespace: parts[0],
+							Cluster:   clusterName,
+						}.String()
+					} else {
+						hostname = ParseHost(gate, namespace, clusterName).String()
+					}
 					for gw := range gatewayNames {
 						if found := FilterByHost(hostname, gw, namespace); found {
 							return true, -1


### PR DESCRIPTION
** Describe the change **

Istio 1.1 has added new format for linking gateway to VS. This is now "namespace/gateway-name". Although the documentation has removed mentions to FQDN, they should still be supported as some (all?) versions of Istio allow them. 

** Issue reference **

KIALI-2772
