### PR TITLE
KIALI-2759 Don't show workloads when service doesn't have selector labels

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -120,19 +120,25 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 	var nsmtls models.MTLSStatus
 
 	wg := sync.WaitGroup{}
-	wg.Add(9)
+	wg.Add(7)
 	errChan := make(chan error, 6)
 
 	labelsSelector := labels.Set(svc.Spec.Selector).String()
+	// If service doesn't have any selector, we can't know which are the pods and workloads applying.
+	if labelsSelector != "" {
+		wg.Add(2)
+	}
 
-	go func() {
-		defer wg.Done()
-		var err2 error
-		pods, err2 = in.k8s.GetPods(namespace, labelsSelector)
-		if err2 != nil {
-			errChan <- err2
-		}
-	}()
+	if labelsSelector != "" {
+		go func() {
+			defer wg.Done()
+			var err2 error
+			pods, err2 = in.k8s.GetPods(namespace, labelsSelector)
+			if err2 != nil {
+				errChan <- err2
+			}
+		}()
+	}
 
 	go func() {
 		defer wg.Done()
@@ -170,15 +176,17 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 		}
 	}()
 
-	go func() {
-		defer wg.Done()
-		var err2 error
-		ws, err2 = fetchWorkloads(in.k8s, namespace, labelsSelector)
-		if err2 != nil {
-			log.Errorf("Error fetching Workloads per namespace %s and service %s: %s", namespace, service, err2)
-			errChan <- err2
-		}
-	}()
+	if labelsSelector != "" {
+		go func() {
+			defer wg.Done()
+			var err2 error
+			ws, err2 = fetchWorkloads(in.k8s, namespace, labelsSelector)
+			if err2 != nil {
+				log.Errorf("Error fetching Workloads per namespace %s and service %s: %s", namespace, service, err2)
+				errChan <- err2
+			}
+		}()
+	}
 
 	var vsCreate, vsUpdate, vsDelete bool
 	go func() {


### PR DESCRIPTION
** Describe the change **

Don't show workloads for a Service that doesn't have selector labels. Also, Istio sidecar shouldn't be computer either bc there aren't pods running under its umbrella.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2759

** Backwards incompatible? **
yes

** Screenshoots **
Before:
![Screenshot of Kiali Console (38)](https://user-images.githubusercontent.com/613814/57930937-85c2df80-78b7-11e9-9008-0a565029abf6.png)

After:
![Screenshot of Kiali Console (39)](https://user-images.githubusercontent.com/613814/57931175-2a452180-78b8-11e9-94f6-51d0586dc72d.png)

Test data: https://issues.jboss.org/browse/KIALI-2759?focusedCommentId=13734911&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13734911
