### PR TITLE
KIALI-3139 Use internal url to determine if kiali user has access to jaeger

### DIFF
--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -40,7 +40,7 @@ func getErrorTracesFromJaeger(namespace string, service string, requestToken str
 			auth.Token = requestToken
 		}
 
-		u, errParse := url.Parse(fmt.Sprintf("http://%s%s/api/traces", appstate.JaegerConfig.Service, appstate.JaegerConfig.Path))
+		u, errParse := GetJaegerInternalURL("/api/traces")
 		if errParse != nil {
 			log.Errorf("Error parse Jaeger URL fetching Error Traces: %s", err)
 			return -1, errParse
@@ -75,6 +75,10 @@ func getErrorTracesFromJaeger(namespace string, service string, requestToken str
 		}
 	}
 	return errorTraces, err
+}
+
+func GetJaegerInternalURL(path string) (*url.URL, error) {
+	return url.Parse(fmt.Sprintf("http://%s%s%s", appstate.JaegerConfig.Service, appstate.JaegerConfig.Path, path))
 }
 
 func GetJaegerServices() (services JaegerServices, err error) {

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/status"
 	"github.com/kiali/kiali/util/httputil"
 )
 
@@ -37,6 +38,11 @@ func getJaegerInfo(requestToken string) (*models.JaegerInfo, int, error) {
 		return nil, http.StatusNoContent, nil
 	}
 
+	externalUrl := status.DiscoverJaeger()
+	if externalUrl == "" {
+		return nil, http.StatusServiceUnavailable, errors.New("Jaeger URL is not set in Kiali configuration")
+	}
+
 	apiURL := jaegerConfig.URL
 
 	// If user doesn't have Jaeger url setup, use the Jaeger information auto-discovered
@@ -63,7 +69,7 @@ func getJaegerInfo(requestToken string) (*models.JaegerInfo, int, error) {
 	}
 
 	info := &models.JaegerInfo{
-		URL: apiURL,
+		URL: externalUrl,
 	}
 
 	return info, http.StatusOK, nil


### PR DESCRIPTION
** Describe the change **

In order to determine if kiali user has access to jaeger, we need to use internal urls

** Issue reference **
https://issues.jboss.org/browse/KIALI-3139

** Backwards incompatible? **
yes
