### PR TITLE
the time format is consistent with the MarshalJSON of k8s

### DIFF
--- a/models/pod_test.go
+++ b/models/pod_test.go
@@ -39,7 +39,7 @@ func TestPodFullyParsing(t *testing.T) {
 	pod := Pod{}
 	pod.Parse(&k8sPod)
 	assert.Equal("details-v1-3618568057-dnkjp", pod.Name)
-	assert.Equal("2018-03-08T17:44:00+03:00", pod.CreatedAt)
+	assert.Equal("2018-03-08T14:44:00Z", pod.CreatedAt)
 	assert.Equal(map[string]string{"apps": "details", "version": "v1"}, pod.Labels)
 	assert.Equal([]Reference{Reference{Name: "details-v1-3618568057", Kind: "ReplicaSet"}}, pod.CreatedBy)
 	assert.Len(pod.IstioContainers, 1)
@@ -71,7 +71,7 @@ func TestPodParsingMissingImage(t *testing.T) {
 	pod := Pod{}
 	pod.Parse(&k8sPod)
 	assert.Equal("details-v1-3618568057-dnkjp", pod.Name)
-	assert.Equal("2018-03-08T17:44:00+03:00", pod.CreatedAt)
+	assert.Equal("2018-03-08T14:44:00Z", pod.CreatedAt)
 	assert.Equal(map[string]string{"apps": "details", "version": "v1"}, pod.Labels)
 	assert.Equal([]Reference{Reference{Name: "details-v1-3618568057", Kind: "ReplicaSet"}}, pod.CreatedBy)
 	assert.Len(pod.IstioContainers, 1)
@@ -98,7 +98,7 @@ func TestPodParsingMissingAnnotations(t *testing.T) {
 	pod := Pod{}
 	pod.Parse(&k8sPod)
 	assert.Equal("details-v1-3618568057-dnkjp", pod.Name)
-	assert.Equal("2018-03-08T17:44:00+03:00", pod.CreatedAt)
+	assert.Equal("2018-03-08T14:44:00Z", pod.CreatedAt)
 	assert.Equal(map[string]string{"apps": "details", "version": "v1"}, pod.Labels)
 	assert.Empty(pod.CreatedBy)
 	assert.Len(pod.IstioContainers, 0)
@@ -120,7 +120,7 @@ func TestPodParsingInvalidAnnotations(t *testing.T) {
 	pod := Pod{}
 	pod.Parse(&k8sPod)
 	assert.Equal("details-v1-3618568057-dnkjp", pod.Name)
-	assert.Equal("2018-03-08T17:44:00+03:00", pod.CreatedAt)
+	assert.Equal("2018-03-08T14:44:00Z", pod.CreatedAt)
 	assert.Equal(map[string]string{"apps": "details", "version": "v1"}, pod.Labels)
 	assert.Empty(pod.CreatedBy)
 	assert.Len(pod.IstioContainers, 0)

--- a/models/service_test.go
+++ b/models/service_test.go
@@ -27,7 +27,7 @@ func TestServiceDetailParsing(t *testing.T) {
 
 	assert.Equal(service.Service.Name, "Name")
 	assert.Equal(service.Service.Namespace.Name, "Namespace")
-	assert.Equal(service.Service.CreatedAt, "2018-03-08T17:44:00+03:00")
+	assert.Equal(service.Service.CreatedAt, "2018-03-08T14:44:00Z")
 	assert.Equal(service.Service.ResourceVersion, "1234")
 	assert.Equal(service.Service.Type, "ClusterIP")
 	assert.Equal(service.Service.Ip, "127.0.0.9")

--- a/models/util.go
+++ b/models/util.go
@@ -3,5 +3,5 @@ package models
 import "time"
 
 func formatTime(t time.Time) string {
-	return t.Format(time.RFC3339)
+	return t.UTC().Format(time.RFC3339)
 }


### PR DESCRIPTION
** Describe the change **

kiali's time format: 2019-05-06T10:56:58+08:00
k8s's time format: 2019-05-06T02:56:58Z

kiali's time format should be consistent with k8s, and UTC should be used by default.

