### PR TITLE
KIALI-2935 Fix operator not honoring istio ns and install tag options

### DIFF
--- a/operator/roles/kiali-deploy/vars/main.yml
+++ b/operator/roles/kiali-deploy/vars/main.yml
@@ -13,8 +13,8 @@
 # everything under a main "kiali_vars" dictionary.
 
 kiali_vars:
-  installation_tag: "{{ kiali_defaults.installation_tag }}"
-  istio_namespace: "{{ kiali_defaults.istio_namespace }}"
+  installation_tag: "{{ installation_tag | default(kiali_defaults.installation_tag) }}"
+  istio_namespace: "{{ istio_namespace | default(kiali_defaults.istio_namespace) }}"
 
   api: |
     {%- if api is defined and api is iterable -%}


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2935

Operator was always using default values for istio_namespace and installation_tag options of the CustomResource. This was creating a wrong config when deploying Kiali to a custom namespace.

Fixing by properly reading the values specified in the CR and using default values as a fallback.