### PR TITLE
KIALI-3081 Alternative Auth POC (Token auth)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,10 +90,12 @@ const (
 	AuthStrategyOpenshift = "openshift"
 	AuthStrategyLogin     = "login"
 	AuthStrategyAnonymous = "anonymous"
+	AuthStrategyToken     = "token"
 
 	TokenCookieName             = "kiali-token"
 	AuthStrategyOpenshiftIssuer = "kiali-openshift"
 	AuthStrategyLoginIssuer     = "kiali-login"
+	AuthStrategyTokenIssuer     = "kiali-token"
 
 	// These constants are used for external services auth (Prometheus, Grafana ...) ; not for Kiali auth
 	AuthTypeBasic  = "basic"

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"github.com/kiali/kiali/util"
 	"net/http"
 	"strconv"
 	"strings"
@@ -206,6 +207,62 @@ func performOpenshiftAuthentication(w http.ResponseWriter, r *http.Request) bool
 	return true
 }
 
+func performTokenAuthentication(w http.ResponseWriter, r *http.Request) bool {
+	err := r.ParseForm()
+
+	if err != nil {
+		RespondWithJSONIndent(w, http.StatusInternalServerError, fmt.Errorf("error parsing form info: %+v", err))
+		return false
+	}
+
+	token := r.Form.Get("token")
+
+	if token == "" {
+		RespondWithJSONIndent(w, http.StatusInternalServerError, "Token is empty.")
+		return false
+	}
+
+	business, err := getBusiness(r)
+	if err != nil {
+		RespondWithJSONIndent(w, http.StatusInternalServerError, "Error retrieving the OAuth package.")
+	}
+
+	err = business.OpenshiftOAuth.ValidateToken(token)
+
+	if err != nil {
+		RespondWithJSONIndent(w, http.StatusUnauthorized, "Token is not valid or is expired.")
+		return false
+	}
+
+
+	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(config.Get().LoginToken.ExpirationSeconds))
+	tokenClaims := config.IanaClaims{
+		SessionId: token,
+		StandardClaims: jwt.StandardClaims{
+			Subject:   "token",
+			ExpiresAt: timeExpire.Unix(),
+			Issuer:    config.AuthStrategyTokenIssuer,
+		},
+	}
+	tokenString, err := config.GetSignedTokenString(tokenClaims)
+	if err != nil {
+		RespondWithJSONIndent(w, http.StatusInternalServerError, err)
+		return false
+	}
+
+	tokenCookie := http.Cookie{
+		Name:     config.TokenCookieName,
+		Value:    tokenString,
+		Expires:  timeExpire,
+		HttpOnly: true,
+		// SameSite: http.SameSiteStrictMode, ** Commented out because unsupported in go < 1.11
+	}
+	http.SetCookie(w, &tokenCookie)
+
+	RespondWithJSONIndent(w, http.StatusOK, TokenResponse{Token: tokenString, ExpiresOn: timeExpire.Format(time.RFC1123Z), Username: "token"})
+	return true
+}
+
 func checkOpenshiftSession(w http.ResponseWriter, r *http.Request) (int, string) {
 	tokenString := getTokenStringFromRequest(r)
 	if claims, err := config.GetTokenClaimsIfValid(tokenString); err != nil {
@@ -314,6 +371,8 @@ func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {
 		case config.AuthStrategyLogin:
 			statusCode = checkKialiSession(w, r)
 			token = aHandler.saToken
+		case config.AuthStrategyToken:
+			statusCode, token = checkOpenshiftSession(w, r)
 		case config.AuthStrategyAnonymous:
 			log.Trace("Access to the server endpoint is not secured with credentials - letting request come in")
 			token = aHandler.saToken
@@ -353,6 +412,8 @@ func Authenticate(w http.ResponseWriter, r *http.Request) {
 		if !performKialiAuthentication(w, r) {
 			writeAuthenticateHeader(w, r)
 		}
+	case config.AuthStrategyToken:
+		performTokenAuthentication(w, r)
 	case config.AuthStrategyAnonymous:
 		log.Warning("Authentication attempt with anonymous access enabled.")
 	default:

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -118,19 +118,21 @@
     msg: "AUTH STRATEGY={{ kiali_vars.auth.strategy }}"
 - name: Confirm auth strategy is valid for OpenShift environments
   fail:
-    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login', 'openshift', or 'anonymous'"
+    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login', 'openshift', 'token', or 'anonymous'"
   when:
   - is_openshift == True
   - kiali_vars.auth.strategy != 'login'
   - kiali_vars.auth.strategy != 'anonymous'
   - kiali_vars.auth.strategy != 'openshift'
+  - kiali_vars.auth.strategy != 'token'
 - name: Confirm auth strategy is valid for Kubernetes environments
   fail:
-    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login' or 'anonymous'"
+    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login', 'token', or 'anonymous'"
   when:
   - is_k8s == True
   - kiali_vars.auth.strategy != 'login'
   - kiali_vars.auth.strategy != 'anonymous'
+  - kiali_vars.auth.strategy != 'token'
 
 # Fail if ingress is disabled but auth_strategy is openshift. This is because the openshift auth strategy
 # requires OAuth Client which requires a Route. So ingress must be enabled if strategy is openshift.


### PR DESCRIPTION
This is not meant to be merged, just a PoC.

This is adding a login mechanism similar to how the [kubernetes dashboard](https://github.com/kubernetes/dashboard/wiki/Access-control#login-view) works (the "token" one).

So, instead of providing a username and a password, Kiali asks for a token. The provided token is meant to be a service account token. Once you provide a valid token, kiali uses that for the session. This works fine when using Kiali with Openshift and works so-so with kubernetes because of RBAC differences. 

![image](https://user-images.githubusercontent.com/23639005/60689800-09945380-9e87-11e9-87f7-983efc9fe995.png)

Adding new auth methods looks easy, but probably, some abstractions are required to make this more "pluggable" and to change less files, and also to make the auth API accept all auth kinds under the same endpoint.

In the UI side (see https://github.com/kiali/kiali-ui/pull/1297) also multiple files needs to be changed to add more auth methods. The LoginDispatcher looks like the abstracted interface. But the login form still needs to be modified and take into account the different auth methods, so probably its still not optimal.

Operator also validates the auth method set and rejects to setup kiali if there is not a valid auth method. The operator, probably, should not validate the auth method and let kiali display an error. Else, it's hard to find the error on all those operator logs.