### PR TITLE
KIALI-2955 Allow for multiple oauthclients

### DIFF
--- a/operator/roles/kiali-deploy/templates/openshift/oauth.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/oauth.yaml
@@ -1,7 +1,7 @@
 apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
 metadata:
-  name: kiali
+  name: kiali-{{ kiali_vars.deployment.namespace }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali

--- a/operator/roles/kiali-remove/tasks/main.yml
+++ b/operator/roles/kiali-remove/tasks/main.yml
@@ -95,7 +95,7 @@
   - os_item.metadata is defined
   - os_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='OAuthClient', resource_name='kiali', api_version='oauth.openshift.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='OAuthClient', resource_name='kiali-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name='kiali', api_version='route.openshift.io/v1') }}"
   loop_control:
     loop_var: os_item


### PR DESCRIPTION
** Describe the change **

We used to use a hardcoded oauth name of "kiali" which doesn't work well if you have multiple Kiali's installed in the same cluster.

This update changes it to be hardcoded to "kiali-${NAMESPACE}" so that multiple Kiali instances can be installed in the cluster without a collision.

Note that installing multiple Kiali instances in the same namespace is not supported. 

** Issue reference **

https://issues.jboss.org/browse/KIALI-2955