### PR TITLE
KIALI-3049 delete oauth client by name

### DIFF
--- a/operator/deploy/deploy-kiali-operator.sh
+++ b/operator/deploy/deploy-kiali-operator.sh
@@ -507,7 +507,8 @@ delete_kiali_resources() {
   fi
 
   # purge OpenShift specific resources
-  ${CLIENT_EXE} delete --ignore-not-found=true oauthclients.oauth.openshift.io,routes --selector="app=kiali" -n "${NAMESPACE}"
+  ${CLIENT_EXE} delete --ignore-not-found=true routes --selector="app=kiali" -n "${NAMESPACE}"
+  ${CLIENT_EXE} delete --ignore-not-found=true oauthclients.oauth.openshift.io "kiali-${NAMESPACE}"
 }
 
 delete_operator_resources() {


### PR DESCRIPTION
We should not delete oauthclients by label as this would delete all of them. We only want the deploy script to remove the one in the namespace where kiali was deployed.