### PR TITLE
KIALI-2818 KIALI-2819 Detect cases when we can't validate

### DIFF
--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -11,6 +11,7 @@ const DestinationRuleCheckerType = "destinationrule"
 type DestinationRulesChecker struct {
 	DestinationRules []kubernetes.IstioObject
 	MTLSDetails      kubernetes.MTLSDetails
+	ServiceEntries   []kubernetes.IstioObject
 }
 
 func (in DestinationRulesChecker) Check() models.IstioValidations {
@@ -25,8 +26,10 @@ func (in DestinationRulesChecker) Check() models.IstioValidations {
 func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
+	seHosts := kubernetes.ServiceEntryHostnames(in.ServiceEntries)
+
 	enabledDRCheckers := []GroupChecker{
-		destinationrules.MultiMatchChecker{DestinationRules: in.DestinationRules},
+		destinationrules.MultiMatchChecker{DestinationRules: in.DestinationRules, ServiceEntries: seHosts},
 		destinationrules.TrafficPolicyChecker{DestinationRules: in.DestinationRules, MTLSDetails: in.MTLSDetails},
 	}
 

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -205,3 +205,23 @@ func TestReviewsExample(t *testing.T) {
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
 	assert.Equal(1, len(validation.Checks))
 }
+
+func TestMultiServiceEntry(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	seA := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-a", "test", []string{"api.service_a.com"}))
+	seB := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-b", "test", []string{"api.service_b.com"}))
+
+	drA := data.CreateEmptyDestinationRule("test", "service-a", "api.service_a.com")
+	drB := data.CreateEmptyDestinationRule("test", "service-b", "api.service_b.com")
+
+	validations := MultiMatchChecker{
+		DestinationRules: []kubernetes.IstioObject{drA, drB},
+		ServiceEntries:   kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{seA, seB}),
+	}.Check()
+
+	assert.Empty(validations)
+}

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -8,6 +8,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 )
@@ -94,7 +95,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.nodest.matchingworkload"), validations[0].Message)
+	assert.Equal(models.CheckMessage("destinationrules.nodest.matchingregistry"), validations[0].Message)
 	assert.Equal("spec/host", validations[0].Path)
 }
 
@@ -172,4 +173,46 @@ func fakeServicesReview() []core_v1.Service {
 			},
 		},
 	}
+}
+
+func TestFailCrossNamespaceHost(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := NoDestinationChecker{
+		Namespace: "test-namespace",
+		WorkloadList: data.CreateWorkloadList("test-namespace",
+			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
+			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
+		),
+		Services: fakeServicesReview(),
+		// Intentionally using the same serviceName, but different NS. This shouldn't fail to match the above workloads
+		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews.different-ns.svc.cluster.local"),
+	}.Check()
+
+	assert.True(valid)
+	assert.NotEmpty(validations)
+	assert.Equal(models.Unknown, validations[0].Severity)
+	assert.Equal(models.CheckMessage("validation.unable.cross-namespace"), validations[0].Message)
+	assert.Equal("spec/host", validations[0].Path)
+}
+
+func TestSNIProxyExample(t *testing.T) {
+	// https://istio.io/docs/examples/advanced-gateways/wildcard-egress-hosts/#setup-egress-gateway-with-sni-proxy
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	dr := data.CreateEmptyDestinationRule("test", "disable-mtls-for-sni-proxy", "sni-proxy.local")
+	se := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(8443, "tcp", "TCP"),
+		data.CreateEmptyMeshExternalServiceEntry("sni-proxy", "test", []string{"sni-proxy.local"}))
+
+	validations, valid := NoDestinationChecker{
+		Namespace:       "test",
+		ServiceEntries:  kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{se}),
+		DestinationRule: dr,
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
 }

--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -36,7 +36,7 @@ func (g GatewayChecker) runSingleChecks(gw kubernetes.IstioObject) models.IstioV
 	key, validations := EmptyValidValidation(gw.GetObjectMeta().Name, GatewayCheckerType)
 
 	enabledCheckers := []Checker{
-		gateways.PortChecker{Gateway: gw},
+		// gateways.PortChecker{Gateway: gw},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -35,9 +35,7 @@ func (g GatewayChecker) Check() models.IstioValidations {
 func (g GatewayChecker) runSingleChecks(gw kubernetes.IstioObject) models.IstioValidations {
 	key, validations := EmptyValidValidation(gw.GetObjectMeta().Name, GatewayCheckerType)
 
-	enabledCheckers := []Checker{
-		// gateways.PortChecker{Gateway: gw},
-	}
+	enabledCheckers := []Checker{}
 
 	for _, checker := range enabledCheckers {
 		checks, validChecker := checker.Check()

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -83,7 +83,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.False(customerDr.Valid)
 	assert.Equal(1, len(customerDr.Checks))
 	assert.Equal("spec/host", customerDr.Checks[0].Path)
-	assert.Equal("This host has no matching workloads", customerDr.Checks[0].Message)
+	assert.Equal(models.CheckMessage("destinationrules.nodest.matchingregistry"), customerDr.Checks[0].Message)
 
 	validations = NoServiceChecker{
 		Namespace: "test",

--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -1,7 +1,6 @@
 package checkers
 
 import (
-	"github.com/kiali/kiali/business/checkers/serviceentries"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -26,7 +25,7 @@ func (s ServiceEntryChecker) runSingleChecks(se kubernetes.IstioObject) models.I
 	key, validations := EmptyValidValidation(se.GetObjectMeta().Name, ServiceEntryCheckerType)
 
 	enabledCheckers := []Checker{
-		serviceentries.PortChecker{ServiceEntry: se},
+		// serviceentries.PortChecker{ServiceEntry: se},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -24,9 +24,7 @@ func (s ServiceEntryChecker) Check() models.IstioValidations {
 func (s ServiceEntryChecker) runSingleChecks(se kubernetes.IstioObject) models.IstioValidations {
 	key, validations := EmptyValidValidation(se.GetObjectMeta().Name, ServiceEntryCheckerType)
 
-	enabledCheckers := []Checker{
-		// serviceentries.PortChecker{ServiceEntry: se},
-	}
+	enabledCheckers := []Checker{}
 
 	for _, checker := range enabledCheckers {
 		checks, validChecker := checker.Check()

--- a/business/checkers/virtual_services/no_host_checker_test.go
+++ b/business/checkers/virtual_services/no_host_checker_test.go
@@ -85,7 +85,7 @@ func TestValidServiceEntryHost(t *testing.T) {
 	virtualService := data.CreateVirtualServiceWithServiceEntryTarget()
 
 	validations, valid := NoHostChecker{
-		Namespace:      "test-namespace",
+		Namespace:      "wikipedia",
 		ServiceNames:   []string{"my-wiki-rule"},
 		VirtualService: virtualService,
 	}.Check()
@@ -97,7 +97,7 @@ func TestValidServiceEntryHost(t *testing.T) {
 	serviceEntry := data.CreateExternalServiceEntry()
 
 	validations, valid = NoHostChecker{
-		Namespace:         "test-namespace",
+		Namespace:         "wikipedia",
 		ServiceNames:      []string{"my-wiki-rule"},
 		VirtualService:    virtualService,
 		ServiceEntryHosts: kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{serviceEntry}),

--- a/business/checkers/virtual_services/subset_presence_checker.go
+++ b/business/checkers/virtual_services/subset_presence_checker.go
@@ -109,6 +109,7 @@ func (checker SubsetPresenceChecker) getDestinationRule(virtualServiceHost strin
 			namespace = domainParts[1]
 		}
 
+		// TODO Host could be in another namespace (FQDN)
 		if kubernetes.FilterByHost(virtualServiceHost, serviceName, namespace) {
 			return destinationRule, true
 		}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -101,7 +101,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 	return []ObjectChecker{
 		checkers.NoServiceChecker{Namespace: namespace, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails},
 		checkers.VirtualServiceChecker{Namespace: namespace, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices},
-		checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails},
+		checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace},
 		checkers.MeshPolicyChecker{MeshPolicies: mtlsDetails.MeshPolicies, MTLSDetails: mtlsDetails},
 		checkers.PolicyChecker{Policies: mtlsDetails.Policies, MTLSDetails: mtlsDetails},
@@ -148,7 +148,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}
 		objectCheckers = []ObjectChecker{noServiceChecker, virtualServiceChecker}
 	case DestinationRules:
-		destinationRulesChecker := checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails}
+		destinationRulesChecker := checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries}
 		objectCheckers = []ObjectChecker{noServiceChecker, destinationRulesChecker}
 	case MeshPolicies:
 		meshPoliciesChecker := checkers.MeshPolicyChecker{MeshPolicies: mtlsDetails.MeshPolicies, MTLSDetails: mtlsDetails}

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -771,9 +771,10 @@ func (in *GenericIstioObjectList) DeepCopyObject() runtime.Object {
 
 // Host represents the FQDN format for Istio hostnames
 type Host struct {
-	Service   string
-	Namespace string
-	Cluster   string
+	Service       string
+	Namespace     string
+	Cluster       string
+	CompleteInput bool
 }
 
 // Parse takes as an input a hostname (simple or full FQDN), namespace and clusterName and returns a parsed Host struct
@@ -787,7 +788,10 @@ func ParseHost(hostName, namespace, cluster string) Host {
 
 		if len(domainParts) > 2 {
 			host.Cluster = strings.Join(domainParts[2:], ".")
+			host.CompleteInput = true
 		}
+	} else {
+		host.CompleteInput = true
 	}
 
 	// Fill in missing details, we take precedence from the full hostname and not from DestinationRule details

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -254,7 +254,17 @@ func (iv IstioValidations) MergeValidations(validations IstioValidations) IstioV
 		if !ok {
 			iv[key] = validation
 		} else {
-			v.Checks = append(v.Checks, validation.Checks...)
+		AddUnique:
+			for _, toAdd := range validation.Checks {
+				for _, existing := range v.Checks {
+					if toAdd.Path == existing.Path &&
+						toAdd.Severity == existing.Severity &&
+						toAdd.Message == existing.Message {
+						continue AddUnique
+					}
+				}
+				v.Checks = append(v.Checks, toAdd)
+			}
 			v.Valid = v.Valid && validation.Valid
 		}
 	}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -61,6 +61,7 @@ type SeverityLevel string
 const (
 	ErrorSeverity   SeverityLevel = "error"
 	WarningSeverity SeverityLevel = "warning"
+	Unknown         SeverityLevel = "unknown"
 )
 
 var ObjectTypeSingular = map[string]string{
@@ -83,8 +84,8 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "More than one DestinationRules for the same host subset combination",
 		Severity: WarningSeverity,
 	},
-	"destinationrules.nodest.matchingworkload": {
-		Message:  "This host has no matching workloads",
+	"destinationrules.nodest.matchingregistry": {
+		Message:  "This host has no matching entry in the service registry (service, workload or service entries)",
 		Severity: ErrorSeverity,
 	},
 	"destinationrules.nodest.subsetlabels": {
@@ -182,6 +183,10 @@ var checkDescriptors = map[string]IstioCheck{
 	"service.deployment.port.mismatch": {
 		Message:  "Service port and deployment port do not match",
 		Severity: ErrorSeverity,
+	},
+	"validation.unable.cross-namespace": {
+		Message:  "Unable to verify the validity, cross-namespace validation is not supported for this field",
+		Severity: Unknown,
 	},
 }
 

--- a/tests/data/service_entry_data.go
+++ b/tests/data/service_entry_data.go
@@ -29,13 +29,17 @@ func CreateExternalServiceEntry() kubernetes.IstioObject {
 }
 
 func CreateEmptyMeshExternalServiceEntry(name, namespace string, hosts []string) kubernetes.IstioObject {
+	hostsI := make([]interface{}, len(hosts))
+	for i, h := range hosts {
+		hostsI[i] = interface{}(h)
+	}
 	return (&kubernetes.GenericIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 		Spec: map[string]interface{}{
-			"hosts":      hosts,
+			"hosts":      hostsI,
 			"location":   "MESH_EXTERNAL",
 			"resolution": "DNS",
 		},
@@ -45,7 +49,8 @@ func CreateEmptyMeshExternalServiceEntry(name, namespace string, hosts []string)
 func AddPortDefinitionToServiceEntry(portDef map[string]interface{}, se kubernetes.IstioObject) kubernetes.IstioObject {
 	if portsSpec, found := se.GetSpec()["ports"]; found {
 		if portsSlice, ok := portsSpec.([]interface{}); ok {
-			se.GetSpec()["ports"] = append(portsSlice, portDef)
+			portsSlice = append(portsSlice, portDef)
+			se.GetSpec()["ports"] = portsSlice
 		}
 	} else {
 		se.GetSpec()["ports"] = []interface{}{portDef}


### PR DESCRIPTION
** Describe the change **

Several cleanups for validations, including detection of cross-namespace request which we can not validate and we flag those with an unknown status.

** Issue reference **

KIALI-2818
KIALI-2819 https://github.com/istio/istio/issues/7659

** Backwards incompatible? **

Yes, requires support from UI to show the new feature, but see @hhovsepy's comment for backwards compatibility.
