### PR TITLE
KIALI-3010 support http by allowing the Kiali CR to define empty identity cert/key files

### DIFF
--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -224,12 +224,16 @@ spec:
 #
 # Certificate file used to identify the file server. If set, you must go over https to access Kiali.
 # The operator will set these if it deploys Kiali behind https.
+# When left undefined, the operator will assign a cluster-specific cert file to provide https by default.
+# When set to an empty string, https will be disabled.
 #    ---
-#    cert_file: ""
+#    #cert_file:
 #
 # Private key file used to identify the server. If set, you must go over https to access Kiali.
+# When left undefined, the operator will assign a cluster-specific private key file to provide https by default.
+# When set to an empty string, https will be disabled.
 #    ---
-#    private_key_file: ""
+#    #private_key_file:
 
 ##########
 #  ---

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -62,9 +62,9 @@ kiali_defaults:
       service: ""
       url: ""
 
-  identity:
-    cert_file: ""
-    private_key_file: ""
+  identity: {}
+    #cert_file:
+    #private_key_file:
 
   istio_labels:
     app_label_name: "app"

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -94,12 +94,12 @@
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'identity': {'cert_file': '/kiali-cert/tls.crt' if is_openshift else '/kiali-cert/cert-chain.pem'}}, recursive=True) }}"
   when:
-  - kiali_vars.identity.cert_file == ""
+  - kiali_vars.identity.cert_file is not defined
 - name: Set default identity private_key_file based on cluster type
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'identity': {'private_key_file': '/kiali-cert/tls.key' if is_openshift else '/kiali-cert/key.pem'}}, recursive=True) }}"
   when:
-  - kiali_vars.identity.private_key_file == ""
+  - kiali_vars.identity.private_key_file is not defined
 
 - name: If image version is latest then we will want to always pull
   set_fact:


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-3010