### PR TITLE
Molecule docker

### DIFF
--- a/operator/molecule/asserts/configmap_asserts.yml
+++ b/operator/molecule/asserts/configmap_asserts.yml
@@ -8,13 +8,12 @@
     that:
     - kiali_configmap.deployment.image_version ==  kiali.image_version
 
-    
 - name: Assert Kiali Configmap has the correct Image Pull Policy
   assert:
     that:
     - kiali_configmap.deployment.image_pull_policy ==  kiali.image_pull_policy
 
-- name: Assert Kiali Configmap has the correct Istio Namespace 
+- name: Assert Kiali Configmap has the correct Istio Namespace
   assert:
     that:
     - kiali_configmap.istio_namespace == istio.control_plane_namespace
@@ -24,25 +23,20 @@
     that:
     - kiali_configmap.external_services.prometheus.custom_metrics_url == "http://prometheus.{{ istio.control_plane_namespace }}:9090"
 
-
-
 - name: Assert Kiali Configmap has the correct Prometheus Url
   assert:
     that:
     - kiali_configmap.external_services.prometheus.url == "http://prometheus.{{ istio.control_plane_namespace }}:9090"
-
 
 - name: Assert Kiali Configmap has the correct Grafana Url
   assert:
     that:
     - kiali_configmap.external_services.grafana.in_cluster_url == "http://grafana.{{ istio.control_plane_namespace }}:3000"
 
-
 - name: Assert Kiali Configmap has the correct Pilot Url Version
   assert:
     that:
     - kiali_configmap.external_services.istio.url_service_version == "http://istio-pilot.{{ istio.control_plane_namespace }}:8080/version"
-
 
 - name: Actual Kiali Accessible namespace list should be the same as the CR
   assert:

--- a/operator/molecule/asserts/multi-tenancy/role_asserts.yml
+++ b/operator/molecule/asserts/multi-tenancy/role_asserts.yml
@@ -1,7 +1,6 @@
-
 - name: Get Kiali Configmap
   set_fact:
-      roles: '{{ lookup("k8s", api_version="rbac.authorization.k8s.io/v1", kind="Role", namespace="istio-system", resource_name="kiali-viewer") }}'
+    roles: '{{ lookup("k8s", api_version="rbac.authorization.k8s.io/v1", kind="Role", namespace="istio-system", resource_name="kiali-viewer") }}'
 
 - name: Get Roles
   k8s_facts:
@@ -11,10 +10,8 @@
    name: "{{ item[1] }}"
   register: roles
   with_nested:
-    - "{{ kiali.accessible_namespaces }}"
-    - ['kiali', 'kiali-viewer']
- 
-
+  - "{{ kiali.accessible_namespaces }}"
+  - ['kiali', 'kiali-viewer']
 
 - name: Multi-Tenancy - Assert that Namespaces have the correct Roles
   assert:

--- a/operator/molecule/asserts/pod_asserts.yml
+++ b/operator/molecule/asserts/pod_asserts.yml
@@ -1,4 +1,3 @@
-
 - name: Assert Kiali Pod is Running on the correct Namespace
   assert:
     that:

--- a/operator/molecule/common/tasks.yml
+++ b/operator/molecule/common/tasks.yml
@@ -8,7 +8,7 @@
     kind: Pod
     namespace: '{{ kiali.operator_namespace }}'
     label_selectors:
-    - app = kiali-operator      
+    - app = kiali-operator
   register: kiali_operator_pod
 
 - name: Get Kiali Pod
@@ -17,14 +17,12 @@
     kind: Pod
     namespace: '{{ istio.control_plane_namespace }}'
     label_selectors:
-    - app = kiali      
+    - app = kiali
   register: kiali_pod
-
 
 - name: Get Kiali Configmap
   set_fact:
-      kiali_configmap: '{{ lookup("k8s", api_version="v1", kind="ConfigMap", namespace=istio.control_plane_namespace, resource_name="kiali") }}'
-
+    kiali_configmap: '{{ lookup("k8s", api_version="v1", kind="ConfigMap", namespace=istio.control_plane_namespace, resource_name="kiali") }}'
 
 - name: Format Configmap
   set_fact:

--- a/operator/molecule/default/destroy.yml
+++ b/operator/molecule/default/destroy.yml
@@ -1,4 +1,3 @@
-
 - name: Destroy
   hosts: localhost
   connection: local
@@ -9,7 +8,6 @@
       namespace: '{{ kiali.operator_namespace }}'
       definition: "{{ lookup('template', cr_file_path) }}"
 
- 
   - name: Produce Files with Correct Parameters
     shell: " {{ item }}"
     with_items:
@@ -30,8 +28,6 @@
       operator: "{{ template.results[4].stdout | regex_replace('---', '') | from_yaml }}"
       role: "{{ template.results[5].stdout | regex_replace('---', '') | from_yaml }}"
 
-
-      
   - name: Combine Namespace on the Files that need it
     set_fact:
       crd: "{{ crd | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
@@ -40,7 +36,6 @@
       role: "{{ role | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
       operator: "{{ operator | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
 
-  
   - name: Pause in order not to create a namespace stuck problem
     pause:
       minutes: 1
@@ -64,16 +59,13 @@
     k8s:
       state: absent
       definition: "{{ service_account  }}"
-      
 
   - name: Removing Operator Deployment
     k8s:
       state: absent
       definition: "{{ operator }}"
-     
 
-
-  - name: Removing kiali-operator namespace 
+  - name: Removing kiali-operator namespace
     k8s:
       state: absent
       definition: "{{ namespace }}"

--- a/operator/molecule/default/molecule.yml
+++ b/operator/molecule/default/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
         istio:
           control_plane_namespace: istio-system
         kiali:
-          accessible_namespaces: 
+          accessible_namespaces:
           - "**"
           operator_namespace: kiali-operator
           operator_image_name: quay.io/kiali/kiali-operator
@@ -38,6 +38,6 @@ provisioner:
 scenario:
   name: default
   test_sequence:
-    - prepare
-    - converge
-    - destroy
+  - prepare
+  - converge
+  - destroy

--- a/operator/molecule/default/playbook.yml
+++ b/operator/molecule/default/playbook.yml
@@ -4,8 +4,6 @@
   vars:
     custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
   tasks:
-  - import_tasks: '../common/tasks.yml' 
+  - import_tasks: '../common/tasks.yml'
   - import_tasks: '../asserts/configmap_asserts.yml'
   - import_tasks: '../asserts/pod_asserts.yml'
-
- 

--- a/operator/molecule/default/prepare.yml
+++ b/operator/molecule/default/prepare.yml
@@ -1,7 +1,7 @@
 
 - name: Prepare
   hosts: localhost
-  connection: local    
+  connection: local
   tasks:
   - name: Produce Files with Correct Parameters
     shell: " {{ item }}"
@@ -23,8 +23,6 @@
       operator: "{{ template.results[4].stdout | regex_replace('---', '') | from_yaml }}"
       role: "{{ template.results[5].stdout | regex_replace('---', '') | from_yaml }}"
 
-
-      
   - name: Combine Namespace on the Files that need it
     set_fact:
       crd: "{{ crd | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
@@ -33,9 +31,8 @@
       role: "{{ role | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
       operator: "{{ operator | combine({'metadata':{'namespace': kiali.operator_namespace }}, recursive=True)   }}"
 
-      
   - name: Deploying Templates on Kubernetes
-    k8s: 
+    k8s:
       definition: "{{ item }}"
     with_items:
     -  "{{ namespace }}"
@@ -49,7 +46,6 @@
     k8s:
       namespace: '{{ kiali.operator_namespace }}'
       definition: "{{ lookup('template', cr_file_path) }}"
- 
 
   - name: Asserting that Kiali is Deployed
     k8s_facts:
@@ -57,7 +53,7 @@
       kind: Deployment
       namespace: 'istio-system'
       label_selectors:
-      - app = kiali      
+      - app = kiali
     register: kiali_deployment
     until: kiali_deployment.resources |length == 1 and kiali_deployment.resources[0].status.availableReplicas is defined and kiali_deployment.resources[0].status.availableReplicas == 1
     retries: 100

--- a/operator/molecule/docker/Dockerfile
+++ b/operator/molecule/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM quay.io/ansible/molecule:latest
+RUN apk add gettext
+RUN pip install openshift

--- a/operator/molecule/multi-tenancy/molecule.yml
+++ b/operator/molecule/multi-tenancy/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
         istio:
           control_plane_namespace: istio-system
         kiali:
-          accessible_namespaces: 
+          accessible_namespaces:
           - "default"
           - "istio-system"
           operator_namespace: kiali-operator
@@ -38,6 +38,6 @@ provisioner:
 scenario:
   name: multi-tenancy
   test_sequence:
-    - prepare
-    - converge
-    - destroy
+  - prepare
+  - converge
+  - destroy

--- a/operator/molecule/multi-tenancy/playbook.yml
+++ b/operator/molecule/multi-tenancy/playbook.yml
@@ -4,11 +4,8 @@
   vars:
     custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
   tasks:
-  - import_tasks: '../common/tasks.yml' 
+  - import_tasks: '../common/tasks.yml'
   - import_tasks: '../asserts/configmap_asserts.yml'
   - import_tasks: '../asserts/pod_asserts.yml'
   - import_tasks: '../asserts/multi-tenancy/label_selector_asserts.yml'
   - import_tasks: '../asserts/multi-tenancy/role_asserts.yml'
-
-
- 


### PR DESCRIPTION
to avoid devs having to install the correct python/pip and then installing pip requirements, just run molecule via docker. This PR does that. "make molecule-test" runs the molecule tests via a docker image.