### PR TITLE
KIALI-3193 Add support for ServiceMeshPolicy,ServiceMeshRbacConfig

### DIFF
--- a/business/checkers/destinationrules/namespacewide_mtls_checker.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker.go
@@ -26,7 +26,13 @@ func (m NamespaceWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 	}
 
 	// In case any Policy enables mTLS, check among MeshPolicies for a rule enabling it
-	for _, mp := range m.MTLSDetails.MeshPolicies {
+	// ServiceMeshPolicies are a clone of MeshPolicies but used in Maistra scenarios
+	// MeshPolicies and ServiceMeshPolicies won't co-exist, only ony array will be populated
+	mPolicies := m.MTLSDetails.MeshPolicies
+	if m.MTLSDetails.ServiceMeshPolicies != nil {
+		mPolicies = m.MTLSDetails.ServiceMeshPolicies
+	}
+	for _, mp := range mPolicies {
 		if enabled, _ := kubernetes.PolicyHasMTLSEnabled(mp); enabled {
 			return validations, true
 		}

--- a/business/checkers/mesh_policies_checker.go
+++ b/business/checkers/mesh_policies_checker.go
@@ -29,7 +29,7 @@ func (m MeshPolicyChecker) runChecks(meshPolicy kubernetes.IstioObject) models.I
 	key, rrValidation := EmptyValidValidation(meshPolicyName, MeshPolicyCheckerType)
 
 	enabledCheckers := []Checker{
-		meshpolicies.MeshMtlsChecker{MeshPolicy: meshPolicy, MTLSDetails: m.MTLSDetails},
+		meshpolicies.MeshMtlsChecker{MeshPolicy: meshPolicy, MTLSDetails: m.MTLSDetails, IsServiceMesh: false},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/meshpolicies/mesh_mtls_checker.go
+++ b/business/checkers/meshpolicies/mesh_mtls_checker.go
@@ -5,9 +5,12 @@ import (
 	"github.com/kiali/kiali/models"
 )
 
+// Note that MeshMtlsChecker will work with MeshPolicy and ServiceMeshPolicy resources
 type MeshMtlsChecker struct {
-	MeshPolicy  kubernetes.IstioObject
-	MTLSDetails kubernetes.MTLSDetails
+	// MeshPolicy or ServiceMeshPolicy, it depends of the parent checker
+	MeshPolicy    kubernetes.IstioObject
+	MTLSDetails   kubernetes.MTLSDetails
+	IsServiceMesh bool
 }
 
 func (t MeshMtlsChecker) Check() ([]*models.IstioCheck, bool) {
@@ -25,7 +28,12 @@ func (t MeshMtlsChecker) Check() ([]*models.IstioCheck, bool) {
 		}
 	}
 
-	check := models.Build("meshpolicies.mtls.destinationrulemissing", "spec/peers/mtls")
+	checkerId := "meshpolicies.mtls.destinationrulemissing"
+	if t.IsServiceMesh {
+		checkerId = "servicemeshpolicies.mtls.destinationrulemissing"
+	}
+
+	check := models.Build(checkerId, "spec/peers/mtls")
 	validations = append(validations, &check)
 
 	return validations, false

--- a/business/checkers/service_mesh_policies_checker.go
+++ b/business/checkers/service_mesh_policies_checker.go
@@ -1,0 +1,43 @@
+package checkers
+
+import (
+	"github.com/kiali/kiali/business/checkers/meshpolicies"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+const ServiceMeshPolicyCheckerType = "servicemeshpolicy"
+
+type ServiceMeshPolicyChecker struct {
+	ServiceMeshPolicies []kubernetes.IstioObject
+	MTLSDetails         kubernetes.MTLSDetails
+}
+
+func (m ServiceMeshPolicyChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, smPolicy := range m.ServiceMeshPolicies {
+		validations.MergeValidations(m.runChecks(smPolicy))
+	}
+
+	return validations
+}
+
+// runChecks runs all the individual checks for a single mesh policy and appends the result into validations.
+func (m ServiceMeshPolicyChecker) runChecks(smPolicy kubernetes.IstioObject) models.IstioValidations {
+	meshPolicyName := smPolicy.GetObjectMeta().Name
+	key, rrValidation := EmptyValidValidation(meshPolicyName, ServiceMeshPolicyCheckerType)
+
+	enabledCheckers := []Checker{
+		// ServiceMeshPolicy is a clone of MeshPolicy so we can reuse the MeshMtlsChecker
+		meshpolicies.MeshMtlsChecker{MeshPolicy: smPolicy, MTLSDetails: m.MTLSDetails, IsServiceMesh: true},
+	}
+
+	for _, checker := range enabledCheckers {
+		checks, validChecker := checker.Check()
+		rrValidation.Checks = append(rrValidation.Checks, checks...)
+		rrValidation.Valid = rrValidation.Valid && validChecker
+	}
+
+	return models.IstioValidations{key: rrValidation}
+}

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -21,68 +21,76 @@ type IstioConfigService struct {
 }
 
 type IstioConfigCriteria struct {
-	Namespace                  string
-	IncludeGateways            bool
-	IncludeVirtualServices     bool
-	IncludeDestinationRules    bool
-	IncludeServiceEntries      bool
-	IncludeRules               bool
-	IncludeAdapters            bool
-	IncludeTemplates           bool
-	IncludeQuotaSpecs          bool
-	IncludeQuotaSpecBindings   bool
-	IncludePolicies            bool
-	IncludeMeshPolicies        bool
-	IncludeClusterRbacConfigs  bool
-	IncludeRbacConfigs         bool
-	IncludeServiceRoles        bool
-	IncludeServiceRoleBindings bool
-	IncludeSidecars            bool
+	Namespace                     string
+	IncludeGateways               bool
+	IncludeVirtualServices        bool
+	IncludeDestinationRules       bool
+	IncludeServiceEntries         bool
+	IncludeRules                  bool
+	IncludeAdapters               bool
+	IncludeTemplates              bool
+	IncludeQuotaSpecs             bool
+	IncludeQuotaSpecBindings      bool
+	IncludePolicies               bool
+	IncludeMeshPolicies           bool
+	IncludeServiceMeshPolicies    bool
+	IncludeClusterRbacConfigs     bool
+	IncludeRbacConfigs            bool
+	IncludeServiceMeshRbacConfigs bool
+	IncludeServiceRoles           bool
+	IncludeServiceRoleBindings    bool
+	IncludeSidecars               bool
 }
 
 const (
-	VirtualServices     = "virtualservices"
-	DestinationRules    = "destinationrules"
-	ServiceEntries      = "serviceentries"
-	Gateways            = "gateways"
-	Rules               = "rules"
-	Adapters            = "adapters"
-	Templates           = "templates"
-	QuotaSpecs          = "quotaspecs"
-	QuotaSpecBindings   = "quotaspecbindings"
-	Policies            = "policies"
-	MeshPolicies        = "meshpolicies"
-	ClusterRbacConfigs  = "clusterrbacconfigs"
-	RbacConfigs         = "rbacconfigs"
-	ServiceRoles        = "serviceroles"
-	ServiceRoleBindings = "servicerolebindings"
-	Sidecars            = "sidecars"
+	VirtualServices        = "virtualservices"
+	DestinationRules       = "destinationrules"
+	ServiceEntries         = "serviceentries"
+	Gateways               = "gateways"
+	Rules                  = "rules"
+	Adapters               = "adapters"
+	Templates              = "templates"
+	QuotaSpecs             = "quotaspecs"
+	QuotaSpecBindings      = "quotaspecbindings"
+	Policies               = "policies"
+	MeshPolicies           = "meshpolicies"
+	ClusterRbacConfigs     = "clusterrbacconfigs"
+	RbacConfigs            = "rbacconfigs"
+	ServiceRoles           = "serviceroles"
+	ServiceRoleBindings    = "servicerolebindings"
+	Sidecars               = "sidecars"
+	ServiceMeshPolicies    = "servicemeshpolicies"
+	ServiceMeshRbacConfigs = "servicemeshrbacconfigs"
 )
 
 var resourceTypesToAPI = map[string]string{
-	DestinationRules:    kubernetes.NetworkingGroupVersion.Group,
-	VirtualServices:     kubernetes.NetworkingGroupVersion.Group,
-	ServiceEntries:      kubernetes.NetworkingGroupVersion.Group,
-	Gateways:            kubernetes.NetworkingGroupVersion.Group,
-	Sidecars:            kubernetes.NetworkingGroupVersion.Group,
-	Adapters:            kubernetes.ConfigGroupVersion.Group,
-	Templates:           kubernetes.ConfigGroupVersion.Group,
-	Rules:               kubernetes.ConfigGroupVersion.Group,
-	QuotaSpecs:          kubernetes.ConfigGroupVersion.Group,
-	QuotaSpecBindings:   kubernetes.ConfigGroupVersion.Group,
-	Policies:            kubernetes.AuthenticationGroupVersion.Group,
-	MeshPolicies:        kubernetes.AuthenticationGroupVersion.Group,
-	ClusterRbacConfigs:  kubernetes.RbacGroupVersion.Group,
-	RbacConfigs:         kubernetes.RbacGroupVersion.Group,
-	ServiceRoles:        kubernetes.RbacGroupVersion.Group,
-	ServiceRoleBindings: kubernetes.RbacGroupVersion.Group,
+	DestinationRules:       kubernetes.NetworkingGroupVersion.Group,
+	VirtualServices:        kubernetes.NetworkingGroupVersion.Group,
+	ServiceEntries:         kubernetes.NetworkingGroupVersion.Group,
+	Gateways:               kubernetes.NetworkingGroupVersion.Group,
+	Sidecars:               kubernetes.NetworkingGroupVersion.Group,
+	Adapters:               kubernetes.ConfigGroupVersion.Group,
+	Templates:              kubernetes.ConfigGroupVersion.Group,
+	Rules:                  kubernetes.ConfigGroupVersion.Group,
+	QuotaSpecs:             kubernetes.ConfigGroupVersion.Group,
+	QuotaSpecBindings:      kubernetes.ConfigGroupVersion.Group,
+	Policies:               kubernetes.AuthenticationGroupVersion.Group,
+	MeshPolicies:           kubernetes.AuthenticationGroupVersion.Group,
+	ClusterRbacConfigs:     kubernetes.RbacGroupVersion.Group,
+	RbacConfigs:            kubernetes.RbacGroupVersion.Group,
+	ServiceRoles:           kubernetes.RbacGroupVersion.Group,
+	ServiceRoleBindings:    kubernetes.RbacGroupVersion.Group,
+	ServiceMeshPolicies:    kubernetes.MaistraAuthenticationGroupVersion.Group,
+	ServiceMeshRbacConfigs: kubernetes.MaistraRbacGroupVersion.Group,
 }
 
 var apiToVersion = map[string]string{
-	kubernetes.NetworkingGroupVersion.Group: kubernetes.ApiNetworkingVersion,
-	kubernetes.ConfigGroupVersion.Group:     kubernetes.ApiConfigVersion,
-	kubernetes.ApiAuthenticationVersion:     kubernetes.ApiAuthenticationVersion,
-	kubernetes.RbacGroupVersion.Group:       kubernetes.ApiRbacVersion,
+	kubernetes.NetworkingGroupVersion.Group:            kubernetes.ApiNetworkingVersion,
+	kubernetes.ConfigGroupVersion.Group:                kubernetes.ApiConfigVersion,
+	kubernetes.AuthenticationGroupVersion.Group:        kubernetes.ApiAuthenticationVersion,
+	kubernetes.RbacGroupVersion.Group:                  kubernetes.ApiRbacVersion,
+	kubernetes.MaistraAuthenticationGroupVersion.Group: kubernetes.ApiMaistraAuthenticationVersion,
+	kubernetes.MaistraRbacGroupVersion.Group:           kubernetes.ApiMaistraRbacVersion,
 }
 
 // GetIstioConfigList returns a list of Istio routing objects, Mixer Rules, (etc.)
@@ -96,180 +104,242 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 		return models.IstioConfigList{}, errors.New("GetIstioConfigList needs a non empty Namespace")
 	}
 	istioConfigList := models.IstioConfigList{
-		Namespace:           models.Namespace{Name: criteria.Namespace},
-		Gateways:            models.Gateways{},
-		VirtualServices:     models.VirtualServices{Items: []models.VirtualService{}},
-		DestinationRules:    models.DestinationRules{Items: []models.DestinationRule{}},
-		ServiceEntries:      models.ServiceEntries{},
-		Rules:               models.IstioRules{},
-		Adapters:            models.IstioAdapters{},
-		Templates:           models.IstioTemplates{},
-		QuotaSpecs:          models.QuotaSpecs{},
-		QuotaSpecBindings:   models.QuotaSpecBindings{},
-		Policies:            models.Policies{},
-		MeshPolicies:        models.MeshPolicies{},
-		ClusterRbacConfigs:  models.ClusterRbacConfigs{},
-		RbacConfigs:         models.RbacConfigs{},
-		Sidecars:            models.Sidecars{},
-		ServiceRoles:        models.ServiceRoles{},
-		ServiceRoleBindings: models.ServiceRoleBindings{},
+		Namespace:              models.Namespace{Name: criteria.Namespace},
+		Gateways:               models.Gateways{},
+		VirtualServices:        models.VirtualServices{Items: []models.VirtualService{}},
+		DestinationRules:       models.DestinationRules{Items: []models.DestinationRule{}},
+		ServiceEntries:         models.ServiceEntries{},
+		Rules:                  models.IstioRules{},
+		Adapters:               models.IstioAdapters{},
+		Templates:              models.IstioTemplates{},
+		QuotaSpecs:             models.QuotaSpecs{},
+		QuotaSpecBindings:      models.QuotaSpecBindings{},
+		Policies:               models.Policies{},
+		MeshPolicies:           models.MeshPolicies{},
+		ServiceMeshPolicies:    models.ServiceMeshPolicies{},
+		ClusterRbacConfigs:     models.ClusterRbacConfigs{},
+		RbacConfigs:            models.RbacConfigs{},
+		ServiceMeshRbacConfigs: models.ServiceMeshRbacConfigs{},
+		Sidecars:               models.Sidecars{},
+		ServiceRoles:           models.ServiceRoles{},
+		ServiceRoleBindings:    models.ServiceRoleBindings{},
 	}
-	var gg, vs, dr, se, qs, qb, aa, tt, mr, pc, mp, crc, rc, sr, srb []kubernetes.IstioObject
-	var ggErr, vsErr, drErr, seErr, mrErr, qsErr, qbErr, aaErr, ttErr, pcErr, mpErr, crcErr, rcErr, srErr, srbErr error
-	var wg sync.WaitGroup
-	wg.Add(16)
 
-	go func() {
+	errChan := make(chan error, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(18)
+
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeGateways {
-			if gg, ggErr = in.k8s.GetGateways(criteria.Namespace); ggErr == nil {
+			if gg, ggErr := in.k8s.GetGateways(criteria.Namespace); ggErr == nil {
 				(&istioConfigList.Gateways).Parse(gg)
+			} else {
+				errChan <- ggErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeVirtualServices {
-			if vs, vsErr = in.k8s.GetVirtualServices(criteria.Namespace, ""); vsErr == nil {
+			if vs, vsErr := in.k8s.GetVirtualServices(criteria.Namespace, ""); vsErr == nil {
 				(&istioConfigList.VirtualServices).Parse(vs)
+			} else {
+				errChan <- vsErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeDestinationRules {
-			if dr, drErr = in.k8s.GetDestinationRules(criteria.Namespace, ""); drErr == nil {
+			if dr, drErr := in.k8s.GetDestinationRules(criteria.Namespace, ""); drErr == nil {
 				(&istioConfigList.DestinationRules).Parse(dr)
+			} else {
+				errChan <- drErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeServiceEntries {
-			if se, seErr = in.k8s.GetServiceEntries(criteria.Namespace); seErr == nil {
+			if se, seErr := in.k8s.GetServiceEntries(criteria.Namespace); seErr == nil {
 				(&istioConfigList.ServiceEntries).Parse(se)
+			} else {
+				errChan <- seErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeRules {
-			if mr, mrErr = in.k8s.GetIstioRules(criteria.Namespace, ""); mrErr == nil {
+			if mr, mrErr := in.k8s.GetIstioRules(criteria.Namespace, ""); mrErr == nil {
 				istioConfigList.Rules = models.CastIstioRulesCollection(mr)
+			} else {
+				errChan <- mrErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeAdapters {
-			if aa, aaErr = in.k8s.GetAdapters(criteria.Namespace, ""); aaErr == nil {
+			if aa, aaErr := in.k8s.GetAdapters(criteria.Namespace, ""); aaErr == nil {
 				istioConfigList.Adapters = models.CastIstioAdaptersCollection(aa)
+			} else {
+				errChan <- aaErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeTemplates {
-			if tt, ttErr = in.k8s.GetTemplates(criteria.Namespace, ""); ttErr == nil {
+			if tt, ttErr := in.k8s.GetTemplates(criteria.Namespace, ""); ttErr == nil {
 				istioConfigList.Templates = models.CastIstioTemplatesCollection(tt)
+			} else {
+				errChan <- ttErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeQuotaSpecs {
-			if qs, qsErr = in.k8s.GetQuotaSpecs(criteria.Namespace); qsErr == nil {
+			if qs, qsErr := in.k8s.GetQuotaSpecs(criteria.Namespace); qsErr == nil {
 				(&istioConfigList.QuotaSpecs).Parse(qs)
+			} else {
+				errChan <- qsErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeQuotaSpecBindings {
-			if qb, qbErr = in.k8s.GetQuotaSpecBindings(criteria.Namespace); qbErr == nil {
+			if qb, qbErr := in.k8s.GetQuotaSpecBindings(criteria.Namespace); qbErr == nil {
 				(&istioConfigList.QuotaSpecBindings).Parse(qb)
+			} else {
+				errChan <- qbErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludePolicies {
-			if pc, pcErr = in.k8s.GetPolicies(criteria.Namespace); pcErr == nil {
+			if pc, pcErr := in.k8s.GetPolicies(criteria.Namespace); pcErr == nil {
 				(&istioConfigList.Policies).Parse(pc)
+			} else {
+				errChan <- pcErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		// MeshPolicies are not namespaced. They will be only listed for the namespace
-		// where istio is deployed.
-		if criteria.IncludeMeshPolicies && criteria.Namespace == config.Get().IstioNamespace {
-			if mp, mpErr = in.k8s.GetMeshPolicies(criteria.Namespace); mpErr == nil {
+		// where Istio is deployed. Only listed in non Maistra environments.
+		if criteria.IncludeMeshPolicies && criteria.Namespace == config.Get().IstioNamespace && !in.k8s.IsMaistraApi() {
+			if mp, mpErr := in.k8s.GetMeshPolicies(criteria.Namespace); mpErr == nil {
 				(&istioConfigList.MeshPolicies).Parse(mp)
+			} else {
+				errChan <- mpErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
-		if criteria.IncludeClusterRbacConfigs && criteria.Namespace == config.Get().IstioNamespace {
-			if crc, crcErr = in.k8s.GetClusterRbacConfigs(criteria.Namespace); crcErr == nil {
+		// ClusterRbacConfigs are not namespaced. They will be only listed for the namespace
+		// where Istio is deployed. Only listed in non Maistra environments.
+		if criteria.IncludeClusterRbacConfigs && criteria.Namespace == config.Get().IstioNamespace && !in.k8s.IsMaistraApi() {
+			if crc, crcErr := in.k8s.GetClusterRbacConfigs(criteria.Namespace); crcErr == nil {
 				(&istioConfigList.ClusterRbacConfigs).Parse(crc)
+			} else {
+				errChan <- crcErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeRbacConfigs {
-			if rc, rcErr = in.k8s.GetRbacConfigs(criteria.Namespace); rcErr == nil {
+			if rc, rcErr := in.k8s.GetRbacConfigs(criteria.Namespace); rcErr == nil {
 				(&istioConfigList.RbacConfigs).Parse(rc)
+			} else {
+				errChan <- rcErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeSidecars {
-			if rc, rcErr = in.k8s.GetSidecars(criteria.Namespace); rcErr == nil {
-				(&istioConfigList.Sidecars).Parse(rc)
+			if sc, scErr := in.k8s.GetSidecars(criteria.Namespace); scErr == nil {
+				(&istioConfigList.Sidecars).Parse(sc)
+			} else {
+				errChan <- scErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeServiceRoles {
-			if sr, srErr = in.k8s.GetServiceRoles(criteria.Namespace); srErr == nil {
+			if sr, srErr := in.k8s.GetServiceRoles(criteria.Namespace); srErr == nil {
 				(&istioConfigList.ServiceRoles).Parse(sr)
+			} else {
+				errChan <- srErr
 			}
 		}
-	}()
+	}(errChan)
 
-	go func() {
+	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeServiceRoleBindings {
-			if srb, srbErr = in.k8s.GetServiceRoleBindings(criteria.Namespace); srbErr == nil {
+			if srb, srbErr := in.k8s.GetServiceRoleBindings(criteria.Namespace); srbErr == nil {
 				(&istioConfigList.ServiceRoleBindings).Parse(srb)
+			} else {
+				errChan <- srbErr
 			}
 		}
-	}()
+	}(errChan)
+
+	go func(errChan chan error) {
+		defer wg.Done()
+		// This query is only executed if Maistra API is present, backend will ignore it in other environments
+		if criteria.IncludeServiceMeshPolicies && in.k8s.IsMaistraApi() {
+			if smp, smpErr := in.k8s.GetServiceMeshPolicies(criteria.Namespace); smpErr == nil {
+				(&istioConfigList.ServiceMeshPolicies).Parse(smp)
+			} else {
+				errChan <- smpErr
+			}
+		}
+	}(errChan)
+
+	go func(errChan chan error) {
+		defer wg.Done()
+		// This query is only executed if Maistra API is present, backend will ignore it in other environments
+		if criteria.IncludeServiceMeshRbacConfigs && in.k8s.IsMaistraApi() {
+			if smrc, smrcErr := in.k8s.GetServiceMeshRbacConfigs(criteria.Namespace); smrcErr == nil {
+				(&istioConfigList.ServiceMeshRbacConfigs).Parse(smrc)
+			} else {
+				errChan <- smrcErr
+			}
+		}
+	}(errChan)
 
 	wg.Wait()
 
-	for _, genErr := range []error{ggErr, vsErr, drErr, seErr, mrErr, qsErr, qbErr, aaErr, ttErr, mpErr, pcErr, rcErr, srErr, srbErr} {
-		if genErr != nil {
-			err = genErr
+	close(errChan)
+	for e := range errChan {
+		if e != nil { // Check that default value wasn't returned
+			err = e // To update the Kiali metric
 			return models.IstioConfigList{}, err
 		}
 	}
@@ -291,7 +361,7 @@ func (in *IstioConfigService) GetIstioConfigDetails(namespace, objectType, objec
 	istioConfigDetail := models.IstioConfigDetails{}
 	istioConfigDetail.Namespace = models.Namespace{Name: namespace}
 	istioConfigDetail.ObjectType = objectType
-	var gw, vs, dr, se, sc, qs, qb, r, a, t, pc, mp, crc, rc, sr, srb kubernetes.IstioObject
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -307,84 +377,130 @@ func (in *IstioConfigService) GetIstioConfigDetails(namespace, objectType, objec
 
 	switch objectType {
 	case Gateways:
-		if gw, err = in.k8s.GetGateway(namespace, object); err == nil {
+		if gw, iErr := in.k8s.GetGateway(namespace, object); iErr == nil {
 			istioConfigDetail.Gateway = &models.Gateway{}
 			istioConfigDetail.Gateway.Parse(gw)
+		} else {
+			err = iErr
 		}
 	case VirtualServices:
-		if vs, err = in.k8s.GetVirtualService(namespace, object); err == nil {
+		if vs, iErr := in.k8s.GetVirtualService(namespace, object); iErr == nil {
 			istioConfigDetail.VirtualService = &models.VirtualService{}
 			istioConfigDetail.VirtualService.Parse(vs)
+		} else {
+			err = iErr
 		}
 	case DestinationRules:
-		if dr, err = in.k8s.GetDestinationRule(namespace, object); err == nil {
+		if dr, iErr := in.k8s.GetDestinationRule(namespace, object); iErr == nil {
 			istioConfigDetail.DestinationRule = &models.DestinationRule{}
 			istioConfigDetail.DestinationRule.Parse(dr)
+		} else {
+			err = iErr
 		}
 	case ServiceEntries:
-		if se, err = in.k8s.GetServiceEntry(namespace, object); err == nil {
+		if se, iErr := in.k8s.GetServiceEntry(namespace, object); iErr == nil {
 			istioConfigDetail.ServiceEntry = &models.ServiceEntry{}
 			istioConfigDetail.ServiceEntry.Parse(se)
+		} else {
+			err = iErr
 		}
 	case Sidecars:
-		if sc, err = in.k8s.GetSidecar(namespace, object); err == nil {
+		if sc, iErr := in.k8s.GetSidecar(namespace, object); iErr == nil {
 			istioConfigDetail.Sidecar = &models.Sidecar{}
 			istioConfigDetail.Sidecar.Parse(sc)
+		} else {
+			err = iErr
 		}
 	case Rules:
-		if r, err = in.k8s.GetIstioRule(namespace, object); err == nil {
+		if r, iErr := in.k8s.GetIstioRule(namespace, object); iErr == nil {
 			istioRule := models.CastIstioRule(r)
 			istioConfigDetail.Rule = &istioRule
+		} else {
+			err = iErr
 		}
 	case Adapters:
-		if a, err = in.k8s.GetAdapter(namespace, objectSubtype, object); err == nil {
+		if a, iErr := in.k8s.GetAdapter(namespace, objectSubtype, object); iErr == nil {
 			adapter := models.CastIstioAdapter(a)
 			istioConfigDetail.Adapter = &adapter
+		} else {
+			err = iErr
 		}
 	case Templates:
-		if t, err = in.k8s.GetTemplate(namespace, objectSubtype, object); err == nil {
+		if t, iErr := in.k8s.GetTemplate(namespace, objectSubtype, object); iErr == nil {
 			template := models.CastIstioTemplate(t)
 			istioConfigDetail.Template = &template
+		} else {
+			err = iErr
 		}
 	case QuotaSpecs:
-		if qs, err = in.k8s.GetQuotaSpec(namespace, object); err == nil {
+		if qs, iErr := in.k8s.GetQuotaSpec(namespace, object); iErr == nil {
 			istioConfigDetail.QuotaSpec = &models.QuotaSpec{}
 			istioConfigDetail.QuotaSpec.Parse(qs)
+		} else {
+			err = iErr
 		}
 	case QuotaSpecBindings:
-		if qb, err = in.k8s.GetQuotaSpecBinding(namespace, object); err == nil {
+		if qb, iErr := in.k8s.GetQuotaSpecBinding(namespace, object); iErr == nil {
 			istioConfigDetail.QuotaSpecBinding = &models.QuotaSpecBinding{}
 			istioConfigDetail.QuotaSpecBinding.Parse(qb)
+		} else {
+			err = iErr
 		}
 	case Policies:
-		if pc, err = in.k8s.GetPolicy(namespace, object); err == nil {
+		if pc, iErr := in.k8s.GetPolicy(namespace, object); iErr == nil {
 			istioConfigDetail.Policy = &models.Policy{}
 			istioConfigDetail.Policy.Parse(pc)
+		} else {
+			err = iErr
 		}
 	case MeshPolicies:
-		if mp, err = in.k8s.GetMeshPolicy(namespace, object); err == nil {
+		if mp, iErr := in.k8s.GetMeshPolicy(namespace, object); iErr == nil {
 			istioConfigDetail.MeshPolicy = &models.MeshPolicy{}
 			istioConfigDetail.MeshPolicy.Parse(mp)
+		} else {
+			err = iErr
+		}
+	case ServiceMeshPolicies:
+		if mp, iErr := in.k8s.GetServiceMeshPolicy(namespace, object); iErr == nil {
+			istioConfigDetail.ServiceMeshPolicy = &models.ServiceMeshPolicy{}
+			istioConfigDetail.ServiceMeshPolicy.Parse(mp)
+		} else {
+			err = iErr
 		}
 	case ClusterRbacConfigs:
-		if crc, err = in.k8s.GetClusterRbacConfig(namespace, object); err == nil {
+		if crc, iErr := in.k8s.GetClusterRbacConfig(namespace, object); iErr == nil {
 			istioConfigDetail.ClusterRbacConfig = &models.ClusterRbacConfig{}
 			istioConfigDetail.ClusterRbacConfig.Parse(crc)
+		} else {
+			err = iErr
 		}
 	case RbacConfigs:
-		if rc, err = in.k8s.GetRbacConfig(namespace, object); err == nil {
+		if rc, iErr := in.k8s.GetRbacConfig(namespace, object); iErr == nil {
 			istioConfigDetail.RbacConfig = &models.RbacConfig{}
 			istioConfigDetail.RbacConfig.Parse(rc)
+		} else {
+			err = iErr
+		}
+	case ServiceMeshRbacConfigs:
+		if rc, iErr := in.k8s.GetServiceMeshRbacConfig(namespace, object); iErr == nil {
+			istioConfigDetail.ServiceMeshRbacConfig = &models.ServiceMeshRbacConfig{}
+			istioConfigDetail.ServiceMeshRbacConfig.Parse(rc)
+		} else {
+			err = iErr
 		}
 	case ServiceRoles:
-		if sr, err = in.k8s.GetServiceRole(namespace, object); err == nil {
+		if sr, iErr := in.k8s.GetServiceRole(namespace, object); iErr == nil {
 			istioConfigDetail.ServiceRole = &models.ServiceRole{}
 			istioConfigDetail.ServiceRole.Parse(sr)
+		} else {
+			err = iErr
 		}
 	case ServiceRoleBindings:
-		if srb, err = in.k8s.GetServiceRoleBinding(namespace, object); err == nil {
+		if srb, iErr := in.k8s.GetServiceRoleBinding(namespace, object); iErr == nil {
 			istioConfigDetail.ServiceRoleBinding = &models.ServiceRoleBinding{}
 			istioConfigDetail.ServiceRoleBinding.Parse(srb)
+		} else {
+			err = iErr
 		}
 	default:
 		err = fmt.Errorf("object type not found: %v", objectType)
@@ -451,6 +567,12 @@ func (in *IstioConfigService) ParseJsonForCreate(resourceType, subresourceType s
 	case MeshPolicies:
 		istioConfigDetail.MeshPolicy = &models.MeshPolicy{}
 		err = json.Unmarshal(body, istioConfigDetail.MeshPolicy)
+	case ServiceMeshPolicies:
+		istioConfigDetail.ServiceMeshPolicy = &models.ServiceMeshPolicy{}
+		err = json.Unmarshal(body, istioConfigDetail.ServiceMeshPolicy)
+	case ServiceMeshRbacConfigs:
+		istioConfigDetail.ServiceMeshRbacConfig = &models.ServiceMeshRbacConfig{}
+		err = json.Unmarshal(body, istioConfigDetail.ServiceMeshRbacConfig)
 	default:
 		err = fmt.Errorf("object type not found: %v", resourceType)
 	}
@@ -550,12 +672,18 @@ func (in *IstioConfigService) modifyIstioConfigDetail(api, namespace, resourceTy
 	case MeshPolicies:
 		istioConfigDetail.MeshPolicy = &models.MeshPolicy{}
 		istioConfigDetail.MeshPolicy.Parse(result)
+	case ServiceMeshPolicies:
+		istioConfigDetail.ServiceMeshPolicy = &models.ServiceMeshPolicy{}
+		istioConfigDetail.ServiceMeshPolicy.Parse(result)
 	case ClusterRbacConfigs:
 		istioConfigDetail.ClusterRbacConfig = &models.ClusterRbacConfig{}
 		istioConfigDetail.ClusterRbacConfig.Parse(result)
 	case RbacConfigs:
 		istioConfigDetail.RbacConfig = &models.RbacConfig{}
 		istioConfigDetail.RbacConfig.Parse(result)
+	case ServiceMeshRbacConfigs:
+		istioConfigDetail.ServiceMeshRbacConfig = &models.ServiceMeshRbacConfig{}
+		istioConfigDetail.ServiceMeshRbacConfig.Parse(result)
 	case ServiceRoles:
 		istioConfigDetail.ServiceRole = &models.ServiceRole{}
 		istioConfigDetail.ServiceRole.Parse(result)

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -176,6 +176,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		// Validations on QuotaSpecBindings are not yet in place
 	case ClusterRbacConfigs:
 		// Validations on ClusterRbacConfigs are not yet in place
+	case ServiceMeshRbacConfigs:
+		// Validations on ServiceMeshRbacConfigs are not yet in place
 	case RbacConfigs:
 		// Validations on RbacConfigs are not yet in place
 	case Sidecars:

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -73,6 +73,7 @@ func mockWorkLoadService(k8s *kubetest.K8SClientMock) WorkloadService {
 func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(false)
+	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("GetGateways", "test", mock.AnythingOfType("string")).Return(getGateway("first"), nil)
 	k8s.On("GetGateways", "test2", mock.AnythingOfType("string")).Return(getGateway("second"), nil)
 	k8s.On("GetNamespaces").Return(fakeNamespaces(), nil)
@@ -102,7 +103,7 @@ func mockCombinedValidationService(istioObjects *kubernetes.IstioDetails, servic
 	k8s.On("GetMeshPolicies", mock.AnythingOfType("string")).Return(fakeMeshPolicies(), nil)
 	k8s.On("GetPolicies", mock.AnythingOfType("string")).Return(fakePolicies(), nil)
 	k8s.On("IsOpenShift").Return(false)
-
+	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("GetGateways", "test", mock.AnythingOfType("string")).Return(getGateway("first"), nil)
 	k8s.On("GetGateways", "test2", mock.AnythingOfType("string")).Return(getGateway("second"), nil)
 	k8s.On("GetGateways", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().Gateways, nil)

--- a/business/tls.go
+++ b/business/tls.go
@@ -62,9 +62,7 @@ func (in *TLSService) hasMeshPolicyEnabled(namespaces []string) (bool, error) {
 		var smps []kubernetes.IstioObject
 		for _, ns := range namespaces {
 			if smps, err = in.k8s.GetServiceMeshPolicies(ns); err == nil {
-				for _, smp := range smps {
-					mps = append(mps, smp)
-				}
+				mps = append(mps, smps...)
 			} else {
 				return false, err
 			}

--- a/business/tls.go
+++ b/business/tls.go
@@ -48,11 +48,27 @@ func (in *TLSService) hasMeshPolicyEnabled(namespaces []string) (bool, error) {
 		return false, fmt.Errorf("Unable to determine mesh-wide mTLS status without access to any namespace")
 	}
 
-	// MeshPolicies are not namespaced. So any namespace user has access to
-	// will work to retrieve all the MeshPolicies.
-	mps, err := in.k8s.GetMeshPolicies(namespaces[0])
-	if err != nil {
-		return false, err
+	var mps = make([]kubernetes.IstioObject, 0)
+	var err error
+	if !in.k8s.IsMaistraApi() {
+		// MeshPolicies are not namespaced. So any namespace user has access to
+		// will work to retrieve all the MeshPolicies.
+		mps, err = in.k8s.GetMeshPolicies(namespaces[0])
+		if err != nil {
+			return false, err
+		}
+	} else {
+		// ServiceMeshPolicies are namespaces. So we need to iterate on available namespaces.
+		var smps []kubernetes.IstioObject
+		for _, ns := range namespaces {
+			if smps, err = in.k8s.GetServiceMeshPolicies(ns); err == nil {
+				for _, smp := range smps {
+					mps = append(mps, smp)
+				}
+			} else {
+				return false, err
+			}
+		}
 	}
 
 	for _, mp := range mps {

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -18,6 +18,7 @@ func TestCorrectMeshPolicy(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEmptyMTLS("default"), nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	meshPolicyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{"test"})
@@ -31,6 +32,7 @@ func TestMeshPolicyWithoutNamespaces(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEmptyMTLS("default"), nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	meshPolicyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{})
@@ -44,6 +46,7 @@ func TestPolicyWithWrongName(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEmptyMTLS("wrong-name"), nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	isGloballyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{"test"})
@@ -57,6 +60,7 @@ func TestPolicyWithPermissiveMode(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetMeshPolicies", "test").Return(fakePermissiveMeshPolicy("default"), nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	isGloballyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{"test"})
@@ -70,6 +74,7 @@ func TestPolicyWithStrictMode(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetMeshPolicies", "test").Return(fakeStrictMeshPolicy("default"), nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	isGloballyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{"test"})
@@ -115,6 +120,7 @@ func TestWithoutMeshPolicy(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetMeshPolicies", "test").Return([]kubernetes.IstioObject{}, nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	meshPolicyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{"test"})
@@ -128,6 +134,7 @@ func TestMeshPolicyWithTargets(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEnablingMTLSSpecificTarget(), nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	meshPolicyEnabled, err := (tlsService).hasMeshPolicyEnabled([]string{"test"})
@@ -218,6 +225,7 @@ func TestMeshStatusEnabled(t *testing.T) {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetDestinationRules", "test", "").Return([]kubernetes.IstioObject{dr}, nil)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEmptyMTLS("default"), nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	status, err := (tlsService).MeshWidemTLSStatus([]string{"test"})
@@ -235,6 +243,7 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetDestinationRules", "test", "").Return([]kubernetes.IstioObject{dr}, nil)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEmptyMTLS("default"), nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	status, err := (tlsService).MeshWidemTLSStatus([]string{"test"})
@@ -252,6 +261,7 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetDestinationRules", "test", "").Return([]kubernetes.IstioObject{dr}, nil)
 	k8s.On("GetMeshPolicies", "test").Return(fakeMeshPolicyEmptyMTLS("wrong-name"), nil)
+	k8s.On("IsMaistraApi").Return(false)
 
 	tlsService := TLSService{k8s: k8s}
 	status, err := (tlsService).MeshWidemTLSStatus([]string{"test"})
@@ -336,6 +346,7 @@ func TestNamespaceHasDestinationRuleEnabledDifferentNs(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("GetProjects").Return(fakeProjects(), nil)
 	k8s.On("GetDestinationRules", "foo", "").Return(drs, nil)
 	k8s.On("GetDestinationRules", "bookinfo", "").Return([]kubernetes.IstioObject{}, nil)
@@ -353,6 +364,7 @@ func testNamespaceScenario(exStatus string, drs []kubernetes.IstioObject, ps []k
 
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("GetProjects").Return(fakeProjects(), nil)
 	k8s.On("GetDestinationRules", "bookinfo", "").Return(drs, nil)
 	k8s.On("GetDestinationRules", "foo", "").Return([]kubernetes.IstioObject{}, nil)

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -102,8 +102,10 @@ func parseCriteria(namespace string, objects string) business.IstioConfigCriteri
 	criteria.IncludeQuotaSpecBindings = defaultInclude
 	criteria.IncludePolicies = defaultInclude
 	criteria.IncludeMeshPolicies = defaultInclude
+	criteria.IncludeServiceMeshPolicies = defaultInclude
 	criteria.IncludeClusterRbacConfigs = defaultInclude
 	criteria.IncludeRbacConfigs = defaultInclude
+	criteria.IncludeServiceMeshRbacConfigs = defaultInclude
 	criteria.IncludeServiceRoles = defaultInclude
 	criteria.IncludeServiceRoleBindings = defaultInclude
 	criteria.IncludeSidecars = defaultInclude
@@ -146,11 +148,17 @@ func parseCriteria(namespace string, objects string) business.IstioConfigCriteri
 	if checkType(types, business.MeshPolicies) {
 		criteria.IncludeMeshPolicies = true
 	}
+	if checkType(types, business.ServiceMeshPolicies) {
+		criteria.IncludeServiceMeshPolicies = true
+	}
 	if checkType(types, business.ClusterRbacConfigs) {
 		criteria.IncludeClusterRbacConfigs = true
 	}
 	if checkType(types, business.RbacConfigs) {
 		criteria.IncludeRbacConfigs = true
+	}
+	if checkType(types, business.ServiceMeshRbacConfigs) {
+		criteria.IncludeServiceMeshRbacConfigs = true
 	}
 	if checkType(types, business.ServiceRoles) {
 		criteria.IncludeServiceRoles = true

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -158,7 +158,6 @@ func (in *IstioClient) getRbacResources() map[string]bool {
 	}
 
 	rbacResources := map[string]bool{}
-	// TODO Update with Maistra API
 	resourceListRaw, err := in.k8s.RESTClient().Get().AbsPath("/apis/rbac.istio.io/v1alpha1").Do().Raw()
 	if err == nil {
 		resourceList := meta_v1.APIResourceList{}

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -102,6 +102,19 @@ func (in *IstioClient) IsOpenShift() bool {
 	return *in.isOpenShift
 }
 
+func (in *IstioClient) IsMaistraApi() bool {
+	if in.isMaistraApi == nil {
+		isMaistraApi := false
+		// Note that if authentication.maistra.io is present, rbac.maistra.io will be present too
+		_, err := in.k8s.RESTClient().Get().AbsPath("/apis/authentication.maistra.io").Do().Raw()
+		if err == nil {
+			isMaistraApi = true
+		}
+		in.isMaistraApi = &isMaistraApi
+	}
+	return *in.isMaistraApi
+}
+
 // GetServices returns a list of services for a given namespace.
 // If selectorLabels is defined the list of services is filtered for those that matches Services selector labels.
 // It returns an error on any problem.

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -326,12 +326,32 @@ func (o *K8SClientMock) GetMeshPolicy(namespace string, policyName string) (kube
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
+func (o *K8SClientMock) GetServiceMeshPolicies(namespace string) ([]kubernetes.IstioObject, error) {
+	args := o.Called(namespace)
+	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
+}
+
+func (o *K8SClientMock) GetServiceMeshPolicy(namespace string, policyName string) (kubernetes.IstioObject, error) {
+	args := o.Called(namespace)
+	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
+}
+
 func (o *K8SClientMock) GetClusterRbacConfigs(namespace string) ([]kubernetes.IstioObject, error) {
 	args := o.Called(namespace)
 	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
 }
 
 func (o *K8SClientMock) GetClusterRbacConfig(namespace string, policyName string) (kubernetes.IstioObject, error) {
+	args := o.Called(namespace)
+	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
+}
+
+func (o *K8SClientMock) GetServiceMeshRbacConfigs(namespace string) ([]kubernetes.IstioObject, error) {
+	args := o.Called(namespace)
+	return args.Get(0).([]kubernetes.IstioObject), args.Error(1)
+}
+
+func (o *K8SClientMock) GetServiceMeshRbacConfig(namespace string, policyName string) (kubernetes.IstioObject, error) {
 	args := o.Called(namespace)
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
@@ -372,6 +392,11 @@ func (o *K8SClientMock) GetAuthorizationDetails(namespace string) (*kubernetes.R
 }
 
 func (o *K8SClientMock) IsOpenShift() bool {
+	args := o.Called()
+	return args.Get(0).(bool)
+}
+
+func (o *K8SClientMock) IsMaistraApi() bool {
 	args := o.Called()
 	return args.Get(0).(bool)
 }

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -58,6 +58,12 @@ const (
 	meshPolicyType     = "MeshPolicy"
 	meshPolicyTypeList = "MeshPolicyList"
 
+	// ServiceMeshPolicies
+
+	serviceMeshPolicies       = "servicemeshpolicies"
+	serviceMeshPolicyType     = "ServiceMeshPolicy"
+	serviceMeshPolicyTypeList = "ServiceMeshPolicyList"
+
 	// Rbac
 	clusterrbacconfigs        = "clusterrbacconfigs"
 	clusterrbacconfigType     = "ClusterRbacConfig"
@@ -74,6 +80,10 @@ const (
 	servicerolebindings        = "servicerolebindings"
 	servicerolebindingType     = "ServiceRoleBinding"
 	servicerolebindingTypeList = "ServiceRoleBindingList"
+
+	serviceMeshRbacConfigs        = "servicemeshrbacconfigs"
+	serviceMeshRbacConfigType     = "ServiceMeshRbacConfig"
+	serviceMeshRbacConfigTypeList = "ServiceMeshRbacConfigList"
 
 	// Config - Rules
 
@@ -251,6 +261,18 @@ var (
 	}
 	ApiRbacVersion = RbacGroupVersion.Group + "/" + RbacGroupVersion.Version
 
+	MaistraAuthenticationGroupVersion = schema.GroupVersion{
+		Group:   "authentication.maistra.io",
+		Version: "v1",
+	}
+	ApiMaistraAuthenticationVersion = MaistraAuthenticationGroupVersion.Group + "/" + MaistraAuthenticationGroupVersion.Version
+
+	MaistraRbacGroupVersion = schema.GroupVersion{
+		Group:   "rbac.maistra.io",
+		Version: "v1",
+	}
+	ApiMaistraRbacVersion = MaistraRbacGroupVersion.Group + "/" + MaistraRbacGroupVersion.Version
+
 	networkingTypes = []struct {
 		objectKind     string
 		collectionKind string
@@ -307,6 +329,16 @@ var (
 		{
 			objectKind:     meshPolicyType,
 			collectionKind: meshPolicyTypeList,
+		},
+	}
+
+	maistraAuthenticationTypes = []struct {
+		objectKind     string
+		collectionKind string
+	}{
+		{
+			objectKind:     serviceMeshPolicyType,
+			collectionKind: serviceMeshPolicyTypeList,
 		},
 	}
 
@@ -486,6 +518,16 @@ var (
 		},
 	}
 
+	maistraRbacTypes = []struct {
+		objectKind     string
+		collectionKind string
+	}{
+		{
+			objectKind:     serviceMeshRbacConfigType,
+			collectionKind: serviceMeshRbacConfigTypeList,
+		},
+	}
+
 	// A map to get the plural for a Istio type using the singlar type
 	// Used for fetch istio actions details, so only applied to handlers (adapters) and instances (templates) types
 	// It should be one entry per adapter/template
@@ -583,14 +625,16 @@ var (
 		tracespans:     tracespanType,
 
 		// Policies
-		policies:     policyType,
-		meshPolicies: meshPolicyType,
+		policies:            policyType,
+		meshPolicies:        meshPolicyType,
+		serviceMeshPolicies: serviceMeshPolicyType,
 
 		// Rbac
-		clusterrbacconfigs:  clusterrbacconfigType,
-		rbacconfigs:         rbacconfigType,
-		serviceroles:        serviceroleType,
-		servicerolebindings: servicerolebindingType,
+		clusterrbacconfigs:     clusterrbacconfigType,
+		rbacconfigs:            rbacconfigType,
+		serviceroles:           serviceroleType,
+		servicerolebindings:    servicerolebindingType,
+		serviceMeshRbacConfigs: serviceMeshRbacConfigType,
 	}
 )
 
@@ -642,16 +686,18 @@ type IstioDetails struct {
 
 // MTLSDetails is a wrapper to group all Istio objects related to non-local mTLS configurations
 type MTLSDetails struct {
-	DestinationRules []IstioObject `json:"destinationrules"`
-	MeshPolicies     []IstioObject `json:"meshpolicies"`
-	Policies         []IstioObject `json:"policies"`
+	DestinationRules    []IstioObject `json:"destinationrules"`
+	MeshPolicies        []IstioObject `json:"meshpolicies"`
+	ServiceMeshPolicies []IstioObject `json:"servicemeshpolicies"`
+	Policies            []IstioObject `json:"policies"`
 }
 
 // RBACDetails is a wrapper for objects related to Istio RBAC (Role Based Access Control)
 type RBACDetails struct {
-	ClusterRbacConfigs  []IstioObject `json:"clusterrbacconfigs"`
-	ServiceRoles        []IstioObject `json:"serviceroles"`
-	ServiceRoleBindings []IstioObject `json:"servicerolebindings"`
+	ClusterRbacConfigs     []IstioObject `json:"clusterrbacconfigs"`
+	ServiceMeshRbacConfigs []IstioObject `json:"servicemeshrbacconfigs"`
+	ServiceRoles           []IstioObject `json:"serviceroles"`
+	ServiceRoleBindings    []IstioObject `json:"servicerolebindings"`
 }
 
 type istioResponse struct {

--- a/models/cluster_rbac_config.go
+++ b/models/cluster_rbac_config.go
@@ -6,15 +6,17 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 )
 
+type ClusterRbacConfigSpec struct {
+	Mode      interface{} `json:"mode"`
+	Inclusion interface{} `json:"inclusion"`
+	Exclusion interface{} `json:"exclusion"`
+}
+
 type ClusterRbacConfigs []ClusterRbacConfig
 type ClusterRbacConfig struct {
 	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
-		Mode      interface{} `json:"mode"`
-		Inclusion interface{} `json:"inclusion"`
-		Exclusion interface{} `json:"exclusion"`
-	} `json:"spec"`
+	Metadata meta_v1.ObjectMeta    `json:"metadata"`
+	Spec     ClusterRbacConfigSpec `json:"spec"`
 }
 
 func (rcs *ClusterRbacConfigs) Parse(clusterRbacConfigs []kubernetes.IstioObject) {
@@ -31,4 +33,30 @@ func (rc *ClusterRbacConfig) Parse(clusterRbacConfig kubernetes.IstioObject) {
 	rc.Spec.Mode = clusterRbacConfig.GetSpec()["mode"]
 	rc.Spec.Inclusion = clusterRbacConfig.GetSpec()["inclusion"]
 	rc.Spec.Exclusion = clusterRbacConfig.GetSpec()["exclusion"]
+}
+
+// ServiceMeshRbacConfig is a clone of ClusterRbacPolicy used by Maistra for multitenancy scenarios
+// Used in the same file for easy maintenance
+
+type ServiceMeshRbacConfigs []ServiceMeshRbacConfig
+type ServiceMeshRbacConfig struct {
+	meta_v1.TypeMeta
+	Metadata meta_v1.ObjectMeta    `json:"metadata"`
+	Spec     ClusterRbacConfigSpec `json:"spec"`
+}
+
+func (rcs *ServiceMeshRbacConfigs) Parse(smRbacConfigs []kubernetes.IstioObject) {
+	for _, rc := range smRbacConfigs {
+		smRbacConfig := ServiceMeshRbacConfig{}
+		smRbacConfig.Parse(rc)
+		*rcs = append(*rcs, smRbacConfig)
+	}
+}
+
+func (rc *ServiceMeshRbacConfig) Parse(smRbacConfig kubernetes.IstioObject) {
+	rc.TypeMeta = smRbacConfig.GetTypeMeta()
+	rc.Metadata = smRbacConfig.GetObjectMeta()
+	rc.Spec.Mode = smRbacConfig.GetSpec()["mode"]
+	rc.Spec.Inclusion = smRbacConfig.GetSpec()["inclusion"]
+	rc.Spec.Exclusion = smRbacConfig.GetSpec()["exclusion"]
 }

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -9,47 +9,51 @@ type IstioConfigList struct {
 	// The namespace of istioConfiglist
 	//
 	// required: true
-	Namespace           Namespace           `json:"namespace"`
-	Gateways            Gateways            `json:"gateways"`
-	VirtualServices     VirtualServices     `json:"virtualServices"`
-	DestinationRules    DestinationRules    `json:"destinationRules"`
-	ServiceEntries      ServiceEntries      `json:"serviceEntries"`
-	Rules               IstioRules          `json:"rules"`
-	Adapters            IstioAdapters       `json:"adapters"`
-	Templates           IstioTemplates      `json:"templates"`
-	QuotaSpecs          QuotaSpecs          `json:"quotaSpecs"`
-	QuotaSpecBindings   QuotaSpecBindings   `json:"quotaSpecBindings"`
-	Policies            Policies            `json:"policies"`
-	MeshPolicies        MeshPolicies        `json:"meshPolicies"`
-	ClusterRbacConfigs  ClusterRbacConfigs  `json:"clusterRbacConfigs"`
-	RbacConfigs         RbacConfigs         `json:"rbacConfigs"`
-	ServiceRoles        ServiceRoles        `json:"serviceRoles"`
-	ServiceRoleBindings ServiceRoleBindings `json:"serviceRoleBindings"`
-	Sidecars            Sidecars            `json:"sidecars"`
-	IstioValidations    IstioValidations    `json:"validations"`
+	Namespace              Namespace              `json:"namespace"`
+	Gateways               Gateways               `json:"gateways"`
+	VirtualServices        VirtualServices        `json:"virtualServices"`
+	DestinationRules       DestinationRules       `json:"destinationRules"`
+	ServiceEntries         ServiceEntries         `json:"serviceEntries"`
+	Rules                  IstioRules             `json:"rules"`
+	Adapters               IstioAdapters          `json:"adapters"`
+	Templates              IstioTemplates         `json:"templates"`
+	QuotaSpecs             QuotaSpecs             `json:"quotaSpecs"`
+	QuotaSpecBindings      QuotaSpecBindings      `json:"quotaSpecBindings"`
+	Policies               Policies               `json:"policies"`
+	MeshPolicies           MeshPolicies           `json:"meshPolicies"`
+	ServiceMeshPolicies    ServiceMeshPolicies    `json:"serviceMeshPolicies"`
+	ClusterRbacConfigs     ClusterRbacConfigs     `json:"clusterRbacConfigs"`
+	RbacConfigs            RbacConfigs            `json:"rbacConfigs"`
+	ServiceMeshRbacConfigs ServiceMeshRbacConfigs `json:"serviceMeshRbacConfigs"`
+	ServiceRoles           ServiceRoles           `json:"serviceRoles"`
+	ServiceRoleBindings    ServiceRoleBindings    `json:"serviceRoleBindings"`
+	Sidecars               Sidecars               `json:"sidecars"`
+	IstioValidations       IstioValidations       `json:"validations"`
 }
 
 type IstioConfigDetails struct {
-	Namespace          Namespace           `json:"namespace"`
-	ObjectType         string              `json:"objectType"`
-	Gateway            *Gateway            `json:"gateway"`
-	VirtualService     *VirtualService     `json:"virtualService"`
-	DestinationRule    *DestinationRule    `json:"destinationRule"`
-	ServiceEntry       *ServiceEntry       `json:"serviceEntry"`
-	Rule               *IstioRule          `json:"rule"`
-	Adapter            *IstioAdapter       `json:"adapter"`
-	Template           *IstioTemplate      `json:"template"`
-	QuotaSpec          *QuotaSpec          `json:"quotaSpec"`
-	QuotaSpecBinding   *QuotaSpecBinding   `json:"quotaSpecBinding"`
-	Policy             *Policy             `json:"policy"`
-	MeshPolicy         *MeshPolicy         `json:"meshPolicy"`
-	ClusterRbacConfig  *ClusterRbacConfig  `json:"clusterRbacConfig"`
-	RbacConfig         *RbacConfig         `json:"rbacConfig"`
-	ServiceRole        *ServiceRole        `json:"serviceRole"`
-	ServiceRoleBinding *ServiceRoleBinding `json:"serviceRoleBinding"`
-	Sidecar            *Sidecar            `json:"sidecar"`
-	Permissions        ResourcePermissions `json:"permissions"`
-	IstioValidation    *IstioValidation    `json:"validation"`
+	Namespace             Namespace              `json:"namespace"`
+	ObjectType            string                 `json:"objectType"`
+	Gateway               *Gateway               `json:"gateway"`
+	VirtualService        *VirtualService        `json:"virtualService"`
+	DestinationRule       *DestinationRule       `json:"destinationRule"`
+	ServiceEntry          *ServiceEntry          `json:"serviceEntry"`
+	Rule                  *IstioRule             `json:"rule"`
+	Adapter               *IstioAdapter          `json:"adapter"`
+	Template              *IstioTemplate         `json:"template"`
+	QuotaSpec             *QuotaSpec             `json:"quotaSpec"`
+	QuotaSpecBinding      *QuotaSpecBinding      `json:"quotaSpecBinding"`
+	Policy                *Policy                `json:"policy"`
+	MeshPolicy            *MeshPolicy            `json:"meshPolicy"`
+	ServiceMeshPolicy     *ServiceMeshPolicy     `json:"serviceMeshPolicy"`
+	ClusterRbacConfig     *ClusterRbacConfig     `json:"clusterRbacConfig"`
+	RbacConfig            *RbacConfig            `json:"rbacConfig"`
+	ServiceMeshRbacConfig *ServiceMeshRbacConfig `json:"serviceMeshRbacConfig"`
+	ServiceRole           *ServiceRole           `json:"serviceRole"`
+	ServiceRoleBinding    *ServiceRoleBinding    `json:"serviceRoleBinding"`
+	Sidecar               *Sidecar               `json:"sidecar"`
+	Permissions           ResourcePermissions    `json:"permissions"`
+	IstioValidation       *IstioValidation       `json:"validation"`
 }
 
 // ResourcePermissions holds permission flags for an object type

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -73,6 +73,7 @@ var ObjectTypeSingular = map[string]string{
 	"quotaspecs":          "quotaspec",
 	"quotaspecbindings":   "quotaspecbinding",
 	"meshpolicies":        "meshpolicy",
+	"servicemeshpolicies": "servicemeshpolicy",
 	"policies":            "policy",
 	"serviceroles":        "servicerole",
 	"servicerolebindings": "servicerolebinding",
@@ -100,6 +101,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "MeshPolicy enabling mTLS is missing",
 		Severity: ErrorSeverity,
 	},
+	"destinationrules.mtls.servicemeshpolicymissing": {
+		Message:  "ServiceMeshPolicy enabling mTLS is missing",
+		Severity: ErrorSeverity,
+	},
 	"destinationrules.mtls.nspolicymissing": {
 		Message:  "Policy enabling namespace-wide mTLS is missing",
 		Severity: ErrorSeverity,
@@ -110,6 +115,10 @@ var checkDescriptors = map[string]IstioCheck{
 	},
 	"destinationrules.mtls.meshpolicymtlsenabled": {
 		Message:  "MeshPolicy enabling mTLS found, permissive policy is needed",
+		Severity: ErrorSeverity,
+	},
+	"destinationrules.mtls.servicemeshpolicymtlsenabled": {
+		Message:  "ServiceMeshPolicy enabling mTLS found, permissive policy is needed",
 		Severity: ErrorSeverity,
 	},
 	"gateways.multimatch": {
@@ -165,6 +174,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"meshpolicies.mtls.destinationrulemissing": {
+		Message:  "Mesh-wide Destination Rule enabling mTLS is missing",
+		Severity: ErrorSeverity,
+	},
+	"servicemeshpolicies.mtls.destinationrulemissing": {
 		Message:  "Mesh-wide Destination Rule enabling mTLS is missing",
 		Severity: ErrorSeverity,
 	},

--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -257,6 +257,26 @@ rules:
   - list
   - patch
   - watch
+- apiGroups: ["authentication.maistra.io"]
+  resources:
+  - servicemeshpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["rbac.maistra.io"]
+  resources:
+  - servicemeshrbacconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups: ["apps.openshift.io"]
   resources:
   - deploymentconfigs

--- a/operator/roles/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -118,6 +118,20 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["authentication.maistra.io"]
+  resources:
+  - servicemeshpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["rbac.maistra.io"]
+  resources:
+  - servicemeshrbacconfigs
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["apps.openshift.io"]
   resources:
   - deploymentconfigs

--- a/operator/roles/kiali-deploy/templates/openshift/role.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/role.yaml
@@ -130,6 +130,26 @@ rules:
   - list
   - patch
   - watch
+- apiGroups: ["authentication.maistra.io"]
+  resources:
+  - servicemeshpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["rbac.maistra.io"]
+  resources:
+  - servicemeshrbacconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups: ["apps.openshift.io"]
   resources:
   - deploymentconfigs

--- a/swagger.json
+++ b/swagger.json
@@ -674,7 +674,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -702,7 +702,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -867,7 +867,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -895,7 +895,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
             "name": "filters[]",
@@ -906,7 +906,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -1025,7 +1025,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -1052,7 +1052,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -1953,7 +1953,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -1981,7 +1981,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -2239,7 +2239,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -2267,7 +2267,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
             "name": "filters[]",
@@ -2278,7 +2278,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -2506,7 +2506,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -2534,7 +2534,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -2800,7 +2800,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -2828,7 +2828,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
             "name": "filters[]",
@@ -2839,7 +2839,7 @@
             "items": {
               "type": "string"
             },
-            "default": "[]",
+            "default": [],
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",

--- a/swagger.json
+++ b/swagger.json
@@ -674,7 +674,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -702,7 +702,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -867,7 +867,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -895,7 +895,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
             "name": "filters[]",
@@ -906,7 +906,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -1025,7 +1025,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -1052,7 +1052,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -1953,7 +1953,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -1981,7 +1981,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -2239,7 +2239,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -2267,7 +2267,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
             "name": "filters[]",
@@ -2278,7 +2278,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -2506,7 +2506,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -2534,7 +2534,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -2800,7 +2800,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of labels to use for grouping metrics (via Prometheus 'by' clause).",
             "name": "byLabels[]",
@@ -2828,7 +2828,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of metrics to fetch. Fetch all metrics when empty. List entries are Kiali internal metric names.",
             "name": "filters[]",
@@ -2839,7 +2839,7 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": "[]",
             "x-go-name": "Name",
             "description": "List of quantiles to fetch. Fetch no quantiles when empty. Ex: [0.5, 0.95, 0.99].",
             "name": "quantiles[]",
@@ -3430,22 +3430,25 @@
           "$ref": "#/definitions/ObjectMeta"
         },
         "spec": {
+          "$ref": "#/definitions/ClusterRbacConfigSpec"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "ClusterRbacConfigSpec": {
+      "type": "object",
+      "properties": {
+        "exclusion": {
           "type": "object",
-          "properties": {
-            "exclusion": {
-              "type": "object",
-              "x-go-name": "Exclusion"
-            },
-            "inclusion": {
-              "type": "object",
-              "x-go-name": "Inclusion"
-            },
-            "mode": {
-              "type": "object",
-              "x-go-name": "Mode"
-            }
-          },
-          "x-go-name": "Spec"
+          "x-go-name": "Exclusion"
+        },
+        "inclusion": {
+          "type": "object",
+          "x-go-name": "Inclusion"
+        },
+        "mode": {
+          "type": "object",
+          "x-go-name": "Mode"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -3757,6 +3760,12 @@
         "serviceEntry": {
           "$ref": "#/definitions/ServiceEntry"
         },
+        "serviceMeshPolicy": {
+          "$ref": "#/definitions/ServiceMeshPolicy"
+        },
+        "serviceMeshRbacConfig": {
+          "$ref": "#/definitions/ServiceMeshRbacConfig"
+        },
         "serviceRole": {
           "$ref": "#/definitions/ServiceRole"
         },
@@ -3821,6 +3830,12 @@
         },
         "serviceEntries": {
           "$ref": "#/definitions/ServiceEntries"
+        },
+        "serviceMeshPolicies": {
+          "$ref": "#/definitions/ServiceMeshPolicies"
+        },
+        "serviceMeshRbacConfigs": {
+          "$ref": "#/definitions/ServiceMeshRbacConfigs"
         },
         "serviceRoleBindings": {
           "$ref": "#/definitions/ServiceRoleBindings"
@@ -3944,34 +3959,37 @@
           "$ref": "#/definitions/ObjectMeta"
         },
         "spec": {
+          "$ref": "#/definitions/MeshPolicySpec"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "MeshPolicySpec": {
+      "type": "object",
+      "properties": {
+        "originIsOptional": {
           "type": "object",
-          "properties": {
-            "originIsOptional": {
-              "type": "object",
-              "x-go-name": "OriginIsOptional"
-            },
-            "origins": {
-              "type": "object",
-              "x-go-name": "Origins"
-            },
-            "peerIsOptional": {
-              "type": "object",
-              "x-go-name": "PeerIsOptional"
-            },
-            "peers": {
-              "type": "object",
-              "x-go-name": "Peers"
-            },
-            "principalBinding": {
-              "type": "object",
-              "x-go-name": "PrincipalBinding"
-            },
-            "targets": {
-              "type": "object",
-              "x-go-name": "Targets"
-            }
-          },
-          "x-go-name": "Spec"
+          "x-go-name": "OriginIsOptional"
+        },
+        "origins": {
+          "type": "object",
+          "x-go-name": "Origins"
+        },
+        "peerIsOptional": {
+          "type": "object",
+          "x-go-name": "PeerIsOptional"
+        },
+        "peers": {
+          "type": "object",
+          "x-go-name": "Peers"
+        },
+        "principalBinding": {
+          "type": "object",
+          "x-go-name": "PrincipalBinding"
+        },
+        "targets": {
+          "type": "object",
+          "x-go-name": "Targets"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -4880,6 +4898,64 @@
         "validations": {
           "$ref": "#/definitions/IstioValidations"
         }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "ServiceMeshPolicies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ServiceMeshPolicy"
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "ServiceMeshPolicy": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "metadata": {
+          "$ref": "#/definitions/ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/MeshPolicySpec"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "ServiceMeshRbacConfig": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "metadata": {
+          "$ref": "#/definitions/ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/ClusterRbacConfigSpec"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "ServiceMeshRbacConfigs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ServiceMeshRbacConfig"
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },


### PR DESCRIPTION
** Describe the change **

Maistra distribution will clone MeshPolicy and ClusterRbacConfig to ServiceMeshPolicy and ServiceMeshRbacConfig objects with identical meaning but these objects are namespaced.
