### PR TITLE
KIALI-3050 Pass authentication data to k-charted

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -3,6 +3,7 @@ package business
 import (
 	dlg "github.com/kiali/k-charted/business"
 	dlgconfig "github.com/kiali/k-charted/config"
+	"github.com/kiali/k-charted/config/promconfig"
 	kmodel "github.com/kiali/k-charted/model"
 
 	"github.com/kiali/kiali/config"
@@ -28,9 +29,19 @@ func DashboardsConfig() dlgconfig.Config {
 	cfg := config.Get()
 	return dlgconfig.Config{
 		GlobalNamespace: cfg.IstioNamespace,
-		PrometheusURL:   cfg.ExternalServices.Prometheus.CustomMetricsURL,
-		Errorf:          log.Errorf,
-		Tracef:          log.Tracef,
+		Prometheus: promconfig.PrometheusConfig{
+			URL: cfg.ExternalServices.Prometheus.CustomMetricsURL,
+			Auth: promconfig.Auth{
+				Type:               cfg.ExternalServices.Prometheus.Auth.Type,
+				Username:           cfg.ExternalServices.Prometheus.Auth.Username,
+				Password:           cfg.ExternalServices.Prometheus.Auth.Password,
+				Token:              cfg.ExternalServices.Prometheus.Auth.Token,
+				InsecureSkipVerify: cfg.ExternalServices.Prometheus.Auth.InsecureSkipVerify,
+				CAFile:             cfg.ExternalServices.Prometheus.Auth.CAFile,
+			},
+		},
+		Errorf: log.Errorf,
+		Tracef: log.Tracef,
 	}
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a287a2dc9bc87d9c056d3006b69a248f2c59ad2952d6af31a9e3522c472578e3
-updated: 2019-06-28T10:58:53.326551118+02:00
+hash: 0bde97198660bd4e14e25938459fd3811ebd1cf9934baf0132bbe9b7bec6fdc8
+updated: 2019-06-28T13:00:51.763939379+02:00
 imports:
 - name: github.com/beorn7/perks
   version: 4b2b341e8d7715fae06375aa633dbb6e91b3fb46
@@ -53,10 +53,11 @@ imports:
 - name: github.com/json-iterator/go
   version: f2b4162afba35581b6d4a50d3b8f34e33c144682
 - name: github.com/kiali/k-charted
-  version: 0f63d3fa1f95c574ab2c5afa8771145ae1a51945
+  version: 378e9360b5d146e419ce8b6203b35b0fa1fcfb07
   subpackages:
   - business
   - config
+  - config/promconfig
   - http
   - kubernetes
   - kubernetes/v1alpha1

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,4 +33,4 @@ import:
 - package: k8s.io/kube-openapi
   version: 91cfa479c814065e420cee7ed227db0f63a5854e
 - package: github.com/kiali/k-charted
-  version: v0.1.0
+  version: 378e9360b5d146e419ce8b6203b35b0fa1fcfb07

--- a/vendor/github.com/kiali/k-charted/business/dashboards.go
+++ b/vendor/github.com/kiali/k-charted/business/dashboards.go
@@ -40,7 +40,7 @@ func (in *DashboardsService) tracef(format string, args ...interface{}) {
 func (in *DashboardsService) prom() (prometheus.ClientInterface, error) {
 	// Lazy init
 	if in.promClient == nil {
-		client, err := prometheus.NewClient(in.config.PrometheusURL)
+		client, err := prometheus.NewClient(in.config.Prometheus)
 		if err != nil {
 			return nil, fmt.Errorf("cannot initialize Prometheus Client: %v", err)
 		}

--- a/vendor/github.com/kiali/k-charted/business/dashboards_test.go
+++ b/vendor/github.com/kiali/k-charted/business/dashboards_test.go
@@ -7,7 +7,7 @@ import (
 
 	pmodel "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/k-charted/config"
 	kmock "github.com/kiali/k-charted/kubernetes/mock"
@@ -252,4 +252,52 @@ func fakeDashboard(id string) *v1alpha1.MonitoringDashboard {
 			},
 		},
 	}
+}
+
+func TestConvertEmptyMetric(t *testing.T) {
+	assert := assert.New(t)
+	in := NewDashboardsService(config.Config{})
+	var metric prometheus.Metric
+
+	// Make sure metric is never nil, but empty slice
+	res, err := in.convertMetric(metric, "foo")
+	assert.Empty(err)
+	assert.NotNil(res)
+	assert.Len(res, 0)
+
+	metric.Err = errors.New("Some error")
+	res, err = in.convertMetric(metric, "foo")
+	assert.Equal("Some error", err)
+	assert.NotNil(res)
+	assert.Len(res, 0)
+}
+
+func TestConvertEmptyHistogram(t *testing.T) {
+	assert := assert.New(t)
+	in := NewDashboardsService(config.Config{})
+	var histo prometheus.Histogram
+
+	// An empty histogram gives an empty map
+	res, err := in.convertHistogram(histo, "foo")
+	assert.Empty(err)
+	assert.NotNil(res)
+	assert.Len(res, 0)
+
+	// ... But empty metrics within an histogram cannot be nil
+	histo = make(prometheus.Histogram)
+	var metric prometheus.Metric
+	histo["0.99"] = metric
+	res, err = in.convertHistogram(histo, "foo")
+	assert.Empty(err)
+	assert.NotNil(res)
+	assert.Len(res, 1)
+	assert.NotNil(res["0.99"])
+	assert.Len(res["0.99"], 0)
+
+	// Check with error (here, histogram is nil)
+	metric.Err = errors.New("Some error")
+	histo["0.99"] = metric
+	res, err = in.convertHistogram(histo, "foo")
+	assert.Equal("Some error", err)
+	assert.Nil(res)
 }

--- a/vendor/github.com/kiali/k-charted/config/config.go
+++ b/vendor/github.com/kiali/k-charted/config/config.go
@@ -1,10 +1,13 @@
 package config
 
-import "github.com/kiali/k-charted/model"
+import (
+	"github.com/kiali/k-charted/config/promconfig"
+	"github.com/kiali/k-charted/model"
+)
 
 type Config struct {
-	PrometheusURL   string `yaml:"prometheus_url,omitempty"`
-	GlobalNamespace string `yaml:"global_namespace,omitempty"`
+	Prometheus      promconfig.PrometheusConfig `yaml:"prometheus"`
+	GlobalNamespace string                      `yaml:"global_namespace"`
 	Errorf          func(string, ...interface{})
 	Tracef          func(string, ...interface{})
 	PodsLoader      func(string, string) ([]model.Pod, error)

--- a/vendor/github.com/kiali/k-charted/config/promconfig/promconfig.go
+++ b/vendor/github.com/kiali/k-charted/config/promconfig/promconfig.go
@@ -1,0 +1,25 @@
+package promconfig
+
+// The valid auth strategies and values for cookie handling
+const (
+	// These constants are used for external services auth (Prometheus, Grafana ...) ; not for Kiali auth
+	AuthTypeBasic  = "basic"
+	AuthTypeBearer = "bearer"
+	AuthTypeNone   = "none"
+)
+
+// PrometheusConfig describes configuration of the Prometheus component
+type PrometheusConfig struct {
+	URL  string `yaml:"url"`
+	Auth Auth   `yaml:"auth"`
+}
+
+// Auth provides authentication data for external services
+type Auth struct {
+	Type               string `yaml:"type"`
+	Username           string `yaml:"username"`
+	Password           string `yaml:"password"`
+	Token              string `yaml:"token"`
+	CAFile             string `yaml:"ca_file"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+}

--- a/vendor/github.com/kiali/k-charted/model/dashboards_test.go
+++ b/vendor/github.com/kiali/k-charted/model/dashboards_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"testing"
 
+	pmod "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/k-charted/kubernetes/v1alpha1"
@@ -79,4 +80,14 @@ func TestJSONMarshallingNaN(t *testing.T) {
 	res, err := json.Marshal(samplePair)
 	assert.Nil(err)
 	assert.Equal("[123456.789,\"NaN\"]", string(res))
+}
+
+func TestConvertEmptyMatrix(t *testing.T) {
+	assert := assert.New(t)
+	var matrix pmod.Matrix
+
+	// Make sure matrices are never nil, but empty slices
+	res := ConvertMatrix(matrix)
+	assert.NotNil(res)
+	assert.Len(res, 0)
 }

--- a/vendor/github.com/kiali/k-charted/prometheus/roundtripper.go
+++ b/vendor/github.com/kiali/k-charted/prometheus/roundtripper.go
@@ -1,0 +1,60 @@
+package prometheus
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/kiali/k-charted/config/promconfig"
+)
+
+type authRoundTripper struct {
+	auth       string
+	originalRT http.RoundTripper
+}
+
+func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", rt.auth)
+	return rt.originalRT.RoundTrip(req)
+}
+
+func newAuthRoundTripper(auth *promconfig.Auth, rt http.RoundTripper) http.RoundTripper {
+	switch auth.Type {
+	case promconfig.AuthTypeBearer:
+		token := auth.Token
+		return &authRoundTripper{auth: "Bearer " + token, originalRT: rt}
+	case promconfig.AuthTypeBasic:
+		encoded := base64.StdEncoding.EncodeToString([]byte(auth.Username + ":" + auth.Password))
+		return &authRoundTripper{auth: "Basic " + encoded, originalRT: rt}
+	default:
+		return rt
+	}
+}
+
+func authTransport(auth *promconfig.Auth, transportConfig *http.Transport) (http.RoundTripper, error) {
+	if auth.InsecureSkipVerify || auth.CAFile != "" {
+		var certPool *x509.CertPool
+		if auth.CAFile != "" {
+			certPool = x509.NewCertPool()
+			cert, err := ioutil.ReadFile(auth.CAFile)
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to get root CA certificates: %s", err)
+			}
+
+			if ok := certPool.AppendCertsFromPEM(cert); !ok {
+				return nil, fmt.Errorf("supplied CA file could not be parsed")
+			}
+		}
+
+		transportConfig.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: auth.InsecureSkipVerify,
+			RootCAs:            certPool,
+		}
+	}
+
+	return newAuthRoundTripper(auth, transportConfig), nil
+}


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-3050

Required PR: https://github.com/kiali/k-charted/pull/19

Note: it doesn't have to be backported to 1.0 because k-charted isn't used in kiali 1.0

## How to test

Suggested steps to quickly setup prometheus with a basic-auth proxy are described in a gist: https://gist.github.com/jotak/48c1d73e82a5a4d2f48cd86d6bccce54 (that's two little steps).

Then you can update Kiali config prom URL to use http://prometheus:8080 (protected w/ admin/admin) instead of http://prometheus:9090 (not protected)

Also, to build kiali with the k-charted PR you need to:

- checkout this branch as usual
- run:
```
glide mirror set https://github.com/kiali/k-charted https://github.com/jotak/k-charted
make dep-update
```
- build/deploy as usual

Once finished:
```
glide mirror remove https://github.com/kiali/k-charted
```