### PR TITLE
KIALI-2570 Adding Selector labels to ServiceDetails endpoint

### DIFF
--- a/models/service.go
+++ b/models/service.go
@@ -47,6 +47,7 @@ type Service struct {
 	ResourceVersion string            `json:"resourceVersion"`
 	Namespace       Namespace         `json:"namespace"`
 	Labels          map[string]string `json:"labels"`
+	Selectors       map[string]string `json:"selectors"`
 	Type            string            `json:"type"`
 	Ip              string            `json:"ip"`
 	Ports           Ports             `json:"ports"`
@@ -70,6 +71,7 @@ func (s *Service) Parse(service *core_v1.Service) {
 		s.Name = service.Name
 		s.Namespace = Namespace{Name: service.Namespace}
 		s.Labels = service.Labels
+		s.Selectors = service.Spec.Selector
 		s.Type = string(service.Spec.Type)
 		s.Ip = service.Spec.ClusterIP
 		s.ExternalName = service.Spec.ExternalName

--- a/swagger.json
+++ b/swagger.json
@@ -4583,6 +4583,13 @@
           "type": "string",
           "x-go-name": "ResourceVersion"
         },
+        "selectors": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Selectors"
+        },
         "type": {
           "type": "string",
           "x-go-name": "Type"


### PR DESCRIPTION
** Describe the change **

Adding selectors field for a Service to ServiceDetails endpoint.

Need the following frontend PR: https://github.com/kiali/kiali-ui/pull/1213

** Issue reference **
https://issues.jboss.org/browse/KIALI-2570

** Backwards incompatible? **
yes
