### PR TITLE
[hack] this fixes some dev tool things. nothing related to the actual code

### DIFF
--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -237,7 +237,7 @@ DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.1.9"
 DEFAULT_CRC_CPUS="5"
 
 # The default memory (in GB) assigned to the CRC VM
-DEFAULT_CRC_MEMORY="16"
+DEFAULT_CRC_MEMORY="20"
 
 # The default virtual disk size (in GB) assigned to the CRC VM
 DEFAULT_CRC_VIRTUAL_DISK_SIZE="30"
@@ -1002,6 +1002,6 @@ elif [ "$_CMD" = "services" ];then
   print_all_service_endpoints
 
 else
-  infomsg "ERROR: Required command must be either: start, stop, delete, status, ssh"
+  infomsg "ERROR: Required command must be either: start, stop, delete, status, ssh, routes, services"
   exit 1
 fi

--- a/operator/dev-playbook.yml
+++ b/operator/dev-playbook.yml
@@ -4,6 +4,13 @@
   vars:
     deployment:
       image_version: dev
+
+    # The Ansible SDK creates a "_kiali_io_kiali" variable that
+    # mimics the Kiali CR but maintains camelCase in key names.
+    # This will only be useful for certain cases (e.g. when
+    # tolerances or affinity are specified) so most times you
+    # can run with this empty (but it has to be defined).
+    _kiali_io_kiali: {}
   roles:
   - kiali-deploy
   - kiali-remove


### PR DESCRIPTION
1. crc hack script bumps to 20g by default - seems the latest version needs it
2. to run the operator in dev mode (i.e. just the ansible playbook on the local dev machine, not running in k8s) we need a variable defined now to mimic the var passed in by the operator sdk
