### PR TITLE
KIALI-2976 Support hiding Jaeger and Grafana based on authorization

### DIFF
--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -22,7 +22,7 @@ const (
 )
 
 // GetGrafanaInfo provides the Grafana URL and other info, first by checking if a config exists
-// then (if not) by inspecting the Kubernetes Grafana service in namespace istio-system
+// then (if not) by inspecting the Kubernetes Grafana service in Istio installation namespace
 func GetGrafanaInfo(w http.ResponseWriter, r *http.Request) {
 	requestToken, err := getToken(r)
 	if err != nil {

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -54,8 +54,7 @@ func getJaegerInfo(requestToken string) (*models.JaegerInfo, int, error) {
 		auth.Token = requestToken
 	}
 
-	ha, code, err := canAccessURL(apiURL, &auth)
-	if !ha {
+	if ha, code, err := canAccessURL(apiURL, &auth); !ha {
 		return nil, code, errors.New("can't reach Jaeger query service")
 	} else if err != nil {
 		return nil, http.StatusInternalServerError, err

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -1,31 +1,76 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
+	"time"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/status"
+	"github.com/kiali/kiali/util/httputil"
 )
 
-// Get JaegerInfo provides the proxy Jaeger URL
+// Get JaegerInfo provides the Jaeger URL and other info, first by checking if a config exists
+// then (if not) by inspecting the Kubernetes Jaeger service in Istio installation namespace
 func GetJaegerInfo(w http.ResponseWriter, r *http.Request) {
-	jaegerConfig := config.Get().ExternalServices.Tracing
-	info := models.JaegerInfo{
-		URL: jaegerConfig.URL,
+	requestToken, err := getToken(r)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Token initialization error: "+err.Error())
+		return
 	}
 
-	// Check if URL is in the configuration
-	if info.URL == "" {
-		RespondWithError(w, http.StatusNotFound, "You need to set the Jaeger URL configuration.")
+	info, code, err := getJaegerInfo(requestToken)
+	if err != nil {
+		log.Error(err)
+		RespondWithError(w, code, err.Error())
 		return
+	}
+	RespondWithJSON(w, code, info)
+}
+
+func getJaegerInfo(requestToken string) (*models.JaegerInfo, int, error) {
+	jaegerConfig := config.Get().ExternalServices.Tracing
+
+	if !jaegerConfig.Enabled {
+		return nil, http.StatusNoContent, nil
+	}
+
+	apiURL := status.DiscoverJaeger()
+	if apiURL == "" {
+		return nil, http.StatusServiceUnavailable, errors.New("Jaeger URL is not set in Kiali configuration")
 	}
 
 	// Check if URL is valid
-	_, error := validateURL(info.URL)
-	if error != nil {
-		RespondWithError(w, http.StatusNotAcceptable, "You need to set a correct format for Jaeger URL in the configuration error: "+error.Error())
-		return
+	_, err := validateURL(apiURL)
+	if err != nil {
+		return nil, http.StatusServiceUnavailable, errors.New("wrong format for Jaeger URL: " + err.Error())
 	}
 
-	RespondWithJSON(w, http.StatusOK, info)
+	// Be sure to copy config.Auth and not modify the existing
+	auth := jaegerConfig.Auth
+	if auth.UseKialiToken {
+		auth.Token = requestToken
+	}
+
+	ha, code, err := canAccessURL(apiURL, &auth)
+	if !ha {
+		return nil, code, errors.New("can't reach Jaeger query service")
+	} else if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+
+	info := &models.JaegerInfo{
+		URL: apiURL,
+	}
+
+	return info, http.StatusOK, nil
+}
+
+func canAccessURL(url string, auth *config.Auth) (bool, int, error) {
+	timeout := time.Duration(1000 * time.Millisecond)
+	_, code, _ := httputil.HttpGet(url, auth, timeout)
+
+	return code == 200, code, nil
 }

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -54,10 +54,8 @@ func getJaegerInfo(requestToken string) (*models.JaegerInfo, int, error) {
 		auth.Token = requestToken
 	}
 
-	if ha, code, err := canAccessURL(apiURL, &auth); !ha {
-		return nil, code, errors.New("can't reach Jaeger query service")
-	} else if err != nil {
-		return nil, http.StatusInternalServerError, err
+	if ha, err := canAccessURL(apiURL, &auth); !ha {
+		return nil, http.StatusServiceUnavailable, err
 	}
 
 	info := &models.JaegerInfo{
@@ -67,7 +65,7 @@ func getJaegerInfo(requestToken string) (*models.JaegerInfo, int, error) {
 	return info, http.StatusOK, nil
 }
 
-func canAccessURL(url string, auth *config.Auth) (bool, int, error) {
+func canAccessURL(url string, auth *config.Auth) (bool, error) {
 	_, code, err := httputil.HttpGet(url, auth, 1000*time.Millisecond)
-	return code == 200, code, err
+	return code == 200, err
 }

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -68,8 +68,6 @@ func getJaegerInfo(requestToken string) (*models.JaegerInfo, int, error) {
 }
 
 func canAccessURL(url string, auth *config.Auth) (bool, int, error) {
-	timeout := time.Duration(1000 * time.Millisecond)
-	_, code, _ := httputil.HttpGet(url, auth, timeout)
-
-	return code == 200, code, nil
+	_, code, err := httputil.HttpGet(url, auth, 1000*time.Millisecond)
+	return code == 200, code, err
 }


### PR DESCRIPTION
** Describe the change **
Preventing URL discovery of Jaeger and grafana in case user doesn't have access to pods of istio install namespace.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2976

** Backwards incompatible? **
yes

Needs: https://github.com/kiali/kiali-ui/pull/1262

PRs:
This PR contents: https://github.com/kiali/kiali/pull/1129, https://github.com/kiali/kiali/pull/1120 and https://github.com/kiali/kiali/pull/1134. They should go first.

Outcome:
Admin with cluster-admin permissions:
![admin - multitenancy](https://user-images.githubusercontent.com/613814/59453436-2dc4bd80-8e10-11e9-945c-bf5165632990.gif)

Foo with permissions only to bookinfo:
![foo - multitenancy (1)](https://user-images.githubusercontent.com/613814/59453469-40d78d80-8e10-11e9-8419-3a35eebe8ab6.gif)

Foo with disabled `authorize_external_services: false` option:
![Screen recording (15)](https://user-images.githubusercontent.com/613814/59456208-230d2700-8e16-11e9-9d7b-b5af455d0c66.gif)
Note that Grafana url discovery actually needs to ping grafana for dashboard discovery. Then Kiali triggers an error.