### PR TITLE
KIALI-2370 Add validation for gateway selector

### DIFF
--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -11,6 +11,7 @@ const GatewayCheckerType = "gateway"
 type GatewayChecker struct {
 	GatewaysPerNamespace [][]kubernetes.IstioObject
 	Namespace            string
+	WorkloadList         models.WorkloadList
 }
 
 // Check runs checks for the all namespaces actions as well as for the single namespace validations
@@ -35,7 +36,12 @@ func (g GatewayChecker) Check() models.IstioValidations {
 func (g GatewayChecker) runSingleChecks(gw kubernetes.IstioObject) models.IstioValidations {
 	key, validations := EmptyValidValidation(gw.GetObjectMeta().Name, GatewayCheckerType)
 
-	enabledCheckers := []Checker{}
+	enabledCheckers := []Checker{
+		gateways.SelectorChecker{
+			WorkloadList: g.WorkloadList,
+			Gateway:      gw,
+		},
+	}
 
 	for _, checker := range enabledCheckers {
 		checks, validChecker := checker.Check()

--- a/business/checkers/gateways/selector_checker.go
+++ b/business/checkers/gateways/selector_checker.go
@@ -1,0 +1,56 @@
+package gateways
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type SelectorChecker struct {
+	WorkloadList models.WorkloadList
+	Gateway      kubernetes.IstioObject
+}
+
+var (
+	// IstioIngressGatewayLabels matching labels for Istio's internal ingressgateway
+	IstioIngressGatewayLabels = labels.Set(map[string]string{"istio": "ingressgateway"})
+	// IstioEgressGatewayLabels matching labels for Istio's internal egressgateway
+	IstioEgressGatewayLabels = labels.Set(map[string]string{"istio": "egressgateway"})
+)
+
+// Check verifies that the Gateway's selector's labels do match a known service inside the same namespace as recommended/required by the docs
+func (s SelectorChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	if selectorSpec, found := s.Gateway.GetSpec()["selector"]; found {
+		if selectors, ok := selectorSpec.(map[string]interface{}); ok {
+			labelSelectors := make(map[string]string, len(selectors))
+			for k, v := range selectors {
+				labelSelectors[k] = v.(string)
+			}
+			if !s.hasMatchingWorkload(labelSelectors) {
+				validation := models.Build("gateways.selector", "spec/selector")
+				validations = append(validations, &validation)
+			}
+		}
+	}
+
+	return validations, len(validations) == 0
+}
+
+func (s SelectorChecker) hasMatchingWorkload(labelSelector map[string]string) bool {
+	selector := labels.SelectorFromSet(labels.Set(labelSelector))
+
+	// Special case for Istio's internal deployments which do not conform to Istio documentation/specs at this point
+	if selector.Matches(IstioIngressGatewayLabels) || selector.Matches(IstioEgressGatewayLabels) {
+		return true
+	}
+
+	for _, wl := range s.WorkloadList.Workloads {
+		wlLabelSet := labels.Set(wl.Labels)
+		if selector.Matches(wlLabelSet) {
+			return true
+		}
+	}
+	return false
+}

--- a/business/checkers/gateways/selector_checker_test.go
+++ b/business/checkers/gateways/selector_checker_test.go
@@ -1,0 +1,84 @@
+package gateways
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidInternalSelector(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	ingress := data.CreateEmptyGateway("gwingress", "test", map[string]string{"istio": "ingressgateway"})
+	egress := data.CreateEmptyGateway("gwegress", "test", map[string]string{"istio": "egressgateway"})
+
+	validations, valid := SelectorChecker{
+		Gateway: ingress,
+		WorkloadList: models.WorkloadList{
+			Namespace: models.Namespace{
+				Name: "test",
+			},
+			Workloads: []models.WorkloadListItem{},
+		},
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+
+	validations, valid = SelectorChecker{
+		Gateway: egress,
+		WorkloadList: models.WorkloadList{
+			Namespace: models.Namespace{
+				Name: "test",
+			},
+			Workloads: []models.WorkloadListItem{},
+		},
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestValidNamespaceSelector(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gw := data.CreateEmptyGateway("gwone", "test", map[string]string{"app": "proxy"})
+
+	validations, valid := SelectorChecker{
+		Gateway: gw,
+		WorkloadList: data.CreateWorkloadList("test",
+			data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestMissingSelectorTarget(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gw := data.CreateEmptyGateway("gwone", "test", map[string]string{"app": "proxy"})
+
+	validations, valid := SelectorChecker{
+		Gateway:      gw,
+		WorkloadList: data.CreateWorkloadList("test"),
+		// data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
+	}.Check()
+
+	assert.False(valid)
+	assert.Equal(1, len(validations))
+	assert.Equal(models.CheckMessage("gateways.selector"), validations[0].Message)
+	assert.Equal(models.WarningSeverity, validations[0].Severity)
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -102,7 +102,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.NoServiceChecker{Namespace: namespace, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails},
 		checkers.VirtualServiceChecker{Namespace: namespace, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices},
 		checkers.DestinationRulesChecker{DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
-		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace},
+		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads},
 		checkers.MeshPolicyChecker{MeshPolicies: mtlsDetails.MeshPolicies, MTLSDetails: mtlsDetails},
 		checkers.PolicyChecker{Policies: mtlsDetails.Policies, MTLSDetails: mtlsDetails},
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
@@ -142,7 +142,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	switch objectType {
 	case Gateways:
 		objectCheckers = []ObjectChecker{
-			checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace},
+			checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads},
 		}
 	case VirtualServices:
 		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -116,6 +116,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "More than one Gateway for the same host port combination",
 		Severity: WarningSeverity,
 	},
+	"gateways.selector": {
+		Message:  "No matching workload found for gateway selector in this namespace",
+		Severity: WarningSeverity,
+	},
 	"port.name.mismatch": {
 		Message:  "Port name must follow <protocol>[-suffix] form",
 		Severity: ErrorSeverity,


### PR DESCRIPTION
** Describe the change **

Gateway object's selector should a match a workload from the same namespace as per Istio documentation. This validation adds that, but also includes a workaround for "istio-ingressgateway" and "istio-egressgateway" which do not match Istio's documentation.

Marking as warning instead of error because older versions did not have this requirement in their documentations. They stated that selector can match any pod in any namespace in Kubernetes, but this has been changed in Istio 1.1 documentation with a note that it will become mandatory to match same namespace.

** Issue reference **

KIALI-2370
