### PR TITLE
KIALI-3156 Relax Maistra version requirements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -81,7 +81,7 @@ const (
 
 // The versions that Kiali requires
 const (
-	IstioVersionSupported   = ">= 1.1"
+	IstioVersionSupported   = ">= 1.0"
 	MaistraVersionSupported = ">= 0.7.0"
 )
 

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -78,7 +78,7 @@ func TestParseIstioRawVersion(t *testing.T) {
 			rawVersion: "root@f72e3d3ef3c2-docker.io/istio-release-1.0-20180927-21-10-deadbeef-Clean",
 			name:       "Istio Snapshot",
 			version:    "1.0-20180927",
-			supported:  false,
+			supported:  true,
 		},
 		{
 			rawVersion: "root@f72e3d3ef3c2-docker.io/istio-release-1.1-20190327-21-10-deadbeef-Clean",


### PR DESCRIPTION
Fixes KIALI-3156.

We just relax the permissions on the version check because Maistra is going to be using Istio 1.0 instead of 1.1 on its GA.