### PR TITLE
KIALI-3220 Fetch ServiceMeshPolicies from control-plane

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -2,13 +2,13 @@ package business
 
 import (
 	"fmt"
-	"github.com/kiali/kiali/config"
 	"sync"
 
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/business/checkers"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"

--- a/business/tls.go
+++ b/business/tls.go
@@ -2,9 +2,11 @@ package business
 
 import (
 	"fmt"
+	"github.com/kiali/kiali/config"
 	"sync"
 
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 )
 
@@ -58,14 +60,17 @@ func (in *TLSService) hasMeshPolicyEnabled(namespaces []string) (bool, error) {
 			return false, err
 		}
 	} else {
-		// ServiceMeshPolicies are namespaces. So we need to iterate on available namespaces.
-		var smps []kubernetes.IstioObject
-		for _, ns := range namespaces {
-			if smps, err = in.k8s.GetServiceMeshPolicies(ns); err == nil {
-				mps = append(mps, smps...)
-			} else {
-				return false, err
-			}
+		// ServiceMeshPolicies are namespace scoped.
+		// And Maistra will only consider resources under control-plane namespace
+		// https://github.com/Maistra/istio/pull/39/files#diff-e3109392080297ee093b7189648289e1R40
+		// see https://github.com/Maistra/istio/blob/maistra-1.0/pilot/pkg/model/config.go#L958
+		// see https://github.com/Maistra/istio/blob/maistra-1.0/pilot/pkg/model/config.go#L990
+		controlPlaneNs := config.Get().IstioNamespace
+		if mps, err = in.k8s.GetServiceMeshPolicies(controlPlaneNs); err != nil {
+			// This query can return false if user can't access to controlPlaneNs
+			// On this case we log internally the error but we return a false with nil
+			log.Warningf("GetServiceMeshPolicies failed during a TLS validation. Probably user can't access to this. Error: %s", err)
+			return false, nil
 		}
 	}
 

--- a/business/tls.go
+++ b/business/tls.go
@@ -50,7 +50,7 @@ func (in *TLSService) hasMeshPolicyEnabled(namespaces []string) (bool, error) {
 		return false, fmt.Errorf("Unable to determine mesh-wide mTLS status without access to any namespace")
 	}
 
-	var mps = make([]kubernetes.IstioObject, 0)
+	var mps []kubernetes.IstioObject
 	var err error
 	if !in.k8s.IsMaistraApi() {
 		// MeshPolicies are not namespaced. So any namespace user has access to

--- a/business/tls.go
+++ b/business/tls.go
@@ -2,9 +2,9 @@ package business
 
 import (
 	"fmt"
-	"github.com/kiali/kiali/config"
 	"sync"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"


### PR DESCRIPTION
In Maistra scenarios, ServiceMeshPolicies need to be queried always from control-plane namespace.
This created some problems in the required object used by Kiali validations to perform DestinationRule checks.