### PR TITLE
KIALI-2776 Support bearer tokens when accessing Prometheus

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,8 @@ const (
 	EnvPrometheusServiceURL         = "PROMETHEUS_SERVICE_URL"
 	EnvPrometheusCustomMetricsURL   = "PROMETHEUS_CUSTOM_METRICS_URL"
 	EnvPrometheusInsecureSkipVerify = "PROMETHEUS_INSECURE_SKIP_VERIFY"
+	EnvPrometheusAuth               = "PROMETHEUS_AUTH"
+	EnvPrometheusCAFile             = "PROMETHEUS_CA_FILE"
 
 	EnvGrafanaDisplayLink              = "GRAFANA_DISPLAY_LINK"
 	EnvGrafanaInCluster                = "GRAFANA_IN_CLUSTER"
@@ -98,6 +100,9 @@ const (
 	TokenCookieName             = "kiali-token"
 	AuthStrategyOpenshiftIssuer = "kiali-openshift"
 	AuthStrategyLoginIssuer     = "kiali-login"
+
+	PrometheusAuthStrategyBearer = "bearer"
+	PrometheusAuthStrategyNone   = "none"
 )
 
 // the paths we expect the login secret to be located
@@ -128,6 +133,8 @@ type PrometheusConfig struct {
 	URL                string `yaml:"url,omitempty"`
 	CustomMetricsURL   string `yaml:"custom_metrics_url,omitempty"`
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify,omitempty"`
+	Auth               string `yaml:"auth,omitempty"`
+	CAFile             string `yaml:"ca_file,omitempty"`
 }
 
 // GrafanaConfig describes configuration used for Grafana links
@@ -268,6 +275,11 @@ func NewConfig() (c *Config) {
 	c.ExternalServices.Prometheus.URL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, fmt.Sprintf("http://prometheus.%s:9090", c.IstioNamespace)))
 	c.ExternalServices.Prometheus.CustomMetricsURL = strings.TrimSpace(getDefaultString(EnvPrometheusCustomMetricsURL, c.ExternalServices.Prometheus.URL))
 	c.ExternalServices.Prometheus.InsecureSkipVerify = getDefaultBool(EnvPrometheusInsecureSkipVerify, false)
+	c.ExternalServices.Prometheus.Auth = strings.TrimSpace(getDefaultString(EnvPrometheusAuth, PrometheusAuthStrategyNone))
+	c.ExternalServices.Prometheus.CAFile = strings.TrimSpace(getDefaultString(EnvPrometheusCAFile, ""))
+	if c.ExternalServices.Prometheus.Auth != PrometheusAuthStrategyNone && c.ExternalServices.Prometheus.Auth != PrometheusAuthStrategyBearer {
+		log.Errorf("Unknown Prometheus Auth strategy. Valid options are %v or %v", PrometheusAuthStrategyNone, PrometheusAuthStrategyBearer)
+	}
 
 	// Grafana Configuration
 	c.ExternalServices.Grafana.DisplayLink = getDefaultBool(EnvGrafanaDisplayLink, true)

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -198,11 +198,17 @@ spec:
 # insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Prometheus over https.
 # url: The URL used to query the Prometheus Server. This URL must be accessible from the Kiali pod.
 #      If empty, assumes it is in the istio namespace at the URL "http://prometheus.<istio_namespace>:9090"
+# auth: The authentication to use when contacting the Prometheus server from the Kiali backend. Use "bearer" to send the
+#       Kiali service account token to the Prometheus server. Use "none" to not use any authentication. Default is "none"
+# ca_file: The certificate authority file to use when accessing Prometheus using https. An empty string means no extra
+#          certificate authority file is used. Default is an empty string.
 #    ---
 #    prometheus:
 #      custom_metrics_url: ""
 #      insecure_skip_verify: false
 #      url: ""
+#      auth: "none"
+#      ca_file: ""
 #
 # **Tracing-specific settings:
 #  - Right now we only support Jaeger

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -56,6 +56,8 @@ kiali_defaults:
       custom_metrics_url: ""
       insecure_skip_verify: false
       url: ""
+      auth: "none"
+      ca_file: ""
     tracing:
       enabled: true
       namespace: ""


### PR DESCRIPTION
**Describe the change**

Allows for connection to Prometheus servers that are behind the oauth proxy. Such as what Maistra is going to be configurable in Maistra.

This introduced two new configuration options under the Prometheus option in external_services:

**ca_file**: The CA file that was used to sign the certificate used by Prometheus. If you are running with Maistra then the endpoint is signed by the service signer and you will need to use `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`. Leaving this empty means that no additional file is used.

**auth**: Setting this to `bearer` means that we send the Kiali service account bearer token in the `Authorization` header when contacting Prometheus. Leaving this as `none` means that it works as it does today where no authentication information is passed to Prometheus.

If you are using the PR from https://github.com/Maistra/istio-operator/pull/80 then your external_services in the kiali configmap should look as follows:

````
external_services:
  prometheus:
    url: https://prometheus.istio-system.svc:9090
    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
    auth: bearer
````
    

**Issue reference**

https://issues.jboss.org/browse/KIALI-2776

**Backwards incompatible?**

Everything should work as before if these values are not specified in the configmap or kiali CR.