### PR TITLE
KIALI-2848 Cannot specify the Tracing URL anymore

### DIFF
--- a/status/discover.go
+++ b/status/discover.go
@@ -65,7 +65,7 @@ func checkTracingService() (url string, err error) {
 	// Save configuration
 	config.Set(conf)
 
-	return url, err
+	return conf.ExternalServices.Tracing.URL, err
 
 }
 


### PR DESCRIPTION
Jira: [KIALI-2848]( https://issues.jboss.org/browse/KIALI-2848)

I wasn't setting the url in the configuration but return the new one instead the url in the configuration.