### PR TITLE
KIALI-2892 Jaeger traces not work when the user use Istio upstream with a QUERY_BASE_PATH

### DIFF
--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -36,7 +36,7 @@ func getErrorTracesFromJaeger(namespace string, service string) (errorTraces int
 		return -1, errors.New("jaeger is not available")
 	}
 	if config.Get().ExternalServices.Tracing.EnableJaeger {
-		u, errParse := url.Parse(fmt.Sprintf("http://%s/api/traces", config.Get().ExternalServices.Tracing.Service))
+		u, errParse := url.Parse(fmt.Sprintf("http://%s%s/api/traces", config.Get().ExternalServices.Tracing.Service, config.Get().ExternalServices.Tracing.Path))
 		if errParse != nil {
 			log.Errorf("Error parse Jaeger URL fetching Error Traces: %s", err)
 			err = errParse
@@ -55,6 +55,7 @@ func getErrorTracesFromJaeger(namespace string, service string) (errorTraces int
 			}
 			resp, reqError := client.Get(u.String())
 			if reqError != nil {
+				log.Errorf("Error new: %s", reqError)
 				err = reqError
 			} else {
 				defer resp.Body.Close()
@@ -80,7 +81,7 @@ func getErrorTracesFromJaeger(namespace string, service string) (errorTraces int
 func GetServices() (services JaegerServices, err error) {
 	services = JaegerServices{Services: []string{}}
 	err = nil
-	u, err := url.Parse(fmt.Sprintf("http://%s/api/services", config.Get().ExternalServices.Tracing.Service))
+	u, err := url.Parse(fmt.Sprintf("http://%s%s/api/services", config.Get().ExternalServices.Tracing.Service, config.Get().ExternalServices.Tracing.Path))
 	if err != nil {
 		log.Errorf("Error parse Jaeger URL fetching Services: %s", err)
 		return services, err

--- a/config/config.go
+++ b/config/config.go
@@ -147,6 +147,8 @@ type TracingConfig struct {
 	Namespace    string `yaml:"namespace"`
 	Service      string `yaml:"service"`
 	URL          string `yaml:"url"`
+	// Path store the value of QUERY_BASE_PATH
+	Path string `yaml:"-"`
 }
 
 // IstioConfig describes configuration used for istio links
@@ -285,6 +287,7 @@ func NewConfig() (c *Config) {
 
 	// Tracing Configuration
 	c.ExternalServices.Tracing.EnableJaeger = false
+	c.ExternalServices.Tracing.Path = ""
 	c.ExternalServices.Tracing.Namespace = strings.TrimSpace(getDefaultString(EnvTracingServiceNamespace, IstioDefaultNamespace))
 
 	// Istio Configuration

--- a/kiali.go
+++ b/kiali.go
@@ -100,6 +100,8 @@ func main() {
 	internalmetrics.RegisterInternalMetrics()
 
 	// check if Jaeger is available
+	// we need first discover Jaeger
+	status.DiscoverJaeger()
 	_, err := business.GetServices()
 	if err != nil {
 		business.JaegerAvailable = false


### PR DESCRIPTION
Detected some problems with QUERY_BASE_PATh and jaeger.

- We are checking the services of jaeger to check if is available or not before the autodiscover so if the user not set the service name of tracing service jaegerAvailable will be false (https://github.com/kiali/kiali/blob/master/business/jaeger_helper.go#L29) and errorTraces will be -1 (Fix with https://github.com/kiali/kiali/pull/1082/files#diff-c19e5972b564f8f7ebd30c662b1974cbR104)

- If user is working with istio community the correct patch to check the services is `<endpoint>/<QUERY_BASE_PATH>/api` so we added a new param in configuration called Path to control this.

Thanks @hhovsepy 