### PR TITLE
Fix install-bookinfo hack script for istio 1.2

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -121,7 +121,15 @@ fi
 if [[ "$CLIENT_EXE" = *"oc" ]]; then
   $CLIENT_EXE new-project ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user anyuid -z bookinfo-details -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user anyuid -z bookinfo-productpage -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user anyuid -z bookinfo-ratings -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user anyuid -z bookinfo-reviews -n ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user privileged -z default -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user privileged -z bookinfo-details -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user privileged -z bookinfo-productpage -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user privileged -z bookinfo-ratings -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user privileged -z bookinfo-reviews -n ${NAMESPACE}
 else
   $CLIENT_EXE create namespace ${NAMESPACE}
 fi


### PR DESCRIPTION
- the 1.2 version uses dedicated service accounts for each service, see:
  https://raw.githubusercontent.com/istio/istio/release-1.2/samples/bookinfo/platform/kube/bookinfo.yaml
