### PR TITLE
KIALI-3094 Explicitly avoid validations on Sidecar resource

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -174,6 +174,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		// Validations on ClusterRbacConfigs are not yet in place
 	case RbacConfigs:
 		// Validations on RbacConfigs are not yet in place
+	case Sidecars:
+		// Validations on Sidecars are not yet in place
 	case ServiceRoles:
 		objectCheckers = []ObjectChecker{noServiceChecker}
 	case ServiceRoleBindings:


### PR DESCRIPTION
** Describe the change **

Error message when trying to load details for Sidecar resources
"object type not found: sidecars"

Fixed it by adding that reference to the validations.

Note: I Think that this did nopt happened before  because we weren't correctly validating the result of "err". @israel-hdez configured a linter and fixed some linting issues some days ago.