### PR TITLE
Add Pod Security Policy for kiali-operator

### DIFF
--- a/operator/deploy/deploy-kiali-operator.sh
+++ b/operator/deploy/deploy-kiali-operator.sh
@@ -568,7 +568,7 @@ delete_operator_resources() {
     ${CLIENT_EXE} delete --ignore-not-found=true customresourcedefinitions --selector="app=kiali-operator"
 
     # now purge all operator resources
-    ${CLIENT_EXE} delete --ignore-not-found=true all,sa,deployments,roles,rolebindings,clusterroles,clusterrolebindings --selector="app=kiali-operator" -n "${OPERATOR_NAMESPACE}"
+    ${CLIENT_EXE} delete --ignore-not-found=true all,sa,deployments,roles,rolebindings,clusterroles,clusterrolebindings,podsecuritypolicies --selector="app=kiali-operator" -n "${OPERATOR_NAMESPACE}"
   fi
 
   # Clean up the operator namespace entirely but only if there are no pods running in it.
@@ -854,7 +854,7 @@ apply_operator_resource() {
 # Now deploy all the Kiali operator components.
 echo "Deploying Kiali operator to namespace [${OPERATOR_NAMESPACE}]"
 
-for yaml in namespace crd service_account role role_binding operator
+for yaml in namespace crd service_account psp role role_binding operator
 do
   apply_operator_resource ${yaml}
 

--- a/operator/deploy/merge-operator-yaml.sh
+++ b/operator/deploy/merge-operator-yaml.sh
@@ -98,7 +98,7 @@ echo OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE}
 echo OPERATOR_VERSION_LABEL="${OPERATOR_VERSION_LABEL}"
 echo OPERATOR_WATCH_NAMESPACE=${OPERATOR_WATCH_NAMESPACE}
 
-YAML_LIST="crd.yaml role.yaml service_account.yaml role_binding.yaml operator.yaml "
+YAML_LIST="crd.yaml role.yaml service_account.yaml psp.yaml role_binding.yaml operator.yaml "
 YAML_FILE="${YAML_FILE:-${YAML_DIR}/kiali-operator.yaml}"
 
 # remove any old file that still exists

--- a/operator/deploy/psp.yaml
+++ b/operator/deploy/psp.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: kiali-operator
+  labels:
+    app: kiali-operator
+    version: ${OPERATOR_VERSION_LABEL}
+spec:
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - downwardAPI
+  - hostPath
+  - secret
+  - configMap
+  - emptyDir

--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -8,6 +8,11 @@ metadata:
     app: kiali-operator
     version: ${OPERATOR_VERSION_LABEL}
 rules:
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+  resourceNames:
+    - kiali-operator
 - apiGroups: [""]
   resources:
   - configmaps


### PR DESCRIPTION
**Why Kiali-operator needs PSP?**
If the cluster enables Pod Security Policy, the kiali-operator pods will fail to start with error "Error: container has runAsNonRoot and image will run as root"

 **Describe the change** 

Add PodSecurityPolicy for kiali-operator, Permits the container to run with root privileges
update the role and rolebinding definition to bind the sa to adopt the PSP. 
Accordingly modify the deploy and merge script to process the psp file. 

 **Issue reference** 
https://github.com/kiali/kiali/issues/1294

