### PR TITLE
KIALI-2677 Assume sidecar exists unless proven otherwise

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -59,12 +59,11 @@ func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
 
 	for keyApp, valueApp := range apps {
 		appItem := &models.AppListItem{Name: keyApp}
-		appItem.IstioSidecar = false
-		if len(valueApp.Workloads) > 0 {
-			appItem.IstioSidecar = true
-		}
+		appItem.IstioSidecar = true
 		for _, w := range valueApp.Workloads {
-			appItem.IstioSidecar = appItem.IstioSidecar && w.Pods.HasIstioSideCar()
+			if appItem.IstioSidecar = w.IstioSidecar; !appItem.IstioSidecar {
+				break
+			}
 		}
 		(*appList).Apps = append((*appList).Apps, *appItem)
 	}
@@ -94,7 +93,7 @@ func (in *AppService) GetApp(namespace string, appName string) (models.App, erro
 	(*appInstance).Workloads = make([]models.WorkloadItem, len(appDetails.Workloads))
 	for i, wkd := range appDetails.Workloads {
 		wkdSvc := &models.WorkloadItem{WorkloadName: wkd.Name}
-		wkdSvc.IstioSidecar = wkd.Pods.HasIstioSideCar()
+		wkdSvc.IstioSidecar = wkd.IstioSidecar
 		(*appInstance).Workloads[i] = *wkdSvc
 	}
 

--- a/business/services.go
+++ b/business/services.go
@@ -88,12 +88,12 @@ func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []core_v
 		/** Check if Service has istioSidecar deployed */
 		mPods := models.Pods{}
 		mPods.Parse(sPods)
-		hasSideCar := mPods.HasIstioSideCar()
+		hasSidecar := mPods.HasIstioSidecar()
 		/** Check if Service has the label app required by Istio */
 		_, appLabel := item.Spec.Selector[conf.IstioLabels.AppLabelName]
 		services[i] = models.ServiceOverview{
 			Name:         item.Name,
-			IstioSidecar: hasSideCar,
+			IstioSidecar: hasSidecar,
 			AppLabel:     appLabel,
 		}
 	}

--- a/models/pod.go
+++ b/models/pod.go
@@ -127,15 +127,19 @@ func lookupImage(containerName string, containers []core_v1.Container) string {
 	return ""
 }
 
-func (pods Pods) HasIstioSideCar() bool {
-	for _, pod := range pods {
-		if pod.HasIstioSideCar() {
-			return true
+// HasIstioSidecar returns true if there are no pods or all pods have a sidecar
+func (pods Pods) HasIstioSidecar() bool {
+	if len(pods) > 0 {
+		for _, p := range pods {
+			if !p.HasIstioSidecar() {
+				return false
+			}
 		}
 	}
-	return false
+	return true
 }
 
-func (pod Pod) HasIstioSideCar() bool {
+// HasIstioSidecar returns true if the pod has an Isio proxy sidecar
+func (pod Pod) HasIstioSidecar() bool {
 	return len(pod.IstioContainers) > 0
 }

--- a/models/service.go
+++ b/models/service.go
@@ -88,7 +88,7 @@ func (s *ServiceDetails) SetEndpoints(eps *core_v1.Endpoints) {
 func (s *ServiceDetails) SetPods(pods []core_v1.Pod) {
 	mPods := Pods{}
 	mPods.Parse(pods)
-	s.IstioSidecar = mPods.HasIstioSideCar()
+	s.IstioSidecar = mPods.HasIstioSidecar()
 }
 
 func (s *ServiceDetails) SetVirtualServices(vs []kubernetes.IstioObject, canCreate, canUpdate, canDelete bool) {


### PR DESCRIPTION
- return true when checking sidecar and there are no pods
- set true when checking apps sidecar and there are no workloads
- defer to Workload.IstioSidecar when possible, at times we were re-calling workload.pods.HasIstioSidecar()
- introduce Workload.HasIstioSidecar()
  - optimize for Deployments where we can assume all pods are the same
- fix case consistency: SideCar -> Sidecar
- some clarity changes in health.go
