### PR TITLE
KIALI-3095 Fix Kubernetes installation

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -21,7 +21,7 @@ KIALI_IMAGE_PULL_POLICY ?= IfNotPresent
 KIALI_IMAGE_VERSION ?= ${OPERATOR_IMAGE_VERSION}
 NAMESPACE ?= istio-system
 VERBOSE_MODE ?= 3
-SERVICE_TYPE ?= NodePort
+SERVICE_TYPE ?= ClusterIP
 
 # Path to CR file for any other parameter
 KIALI_CR_FILE ?= deploy/kiali/kiali_cr_dev.yaml

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -147,7 +147,7 @@ spec:
 # The Kiali service type. Kubernetes determines what values are valid.
 # Common values are "NodePort", "ClusterIP", and "LoadBalancer".
 #    ---
-#    service_type: "NodePort"
+#    #service_type: "NodePort"
 #
 # A list of tolerations which declare which node taints Kiali can tolerate.
 # See the Kubernetes documentation on Taints and Tolerations for more details.

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -38,7 +38,6 @@ kiali_defaults:
     ingress_enabled: true
     namespace: "istio-system"
     secret_name: "kiali"
-    service_type: "NodePort"
     tolerations: []
     verbose_mode: "3"
     version_label: ""

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -38,6 +38,7 @@ kiali_defaults:
     ingress_enabled: true
     namespace: "istio-system"
     secret_name: "kiali"
+    #service_type: "NodePort"
     tolerations: []
     verbose_mode: "3"
     version_label: ""

--- a/operator/roles/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -7,8 +7,16 @@ metadata:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
   annotations:
+    # For ingress-nginx versions older than 0.20.0
+    # (see: https://github.com/kubernetes/ingress-nginx/issues/3416#issuecomment-438247948)
     nginx.ingress.kubernetes.io/secure-backends: "true"
+    # For ingress-nginx versions 0.20.0 and later
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
-  backend:
-    serviceName: kiali
-    servicePort: {{ kiali_vars.server.port }}
+  rules:
+  - http:
+      paths:
+      - path: {{ kiali_vars.server.web_root }}
+        backend:
+          serviceName: kiali
+          servicePort: {{ kiali_vars.server.port }}

--- a/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/service.yaml
@@ -7,7 +7,9 @@ metadata:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
 spec:
+{% if kiali_vars.deployment.service_type is defined %}
   type: {{ kiali_vars.deployment.service_type }}
+{% endif %}
   ports:
   - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}
     protocol: TCP

--- a/operator/roles/kiali-deploy/templates/openshift/service.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/service.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
 spec:
+{% if kiali_vars.deployment.service_type is defined %}
   type: {{ kiali_vars.deployment.service_type }}
+{% endif %}
   ports:
   - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}
     protocol: TCP


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-3095

* Switching to default service type (ClusterIP) instead of NodePort
* Less invasive Ingress entry for Kubernetes
* Adds annotation to make Ingress to use the right protocol to forward the request to the Kiali service

Fixes #1308