### PR TITLE
KIALI-2958: Move to UBI7 as our base image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM registry.access.redhat.com/ubi7
 
 LABEL maintainer="kiali-dev@googlegroups.com"
 


### PR DESCRIPTION
** Describe the change **

Changes the base image to be UBI7

** Issue reference **

https://issues.jboss.org/browse/KIALI-2958

** Backwards incompatible? **

Everything should work the same as before, we are just using a different base image now that seems to have more updated packages.