### PR TITLE
[PoC]: When kubernetes cache is enabled, create a cluster role to help with cache operation

### DIFF
--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -269,6 +269,8 @@ rules:
   - projects
   verbs:
   - get
+  - list
+  - watch
 - apiGroups: ["route.openshift.io"]
   resources:
   - routes

--- a/operator/roles/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/operator/roles/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -50,3 +50,16 @@
   when:
   - is_k8s == True
   - '"**" not in kiali_vars.deployment.accessible_namespaces'
+
+- name: Create cache cluster roles on Kubernetes if required
+  include_tasks: process-resource.yml
+  vars:
+    process_resource_cluster: "kubernetes"
+  loop:
+  - cache-clusterrole
+  - cache-clusterrolebinding
+  loop_control:
+    loop_var: process_resource_item
+  when:
+  - is_k8s == True
+  - kiali_vars.kubernetes_config.cache_enabled == True

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -327,6 +327,13 @@
   - '"**" in current_accessible_namespaces'
   - '"**" not in kiali_vars.deployment.accessible_namespaces'
 
+- name: Delete Kiali cache cluster roles if no longer required
+  vars:
+    role_namespace: "{{ kiali_vars.deployment.namespace }}"
+  include_tasks: remove-cache-clusterroles.yml
+  when:
+  - kiali_vars.kubernetes_config.cache_enabled != True
+
 - name: Delete all Kiali roles from namespaces if view_only_mode is changing since role bindings are immutable
   include_tasks: remove-roles.yml
   loop: "{{ kiali_vars.deployment.accessible_namespaces }}"

--- a/operator/roles/kiali-deploy/tasks/openshift/os-main.yml
+++ b/operator/roles/kiali-deploy/tasks/openshift/os-main.yml
@@ -51,6 +51,19 @@
   - is_openshift == True
   - '"**" not in kiali_vars.deployment.accessible_namespaces'
 
+- name: Create cache cluster roles on OpenShift if required
+  include_tasks: process-resource.yml
+  vars:
+    process_resource_cluster: "openshift"
+  loop:
+  - cache-clusterrole
+  - cache-clusterrolebinding
+  loop_control:
+    loop_var: process_resource_item
+  when:
+  - is_openshift == True
+  - kiali_vars.kubernetes_config.cache_enabled == True
+
 - name: Process Kiali OAuth client on OpenShift
   include: openshift/os-oauth.yml
   when:

--- a/operator/roles/kiali-deploy/tasks/remove-cache-clusterroles.yml
+++ b/operator/roles/kiali-deploy/tasks/remove-cache-clusterroles.yml
@@ -1,0 +1,25 @@
+- name: Delete cache-related Kiali roles that are cluster-scoped
+  ignore_errors: yes
+  k8s:
+    state: absent
+    api_version: "{{ k8s_item.apiVersion }}"
+    kind: "{{ k8s_item.kind }}"
+    namespace: "{{ role_namespace }}"
+    name: "{{ k8s_item.metadata.name }}"
+  register: delete_result
+  until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
+  retries: 6
+  delay: 10
+  when:
+  - is_openshift == True or is_k8s == True
+  - role_namespace is defined
+  - k8s_item is defined
+  - k8s_item.apiVersion is defined
+  - k8s_item.kind is defined
+  - k8s_item.metadata is defined
+  - k8s_item.metadata.name is defined
+  with_items:
+  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRoleBinding', resource_name='kiali-cache', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali-cache', api_version='rbac.authorization.k8s.io/v1') }}"
+  loop_control:
+    loop_var: k8s_item

--- a/operator/roles/kiali-deploy/templates/kubernetes/cache-clusterrole.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/cache-clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kiali-cache
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/operator/roles/kiali-deploy/templates/kubernetes/cache-clusterrolebinding.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/cache-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kiali-cache
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kiali-cache
+subjects:
+- kind: ServiceAccount
+  name: kiali-service-account
+  namespace: {{ kiali_vars.deployment.namespace }}

--- a/operator/roles/kiali-deploy/templates/openshift/cache-clusterrole.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/cache-clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kiali-cache
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+  - list
+  - watch

--- a/operator/roles/kiali-deploy/templates/openshift/cache-clusterrolebinding.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/cache-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kiali-cache
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kiali-cache
+subjects:
+- kind: ServiceAccount
+  name: kiali-service-account
+  namespace: {{ kiali_vars.deployment.namespace }}

--- a/operator/roles/kiali-deploy/templates/openshift/role.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/role.yaml
@@ -142,6 +142,8 @@ rules:
   - projects
   verbs:
   - get
+  - list
+  - watch
 - apiGroups: ["route.openshift.io"]
   resources:
   - routes

--- a/operator/roles/kiali-remove/tasks/main.yml
+++ b/operator/roles/kiali-remove/tasks/main.yml
@@ -106,6 +106,14 @@
   - current_accessible_namespaces is defined
   - '"**" in current_accessible_namespaces'
 
+- name: Delete Kiali cache cluster roles
+  ignore_errors: yes
+  vars:
+    role_namespace: "{{ kiali_vars.deployment.namespace }}"
+  include_tasks: remove-cache-clusterroles.yml
+  when:
+  - is_openshift == True or is_k8s == True
+
 - name: Delete Kiali resources
   ignore_errors: yes
   k8s:

--- a/operator/roles/kiali-remove/tasks/remove-cache-clusterroles.yml
+++ b/operator/roles/kiali-remove/tasks/remove-cache-clusterroles.yml
@@ -1,0 +1,25 @@
+- name: Delete cache-related Kiali roles that are cluster-scoped
+  ignore_errors: yes
+  k8s:
+    state: absent
+    api_version: "{{ k8s_item.apiVersion }}"
+    kind: "{{ k8s_item.kind }}"
+    namespace: "{{ role_namespace }}"
+    name: "{{ k8s_item.metadata.name }}"
+  register: delete_result
+  until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
+  retries: 6
+  delay: 10
+  when:
+  - is_openshift == True or is_k8s == True
+  - role_namespace is defined
+  - k8s_item is defined
+  - k8s_item.apiVersion is defined
+  - k8s_item.kind is defined
+  - k8s_item.metadata is defined
+  - k8s_item.metadata.name is defined
+  with_items:
+  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRoleBinding', resource_name='kiali-cache', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali-cache', api_version='rbac.authorization.k8s.io/v1') }}"
+  loop_control:
+    loop_var: k8s_item


### PR DESCRIPTION
_Just a PoC. Do not merge._

cluster role for get/list/watch on namespaces for kubernetes and namespaces/projects for openshift is created if the cache is enabled.

This also gives Kiali project list and and project watch permissions on its non-cluster openshift role.

@burmanm I have not attempted to built, run, or test this :) I have no idea if this is what you would need. But all this does is give cluster access to namespace and projects only (literally just those 2 resources - there is no cluster-wide access to the resources in those namespaces/projects - which I think you might need. If so, this PR is useless).  If the cache DOES need full cluster-wide access to all these resources inside namespaces/projects, then that cache will need to be implemented differently because we will not be allowed to create such cluster roles when in "multitenancy mode" (i.e. accessible_namespaces NOT set to `[**]`). To get this cluster-wide access to all resources in all namespaces/projects, you will need to install with "accessible_namespaces" set to `[**]` but this is essentially assuming a single cluster-wide mesh and is not how Maistra will deploy Kiali.

Another note: if you have multiple Kialis installed in the cluster, then the cache enabled flag needs to be the same value for all of them, or else you will get indeterminate results (either the cluster roles will exist or not depending on which Kiali you last installed). For example, if you install kiali with cache_enabled == False, the cluster roles will be removed. If you then follow up by installing a Kiali with cache_enabled=True, the cluster roles will be created. So the last Kiali installed wins (either the cluster roles will be removed or created depending on the cache_enabled flag of the last kiali installed).

Related to https://github.com/kiali/kiali/issues/1386
