### PR TITLE
Update hack/cluster-openshift.sh with maistra-0.11

### DIFF
--- a/hack/cluster-openshift.sh
+++ b/hack/cluster-openshift.sh
@@ -46,10 +46,10 @@ SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPT_ROOT}
 
 # The default version of the istiooc command to be downloaded
-DEFAULT_MAISTRA_ISTIO_OC_DOWNLOAD_VERSION="v3.11.0+maistra-0.10.0"
+DEFAULT_MAISTRA_ISTIO_OC_DOWNLOAD_VERSION="v3.11.0+maistra-0.11.0"
 
 # The default installation custom resource used to define what to install
-DEFAULT_MAISTRA_INSTALL_YAML="https://raw.githubusercontent.com/Maistra/openshift-ansible/maistra-0.10/istio/istio-installation-minimal.yaml"
+DEFAULT_MAISTRA_INSTALL_YAML="${SCRIPT_ROOT}/maistra_v1_servicemeshcontrolplane_cr_basic.yaml"
 
 # set the default openshift address here so that it can be used for the usage text
 #
@@ -523,8 +523,14 @@ if [ "$_CMD" = "up" ]; then
     if [ "${ISTIO_ENABLED}" == "true" ] ; then
       if [ "${_CREATE_INSTALLATION_RESOURCE}" == "true" ] ; then
         echo "Installing Istio via Installation Custom Resource"
-        debug "${MAISTRA_ISTIO_OC_COMMAND} create -n istio-operator -f ${MAISTRA_INSTALL_YAML}"
-        ${MAISTRA_ISTIO_OC_COMMAND} create -n istio-operator -f ${MAISTRA_INSTALL_YAML}
+        echo "Creating a istio-system namespace"
+        debug "${MAISTRA_ISTIO_OC_COMMAND} new-project istio-system"
+        ${MAISTRA_ISTIO_OC_COMMAND} new-project istio-system
+        # Note, Maistra requires to install the CR in the target namespace not in the operator one
+        # https://maistra.io/docs/getting_started/install/
+        echo "Creating a CR under istio-system namespace"
+        debug "${MAISTRA_ISTIO_OC_COMMAND} create -n istio-system -f ${MAISTRA_INSTALL_YAML}"
+        ${MAISTRA_ISTIO_OC_COMMAND} create -n istio-system -f ${MAISTRA_INSTALL_YAML}
       else
         echo "It appears Istio has not yet been installed - after you have ensured that your OpenShift user has the proper"
         echo "permissions, you will need to run the following command:"
@@ -541,19 +547,34 @@ if [ "$_CMD" = "up" ]; then
     fi
   fi
 
+  checkApp () {
+    local expected="$1"
+    apps=$(${MAISTRA_ISTIO_OC_COMMAND} get deployment.apps -n istio-system -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' 2> /dev/null)
+    for app in ${apps[@]}
+    do
+	  if [[ "$expected" == "$app" ]]; then
+	    return 0
+	  fi
+    done
+    return 1
+  }
+
   # If Istio is enabled, it should be installing now - if we need to, wait for it to finish
   if [ "${ISTIO_ENABLED}" == "true" ] ; then
     if [ "${KIALI_ENABLED}" == "true" -o "${WAIT_FOR_ISTIO}" == "true" ]; then
       echo "Wait for Istio to fully start (this is going to take a while)..."
+      expected_apps=(grafana istio-citadel istio-egressgateway istio-galley istio-ingressgateway istio-pilot istio-policy istio-sidecar-injector istio-telemetry jaeger-collector jaeger-query prometheus)
+      for expected in ${expected_apps[@]}
+      do
+        echo "Waiting for $expected"
+        while ! checkApp $expected
+        do
+             sleep 5
+             echo -n '.'
+        done
+      done
 
       echo -n "Waiting for Istio Deployments to be created..."
-      while [ "$(${MAISTRA_ISTIO_OC_COMMAND} get pods -l job-name=openshift-ansible-istio-installer-job -n istio-system -o jsonpath='{.items..status.conditions[0].reason}' 2> /dev/null)" != "PodCompleted" ]
-      do
-         sleep 5
-         echo -n '.'
-      done
-      echo "done."
-
       for app in $(${MAISTRA_ISTIO_OC_COMMAND} get deployment.apps -n istio-system -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' 2> /dev/null)
       do
          echo -n "Waiting for ${app} to be ready..."

--- a/hack/maistra_v1_servicemeshcontrolplane_cr_basic.yaml
+++ b/hack/maistra_v1_servicemeshcontrolplane_cr_basic.yaml
@@ -1,0 +1,69 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic-install
+spec:
+  # NOTE, if you remove all children from an element, you should remove the
+  # element too.  An empty element is interpreted as null and will override all
+  # default values (i.e. no values will be specified for that element, not even
+  # the defaults baked into the chart values.yaml).
+  istio:
+    global:
+      proxy:
+        # constrain resources for use in smaller environments
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 128Mi
+
+    gateways:
+      istio-egressgateway:
+        # disable autoscaling for use in smaller environments
+        autoscaleEnabled: false
+      istio-ingressgateway:
+        # disable autoscaling for use in smaller environments
+        autoscaleEnabled: false
+        # set to true to enable IOR
+        ior_enabled: false
+
+    mixer:
+      policy:
+        # disable autoscaling for use in smaller environments
+        autoscaleEnabled: false
+
+      telemetry:
+        # disable autoscaling for use in smaller environments
+        autoscaleEnabled: false
+        # constrain resources for use in smaller environments
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1G
+          limits:
+            cpu: 500m
+            memory: 4G
+
+    pilot:
+      # disable autoscaling for use in smaller environments
+      autoscaleEnabled: false
+      # increase random sampling rate for development/testing
+      traceSampling: 100.0
+
+    kiali:
+      ## Changed on kiali/hack folder to false
+      ## Kiali will be installed using cluster-openshift.sh steps not via the istio-operator
+      # change to false to disable kiali
+      enabled: false
+    
+      # to use oauth, remove the following 'dashboard' section (note, oauth is broken on OCP 4.0 with kiali 0.16.2)
+      # create a secret for accessing kiali dashboard with the following credentials
+      dashboard:
+        user: admin
+        passphrase: admin
+
+    tracing:
+      # change to false to disable tracing (i.e. jaeger)
+      enabled: true

--- a/hack/maistra_v1_servicemeshcontrolplane_cr_basic.yaml
+++ b/hack/maistra_v1_servicemeshcontrolplane_cr_basic.yaml
@@ -66,4 +66,4 @@ spec:
 
     tracing:
       # change to false to disable tracing (i.e. jaeger)
-      enabled: true
+      enabled: $TRACING_ENABLED


### PR DESCRIPTION
Bump hack/cluster-openshift.so to use maistra-0.11.
Note that we have changed the way that control plane is created, so I've added a local template into the hack folder and also updated how script waits for the installation.