### PR TITLE
KIALI-3153 Add response_flags to metrics

### DIFF
--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -32,7 +32,7 @@ func TestGetIstioDashboard(t *testing.T) {
 
 	assert.Nil(err)
 	assert.Equal("Inbound Metrics", dashboard.Title)
-	assert.Len(dashboard.Aggregations, 4)
+	assert.Len(dashboard.Aggregations, 5)
 	assert.Equal("Local version", dashboard.Aggregations[0].DisplayName)
 	assert.Equal("destination_version", dashboard.Aggregations[0].Label)
 	assert.Equal("Remote app", dashboard.Aggregations[1].DisplayName)

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -56,6 +56,10 @@ func buildIstioAggregations(local, remote string) []kmodel.Aggregation {
 			Label:       "response_code",
 			DisplayName: "Response code",
 		},
+		{
+			Label:       "response_flags",
+			DisplayName: "Response flags",
+		},
 	}...)
 	return aggs
 }

--- a/models/dashboards_test.go
+++ b/models/dashboards_test.go
@@ -13,10 +13,11 @@ func TestPrepareIstioDashboard(t *testing.T) {
 	dashboard := PrepareIstioDashboard("Outbound", "source", "destination")
 
 	assert.Equal(dashboard.Title, "Outbound Metrics")
-	assert.Len(dashboard.Aggregations, 5)
+	assert.Len(dashboard.Aggregations, 6)
 	assert.Equal(model.Aggregation{Label: "source_version", DisplayName: "Local version"}, dashboard.Aggregations[0])
 	assert.Equal(model.Aggregation{Label: "destination_service_name", DisplayName: "Remote service"}, dashboard.Aggregations[1])
 	assert.Equal(model.Aggregation{Label: "destination_app", DisplayName: "Remote app"}, dashboard.Aggregations[2])
 	assert.Equal(model.Aggregation{Label: "destination_version", DisplayName: "Remote version"}, dashboard.Aggregations[3])
 	assert.Equal(model.Aggregation{Label: "response_code", DisplayName: "Response code"}, dashboard.Aggregations[4])
+	assert.Equal(model.Aggregation{Label: "response_flags", DisplayName: "Response flags"}, dashboard.Aggregations[5])
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-3153

As mentioned in the JIRA, adding this new label is an easy one however the codes can be kind of cryptic (FI, UF, URX, etc.), so I suggest to prioritize task https://issues.jboss.org/browse/KIALI-1690 for an in-app help on the metrics page, which would add info about all codes.

![codes](https://i.imgur.com/PICODvm.png)
