### PR TITLE
KIALI-2845 abort the install if we can't get the image version info from github

### DIFF
--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -145,6 +145,10 @@
     kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': github_lastrelease.stdout}}, recursive=True) }}"
   when:
   - kiali_vars.deployment.image_version == "lastrelease"
+- fail:
+    msg: "Could not determine what the image version should be. Set deployment.image_version to a valid value"
+  when:
+  - kiali_vars.deployment.image_version == ""
 
 - name: Determine version_label based on image_version
   set_fact:


### PR DESCRIPTION
@jotak was seeing this - his cluster couldn't get to github.com