### PR TITLE
KIALI-3082 Enable check to enforce QE approvals

### DIFF
--- a/.github/kiali.yml
+++ b/.github/kiali.yml
@@ -1,0 +1,4 @@
+checks:
+  pull_requests:
+    required_approvals:
+      - [gbaufake, mattmahoneyrh, hhovsepy, skondkar]


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-3082

This will enable the kiali-bot to require a review from, at least, one of the QE people.

The PR will still be mergeable. In order to get real mandatory checks, the repository will need to be configured turn the checks from the kiali-bot as required (this is good until we know that the bot works OK).