### PR TITLE
KIALI-2920 Make Grafana off-cluster still accessible

### DIFF
--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/kiali/kiali/log"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
 )
 
 type Trace struct {

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ const (
 	EnvServerMetricsEnabled             = "SERVER_METRICS_ENABLED"
 
 	EnvGrafanaDisplayLink              = "GRAFANA_DISPLAY_LINK"
+	EnvGrafanaInCluster                = "GRAFANA_IN_CLUSTER"
 	EnvGrafanaURL                      = "GRAFANA_URL"
 	EnvGrafanaServiceNamespace         = "GRAFANA_SERVICE_NAMESPACE"
 	EnvGrafanaService                  = "GRAFANA_SERVICE"
@@ -128,6 +129,7 @@ type PrometheusConfig struct {
 // GrafanaConfig describes configuration used for Grafana links
 type GrafanaConfig struct {
 	DisplayLink              bool   `yaml:"display_link"`
+	InCluster                bool   `yaml:"in_cluster"`
 	URL                      string `yaml:"url"`
 	ServiceNamespace         string `yaml:"service_namespace"`
 	Service                  string `yaml:"service"`
@@ -273,6 +275,7 @@ func NewConfig() (c *Config) {
 
 	// Grafana Configuration
 	c.ExternalServices.Grafana.DisplayLink = getDefaultBool(EnvGrafanaDisplayLink, true)
+	c.ExternalServices.Grafana.InCluster = getDefaultBool(EnvGrafanaInCluster, true)
 	c.ExternalServices.Grafana.URL = strings.TrimSpace(getDefaultString(EnvGrafanaURL, ""))
 	c.ExternalServices.Grafana.ServiceNamespace = strings.TrimSpace(getDefaultString(EnvGrafanaServiceNamespace, IstioDefaultNamespace))
 	c.ExternalServices.Grafana.Service = strings.TrimSpace(getDefaultString(EnvGrafanaService, "grafana"))

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 )
 
@@ -294,14 +294,11 @@ func writeAuthenticateHeader(w http.ResponseWriter, r *http.Request) {
 
 func NewAuthenticationHandler() (AuthenticationHandler, error) {
 	// Read token from the filesystem
-	saToken, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	saToken, err := kubernetes.GetKialiToken()
 	if err != nil {
 		return AuthenticationHandler{}, err
-	} else {
-		return AuthenticationHandler{
-			saToken: string(saToken),
-		}, nil
 	}
+	return AuthenticationHandler{saToken: saToken}, nil
 }
 
 func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -1,0 +1,19 @@
+package kubernetes
+
+import "io/ioutil"
+
+// Be careful with how you use this token. This is the Kiali Service Account token, not the user token.
+// We need the Service Account token to access third-party in-cluster services (e.g. Grafana).
+
+var KialiToken string
+
+func GetKialiToken() (string, error) {
+	if KialiToken == "" {
+		token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+		if err != nil {
+			return "", err
+		}
+		KialiToken = string(token)
+	}
+	return KialiToken, nil
+}

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -140,6 +140,7 @@ spec:
 # **Grafana-specific settings:
 # api_key: API key to access Grafana. API key only requires viewer permissions.
 # display_link: When true, a link to Grafana will be displayed for more dashboards.
+# in_cluster: Set true to indicate that Grafana service is accessible in the Kubernetes cluster.
 # password: Password to be used when making requests to Grafana. User only requires viewer permissions.
 # service: The Kubernetes service name for Grafana. Kiali uses this to connect within the cluster to Grafana.
 #          If "service" and "service_namespace" are empty then "url" is used for communication.
@@ -156,6 +157,7 @@ spec:
 #    grafana:
 #      api_key: ""
 #      display_link: true
+#      in_cluster: true
 #      password: ""
 #      service: "grafana"
 #      service_dashboard_pattern: "Istio%20Service%20Dashboard"

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -40,6 +40,7 @@ kiali_defaults:
     grafana:
       api_key: ""
       display_link: true
+      in_cluster: true
       password: ""
       service: "grafana"
       service_dashboard_pattern: "Istio%20Service%20Dashboard"


### PR DESCRIPTION
- Also fix KIALI-2921 for Grafana / potential race condition while setting config.
- Add a new config "InCluster" to tell if Grafana is in cluster or not
- Factorize code for access to service account token, and fix test failing while running that code

JIRA: https://issues.jboss.org/browse/KIALI-2920
See also #865 