### PR TITLE
make default grafana in_cluster_url dynamic

### DIFF
--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -48,7 +48,7 @@ kiali_defaults:
         use_kiali_token: false
         username: ""
       display_link: true
-      in_cluster_url: "http://grafana.istio-system:3000"
+      in_cluster_url: ""
       url: ""
     istio:
       istio_identity_domain: "svc.cluster.local"

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -46,6 +46,12 @@
   when:
   - kiali_vars.istio_namespace == ""
 
+- name: Set default Grafana in_cluster_url
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'in_cluster_url': 'http://grafana.' + kiali_vars.istio_namespace + ':3000'}}}, recursive=True) }}"
+  when:
+    kiali_vars.external_services.grafana.in_cluster_url == ""
+
 - name: Set default Tracing service namespace
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'namespace': kiali_vars.istio_namespace}}}, recursive=True) }}"


### PR DESCRIPTION
Addresses something that was missed in https://github.com/kiali/kiali/pull/1120

We want the grafana URL to be dynamically generated since the istio namespace may be different.