### PR TITLE
KIALI-3034 ServiceEntry nodes should represent an actual ServiceEntry (#1172)

### DIFF
--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -228,7 +228,7 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		// node may have destination service info
 		if val, ok := n.Metadata[graph.DestServices]; ok {
 			nd.DestServices = []graph.Service{}
-			for _, val := range val.(map[string]graph.Service) {
+			for _, val := range val.(graph.DestServicesMetadata) {
 				nd.DestServices = append(nd.DestServices, val)
 			}
 		}

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -28,3 +28,17 @@ const (
 	ProtocolKey     MetadataKey = "protocol"
 	ResponseTime    MetadataKey = "responseTime"
 )
+
+// DestServicesMetadata key=Service.Key()
+type DestServicesMetadata map[string]Service
+
+// NewDestServicesMetadata returns an empty DestServicesMetadata map
+func NewDestServicesMetadata() DestServicesMetadata {
+	return make(map[string]Service)
+}
+
+// Add adds or replaces a destService
+func (dsm DestServicesMetadata) Add(key string, service Service) DestServicesMetadata {
+	dsm[key] = service
+	return dsm
+}

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -65,7 +65,7 @@ NODES:
 			}
 		case !versionOk && (n.NodeType == graph.NodeTypeApp):
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
-				for _, ds := range destServices.(map[string]graph.Service) {
+				for _, ds := range destServices.(graph.DestServicesMetadata) {
 					for _, destinationRule := range istioCfg.DestinationRules.Items {
 						if destinationRule.HasCircuitBreaker(ds.Namespace, ds.Name, "") {
 							n.Metadata[graph.HasCB] = true
@@ -76,7 +76,7 @@ NODES:
 			}
 		case versionOk:
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
-				for _, ds := range destServices.(map[string]graph.Service) {
+				for _, ds := range destServices.(graph.DestServicesMetadata) {
 					for _, destinationRule := range istioCfg.DestinationRules.Items {
 						if destinationRule.HasCircuitBreaker(ds.Namespace, ds.Name, n.Version) {
 							n.Metadata[graph.HasCB] = true
@@ -119,7 +119,7 @@ func addLabels(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo
 	appLabelName := config.Get().IstioLabels.AppLabelName
 	for _, n := range trafficMap {
 		// make sure service nodes have the defined app label so it can be used for app grouping in the UI.
-		if n.NodeType == graph.NodeTypeService && n.App == "" {
+		if n.NodeType == graph.NodeTypeService && n.Namespace != graph.Unknown && n.App == "" {
 			// A service node that is a service entry will not have a service definition
 			if _, ok := n.Metadata[graph.IsServiceEntry]; ok {
 				continue

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -19,22 +19,22 @@ func setupTrafficMap() (map[string]*graph.Node, string, string, string, string, 
 	trafficMap := graph.NewTrafficMap()
 
 	appNode := graph.NewNode("testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
-	appNode.Metadata[graph.DestServices] = map[string]graph.Service{"testNamespace ratings": graph.Service{Namespace: "testNamespace", Name: "ratings"}}
+	appNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.Service{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNode.ID] = &appNode
 
 	appNodeV1 := graph.NewNode("testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
-	appNodeV1.Metadata[graph.DestServices] = map[string]graph.Service{"testNamespace ratings": graph.Service{Namespace: "testNamespace", Name: "ratings"}}
+	appNodeV1.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.Service{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV1.ID] = &appNodeV1
 
 	appNodeV2 := graph.NewNode("testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
-	appNodeV2.Metadata[graph.DestServices] = map[string]graph.Service{"testNamespace ratings": graph.Service{Namespace: "testNamespace", Name: "ratings"}}
+	appNodeV2.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.Service{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV2.ID] = &appNodeV2
 
 	serviceNode := graph.NewNode("testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[serviceNode.ID] = &serviceNode
 
 	workloadNode := graph.NewNode("testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
-	workloadNode.Metadata[graph.DestServices] = map[string]graph.Service{"testNamespace ratings": graph.Service{Namespace: "testNamespace", Name: "ratings"}}
+	workloadNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.Service{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[workloadNode.ID] = &workloadNode
 
 	fooServiceNode := graph.NewNode("testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)

--- a/graph/types.go
+++ b/graph/types.go
@@ -62,7 +62,7 @@ type TrafficMap map[string]*Node
 func NewNode(serviceNamespace, service, workloadNamespace, workload, app, version, graphType string) Node {
 	id, nodeType := Id(serviceNamespace, service, workloadNamespace, workload, app, version, graphType)
 	namespace := workloadNamespace
-	if IsOK(namespace) {
+	if !IsOK(namespace) {
 		namespace = serviceNamespace
 	}
 


### PR DESCRIPTION
- aggregate se-host service nodes into one serviceEntry node
  - add destServices aggregation
- fix bug in graph.NewNode
- don't mark serviceEntries as inaccessible so that the UI can generate a link to the detail.
  - to specialCase serviceEntries test against the isServiceEntry metadata
- Handle non-leaf serviceEntry with outgoing traffic to an edgress gateway
- Fix 2 bugs(!) in edge aggregation (these affected serviceGraph generation as well)
- minor fix to prevent fetch of unknown service in badging appender
