### PR TITLE
issue 1215 - Kubernetes role bindings are immutable, this works around that limitation

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -149,7 +149,7 @@ kiali-delete: secret-delete
 purge-kiali:
 	@echo Purge Kiali resources
 	${OC} patch kiali kiali -n "${OPERATOR_WATCH_NAMESPACE}" -p '{"metadata":{"finalizers": []}}' --type=merge ; true
-	${OC} delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n "${NAMESPACE}"
+	${OC} delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,roles,rolebindings,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n "${NAMESPACE}"
 	${OC} delete --ignore-not-found=true oauthclients.oauth.openshift.io --selector="app=kiali" -n "${NAMESPACE}" ; true
 
 ## run-playbook: Run the dev playbook to run the Ansible script locally.

--- a/operator/molecule/asserts/multi-tenancy/role_asserts.yml
+++ b/operator/molecule/asserts/multi-tenancy/role_asserts.yml
@@ -1,7 +1,3 @@
-- name: Get Kiali Configmap
-  set_fact:
-    roles: '{{ lookup("k8s", api_version="rbac.authorization.k8s.io/v1", kind="Role", namespace="istio-system", resource_name="kiali-viewer") }}'
-
 - name: Get Roles
   k8s_facts:
    api_version: rbac.authorization.k8s.io/v1

--- a/operator/molecule/asserts/roles-test/ro_clusterrole_asserts.yml
+++ b/operator/molecule/asserts/roles-test/ro_clusterrole_asserts.yml
@@ -1,0 +1,28 @@
+- name: Get cluster roles
+  k8s_facts:
+   api_version: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   name: "{{ item }}"
+  register: clusterroles
+  loop:
+  - kiali
+  - kiali-viewer
+
+- name: Assert that cluster roles exist
+  assert:
+    that: "{{ item.resources | length == 1 }}"
+  with_items:
+  - "{{ clusterroles.results }}"
+
+- name: Get cluster role binding
+  k8s_facts:
+   api_version: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   name: kiali
+  register: clusterrolebindings
+
+- name: Assert the cluster role binding provides the read-only viewer role
+  assert:
+    that:
+    - "{{ clusterrolebindings.resources[0] | default({}) | json_query('roleRef.name') == 'kiali-viewer' }}"
+    fail_msg: "The kiali cluster role binding did not have the read-only roleref 'kiali-viewer'"

--- a/operator/molecule/asserts/roles-test/ro_role_asserts.yml
+++ b/operator/molecule/asserts/roles-test/ro_role_asserts.yml
@@ -1,0 +1,35 @@
+- name: Get roles
+  k8s_facts:
+   api_version: rbac.authorization.k8s.io/v1
+   kind: Role
+   namespace: "{{ item[0] }}"
+   name: "{{ item[1] }}"
+  register: roles
+  with_nested:
+  - "{{ kiali.accessible_namespaces }}"
+  - ['kiali', 'kiali-viewer']
+
+- name: Assert that namespaces have the correct roles
+  assert:
+    that: "{{ item.resources | length == 1 }}"
+  with_items:
+  - "{{ roles.results }}"
+
+- name: Get role binding
+  k8s_facts:
+   api_version: rbac.authorization.k8s.io/v1
+   kind: RoleBinding
+   namespace: "{{ item[0] }}"
+   name: "{{ item[1] }}"
+  register: rolebindings
+  with_nested:
+  - "{{ kiali.accessible_namespaces }}"
+  - kiali
+
+- name: Assert the role binding provides the read-only viewer role
+  assert:
+    that:
+    - "{{ item.resources[0] | default({}) | json_query('roleRef.name') == 'kiali-viewer' }}"
+    fail_msg: "The kiali role binding did not have the read-only roleref 'kiali-viewer'"
+  with_items:
+  - "{{ rolebindings.results }}"

--- a/operator/molecule/asserts/roles-test/rw_clusterrole_asserts.yml
+++ b/operator/molecule/asserts/roles-test/rw_clusterrole_asserts.yml
@@ -1,0 +1,28 @@
+- name: Get cluster roles
+  k8s_facts:
+   api_version: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   name: "{{ item }}"
+  register: clusterroles
+  loop:
+  - kiali
+  - kiali-viewer
+
+- name: Assert that cluster roles exist
+  assert:
+    that: "{{ item.resources | length == 1 }}"
+  with_items:
+  - "{{ clusterroles.results }}"
+
+- name: Get cluster role binding
+  k8s_facts:
+   api_version: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   name: kiali
+  register: clusterrolebindings
+
+- name: Assert the cluster role binding provides the read-write role
+  assert:
+    that:
+    - "{{ clusterrolebindings.resources[0] | default({}) | json_query('roleRef.name') == 'kiali' }}"
+    fail_msg: "The kiali cluster role binding did not have the read-write roleref 'kiali'"

--- a/operator/molecule/asserts/roles-test/rw_role_asserts.yml
+++ b/operator/molecule/asserts/roles-test/rw_role_asserts.yml
@@ -1,0 +1,35 @@
+- name: Get roles
+  k8s_facts:
+   api_version: rbac.authorization.k8s.io/v1
+   kind: Role
+   namespace: "{{ item[0] }}"
+   name: "{{ item[1] }}"
+  register: roles
+  with_nested:
+  - "{{ kiali.accessible_namespaces }}"
+  - ['kiali', 'kiali-viewer']
+
+- name: Assert that namespaces have the correct roles
+  assert:
+    that: "{{ item.resources | length == 1 }}"
+  with_items:
+  - "{{ roles.results }}"
+
+- name: Get role binding
+  k8s_facts:
+   api_version: rbac.authorization.k8s.io/v1
+   kind: RoleBinding
+   namespace: "{{ item[0] }}"
+   name: "{{ item[1] }}"
+  register: rolebindings
+  with_nested:
+  - "{{ kiali.accessible_namespaces }}"
+  - kiali
+
+- name: Assert the role binding provides the read-write role
+  assert:
+    that:
+    - "{{ item.resources[0] | default({}) | json_query('roleRef.name') == 'kiali' }}"
+    fail_msg: "The kiali role binding did not have the read-write roleref 'kiali'"
+  with_items:
+  - "{{ rolebindings.results }}"

--- a/operator/molecule/common/set_accessible_namespaces_to_all.yml
+++ b/operator/molecule/common/set_accessible_namespaces_to_all.yml
@@ -1,0 +1,11 @@
+
+- name: Set accessible namespace to ** in current Kiali CR
+  vars:
+    current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=kiali.operator_namespace, resource_name=custom_resource.metadata.name) }}"
+  set_fact:
+    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'accessible_namespaces': ['**'] }}}, recursive=True) }}"
+
+- name: Change Kiali CR with accessible namespaces set to **
+  k8s:
+    namespace: '{{ kiali.operator_namespace }}'
+    definition: "{{ new_kiali_cr }}"

--- a/operator/molecule/common/set_view_only_mode.yml
+++ b/operator/molecule/common/set_view_only_mode.yml
@@ -1,0 +1,10 @@
+- name: Set view_only_mode to true in current Kiali CR
+  vars:
+    current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=kiali.operator_namespace, resource_name=custom_resource.metadata.name) }}"
+  set_fact:
+    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'view_only_mode': true }}}, recursive=True) }}"
+
+- name: Change Kiali CR with view_only_mode set to true
+  k8s:
+    namespace: '{{ kiali.operator_namespace }}'
+    definition: "{{ new_kiali_cr }}"

--- a/operator/molecule/common/tasks.yml
+++ b/operator/molecule/common/tasks.yml
@@ -1,12 +1,12 @@
-- name: Get Kiali CR is present
+- name: Get Kiali CR if present
   set_fact:
-    kiali_cr: "{{ lookup('k8s', group='kiali.io/v1alpha1', api_version='v1alpha1', kind='Kiali', namespace=kiali.operator_namespace, resource_name=custom_resource.metadata.name) }}"
+    kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=kiali.operator_namespace, resource_name=custom_resource.metadata.name) }}"
 
 - name: Get Kiali Operator Pod
   k8s_facts:
     api_version: v1
     kind: Pod
-    namespace: '{{ kiali.operator_namespace }}'
+    namespace: "{{ kiali.operator_namespace }}"
     label_selectors:
     - app = kiali-operator
   register: kiali_operator_pod
@@ -15,14 +15,14 @@
   k8s_facts:
     api_version: v1
     kind: Pod
-    namespace: '{{ istio.control_plane_namespace }}'
+    namespace: "{{ istio.control_plane_namespace }}"
     label_selectors:
     - app = kiali
   register: kiali_pod
 
 - name: Get Kiali Configmap
   set_fact:
-    kiali_configmap: '{{ lookup("k8s", api_version="v1", kind="ConfigMap", namespace=istio.control_plane_namespace, resource_name="kiali") }}'
+    kiali_configmap: "{{ lookup('k8s', api_version='v1', kind='ConfigMap', namespace=istio.control_plane_namespace, resource_name='kiali') }}"
 
 - name: Format Configmap
   set_fact:

--- a/operator/molecule/common/unset_view_only_mode.yml
+++ b/operator/molecule/common/unset_view_only_mode.yml
@@ -1,0 +1,10 @@
+- name: Unset view_only_mode in current Kiali CR
+  vars:
+    current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=kiali.operator_namespace, resource_name=custom_resource.metadata.name) }}"
+  set_fact:
+    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'view_only_mode': false }}}, recursive=True) }}"
+
+- name: Change Kiali CR with view_only_mode set to false
+  k8s:
+    namespace: '{{ kiali.operator_namespace }}'
+    definition: "{{ new_kiali_cr }}"

--- a/operator/molecule/common/wait_for_kiali_cr_changes.yml
+++ b/operator/molecule/common/wait_for_kiali_cr_changes.yml
@@ -1,0 +1,11 @@
+- name: Wait for changes to take effect
+  k8s_facts:
+    api_version: kiali.io/v1alpha1
+    kind: Kiali
+    name: "{{ custom_resource.metadata.name }}"
+    namespace: "{{ kiali.operator_namespace }}"
+  register: kiali_cr_list
+  until:
+  - kiali_cr_list | default({}) | json_query('resources[*].status.conditions[?reason==`Successful`].status') | flatten | join == 'True'
+  retries: 60
+  delay: 5

--- a/operator/molecule/default/destroy.yml
+++ b/operator/molecule/default/destroy.yml
@@ -3,47 +3,76 @@
   connection: local
   tasks:
   - name: Remove Kiali CR
+    vars:
+      custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
     k8s:
       state: absent
-      namespace: '{{ kiali.operator_namespace }}'
-      definition: "{{ lookup('template', cr_file_path) }}"
+      api_version: kiali.io/v1alpha1
+      kind: Kiali
+      namespace: "{{ kiali.operator_namespace }}"
+      name: "{{ custom_resource.metadata.name }}"
 
   - name: Produce Files with Correct Parameters
     shell: " {{ item }}"
     with_items:
-    - cat {{ kiali_operator_assets_path }}/namespace.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} OPERATOR_NAMESPACE={{ kiali.operator_namespace }}  envsubst
-    - cat {{ kiali_operator_assets_path }}/crd.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} envsubst
-    - cat {{ kiali_operator_assets_path }}/role_binding.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} OPERATOR_NAMESPACE={{ kiali.operator_namespace }} envsubst
-    - cat {{ kiali_operator_assets_path }}/service_account.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} envsubst
-    - cat {{ kiali_operator_assets_path }}/operator.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} OPERATOR_IMAGE_NAME={{ kiali.operator_image_name}} OPERATOR_IMAGE_VERSION={{ kiali.operator_version }} OPERATOR_IMAGE_PULL_POLICY={{ kiali.image_pull_policy}} OPERATOR_WATCH_NAMESPACE={{ kiali.operator_watch_namespace }} envsubst
-    - cat {{ kiali_operator_assets_path }}/role.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} OPERATOR_ROLE_CLUSTERROLEBINDINGS="{{ kiali.operator_clusterrolebindings}}" OPERATOR_ROLE_CLUSTERROLES="{{ kiali.operator_clusterroles }}" envsubst
+    - cat {{ kiali_operator_assets_path }}/namespace.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} OPERATOR_NAMESPACE={{ kiali.operator_namespace }}  envsubst
+    - cat {{ kiali_operator_assets_path }}/crd.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} envsubst
+    - cat {{ kiali_operator_assets_path }}/role_binding.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} OPERATOR_NAMESPACE={{ kiali.operator_namespace }} envsubst
+    - cat {{ kiali_operator_assets_path }}/service_account.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} envsubst
+    - cat {{ kiali_operator_assets_path }}/operator.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} OPERATOR_IMAGE_NAME={{ kiali.operator_image_name}} OPERATOR_IMAGE_VERSION={{ kiali.operator_version }} OPERATOR_IMAGE_PULL_POLICY={{ kiali.image_pull_policy}} OPERATOR_WATCH_NAMESPACE={{ kiali.operator_watch_namespace }} envsubst
+    - cat {{ kiali_operator_assets_path }}/role.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} OPERATOR_ROLE_CLUSTERROLEBINDINGS="{{ kiali.operator_clusterrolebindings}}" OPERATOR_ROLE_CLUSTERROLES="{{ kiali.operator_clusterroles }}" envsubst
     register: template
 
-  - name: "Clean Files"
+  - name: Parse Template Yaml Files
     set_fact:
-      namespace: "{{ template.results[0].stdout | regex_replace('---', '') | from_yaml }}"
-      crd: "{{ template.results[1].stdout | regex_replace('---', '') | from_yaml }}"
-      role_binding: "{{ template.results[2].stdout | regex_replace('---', '') | from_yaml }}"
-      service_account: "{{ template.results[3].stdout | regex_replace('---', '') | from_yaml }}"
-      operator: "{{ template.results[4].stdout | regex_replace('---', '') | from_yaml }}"
-      role: "{{ template.results[5].stdout | regex_replace('---', '') | from_yaml }}"
+      namespace: "{{ (template.results[0].stdout | from_yaml_all | list)[0] }}"
+      crd0: "{{ (template.results[1].stdout | from_yaml_all | list)[0] }}"
+      crd1: "{{ (template.results[1].stdout | from_yaml_all | list)[1] }}"
+      role_binding: "{{ (template.results[2].stdout | from_yaml_all | list)[0] }}"
+      service_account: "{{ (template.results[3].stdout | from_yaml_all | list)[0] }}"
+      operator: "{{ (template.results[4].stdout | from_yaml_all | list)[0] }}"
+      role: "{{ (template.results[5].stdout | from_yaml_all | list)[0] }}"
 
   - name: Combine Namespace on the Files that need it
     set_fact:
-      crd: "{{ crd | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
       service_account: "{{ service_account | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
       role_binding: "{{ role_binding | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
       role: "{{ role | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
       operator: "{{ operator | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
 
-  - name: Pause in order not to create a namespace stuck problem
-    pause:
-      minutes: 1
+  # Wait for the last things to be removed (which are the configmap and monitoring dashboards). This avoids the namespace-stuck-problem.
+  - name: Wait for Kiali ConfigMap to be uninstalled
+    k8s_facts:
+      api_version: v1
+      kind: ConfigMap
+      namespace: "{{ istio.control_plane_namespace }}"
+      name: kiali
+    register: doomed_list
+    until:
+    - doomed_list | default({}) | json_query("resources[*]") | length == 0
+    retries: 60
+    delay: 5
 
-  - name: Removing Custom Resource Definition
+  - name: Wait for Kiali MonitoringDashboards to be uninstalled
+    k8s_facts:
+      api_version: monitoring.kiali.io/v1alpha1
+      kind: MonitoringDashboard
+      namespace: "{{ istio.control_plane_namespace }}"
+    register: doomed_list
+    until:
+    - doomed_list | default({}) | json_query("resources[*]") | length == 0
+    retries: 60
+    delay: 5
+
+  - name: Removing First Custom Resource Definition
     k8s:
       state: absent
-      definition: "{{ crd }}"
+      definition: "{{ crd0 }}"
+
+  - name: Removing Second Custom Resource Definition
+    k8s:
+      state: absent
+      definition: "{{ crd1 }}"
 
   - name: Removing Role
     k8s:
@@ -65,7 +94,9 @@
       state: absent
       definition: "{{ operator }}"
 
-  - name: Removing kiali-operator namespace
+  - name: Removing Operator namespace
     k8s:
       state: absent
       definition: "{{ namespace }}"
+    when:
+    - kiali.operator_namespace != istio.control_plane_namespace

--- a/operator/molecule/default/playbook.yml
+++ b/operator/molecule/default/playbook.yml
@@ -4,6 +4,6 @@
   vars:
     custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
   tasks:
-  - import_tasks: '../common/tasks.yml'
-  - import_tasks: '../asserts/configmap_asserts.yml'
-  - import_tasks: '../asserts/pod_asserts.yml'
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/configmap_asserts.yml
+  - import_tasks: ../asserts/pod_asserts.yml

--- a/operator/molecule/default/prepare.yml
+++ b/operator/molecule/default/prepare.yml
@@ -1,4 +1,3 @@
-
 - name: Prepare
   hosts: localhost
   connection: local
@@ -6,26 +5,26 @@
   - name: Produce Files with Correct Parameters
     shell: " {{ item }}"
     with_items:
-    - cat {{ kiali_operator_assets_path }}/namespace.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} OPERATOR_NAMESPACE={{ kiali.operator_namespace }}  envsubst
-    - cat {{ kiali_operator_assets_path }}/crd.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} envsubst
-    - cat {{ kiali_operator_assets_path }}/role_binding.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} OPERATOR_NAMESPACE={{ kiali.operator_namespace }} envsubst
-    - cat {{ kiali_operator_assets_path }}/service_account.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} envsubst
-    - cat {{ kiali_operator_assets_path }}/operator.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} OPERATOR_IMAGE_NAME={{ kiali.operator_image_name}} OPERATOR_IMAGE_VERSION={{ kiali.operator_version }} OPERATOR_IMAGE_PULL_POLICY={{ kiali.image_pull_policy}} OPERATOR_WATCH_NAMESPACE={{ kiali.operator_watch_namespace }} envsubst
-    - cat {{ kiali_operator_assets_path }}/role.yaml | OPERATOR_VERSION_LABEL={{ kiali.image_version }} OPERATOR_ROLE_CLUSTERROLEBINDINGS="{{ kiali.operator_clusterrolebindings}}" OPERATOR_ROLE_CLUSTERROLES="{{ kiali.operator_clusterroles }}" envsubst
+    - cat {{ kiali_operator_assets_path }}/namespace.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} OPERATOR_NAMESPACE={{ kiali.operator_namespace }}  envsubst
+    - cat {{ kiali_operator_assets_path }}/crd.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} envsubst
+    - cat {{ kiali_operator_assets_path }}/role_binding.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} OPERATOR_NAMESPACE={{ kiali.operator_namespace }} envsubst
+    - cat {{ kiali_operator_assets_path }}/service_account.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} envsubst
+    - cat {{ kiali_operator_assets_path }}/operator.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} OPERATOR_IMAGE_NAME={{ kiali.operator_image_name}} OPERATOR_IMAGE_VERSION={{ kiali.operator_version }} OPERATOR_IMAGE_PULL_POLICY={{ kiali.image_pull_policy}} OPERATOR_WATCH_NAMESPACE={{ kiali.operator_watch_namespace }} envsubst
+    - cat {{ kiali_operator_assets_path }}/role.yaml | OPERATOR_VERSION_LABEL={{ kiali.operator_version }} OPERATOR_ROLE_CLUSTERROLEBINDINGS="{{ kiali.operator_clusterrolebindings}}" OPERATOR_ROLE_CLUSTERROLES="{{ kiali.operator_clusterroles }}" envsubst
     register: template
 
-  - name: "Clean Files"
+  - name: Parse Template Yaml Files
     set_fact:
-      namespace: "{{ template.results[0].stdout | regex_replace('---', '') | from_yaml }}"
-      crd: "{{ template.results[1].stdout | regex_replace('---', '') | from_yaml }}"
-      role_binding: "{{ template.results[2].stdout | regex_replace('---', '') | from_yaml }}"
-      service_account: "{{ template.results[3].stdout | regex_replace('---', '') | from_yaml }}"
-      operator: "{{ template.results[4].stdout | regex_replace('---', '') | from_yaml }}"
-      role: "{{ template.results[5].stdout | regex_replace('---', '') | from_yaml }}"
+      namespace: "{{ (template.results[0].stdout | from_yaml_all | list)[0] }}"
+      crd0: "{{ (template.results[1].stdout | from_yaml_all | list)[0] }}"
+      crd1: "{{ (template.results[1].stdout | from_yaml_all | list)[1] }}"
+      role_binding: "{{ (template.results[2].stdout | from_yaml_all | list)[0] }}"
+      service_account: "{{ (template.results[3].stdout | from_yaml_all | list)[0] }}"
+      operator: "{{ (template.results[4].stdout | from_yaml_all | list)[0] }}"
+      role: "{{ (template.results[5].stdout | from_yaml_all | list)[0] }}"
 
   - name: Combine Namespace on the Files that need it
     set_fact:
-      crd: "{{ crd | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
       service_account: "{{ service_account | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
       role_binding: "{{ role_binding | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
       role: "{{ role | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
@@ -36,7 +35,8 @@
       definition: "{{ item }}"
     with_items:
     -  "{{ namespace }}"
-    -  "{{ crd }}"
+    -  "{{ crd0 }}"
+    -  "{{ crd1 }}"
     -  "{{ role }}"
     -  "{{ role_binding }}"
     -  "{{ service_account }}"
@@ -44,17 +44,17 @@
 
   - name: Create Kiali CR
     k8s:
-      namespace: '{{ kiali.operator_namespace }}'
+      namespace: "{{ kiali.operator_namespace }}"
       definition: "{{ lookup('template', cr_file_path) }}"
 
   - name: Asserting that Kiali is Deployed
     k8s_facts:
       api_version: v1
       kind: Deployment
-      namespace: 'istio-system'
+      namespace: "{{ istio.control_plane_namespace }}"
       label_selectors:
       - app = kiali
     register: kiali_deployment
     until: kiali_deployment.resources |length == 1 and kiali_deployment.resources[0].status.availableReplicas is defined and kiali_deployment.resources[0].status.availableReplicas == 1
-    retries: 100
-    delay: 20
+    retries: 60
+    delay: 5

--- a/operator/molecule/docker/Dockerfile
+++ b/operator/molecule/docker/Dockerfile
@@ -1,3 +1,4 @@
 FROM quay.io/ansible/molecule:latest
 RUN apk add gettext
 RUN pip install openshift
+RUN pip install junit-xml

--- a/operator/molecule/roles-test/molecule.yml
+++ b/operator/molecule/roles-test/molecule.yml
@@ -1,0 +1,43 @@
+---
+dependency:
+  name: galaxy
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+  inventory:
+    group_vars:
+      all:
+        kiali_operator_assets_path : "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/kiali-cr.yaml"
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          accessible_namespaces:
+          - istio-system
+          auth_strategy: openshift
+          operator_namespace: kiali-operator
+          operator_image_name: quay.io/kiali/kiali-operator
+          operator_version: latest
+          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
+          #operator_version: dev
+          operator_watch_namespace: kiali-operator
+          operator_clusterrolebindings: "- clusterrolebindings"
+          operator_clusterroles: "- clusterroles"
+          image_name: quay.io/kiali/kiali
+          image_version: latest
+          image_pull_policy: Always
+scenario:
+  name: roles-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/operator/molecule/roles-test/playbook.yml
+++ b/operator/molecule/roles-test/playbook.yml
@@ -1,0 +1,27 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/configmap_asserts.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+  # by default, view only mode is off, so the read-write role should be in effect
+  - import_tasks: ../asserts/roles-test/rw_role_asserts.yml
+  # turn on view only mode and see the viewer (read-only) role is now in effect
+  - import_tasks: ../common/set_view_only_mode.yml
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../asserts/roles-test/ro_role_asserts.yml
+  # turn off view only mode which should return back to the read-write role
+  - import_tasks: ../common/unset_view_only_mode.yml
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../asserts/roles-test/rw_role_asserts.yml
+  # change to accessible_namespaces=** which switches to cluster roles
+  - import_tasks: ../common/set_accessible_namespaces_to_all.yml
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../asserts/roles-test/rw_clusterrole_asserts.yml
+  # turn on view only mode and see the viewer (read-only) cluster role is now in effect
+  - import_tasks: ../common/set_view_only_mode.yml
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../asserts/roles-test/ro_clusterrole_asserts.yml

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -281,6 +281,14 @@
   - current_configmap.data is defined
   - current_configmap.data['config.yaml'] is defined
 
+- name: Find currently configured view_only_mode flag
+  set_fact:
+    current_view_only_mode: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.view_only_mode') }}"
+  when:
+  - current_configmap is defined
+  - current_configmap.data is defined
+  - current_configmap.data['config.yaml'] is defined
+
 # Because we need to remove the labels that were created before, we must not allow the user to change
 # the label_selector. So if the current accessible_namespaces is not ** but the label_select is being changed,
 # we need to abort since we won't know what the old labels were. If current accessible_namespaces is ** then
@@ -315,6 +323,28 @@
     role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
+  - current_accessible_namespaces is defined
+  - '"**" in current_accessible_namespaces'
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+
+- name: Delete all Kiali roles from namespaces if view_only_mode is changing since role bindings are immutable
+  include_tasks: remove-roles.yml
+  loop: "{{ kiali_vars.deployment.accessible_namespaces }}"
+  loop_control:
+    loop_var: role_namespace
+  when:
+  - current_view_only_mode is defined
+  - current_view_only_mode != kiali_vars.deployment.view_only_mode
+  - current_accessible_namespaces is defined
+  - '"**" not in current_accessible_namespaces'
+
+- name: Delete Kiali cluster roles if view_only_mode is changing since role bindings are immutable
+  vars:
+    role_namespace: "{{ kiali_vars.deployment.namespace }}"
+  include_tasks: remove-clusterroles.yml
+  when:
+  - current_view_only_mode is defined
+  - current_view_only_mode != kiali_vars.deployment.view_only_mode
   - current_accessible_namespaces is defined
   - '"**" in current_accessible_namespaces'
 


### PR DESCRIPTION
Attempts to fix issue #1215 

Kubernetes role bindings are immutable. This means you cannot change a role binding to refer to a different role ref. Instead, you must delete and then create.

This PR deletes all role-related resources when view_only_mode is changing. That way, the tasks that reconcile the roles/rolebindings will perform a create as opposed to patch/merge.

~~This has NOT been tested. This is just my initial attempt based on what I think will work.~~ (UPDATE: there is now a molecule test in this PR that shows this working)

The molecule tests are fairly simple - this is what those tests do (you can do them as well):

1. Install Kiali Operator and a Kiali CR with all the defaults. This sets `deployment.view_only_mode` to false. Check the read-write roles are in effect.
2. Edit the Kiali CR (e.g. `oc edit kiali kiali -n kiali-operator`) and add a `deployment.view_only_mode` setting, and set it to the value `true`). After the operator updates, the viewer (read-only) roles should be in effect.

This should work when `deployment.accessible_namespaces` is set to either `[**]` or a list of namespaces - both of those conditions are tested. The molecule test changes accessible_namespaces and then confirms the read-write or viewer clusterroles are in effect when appropriate.

To run the molecule tests and see it pass:

```
cd operator/
MOLECULE_SCENARIO=roles-test make molecule-test
```
