### PR TITLE
fix: Use correct port name when https is disabled

### DIFF
--- a/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: {{ kiali_vars.deployment.service_type }}
   ports:
-  - name: tcp
+  - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}
     protocol: TCP
     port: {{ kiali_vars.server.port }}
   selector:

--- a/operator/roles/kiali-deploy/templates/openshift/service.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: {{ kiali_vars.deployment.service_type }}
   ports:
-  - name: tcp
+  - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}
     protocol: TCP
     port: {{ kiali_vars.server.port }}
   selector:


### PR DESCRIPTION
** Describe the change **

Use the correct port name when https is disabled

** Issue reference **

https://github.com/kiali/kiali/issues/1259

** Backwards incompatible? **

Maybe, if someone is targeting the tcp port name

** Documentation **

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
I don't think this needs a readme change
