### PR TITLE
KIALI-3115 Check TargetPort with string and port number, fixes #1228

### DIFF
--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -54,10 +56,26 @@ func (p PortMappingChecker) findMatchingDeployment(selectors map[string]string) 
 func (p PortMappingChecker) matchPorts(service *v1.Service, deployment *apps_v1.Deployment, validations *[]*models.IstioCheck) {
 Service:
 	for portIndex, sp := range service.Spec.Ports {
-		for _, c := range deployment.Spec.Template.Spec.Containers {
-			for _, cp := range c.Ports {
-				if cp.ContainerPort == sp.Port {
-					continue Service
+		if sp.TargetPort.Type == intstr.String && sp.TargetPort.StrVal != "" {
+			// Check port name in this case
+			for _, c := range deployment.Spec.Template.Spec.Containers {
+				for _, cp := range c.Ports {
+					if cp.Name == sp.TargetPort.StrVal {
+						continue Service
+					}
+				}
+			}
+		} else {
+			portNumber := sp.Port
+			if sp.TargetPort.Type == intstr.Int && sp.TargetPort.IntVal > 0 {
+				// Check port number from here
+				portNumber = sp.TargetPort.IntVal
+			}
+			for _, c := range deployment.Spec.Template.Spec.Containers {
+				for _, cp := range c.Ports {
+					if cp.ContainerPort == portNumber {
+						continue Service
+					}
 				}
 			}
 		}


### PR DESCRIPTION
** Describe the change **

Modify port validation to allow TargetPort to override Port definition (default is Port == TargetPort). In case of string in the TargetPort, search by the Port name in the deployment definition.

** Issue reference **

KIALI-3115, github issue #1228 

** Backwards incompatible? **

Yes

** Documentation **

Will need kiali.io update to the validation page, kiali/kiali.io#154
