### PR TITLE
Trivial: allow to use Jaeger out-cluster

### DIFF
--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -41,6 +41,10 @@ func getErrorTracesFromJaeger(namespace string, service string, requestToken str
 		}
 
 		u, errParse := GetJaegerInternalURL("/api/traces")
+		if !config.Get().InCluster {
+			u, errParse = url.Parse(config.Get().ExternalServices.Tracing.URL + "/api/traces")
+		}
+
 		if errParse != nil {
 			log.Errorf("Error parse Jaeger URL fetching Error Traces: %s", err)
 			return -1, errParse


### PR DESCRIPTION
This is a developer helper.
When working with an external Kiali process, as a developer I'd like to configure the jaeger service to fetch traces errors from service details.

It's transparent to normal behaviour.