### PR TITLE
Fix several warnings from lint

### DIFF
--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -78,16 +78,6 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 	return validations
 }
 
-func (m MultiMatchChecker) matchingServiceEntry(host string) bool {
-	for k := range m.ServiceEntries {
-		if k == host {
-			return true
-		}
-	}
-
-	return false
-}
-
 func isNonLocalmTLSForServiceEnabled(dr kubernetes.IstioObject, service string) bool {
 	return strings.HasPrefix(service, "*") && ismTLSEnabled(dr)
 }

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -39,7 +39,7 @@ func getJaegerInfo(requestToken string) (*models.JaegerInfo, int, error) {
 
 	apiURL := status.DiscoverJaeger()
 	if apiURL == "" {
-		return nil, http.StatusServiceUnavailable, errors.New("Jaeger URL is not set in Kiali configuration")
+		return nil, http.StatusServiceUnavailable, errors.New("wrong config for Jaeger URL: not found in Kiali configuration")
 	}
 
 	// Check if URL is valid

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -5,10 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
-	core_v1 "k8s.io/api/core/v1"
-
 	"github.com/kiali/kiali/business"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
@@ -17,28 +14,6 @@ import (
 type promClientSupplier func() (*prometheus.Client, error)
 
 var defaultPromClientSupplier = prometheus.NewClient
-
-var clientFactory kubernetes.ClientFactory
-
-func getService(token string, namespace string, service string) (*core_v1.ServiceSpec, error) {
-	if clientFactory == nil {
-		userClientFactory, err := kubernetes.GetClientFactory()
-		if err != nil {
-			return nil, err
-		}
-		clientFactory = userClientFactory
-	}
-
-	client, err := clientFactory.GetClient(token)
-	if err != nil {
-		return nil, err
-	}
-	svc, err := client.GetService(namespace, service)
-	if err != nil {
-		return nil, err
-	}
-	return &svc.Spec, nil
-}
 
 func validateURL(serviceURL string) (*url.URL, error) {
 	return url.ParseRequestURI(serviceURL)


### PR DESCRIPTION
Fixes some warnings discovered locally and in travis:

```
[lponce@recopolis kiali]$ make lint
gometalinter --disable-all --enable=vet --enable=staticcheck --tests --deadline=500s --vendor $(glide nv | grep -v '^\.$')
business/checkers/destinationrules/multi_match_checker.go:81:28:warning: func MultiMatchChecker.matchingServiceEntry is unused (U1000) (staticcheck)
handlers/jaeger.go:42:56:warning: error strings should not be capitalized (ST1005) (staticcheck)
handlers/utils.go:21:5:warning: var clientFactory is unused (U1000) (staticcheck)
handlers/utils.go:23:6:warning: func getService is unused (U1000) (staticcheck)
make: *** [Makefile:289: lint] Error 1
```

