### PR TITLE
Add backend for ApiDocumentation feature

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -333,12 +333,12 @@ spec:
 
 == Services API Documentation
 
-Kiali can display API Documentation of your services. See https://user-images.githubusercontent.com/1235410/61569413-0e870480-aa3c-11e9-9527-bbea18eff475.png[Api documentation screen capture] and https://user-images.githubusercontent.com/1235410/61569419-1777d600-aa3c-11e9-82cc-f9510e5b9808.png[Api type list screen capture].
+Kiali can display API Documentation of your services. See https://user-images.githubusercontent.com/1235410/61569413-0e870480-aa3c-11e9-9527-bbea18eff475.png[API documentation screen capture] and https://user-images.githubusercontent.com/1235410/61569419-1777d600-aa3c-11e9-82cc-f9510e5b9808.png[API type list screen capture].
 
 === Configure your services
 
-Your services must be annotated with the type of api ('rest', 'grpc', 'graphql') and a url to the spec of the api. 
-If the api spec is served from the service itself, Kiali will infer the hostname and port :
+Your services must be annotated with the type of API ('rest', 'grpc', 'graphql') and a URL to the spec of the API. 
+If the API spec is served from the service itself, Kiali will infer the hostname and port :
 
 [source,yaml]
 ----
@@ -353,7 +353,7 @@ spec:
 ...
 ----
 
-The api spec can also be served from any http/s url, internal or external to the cluster :
+The API spec can also be served from any http/s URL, internal or external to the cluster :
 
 [source,yaml]
 ----
@@ -368,12 +368,12 @@ spec:
 ...
 ----
 
-For now, only REST apis have their spec displayed but we are working to support gRpc and GraphQL soon.
+For now, only REST APIs have their spec displayed but we are working to support gRpc and GraphQL soon.
 A live console to test your APIs directly with Kiali is also being worked on.
 
-=== Customize api docs annotations
+=== Customize API docs annotations
 
-You can configure Kiali to use your own annotation names with the operator cr
+You can configure Kiali to use your own annotation names with the Kiali CR
 
 [source,yaml]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -331,6 +331,60 @@ spec:
 ...
 ----
 
+== Services API Documentation
+
+Kiali can display API Documentation of your services. See https://user-images.githubusercontent.com/1235410/61569413-0e870480-aa3c-11e9-9527-bbea18eff475.png[Api documentation screen capture] and https://user-images.githubusercontent.com/1235410/61569419-1777d600-aa3c-11e9-82cc-f9510e5b9808.png[Api type list screen capture].
+
+=== Configure your services
+
+Your services must be annotated with the type of api ('rest', 'grpc', 'graphql') and a url to the spec of the api. 
+If the api spec is served from the service itself, Kiali will infer the hostname and port :
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: myservice
+  annotations:
+    kiali.kubernetes.io/api-type: rest
+    kiali.kubernetes.io/api-spec: /v1/api-spec  
+spec:
+...
+----
+
+The api spec can also be served from any http/s url, internal or external to the cluster :
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: petstore
+  annotations:
+    kiali.kubernetes.io/api-type: rest
+    kiali.kubernetes.io/api-spec: https://petstore.swagger.io/v2/swagger.json  
+spec:
+...
+----
+
+For now, only REST apis have their spec displayed but we are working to support gRpc and GraphQL soon.
+A live console to test your APIs directly with Kiali is also being worked on.
+
+=== Customize api docs annotations
+
+You can configure Kiali to use your own annotation names with the operator cr
+
+[source,yaml]
+----
+...
+apidocs:
+  annotations:
+    api_spec_annotation_name: "my-annotation-for-api-spec"
+    api_type_annotation_name: "my-annotation-for-api-type"
+...
+---
+
 == Additional Notes
 
 === Customize the UI web context root

--- a/business/services.go
+++ b/business/services.go
@@ -1,19 +1,19 @@
 package business
 
 import (
-        "io/ioutil"
-        "net/http"
-        "strconv"
-        "strings"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
-        meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-        "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/config"
@@ -98,74 +98,74 @@ func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []core_v
 		hasSidecar := mPods.HasIstioSidecar()
 		/** Check if Service has the label app required by Istio */
 		_, appLabel := item.Spec.Selector[conf.IstioLabels.AppLabelName]
-                /** Check if Service has the api annotation */
-                apiTypeFromAnnotation, _ := item.ObjectMeta.Annotations[conf.ApiDocumentation.ApiTypeAnnotationName]
+		/** Check if Service has the api annotation */
+		apiTypeFromAnnotation, _ := item.ObjectMeta.Annotations[conf.ApiDocumentation.ApiTypeAnnotationName]
 		services[i] = models.ServiceOverview{
 			Name:         item.Name,
 			IstioSidecar: hasSidecar,
 			AppLabel:     appLabel,
-                        ApiType:      apiTypeFromAnnotation,
+			ApiType:      apiTypeFromAnnotation,
 		}
 	}
 
 	return &models.ServiceList{Namespace: namespace, Services: services, Validations: validations}
 }
 
-//GetServiceApiDocumentation returns the api documentation fetched from a service 
+//GetServiceApiDocumentation returns the api documentation fetched from a service
 func (in *SvcService) GetServiceApiDocumentation(namespace, service string) (string, error) {
-        var err error
-        promtimer := internalmetrics.GetGoFunctionMetric("business", "SvcService", "GetServiceApiDocumentation")
-        defer promtimer.ObserveNow(&err)
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "SvcService", "GetServiceApiDocumentation")
+	defer promtimer.ObserveNow(&err)
 
-        conf := config.Get()
-        svc, err := in.k8s.GetService(namespace, service)
-        if err != nil {
-                log.Errorf("Error fetching Service per namespace %s and service %s: %s", namespace, service, err)
-                return "", errors.NewInternalError(err)
-        }
-        apiSpecPath, _ := svc.ObjectMeta.Annotations[conf.ApiDocumentation.ApiSpecAnnotationName]
+	conf := config.Get()
+	svc, err := in.k8s.GetService(namespace, service)
+	if err != nil {
+		log.Errorf("Error fetching Service per namespace %s and service %s: %s", namespace, service, err)
+		return "", errors.NewInternalError(err)
+	}
+	apiSpecPath, _ := svc.ObjectMeta.Annotations[conf.ApiDocumentation.ApiSpecAnnotationName]
 
-        if apiSpecPath == "" {
-                qualifiedResource := schema.GroupResource{
-                        Group: "",
-                        Resource:  "",
-                }
-                return "", errors.NewNotFound(qualifiedResource, "No spec annotation found for service")
-        }
-
-	if !strings.HasPrefix(apiSpecPath, "http://") && !strings.HasPrefix(apiSpecPath, "https://") {
-                service := svc.ObjectMeta.Name + "." + svc.ObjectMeta.Namespace
-                if svc.ObjectMeta.Name == "kiali" {
-                       // k8s doesn't want to call the service from the pod
-                       service = "localhost"
-                }
-	        apiSpecPath = "http://" + service + ":" + strconv.Itoa(int(svc.Spec.Ports[0].Port)) + apiSpecPath
+	if apiSpecPath == "" {
+		qualifiedResource := schema.GroupResource{
+			Group:    "",
+			Resource: "",
+		}
+		return "", errors.NewNotFound(qualifiedResource, "No spec annotation found for service")
 	}
 
-        resp, err2 := http.Get(apiSpecPath)
-        if err2 != nil {
-                log.Errorf("GET error: %v", err)
-                return "", errors.NewInternalError(err2)
-        }
-        defer resp.Body.Close()
+	if !strings.HasPrefix(apiSpecPath, "http://") && !strings.HasPrefix(apiSpecPath, "https://") {
+		service := svc.ObjectMeta.Name + "." + svc.ObjectMeta.Namespace
+		if svc.ObjectMeta.Name == "kiali" {
+			// k8s doesn't want to call the service from the pod
+			service = "localhost"
+		}
+		apiSpecPath = "http://" + service + ":" + strconv.Itoa(int(svc.Spec.Ports[0].Port)) + apiSpecPath
+	}
 
-        if resp.StatusCode != http.StatusOK {
-                log.Errorf("Status error: %v", resp.StatusCode)
-                return "", &errors.StatusError{meta_v1.Status{
-                        Status:  meta_v1.StatusFailure,
-                        Code:    int32(resp.StatusCode),
-                        Reason: "",
-                        Message: "",
-                }}
-        }
+	resp, err2 := http.Get(apiSpecPath)
+	if err2 != nil {
+		log.Errorf("GET error: %v", err)
+		return "", errors.NewInternalError(err2)
+	}
+	defer resp.Body.Close()
 
-        data, err3 := ioutil.ReadAll(resp.Body)
-        if err3 != nil {
-                log.Errorf("Read body: %v", err)
-                return "", errors.NewInternalError(err3)
-        }
+	if resp.StatusCode != http.StatusOK {
+		log.Errorf("Status error: %v", resp.StatusCode)
+		return "", &errors.StatusError{meta_v1.Status{
+			Status:  meta_v1.StatusFailure,
+			Code:    int32(resp.StatusCode),
+			Reason:  "",
+			Message: "",
+		}}
+	}
 
-        return string(data), nil
+	data, err3 := ioutil.ReadAll(resp.Body)
+	if err3 != nil {
+		log.Errorf("Read body: %v", err)
+		return "", errors.NewInternalError(err3)
+	}
+
+	return string(data), nil
 }
 
 // GetService returns a single service and associated data using the interval and queryTime
@@ -184,20 +184,20 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 	var vs, dr []kubernetes.IstioObject
 	var ws models.Workloads
 	var nsmtls models.MTLSStatus
-        var apidoc models.ApiDocumentation
+	var apidoc models.ApiDocumentation
 
-        conf := config.Get()
-        apiSpecFromAnnotation, _ := svc.ObjectMeta.Annotations[conf.ApiDocumentation.ApiSpecAnnotationName]
-        apiTypeFromAnnotation, _ := svc.ObjectMeta.Annotations[conf.ApiDocumentation.ApiTypeAnnotationName]
-        apiBaseUrl := ""
-        if apiSpecFromAnnotation != "" {
-                apiBaseUrl = conf.Server.WebRoot + "/api/namespaces/" + namespace + "/services/" + service
-        }
+	conf := config.Get()
+	apiSpecFromAnnotation, _ := svc.ObjectMeta.Annotations[conf.ApiDocumentation.ApiSpecAnnotationName]
+	apiTypeFromAnnotation, _ := svc.ObjectMeta.Annotations[conf.ApiDocumentation.ApiTypeAnnotationName]
+	apiBaseUrl := ""
+	if apiSpecFromAnnotation != "" {
+		apiBaseUrl = conf.Server.WebRoot + "/api/namespaces/" + namespace + "/services/" + service
+	}
 
-        apidoc = models.ApiDocumentation {
-                Type:     apiTypeFromAnnotation,
-                BaseUrl:  apiBaseUrl,
-        }
+	apidoc = models.ApiDocumentation{
+		Type:    apiTypeFromAnnotation,
+		BaseUrl: apiBaseUrl,
+	}
 
 	wg := sync.WaitGroup{}
 	wg.Add(7)
@@ -303,7 +303,7 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 	s.SetVirtualServices(vs, vsCreate, vsUpdate, vsDelete)
 	s.SetDestinationRules(dr, drCreate, drUpdate, drDelete)
 	s.SetErrorTraces(eTraces)
-        s.SetApiDocumentation(apidoc)
+	s.SetApiDocumentation(apidoc)
 	return &s, nil
 }
 

--- a/business/services.go
+++ b/business/services.go
@@ -187,14 +187,10 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 	conf := config.Get()
 	apiSpecFromAnnotation := svc.ObjectMeta.Annotations[conf.ApiDocumentation.Annotations.ApiSpecAnnotationName]
 	apiTypeFromAnnotation := svc.ObjectMeta.Annotations[conf.ApiDocumentation.Annotations.ApiTypeAnnotationName]
-	apiBaseUrl := ""
-	if apiSpecFromAnnotation != "" {
-		apiBaseUrl = conf.Server.WebRoot + "/api/namespaces/" + namespace + "/services/" + service
-	}
 
 	apidoc = models.ApiDocumentation{
 		Type:    apiTypeFromAnnotation,
-		BaseUrl: apiBaseUrl,
+		HasSpec: (apiSpecFromAnnotation != ""),
 	}
 
 	wg := sync.WaitGroup{}

--- a/business/services.go
+++ b/business/services.go
@@ -1,13 +1,19 @@
 package business
 
 import (
+        "io/ioutil"
+        "net/http"
+        "strconv"
+        "strings"
 	"sync"
 	"time"
 
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
+        meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+        "k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/config"
@@ -92,14 +98,74 @@ func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []core_v
 		hasSidecar := mPods.HasIstioSidecar()
 		/** Check if Service has the label app required by Istio */
 		_, appLabel := item.Spec.Selector[conf.IstioLabels.AppLabelName]
+                /** Check if Service has the api annotation */
+                apiTypeFromAnnotation, _ := item.ObjectMeta.Annotations[conf.ApiDocumentation.ApiTypeAnnotationName]
 		services[i] = models.ServiceOverview{
 			Name:         item.Name,
 			IstioSidecar: hasSidecar,
 			AppLabel:     appLabel,
+                        ApiType:      apiTypeFromAnnotation,
 		}
 	}
 
 	return &models.ServiceList{Namespace: namespace, Services: services, Validations: validations}
+}
+
+//GetServiceApiDocumentation returns the api documentation fetched from a service 
+func (in *SvcService) GetServiceApiDocumentation(namespace, service string) (string, error) {
+        var err error
+        promtimer := internalmetrics.GetGoFunctionMetric("business", "SvcService", "GetServiceApiDocumentation")
+        defer promtimer.ObserveNow(&err)
+
+        conf := config.Get()
+        svc, err := in.k8s.GetService(namespace, service)
+        if err != nil {
+                log.Errorf("Error fetching Service per namespace %s and service %s: %s", namespace, service, err)
+                return "", errors.NewInternalError(err)
+        }
+        apiSpecPath, _ := svc.ObjectMeta.Annotations[conf.ApiDocumentation.ApiSpecAnnotationName]
+
+        if apiSpecPath == "" {
+                qualifiedResource := schema.GroupResource{
+                        Group: "",
+                        Resource:  "",
+                }
+                return "", errors.NewNotFound(qualifiedResource, "No spec annotation found for service")
+        }
+
+	if !strings.HasPrefix(apiSpecPath, "http://") && !strings.HasPrefix(apiSpecPath, "https://") {
+                service := svc.ObjectMeta.Name + "." + svc.ObjectMeta.Namespace
+                if svc.ObjectMeta.Name == "kiali" {
+                       // k8s doesn't want to call the service from the pod
+                       service = "localhost"
+                }
+	        apiSpecPath = "http://" + service + ":" + strconv.Itoa(int(svc.Spec.Ports[0].Port)) + apiSpecPath
+	}
+
+        resp, err2 := http.Get(apiSpecPath)
+        if err2 != nil {
+                log.Errorf("GET error: %v", err)
+                return "", errors.NewInternalError(err2)
+        }
+        defer resp.Body.Close()
+
+        if resp.StatusCode != http.StatusOK {
+                log.Errorf("Status error: %v", resp.StatusCode)
+                return "", &errors.StatusError{meta_v1.Status{
+                        Status:  meta_v1.StatusFailure,
+                        Code:    int32(resp.StatusCode),
+                        Reason: "",
+                        Message: "",
+                }}
+        }
+
+        data, err3 := ioutil.ReadAll(resp.Body)
+        if err3 != nil {
+                log.Errorf("Read body: %v", err)
+                return "", errors.NewInternalError(err3)
+        }
+
+        return string(data), nil
 }
 
 // GetService returns a single service and associated data using the interval and queryTime
@@ -118,6 +184,20 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 	var vs, dr []kubernetes.IstioObject
 	var ws models.Workloads
 	var nsmtls models.MTLSStatus
+        var apidoc models.ApiDocumentation
+
+        conf := config.Get()
+        apiSpecFromAnnotation, _ := svc.ObjectMeta.Annotations[conf.ApiDocumentation.ApiSpecAnnotationName]
+        apiTypeFromAnnotation, _ := svc.ObjectMeta.Annotations[conf.ApiDocumentation.ApiTypeAnnotationName]
+        apiBaseUrl := ""
+        if apiSpecFromAnnotation != "" {
+                apiBaseUrl = conf.Server.WebRoot + "/api/namespaces/" + namespace + "/services/" + service
+        }
+
+        apidoc = models.ApiDocumentation {
+                Type:     apiTypeFromAnnotation,
+                BaseUrl:  apiBaseUrl,
+        }
 
 	wg := sync.WaitGroup{}
 	wg.Add(7)
@@ -223,6 +303,7 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 	s.SetVirtualServices(vs, vsCreate, vsUpdate, vsDelete)
 	s.SetDestinationRules(dr, drCreate, drUpdate, drDelete)
 	s.SetErrorTraces(eTraces)
+        s.SetApiDocumentation(apidoc)
 	return &s, nil
 }
 

--- a/config.yaml
+++ b/config.yaml
@@ -39,3 +39,12 @@ external_services:
   # Uncomment service_label_name to set up a different label name for grouping all resources of an app version.
   # Default is "version"
   # version_label_name: version
+
+#apidoc_annotations:
+  # Uncomment api_type_annotation_name to set up a different annotation name for defining a service api type
+  # Default is "kiali.kubernetes.io/api-type"
+  # api_type_annotation_name: kiali.kubernetes.io/api-type
+
+  # Uncomment api_type_annotation_name to set up a different annotation name for defining a service api spec location
+  # Default is "kiali.kubernetes.io/api-spec"
+  # api_spec_annotation_name: kiali.kubernetes.io/api-spec

--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,8 @@ external_services:
   # Default is "version"
   # version_label_name: version
 
-#apidoc_annotations:
+#Uncomment to configure api documentation options
+#apidocs:
   # Uncomment api_type_annotation_name to set up a different annotation name for defining a service api type
   # Default is "kiali.kubernetes.io/api-type"
   # api_type_annotation_name: kiali.kubernetes.io/api-type

--- a/config.yaml
+++ b/config.yaml
@@ -42,10 +42,10 @@ external_services:
 
 #Uncomment to configure api documentation options
 #apidocs:
-  # Uncomment api_type_annotation_name to set up a different annotation name for defining a service api type
-  # Default is "kiali.kubernetes.io/api-type"
-  # api_type_annotation_name: kiali.kubernetes.io/api-type
-
   # Uncomment api_type_annotation_name to set up a different annotation name for defining a service api spec location
   # Default is "kiali.kubernetes.io/api-spec"
   # api_spec_annotation_name: kiali.kubernetes.io/api-spec
+
+  # Uncomment api_type_annotation_name to set up a different annotation name for defining a service api type
+  # Default is "kiali.kubernetes.io/api-type"
+  # api_type_annotation_name: kiali.kubernetes.io/api-type

--- a/config/config.go
+++ b/config/config.go
@@ -79,8 +79,8 @@ const (
 
 	EnvNamespaceLabelSelector = "NAMESPACE_LABEL_SELECTOR"
 
-        EnvApiDocAnnotationNameApiType = "APIDOC_ANNOTATION_NAME_API_TYPE"
-        EnvApiDocAnnotationNameApiSpec = "APIDOC_ANNOTATION_NAME_API_SPEC"
+	EnvApiDocAnnotationNameApiType = "APIDOC_ANNOTATION_NAME_API_TYPE"
+	EnvApiDocAnnotationNameApiSpec = "APIDOC_ANNOTATION_NAME_API_SPEC"
 )
 
 // The versions that Kiali requires
@@ -224,8 +224,8 @@ type ApiNamespacesConfig struct {
 
 // ApiDocAnnotations contains the annotation names used for API documentation
 type ApiDocAnnotations struct {
-        ApiTypeAnnotationName string `yaml:"api_type_annotation_name,omitempty" json:"apiTypeAnnotationName"`
-        ApiSpecAnnotationName string `yaml:"api_spec_annotation_name,omitempty" json:"apiSpecAnnotationName"`
+	ApiTypeAnnotationName string `yaml:"api_type_annotation_name,omitempty" json:"apiTypeAnnotationName"`
+	ApiSpecAnnotationName string `yaml:"api_spec_annotation_name,omitempty" json:"apiSpecAnnotationName"`
 }
 
 // AuthConfig provides details on how users are to authenticate
@@ -252,7 +252,7 @@ type Config struct {
 	API              ApiConfig         `yaml:"api,omitempty"`
 	Auth             AuthConfig        `yaml:"auth,omitempty"`
 	Deployment       DeploymentConfig  `yaml:"deployment,omitempty"`
-        ApiDocumentation ApiDocAnnotations `yaml:"apidoc_annotations,omitempty"`
+	ApiDocumentation ApiDocAnnotations `yaml:"apidoc_annotations,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -285,9 +285,9 @@ func NewConfig() (c *Config) {
 	c.Server.MetricsPort = getDefaultInt(EnvServerMetricsPort, 9090)
 	c.Server.MetricsEnabled = getDefaultBool(EnvServerMetricsEnabled, true)
 
-        // API Documentation
-        c.ApiDocumentation.ApiTypeAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiType, "kiali.kubernetes.io/api-type"))
-        c.ApiDocumentation.ApiSpecAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiSpec, "kiali.kubernetes.io/api-spec"))
+	// API Documentation
+	c.ApiDocumentation.ApiTypeAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiType, "kiali.kubernetes.io/api-type"))
+	c.ApiDocumentation.ApiSpecAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiSpec, "kiali.kubernetes.io/api-spec"))
 
 	// Prometheus configuration
 	c.ExternalServices.Prometheus.URL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, fmt.Sprintf("http://prometheus.%s:9090", c.IstioNamespace)))

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,9 @@ const (
 	EnvAuthStrategy = "AUTH_STRATEGY"
 
 	EnvNamespaceLabelSelector = "NAMESPACE_LABEL_SELECTOR"
+
+        EnvApiDocAnnotationNameApiType = "APIDOC_ANNOTATION_NAME_API_TYPE"
+        EnvApiDocAnnotationNameApiSpec = "APIDOC_ANNOTATION_NAME_API_SPEC"
 )
 
 // The versions that Kiali requires
@@ -219,6 +222,12 @@ type ApiNamespacesConfig struct {
 	LabelSelector string `yaml:"label_selector,omitempty" json:"labelSelector"`
 }
 
+// ApiDocAnnotations contains the annotation names used for API documentation
+type ApiDocAnnotations struct {
+        ApiTypeAnnotationName string `yaml:"api_type_annotation_name,omitempty" json:"apiTypeAnnotationName"`
+        ApiSpecAnnotationName string `yaml:"api_spec_annotation_name,omitempty" json:"apiSpecAnnotationName"`
+}
+
 // AuthConfig provides details on how users are to authenticate
 type AuthConfig struct {
 	Strategy string `yaml:"strategy,omitempty"`
@@ -243,6 +252,7 @@ type Config struct {
 	API              ApiConfig         `yaml:"api,omitempty"`
 	Auth             AuthConfig        `yaml:"auth,omitempty"`
 	Deployment       DeploymentConfig  `yaml:"deployment,omitempty"`
+        ApiDocumentation ApiDocAnnotations `yaml:"apidoc_annotations,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -274,6 +284,10 @@ func NewConfig() (c *Config) {
 	c.Server.AuditLog = getDefaultBool(EnvServerAuditLog, true)
 	c.Server.MetricsPort = getDefaultInt(EnvServerMetricsPort, 9090)
 	c.Server.MetricsEnabled = getDefaultBool(EnvServerMetricsEnabled, true)
+
+        // API Documentation
+        c.ApiDocumentation.ApiTypeAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiType, "kiali.kubernetes.io/api-type"))
+        c.ApiDocumentation.ApiSpecAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiSpec, "kiali.kubernetes.io/api-spec"))
 
 	// Prometheus configuration
 	c.ExternalServices.Prometheus.URL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, fmt.Sprintf("http://prometheus.%s:9090", c.IstioNamespace)))

--- a/config/config.go
+++ b/config/config.go
@@ -222,6 +222,11 @@ type ApiNamespacesConfig struct {
 	LabelSelector string `yaml:"label_selector,omitempty" json:"labelSelector"`
 }
 
+// ApiDocumentation is the top level configuration for API documentation
+type ApiDocumentation struct {
+	Annotations ApiDocAnnotations `yaml:"annotations,omitempty" json:"annotations"`
+}
+
 // ApiDocAnnotations contains the annotation names used for API documentation
 type ApiDocAnnotations struct {
 	ApiTypeAnnotationName string `yaml:"api_type_annotation_name,omitempty" json:"apiTypeAnnotationName"`
@@ -252,7 +257,7 @@ type Config struct {
 	API              ApiConfig         `yaml:"api,omitempty"`
 	Auth             AuthConfig        `yaml:"auth,omitempty"`
 	Deployment       DeploymentConfig  `yaml:"deployment,omitempty"`
-	ApiDocumentation ApiDocAnnotations `yaml:"apidoc_annotations,omitempty"`
+	ApiDocumentation ApiDocumentation  `yaml:"apidocs,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -286,8 +291,8 @@ func NewConfig() (c *Config) {
 	c.Server.MetricsEnabled = getDefaultBool(EnvServerMetricsEnabled, true)
 
 	// API Documentation
-	c.ApiDocumentation.ApiTypeAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiType, "kiali.kubernetes.io/api-type"))
-	c.ApiDocumentation.ApiSpecAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiSpec, "kiali.kubernetes.io/api-spec"))
+	c.ApiDocumentation.Annotations.ApiTypeAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiType, "kiali.kubernetes.io/api-type"))
+	c.ApiDocumentation.Annotations.ApiSpecAnnotationName = strings.TrimSpace(getDefaultString(EnvApiDocAnnotationNameApiSpec, "kiali.kubernetes.io/api-spec"))
 
 	// Prometheus configuration
 	c.ExternalServices.Prometheus.URL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, fmt.Sprintf("http://prometheus.%s:9090", c.IstioNamespace)))

--- a/deploy/get-console.sh
+++ b/deploy/get-console.sh
@@ -17,6 +17,9 @@ if [ "$VERSION" = "local" ]; then
   rm -rf $DIR/_output/docker/console && mkdir $DIR/_output/docker/console
   cp -r $CONSOLE_DIR/build/* $DIR/_output/docker/console
 
+  # Copy swagger.json to serve it and display kiali api doc
+  cp $DIR/swagger.json $DIR/_output/docker/console/
+
   # If there is a version.txt file, use it (required for continuous delivery)
   if [ ! -f "$DIR/_output/docker/console/version.txt" ]; then
     # If jq command is available, don't do a trip to the web

--- a/doc.go
+++ b/doc.go
@@ -41,7 +41,7 @@ type ContainerParam struct {
 	Name string `json:"container"`
 }
 
-// swagger:parameters istioConfigList workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard istioConfigCreate istioConfigCreateSubtype namespaceTls podDetails podLogs getThreeScaleService postThreeScaleService patchThreeScaleService deleteThreeScaleService
+// swagger:parameters istioConfigList workloadList workloadDetails serviceDetails workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard istioConfigCreate istioConfigCreateSubtype namespaceTls podDetails podLogs getThreeScaleService postThreeScaleService patchThreeScaleService deleteThreeScaleService serviceApiDocumentation
 type NamespaceParam struct {
 	// The namespace name.
 	//
@@ -87,7 +87,7 @@ type PodParam struct {
 	Name string `json:"pod"`
 }
 
-// swagger:parameters serviceDetails serviceMetrics graphService serviceDashboard getThreeScaleService patchThreeScaleService deleteThreeScaleService
+// swagger:parameters serviceDetails serviceMetrics graphService serviceDashboard getThreeScaleService patchThreeScaleService deleteThreeScaleService serviceApiDocumentation
 type ServiceParam struct {
 	// The service name.
 	//

--- a/handlers/apidocumentation.go
+++ b/handlers/apidocumentation.go
@@ -1,0 +1,35 @@
+package handlers
+  
+import (
+        "net/http"
+
+        "github.com/gorilla/mux"
+        "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ServiceApiDocumentation is the API handler to get api documentation of a single service
+func ServiceApiDocumentation(w http.ResponseWriter, r *http.Request) {
+        business, err := getBusiness(r)
+        if err != nil {
+                RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+                return
+        }
+        vars := mux.Vars(r)
+        apidoc, err := business.Svc.GetServiceApiDocumentation(vars["namespace"], vars["service"])
+        handleApiDocumentationResponse(w, apidoc, err)
+}
+
+func handleApiDocumentationResponse(w http.ResponseWriter, apidoc string, err error) {
+        if err != nil {
+                if errors.IsNotFound(err) {
+                        RespondWithError(w, http.StatusNotFound, err.Error())
+                } else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+                        RespondWithError(w, int(statusError.ErrStatus.Code), statusError.ErrStatus.Message)
+                } else {
+                        RespondWithError(w, http.StatusInternalServerError, err.Error())
+                }
+        } else {
+                w.WriteHeader(http.StatusOK)
+                w.Write([]byte(apidoc))
+        }
+}

--- a/handlers/apidocumentation.go
+++ b/handlers/apidocumentation.go
@@ -1,35 +1,35 @@
 package handlers
-  
-import (
-        "net/http"
 
-        "github.com/gorilla/mux"
-        "k8s.io/apimachinery/pkg/api/errors"
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 // ServiceApiDocumentation is the API handler to get api documentation of a single service
 func ServiceApiDocumentation(w http.ResponseWriter, r *http.Request) {
-        business, err := getBusiness(r)
-        if err != nil {
-                RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-                return
-        }
-        vars := mux.Vars(r)
-        apidoc, err := business.Svc.GetServiceApiDocumentation(vars["namespace"], vars["service"])
-        handleApiDocumentationResponse(w, apidoc, err)
+	business, err := getBusiness(r)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+		return
+	}
+	vars := mux.Vars(r)
+	apidoc, err := business.Svc.GetServiceApiDocumentation(vars["namespace"], vars["service"])
+	handleApiDocumentationResponse(w, apidoc, err)
 }
 
 func handleApiDocumentationResponse(w http.ResponseWriter, apidoc string, err error) {
-        if err != nil {
-                if errors.IsNotFound(err) {
-                        RespondWithError(w, http.StatusNotFound, err.Error())
-                } else if statusError, isStatus := err.(*errors.StatusError); isStatus {
-                        RespondWithError(w, int(statusError.ErrStatus.Code), statusError.ErrStatus.Message)
-                } else {
-                        RespondWithError(w, http.StatusInternalServerError, err.Error())
-                }
-        } else {
-                w.WriteHeader(http.StatusOK)
-                w.Write([]byte(apidoc))
-        }
+	if err != nil {
+		if errors.IsNotFound(err) {
+			RespondWithError(w, http.StatusNotFound, err.Error())
+		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+			RespondWithError(w, int(statusError.ErrStatus.Code), statusError.ErrStatus.Message)
+		} else {
+			RespondWithError(w, http.StatusInternalServerError, err.Error())
+		}
+	} else {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(apidoc))
+	}
 }

--- a/models/service.go
+++ b/models/service.go
@@ -61,7 +61,7 @@ type Service struct {
 
 type ApiDocumentation struct {
 	Type    string `json:"type,omitempty"`
-	BaseUrl string `json:"baseUrl,omitempty"`
+	HasSpec bool `json:"hasSpec,omitempty"`
 }
 
 func (ss *Services) Parse(services []core_v1.Service) {

--- a/models/service.go
+++ b/models/service.go
@@ -19,10 +19,10 @@ type ServiceOverview struct {
 	// required: true
 	// example: true
 	AppLabel bool `json:"appLabel"`
-        // Type of api being served (graphql, grpc, rest)
-        // example: rest
-        // required: false
-        ApiType string `json:"apiType,omitempty"`
+	// Type of api being served (graphql, grpc, rest)
+	// example: rest
+	// required: false
+	ApiType string `json:"apiType,omitempty"`
 }
 
 type ServiceList struct {
@@ -42,26 +42,26 @@ type ServiceDetails struct {
 	Validations      IstioValidations  `json:"validations"`
 	ErrorTraces      int               `json:"errorTraces"`
 	NamespaceMTLS    MTLSStatus        `json:"namespaceMTLS"`
-        ApiDocumentation ApiDocumentation  `json:"apiDocumentation"`
+	ApiDocumentation ApiDocumentation  `json:"apiDocumentation"`
 }
 
 type Services []*Service
 type Service struct {
-	Name             string            `json:"name"`
-	CreatedAt        string            `json:"createdAt"`
-	ResourceVersion  string            `json:"resourceVersion"`
-	Namespace        Namespace         `json:"namespace"`
-	Labels           map[string]string `json:"labels"`
-	Selectors        map[string]string `json:"selectors"`
-	Type             string            `json:"type"`
-	Ip               string            `json:"ip"`
-	Ports            Ports             `json:"ports"`
-	ExternalName     string            `json:"externalName"`
+	Name            string            `json:"name"`
+	CreatedAt       string            `json:"createdAt"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Namespace       Namespace         `json:"namespace"`
+	Labels          map[string]string `json:"labels"`
+	Selectors       map[string]string `json:"selectors"`
+	Type            string            `json:"type"`
+	Ip              string            `json:"ip"`
+	Ports           Ports             `json:"ports"`
+	ExternalName    string            `json:"externalName"`
 }
 
 type ApiDocumentation struct {
-        Type          string `json:"type,omitempty"`
-        BaseUrl       string `json:"baseUrl,omitempty"`
+	Type    string `json:"type,omitempty"`
+	BaseUrl string `json:"baseUrl,omitempty"`
 }
 
 func (ss *Services) Parse(services []core_v1.Service) {
@@ -120,5 +120,5 @@ func (s *ServiceDetails) SetErrorTraces(errorTraces int) {
 }
 
 func (s *ServiceDetails) SetApiDocumentation(apidoc ApiDocumentation) {
-        s.ApiDocumentation  = apidoc
+	s.ApiDocumentation = apidoc
 }

--- a/models/service.go
+++ b/models/service.go
@@ -19,6 +19,10 @@ type ServiceOverview struct {
 	// required: true
 	// example: true
 	AppLabel bool `json:"appLabel"`
+        // Type of api being served (graphql, grpc, rest)
+        // example: rest
+        // required: false
+        ApiType string `json:"apiType,omitempty"`
 }
 
 type ServiceList struct {
@@ -38,20 +42,26 @@ type ServiceDetails struct {
 	Validations      IstioValidations  `json:"validations"`
 	ErrorTraces      int               `json:"errorTraces"`
 	NamespaceMTLS    MTLSStatus        `json:"namespaceMTLS"`
+        ApiDocumentation ApiDocumentation  `json:"apiDocumentation"`
 }
 
 type Services []*Service
 type Service struct {
-	Name            string            `json:"name"`
-	CreatedAt       string            `json:"createdAt"`
-	ResourceVersion string            `json:"resourceVersion"`
-	Namespace       Namespace         `json:"namespace"`
-	Labels          map[string]string `json:"labels"`
-	Selectors       map[string]string `json:"selectors"`
-	Type            string            `json:"type"`
-	Ip              string            `json:"ip"`
-	Ports           Ports             `json:"ports"`
-	ExternalName    string            `json:"externalName"`
+	Name             string            `json:"name"`
+	CreatedAt        string            `json:"createdAt"`
+	ResourceVersion  string            `json:"resourceVersion"`
+	Namespace        Namespace         `json:"namespace"`
+	Labels           map[string]string `json:"labels"`
+	Selectors        map[string]string `json:"selectors"`
+	Type             string            `json:"type"`
+	Ip               string            `json:"ip"`
+	Ports            Ports             `json:"ports"`
+	ExternalName     string            `json:"externalName"`
+}
+
+type ApiDocumentation struct {
+        Type          string `json:"type,omitempty"`
+        BaseUrl       string `json:"baseUrl,omitempty"`
 }
 
 func (ss *Services) Parse(services []core_v1.Service) {
@@ -107,4 +117,8 @@ func (s *ServiceDetails) SetDestinationRules(dr []kubernetes.IstioObject, canCre
 
 func (s *ServiceDetails) SetErrorTraces(errorTraces int) {
 	s.ErrorTraces = errorTraces
+}
+
+func (s *ServiceDetails) SetApiDocumentation(apidoc ApiDocumentation) {
+        s.ApiDocumentation  = apidoc
 }

--- a/models/service.go
+++ b/models/service.go
@@ -61,7 +61,7 @@ type Service struct {
 
 type ApiDocumentation struct {
 	Type    string `json:"type,omitempty"`
-	HasSpec bool `json:"hasSpec,omitempty"`
+	HasSpec bool   `json:"hasSpec,omitempty"`
 }
 
 func (ss *Services) Parse(services []core_v1.Service) {

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -64,6 +64,20 @@ spec:
 
 ##########
 #  ---
+#  apidocs:
+# 
+# Configure the api documentation
+# Use  api_spec_annotation_name and api_type_annotation_name if you want 
+# to customize the annotation names to use on your services
+# 
+#    ---
+#    annotations:
+#      api_spec_annotation_name: "kiali.kubernetes.io/api-spec"
+#      api_type_annotation_name: "kiali.kubernetes.io/api-type"
+
+
+##########
+#  ---
 #  auth:
 #
 # Determines what authentication strategy to use when users log into Kiali.

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -23,8 +23,8 @@ kiali_defaults:
 
   apidocs:
     annotations:
-      api_type_annotation_name: "kiali.kubernetes.io/api-type"
       api_spec_annotation_name: "kiali.kubernetes.io/api-spec"
+      api_type_annotation_name: "kiali.kubernetes.io/api-type"
 
   auth:
     strategy: ""

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -21,6 +21,11 @@ kiali_defaults:
       - "kiali-operator"
       #label_selector:
 
+  apidocs:
+    annotations:
+      api_type_annotation_name: "kiali.kubernetes.io/api-type"
+      api_spec_annotation_name: "kiali.kubernetes.io/api-spec"
+
   auth:
     strategy: ""
 

--- a/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
   annotations:
-    {{ kiali_vars.apidocs.annotations.api_spec_annotation_name }}: {{ kiali_vars.server.web_root }}/swagger.json
+    {{ kiali_vars.apidocs.annotations.api_spec_annotation_name }}: {{ '' if kiali_vars.server.web_root == '/' else kiali_vars.server.web_root }}/swagger.json
     {{ kiali_vars.apidocs.annotations.api_type_annotation_name }}: rest
 spec:
   type: {{ kiali_vars.deployment.service_type }}

--- a/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
+  annotations:
+    {{ kiali_vars.apidocs.annotations.api_spec_annotation_name }}: {{ kiali_vars.server.web_root }}/swagger.json
+    {{ kiali_vars.apidocs.annotations.api_type_annotation_name }}: rest
 spec:
   type: {{ kiali_vars.deployment.service_type }}
   ports:

--- a/operator/roles/kiali-deploy/templates/openshift/service.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/service.yaml
@@ -8,7 +8,7 @@ metadata:
     version: {{ kiali_vars.deployment.version_label }}
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
-    {{ kiali_vars.apidocs.annotations.api_spec_annotation_name }}: {{ kiali_vars.server.web_root }}/swagger.json
+    {{ kiali_vars.apidocs.annotations.api_spec_annotation_name }}: {{ '' if kiali_vars.server.web_root == '/' else kiali_vars.server.web_root }}/swagger.json
     {{ kiali_vars.apidocs.annotations.api_type_annotation_name }}: rest
 spec:
   type: {{ kiali_vars.deployment.service_type }}

--- a/operator/roles/kiali-deploy/templates/openshift/service.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/service.yaml
@@ -8,6 +8,8 @@ metadata:
     version: {{ kiali_vars.deployment.version_label }}
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
+    {{ kiali_vars.apidocs.annotations.api_spec_annotation_name }}: {{ kiali_vars.server.web_root }}/swagger.json
+    {{ kiali_vars.apidocs.annotations.api_type_annotation_name }}: rest
 spec:
   type: {{ kiali_vars.deployment.service_type }}
   ports:

--- a/operator/roles/kiali-deploy/vars/main.yml
+++ b/operator/roles/kiali-deploy/vars/main.yml
@@ -23,6 +23,13 @@ kiali_vars:
     {{ kiali_defaults.api }}
     {%- endif -%}
 
+  apidocs: |
+    {%- if apidocs is defined and apidocs is iterable -%}
+    {{ kiali_defaults.apidocs | combine(apidocs, recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.apidocs }}
+    {%- endif -%}
+
   auth: |
     {%- if auth is defined and auth is iterable -%}
     {{ kiali_defaults.auth | combine(auth, recursive=True) }}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -421,24 +421,24 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceDetails,
 			true,
 		},
-                // swagger:route GET /namespaces/{namespace}/services/{service}/apispec services string
-                // ---
-                // Get api spec associated to the given service. This is just a proxy to the url of the service serving the spec
-                //
-                //
-                //     Schemes: http, https
-                //
-                // responses:
-                //      404: notFoundError
-                //      500: internalError
-                //      200
-                {
-                        "ServiceApiDocumentation",
-                        "GET",
-                        "/api/namespaces/{namespace}/services/{service}/apispec",
-                        handlers.ServiceApiDocumentation,
-                        true,
-                },
+		// swagger:route GET /namespaces/{namespace}/services/{service}/apispec services string
+		// ---
+		// Get api spec associated to the given service. This is just a proxy to the url of the service serving the spec
+		//
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      404: notFoundError
+		//      500: internalError
+		//      200
+		{
+			"ServiceApiDocumentation",
+			"GET",
+			"/api/namespaces/{namespace}/services/{service}/apispec",
+			handlers.ServiceApiDocumentation,
+			true,
+		},
 		// swagger:route GET /namespaces/{namespace}/workloads workloads workloadList
 		// ---
 		// Endpoint to get the list of workloads for a namespace

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -421,6 +421,24 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceDetails,
 			true,
 		},
+                // swagger:route GET /namespaces/{namespace}/services/{service}/apispec services string
+                // ---
+                // Get api spec associated to the given service. This is just a proxy to the url of the service serving the spec
+                //
+                //
+                //     Schemes: http, https
+                //
+                // responses:
+                //      404: notFoundError
+                //      500: internalError
+                //      200
+                {
+                        "ServiceApiDocumentation",
+                        "GET",
+                        "/api/namespaces/{namespace}/services/{service}/apispec",
+                        handlers.ServiceApiDocumentation,
+                        true,
+                },
 		// swagger:route GET /namespaces/{namespace}/workloads workloads workloadList
 		// ---
 		// Endpoint to get the list of workloads for a namespace

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -421,7 +421,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceDetails,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/services/{service}/apispec services string
+		// swagger:route GET /namespaces/{namespace}/services/{service}/apispec services serviceApiDocumentation
 		// ---
 		// Get api spec associated to the given service. This is just a proxy to the url of the service serving the spec
 		//

--- a/swagger.json
+++ b/swagger.json
@@ -1870,6 +1870,45 @@
         }
       }
     },
+    "/namespaces/{namespace}/services/{service}/apispec": {
+      "get": {
+        "description": "Get api spec associated to the given service. This is just a proxy to the url of the service serving the spec",
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "services"
+        ],
+        "operationId": "serviceApiDocumentation",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace name.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The service name.",
+            "name": "service",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
     "/namespaces/{namespace}/services/{service}/dashboard": {
       "get": {
         "description": "Endpoint to fetch dashboard to be displayed, related to a single service",
@@ -3207,6 +3246,20 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/vendor/github.com/kiali/k-charted/model"
+    },
+    "ApiDocumentation": {
+      "type": "object",
+      "properties": {
+        "baseUrl": {
+          "type": "string",
+          "x-go-name": "BaseUrl"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
     },
     "App": {
       "type": "object",
@@ -4698,6 +4751,9 @@
     "ServiceDetails": {
       "type": "object",
       "properties": {
+        "apiDocumentation": {
+          "$ref": "#/definitions/ApiDocumentation"
+        },
         "destinationRules": {
           "$ref": "#/definitions/destinationRules"
         },
@@ -4835,6 +4891,12 @@
         "appLabel"
       ],
       "properties": {
+        "apiType": {
+          "description": "Type of api being served (graphql, grpc, rest)",
+          "type": "string",
+          "x-go-name": "ApiType",
+          "example": "rest"
+        },
         "appLabel": {
           "description": "Has label app",
           "type": "boolean",

--- a/swagger.json
+++ b/swagger.json
@@ -3250,9 +3250,9 @@
     "ApiDocumentation": {
       "type": "object",
       "properties": {
-        "baseUrl": {
-          "type": "string",
-          "x-go-name": "BaseUrl"
+        "hasSpec": {
+          "type": "boolean",
+          "x-go-name": "HasSpec"
         },
         "type": {
           "type": "string",


### PR DESCRIPTION
** Describe the change **

This adds backend to support API Documentation feature. We are collecting the api type and api spec fields from annotations if they are present and add it to the JSON that is sent to the FrontEnd. This also add a new endpoint to proxy the api spec

** Issue reference **

https://github.com/kiali/kiali/issues/1237

** Backwards incompatible? **

No

** Documentation **

https://github.com/kiali/kiali/pull/1266/commits/94a0441f7976b7039f1d45dd0f941bba3a173876