### PR TITLE
Gateway host/port matching: make case-insensitive.  

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -122,8 +122,8 @@ func (m MultiMatchChecker) findMatch(host Host) (bool, []Host) {
 			}
 
 			// Either one could include wildcards, so we need to check both ways and fix "*" -> ".*" for regexp engine
-			current := strings.Replace(host.Hostname, "*", ".*", -1)
-			previous := strings.Replace(h.Hostname, "*", ".*", -1)
+			current := strings.ToLower(strings.Replace(host.Hostname, "*", ".*", -1))
+			previous := strings.ToLower(strings.Replace(h.Hostname, "*", ".*", -1))
 
 			if regexp.MustCompile(current).MatchString(previous) || regexp.MustCompile(previous).MatchString(current) {
 				duplicates = append(duplicates, h)

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -32,6 +32,35 @@ func TestCorrectGateways(t *testing.T) {
 	assert.False(ok)
 }
 
+func TestCaseMatching(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer(
+		[]string{
+			"NOTFINE.example.com",
+			"notfine.example.com",
+		}, 80, "http", "http"),
+
+		data.CreateEmptyGateway("foxxed", "test", map[string]string{
+			"app": "canidae",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "foxxed"}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+}
+
 func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)


### PR DESCRIPTION
It turns out that Kiali doesn't throw a warning if adding both `FOO.com` and `foo.com` to a gateway, while in fact, [DNS should be case insensitive](https://tools.ietf.org/html/rfc4343).

I've updated the matcher to downcase both hostnames before comparison to achieve this.  I could've use a [case-insensitive flag on Golang's `regexp` library](https://tip.golang.org/pkg/regexp/syntax/) but that felt like overkill.

Closes #1285.

* business/checkers/gateways/multi_match_checker.go(findMatch): Adapt  the function to do case-insensitive match on hostnames.
* business/checkers/gateways/multi_match_checker_test.go(TestCaseMatching):   Add test case for the above.
