### PR TITLE
KIALI-3183 - Updating Kiali Operator to use 0.9.0

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -45,7 +45,7 @@ help: Makefile
 	    echo "You do not have operator-sdk installed in your PATH. Will use the one found here: ../_output/operator-sdk-install/operator-sdk" ;\
 	  else \
 	    echo "You do not have operator-sdk installed in your PATH. The binary will be downloaded to ../_output/operator-sdk-install/operator-sdk" ;\
-	    curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.8.0/operator-sdk-v0.8.0-x86_64-linux-gnu > ../_output/operator-sdk-install/operator-sdk ;\
+	    curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu > ../_output/operator-sdk-install/operator-sdk ;\
 	    chmod +x ../_output/operator-sdk-install/operator-sdk ;\
 	  fi ;\
 	fi

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.8.0
+FROM quay.io/operator-framework/ansible-operator:v0.9.0
 
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/


### PR DESCRIPTION
## Describe the change 

- Updating Kiali Operator to use Operator SDK 0.9.0 (https://github.com/operator-framework/operator-sdk/releases/tag/v0.9.0) 

I have built a custom version of the Kiali operator and uploaded on https://quay.io/repository/gbaufake/kiali-operator 
with ``operator-sdk version: v0.9.0, commit: 560208dc998de497bbf59fea1b63426aec430934`` and I ran all molecule testing and I didn't find any regressions.

## Issue reference 
https://issues.jboss.org/browse/KIALI-3183
