### PR TITLE
Kiali 2779 Handle Jaeger connections with authentication

### DIFF
--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kiali/kiali/appstate"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/util/httputil"
 )
 
 type Trace struct {
@@ -26,13 +27,19 @@ type JaegerServices struct {
 	Services []string `json:"data"`
 }
 
-func getErrorTracesFromJaeger(namespace string, service string) (errorTraces int, err error) {
+func getErrorTracesFromJaeger(namespace string, service string, requestToken string) (errorTraces int, err error) {
 	errorTraces = 0
 	err = nil
 	if !config.Get().ExternalServices.Tracing.Enabled {
 		return -1, errors.New("jaeger is not available")
 	}
 	if appstate.JaegerEnabled {
+		// Be sure to copy config.Auth and not modify the existing
+		auth := config.Get().ExternalServices.Tracing.Auth
+		if auth.UseKialiToken {
+			auth.Token = requestToken
+		}
+
 		u, errParse := url.Parse(fmt.Sprintf("http://%s%s/api/traces", appstate.JaegerConfig.Service, appstate.JaegerConfig.Path))
 		if errParse != nil {
 			log.Errorf("Error parse Jaeger URL fetching Error Traces: %s", err)
@@ -45,26 +52,21 @@ func getErrorTracesFromJaeger(namespace string, service string) (errorTraces int
 			q.Set("start", fmt.Sprintf("%d", t-60*60*1000*1000))
 			q.Set("end", fmt.Sprintf("%d", t))
 			q.Set("tags", "{\"error\":\"true\"}")
+
 			u.RawQuery = q.Encode()
 			timeout := time.Duration(1000 * time.Millisecond)
-			client := http.Client{
-				Timeout: timeout,
-			}
-			resp, reqError := client.Get(u.String())
+
+			body, code, reqError := httputil.HttpGet(u.String(), &auth, timeout)
 			if reqError != nil {
-				log.Errorf("Error fetching Jaeger Error Traces: %s", reqError)
+				log.Errorf("Error fetching Jaeger Error Traces (%d): %s", code, reqError)
 				return -1, reqError
 			} else {
-				defer resp.Body.Close()
-				body, errRead := ioutil.ReadAll(resp.Body)
-				if errRead != nil {
-					log.Errorf("Error Reading Jaeger Response fetching Error Traces: %s", errRead)
-					err = errRead
-					return -1, err
+				if code != http.StatusOK {
+					return -1, fmt.Errorf("error from Jaeger (%d)", code)
 				}
 				var traces RequestTrace
 				if errMarshal := json.Unmarshal([]byte(body), &traces); errMarshal != nil {
-					log.Errorf("Error Unmarshal Jaeger Response fetching Error Traces: %s", errRead)
+					log.Errorf("Error Unmarshal Jaeger Response fetching Error Traces: %s", errMarshal)
 					err = errMarshal
 					return -1, err
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -157,6 +157,7 @@ type TracingConfig struct {
 	Namespace string `yaml:"namespace"`
 	Service   string `yaml:"service"`
 	URL       string `yaml:"url"`
+	Auth      Auth   `yaml:"auth"`
 	// Path store the value of QUERY_BASE_PATH
 	Path string `yaml:"-"`
 }
@@ -287,6 +288,7 @@ func NewConfig() (c *Config) {
 	c.ExternalServices.Tracing.Path = ""
 	c.ExternalServices.Tracing.URL = strings.TrimSpace(getDefaultString(EnvTracingURL, ""))
 	c.ExternalServices.Tracing.Namespace = strings.TrimSpace(getDefaultString(EnvTracingServiceNamespace, c.IstioNamespace))
+	c.ExternalServices.Tracing.Auth = getAuthFromEnv("TRACING")
 
 	// Istio Configuration
 	c.ExternalServices.Istio.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -109,8 +109,13 @@ func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 			}
 		}(&istioConfigValidations, &err)
 	}
+	requestToken, err := getToken(r)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Token initialization error: "+err.Error())
+		return
+	}
 
-	serviceDetails, err := business.Svc.GetService(namespace, service, rateInterval, queryTime)
+	serviceDetails, err := business.Svc.GetService(namespace, service, rateInterval, queryTime, requestToken)
 	if includeValidations && err == nil {
 		wg.Wait()
 		serviceDetails.Validations = istioConfigValidations

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -232,18 +232,18 @@ spec:
 #
 # **Tracing-specific settings:
 #  - Right now we only support Jaeger
-# auth: authentication settings to connect to Grafana:
-#   ca_file: The certificate authority file to use when accessing Grafana using https. An empty string means no extra
+# auth: authentication settings to connect to Jaeger:
+#   ca_file: The certificate authority file to use when accessing Jaeger using https. An empty string means no extra
 #       certificate authority file is used. Default is an empty string.
-#   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Grafana over https.
-#   password: Password to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
-#   token: Token / API key to access Grafana, for token-based authentication. It only requires viewer permissions.
+#   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Jaeger over https.
+#   password: Password to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions.
+#   token: Token / API key to access Jaeger, for token-based authentication. It only requires viewer permissions.
 #   type: The type of authentication to use when contacting the server from the Kiali backend. Use "bearer" to send the
 #       token to the Prometheus server. Use "basic" to connect with username and password credentials. Use "none" to not use any authentication.
 #       Default is "none"
 #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Grafana,
 #       and auth.token config is ignored then.
-#   username: Username to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
+#   username: Username to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions.
 # enabled: When true, Kiali shows Jaeger and will attempt to autodiscover it.
 # namespace: The Kubernetes namespace that holds the Tracing service (if empty, assumes the same value as deployment.namespace)
 # service: The Kubernetes service name for tracing. Kiali uses this to connect within the cluster to Jaeger.

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -232,6 +232,18 @@ spec:
 #
 # **Tracing-specific settings:
 #  - Right now we only support Jaeger
+# auth: authentication settings to connect to Grafana:
+#   ca_file: The certificate authority file to use when accessing Grafana using https. An empty string means no extra
+#       certificate authority file is used. Default is an empty string.
+#   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Grafana over https.
+#   password: Password to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
+#   token: Token / API key to access Grafana, for token-based authentication. It only requires viewer permissions.
+#   type: The type of authentication to use when contacting the server from the Kiali backend. Use "bearer" to send the
+#       token to the Prometheus server. Use "basic" to connect with username and password credentials. Use "none" to not use any authentication.
+#       Default is "none"
+#   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Grafana,
+#       and auth.token config is ignored then.
+#   username: Username to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
 # enabled: When true, Kiali shows Jaeger and will attempt to autodiscover it.
 # namespace: The Kubernetes namespace that holds the Tracing service (if empty, assumes the same value as deployment.namespace)
 # service: The Kubernetes service name for tracing. Kiali uses this to connect within the cluster to Jaeger.
@@ -239,6 +251,14 @@ spec:
 #      the cluster in order for the integration to work properly. If empty, an attempt to auto-discover it is made.
 #    ---
 #    tracing:
+#      auth:
+#        ca_file: ""
+#        insecure_skip_verify: false
+#        password: ""
+#        token: ""
+#        type: "none"
+#        use_kiali_token: false
+#        username: ""
 #      enabled: true
 #      namespace: ""
 #      service : ""

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -66,6 +66,14 @@ kiali_defaults:
       custom_metrics_url: ""
       url: ""
     tracing:
+      auth:
+        ca_file: ""
+        insecure_skip_verify: false
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
       enabled: true
       namespace: ""
       service: ""


### PR DESCRIPTION
JIRA: [KIALI-2779](https://issues.jboss.org/browse/KIALI-2779)

Require: 

1. https://github.com/kiali/kiali/pull/1129
2. https://github.com/kiali/kiali/pull/1120


Configmap

```yaml
  tracing:
    auth:
      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
      insecure_skip_verify: true
      password: ''
      token: ''
      type: bearer
      use_kiali_token: true
      username: ''
    enabled: true
    namespace: istio-system
    service: ''
    url: ''
```