### PR TITLE
KIALI-3161 Unused Nodes option should include service nodes

### DIFF
--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -94,8 +94,9 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 	if _, ok := requestedAppenders[UnusedNodeAppenderName]; ok || o.Appenders.All {
 		hasNodeOptions := o.App != "" || o.Workload != "" || o.Service != ""
 		a := UnusedNodeAppender{
-			GraphType:   o.GraphType,
-			IsNodeGraph: hasNodeOptions,
+			GraphType:          o.GraphType,
+			InjectServiceNodes: o.InjectServiceNodes,
+			IsNodeGraph:        hasNodeOptions,
 		}
 		appenders = append(appenders, a)
 	}

--- a/graph/telemetry/istio/appender/unused_node.go
+++ b/graph/telemetry/istio/appender/unused_node.go
@@ -13,8 +13,9 @@ const UnusedNodeAppenderName = "unusedNode"
 // unused definitions.  The added node types depend on the graph type and/or labeling on the definition.
 // Name: unusedNode
 type UnusedNodeAppender struct {
-	GraphType   string // This appender does not operate on service graphs because it adds workload nodes.
-	IsNodeGraph bool   // This appender does not operate on node detail graphs because we want to focus on the specific node.
+	GraphType          string
+	InjectServiceNodes bool // This appender addes unused services only when service node are injected or graphType=service
+	IsNodeGraph        bool // This appender does not operate on node detail graphs because we want to focus on the specific node.
 }
 
 // Name implements Appender
@@ -24,22 +25,33 @@ func (a UnusedNodeAppender) Name() string {
 
 // AppendGraph implements Appender
 func (a UnusedNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
-	if graph.GraphTypeService == a.GraphType || a.IsNodeGraph {
+	if a.IsNodeGraph {
 		return
 	}
 
-	if getWorkloadList(namespaceInfo) == nil {
-		workloadList, err := globalInfo.Business.Workload.GetWorkloadList(namespaceInfo.Namespace)
-		graph.CheckError(err)
-		namespaceInfo.Vendor[workloadListKey] = &workloadList
+	services := []models.ServiceOverview{}
+	workloads := []models.WorkloadListItem{}
+
+	if a.GraphType != graph.GraphTypeService {
+		if getWorkloadList(namespaceInfo) == nil {
+			workloadList, err := globalInfo.Business.Workload.GetWorkloadList(namespaceInfo.Namespace)
+			graph.CheckError(err)
+			namespaceInfo.Vendor[workloadListKey] = &workloadList
+		}
+		workloads = getWorkloadList(namespaceInfo).Workloads
 	}
 
-	workloadList := getWorkloadList(namespaceInfo)
-	a.addUnusedNodes(trafficMap, namespaceInfo.Namespace, workloadList.Workloads)
+	if a.GraphType == graph.GraphTypeService || a.InjectServiceNodes {
+		serviceList, err := globalInfo.Business.Svc.GetServiceList(namespaceInfo.Namespace)
+		graph.CheckError(err)
+		services = serviceList.Services
+	}
+
+	a.addUnusedNodes(trafficMap, namespaceInfo.Namespace, services, workloads)
 }
 
-func (a UnusedNodeAppender) addUnusedNodes(trafficMap graph.TrafficMap, namespace string, workloads []models.WorkloadListItem) {
-	unusedTrafficMap := a.buildUnusedTrafficMap(trafficMap, namespace, workloads)
+func (a UnusedNodeAppender) addUnusedNodes(trafficMap graph.TrafficMap, namespace string, services []models.ServiceOverview, workloads []models.WorkloadListItem) {
+	unusedTrafficMap := a.buildUnusedTrafficMap(trafficMap, namespace, services, workloads)
 
 	// Integrate the unused nodes into the existing traffic map
 	for id, unusedNode := range unusedTrafficMap {
@@ -47,8 +59,22 @@ func (a UnusedNodeAppender) addUnusedNodes(trafficMap graph.TrafficMap, namespac
 	}
 }
 
-func (a UnusedNodeAppender) buildUnusedTrafficMap(trafficMap graph.TrafficMap, namespace string, workloads []models.WorkloadListItem) graph.TrafficMap {
+func (a UnusedNodeAppender) buildUnusedTrafficMap(trafficMap graph.TrafficMap, namespace string, services []models.ServiceOverview, workloads []models.WorkloadListItem) graph.TrafficMap {
 	unusedTrafficMap := graph.NewTrafficMap()
+
+	for _, s := range services {
+		id, nodeType := graph.Id(namespace, s.Name, "", "", "", "", a.GraphType)
+		if _, found := trafficMap[id]; !found {
+			if _, found = unusedTrafficMap[id]; !found {
+				log.Tracef("Adding unused node for service [%s]", s.Name)
+				node := graph.NewNodeExplicit(id, namespace, "", "", "", s.Name, nodeType, a.GraphType)
+				// note: we don't know what the protocol really should be, http is most common, it's a dead edge anyway
+				node.Metadata = graph.Metadata{"httpIn": 0.0, "httpOut": 0.0, "isUnused": true}
+				unusedTrafficMap[id] = &node
+			}
+		}
+	}
+
 	cfg := config.Get()
 	appLabel := cfg.IstioLabels.AppLabelName
 	versionLabel := cfg.IstioLabels.VersionLabelName


### PR DESCRIPTION
- show unused services for service graphs and non-service graphs
  when service nodes are injected.

Before:
![image](https://user-images.githubusercontent.com/2104052/62236073-4e36e000-b39c-11e9-93d4-ec15cf81f076.png)

After:
![image](https://user-images.githubusercontent.com/2104052/62236033-3d866a00-b39c-11e9-9122-852ae8fe89a9.png)
