### PR TITLE
KIALI-2761 Modify validation service filtering 

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -85,7 +85,7 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 	// Get group validations for same kind istio objects
 	validations := runObjectCheckers(objectCheckers)
 	if service != "" {
-		validations = validations.FilterByKey("service", service)
+		validations = validations.FilterBySingleType("service", service)
 	}
 
 	return validations, nil

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -199,6 +199,23 @@ func CheckMessage(checkId string) string {
 	return checkDescriptors[checkId].Message
 }
 
+func (iv IstioValidations) FilterBySingleType(objectType, name string) IstioValidations {
+	fiv := IstioValidations{}
+	for k, v := range iv {
+		// We don't want to filter other types
+		if k.ObjectType != objectType {
+			fiv[k] = v
+		} else {
+			// But for this exact type we're strict
+			if k.Name == name {
+				fiv[k] = v
+			}
+		}
+	}
+
+	return fiv
+}
+
 func (iv IstioValidations) FilterByKey(objectType, name string) IstioValidations {
 	fiv := IstioValidations{}
 	for k, v := range iv {


### PR DESCRIPTION
** Describe the change **

Previous filtering was too aggressive and it removed validations for other object types as well, instead of only filtering the non-relevant services from the return JSON document. This changes the filtering to filter only the relevant type, not other types.

** Issue reference **

KIALI-2761
