### PR TITLE
Fix Jaeger in kubernetes, improve discovery, clean

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -121,7 +121,7 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 
 	wg := sync.WaitGroup{}
 	wg.Add(7)
-	errChan := make(chan error, 7)
+	errChan := make(chan error, 6)
 
 	labelsSelector := labels.Set(svc.Spec.Selector).String()
 	// If service doesn't have any selector, we can't know which are the pods and workloads applying.
@@ -201,9 +201,6 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 		// Maybe a future jaeger business layer
 		defer wg.Done()
 		eTraces, err = getErrorTracesFromJaeger(namespace, service, requestToken)
-		if err != nil {
-			errChan <- err
-		}
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
- Addded **istio-tracing** service to the list, it's the name in kubernetes environments.
- Now kiali check if there is a service "istio-tracing", "tracing", "jaeger-query" in **kubernetes** and **openshift** +1
- Now kiali check if there is a QUERY_BASE_PATH in **openshift** and **kubernetes** +1 (There was a bug here in errorTraces in the UI)
- Kiali only discover URL in openshift, routes are exposed only in this environment