### PR TITLE
KIALI-2865 when not using login mode, do not abort script with wrong error

### DIFF
--- a/operator/deploy/deploy-kiali-operator.sh
+++ b/operator/deploy/deploy-kiali-operator.sh
@@ -595,6 +595,7 @@ if [ "${AUTH_STRATEGY}" == "login" ]; then
   fi
 else
   echo "Using auth strategy [${AUTH_STRATEGY}] - a secret is not needed so none will be created."
+  CREDENTIALS_CREATE_SECRET="false"
 fi
 
 echo "=== KIALI SETTINGS ==="


### PR DESCRIPTION
see https://issues.jboss.org/browse/KIALI-2865 for the bug. To replicate, just pick "anonymous" when asked for the auth strategy. It should not fail with an error about can't create a secret.