### PR TITLE
Update the base url to run kiali in relative path

### DIFF
--- a/kiali.go
+++ b/kiali.go
@@ -184,13 +184,10 @@ func validateConfig() error {
 		return fmt.Errorf("server static content root directory does not exist: %v", config.Get().Server.StaticContentRootDirectory)
 	}
 
-	validPathRegEx := regexp.MustCompile(`^\/[a-zA-Z0-9\-\._~!\$&\'()\*\+\,;=:@%/]*$`)
+	validPathRegEx := regexp.MustCompile(`^[a-zA-Z0-9\-\._~!\$&\'()\*\+\,;=:@%/]*$`)
 	webRoot := config.Get().Server.WebRoot
 	if !validPathRegEx.MatchString(webRoot) {
 		return fmt.Errorf("web root must begin with a / and contain valid URL path characters: %v", webRoot)
-	}
-	if webRoot != "/" && strings.HasSuffix(webRoot, "/") {
-		return fmt.Errorf("web root must not contain a trailing /: %v", webRoot)
 	}
 	if strings.Contains(webRoot, "/../") {
 		return fmt.Errorf("for security purposes, web root must not contain '/../': %v", webRoot)
@@ -268,7 +265,7 @@ func updateBaseURL(webRootPath string) {
 	html := string(b)
 
 	searchStr := `<base href="/"`
-	newStr := `<base href="` + webRootPath + `/"`
+	newStr := `<base href="` + webRootPath + `"`
 	newHTML := strings.Replace(html, searchStr, newStr, -1)
 	if html != newHTML && strings.Contains(newHTML, newStr) {
 		log.Debugf("Base URL has been updated to [%v]", newStr)

--- a/kiali_test.go
+++ b/kiali_test.go
@@ -16,17 +16,19 @@ func TestValidateWebRoot(t *testing.T) {
 	validWebRoots := []string{
 		"/",
 		"/kiali",
+		"/kiali/",
+		"./kiali",
 		"/abc/clustername/api/v1/namespaces/istio-system/services/kiali:80/proxy/kiali",
 		"/a/0/-/./_/~/!/$/&/'/(/)/*/+/,/;/=/:/@/%aa",
 		"/kiali0-._~!$&'()*+,;=:@%aa",
 	}
 	invalidWebRoots := []string{
-		"/kiali/",
-		"kiali/",
+		"/../",
+		"/../bar",
 		"/^kiali",
 		"/foo/../bar",
 		"/../bar",
-		"../bar",
+		"/../bar/..",
 	}
 
 	for _, webroot := range validWebRoots {


### PR DESCRIPTION
** Describe the change **

 Update the base url to take the relative url not the absolute path
  while running the kiali under reverse proxy for the url like
 `abc.com/xyz/def/api/v1/namespaces/istio-system/services/kiali:20001/proxy/`
   it takes the wrong base url URL `abc.com/api/v1/namespaces/istio-system/services/kiali:20001/proxy/`

 To solve this I have taken the relative URL and it starts taking the relative url 

** Issue reference ** 
* If this is a fix for a GH-issue, please link it here
 https://github.com/kiali/kiali/issues/1059

** Backwards incompatible? **

- Is your change introducing backwards incompatible changes?
  NO

