### PR TITLE
KIALI-3051 [operator] do a rolling upgrade rather than deleting the pod

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -188,3 +188,7 @@ molecule-docker-build:
 ## molecule-test: Runs Molecule tests using the Molecule docker image
 molecule-test: .molecule-docker-build-if-needed
 	docker run --rm -it -v "${PWD}":/tmp/$(basename "${PWD}"):ro -v "${HOME}/.kube":/root/.kube:ro -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") --network="host" --add-host="api.crc.testing:192.168.130.11" kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name ${MOLECULE_SCENARIO}
+
+## molecule-test-all: Runs all Molecule tests using the Molecule docker image
+molecule-test-all: .molecule-docker-build-if-needed
+	docker run --rm -it -v "${PWD}":/tmp/$(basename "${PWD}"):ro -v "${HOME}/.kube":/root/.kube:ro -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") --network="host" --add-host="api.crc.testing:192.168.130.11" kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --all

--- a/operator/molecule/accessible-namespaces-test/kiali-cr.yaml
+++ b/operator/molecule/accessible-namespaces-test/kiali-cr.yaml
@@ -11,4 +11,5 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
+    service_type: NodePort
 

--- a/operator/molecule/accessible-namespaces-test/playbook.yml
+++ b/operator/molecule/accessible-namespaces-test/playbook.yml
@@ -23,6 +23,7 @@
     vars:
       namespace_list: [ 'istio-system', 'foo' ]
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
   - import_tasks: ../asserts/accessible_namespaces_equals.yml
@@ -40,6 +41,7 @@
   # change to accessible_namespaces back to **
   - import_tasks: ../common/set_accessible_namespaces_to_all.yml
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
   - import_tasks: ../asserts/accessible_namespaces_contains.yml

--- a/operator/molecule/affinity-tolerations-test/kiali-cr.yaml
+++ b/operator/molecule/affinity-tolerations-test/kiali-cr.yaml
@@ -16,3 +16,4 @@ spec:
     # while we are here, make sure the additional service yaml retains camelCase
     additional_service_yaml:
       externalName: my.kiali.example.com
+    service_type: NodePort

--- a/operator/molecule/affinity-tolerations-test/playbook.yml
+++ b/operator/molecule/affinity-tolerations-test/playbook.yml
@@ -51,6 +51,7 @@
         operator: Exists
         tolerationSeconds: 777
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
 

--- a/operator/molecule/asserts/pod_asserts.yml
+++ b/operator/molecule/asserts/pod_asserts.yml
@@ -1,3 +1,10 @@
+# This will assume the pod is already running and there is only one.
+# Use common/wait_for_kiali_running.yml if you want to wait for this condition to occur.
+- name: Assert Kiali Pod is Running and there is only one
+  assert:
+    that:
+    - kiali_pod.resources | length == 1 and kiali_pod.resources[0].status.phase is defined and kiali_pod.resources[0].status.phase == "Running"
+
 - name: Assert Kiali Pod is Running on the correct Namespace
   assert:
     that:

--- a/operator/molecule/common/set_auth_strategy.yml
+++ b/operator/molecule/common/set_auth_strategy.yml
@@ -1,0 +1,10 @@
+- name: "Set auth_strategy to {{ new_auth_strategy }} in current Kiali CR"
+  vars:
+    current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=kiali.operator_namespace, resource_name=custom_resource.metadata.name) }}"
+  set_fact:
+    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'auth': {'strategy': new_auth_strategy }}}, recursive=True) }}"
+
+- name: "Change Kiali CR with auth_strategy to {{ new_auth_strategy }}"
+  k8s:
+    namespace: '{{ kiali.operator_namespace }}'
+    definition: "{{ new_kiali_cr }}"

--- a/operator/molecule/common/tasks.yml
+++ b/operator/molecule/common/tasks.yml
@@ -56,4 +56,11 @@
     kiali_port: "{{ kiali_service | json_query('resources[0].spec.ports[?name==`tcp`].nodePort') | join() }}"
 - set_fact:
     kiali_base_url: "https://{{ cluster_node_ip }}:{{ kiali_port }}"
+  when:
+  - kiali_service.resources[0].spec.type == 'NodePort'
+- debug:
+    msg: "This test does not have kiali_base_url set because the kiali service is not of type NodePort"
+  when:
+  - kiali_service.resources[0].spec.type != 'NodePort'
+
 

--- a/operator/molecule/common/wait_for_kiali_running.yml
+++ b/operator/molecule/common/wait_for_kiali_running.yml
@@ -1,3 +1,15 @@
+- name: Asserting that Kiali Pod exists and there is only one
+  k8s_facts:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ istio.control_plane_namespace }}"
+    label_selectors:
+    - app = kiali
+  register: kiali_pod
+  until: kiali_pod.resources | length == 1 and kiali_pod.resources[0].status.phase is defined and kiali_pod.resources[0].status.phase == "Running"
+  retries: 60
+  delay: 5
+
 - name: Wait for Kiali to be running and accepting requests
   uri:
     url: "{{ kiali_base_url }}/api"

--- a/operator/molecule/default/playbook.yml
+++ b/operator/molecule/default/playbook.yml
@@ -6,4 +6,5 @@
   tasks:
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/configmap_asserts.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../asserts/pod_asserts.yml

--- a/operator/molecule/kiali-cr.yaml
+++ b/operator/molecule/kiali-cr.yaml
@@ -11,4 +11,5 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
+    service_type: NodePort
 

--- a/operator/molecule/ldap-test/playbook.yml
+++ b/operator/molecule/ldap-test/playbook.yml
@@ -22,6 +22,7 @@
       namespace: "{{ kiali.operator_namespace }}"
       definition: "{{ lookup('template', cr_file_path) }}"
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
 
   # test Kiali access to secure LDAP
   - import_tasks: ../asserts/ldap-test/assert-ldap-access.yml

--- a/operator/molecule/roles-test/playbook.yml
+++ b/operator/molecule/roles-test/playbook.yml
@@ -12,16 +12,20 @@
   # turn on view only mode and see the viewer (read-only) role is now in effect
   - import_tasks: ../common/set_view_only_mode.yml
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../asserts/roles-test/ro_role_asserts.yml
   # turn off view only mode which should return back to the read-write role
   - import_tasks: ../common/unset_view_only_mode.yml
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../asserts/roles-test/rw_role_asserts.yml
   # change to accessible_namespaces=** which switches to cluster roles
   - import_tasks: ../common/set_accessible_namespaces_to_all.yml
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../asserts/roles-test/rw_clusterrole_asserts.yml
   # turn on view only mode and see the viewer (read-only) cluster role is now in effect
   - import_tasks: ../common/set_view_only_mode.yml
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../asserts/roles-test/ro_clusterrole_asserts.yml

--- a/operator/molecule/rolling-restart-test/kiali-cr.yaml
+++ b/operator/molecule/rolling-restart-test/kiali-cr.yaml
@@ -1,0 +1,14 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+spec:
+  istio_namespace: {{ istio.control_plane_namespace }}
+  auth:
+    strategy: {{ kiali.auth_strategy }}
+  deployment:
+    image_name: {{ kiali.image_name }}
+    image_pull_policy: {{ kiali.image_pull_policy }}
+    image_version: {{ kiali.image_version }}
+    accessible_namespaces: {{ kiali.accessible_namespaces }}
+    service_type: NodePort

--- a/operator/molecule/rolling-restart-test/molecule.yml
+++ b/operator/molecule/rolling-restart-test/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+  inventory:
+    group_vars:
+      all:
+        kiali_operator_assets_path : "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/rolling-restart-test/kiali-cr.yaml"
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          accessible_namespaces: ["**"]
+          auth_strategy: openshift
+          operator_namespace: kiali-operator
+          operator_image_name: quay.io/kiali/kiali-operator
+          operator_version: latest
+          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
+          #operator_version: dev
+          operator_watch_namespace: kiali-operator
+          operator_clusterrolebindings: "- clusterrolebindings"
+          operator_clusterroles: "- clusterroles"
+          image_name: quay.io/kiali/kiali
+          image_version: latest
+          image_pull_policy: Always
+scenario:
+  name: rolling-restart-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/operator/molecule/rolling-restart-test/playbook.yml
+++ b/operator/molecule/rolling-restart-test/playbook.yml
@@ -1,0 +1,32 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  # Try to access Kiali api endpoint that requires authentication (should return 401)
+  # This means our auth-strategy is not anonymous and we need to login.
+  - name: Attempt unauthorized access to api endpoint
+    uri:
+      url: "{{ kiali_base_url }}/api/namespaces"
+      status_code: 401
+      validate_certs: false
+
+  # now change auth-strategy to anonymous - this change should force the pod to restart
+  - import_tasks: ../common/set_auth_strategy.yml
+    vars:
+      new_auth_strategy: anonymous
+
+  # see that we are not required to log in - this means the pod restarted and picked up the change
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
+
+  - name: Attempt authorized anonymous access to api endpoint
+    uri:
+      url: "{{ kiali_base_url }}/api/namespaces"
+      status_code: 200
+      validate_certs: false

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -412,7 +412,8 @@
   when:
   - '"**" not in kiali_vars.deployment.accessible_namespaces'
 
-- name: Delete Kiali deployment if image is changing since image is immutable
+# TODO: do we want to remove the label selector "version" so the Deployment only tracks by app=kiali label?
+- name: Delete Kiali deployment if image is changing since label selectors are immutable and we have version in a label
   k8s:
     state: absent
     api_version: apps/v1
@@ -424,15 +425,44 @@
   - current_image_name is defined and current_image_version is defined
   - (current_image_name != kiali_vars.deployment.image_name) or (current_image_version != kiali_vars.deployment.image_version)
 
+# Get the deployment's custom annotation we set that tells us when we last updated the Deployment.
+# We need this to ensure the Deployment we update retains this same timestamp unless changes are made
+# that requires a pod restart - in which case we update this timestamp.
+- name: Find current deployment, if it exists
+  set_fact:
+    current_deployment: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
+
+- name: Get current deployment last-updated annotation timestamp from existing deployment
+  set_fact:
+    current_deployment_last_updated: "{{ current_deployment.spec.template.metadata.annotations['operator.kiali.io/last-updated'] if current_deployment.spec.template.metadata.annotations['operator.kiali.io/last-updated'] is defined else lookup('pipe','date') }}"
+    deployment_is_new: false
+  when:
+  - current_deployment is defined
+  - current_deployment.spec is defined
+  - current_deployment.spec.template is defined
+  - current_deployment.spec.template.metadata is defined
+  - current_deployment.spec.template.metadata.annotations is defined
+
+- name: Set current deployment last-updated annotation timestamp for new deployments
+  set_fact:
+    current_deployment_last_updated: "{{ lookup('pipe','date') }}"
+    deployment_is_new: true
+  when:
+  - current_deployment_last_updated is not defined
+
 # Now deploy all resources for the specific cluster environment
 
 - name: Execute for OpenShift environment
   include: openshift/os-main.yml
+  vars:
+    deployment_last_updated: "{{ current_deployment_last_updated }}"
   when:
   - is_openshift == True
 
 - name: Execute for Kubernetes environment
   include: kubernetes/k8s-main.yml
+  vars:
+    deployment_last_updated: "{{ current_deployment_last_updated }}"
   when:
   - is_k8s == True
 
@@ -472,17 +502,13 @@
   - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
 
 - name: Force the Kiali pod to restart if necessary
-  k8s:
-    state: "absent"
-    api_version: "v1"
-    kind: "Pod"
-    namespace: "{{ item.metadata.namespace }}"
-    name: "{{ item.metadata.name }}"
   vars:
-    pods: "{{ query('k8s', kind='Pod', namespace=kiali_vars.deployment.namespace, label_selector='app=kiali') }}"
-  loop: "{{ pods }}"
+    updated_deployment: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
+  k8s:
+    state: "present"
+    definition: "{{ updated_deployment }}"
   when:
-  - pods is defined
+  - deployment_is_new == False
   - processed_resources.configmap is defined
   - processed_resources.configmap.changed == True
   - processed_resources.configmap.method == "patch"

--- a/operator/roles/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ kiali_vars.server.metrics_port }}"
         kiali.io/runtimes: go,kiali
+        operator.kiali.io/last-updated: "{{ deployment_last_updated }}"
     spec:
       serviceAccount: kiali-service-account
 {% if kiali_vars.deployment.image_pull_secrets | default([]) | length > 0 %}

--- a/operator/roles/kiali-deploy/templates/openshift/deployment.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ kiali_vars.server.metrics_port }}"
         kiali.io/runtimes: go,kiali
+        operator.kiali.io/last-updated: "{{ deployment_last_updated }}"
     strategy:
       rollingUpdate:
         maxSurge: 1


### PR DESCRIPTION
When we need to restart Kiali, limit the downtime that the user will see by using the trick of adding an annotation to the deployment's template metadata. When a change to an annotation is made,
k8s will do a rolling upgrade to the pods when updating the annotation, thus restarting the pod.

https://issues.jboss.org/browse/KIALI-3051