### PR TITLE
KIALI-2964 Remove JaegerAvailable flag

### DIFF
--- a/appstate/jaeger_state.go
+++ b/appstate/jaeger_state.go
@@ -5,8 +5,5 @@ import "github.com/kiali/kiali/config"
 // JaegerEnabled is a memo-flag to tell if Jaeger was configured or succesfully discovered
 var JaegerEnabled = false
 
-// JaegerAvailable tells if Jaeger is ready
-var JaegerAvailable = true
-
 // JaegerConfig is a copy of config.TracingConfig from global config, that can be mutated (e.g. for URL discovery)
 var JaegerConfig config.TracingConfig

--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -29,7 +29,7 @@ type JaegerServices struct {
 func getErrorTracesFromJaeger(namespace string, service string) (errorTraces int, err error) {
 	errorTraces = 0
 	err = nil
-	if !appstate.JaegerAvailable || !config.Get().ExternalServices.Tracing.Enabled {
+	if !config.Get().ExternalServices.Tracing.Enabled {
 		return -1, errors.New("jaeger is not available")
 	}
 	if appstate.JaegerEnabled {

--- a/kiali.go
+++ b/kiali.go
@@ -28,8 +28,6 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/kiali/kiali/appstate"
-	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/config/security"
 	"github.com/kiali/kiali/log"
@@ -104,11 +102,6 @@ func main() {
 	// we need first discover Jaeger
 	if config.Get().ExternalServices.Tracing.Enabled {
 		status.DiscoverJaeger()
-		_, err := business.GetJaegerServices()
-		if err != nil {
-			appstate.JaegerAvailable = false
-			log.Errorf("Jaeger is not available : %s", err)
-		}
 	}
 
 	// Start listening to requests


### PR DESCRIPTION
When Jaeger is temporary not available, it shows an error in Kiali console.
If Jaeger is not available at all then it should be configured with "Enabled: false".

JIRA: https://issues.jboss.org/browse/KIALI-2964