### PR TITLE
KIALI-3181 [v1.0] Support OSSM in version checks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,7 @@ const (
 const (
 	IstioVersionSupported   = ">= 1.0"
 	MaistraVersionSupported = ">= 0.7.0"
+	OSSMVersionSupported    = ">= 1.0"
 )
 
 // The valid auth strategies and values for cookie handling

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -45,6 +45,18 @@ func TestParseIstioRawVersion(t *testing.T) {
 			supported:  true,
 		},
 		{
+			rawVersion: "redhat@redhat-docker.io/openshift-service-mesh-1.0.0-1-123454535353-unknown",
+			name:       "OpenShift Service Mesh",
+			version:    "1.0.0",
+			supported:  true,
+		},
+		{
+			rawVersion: "redhat@redhat-docker.io/openshift-service-mesh-0.9.0-1-123454535353-unknown",
+			name:       "OpenShift Service Mesh",
+			version:    "0.9.0",
+			supported:  false,
+		},
+		{
 			rawVersion: "foobar-maistra-11.12.13-wotgorilla?",
 			name:       "Maistra",
 			version:    "11.12.13",


### PR DESCRIPTION
Backport of KIALI 3181 into the v1.0 branch.