### PR TITLE
KIALI-2947 Fix detection of valid+false pair of gateways in VS

### DIFF
--- a/business/checkers/virtual_services/no_gateway_checker.go
+++ b/business/checkers/virtual_services/no_gateway_checker.go
@@ -2,7 +2,9 @@ package virtual_services
 
 import (
 	"strconv"
+	"strings"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -16,12 +18,45 @@ type NoGatewayChecker struct {
 func (s NoGatewayChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
-	valid, index := kubernetes.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.GatewayNames, s.VirtualService.GetObjectMeta().Namespace, s.VirtualService.GetObjectMeta().ClusterName)
-	if !valid {
-		path := "spec/gateways[" + strconv.Itoa(index) + "]"
-		validation := models.Build("virtualservices.nogateway", path)
-		validations = append(validations, &validation)
-	}
+	s.ValidateVirtualServiceGateways(s.VirtualService.GetSpec(), s.VirtualService.GetObjectMeta().Namespace, s.VirtualService.GetObjectMeta().ClusterName, &validations)
 
-	return validations, valid
+	return validations, len(validations) == 0
+}
+
+// ValidateVirtualServiceGateways checks all VirtualService gateways (except mesh, which is reserved word) and checks that they're found from the given list of gatewayNames. Also return index of missing gatways to show clearer error path in editor
+func (s NoGatewayChecker) ValidateVirtualServiceGateways(spec map[string]interface{}, namespace, clusterName string, validations *[]*models.IstioCheck) {
+	if clusterName == "" {
+		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
+	}
+	if gatewaysSpec, found := spec["gateways"]; found {
+		if gateways, ok := gatewaysSpec.([]interface{}); ok {
+		GatewaySearch:
+			for index, g := range gateways {
+				if gate, ok := g.(string); ok {
+					if gate == "mesh" {
+						continue GatewaySearch
+					}
+					var hostname string
+					if strings.Contains(gate, "/") {
+						parts := strings.Split(gate, "/")
+						hostname = kubernetes.Host{
+							Service:   parts[1],
+							Namespace: parts[0],
+							Cluster:   clusterName,
+						}.String()
+					} else {
+						hostname = kubernetes.ParseHost(gate, namespace, clusterName).String()
+					}
+					for gw := range s.GatewayNames {
+						if found := kubernetes.FilterByHost(hostname, gw, namespace); found {
+							continue GatewaySearch
+						}
+					}
+					path := "spec/gateways[" + strconv.Itoa(index) + "]"
+					validation := models.Build("virtualservices.nogateway", path)
+					*validations = append(*validations, &validation)
+				}
+			}
+		}
+	}
 }

--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -28,6 +28,26 @@ func TestMissingGateway(t *testing.T) {
 	assert.Equal(models.CheckMessage("virtualservices.nogateway"), validations[0].Message)
 }
 
+func TestValidAndMissingGateway(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	var empty struct{}
+
+	virtualService := data.AddGatewaysToVirtualService([]string{"correctgw", "my-gateway", "mesh"}, data.CreateVirtualService())
+	checker := NoGatewayChecker{
+		VirtualService: virtualService,
+		GatewayNames:   map[string]struct{}{"correctgw": empty},
+	}
+
+	validations, valid := checker.Check()
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal(models.ErrorSeverity, validations[0].Severity)
+	assert.Equal(models.CheckMessage("virtualservices.nogateway"), validations[0].Message)
+}
+
 func TestFoundGateway(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -939,43 +939,6 @@ func GatewayNames(gateways [][]IstioObject) map[string]struct{} {
 	return names
 }
 
-// ValidateVirtualServiceGateways checks all VirtualService gateways (except mesh, which is reserved word) and checks that they're found from the given list of gatewayNames. Also return index of missing gatways to show clearer error path in editor
-func ValidateVirtualServiceGateways(spec map[string]interface{}, gatewayNames map[string]struct{}, namespace, clusterName string) (bool, int) {
-	if clusterName == "" {
-		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
-	}
-	if gatewaysSpec, found := spec["gateways"]; found {
-		if gateways, ok := gatewaysSpec.([]interface{}); ok {
-			for index, g := range gateways {
-				if gate, ok := g.(string); ok {
-					if gate == "mesh" {
-						return true, -1
-					}
-					var hostname string
-					if strings.Contains(gate, "/") {
-						parts := strings.Split(gate, "/")
-						hostname = Host{
-							Service:   parts[1],
-							Namespace: parts[0],
-							Cluster:   clusterName,
-						}.String()
-					} else {
-						hostname = ParseHost(gate, namespace, clusterName).String()
-					}
-					for gw := range gatewayNames {
-						if found := FilterByHost(hostname, gw, namespace); found {
-							return true, -1
-						}
-					}
-					return false, index
-				}
-			}
-		}
-	}
-	// No gateways defined or all found. Return -1 indicates no missing gateway
-	return true, -1
-}
-
 func PolicyHasStrictMTLS(policy IstioObject) bool {
 	_, mode := PolicyHasMTLSEnabled(policy)
 	return mode == "STRICT"


### PR DESCRIPTION
** Describe the change **

If the first item in the gateways list was valid, the VS validation did not return the correct result. Validates correctly all the cases now.

** Issue reference **

KIALI-2947
