### PR TITLE
KIALI-3102 Always add the protocol to the edge

### DIFF
--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -256,6 +256,9 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 				Id:     edgeId,
 				Source: sourceIdHash,
 				Target: destIdHash,
+				Traffic: ProtocolTraffic{
+					Protocol: protocol,
+				},
 			}
 			addEdgeTelemetry(e, &ed)
 


### PR DESCRIPTION
** Describe the change **

This lets the UI know the protocol an edge has, even if there is no traffic.

** Issue reference **

[KIALI-3102](https://issues.jboss.org/browse/KIALI-3102)

** Backwards incompatible? **

- Is your change introducing backwards incompatible changes?

No

