### PR TITLE
Add NPM registry parameter

### DIFF
--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -1,73 +1,54 @@
-properties([
-  disableConcurrentBuilds(),
-  parameters([
-    string(name: 'RELEASE_TYPE',
-      defaultValue: 'auto',
-      trim: true,
-      description: 'Valid values are: auto, minor, snapshot.0, snapshot.1, edge. When "auto" is\n' +
-                    'specified, the type of the release will be determined based on the current date.'),
-    string(name: 'BACKEND_RELEASING_BRANCH',
-      defaultValue: 'refs/heads/master',
-      trim: true,
-      description: 'Branch of the backend to release'),
-    string(
-      name: 'UI_RELEASING_BRANCH',
-      defaultValue: 'refs/heads/master',
-      trim: true,
-      description: 'Branch of the UI to release'),
-    string(
-      name: 'BACKEND_GITHUB_URI',
-      defaultValue: 'git@github.com:kiali/kiali.git',
-      trim: true,
-      description: 'SSH Url of the kiali-backend GitHub repository'),
-    string(
-      name: 'UI_GITHUB_URI',
-      defaultValue: 'git@github.com:kiali/kiali-ui.git',
-      trim: true,
-      description: 'SSH Url of the kiali-ui GitHub repository'),
-    string(
-      name: 'DOCKER_NAME',
-      defaultValue: 'docker.io/kiali/kiali',
-      trim: true,
-      description: 'The name of the Docker repository to push the release'),
-    string(
-      name: 'QUAY_NAME',
-      defaultValue: 'quay.io/kiali/kiali',
-      trim: true,
-      description: 'The name of the Quay repository to push the release'),
-    string(
-      name: 'QUAY_OPERATOR_NAME',
-      defaultValue: 'quay.io/kiali/kiali-operator',
-      trim: true,
-      description: 'The name of the Quay repository to push the operator release'),
-    string(
-      name: 'BACKEND_PULL_URI',
-      defaultValue: 'https://api.github.com/repos/kiali/kiali/pulls',
-      trim: true,
-      description: 'The URL of the GitHub API to use to create pull requests for the\nback-end (changes to prepare for next version)'),
-    string(
-      name: 'UI_PULL_URI',
-      defaultValue: 'https://api.github.com/repos/kiali/kiali-ui/pulls',
-      trim: true,
-      description: 'The URL of the GitHub API to use to create pull requests for the\nUI (changes to prepare for next version)'),
-    string(
-      name: 'NPM_DRY_RUN',
-      defaultValue: 'n',
-      trim: true,
-      description: 'Set to "y" if you want to make a "dry run" of the front-end release process'),
-    string(
-      name: 'SKIP_UI_RELEASE',
-      defaultValue: 'n',
-      trim: true,
-      description: "Set to 'y' if you don't want to release the UI"),
-    string(
-         name: 'UI_VERSION',
-         defaultValue: '',
-         trim: true,
-         description: "If you are skipping UI release. Specify the UI version to package, or leave \n" +
-                      "unset to use the version present in the main Makefile (e.g. leave unset for patch releases)")
-  ])
-])
+/*
+ * The Jenkins job should be configured with the following properties:
+ *
+ * - Disable concurrent builds
+ * - Parameters (all must be trimmed; all are strings):
+ *   - RELEASE_TYPE
+ *      defaultValue: auto
+ *      description: Valid values are: auto, minor, snapshot.0, snapshot.1, edge. When "auto" is
+ *                   specified, the type of the release will be determined based on the current date.
+ *   - BACKEND_RELEASING_BRANCH
+ *      defaultValue: refs/heads/master
+ *      description: Branch of the backend to release
+ *   - UI_RELEASING_BRANCH
+ *      defaultValue: refs/heads/master
+ *      description: Branch of the UI to release
+ *   - BACKEND_GITHUB_URI
+ *      defaultValue: git@github.com:kiali/kiali.git
+ *      description: SSH Url of the kiali-backend GitHub repository
+ *   - UI_GITHUB_URI
+ *      defaultValue: git@github.com:kiali/kiali-ui.git
+ *      description: SSH Url of the kiali-ui GitHub repository
+ *   - DOCKER_NAME
+ *      defaultValue: docker.io/kiali/kiali
+ *      description: The name of the Docker repository to push the release
+ *   - QUAY_NAME
+ *      defaultValue: quay.io/kiali/kiali
+ *      description: The name of the Quay repository to push the release
+ *   - QUAY_OPERATOR_NAME
+ *      defaultValue: quay.io/kiali/kiali-operator
+ *      description: The name of the Quay repository to push the operator release
+ *   - BACKEND_PULL_URI
+ *      defaultValue: https://api.github.com/repos/kiali/kiali/pulls
+ *      description: The URL of the GitHub API to use to create pull requests for the back-end (changes to prepare for next version)
+ *   - UI_PULL_URI
+ *      defaultValue: https://api.github.com/repos/kiali/kiali-ui/pulls
+ *      description: The URL of the GitHub API to use to create pull requests for the UI (changes to prepare for next version)
+ *   - NPM_DRY_RUN
+ *      defaultValue: n
+ *      description: Set to "y" if you want to make a "dry run" of the front-end release process
+ *   - SKIP_UI_RELEASE
+ *      defaultValue: n
+ *      description: Set to 'y' if you don't want to release the UI
+ *   - UI_VERSION
+ *       defaultValue: ''
+ *       description: If you are skipping UI release. Specify the UI version to package, or leave
+ *                    unset to use the version present in the main Makefile (e.g. leave unset for patch releases)
+ *   - NPM_CONFIG_REGISTRY
+ *       defaultValue: ''
+ *       description: Registry to use for fetching packages. This is not used for publishing releases.
+ *                    Do not include the trailing slash.
+ */
 
 node('kiali-build') {
   def (backendForkUri, uiForkUri) = ['git@github.com:kiali-bot/kiali.git', 'git@github.com:kiali-bot/kiali-ui.git']

--- a/deploy/jenkins-ci/jenkins_ref/jobs/kiali-release/config.xml
+++ b/deploy/jenkins-ci/jenkins_ref/jobs/kiali-release/config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.31">
+<flow-definition plugin="workflow-job@2.33">
   <actions>
-    <org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction plugin="workflow-multibranch@2.20">
+    <org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction plugin="workflow-multibranch@2.21">
       <jobPropertyDescriptors>
         <string>org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty</string>
         <string>hudson.model.ParametersDefinitionProperty</string>
@@ -11,11 +11,11 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.29">
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.31">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
-    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
@@ -100,11 +100,17 @@ unset to use the version present in the main Makefile (e.g. leave unset for patc
           <defaultValue></defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>NPM_CONFIG_REGISTRY</name>
+          <description>Registry to use for fetching packages. This is not used for publishing releases. Do not include the trailing slash.</description>
+          <defaultValue></defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.63">
-    <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.3">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.70">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@3.10.0">
       <configVersion>2</configVersion>
       <userRemoteConfigs>
         <hudson.plugins.git.UserRemoteConfig>


### PR DESCRIPTION
Adds NPM_CONFIG_REGISTRY parameter to the sample job.

Unfortunately, since different envs may need to use different package registries it's no longer possible to hardcode the parameters to make the Pipeline to "auto configure" itself if created manually (harcoding configs replaces any customized configs of the Pipeline on every run)

This means, that the Pipeline will need to be configured manually if the config.xml file cannot be placed in the Jenkins instance.