### PR TITLE
KIALI-2859 Replace gometalinter with golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-- 1.9.4
+- 1.12.1
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ env:
 # decided to no longer commit vendor dependencies into the source tree.
 # See: https://github.com/golang/dep/blob/master/docs/FAQ.md#should-i-commit-my-vendor-directory
 install:
- - make dep-install
  - make swagger-install
- - make gometalinter-install
+ - make lint-install
+#- make dep-install
 #- make dep-update
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -276,18 +276,14 @@ openshift-reload-image: .ensure-oc-exists
 ## k8s-reload-image: Refreshing image in Kubernetes namespace.
 k8s-reload-image: openshift-reload-image
 
-## gometalinter-install: Installs gometalinter
-gometalinter-install:
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
-	curl -L https://github.com/dominikh/go-tools/releases/download/2019.1.1/staticcheck_linux_amd64 -o $$GOPATH/bin/staticcheck
-	chmod +x $$GOPATH/bin/staticcheck
+## lint-install: Installs golangci-lint
+lint-install:
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $$(go env GOPATH)/bin v1.17.1
 
-## lint: Runs gometalinter
+## lint: Runs golangci-lint
 # doc.go is ommited for linting, because it generates lots of warnings.
 lint:
-	gometalinter --disable-all --enable=vet --enable=staticcheck --tests --deadline=500s --vendor $$(glide nv | grep -v '^\.$$')
-	gometalinter --disable-all --enable=vet --enable=staticcheck --tests --deadline=500s --vendor kiali.go
+	golangci-lint run --skip-files "doc\.go" --tests -D errcheck
 
 ## lint-all: Runs gometalinter with items from good to have list but does not run during travis
 lint-all:

--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -78,16 +78,6 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 	return validations
 }
 
-func (m MultiMatchChecker) matchingServiceEntry(host string) bool {
-	for k := range m.ServiceEntries {
-		if k == host {
-			return true
-		}
-	}
-
-	return false
-}
-
 func isNonLocalmTLSForServiceEnabled(dr kubernetes.IstioObject, service string) bool {
 	return strings.HasPrefix(service, "*") && ismTLSEnabled(dr)
 }

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -170,7 +170,7 @@ func getAppWorkloads(app, version string, ni *graph.AppenderNamespaceInfo) []mod
 }
 
 func IncludeIstio(o graph.TelemetryOptions) bool {
-	includeIstio := defaultIncludeIstio
+	var includeIstio bool
 	includeIstioString := o.Params.Get("includeIstio")
 	if includeIstioString == "" {
 		includeIstio = defaultIncludeIstio

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -51,7 +51,7 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 			defer wg.Done()
 			// We don't filter by objects when calling validations, because certain validations require fetching all types to get the correct errors
 			istioConfigValidationResults, errValidations := business.Validations.GetValidations(namespace, "")
-			if errValidations != nil && err == nil {
+			if errValidations != nil && *err == nil {
 				*err = errValidations
 			} else {
 				if len(parsedTypes) > 0 {
@@ -197,7 +197,7 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 		go func(istioConfigValidations *models.IstioValidations, err *error) {
 			defer wg.Done()
 			istioConfigValidationResults, errValidations := business.Validations.GetIstioObjectValidations(namespace, objectType, object)
-			if errValidations != nil && err == nil {
+			if errValidations != nil && *err == nil {
 				*err = errValidations
 			} else {
 				*istioConfigValidations = istioConfigValidationResults

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -102,7 +102,7 @@ func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 		go func(istioConfigValidations *models.IstioValidations, err *error) {
 			defer wg.Done()
 			istioConfigValidationResults, errValidations := business.Validations.GetValidations(namespace, service)
-			if errValidations != nil && err == nil {
+			if errValidations != nil && *err == nil {
 				*err = errValidations
 			} else {
 				*istioConfigValidations = istioConfigValidationResults

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -5,10 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
-	core_v1 "k8s.io/api/core/v1"
-
 	"github.com/kiali/kiali/business"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
@@ -17,28 +14,6 @@ import (
 type promClientSupplier func() (*prometheus.Client, error)
 
 var defaultPromClientSupplier = prometheus.NewClient
-
-var clientFactory kubernetes.ClientFactory
-
-func getService(token string, namespace string, service string) (*core_v1.ServiceSpec, error) {
-	if clientFactory == nil {
-		userClientFactory, err := kubernetes.GetClientFactory()
-		if err != nil {
-			return nil, err
-		}
-		clientFactory = userClientFactory
-	}
-
-	client, err := clientFactory.GetClient(token)
-	if err != nil {
-		return nil, err
-	}
-	svc, err := client.GetService(namespace, service)
-	if err != nil {
-		return nil, err
-	}
-	return &svc.Spec, nil
-}
 
 func validateURL(serviceURL string) (*url.URL, error) {
 	return url.ParseRequestURI(serviceURL)


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2859

Also, fixing the newly reported issues with the additional linter introduced by golangci-lint.

From the default linters set, only "errcheck" is disabled because it generates too many errors to fix under the scope of this PR/JIRA.