### PR TITLE
KIALI-3047 Enable errcheck linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,10 +335,4 @@ lint-install:
 ## lint: Runs golangci-lint
 # doc.go is ommited for linting, because it generates lots of warnings.
 lint:
-	golangci-lint run --skip-files "doc\.go" --tests -D errcheck
-
-## lint-all: Runs gometalinter with items from good to have list but does not run during travis
-lint-all:
-	gometalinter --disable-all --enable=vet --enable=vetshadow --enable=varcheck --enable=structcheck \
-	--enable=ineffassign --enable=unconvert --enable=goimports -enable=gosimple --enable=staticcheck \
-	--enable=nakedret --tests  --vendor ./...
+	golangci-lint run --skip-files "doc\.go" --tests

--- a/business/health_test.go
+++ b/business/health_test.go
@@ -153,7 +153,7 @@ func TestGetNamespaceAppHealthWithoutIstio(t *testing.T) {
 	k8s.On("GetDeployments", "ns").Return(fakeDeploymentsHealthReview(), nil)
 	k8s.On("GetPods", "ns", "app").Return(fakePodsHealthReviewWithoutIstio(), nil)
 
-	hs.GetNamespaceAppHealth("ns", "1m", time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC))
+	_, _ = hs.GetNamespaceAppHealth("ns", "1m", time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC))
 
 	// Make sure unnecessary call isn't performed
 	prom.AssertNumberOfCalls(t, "GetAllRequestRates", 0)

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -421,7 +421,10 @@ func Logout(w http.ResponseWriter, r *http.Request) {
 	// We need to perform an extra step to invalidate the user token when using OpenShift OAuth
 	conf := config.Get()
 	if conf.Auth.Strategy == config.AuthStrategyOpenshift {
-		performOpenshiftLogout(w, r)
+		err := performOpenshiftLogout(w, r)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, err.Error())
+		}
 	}
 	RespondWithCode(w, http.StatusNoContent)
 }

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -181,7 +181,7 @@ func TestMissingSecretFlagPresent(t *testing.T) {
 
 	var reply map[string]interface{}
 	body, _ := ioutil.ReadAll(response.Body)
-	json.Unmarshal(body, &reply)
+	_ = json.Unmarshal(body, &reply)
 
 	assert.Contains(t, reply, "secretMissing")
 	assert.Equal(t, true, reply["secretMissing"])
@@ -206,7 +206,7 @@ func TestMissingSecretFlagAbsent(t *testing.T) {
 
 	var reply map[string]interface{}
 	body, _ := ioutil.ReadAll(response.Body)
-	json.Unmarshal(body, &reply)
+	_ = json.Unmarshal(body, &reply)
 
 	assert.NotContains(t, reply, "secretMissing")
 }

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -14,7 +14,7 @@ func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	w.Write(response)
+	_, _ = w.Write(response)
 }
 
 func RespondWithJSONIndent(w http.ResponseWriter, code int, payload interface{}) {
@@ -26,7 +26,7 @@ func RespondWithJSONIndent(w http.ResponseWriter, code int, payload interface{})
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	w.Write(response)
+	_, _ = w.Write(response)
 }
 
 func RespondWithError(w http.ResponseWriter, code int, message string) {

--- a/kiali.go
+++ b/kiali.go
@@ -50,7 +50,7 @@ var (
 
 func init() {
 	// log everything to stderr so that it can be easily gathered by logs, separate log files are problematic with containers
-	flag.Set("logtostderr", "true")
+	_ = flag.Set("logtostderr", "true")
 
 }
 

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -323,7 +323,11 @@ func (in *IstioClient) GetPodLogs(namespace, name string, opts *core_v1.PodLogOp
 
 	defer readCloser.Close()
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(readCloser)
+	_, err = buf.ReadFrom(readCloser)
+	if err != nil {
+		return nil, err
+	}
+
 	return &PodLogs{Logs: buf.String()}, nil
 }
 

--- a/prometheus/internalmetrics/internal_metrics_test.go
+++ b/prometheus/internalmetrics/internal_metrics_test.go
@@ -29,7 +29,7 @@ func TestSuccessOrFailureMetric(t *testing.T) {
 	}
 
 	// simulate a failure - our failure counter metric should increment to 1
-	doSomeWork(true)
+	_ = doSomeWork(true)
 	metrics, err = registry.Gather()
 	assert.Nil(t, err)
 	if len(metrics) != 2 {
@@ -50,7 +50,7 @@ func TestSuccessOrFailureMetric(t *testing.T) {
 	}
 
 	// simulate a success
-	doSomeWork(false)
+	_ = doSomeWork(false)
 	metrics, err = registry.Gather()
 	assert.Nil(t, err)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -363,7 +363,7 @@ func generateCertificate(t *testing.T, certPath string, keyPath string, host str
 	if err != nil {
 		return err
 	}
-	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	_ = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	certOut.Close()
 
 	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
@@ -372,7 +372,7 @@ func generateCertificate(t *testing.T, certPath string, keyPath string, host str
 	}
 
 	pemBlockForKey := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}
-	pem.Encode(keyOut, pemBlockForKey)
+	_ = pem.Encode(keyOut, pemBlockForKey)
 	keyOut.Close()
 
 	t.Logf("Generated security data: %v|%v|%v", certPath, keyPath, host)


### PR DESCRIPTION
Fixing errcheck linting errors and removing a Makefile target no longer necessary.