### PR TITLE
Gateway validations: tighten up duplicate host matching regex.

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -125,7 +125,15 @@ func (m MultiMatchChecker) findMatch(host Host) (bool, []Host) {
 			current := strings.Replace(host.Hostname, "*", ".*", -1)
 			previous := strings.Replace(h.Hostname, "*", ".*", -1)
 
-			if regexp.MustCompile(current).MatchString(previous) || regexp.MustCompile(previous).MatchString(current) {
+			// We anchor the beginning and end of the string when it's
+			// to be used as a regex, so that we don't get spurious
+			// substring matches, e.g., "example.com" matching
+			// "foo.example.com".
+			current_re := strings.Join([]string{"^", current, "$"}, "")
+			previous_re := strings.Join([]string{"^", previous, "$"}, "")
+
+			if regexp.MustCompile(current_re).MatchString(previous) ||
+				regexp.MustCompile(previous_re).MatchString(current) {
 				duplicates = append(duplicates, h)
 				break
 			}

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -99,6 +99,31 @@ func TestWildCardMatchingHost(t *testing.T) {
 
 }
 
+func TestNoMatchOnSubdomainHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer(
+		[]string{
+			"example.com",
+			"thisisfine.example.com",
+		}, 80, "http", "http"),
+
+		data.CreateEmptyGateway("shouldbevalid", "test", map[string]string{
+			"app": "someother",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.Empty(validations)
+}
+
 func TestTwoWildCardsMatching(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -99,6 +99,35 @@ func TestWildCardMatchingHost(t *testing.T) {
 
 }
 
+func TestAnotherSubdomainWildcardCombination(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer(
+		[]string{
+			"*.echidna.com",
+			"tachyglossa.echidna.com",
+		}, 80, "http", "http"),
+
+		data.CreateEmptyGateway("shouldnotbevalid", "test", map[string]string{
+			"app": "monotreme",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "shouldnotbevalid"}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+}
+
 func TestNoMatchOnSubdomainHost(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)


### PR DESCRIPTION
This is to address an issue where a perfectly legitimate `Gateway`
with hostnames `example.com` and `foo.example.com` would get flagged
with a duplicate-host warning.  This was as a result of an unanchored
regular expression.  This PR introduces a test case to illustrate it,
as well as a fix.

Closes #1272.

* business/checkers/gateways/multi_match_checker.go (findMatch):
  Anchor the hostname with `^$` when it is used as a regular
  expression.  This avoids incorrect substring matching behaviour.
* business/checkers/gateways/multi_match_checker_test.go (TestNoMatchOnSubdomainHost):
  Introduce a regression test of the above.