### PR TITLE
fix the kiali_cr.yaml file

### DIFF
--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -35,13 +35,14 @@ spec:
 #
 # Allows for controlling what namespaces/projects are returned by Kiali.
 #
-# 'exclude' is optional takes an list of namespace/projects to be excluded from the list 
-# of namespaces provided by the API and UI. Regex is supported. This does not affect 
+# 'exclude' is optional takes an list of namespace/projects to be excluded from the list
+# of namespaces provided by the API and UI. Regex is supported. This does not affect
 # explicit namespace access.
 #
-# 'label_selector' is optional and takes a string value of a Kubernetes label selector which
-# is used when fetching the list of available namespaces. This does not affect explicit namespace
-# access.
+# 'label_selector' is optional and takes a string value of a Kubernetes label selector
+# (e.g. "myLabel=myValue") which is used when fetching the list of available namespaces.
+# This does not affect explicit namespace access.
+#
 #    ---
 #    namespaces:
 #      exclude:
@@ -50,7 +51,7 @@ spec:
 #      - "openshift.*"
 #      - "ibm.*"
 #      - "kiali.*"
-#      label_selector: "myLabel=myValue"
+#      #label_selector:
 
 ##########
 #  ---

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -19,6 +19,7 @@ kiali_defaults:
       - "openshift.*"
       - "ibm.*"
       - "kiali.*"
+      #label_selector:
 
   auth:
     strategy: ""


### PR DESCRIPTION
The kiali_cr.yaml file, though all comments, is a reference document.

The values you see in here are the actual defaults. So people can look up
kiali_cr.yaml and know what the defaults are if the user doesn't set it
(for example, if they use the minimal cr.yaml).

Therefore, this PR is changing the comments in kiali_cr.yaml to fix
the label_selector - the default is not "myLabel=myValue" so this removes
that. The example value is put in the description of the setting which
is where it belongs.

As the top-comment describing this file mentions, "If the setting is not defined by default, its name will be prefixed with "#"" - thus, kiali_cr.yaml will show "#label_selector:" informing the reader that this setting is not set by default.
