### PR TITLE
KIALI-2714 Update to use UBI7 base image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM registry.access.redhat.com/ubi7
 
 LABEL maintainer="kiali-dev@googlegroups.com"
 


### PR DESCRIPTION
**Describe the change**

Move to UBI7 Base image.

On the 0.16 branch since we want to have this change pushed out for users on Istio 1.1.x

**Issue reference**

https://issues.jboss.org/browse/KIALI-2714
