### PR TITLE
KIALI-2760 Exclude services with empty selector from workload details page

### DIFF
--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -101,7 +101,7 @@ func (in *IstioClient) GetServices(namespace string, selectorLabels map[string]s
 	var services []core_v1.Service
 	for _, svc := range allServices {
 		svcSelector := labels.Set(svc.Spec.Selector).AsSelector()
-		if svcSelector.Matches(labels.Set(selectorLabels)) {
+		if !svcSelector.Empty() && svcSelector.Matches(labels.Set(selectorLabels)) {
 			services = append(services, svc)
 		}
 	}


### PR DESCRIPTION
** Describe the change **
Prevent workload details page to list services that aren't from its own scope.

Bug:
![Screenshot of Kiali Console (21) (1)](https://user-images.githubusercontent.com/613814/56977456-81878a00-6b75-11e9-9602-7f9aa8baf79f.png)

Solution:
![Screenshot of Kiali Console (28)](https://user-images.githubusercontent.com/613814/56977502-98c67780-6b75-11e9-92a6-3c95f846dc20.png)

** Issue reference **
https://issues.jboss.org/browse/KIALI-2760

** Backwards incompatible? **
yes