### PR TITLE
1142 - Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ image:https://img.shields.io/badge/license-Apache2-blue.svg["Apache 2.0 license"
 
 Kiali provides answers to the questions: _What microservices are part of my Istio service mesh and how are they connected?_
 
-image::https://raw.githubusercontent.com/kiali/kiali.io/master/static/images/features/graph-overview.png[Kiali Graph, width=480]
+image::https://raw.githubusercontent.com/kiali/kiali.io/master/static/images/documentation/features/graph-overview.png[Kiali Graph, width=880]
 
 == Table of contents
 


### PR DESCRIPTION
Fix broken Kiali Graph image link in Documentation.

https://github.com/kiali/kiali/issues/1142

README.adoc file properly updated.