### PR TITLE
Filter out packages which should not be included in code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ format:
 ## build-system-test: Building executable for system tests with code coverage enabled
 build-system-test:
 	@echo Building executable for system tests with code coverage enabled
-	go test -c -covermode=count -coverpkg ./...  -o ${GOPATH}/bin/kiali
+	go test -c -covermode=count -coverpkg $(shell go list ./... | grep -v test |  awk -vORS=, "{ print $$1 }" | sed "s/,$$//") -o ${GOPATH}/bin/kiali
 
 ## build-test: Run tests and installing test dependencies, excluding third party tests under vendor. Runs `go test -i` internally
 build-test:


### PR DESCRIPTION
** Describe the change **
Filter out packages which should not be part of binary for system tests code coverage.
e.g. test/data, kubetest,...

** Backwards incompatible? **

- Is your change introducing backwards incompatible changes?
no

** Documentation **

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
no
