### PR TITLE
[v1.0] Gateway validations fixes: #1284 and #1286

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -125,7 +125,15 @@ func (m MultiMatchChecker) findMatch(host Host) (bool, []Host) {
 			current := strings.Replace(host.Hostname, "*", ".*", -1)
 			previous := strings.Replace(h.Hostname, "*", ".*", -1)
 
-			if regexp.MustCompile(current).MatchString(previous) || regexp.MustCompile(previous).MatchString(current) {
+			// We anchor the beginning and end of the string when it's
+			// to be used as a regex, so that we don't get spurious
+			// substring matches, e.g., "example.com" matching
+			// "foo.example.com".
+			current_re := strings.Join([]string{"^", current, "$"}, "")
+			previous_re := strings.Join([]string{"^", previous, "$"}, "")
+
+			if regexp.MustCompile(current_re).MatchString(previous) ||
+				regexp.MustCompile(previous_re).MatchString(current) {
 				duplicates = append(duplicates, h)
 				break
 			}

--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -122,8 +122,8 @@ func (m MultiMatchChecker) findMatch(host Host) (bool, []Host) {
 			}
 
 			// Either one could include wildcards, so we need to check both ways and fix "*" -> ".*" for regexp engine
-			current := strings.Replace(host.Hostname, "*", ".*", -1)
-			previous := strings.Replace(h.Hostname, "*", ".*", -1)
+			current := strings.ToLower(strings.Replace(host.Hostname, "*", ".*", -1))
+			previous := strings.ToLower(strings.Replace(h.Hostname, "*", ".*", -1))
 
 			// We anchor the beginning and end of the string when it's
 			// to be used as a regex, so that we don't get spurious

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -32,6 +32,35 @@ func TestCorrectGateways(t *testing.T) {
 	assert.False(ok)
 }
 
+func TestCaseMatching(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer(
+		[]string{
+			"NOTFINE.example.com",
+			"notfine.example.com",
+		}, 80, "http", "http"),
+
+		data.CreateEmptyGateway("foxxed", "test", map[string]string{
+			"app": "canidae",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "foxxed"}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+}
+
 func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -99,6 +99,60 @@ func TestWildCardMatchingHost(t *testing.T) {
 
 }
 
+func TestAnotherSubdomainWildcardCombination(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer(
+		[]string{
+			"*.echidna.com",
+			"tachyglossa.echidna.com",
+		}, 80, "http", "http"),
+
+		data.CreateEmptyGateway("shouldnotbevalid", "test", map[string]string{
+			"app": "monotreme",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(1, len(validations))
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "shouldnotbevalid"}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+}
+
+func TestNoMatchOnSubdomainHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer(
+		[]string{
+			"example.com",
+			"thisisfine.example.com",
+		}, 80, "http", "http"),
+
+		data.CreateEmptyGateway("shouldbevalid", "test", map[string]string{
+			"app": "someother",
+		}))
+
+	gws := [][]kubernetes.IstioObject{[]kubernetes.IstioObject{gwObject}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.Empty(validations)
+}
+
 func TestTwoWildCardsMatching(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)


### PR DESCRIPTION
Cherry-pick from 
https://github.com/kiali/kiali/pull/1284
https://github.com/kiali/kiali/pull/1286

* Gateway validations: tighten up duplicate host matching regex.

This is to address an issue where a perfectly legitimate `Gateway`
with hostnames `example.com` and `foo.example.com` would get flagged
with a duplicate-host warning.  This was as a result of an unanchored
regular expression.  This PR introduces a test case to illustrate it,
as well as a fix.

Closes #1272.

* Gateway host/port matching: make case-insensitive.
It turns out that Kiali doesn't throw a warning if adding both FOO.com and foo.com to a gateway, while in fact, DNS should be case insensitive.

I've updated the matcher to downcase both hostnames before comparison to achieve this. I could've use a case-insensitive flag on Golang's regexp library but that felt like overkill.

Closes #1285.