### PR TITLE
KIALI-3066 Rename Grafana display_link to enabled

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,7 @@ const (
 	EnvPrometheusServiceURL       = "PROMETHEUS_SERVICE_URL"
 	EnvPrometheusCustomMetricsURL = "PROMETHEUS_CUSTOM_METRICS_URL"
 
-	EnvGrafanaDisplayLink  = "GRAFANA_DISPLAY_LINK"
+	EnvGrafanaEnabled      = "GRAFANA_ENABLED"
 	EnvGrafanaInClusterURL = "GRAFANA_IN_CLUSTER_URL"
 	EnvGrafanaURL          = "GRAFANA_URL"
 
@@ -144,7 +144,8 @@ type PrometheusConfig struct {
 
 // GrafanaConfig describes configuration used for Grafana links
 type GrafanaConfig struct {
-	DisplayLink  bool   `yaml:"display_link"`
+	// Enable or disable Grafana support in Kiali
+	Enabled      bool   `yaml:"enabled"`
 	InClusterURL string `yaml:"in_cluster_url"`
 	URL          string `yaml:"url"`
 	Auth         Auth   `yaml:"auth"`
@@ -278,7 +279,7 @@ func NewConfig() (c *Config) {
 	c.ExternalServices.Prometheus.Auth = getAuthFromEnv("PROMETHEUS")
 
 	// Grafana Configuration
-	c.ExternalServices.Grafana.DisplayLink = getDefaultBool(EnvGrafanaDisplayLink, true)
+	c.ExternalServices.Grafana.Enabled = getDefaultBool(EnvGrafanaEnabled, true)
 	c.ExternalServices.Grafana.InClusterURL = strings.TrimSpace(getDefaultString(EnvGrafanaInClusterURL, ""))
 	c.ExternalServices.Grafana.URL = strings.TrimSpace(getDefaultString(EnvGrafanaURL, ""))
 	c.ExternalServices.Grafana.Auth = getAuthFromEnv("GRAFANA")

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -43,7 +43,7 @@ func GetGrafanaInfo(w http.ResponseWriter, r *http.Request) {
 func getGrafanaInfo(requestToken string, dashboardSupplier dashboardSupplier) (*models.GrafanaInfo, int, error) {
 	grafanaConfig := config.Get().ExternalServices.Grafana
 
-	if !grafanaConfig.DisplayLink {
+	if !grafanaConfig.Enabled {
 		return nil, http.StatusNoContent, nil
 	}
 

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -22,7 +22,7 @@ var anError = map[string]string{
 
 func TestGetGrafanaInfoDisabled(t *testing.T) {
 	conf := config.NewConfig()
-	conf.ExternalServices.Grafana.DisplayLink = false
+	conf.ExternalServices.Grafana.Enabled = false
 	config.Set(conf)
 	info, code, err := getGrafanaInfo("", buildDashboardSupplier(dashboard, 200, "whatever", t))
 	assert.Nil(t, err)

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -174,7 +174,7 @@ spec:
 #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Grafana,
 #       and auth.token config is ignored then.
 #   username: Username to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
-# display_link: When true, a link to Grafana will be displayed for more dashboards.
+# enabled: When true, Grafana support will be enabled in Kiali.
 # in_cluster_url: Set URL for in-cluster access. Example: "http://grafana.istio-system:3000".
 # url: The URL that Kiali uses when integrating with Grafana. This URL must be accessible to clients external to
 #      the cluster in order for the integration to work properly. If empty, an attempt to auto-discover it is made.
@@ -188,7 +188,7 @@ spec:
 #        type: "none"
 #        use_kiali_token: false
 #        username: ""
-#      display_link: true
+#      enabled: true
 #      in_cluster_url: "http://grafana.istio-system:3000"
 #      url: ""
 #

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -48,7 +48,7 @@ kiali_defaults:
         type: "none"
         use_kiali_token: false
         username: ""
-      display_link: true
+      enabled: true
       in_cluster_url: ""
       url: ""
     istio:

--- a/status/discover.go
+++ b/status/discover.go
@@ -176,8 +176,9 @@ func DiscoverJaeger() string {
 // or will try to retrieve it if an OpenShift Route is defined.
 func DiscoverGrafana() string {
 	grafanaConf := config.Get().ExternalServices.Grafana
-	// If display link is disable in Grafana configuration return empty string and avoid discovery
-	if !grafanaConf.DisplayLink {
+
+	// If Grafana is disabled in the configuration return an empty string and avoid discovery
+	if !grafanaConf.Enabled {
 		return ""
 	}
 	if grafanaConf.URL != "" || grafanaConf.InClusterURL == "" {

--- a/status/versions.go
+++ b/status/versions.go
@@ -41,7 +41,7 @@ func getVersions() {
 		kubernetesVersion,
 	}
 
-	if config.Get().ExternalServices.Grafana.DisplayLink {
+	if config.Get().ExternalServices.Grafana.Enabled {
 		components = append(components, grafanaVersion)
 	} else {
 		log.Debugf("Grafana is disabled in Kiali by configuration")


### PR DESCRIPTION
** Describe the change **

Renamed the Grafana 'display_link' property to 'enabled'. This is to be more aligned with the Jaeger 'enabled' configuration option.

** Issue reference **

https://issues.jboss.org/browse/KIALI-3066

** Backwards incompatible? **

Anyone with an existing configmap / kiali resource will need to update the value being used.

** Documentation **

The example operator files are updated to include this change. I don't believe the display_link option is listed in any of our other documentation.