### PR TITLE
Ensure expose ingressgateway on http2 port or traffic-gen may not work

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -173,7 +173,7 @@ $CLIENT_EXE get pods -n ${NAMESPACE}
 # If OpenShift, we need to do some additional things
 if [[ "$CLIENT_EXE" = *"oc" ]]; then
   $CLIENT_EXE expose svc productpage -n ${NAMESPACE}
-  $CLIENT_EXE expose svc istio-ingressgateway -n istio-system
+  $CLIENT_EXE expose svc istio-ingressgateway --port http2 -n istio-system
 fi
 
 if [ "${TRAFFIC_GENERATOR_ENABLED}" == "true" ]; then


### PR DESCRIPTION

@jmazzitelli This fixed the issue I was having yesterday istalling bookinfo via the hack script but not having traffic generator work.  I think if you don't specify port you get the first one in the list of ports for the ingressgateway service.  And for me it was some weird "status-port", not the necessary http port.