### PR TITLE
KIALI-2877 Remove outdated documentation in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,13 +2,6 @@ server:
   address: localhost
   port: 8000
 
-  # Uncomment credentials to enable basic authentication for server
-  # If you are deploying Kiali in Kubernetes or Openshift, to enable authentication you should use Secrets
-  # and pass credentials through environment variables.
-  # credentials:
-  #  username: admin
-  #  password: admin
-
   # Web context path to serve Kiali API and frontend from.
   # Default is /
   # web_root: /kiali


### PR DESCRIPTION
Reported in https://github.com/kiali/kiali/issues/1059#issuecomment-492785576.

Support for credentials in config.yaml was removed in PR #883. So this looks safe to remove, since credentials in config.yaml are no longer honored.