### PR TITLE
KIALI-2880 KIALI-2879 Modify the FQDN parsing

### DIFF
--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -131,6 +131,16 @@ func (n NoDestinationChecker) hasMatchingService(host kubernetes.Host, itemNames
 	}
 
 	// Check ServiceEntries
+	for k := range n.ServiceEntries {
+		hostKey := k
+		if i := strings.Index(k, "*"); i > -1 {
+			hostKey = k[i+1:]
+		}
+		if strings.HasSuffix(host.Service, hostKey) {
+			return true
+		}
+	}
+
 	if _, found := n.ServiceEntries[host.Service]; found {
 		return true
 	}

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -216,3 +216,23 @@ func TestSNIProxyExample(t *testing.T) {
 	assert.True(valid)
 	assert.Empty(validations)
 }
+
+func TestWildcardServiceEntry(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	dr := data.CreateEmptyDestinationRule("test", "disable-mtls-for-sni-proxy", "sni-proxy.local")
+	se := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(8443, "tcp", "TCP"),
+		data.CreateEmptyMeshExternalServiceEntry("sni-proxy", "test", []string{"*.local"}))
+
+	validations, valid := NoDestinationChecker{
+		Namespace:       "test",
+		ServiceEntries:  kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{se}),
+		DestinationRule: dr,
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}

--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -2,6 +2,7 @@ package virtual_services
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -88,9 +89,15 @@ func (n NoHostChecker) checkDestination(sHost, protocol string) bool {
 			}
 		}
 	}
-	// TODO ServiceEntries can be wildcarded also..
-	if _, found := n.ServiceEntryHosts[sHost]; found {
-		return true
+	// Check ServiceEntries
+	for k := range n.ServiceEntryHosts {
+		hostKey := k
+		if i := strings.Index(k, "*"); i > -1 {
+			hostKey = k[i+1:]
+		}
+		if strings.HasSuffix(sHost, hostKey) {
+			return true
+		}
 	}
 	return false
 }

--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -2,7 +2,6 @@ package virtual_services
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -89,12 +88,9 @@ func (n NoHostChecker) checkDestination(sHost, protocol string) bool {
 			}
 		}
 	}
-	if protocols, found := n.ServiceEntryHosts[sHost]; found {
-		for _, prot := range protocols {
-			if prot == strings.ToLower(protocol) {
-				return true
-			}
-		}
+	// TODO ServiceEntries can be wildcarded also..
+	if _, found := n.ServiceEntryHosts[sHost]; found {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
** Describe the change **

Modify the FQDN parsing to parse ServiceEntries to fqdn.Service part only, as the SEs are global scoped and do not adhere to the cluster parsing otherwise

This simplifies our code in some parts and makes it hopefully more reliable when catching SEs. Also, change certain parsing to use prefix matching instead of only "*" to avoid false positives.

Same PR adds support for wildcard ServiceEntries, which would in certain cases fail otherwise.

** Issue reference **

KIALI-2879, KIALI-2880

** Backwards incompatible? **

Yes.
