### PR TITLE
KIALI-3151 Add namespace and port for Jaeger integration test

### DIFF
--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -82,7 +82,8 @@ func getErrorTracesFromJaeger(namespace string, service string, requestToken str
 }
 
 func GetJaegerInternalURL(path string) (*url.URL, error) {
-	return url.Parse(fmt.Sprintf("http://%s%s%s", appstate.JaegerConfig.Service, appstate.JaegerConfig.Path, path))
+	return url.Parse(fmt.Sprintf("http://%s.%s:%d%s%s", appstate.JaegerConfig.Service,
+		appstate.JaegerConfig.Namespace, appstate.JaegerConfig.Port, appstate.JaegerConfig.Path, path))
 }
 
 func GetJaegerServices() (services JaegerServices, err error) {

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ const (
 	EnvTracingEnabled          = "TRACING_ENABLED"
 	EnvTracingURL              = "TRACING_URL"
 	EnvTracingServiceNamespace = "TRACING_SERVICE_NAMESPACE"
-	EnvTracingServicePort 	   = "TRACING_SERVICE_PORT"
+	EnvTracingServicePort      = "TRACING_SERVICE_PORT"
 
 	EnvThreeScaleAdapterName = "THREESCALE_ADAPTER_NAME"
 	EnvThreeScaleServiceName = "THREESCALE_SERVICE_NAME"
@@ -158,7 +158,7 @@ type TracingConfig struct {
 	Enabled   bool   `yaml:"enabled"`
 	Namespace string `yaml:"namespace"`
 	Service   string `yaml:"service"`
-	Port      int32 `yaml: "port""`
+	Port      int32  `yaml:"port"`
 	Protocol  string `yaml:"protocol"`
 	URL       string `yaml:"url"`
 	Auth      Auth   `yaml:"auth"`

--- a/config/config.go
+++ b/config/config.go
@@ -159,7 +159,6 @@ type TracingConfig struct {
 	Namespace string `yaml:"namespace"`
 	Service   string `yaml:"service"`
 	Port      int32  `yaml:"port"`
-	Protocol  string `yaml:"protocol"`
 	URL       string `yaml:"url"`
 	Auth      Auth   `yaml:"auth"`
 	// Path store the value of QUERY_BASE_PATH

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ const (
 	EnvTracingEnabled          = "TRACING_ENABLED"
 	EnvTracingURL              = "TRACING_URL"
 	EnvTracingServiceNamespace = "TRACING_SERVICE_NAMESPACE"
+	EnvTracingServicePort 	   = "TRACING_SERVICE_PORT"
 
 	EnvThreeScaleAdapterName = "THREESCALE_ADAPTER_NAME"
 	EnvThreeScaleServiceName = "THREESCALE_SERVICE_NAME"
@@ -157,6 +158,8 @@ type TracingConfig struct {
 	Enabled   bool   `yaml:"enabled"`
 	Namespace string `yaml:"namespace"`
 	Service   string `yaml:"service"`
+	Port      int32 `yaml: "port""`
+	Protocol  string `yaml:"protocol"`
 	URL       string `yaml:"url"`
 	Auth      Auth   `yaml:"auth"`
 	// Path store the value of QUERY_BASE_PATH
@@ -289,6 +292,7 @@ func NewConfig() (c *Config) {
 	c.ExternalServices.Tracing.Path = ""
 	c.ExternalServices.Tracing.URL = strings.TrimSpace(getDefaultString(EnvTracingURL, ""))
 	c.ExternalServices.Tracing.Namespace = strings.TrimSpace(getDefaultString(EnvTracingServiceNamespace, c.IstioNamespace))
+	c.ExternalServices.Tracing.Port = getDefaultInt32(EnvTracingServicePort, 16686)
 	c.ExternalServices.Tracing.Auth = getAuthFromEnv("TRACING")
 
 	// Istio Configuration
@@ -388,6 +392,14 @@ func getDefaultInt(envvar string, defaultValue int) (retVal int) {
 }
 
 func getDefaultInt64(envvar string, defaultValue int64) (retVal int64) {
+	return envToInteger(envvar, defaultValue)
+}
+
+func getDefaultInt32(envvar string, defaultValue int32) (retVal int32) {
+	return int32(envToInteger(envvar, int64(defaultValue)))
+}
+
+func envToInteger(envvar string, defaultValue int64) (retVal int64) {
 	retValString := os.Getenv(envvar)
 	if retValString == "" {
 		retVal = defaultValue

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -256,6 +256,7 @@ spec:
 # enabled: When true, Kiali shows Jaeger and will attempt to autodiscover it.
 # namespace: The Kubernetes namespace that holds the Tracing service (if empty, assumes the same value as deployment.namespace)
 # service: The Kubernetes service name for tracing. Kiali uses this to connect within the cluster to Jaeger.
+# port: The kubernetes port where the tracing service is mount. Default port is Jaeger port, 16686. Autodiscovered when service is not specified.
 # url: The URL that Kiali uses when integrating with Tracing. This URL must be accessible to clients external to
 #      the cluster in order for the integration to work properly. If empty, an attempt to auto-discover it is made.
 #      If tracing service is deployed in a QUERY_BASE_PATH set this in the url like https://<hostname>/<QUERY_BASE_PATH> . EX: https://tracing-service:8080/jaeger
@@ -272,6 +273,7 @@ spec:
 #      enabled: true
 #      namespace: ""
 #      service : ""
+#      port: 16686
 #      url: ""
 
 ##########

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -79,6 +79,7 @@ kiali_defaults:
       enabled: true
       namespace: ""
       service: ""
+      port: 16686
       url: ""
 
   identity: {}

--- a/status/discover.go
+++ b/status/discover.go
@@ -118,7 +118,7 @@ func discoverTracingService() (service string, port int32) {
 }
 
 func discoverTracingPath() (path string) {
-	tracingConfig := config.Get().ExternalServices.Tracing
+	tracingConfig := appstate.JaegerConfig
 	// We had the service so we can check the Path
 	path, err := checkIfQueryBasePath(tracingConfig.Namespace, tracingConfig.Service)
 	if err != nil {

--- a/status/discover.go
+++ b/status/discover.go
@@ -107,7 +107,7 @@ func discoverTracingService() (service string, port int32) {
 				port = serv.Spec.Ports[0].Port
 			}
 
-			log.Debugf("[TRACING] Service in: %s", service)
+			log.Debugf("[TRACING] Discovered Service and Port:  %s, %d", service, port)
 			break
 		} else {
 			// No service found set to empty for the last iteration


### PR DESCRIPTION
** Describe the change **

Don't assume that jaeger is in port 80 when testing if jaeger integration is enabled.
Also fixed the auto-discovery of the path.

** Issue reference **
https://issues.jboss.org/browse/KIALI-3151

** Backwards incompatible? **
yes
