### PR TITLE
Update Go dashboard

### DIFF
--- a/operator/roles/kiali-deploy/templates/dashboards/go.yaml
+++ b/operator/roles/kiali-deploy/templates/dashboards/go.yaml
@@ -8,27 +8,53 @@ spec:
   discoverOn: "go_info"
   items:
   - chart:
-      name: "Threads"
+      name: "CPU ratio"
       spans: 6
-      metricName: "go_threads"
+      metricName: "process_cpu_seconds_total"
+      dataType: "rate"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"
+  - chart:
+      name: "RSS Memory"
+      unit: "bytes"
+      spans: 6
+      metricName: "process_resident_memory_bytes"
       dataType: "raw"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"
   - chart:
       name: "Goroutines"
       spans: 6
       metricName: "go_goroutines"
       dataType: "raw"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"
   - chart:
-      name: "GC duration"
-      unit: "seconds"
+      name: "Heap allocation rate"
+      unit: "bytes/s"
       spans: 6
-      metricName: "go_gc_duration_seconds"
+      metricName: "go_memstats_alloc_bytes_total"
       dataType: "rate"
       aggregations:
-      - label: "quantile"
-        displayName: "Quantile"
+      - label: "pod_name"
+        displayName: "Pod"
   - chart:
-      name: "Heap allocated"
+      name: "GC rate"
+      spans: 6
+      metricName: "go_gc_duration_seconds_count"
+      dataType: "rate"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"
+  - chart:
+      name: "Next GC"
       unit: "bytes"
       spans: 6
-      metricName: "go_memstats_heap_alloc_bytes"
+      metricName: "go_memstats_next_gc_bytes"
       dataType: "raw"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"


### PR DESCRIPTION
**Describe the change**
CPU and RSS memory panels are added at the top. The rate of heap
allocations is also added.

The 'pod_name' label is added to all panels.

The 'go_gc_duration_seconds' panel is removed because it is based on a
summary metric that can't be aggregated. Instead the rate of GC events
is added.

The 'go_threads' panel is removed, tracking the number of goroutines is
usually enough.

![image](https://user-images.githubusercontent.com/2587585/59281967-717cc300-8c68-11e9-9ce5-fe5a0f05b4fa.png)

![image](https://user-images.githubusercontent.com/2587585/59282020-85282980-8c68-11e9-872f-a374cdb4f735.png)

![image](https://user-images.githubusercontent.com/2587585/59282074-9a9d5380-8c68-11e9-9245-40248b1c23e0.png)


**Issue reference**

None. It was discussed directly with @jotak 

**Backwards incompatible?**

No

**Documentation**

If this is merged, [kiali.io](https://www.kiali.io/documentation/runtimes-monitoring/#_go) would need to be updated too.