### PR TITLE
issue 1289 support tolerations and affinity config

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -170,7 +170,10 @@ run-playbook-tag:
 
 MOLECULE_SCENARIO ?= default
 ifeq ($(MOLECULE_DEBUG),true)
-MOLECULE_DEBUG_ARG="--debug"
+MOLECULE_DEBUG_ARG = --debug
+endif
+ifeq ($(MOLECULE_DESTROY_NEVER),true)
+MOLECULE_DESTROY_NEVER_ARG = --destroy never
 endif
 
 .molecule-docker-build-if-needed:
@@ -184,4 +187,4 @@ molecule-docker-build:
 
 ## molecule-test: Runs Molecule tests using the Molecule docker image
 molecule-test: .molecule-docker-build-if-needed
-	docker run --rm -it -v "${PWD}":/tmp/$(basename "${PWD}"):ro -v "${HOME}/.kube":/root/.kube:ro -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") --network="host" --add-host="api.crc.testing:192.168.130.11" kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test --scenario-name ${MOLECULE_SCENARIO}
+	docker run --rm -it -v "${PWD}":/tmp/$(basename "${PWD}"):ro -v "${HOME}/.kube":/root/.kube:ro -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") --network="host" --add-host="api.crc.testing:192.168.130.11" kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name ${MOLECULE_SCENARIO}

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -99,6 +99,15 @@ spec:
 #    ---
 #    #additional_service_yaml:
 #
+# Affinity definitions that are to be used to define the nodes where the Kiali pod should be contrained.
+# See the Kubernetes documentation on Assigning Pods to Nodes for the proper syntax for these three
+# different affinity types.
+#    ---
+#    affinity:
+#      node: {}
+#      pod: {}
+#      pod_anti: {}
+#
 # Determines which Kiali image to download and install.
 #    ---
 #    image_name: "kiali/kiali"
@@ -139,6 +148,11 @@ spec:
 # Common values are "NodePort", "ClusterIP", and "LoadBalancer".
 #    ---
 #    service_type: "NodePort"
+#
+# A list of tolerations which declare which node taints Kiali can tolerate.
+# See the Kubernetes documentation on Taints and Tolerations for more details.
+#    ---
+#    tolerations: []
 #
 # Determines which priority levels of log messages Kiali will output.
 # Typical values are "3" for INFO and higher priority, "4" for DEBUG and higher priority.

--- a/operator/molecule/affinity-tolerations-test/kiali-cr.yaml
+++ b/operator/molecule/affinity-tolerations-test/kiali-cr.yaml
@@ -7,8 +7,12 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    # Note that we start with no affinity or tolerations sections,
+    # so the first time through we just pick up the defaults.
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-
+    # while we are here, make sure the additional service yaml retains camelCase
+    additional_service_yaml:
+      externalName: my.kiali.example.com

--- a/operator/molecule/affinity-tolerations-test/molecule.yml
+++ b/operator/molecule/affinity-tolerations-test/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+  inventory:
+    group_vars:
+      all:
+        kiali_operator_assets_path : "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/affinity-tolerations-test/kiali-cr.yaml"
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          accessible_namespaces: ["**"]
+          auth_strategy: openshift
+          operator_namespace: kiali-operator
+          operator_image_name: quay.io/kiali/kiali-operator
+          operator_version: latest
+          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
+          #operator_version: dev
+          operator_watch_namespace: kiali-operator
+          operator_clusterrolebindings: "- clusterrolebindings"
+          operator_clusterroles: "- clusterroles"
+          image_name: quay.io/kiali/kiali
+          image_version: latest
+          image_pull_policy: Always
+scenario:
+  name: affinity-tolerations-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/operator/molecule/affinity-tolerations-test/playbook.yml
+++ b/operator/molecule/affinity-tolerations-test/playbook.yml
@@ -1,0 +1,74 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+  # set affinity and tolerations
+  - import_tasks: set_affinity_tolerations.yml
+    vars:
+      new_affinity:
+        node:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 71
+            preference:
+              matchExpressions:
+              - key: affinity-kiali-test
+                operator: In
+                values:
+                - affinity-kiali-test
+        pod:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 72
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: affinity-kiali-test
+                  operator: In
+                  values:
+                  - affinity-kiali-test1
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+        pod_anti:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 73
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: affinity-kiali-test
+                  operator: In
+                  values:
+                  - affinity-kiali-test2
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+      new_tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 777
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 777
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  - name: Assert that tolerations were applied to the deployment
+    assert:
+      that:
+      - "{{ kiali_deployment.resources[0].spec.template.spec.tolerations | length > 0 }}"
+      fail_msg: "Tolerations were not applied successfully: {{ kiali_deployment.resources[0].spec.template.spec.tolerations }}"
+  - name: Assert that affinity was applied
+    assert:
+      that:
+      - "{{ kiali_deployment.resources[0].spec.template.spec.affinity.nodeAffinity | length > 0 }}"
+      - "{{ kiali_deployment.resources[0].spec.template.spec.affinity.podAffinity | length > 0 }}"
+      - "{{ kiali_deployment.resources[0].spec.template.spec.affinity.podAntiAffinity | length > 0 }}"
+      fail_msg: "Affinity was not applied successfully: {{ kiali_deployment.resources[0].spec.template.spec.affinity }}"
+  - name: Assert that camelCase is retained in additional service yaml
+    assert:
+      that:
+      - "{{ kiali_service.resources[0].spec.externalName is defined }}"
+      - "{{ kiali_service.resources[0].spec.externalName == 'my.kiali.example.com' }}"
+      fail_msg: "Additional service yaml was not applied successfully: {{ kiali_service.resources[0].spec }}"

--- a/operator/molecule/affinity-tolerations-test/set_affinity_tolerations.yml
+++ b/operator/molecule/affinity-tolerations-test/set_affinity_tolerations.yml
@@ -1,0 +1,10 @@
+- name: Set affinity and tolerations in current Kiali CR
+  vars:
+    current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=kiali.operator_namespace, resource_name=custom_resource.metadata.name) }}"
+  set_fact:
+    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'affinity': new_affinity, 'tolerations': new_tolerations }}}, recursive=True) }}"
+
+- name: Change Kiali CR with new affinity and tolerations
+  k8s:
+    namespace: '{{ kiali.operator_namespace }}'
+    definition: "{{ new_kiali_cr }}"

--- a/operator/molecule/common/tasks.yml
+++ b/operator/molecule/common/tasks.yml
@@ -27,3 +27,21 @@
 - name: Format Configmap
   set_fact:
     kiali_configmap: "{{ kiali_configmap.data['config.yaml'] | from_yaml }}"
+
+- name: Get Kiali Deployment
+  k8s_facts:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ istio.control_plane_namespace }}"
+    label_selectors:
+    - app = kiali
+  register: kiali_deployment
+
+- name: Get Kiali Service
+  k8s_facts:
+    api_version: v1
+    kind: Service
+    namespace: "{{ istio.control_plane_namespace }}"
+    label_selectors:
+    - app = kiali
+  register: kiali_service

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -27,6 +27,10 @@ kiali_defaults:
   deployment:
     accessible_namespaces: ["^((?!(istio-operator|kube.*|openshift.*|ibm.*|kiali-operator)).)*$"]
     #additional_service_yaml:
+    affinity:
+      node: {}
+      pod: {}
+      pod_anti: {}
     image_name: "kiali/kiali"
     image_pull_policy: "IfNotPresent"
     image_pull_secrets: []
@@ -35,6 +39,7 @@ kiali_defaults:
     namespace: "istio-system"
     secret_name: "kiali"
     service_type: "NodePort"
+    tolerations: []
     verbose_mode: "3"
     version_label: ""
     view_only_mode: false

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -25,6 +25,62 @@
   - is_openshift == False
   - is_k8s == False
 
+# Because we are passing through some yaml directly to Kubernetes resources, we have to retain the camelCase keys.
+# All CR parameters are converted to snake_case, but the original yaml is found in the special _kiali_io_kiali param.
+# We need to copy that original yaml into our vars where appropriate to keep the camelCase.
+
+- name: Get the original CR as-is for the camelCase keys
+  set_fact:
+    current_cr: "{{ _kiali_io_kiali }}"
+
+- name: Replace snake_case with camelCase in deployment.affinity.node
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment']['affinity'].pop('node') %}
+      {{ kiali_vars | combine({'deployment': {'affinity': {'node': current_cr.spec.deployment.affinity.node }}}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.affinity is defined
+  - kiali_vars.deployment.affinity.node is defined
+  - kiali_vars.deployment.affinity.node | length > 0
+
+- name: Replace snake_case with camelCase in deployment.affinity.pod
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment']['affinity'].pop('pod') %}
+      {{ kiali_vars | combine({'deployment': {'affinity': {'pod': current_cr.spec.deployment.affinity.pod }}}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.affinity is defined
+  - kiali_vars.deployment.affinity.pod is defined
+  - kiali_vars.deployment.affinity.pod | length > 0
+
+- name: Replace snake_case with camelCase in deployment.affinity.pod_anti
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment']['affinity'].pop('pod_anti') %}
+      {{ kiali_vars | combine({'deployment': {'affinity': {'pod_anti': current_cr.spec.deployment.affinity.pod_anti }}}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.affinity is defined
+  - kiali_vars.deployment.affinity.pod_anti is defined
+  - kiali_vars.deployment.affinity.pod_anti | length > 0
+
+- name: Replace snake_case with camelCase in deployment.tolerations
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('tolerations') %}
+      {{ kiali_vars | combine({'deployment': {'tolerations': current_cr.spec.deployment.tolerations }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.tolerations is defined
+  - kiali_vars.deployment.tolerations | length > 0
+
+- name: Replace snake_case with camelCase in deployment.additional_service_yaml
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('additional_service_yaml') %}
+      {{ kiali_vars | combine({'deployment': {'additional_service_yaml': current_cr.spec.deployment.additional_service_yaml }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.additional_service_yaml is defined
+  - kiali_vars.deployment.additional_service_yaml | length > 0
+
 - name: Print some debug information
   vars:
     msg: |

--- a/operator/roles/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -85,3 +85,22 @@ spec:
         secret:
           secretName: {{ kiali_vars.deployment.secret_name }}
           optional: true
+{% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+      affinity:
+{% if kiali_vars.deployment.affinity.node|length > 0 %}
+        nodeAffinity:
+          {{ kiali_vars.deployment.affinity.node | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod|length > 0 %}
+        podAffinity:
+          {{ kiali_vars.deployment.affinity.pod | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+        podAntiAffinity:
+          {{ kiali_vars.deployment.affinity.pod_anti | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% endif %}
+{% endif %}
+{% if kiali_vars.deployment.tolerations|length > 0 %}
+      tolerations:
+      {{ kiali_vars.deployment.tolerations | to_nice_yaml(indent=0) | trim | indent(6) }}
+{% endif %}

--- a/operator/roles/kiali-deploy/templates/openshift/deployment.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/deployment.yaml
@@ -85,3 +85,22 @@ spec:
         secret:
           secretName: {{ kiali_vars.deployment.secret_name }}
           optional: true
+{% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+      affinity:
+{% if kiali_vars.deployment.affinity.node|length > 0 %}
+        nodeAffinity:
+          {{ kiali_vars.deployment.affinity.node | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod|length > 0 %}
+        podAffinity:
+          {{ kiali_vars.deployment.affinity.pod | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+        podAntiAffinity:
+          {{ kiali_vars.deployment.affinity.pod_anti | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% endif %}
+{% endif %}
+{% if kiali_vars.deployment.tolerations|length > 0 %}
+      tolerations:
+      {{ kiali_vars.deployment.tolerations | to_nice_yaml(indent=0) | trim | indent(6) }}
+{% endif %}


### PR DESCRIPTION
Provide a way for the user to tell the operator what tolerations and affinities to assign to Kiali. The Kiali CR will have `affinity` and `tolerations` settings.

This is to address https://github.com/kiali/kiali/issues/1289