### PR TITLE
KIALI-3034 ServiceEntry nodes should represent an actual ServiceEntry

### DIFF
--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -228,7 +228,7 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		// node may have destination service info
 		if val, ok := n.Metadata[graph.DestServices]; ok {
 			nd.DestServices = []graph.Service{}
-			for _, val := range val.(map[string]graph.Service) {
+			for _, val := range val.(graph.DestServicesMetadata) {
 				nd.DestServices = append(nd.DestServices, val)
 			}
 		}

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -36,3 +36,9 @@ type DestServicesMetadata map[string]Service
 func NewDestServicesMetadata() DestServicesMetadata {
 	return make(map[string]Service)
 }
+
+// Add adds or replaces a destService
+func (dsm DestServicesMetadata) Add(key string, service Service) DestServicesMetadata {
+	dsm[key] = service
+	return dsm
+}

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -28,3 +28,11 @@ const (
 	ProtocolKey     MetadataKey = "protocol"
 	ResponseTime    MetadataKey = "responseTime"
 )
+
+// DestServicesMetadata key=Service.Key()
+type DestServicesMetadata map[string]Service
+
+// NewDestServicesMetadata returns an empty DestServicesMetadata map
+func NewDestServicesMetadata() DestServicesMetadata {
+	return make(map[string]Service)
+}

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -205,7 +205,7 @@ func addToMetadataTcp(val float64, flags string, sourceMetadata, destMetadata, e
 	addToMetadataResponses(edgeMetadata, tcpResponses, "-", flags, val)
 }
 
-// AddOutgoingEdgeToMetadata updates the source node's outgoing traffic with the outgoing edge traffoc value
+// AddOutgoingEdgeToMetadata updates the source node's outgoing traffic with the outgoing edge traffic value
 func AddOutgoingEdgeToMetadata(sourceMetadata, edgeMetadata Metadata) {
 	if val, valOk := edgeMetadata[grpc]; valOk {
 		addToMetadataValue(sourceMetadata, grpcOut, val.(float64))
@@ -219,60 +219,61 @@ func AddOutgoingEdgeToMetadata(sourceMetadata, edgeMetadata Metadata) {
 }
 
 // AggregateNodeMetadata adds all <nodeMetadata> values (for all protocols) into aggregateNodeMetadata.
-func AggregateNodeMetadata(nodeMetadata, aggregateNodeMetadata Metadata) {
+func AggregateNodeTraffic(node, aggregateNode *Node) {
 	for _, protocol := range Protocols {
 		for _, rate := range protocol.NodeRates {
-			if val, ok := nodeMetadata[rate.Name]; ok {
-				addToMetadataValue(aggregateNodeMetadata, rate.Name, val.(float64))
+			if val, ok := node.Metadata[rate.Name]; ok {
+				addToMetadataValue(aggregateNode.Metadata, rate.Name, val.(float64))
 			}
 		}
 	}
 }
 
-// AddServiceGraphTraffic is for aggregating edge traffic when reducing to service graph from workload graph
-func AddServiceGraphTraffic(toEdge, fromEdge *Edge) {
-	protocol, ok := toEdge.Metadata["protocol"]
+// AggregateEdgeTraffic is for aggregating edge traffic when reducing multiple edges into one edge (e.g.
+// when generating service graph from workload graph, or aggregating serviceEntry nodes).
+func AggregateEdgeTraffic(edge, aggregateEdge *Edge) {
+	protocol, ok := edge.Metadata["protocol"]
 	if !ok {
 		return
 	}
 
 	switch protocol {
 	case grpc:
-		if val, ok := fromEdge.Metadata[grpc]; ok {
-			addToMetadataValue(toEdge.Metadata, grpc, val.(float64))
+		if val, ok := edge.Metadata[grpc]; ok {
+			addToMetadataValue(aggregateEdge.Metadata, grpc, val.(float64))
 		}
-		if val, ok := fromEdge.Metadata[grpcErr]; ok {
-			addToMetadataValue(toEdge.Metadata, grpcErr, val.(float64))
+		if val, ok := edge.Metadata[grpcErr]; ok {
+			addToMetadataValue(aggregateEdge.Metadata, grpcErr, val.(float64))
 		}
-		if responses, ok := fromEdge.Metadata[grpcResponses]; ok {
-			addToResponses(toEdge.Metadata, grpcResponses, responses.(Responses))
+		if responses, ok := edge.Metadata[grpcResponses]; ok {
+			addToResponses(aggregateEdge.Metadata, grpcResponses, responses.(Responses))
 		}
 	case http:
-		if val, ok := fromEdge.Metadata[http]; ok {
-			addToMetadataValue(toEdge.Metadata, http, val.(float64))
+		if val, ok := edge.Metadata[http]; ok {
+			addToMetadataValue(aggregateEdge.Metadata, http, val.(float64))
 		}
-		if val, ok := fromEdge.Metadata[http3xx]; ok {
-			addToMetadataValue(toEdge.Metadata, http3xx, val.(float64))
+		if val, ok := edge.Metadata[http3xx]; ok {
+			addToMetadataValue(aggregateEdge.Metadata, http3xx, val.(float64))
 		}
-		if val, ok := fromEdge.Metadata[http4xx]; ok {
-			addToMetadataValue(toEdge.Metadata, http4xx, val.(float64))
+		if val, ok := edge.Metadata[http4xx]; ok {
+			addToMetadataValue(aggregateEdge.Metadata, http4xx, val.(float64))
 		}
-		if val, ok := fromEdge.Metadata[http5xx]; ok {
-			addToMetadataValue(toEdge.Metadata, http5xx, val.(float64))
+		if val, ok := edge.Metadata[http5xx]; ok {
+			addToMetadataValue(aggregateEdge.Metadata, http5xx, val.(float64))
 		}
-		if responses, ok := fromEdge.Metadata[httpResponses]; ok {
-			addToResponses(toEdge.Metadata, httpResponses, responses.(Responses))
+		if responses, ok := edge.Metadata[httpResponses]; ok {
+			addToResponses(aggregateEdge.Metadata, httpResponses, responses.(Responses))
 		}
 	case tcp:
-		if val, ok := fromEdge.Metadata[tcp]; ok {
-			addToMetadataValue(toEdge.Metadata, grpc, val.(float64))
+		if val, ok := edge.Metadata[tcp]; ok {
+			addToMetadataValue(aggregateEdge.Metadata, tcp, val.(float64))
 		}
-		if responses, ok := fromEdge.Metadata[tcpResponses]; ok {
-			addToResponses(toEdge.Metadata, tcpResponses, responses.(Responses))
+		if responses, ok := edge.Metadata[tcpResponses]; ok {
+			addToResponses(aggregateEdge.Metadata, tcpResponses, responses.(Responses))
 		}
 
 	default:
-		Error(fmt.Sprintf("Unexpected edge protocol [%v] for edge [%+v]", protocol, toEdge))
+		Error(fmt.Sprintf("Unexpected edge protocol [%v] for edge [%+v]", protocol, aggregateEdge))
 	}
 
 	// handle any appender-based edge data (nothing currently)

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -220,9 +220,11 @@ func AddOutgoingEdgeToMetadata(sourceMetadata, edgeMetadata Metadata) {
 
 // AggregateNodeMetadata adds all <nodeMetadata> values (for all protocols) into aggregateNodeMetadata.
 func AggregateNodeMetadata(nodeMetadata, aggregateNodeMetadata Metadata) {
+	log.Warning("In AggregateNodemetadata...")
 	for _, protocol := range Protocols {
 		for _, rate := range protocol.NodeRates {
 			if val, ok := nodeMetadata[rate.Name]; ok {
+				log.Warningf("protocol=%s: rate=%s: add %v.2", protocol.Name, rate.Name, val)
 				addToMetadataValue(aggregateNodeMetadata, rate.Name, val.(float64))
 			}
 		}

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -220,11 +220,9 @@ func AddOutgoingEdgeToMetadata(sourceMetadata, edgeMetadata Metadata) {
 
 // AggregateNodeMetadata adds all <nodeMetadata> values (for all protocols) into aggregateNodeMetadata.
 func AggregateNodeMetadata(nodeMetadata, aggregateNodeMetadata Metadata) {
-	log.Warning("In AggregateNodemetadata...")
 	for _, protocol := range Protocols {
 		for _, rate := range protocol.NodeRates {
 			if val, ok := nodeMetadata[rate.Name]; ok {
-				log.Warningf("protocol=%s: rate=%s: add %v.2", protocol.Name, rate.Name, val)
 				addToMetadataValue(aggregateNodeMetadata, rate.Name, val.(float64))
 			}
 		}

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -53,6 +53,7 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 	if _, ok := requestedAppenders[ServiceEntryAppenderName]; ok || o.Appenders.All {
 		a := ServiceEntryAppender{
 			AccessibleNamespaces: o.AccessibleNamespaces,
+			GraphType:            o.GraphType,
 		}
 		appenders = append(appenders, a)
 	}

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -114,9 +114,14 @@ const (
 	workloadListKey      = "workloadList"      // namespace vendor info
 )
 
-type serviceEntryHost struct {
+type serviceEntry struct {
 	location string
-	host     string
+	name     string // serviceEntry name
+}
+
+type serviceEntryHost struct {
+	host string
+	serviceEntry
 }
 
 func newServiceEntryHosts() []serviceEntryHost {

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 )
 
@@ -120,18 +121,22 @@ type serviceEntry struct {
 	name     string // serviceEntry name
 }
 
-type serviceEntryHost struct {
-	host string
-	serviceEntry
+type serviceEntryHosts map[string]*serviceEntry
+
+func newServiceEntryHosts() serviceEntryHosts {
+	return make(map[string]*serviceEntry)
 }
 
-func newServiceEntryHosts() []serviceEntryHost {
-	return []serviceEntryHost{}
+func (seh serviceEntryHosts) addHost(host string, se *serviceEntry) {
+	if existingSe, ok := seh[host]; ok {
+		log.Warningf("Same host [%s] found in ServiceEntry [%s] and [%s]", host, existingSe.name, se.name)
+	}
+	seh[host] = se
 }
 
-func getServiceEntryHosts(gi *graph.AppenderGlobalInfo) ([]serviceEntryHost, bool) {
+func getServiceEntryHosts(gi *graph.AppenderGlobalInfo) (serviceEntryHosts, bool) {
 	if seHosts, ok := gi.Vendor[serviceEntryHostsKey]; ok {
-		return seHosts.([]serviceEntryHost), true
+		return seHosts.(serviceEntryHosts), true
 	}
 	return newServiceEntryHosts(), false
 }

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -65,7 +65,7 @@ NODES:
 			}
 		case !versionOk && (n.NodeType == graph.NodeTypeApp):
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
-				for _, ds := range destServices.(map[string]graph.Service) {
+				for _, ds := range destServices.(graph.DestServicesMetadata) {
 					for _, destinationRule := range istioCfg.DestinationRules.Items {
 						if destinationRule.HasCircuitBreaker(ds.Namespace, ds.Name, "") {
 							n.Metadata[graph.HasCB] = true
@@ -76,7 +76,7 @@ NODES:
 			}
 		case versionOk:
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
-				for _, ds := range destServices.(map[string]graph.Service) {
+				for _, ds := range destServices.(graph.DestServicesMetadata) {
 					for _, destinationRule := range istioCfg.DestinationRules.Items {
 						if destinationRule.HasCircuitBreaker(ds.Namespace, ds.Name, n.Version) {
 							n.Metadata[graph.HasCB] = true

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -119,7 +119,7 @@ func addLabels(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo
 	appLabelName := config.Get().IstioLabels.AppLabelName
 	for _, n := range trafficMap {
 		// make sure service nodes have the defined app label so it can be used for app grouping in the UI.
-		if n.NodeType == graph.NodeTypeService && n.App == "" {
+		if n.NodeType == graph.NodeTypeService && n.Namespace != graph.Unknown && n.App == "" {
 			// A service node that is a service entry will not have a service definition
 			if _, ok := n.Metadata[graph.IsServiceEntry]; ok {
 				continue

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -19,22 +19,22 @@ func setupTrafficMap() (map[string]*graph.Node, string, string, string, string, 
 	trafficMap := graph.NewTrafficMap()
 
 	appNode := graph.NewNode("testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
-	appNode.Metadata[graph.DestServices] = map[string]graph.Service{"testNamespace ratings": graph.Service{Namespace: "testNamespace", Name: "ratings"}}
+	appNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.Service{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNode.ID] = &appNode
 
 	appNodeV1 := graph.NewNode("testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
-	appNodeV1.Metadata[graph.DestServices] = map[string]graph.Service{"testNamespace ratings": graph.Service{Namespace: "testNamespace", Name: "ratings"}}
+	appNodeV1.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.Service{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV1.ID] = &appNodeV1
 
 	appNodeV2 := graph.NewNode("testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
-	appNodeV2.Metadata[graph.DestServices] = map[string]graph.Service{"testNamespace ratings": graph.Service{Namespace: "testNamespace", Name: "ratings"}}
+	appNodeV2.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.Service{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV2.ID] = &appNodeV2
 
 	serviceNode := graph.NewNode("testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[serviceNode.ID] = &serviceNode
 
 	workloadNode := graph.NewNode("testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
-	workloadNode.Metadata[graph.DestServices] = map[string]graph.Service{"testNamespace ratings": graph.Service{Namespace: "testNamespace", Name: "ratings"}}
+	workloadNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.Service{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[workloadNode.ID] = &workloadNode
 
 	fooServiceNode := graph.NewNode("testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -79,19 +79,19 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 	// Replace "se" nodes with an aggregated serviceEntry node
 	for se, serviceNodes := range seMap {
 		serviceEntryNode := graph.NewNode(namespaceInfo.Namespace, se.name, "", "", "", "", a.GraphType)
+		serviceEntryNode.Metadata[graph.IsServiceEntry] = se.location
 		for _, doomedServiceNode := range serviceNodes {
 			// redirect edges leading to the doomed service node to the new aggregate
 			for _, n := range trafficMap {
 				for _, edge := range n.Edges {
 					if edge.Dest.ID == doomedServiceNode.ID {
 						edge.Dest = &serviceEntryNode
-						// TODO aggregate traffic
+						graph.AggregateNodeMetadata(doomedServiceNode.Metadata, serviceEntryNode.Metadata)
 					}
 				}
 			}
 		}
 	}
-
 }
 
 // getServiceEntry queries the cluster API to resolve service entries across all accessible namespaces

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -85,8 +85,10 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 			// aggregate traffic
 			graph.AggregateNodeMetadata(doomedServiceNode.Metadata, serviceEntryNode.Metadata)
 			// aggregate dest-services to capture all of the distinct requested services
-			for k, v := range doomedServiceNode.Metadata[graph.DestServices].(graph.DestServicesMetadata) {
-				serviceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)[k] = v
+			if destServices, ok := doomedServiceNode.Metadata[graph.DestServices]; ok {
+				for k, v := range destServices.(graph.DestServicesMetadata) {
+					serviceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)[k] = v
+				}
 			}
 			// redirect edges leading to the doomed service node to the new aggregate
 			for _, n := range trafficMap {

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -1,7 +1,6 @@
 package appender
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -90,9 +89,7 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 		serviceEntryNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata()
 		for _, doomedSeServiceNode := range seServiceNodes {
 			// aggregate node traffic
-			fmt.Printf("DoomedMD: %+v\n", doomedSeServiceNode.Metadata)
 			graph.AggregateNodeTraffic(doomedSeServiceNode, &serviceEntryNode)
-			fmt.Printf("AggregateMD: %+v\n", serviceEntryNode.Metadata)
 			// aggregate node dest-services to capture all of the distinct requested services
 			if destServices, ok := doomedSeServiceNode.Metadata[graph.DestServices]; ok {
 				for k, v := range destServices.(graph.DestServicesMetadata) {

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/log"
 )
 
 const ServiceEntryAppenderName = "serviceEntry"
@@ -49,6 +50,7 @@ func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInf
 		return
 	}
 
+	log.Warningf("NamespaceInfo=%+v", *namespaceInfo)
 	a.applyServiceEntries(trafficMap, globalInfo, namespaceInfo)
 }
 
@@ -78,6 +80,7 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 
 	// Replace "se" nodes with an aggregated serviceEntry node
 	for se, serviceNodes := range seMap {
+		log.Warningf("Aggregating into %+v", *se)
 		serviceEntryNode := graph.NewNode(namespaceInfo.Namespace, se.name, "", "", "", "", a.GraphType)
 		serviceEntryNode.Metadata[graph.IsServiceEntry] = se.location
 		for _, doomedServiceNode := range serviceNodes {
@@ -90,7 +93,11 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 					}
 				}
 			}
+			log.Warningf("Deleting %+v", *doomedServiceNode)
+			delete(trafficMap, doomedServiceNode.ID)
 		}
+		log.Warningf("Adding %+v", serviceEntryNode)
+		trafficMap[serviceEntryNode.ID] = &serviceEntryNode
 	}
 }
 

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -107,9 +107,7 @@ func markOutsideOrInaccessible(trafficMap graph.TrafficMap, o graph.TelemetryOpt
 		case graph.NodeTypeUnknown:
 			n.Metadata[graph.IsInaccessible] = true
 		case graph.NodeTypeService:
-			if _, ok := n.Metadata[graph.IsServiceEntry]; ok {
-				n.Metadata[graph.IsInaccessible] = true
-			} else if n.Namespace == graph.Unknown && n.Service == graph.Unknown {
+			if n.Namespace == graph.Unknown && n.Service == graph.Unknown {
 				n.Metadata[graph.IsInaccessible] = true
 			} else {
 				if isOutside(n, o.Namespaces) {

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -228,7 +228,7 @@ func reduceToServiceGraph(trafficMap graph.TrafficMap) graph.TrafficMap {
 }
 
 func addServiceGraphTraffic(toEdge, fromEdge *graph.Edge) {
-	graph.AddServiceGraphTraffic(toEdge, fromEdge)
+	graph.AggregateEdgeTraffic(fromEdge, toEdge)
 
 	// handle any appender-based edge data (nothing currently)
 	// note: We used to average response times of the aggregated edges but realized that

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -526,11 +526,11 @@ func addToDestServices(md graph.Metadata, namespace, service string) {
 	}
 	destServices, ok := md[graph.DestServices]
 	if !ok {
-		destServices = make(map[string]graph.Service)
+		destServices = graph.NewDestServicesMetadata()
 		md[graph.DestServices] = destServices
 	}
 	destService := graph.Service{Namespace: namespace, Name: service}
-	destServices.(map[string]graph.Service)[destService.Key()] = destService
+	destServices.(graph.DestServicesMetadata)[destService.Key()] = destService
 }
 
 func handleMisconfiguredLabels(node *graph.Node, app, version string, rate float64, o graph.TelemetryOptions) {

--- a/graph/types.go
+++ b/graph/types.go
@@ -62,7 +62,7 @@ type TrafficMap map[string]*Node
 func NewNode(serviceNamespace, service, workloadNamespace, workload, app, version, graphType string) Node {
 	id, nodeType := Id(serviceNamespace, service, workloadNamespace, workload, app, version, graphType)
 	namespace := workloadNamespace
-	if IsOK(namespace) {
+	if !IsOK(namespace) {
 		namespace = serviceNamespace
 	}
 

--- a/hack/istio/install-istio-kiali-via-helm.sh
+++ b/hack/istio/install-istio-kiali-via-helm.sh
@@ -331,7 +331,7 @@ if [ ! -f "/tmp/istio.yaml" ]; then
     ${HELM_EXE} dep update "${ISTIO_DIR}/install/kubernetes/helm/istio"
   fi
   echo Building Helm yaml for Istio...
-  ${HELM_EXE} template ${_HELM_VALUES} ${CUSTOM_HELM_VALUES} "${ISTIO_DIR}/install/kubernetes/helm/istio" --name istio --namespace ${NAMESPACE} > /tmp/istio.yaml
+  ${HELM_EXE} template ${_HELM_VALUES} ${CUSTOM_HELM_VALUES} "${ISTIO_DIR}/install/kubernetes/helm/istio" --name istio --namespace ${NAMESPACE} --set gateways.istio-egressgateway.enabled=true > /tmp/istio.yaml
 fi
 
 if [ "${DELETE_ISTIO}" == "true" ]; then

--- a/hack/istio/install-istio-kiali-via-helm.sh
+++ b/hack/istio/install-istio-kiali-via-helm.sh
@@ -331,7 +331,7 @@ if [ ! -f "/tmp/istio.yaml" ]; then
     ${HELM_EXE} dep update "${ISTIO_DIR}/install/kubernetes/helm/istio"
   fi
   echo Building Helm yaml for Istio...
-  ${HELM_EXE} template ${_HELM_VALUES} ${CUSTOM_HELM_VALUES} "${ISTIO_DIR}/install/kubernetes/helm/istio" --name istio --namespace ${NAMESPACE} --set gateways.istio-egressgateway.enabled=true > /tmp/istio.yaml
+  ${HELM_EXE} template ${_HELM_VALUES} ${CUSTOM_HELM_VALUES} "${ISTIO_DIR}/install/kubernetes/helm/istio" --name istio --namespace ${NAMESPACE} > /tmp/istio.yaml
 fi
 
 if [ "${DELETE_ISTIO}" == "true" ]; then


### PR DESCRIPTION
Service entry nodes have previously represented the actual requested endpoint and not an actual serviceEntry.  For example, the node may represent requests for  "en.wikipedia.com".  But in reality the actual "service" handling the request is a serviceEntry with a host that matches "en.wikipedia.com".  Moreover its hosts may match many different service requests (e.g. "en.wikipedia.com", "de.wikipedia.con" may both be handled by serviceEntry named "wikipedia" with host "*.wikipedia.com".

This PR changes the handling to generate nodes that represent the serviceEntry, not just a matching destination.  The new node will aggregate the traffic for the different requested endpoints.

*** REQUIRES UI PR: https://github.com/kiali/kiali-ui/pull/1271