### PR TITLE
KIALI-2921 Fix possible race on config write

### DIFF
--- a/appstate/grafana_state.go
+++ b/appstate/grafana_state.go
@@ -1,0 +1,3 @@
+package appstate
+
+var GrafanaDiscoveredURL string

--- a/appstate/jaeger_state.go
+++ b/appstate/jaeger_state.go
@@ -1,0 +1,12 @@
+package appstate
+
+import "github.com/kiali/kiali/config"
+
+// JaegerEnabled is a memo-flag to tell if Jaeger was configured or succesfully discovered
+var JaegerEnabled = false
+
+// JaegerAvailable tells if Jaeger is ready
+var JaegerAvailable = true
+
+// JaegerConfig is a copy of config.TracingConfig from global config, that can be mutated (e.g. for URL discovery)
+var JaegerConfig config.TracingConfig

--- a/config/config.go
+++ b/config/config.go
@@ -145,8 +145,6 @@ type GrafanaConfig struct {
 
 // TracingConfig describes configuration used for tracing links
 type TracingConfig struct {
-	// EnableJaeger is false by default, in the discover feature will be true if the user set the configuration or Kiali found the service.
-	EnableJaeger bool `yaml:"-"`
 	// Enable autodiscover and Jaeger in Kiali
 	Enabled   bool   `yaml:"enabled"`
 	Namespace string `yaml:"namespace"`
@@ -233,12 +231,6 @@ type Config struct {
 // Istio System namespace by default
 const IstioDefaultNamespace = "istio-system"
 
-// Tracing Service by default
-const TracingDefaultService = "tracing"
-
-// Jaeger Query Service by default
-const JaegerQueryDefaultService = "jaeger-query"
-
 // NewConfig creates a default Config struct
 func NewConfig() (c *Config) {
 	c = new(Config)
@@ -293,7 +285,6 @@ func NewConfig() (c *Config) {
 
 	// Tracing Configuration
 	c.ExternalServices.Tracing.Enabled = getDefaultBool(EnvTracingEnabled, true)
-	c.ExternalServices.Tracing.EnableJaeger = false
 	c.ExternalServices.Tracing.Path = ""
 	c.ExternalServices.Tracing.URL = strings.TrimSpace(getDefaultString(EnvTracingURL, ""))
 	c.ExternalServices.Tracing.Namespace = strings.TrimSpace(getDefaultString(EnvTracingServiceNamespace, IstioDefaultNamespace))
@@ -343,6 +334,8 @@ func Get() (conf *Config) {
 }
 
 // Set the global Config
+// This function should not be called outside of main or tests.
+// If possible keep config unmutated and use globals and/or appstate package for mutable states to avoid concurrent writes risk.
 func Set(conf *Config) {
 	rwMutex.Lock()
 	defer rwMutex.Unlock()

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -41,7 +41,7 @@ func getGrafanaInfo(serviceSupplier serviceSupplier, dashboardSupplier dashboard
 		return nil, http.StatusNoContent, nil
 	}
 
-	externalURL, _ := status.DiscoverGrafana()
+	externalURL := status.DiscoverGrafana()
 	if externalURL == "" {
 		return nil, http.StatusServiceUnavailable, errors.New("Grafana URL is not set in Kiali configuration")
 	}

--- a/kiali.go
+++ b/kiali.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"github.com/kiali/kiali/appstate"
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/config/security"
@@ -103,9 +104,9 @@ func main() {
 	// we need first discover Jaeger
 	if config.Get().ExternalServices.Tracing.Enabled {
 		status.DiscoverJaeger()
-		_, err := business.GetServices()
+		_, err := business.GetJaegerServices()
 		if err != nil {
-			business.JaegerAvailable = false
+			appstate.JaegerAvailable = false
 			log.Errorf("Jaeger is not available : %s", err)
 		}
 	}

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -71,7 +71,7 @@ type IstioClientInterface interface {
 	GetQuotaSpecBindings(namespace string) ([]IstioObject, error)
 	GetReplicationControllers(namespace string) ([]core_v1.ReplicationController, error)
 	GetReplicaSets(namespace string) ([]apps_v1.ReplicaSet, error)
-	GetRoute(namespace string, service string) (*osroutes_v1.Route, error)
+	GetRoute(namespace string, name string) (*osroutes_v1.Route, error)
 	GetSelfSubjectAccessReview(namespace, api, resourceType string, verbs []string) ([]*auth_v1.SelfSubjectAccessReview, error)
 	GetService(namespace string, serviceName string) (*core_v1.Service, error)
 	GetServices(namespace string, selectorLabels map[string]string) ([]core_v1.Service, error)

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"bytes"
+
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	osroutes_v1 "github.com/openshift/api/route/v1"
@@ -139,11 +140,11 @@ func (in *IstioClient) GetDeployment(namespace, deploymentName string) (*apps_v1
 	return in.k8s.AppsV1().Deployments(namespace).Get(deploymentName, emptyGetOptions)
 }
 
-// GetRoute returns the external URL endpoint of a specific service.
+// GetRoute returns the external URL endpoint of a specific route name.
 // It returns an error on any problem.
-func (in *IstioClient) GetRoute(namespace, service string) (*osroutes_v1.Route, error) {
+func (in *IstioClient) GetRoute(namespace, name string) (*osroutes_v1.Route, error) {
 	result := &osroutes_v1.Route{}
-	err := in.k8s.RESTClient().Get().Prefix("apis", "route.openshift.io", "v1").Namespace(namespace).Resource("routes").SubResource(service).Do().Into(result)
+	err := in.k8s.RESTClient().Get().Prefix("apis", "route.openshift.io", "v1").Namespace(namespace).Resource("routes").SubResource(name).Do().Into(result)
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -116,8 +116,8 @@ func (o *K8SClientMock) GetDeploymentsByLabel(namespace string, labelSelector st
 	return args.Get(0).([]apps_v1.Deployment), args.Error(1)
 }
 
-func (o *K8SClientMock) GetRoute(namespace, service string) (*osroutes_v1.Route, error) {
-	args := o.Called(namespace, service)
+func (o *K8SClientMock) GetRoute(namespace, name string) (*osroutes_v1.Route, error) {
+	args := o.Called(namespace, name)
 	return args.Get(0).(*osroutes_v1.Route), args.Error(1)
 }
 

--- a/status/versions.go
+++ b/status/versions.go
@@ -191,7 +191,7 @@ type p8sResponseVersion struct {
 func jaegerVersion() (*ExternalServiceInfo, error) {
 	product := ExternalServiceInfo{}
 	product.Name = "Jaeger"
-	product.Url, _ = DiscoverJaeger()
+	product.Url = DiscoverJaeger()
 
 	return &product, nil
 }
@@ -199,7 +199,7 @@ func jaegerVersion() (*ExternalServiceInfo, error) {
 func grafanaVersion() (*ExternalServiceInfo, error) {
 	product := ExternalServiceInfo{}
 	product.Name = "Grafana"
-	product.Url, _ = DiscoverGrafana()
+	product.Url = DiscoverGrafana()
 
 	return &product, nil
 }


### PR DESCRIPTION
Introduce 'appstate' package, which can hold states more domain-specific, in order to avoid writes on global config.
The idea is to try to not mutate config (exception for kiali main and tests), hence avoiding concurrent writes.

Also try to clarify a couple of things:
- Renaming business.GetServices to business.GetJaegerServices
- In k8s client GetRoute, clarify that argument is route name and not service name (although they match most of the time)
- More consistent logging in discovery function

JIRA: https://issues.jboss.org/browse/KIALI-2921