### PR TITLE
KIALI-3057 Fixing MeshPolicy error when user hasn't access to any namespace

### DIFF
--- a/business/tls.go
+++ b/business/tls.go
@@ -1,7 +1,6 @@
 package business
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/kiali/kiali/kubernetes"
@@ -45,7 +44,7 @@ func (in *TLSService) MeshWidemTLSStatus(namespaces []string) (models.MTLSStatus
 
 func (in *TLSService) hasMeshPolicyEnabled(namespaces []string) (bool, error) {
 	if len(namespaces) < 1 {
-		return false, fmt.Errorf("can't find MeshPolicies without a namespace")
+		return false, nil
 	}
 
 	// MeshPolicies are not namespaced. So any namespace user has access to

--- a/business/tls.go
+++ b/business/tls.go
@@ -45,7 +45,7 @@ func (in *TLSService) MeshWidemTLSStatus(namespaces []string) (models.MTLSStatus
 
 func (in *TLSService) hasMeshPolicyEnabled(namespaces []string) (bool, error) {
 	if len(namespaces) < 1 {
-		return false, fmt.Errorf("Unable to determine mesh-wide mTLS status without access to a namespace")
+		return false, fmt.Errorf("Unable to determine mesh-wide mTLS status without access to any namespace")
 	}
 
 	// MeshPolicies are not namespaced. So any namespace user has access to

--- a/business/tls.go
+++ b/business/tls.go
@@ -1,6 +1,7 @@
 package business
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/kiali/kiali/kubernetes"
@@ -44,7 +45,7 @@ func (in *TLSService) MeshWidemTLSStatus(namespaces []string) (models.MTLSStatus
 
 func (in *TLSService) hasMeshPolicyEnabled(namespaces []string) (bool, error) {
 	if len(namespaces) < 1 {
-		return false, nil
+		return false, fmt.Errorf("Unable to determine mesh-wide mTLS status without access to a namespace")
 	}
 
 	// MeshPolicies are not namespaced. So any namespace user has access to

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -35,7 +35,7 @@ func TestMeshPolicyWithoutNamespaces(t *testing.T) {
 	tlsService := TLSService{k8s: k8s}
 	meshPolicyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{})
 
-	assert.NoError(err)
+	assert.EqualError(err, "Unable to determine mesh-wide mTLS status without access to a namespace")
 	assert.Equal(false, meshPolicyEnabled)
 }
 

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -35,7 +35,7 @@ func TestMeshPolicyWithoutNamespaces(t *testing.T) {
 	tlsService := TLSService{k8s: k8s}
 	meshPolicyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{})
 
-	assert.EqualError(err, "Unable to determine mesh-wide mTLS status without access to a namespace")
+	assert.EqualError(err, "Unable to determine mesh-wide mTLS status without access to any namespace")
 	assert.Equal(false, meshPolicyEnabled)
 }
 

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -26,6 +26,19 @@ func TestCorrectMeshPolicy(t *testing.T) {
 	assert.Equal(true, meshPolicyEnabled)
 }
 
+func TestMeshPolicyWithoutNamespaces(t *testing.T) {
+	assert := assert.New(t)
+
+	k8s := new(kubetest.K8SClientMock)
+	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEmptyMTLS("default"), nil)
+
+	tlsService := TLSService{k8s: k8s}
+	meshPolicyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{})
+
+	assert.NoError(err)
+	assert.Equal(false, meshPolicyEnabled)
+}
+
 func TestPolicyWithWrongName(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
** Describe the change **

Users receive an error regarding to MeshPolicies when they don't have access to any namespace.

![Screenshot of Kiali Console (47)](https://user-images.githubusercontent.com/613814/60111173-becf5900-976d-11e9-8ed9-ed5c279ab424.png)

I rename the error to a proper error message. Kiali is unable to determine the mesh-wide mTLS status without accessing to, at least, one namespace. Removing the error is not a solution.
Once the user has one namespaces added, the MeshPolicy could be fetch. However, the total mTLS status might be inaccurate.

![Screenshot of Kiali Console (51)](https://user-images.githubusercontent.com/613814/60180327-13331100-9820-11e9-931a-575b8e10eb86.png)

Goes with: https://github.com/kiali/kiali-ui/pull/1284

** Issue reference **

https://issues.jboss.org/browse/KIALI-3057

** Backwards incompatible? **
yes

