### PR TITLE
KIALI-3077 Move to the ubi-minimal base image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7
+FROM registry.access.redhat.com/ubi7-minimal
 
 LABEL maintainer="kiali-dev@googlegroups.com"
 


### PR DESCRIPTION
** Describe the change **

Moves to using the ubi-minimal base image instead of the full ubi base image. This should help to prevent rebuilds due to security issues in unused packages.

** Issue reference **

https://issues.jboss.org/browse/KIALI-3077