### PR TITLE
KIALI-3181 Support OSSM in version checks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,7 @@ const (
 const (
 	IstioVersionSupported   = ">= 1.0"
 	MaistraVersionSupported = ">= 0.7.0"
+	OSSMVersionSupported    = ">= 1.0"
 )
 
 // The valid auth strategies and values for cookie handling

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -45,6 +45,18 @@ func TestParseIstioRawVersion(t *testing.T) {
 			supported:  true,
 		},
 		{
+			rawVersion: "redhat@redhat-docker.io/openshift-service-mesh-1.0.0-1-123454535353-unknown",
+			name:       "OpenShift Service Mesh",
+			version:    "1.0.0",
+			supported:  true,
+		},
+		{
+			rawVersion: "redhat@redhat-docker.io/openshift-service-mesh-0.9.0-1-123454535353-unknown",
+			name:       "OpenShift Service Mesh",
+			version:    "0.9.0",
+			supported:  false,
+		},
+		{
 			rawVersion: "foobar-maistra-11.12.13-wotgorilla?",
 			name:       "Maistra",
 			version:    "11.12.13",


### PR DESCRIPTION
** Describe the change **

OSSM has a different naming and our old checks were incorrectly marking it as being 'Istio' in the about box.

![image](https://user-images.githubusercontent.com/691166/62384366-31c3b080-b520-11e9-9580-8e1acf669648.png)

This change allows us to detect that its running OSSM.

The new screen shot:

![Screenshot from 2019-08-02 12-10-54](https://user-images.githubusercontent.com/691166/62384399-54ee6000-b520-11e9-9ed7-a1c2049dd03e.png)

** Issue reference **

https://issues.jboss.org/browse/KIALI-3181
