### PR TITLE
Add references to IstioValidation type and validators

### DIFF
--- a/business/checkers/checker.go
+++ b/business/checkers/checker.go
@@ -11,13 +11,13 @@ type GroupChecker interface {
 }
 
 // EmptyValidValidation returns a stub validation object which can be used by checkers
-func EmptyValidValidations(name, objectType string) models.IstioValidations {
-	key, emptyValidation := EmptyValidValidation(name, objectType)
+func EmptyValidValidations(name, namespace, objectType string) models.IstioValidations {
+	key, emptyValidation := EmptyValidValidation(name, namespace, objectType)
 	return models.IstioValidations{key: emptyValidation}
 }
 
-func EmptyValidValidation(name, objectType string) (models.IstioValidationKey, *models.IstioValidation) {
-	key := models.IstioValidationKey{Name: name, ObjectType: objectType}
+func EmptyValidValidation(name, namespace, objectType string) (models.IstioValidationKey, *models.IstioValidation) {
+	key := models.IstioValidationKey{Name: name, Namespace: namespace, ObjectType: objectType}
 	emptyValidation := &models.IstioValidation{
 		Name:       key.Name,
 		ObjectType: key.ObjectType,

--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -52,7 +52,7 @@ func (in DestinationRulesChecker) runIndividualChecks() models.IstioValidations 
 
 func (in DestinationRulesChecker) runChecks(destinationRule kubernetes.IstioObject) models.IstioValidations {
 	destinationRuleName := destinationRule.GetObjectMeta().Name
-	key, rrValidation := EmptyValidValidation(destinationRuleName, DestinationRuleCheckerType)
+	key, rrValidation := EmptyValidValidation(destinationRuleName, destinationRule.GetObjectMeta().Namespace, DestinationRuleCheckerType)
 
 	enabledCheckers := []Checker{
 		destinationrules.MeshWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},

--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -140,14 +140,17 @@ func checkCollisions(validations models.IstioValidations, destinationRulesName s
 	}
 }
 
+// addError links new validation errors to the validations. destinationRuleNames must always be a pair
 func addError(validations models.IstioValidations, destinationRuleNames []string) models.IstioValidations {
-	for _, destinationRuleName := range destinationRuleNames {
-		key, rrValidation := createError("destinationrules.multimatch", destinationRuleName, true)
+	key0, rrValidation0 := createError("destinationrules.multimatch", destinationRuleNames[0], true)
+	key1, rrValidation1 := createError("destinationrules.multimatch", destinationRuleNames[1], true)
 
-		if _, exists := validations[key]; !exists {
-			validations.MergeValidations(models.IstioValidations{key: rrValidation})
-		}
-	}
+	rrValidation0.References[0] = key1
+	rrValidation1.References[0] = key0
+
+	validations.MergeValidations(models.IstioValidations{key0: rrValidation0})
+	validations.MergeValidations(models.IstioValidations{key1: rrValidation1})
+
 	return validations
 }
 
@@ -161,6 +164,7 @@ func createError(errorText, destinationRuleName string, valid bool) (models.Isti
 		Checks: []*models.IstioCheck{
 			&checks,
 		},
+		References: make([]models.IstioValidationKey, 1),
 	}
 
 	return key, rrValidation

--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -29,13 +29,14 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 	for _, dr := range m.DestinationRules {
 		if host, ok := dr.GetSpec()["host"]; ok {
 			destinationRulesName := dr.GetObjectMeta().Name
+			destinationRulesNamespace := dr.GetObjectMeta().Namespace
 			if dHost, ok := host.(string); ok {
 				fqdn := kubernetes.ParseHost(dHost, dr.GetObjectMeta().Namespace, dr.GetObjectMeta().ClusterName)
 
 				if fqdn.Namespace != dr.GetObjectMeta().Namespace && !strings.HasPrefix(fqdn.Service, "*") && fqdn.Namespace != "" {
 					// Unable to verify if the same host+subset combination is targeted from different namespace DRs
 					// "*" check removes the prefix errors
-					key, rrValidation := createError("validation.unable.cross-namespace", dr.GetObjectMeta().Name, true)
+					key, rrValidation := createError("validation.unable.cross-namespace", destinationRulesNamespace, destinationRulesName, true)
 					validations.MergeValidations(models.IstioValidations{key: rrValidation})
 					continue
 				}
@@ -50,19 +51,19 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 				if fqdn.Service == "*" {
 					// We need to check the matching subsets from all hosts now
 					for _, h := range seenHostSubsets {
-						checkCollisions(validations, destinationRulesName, foundSubsets, h)
+						checkCollisions(validations, destinationRulesNamespace, destinationRulesName, foundSubsets, h)
 					}
 					// We add * later
 				}
 				// Search "*" first and then exact name
 				if previous, found := seenHostSubsets["*"]; found {
 					// Need to check subsets of "*"
-					checkCollisions(validations, destinationRulesName, foundSubsets, previous)
+					checkCollisions(validations, destinationRulesNamespace, destinationRulesName, foundSubsets, previous)
 				}
 
 				if previous, found := seenHostSubsets[fqdn.Service]; found {
 					// Host found, need to check underlying subsets
-					checkCollisions(validations, destinationRulesName, foundSubsets, previous)
+					checkCollisions(validations, destinationRulesNamespace, destinationRulesName, foundSubsets, previous)
 				}
 				// Nothing threw an error, so add these
 				if _, found := seenHostSubsets[fqdn.Service]; !found {
@@ -119,31 +120,31 @@ func extractSubsets(dr kubernetes.IstioObject, destinationRulesName string) []su
 	return []subset{subset{"~", destinationRulesName}}
 }
 
-func checkCollisions(validations models.IstioValidations, destinationRulesName string, foundSubsets []subset, existing map[string]string) {
+func checkCollisions(validations models.IstioValidations, namespace, destinationRulesName string, foundSubsets []subset, existing map[string]string) {
 	// If current subset is ~
 	if len(foundSubsets) == 1 && foundSubsets[0].Name == "~" {
 		// This should match any subset in the same hostname
 		for _, v := range existing {
-			addError(validations, []string{destinationRulesName, v})
+			addError(validations, namespace, []string{destinationRulesName, v})
 		}
 	}
 
 	// If we have existing subset with ~
 	if ruleName, found := existing["~"]; found {
-		addError(validations, []string{destinationRulesName, ruleName})
+		addError(validations, namespace, []string{destinationRulesName, ruleName})
 	}
 
 	for _, s := range foundSubsets {
 		if ruleName, found := existing[s.Name]; found {
-			addError(validations, []string{destinationRulesName, ruleName})
+			addError(validations, namespace, []string{destinationRulesName, ruleName})
 		}
 	}
 }
 
 // addError links new validation errors to the validations. destinationRuleNames must always be a pair
-func addError(validations models.IstioValidations, destinationRuleNames []string) models.IstioValidations {
-	key0, rrValidation0 := createError("destinationrules.multimatch", destinationRuleNames[0], true)
-	key1, rrValidation1 := createError("destinationrules.multimatch", destinationRuleNames[1], true)
+func addError(validations models.IstioValidations, namespace string, destinationRuleNames []string) models.IstioValidations {
+	key0, rrValidation0 := createError("destinationrules.multimatch", namespace, destinationRuleNames[0], true)
+	key1, rrValidation1 := createError("destinationrules.multimatch", namespace, destinationRuleNames[1], true)
 
 	rrValidation0.References[0] = key1
 	rrValidation1.References[0] = key0
@@ -154,8 +155,8 @@ func addError(validations models.IstioValidations, destinationRuleNames []string
 	return validations
 }
 
-func createError(errorText, destinationRuleName string, valid bool) (models.IstioValidationKey, *models.IstioValidation) {
-	key := models.IstioValidationKey{Name: destinationRuleName, ObjectType: DestinationRulesCheckerType}
+func createError(errorText, namespace, destinationRuleName string, valid bool) (models.IstioValidationKey, *models.IstioValidation) {
+	key := models.IstioValidationKey{Name: destinationRuleName, Namespace: namespace, ObjectType: DestinationRulesCheckerType}
 	checks := models.Build(errorText, "spec/host")
 	rrValidation := &models.IstioValidation{
 		Name:       destinationRuleName,

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -54,6 +54,9 @@ func TestMultiHostMatchInvalid(t *testing.T) {
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
 	assert.Equal(models.CheckMessage("destinationrules.multimatch"), validation.Checks[0].Message)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule1", validation.References[0].Name)
 }
 
 func TestMultiHostMatchWildcardInvalid(t *testing.T) {
@@ -78,6 +81,9 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
 
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule1", validation.References[0].Name)
+
 	destinationRules = []kubernetes.IstioObject{
 		data.CreateTestDestinationRule("test", "rule2", "*.test.svc.cluster.local"),
 		data.CreateTestDestinationRule("test", "rule1", "host1"),
@@ -94,6 +100,8 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
 
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule2", validation.References[0].Name)
 }
 
 func TestMultiHostMatchingMeshWideMTLSDestinationRule(t *testing.T) {
@@ -198,12 +206,15 @@ func TestReviewsExample(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
+	assert.Equal(3, len(validations))
 	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "reviews3"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
 	assert.Equal(1, len(validation.Checks))
+
+	assert.Equal(2, len(validation.References)) // Both reviews and reviews2 is faulty
 }
 
 func TestMultiServiceEntry(t *testing.T) {

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -26,7 +26,7 @@ func TestMultiHostMatchCorrect(t *testing.T) {
 	}.Check()
 
 	assert.Empty(validations)
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "rule2"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
 	assert.False(ok)
 	assert.Nil(validation)
 }
@@ -48,7 +48,7 @@ func TestMultiHostMatchInvalid(t *testing.T) {
 
 	assert.NotEmpty(validations)
 	assert.Equal(2, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "rule2"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
 	assert.True(ok)
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)
@@ -75,7 +75,7 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "rule2"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
 	assert.True(ok)
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)
@@ -94,7 +94,7 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	validation, ok = validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "rule1"}]
+	validation, ok = validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule1"}]
 	assert.True(ok)
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)
@@ -121,7 +121,7 @@ func TestMultiHostMatchingMeshWideMTLSDestinationRule(t *testing.T) {
 	}.Check()
 
 	assert.Empty(validations)
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "rule2"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
 	assert.False(ok)
 	assert.Nil(validation)
 }
@@ -143,7 +143,7 @@ func TestMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
 	}.Check()
 
 	assert.Empty(validations)
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "rule2"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
 	assert.False(ok)
 	assert.Nil(validation)
 }
@@ -207,7 +207,7 @@ func TestReviewsExample(t *testing.T) {
 
 	assert.NotEmpty(validations)
 	assert.Equal(3, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "reviews3"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "bookinfo", Name: "reviews3"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 	assert.NotEmpty(validation.Checks)

--- a/business/checkers/destinationrules/traffic_policy_checker.go
+++ b/business/checkers/destinationrules/traffic_policy_checker.go
@@ -21,14 +21,14 @@ func (t TrafficPolicyChecker) Check() models.IstioValidations {
 
 	refKeys := make([]models.IstioValidationKey, 0, len(refdMtls))
 	for _, dr := range refdMtls {
-		refKeys = append(refKeys, models.BuildKey(DestinationRulesCheckerType, dr.GetObjectMeta().Name))
+		refKeys = append(refKeys, models.BuildKey(DestinationRulesCheckerType, dr.GetObjectMeta().Name, dr.GetObjectMeta().Namespace))
 	}
 
 	// Check whether DRs override mTLS.
 	for _, dr := range t.DestinationRules {
 		if !hasTrafficPolicy(dr) || !hasTLSSettings(dr) {
 			check := models.Build("destinationrules.trafficpolicy.notlssettings", "spec/trafficPolicy")
-			key := models.BuildKey(DestinationRulesCheckerType, dr.GetObjectMeta().Name)
+			key := models.BuildKey(DestinationRulesCheckerType, dr.GetObjectMeta().Name, dr.GetObjectMeta().Namespace)
 			validation := buildDestinationRuleValidation(dr, check, true, refKeys)
 
 			if _, exists := validations[key]; !exists {

--- a/business/checkers/destinationrules/traffic_policy_checker.go
+++ b/business/checkers/destinationrules/traffic_policy_checker.go
@@ -13,9 +13,15 @@ type TrafficPolicyChecker struct {
 func (t TrafficPolicyChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
+	refdMtls := t.drsWithNonLocalmTLSEnabled()
 	// When mTLS is not enabled, there is no validation to be added.
-	if !t.isNonLocalmTLSEnabled() {
+	if len(refdMtls) == 0 {
 		return validations
+	}
+
+	refKeys := make([]models.IstioValidationKey, 0, len(refdMtls))
+	for _, dr := range refdMtls {
+		refKeys = append(refKeys, models.BuildKey(DestinationRulesCheckerType, dr.GetObjectMeta().Name))
 	}
 
 	// Check whether DRs override mTLS.
@@ -23,7 +29,7 @@ func (t TrafficPolicyChecker) Check() models.IstioValidations {
 		if !hasTrafficPolicy(dr) || !hasTLSSettings(dr) {
 			check := models.Build("destinationrules.trafficpolicy.notlssettings", "spec/trafficPolicy")
 			key := models.BuildKey(DestinationRulesCheckerType, dr.GetObjectMeta().Name)
-			validation := buildDestinationRuleValidation(dr, check, true)
+			validation := buildDestinationRuleValidation(dr, check, true, refKeys)
 
 			if _, exists := validations[key]; !exists {
 				validations.MergeValidations(models.IstioValidations{key: validation})
@@ -34,18 +40,19 @@ func (t TrafficPolicyChecker) Check() models.IstioValidations {
 	return validations
 }
 
-func (t TrafficPolicyChecker) isNonLocalmTLSEnabled() bool {
+func (t TrafficPolicyChecker) drsWithNonLocalmTLSEnabled() []kubernetes.IstioObject {
+	mtlsDrs := make([]kubernetes.IstioObject, 0)
 	for _, dr := range t.MTLSDetails.DestinationRules {
 		if host, ok := dr.GetSpec()["host"]; ok {
 			if dHost, ok := host.(string); ok {
 				fqdn := kubernetes.ParseHost(dHost, dr.GetObjectMeta().Namespace, dr.GetObjectMeta().ClusterName)
 				if isNonLocalmTLSForServiceEnabled(dr, fqdn.Service) {
-					return true
+					mtlsDrs = append(mtlsDrs, dr)
 				}
 			}
 		}
 	}
-	return false
+	return mtlsDrs
 }
 
 func hasTrafficPolicy(dr kubernetes.IstioObject) bool {
@@ -89,7 +96,7 @@ func hasTrafficPolicyTLS(dr kubernetes.IstioObject) bool {
 	return false
 }
 
-func buildDestinationRuleValidation(dr kubernetes.IstioObject, checks models.IstioCheck, valid bool) *models.IstioValidation {
+func buildDestinationRuleValidation(dr kubernetes.IstioObject, checks models.IstioCheck, valid bool, refKeys []models.IstioValidationKey) *models.IstioValidation {
 	validation := &models.IstioValidation{
 		Name:       dr.GetObjectMeta().Name,
 		ObjectType: DestinationRulesCheckerType,
@@ -97,6 +104,7 @@ func buildDestinationRuleValidation(dr kubernetes.IstioObject, checks models.Ist
 		Checks: []*models.IstioCheck{
 			&checks,
 		},
+		References: refKeys,
 	}
 
 	return validation

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -211,6 +211,8 @@ func testValidationAdded(t *testing.T, destinationRules []kubernetes.IstioObject
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
 	assert.Equal("spec/trafficPolicy", validation.Checks[0].Path)
 	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.notlssettings"), validation.Checks[0].Message)
+
+	assert.True(len(validation.References) > 0)
 }
 
 func testValidationsNotAdded(t *testing.T, destinationRules []kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -203,7 +203,7 @@ func testValidationAdded(t *testing.T, destinationRules []kubernetes.IstioObject
 	assert.NotEmpty(validations)
 	assert.Equal(1, len(validations))
 
-	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews", "bookinfo")]
 	assert.True(ok)
 	assert.True(validation.Valid)
 
@@ -224,7 +224,7 @@ func testValidationsNotAdded(t *testing.T, destinationRules []kubernetes.IstioOb
 	}.Check()
 
 	assert.Empty(validations)
-	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews")]
+	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews", "bookinfo")]
 
 	assert.False(ok)
 	assert.Nil(validation)

--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -34,7 +34,7 @@ func (g GatewayChecker) Check() models.IstioValidations {
 }
 
 func (g GatewayChecker) runSingleChecks(gw kubernetes.IstioObject) models.IstioValidations {
-	key, validations := EmptyValidValidation(gw.GetObjectMeta().Name, GatewayCheckerType)
+	key, validations := EmptyValidValidation(gw.GetObjectMeta().Name, gw.GetObjectMeta().Namespace, GatewayCheckerType)
 
 	enabledCheckers := []Checker{
 		gateways.SelectorChecker{

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -95,10 +95,8 @@ func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 	assert.True(secValidation.Valid)
 
 	// Check references
-	// assert.Equal(1, len(validation.References))
-	// assert.Equal(1, len(secValidation.References))
-	// _, ok = validation.References[models.IstioValidationKey{ObjectType: "gateway", Name: "validgateway"}]
-	// assert.True(ok)
+	assert.Equal(1, len(validation.References))
+	assert.Equal(1, len(secValidation.References))
 }
 
 func TestWildCardMatchingHost(t *testing.T) {

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -89,6 +89,16 @@ func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "stillvalid"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
+
+	secValidation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "validgateway"}]
+	assert.True(ok)
+	assert.True(secValidation.Valid)
+
+	// Check references
+	// assert.Equal(1, len(validation.References))
+	// assert.Equal(1, len(secValidation.References))
+	// _, ok = validation.References[models.IstioValidationKey{ObjectType: "gateway", Name: "validgateway"}]
+	// assert.True(ok)
 }
 
 func TestWildCardMatchingHost(t *testing.T) {
@@ -126,6 +136,16 @@ func TestWildCardMatchingHost(t *testing.T) {
 	assert.True(ok)
 	assert.True(validation.Valid)
 
+	// valid should have "*" as ref
+	// "*" should have valid and *.just as ref
+	// *.just should have "*" as ref
+	for _, v := range validations {
+		if v.Name == "stillvalid" {
+			assert.Equal(2, len(v.References))
+		} else {
+			assert.Equal(1, len(v.References))
+		}
+	}
 }
 
 func TestAnotherSubdomainWildcardCombination(t *testing.T) {

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -28,7 +28,7 @@ func TestCorrectGateways(t *testing.T) {
 	}.Check()
 
 	assert.Empty(validations)
-	_, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "validgateway"}]
+	_, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "validgateway"}]
 	assert.False(ok)
 }
 
@@ -56,7 +56,7 @@ func TestCaseMatching(t *testing.T) {
 
 	assert.NotEmpty(validations)
 	assert.Equal(1, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "foxxed"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "foxxed"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 }
@@ -86,11 +86,11 @@ func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 
 	assert.NotEmpty(validations)
 	assert.Equal(2, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "stillvalid"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "stillvalid"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 
-	secValidation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "validgateway"}]
+	secValidation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "validgateway"}]
 	assert.True(ok)
 	assert.True(secValidation.Valid)
 
@@ -130,7 +130,7 @@ func TestWildCardMatchingHost(t *testing.T) {
 
 	assert.NotEmpty(validations)
 	assert.Equal(3, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "stillvalid"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "stillvalid"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 
@@ -170,7 +170,7 @@ func TestAnotherSubdomainWildcardCombination(t *testing.T) {
 
 	assert.NotEmpty(validations)
 	assert.Equal(1, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "shouldnotbevalid"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "shouldnotbevalid"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 }
@@ -225,9 +225,10 @@ func TestTwoWildCardsMatching(t *testing.T) {
 
 	assert.NotEmpty(validations)
 	assert.Equal(2, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "stillvalid"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "stillvalid"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
+	assert.Equal("spec/servers[0]/hosts[0]", validation.Checks[0].Path)
 }
 
 func TestDuplicateGatewaysErrorCount(t *testing.T) {
@@ -253,10 +254,10 @@ func TestDuplicateGatewaysErrorCount(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	validgateway, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "validgateway"}]
+	validgateway, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "validgateway"}]
 	assert.True(ok)
 
-	duplicatevalidgateway, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Name: "duplicatevalidgateway"}]
+	duplicatevalidgateway, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "duplicatevalidgateway"}]
 	assert.True(ok)
 
 	assert.Equal(2, len(validgateway.Checks))

--- a/business/checkers/mesh_policies_checker.go
+++ b/business/checkers/mesh_policies_checker.go
@@ -26,7 +26,7 @@ func (m MeshPolicyChecker) Check() models.IstioValidations {
 // runChecks runs all the individual checks for a single mesh policy and appends the result into validations.
 func (m MeshPolicyChecker) runChecks(meshPolicy kubernetes.IstioObject) models.IstioValidations {
 	meshPolicyName := meshPolicy.GetObjectMeta().Name
-	key, rrValidation := EmptyValidValidation(meshPolicyName, MeshPolicyCheckerType)
+	key, rrValidation := EmptyValidValidation(meshPolicyName, meshPolicy.GetObjectMeta().Namespace, MeshPolicyCheckerType)
 
 	enabledCheckers := []Checker{
 		meshpolicies.MeshMtlsChecker{MeshPolicy: meshPolicy, MTLSDetails: m.MTLSDetails, IsServiceMesh: false},

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -47,7 +47,7 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 }
 
 func runVirtualServiceCheck(virtualService kubernetes.IstioObject, namespace string, serviceNames []string, serviceHosts map[string][]string) models.IstioValidations {
-	key, validations := EmptyValidValidation(virtualService.GetObjectMeta().Name, VirtualCheckerType)
+	key, validations := EmptyValidValidation(virtualService.GetObjectMeta().Name, virtualService.GetObjectMeta().Namespace, VirtualCheckerType)
 
 	result, valid := virtual_services.NoHostChecker{
 		Namespace:         namespace,
@@ -63,7 +63,7 @@ func runVirtualServiceCheck(virtualService kubernetes.IstioObject, namespace str
 }
 
 func runGatewayCheck(virtualService kubernetes.IstioObject, gatewayNames map[string]struct{}) models.IstioValidations {
-	key, validations := EmptyValidValidation(virtualService.GetObjectMeta().Name, VirtualCheckerType)
+	key, validations := EmptyValidValidation(virtualService.GetObjectMeta().Name, virtualService.GetObjectMeta().Namespace, VirtualCheckerType)
 
 	result, valid := virtual_services.NoGatewayChecker{
 		VirtualService: virtualService,
@@ -77,7 +77,7 @@ func runGatewayCheck(virtualService kubernetes.IstioObject, gatewayNames map[str
 }
 
 func runDestinationRuleCheck(destinationRule kubernetes.IstioObject, namespace string, workloads models.WorkloadList, services []core_v1.Service, serviceHosts map[string][]string) models.IstioValidations {
-	key, validations := EmptyValidValidation(destinationRule.GetObjectMeta().Name, DestinationRuleCheckerType)
+	key, validations := EmptyValidValidation(destinationRule.GetObjectMeta().Name, destinationRule.GetObjectMeta().Namespace, DestinationRuleCheckerType)
 
 	result, valid := destinationrules.NoDestinationChecker{
 		Namespace:       namespace,
@@ -94,7 +94,7 @@ func runDestinationRuleCheck(destinationRule kubernetes.IstioObject, namespace s
 }
 
 func runServiceRoleCheck(serviceRole kubernetes.IstioObject, services []core_v1.Service) models.IstioValidations {
-	key, validations := EmptyValidValidation(serviceRole.GetObjectMeta().Name, ServiceRoleCheckerType)
+	key, validations := EmptyValidValidation(serviceRole.GetObjectMeta().Name, serviceRole.GetObjectMeta().Namespace, ServiceRoleCheckerType)
 
 	result, valid := authorization.ServiceChecker{
 		ServiceRole: serviceRole,

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -50,10 +50,10 @@ func TestAllIstioObjectWithServices(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	assert.NotEmpty(validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}])
-	assert.NotEmpty(validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "customer-dr"}])
-	assert.True(validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}].Valid)
-	assert.True(validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "customer-dr"}].Valid)
+	assert.NotEmpty(validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}])
+	assert.NotEmpty(validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "customer-dr"}])
+	assert.True(validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}].Valid)
+	assert.True(validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "customer-dr"}].Valid)
 }
 
 func TestDetectObjectWithoutService(t *testing.T) {
@@ -78,8 +78,8 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	assert.True(validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}].Valid)
-	customerDr := validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "customer-dr"}]
+	assert.True(validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}].Valid)
+	customerDr := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "customer-dr"}]
 	assert.False(customerDr.Valid)
 	assert.Equal(1, len(customerDr.Checks))
 	assert.Equal("spec/host", customerDr.Checks[0].Path)
@@ -101,8 +101,8 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	assert.True(validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "customer-dr"}].Valid)
-	productVs := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}]
+	assert.True(validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "customer-dr"}].Valid)
+	productVs := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}]
 	assert.False(productVs.Valid)
 	assert.Equal(2, len(productVs.Checks))
 	assert.Equal("spec/http[0]/route[0]/destination/host", productVs.Checks[0].Path)
@@ -126,7 +126,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	assert.True(validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "customer-dr"}].Valid)
+	assert.True(validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "customer-dr"}].Valid)
 
 	validations = NoServiceChecker{
 		Namespace: "test",
@@ -144,7 +144,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	}.Check()
 
 	assert.NotEmpty(validations)
-	assert.True(validations[models.IstioValidationKey{ObjectType: "destinationrule", Name: "customer-dr"}].Valid)
+	assert.True(validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "customer-dr"}].Valid)
 }
 
 func TestObjectWithoutGateway(t *testing.T) {
@@ -166,7 +166,7 @@ func TestObjectWithoutGateway(t *testing.T) {
 
 	assert.NotEmpty(validations)
 
-	productVs := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}]
+	productVs := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}]
 	assert.False(productVs.Valid)
 	assert.Equal("VirtualService is pointing to a non-existent gateway", productVs.Checks[0].Message)
 }

--- a/business/checkers/policies_checker.go
+++ b/business/checkers/policies_checker.go
@@ -26,7 +26,7 @@ func (m PolicyChecker) Check() models.IstioValidations {
 // runChecks runs all the individual checks for a single mesh policy and appends the result into validations.
 func (m PolicyChecker) runChecks(policy kubernetes.IstioObject) models.IstioValidations {
 	policyName := policy.GetObjectMeta().Name
-	key, rrValidation := EmptyValidValidation(policyName, PolicyCheckerType)
+	key, rrValidation := EmptyValidValidation(policyName, policy.GetObjectMeta().Namespace, PolicyCheckerType)
 
 	enabledCheckers := []Checker{
 		policies.NamespaceMtlsChecker{Policy: policy, MTLSDetails: m.MTLSDetails},

--- a/business/checkers/service_checker.go
+++ b/business/checkers/service_checker.go
@@ -25,7 +25,7 @@ func (sc ServiceChecker) Check() models.IstioValidations {
 }
 
 func (sc ServiceChecker) runSingleChecks(service v1.Service) models.IstioValidations {
-	key, validations := EmptyValidValidation(service.GetObjectMeta().GetName(), ServiceCheckerType)
+	key, validations := EmptyValidValidation(service.GetObjectMeta().GetName(), service.GetObjectMeta().GetNamespace(), ServiceCheckerType)
 
 	enabledCheckers := []Checker{
 		services.PortMappingChecker{Service: service, Deployments: sc.Deployments},

--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -22,7 +22,7 @@ func (s ServiceEntryChecker) Check() models.IstioValidations {
 }
 
 func (s ServiceEntryChecker) runSingleChecks(se kubernetes.IstioObject) models.IstioValidations {
-	key, validations := EmptyValidValidation(se.GetObjectMeta().Name, ServiceEntryCheckerType)
+	key, validations := EmptyValidValidation(se.GetObjectMeta().Name, se.GetObjectMeta().Namespace, ServiceEntryCheckerType)
 
 	enabledCheckers := []Checker{}
 

--- a/business/checkers/service_mesh_policies_checker.go
+++ b/business/checkers/service_mesh_policies_checker.go
@@ -26,7 +26,7 @@ func (m ServiceMeshPolicyChecker) Check() models.IstioValidations {
 // runChecks runs all the individual checks for a single mesh policy and appends the result into validations.
 func (m ServiceMeshPolicyChecker) runChecks(smPolicy kubernetes.IstioObject) models.IstioValidations {
 	meshPolicyName := smPolicy.GetObjectMeta().Name
-	key, rrValidation := EmptyValidValidation(meshPolicyName, ServiceMeshPolicyCheckerType)
+	key, rrValidation := EmptyValidValidation(meshPolicyName, smPolicy.GetObjectMeta().Namespace, ServiceMeshPolicyCheckerType)
 
 	enabledCheckers := []Checker{
 		// ServiceMeshPolicy is a clone of MeshPolicy so we can reuse the MeshMtlsChecker

--- a/business/checkers/service_role_bind_checker.go
+++ b/business/checkers/service_role_bind_checker.go
@@ -25,7 +25,7 @@ func (s ServiceRoleBindChecker) Check() models.IstioValidations {
 
 func (s ServiceRoleBindChecker) runChecks(roleBind kubernetes.IstioObject) models.IstioValidations {
 	serviceRoleBindName := roleBind.GetObjectMeta().Name
-	key := models.IstioValidationKey{Name: serviceRoleBindName, ObjectType: ServiceRoleBindingCheckerType}
+	key := models.IstioValidationKey{Name: serviceRoleBindName, Namespace: roleBind.GetObjectMeta().Namespace, ObjectType: ServiceRoleBindingCheckerType}
 	validations := &models.IstioValidation{
 		Name:       key.Name,
 		ObjectType: key.ObjectType,

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -56,7 +56,7 @@ func (in VirtualServiceChecker) runGroupChecks() models.IstioValidations {
 // runChecks runs all the individual checks for a single virtual service and appends the result into validations.
 func (in VirtualServiceChecker) runChecks(virtualService kubernetes.IstioObject) models.IstioValidations {
 	virtualServiceName := virtualService.GetObjectMeta().Name
-	key, rrValidation := EmptyValidValidation(virtualServiceName, VirtualCheckerType)
+	key, rrValidation := EmptyValidValidation(virtualServiceName, virtualService.GetObjectMeta().Namespace, VirtualCheckerType)
 
 	enabledCheckers := []Checker{
 		virtual_services.RouteChecker{Route: virtualService},

--- a/business/checkers/virtual_service_checker_test.go
+++ b/business/checkers/virtual_service_checker_test.go
@@ -16,7 +16,7 @@ func prepareTestForVirtualService(istioObject kubernetes.IstioObject) models.Ist
 
 	// Setup mocks
 	destinationList := []kubernetes.IstioObject{
-		data.CreateTestDestinationRule("test", "reviewsrule", "reviews"),
+		data.CreateTestDestinationRule("bookinfo", "reviewsrule", "reviews"),
 	}
 
 	virtualServiceChecker := VirtualServiceChecker{"bookinfo", destinationList, istioObjects}
@@ -34,7 +34,7 @@ func TestWellVirtualServiceValidation(t *testing.T) {
 	assert.NotEmpty(validations)
 
 	// Well configured object
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "reviews-well"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "reviews-well"}]
 	assert.True(ok)
 	assert.Equal(validation.Name, "reviews-well")
 	assert.Equal(validation.ObjectType, "virtualservice")
@@ -50,7 +50,7 @@ func TestVirtualServiceMultipleCheck(t *testing.T) {
 	assert.NotEmpty(validations)
 
 	// route rule with multiple problems
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "reviews-multiple"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "reviews-multiple"}]
 	assert.True(ok)
 	assert.Equal(validation.Name, "reviews-multiple")
 	assert.Equal(validation.ObjectType, "virtualservice")
@@ -66,7 +66,7 @@ func TestVirtualServiceMixedChecker(t *testing.T) {
 	assert.NotEmpty(validations)
 
 	// Precedence is incorrect
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "reviews-mixed"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "reviews-mixed"}]
 	assert.True(ok)
 	assert.Equal(validation.Name, "reviews-mixed")
 	assert.Equal(validation.ObjectType, "virtualservice")
@@ -79,7 +79,7 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 
 	// Setup mocks
 	destinationList := []kubernetes.IstioObject{
-		data.CreateTestDestinationRule("test", "reviewsrule1", "reviews"),
+		data.CreateTestDestinationRule("bookinfo", "reviewsrule1", "reviews"),
 	}
 
 	virtualServiceChecker := VirtualServiceChecker{"bookinfo",
@@ -88,14 +88,14 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 	validations := virtualServiceChecker.Check()
 	assert.NotEmpty(validations)
 
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "reviews-mixed"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "reviews-mixed"}]
 	assert.True(ok)
 	assert.Equal(validation.Name, "reviews-mixed")
 	assert.Equal(validation.ObjectType, "virtualservice")
 	assert.False(validation.Valid)
 	assert.Len(validation.Checks, 3)
 
-	validation, ok = validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "reviews-multiple"}]
+	validation, ok = validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "reviews-multiple"}]
 	assert.True(ok)
 	assert.Equal(validation.Name, "reviews-multiple")
 	assert.Equal(validation.ObjectType, "virtualservice")
@@ -106,7 +106,7 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 func fakeVirtualServices() kubernetes.IstioObject {
 	validVirtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 55),
 		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v2", 45),
-			data.CreateEmptyVirtualService("reviews-well", "prod", []string{"reviews.prod.svc.cluster.local"}),
+			data.CreateEmptyVirtualService("reviews-well", "bookinfo", []string{"reviews.prod.svc.cluster.local"}),
 		),
 	).DeepCopyIstioObject()
 

--- a/business/checkers/virtual_services/single_host_checker.go
+++ b/business/checkers/virtual_services/single_host_checker.go
@@ -31,8 +31,8 @@ func (in SingleHostChecker) Check() models.IstioValidations {
 
 	for _, clusterCounter := range hostCounter {
 		for _, namespaceCounter := range clusterCounter {
-			isNamespaceWildcard := len(namespaceCounter["*"]) > 0
 			for _, serviceCounter := range namespaceCounter {
+				isNamespaceWildcard := len(namespaceCounter["*"]) > 0
 				targetSameHost := len(serviceCounter) > 1
 				otherServiceHosts := len(namespaceCounter) > 1
 				for _, virtualService := range serviceCounter {
@@ -40,10 +40,23 @@ func (in SingleHostChecker) Check() models.IstioValidations {
 					// - there is more than one virtual service per a host
 					// - there is one virtual service with wildcard and there are other virtual services pointing
 					//   a host for that namespace
-					if targetSameHost || isNamespaceWildcard && otherServiceHosts {
-						if !hasGateways(virtualService) {
-							multipleVirtualServiceCheck(*virtualService, validations)
+					if hasGateways(virtualService) {
+						continue
+					}
+
+					if targetSameHost {
+						// Reference everything within serviceCounter
+						multipleVirtualServiceCheck(*virtualService, validations, serviceCounter)
+					}
+
+					if isNamespaceWildcard && otherServiceHosts {
+						// Reference the * or in case of * the other hosts inside namespace
+						// or other stars
+						refs := make([]*kubernetes.IstioObject, 0, len(namespaceCounter))
+						for _, serviceCounter := range namespaceCounter {
+							refs = append(refs, serviceCounter...)
 						}
+						multipleVirtualServiceCheck(*virtualService, validations, refs)
 					}
 				}
 			}
@@ -53,7 +66,7 @@ func (in SingleHostChecker) Check() models.IstioValidations {
 	return validations
 }
 
-func multipleVirtualServiceCheck(virtualService kubernetes.IstioObject, validations models.IstioValidations) {
+func multipleVirtualServiceCheck(virtualService kubernetes.IstioObject, validations models.IstioValidations, references []*kubernetes.IstioObject) {
 	virtualServiceName := virtualService.GetObjectMeta().Name
 	key := models.IstioValidationKey{Name: virtualServiceName, ObjectType: "virtualservice"}
 	checks := models.Build("virtualservices.singlehost", "spec/hosts")
@@ -64,6 +77,15 @@ func multipleVirtualServiceCheck(virtualService kubernetes.IstioObject, validati
 		Checks: []*models.IstioCheck{
 			&checks,
 		},
+		References: make([]models.IstioValidationKey, 0, len(references)),
+	}
+
+	for _, ref := range references {
+		ref := *ref
+		refKey := models.IstioValidationKey{Name: ref.GetObjectMeta().Name, ObjectType: "virtualservice"}
+		if refKey != key {
+			rrValidation.References = append(rrValidation.References, refKey)
+		}
 	}
 
 	validations.MergeValidations(models.IstioValidations{key: rrValidation})
@@ -131,12 +153,9 @@ func formatHostForSearch(hostName, virtualServiceNamespace string) Host {
 		if len(domainParts) > 2 {
 			host.Cluster = strings.Join(domainParts[2:], ".")
 		}
-	} else if host.Service != "*" {
+	} else {
 		host.Namespace = virtualServiceNamespace
 		host.Cluster = "svc.cluster.local"
-	} else if host.Service == "*" {
-		host.Namespace = "*"
-		host.Cluster = "*"
 	}
 
 	return host

--- a/business/checkers/virtual_services/single_host_checker.go
+++ b/business/checkers/virtual_services/single_host_checker.go
@@ -68,7 +68,7 @@ func (in SingleHostChecker) Check() models.IstioValidations {
 
 func multipleVirtualServiceCheck(virtualService kubernetes.IstioObject, validations models.IstioValidations, references []*kubernetes.IstioObject) {
 	virtualServiceName := virtualService.GetObjectMeta().Name
-	key := models.IstioValidationKey{Name: virtualServiceName, ObjectType: "virtualservice"}
+	key := models.IstioValidationKey{Name: virtualServiceName, Namespace: virtualService.GetObjectMeta().Namespace, ObjectType: "virtualservice"}
 	checks := models.Build("virtualservices.singlehost", "spec/hosts")
 	rrValidation := &models.IstioValidation{
 		Name:       virtualServiceName,
@@ -82,7 +82,7 @@ func multipleVirtualServiceCheck(virtualService kubernetes.IstioObject, validati
 
 	for _, ref := range references {
 		ref := *ref
-		refKey := models.IstioValidationKey{Name: ref.GetObjectMeta().Name, ObjectType: "virtualservice"}
+		refKey := models.IstioValidationKey{Name: ref.GetObjectMeta().Name, Namespace: ref.GetObjectMeta().Namespace, ObjectType: "virtualservice"}
 		if refKey != key {
 			rrValidation.References = append(rrValidation.References, refKey)
 		}

--- a/business/checkers/virtual_services/single_host_checker_test.go
+++ b/business/checkers/virtual_services/single_host_checker_test.go
@@ -346,11 +346,11 @@ func emptyValidationTest(t *testing.T, validations models.IstioValidations) {
 	assert := assert.New(t)
 	assert.Empty(validations)
 
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "virtual-1"}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-1"}]
 	assert.False(ok)
 	assert.Nil(validation)
 
-	validation, ok = validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "virtual-2"}]
+	validation, ok = validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-2"}]
 	assert.False(ok)
 	assert.Nil(validation)
 }
@@ -358,7 +358,7 @@ func emptyValidationTest(t *testing.T, validations models.IstioValidations) {
 func noObjectValidationTest(t *testing.T, validations models.IstioValidations, name string) {
 	assert := assert.New(t)
 
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: name}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: name}]
 	assert.False(ok)
 	assert.Nil(validation)
 }
@@ -367,7 +367,7 @@ func presentValidationTest(t *testing.T, validations models.IstioValidations, se
 	assert := assert.New(t)
 	assert.NotEmpty(validations)
 
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: serviceName}]
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: serviceName}]
 	assert.True(ok)
 
 	assert.True(validation.Valid)
@@ -379,7 +379,7 @@ func presentValidationTest(t *testing.T, validations models.IstioValidations, se
 
 func presentReference(t *testing.T, validation models.IstioValidation, serviceName string) {
 	assert := assert.New(t)
-	refKey := models.IstioValidationKey{ObjectType: "virtualservice", Name: serviceName}
+	refKey := models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: serviceName}
 
 	assert.True(len(validation.References) > 0)
 	assert.Contains(validation.References, refKey)

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -29,7 +29,7 @@ func TestGetNamespaceValidations(t *testing.T) {
 
 	validations, _ := vs.GetValidations("test", "")
 	assert.NotEmpty(validations)
-	assert.True(validations[models.IstioValidationKey{ObjectType: "virtualservice", Name: "product-vs"}].Valid)
+	assert.True(validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}].Valid)
 }
 
 func TestGetIstioObjectValidations(t *testing.T) {

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -218,7 +218,7 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 	if includeValidations && err == nil {
 		wg.Wait()
 
-		if validation, found := istioConfigValidations[models.IstioValidationKey{ObjectType: models.ObjectTypeSingular[objectType], Name: object}]; found {
+		if validation, found := istioConfigValidations[models.IstioValidationKey{ObjectType: models.ObjectTypeSingular[objectType], Namespace: namespace, Name: object}]; found {
 			istioConfigDetails.IstioValidation = validation
 		}
 	}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -286,7 +286,15 @@ func (iv IstioValidations) MergeValidations(validations IstioValidations) IstioV
 				v.Checks = append(v.Checks, toAdd)
 			}
 			v.Valid = v.Valid && validation.Valid
-			v.References = append(v.References, validation.References...)
+		AddUniqueReference:
+			for _, toAdd := range validation.References {
+				for _, existing := range v.References {
+					if toAdd == existing {
+						continue AddUniqueReference
+					}
+				}
+				v.References = append(v.References, toAdd)
+			}
 		}
 	}
 	return iv

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -9,8 +9,8 @@ type NamespaceValidations map[string]IstioValidations
 
 // IstioValidationKey is the key value composed of an Istio ObjectType and Name.
 type IstioValidationKey struct {
-	ObjectType string
-	Name       string
+	ObjectType string `json:"objectType"`
+	Name       string `json:"name"`
 }
 
 // IstioValidations represents a set of IstioValidation grouped by IstioValidationKey.
@@ -38,7 +38,7 @@ type IstioValidation struct {
 	Checks []*IstioCheck `json:"checks"`
 
 	// Related objects (only validation errors)
-	References []IstioValidationKey
+	References []IstioValidationKey `json:"references"`
 }
 
 // IstioCheck represents an individual check.

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -36,6 +36,9 @@ type IstioValidation struct {
 
 	// Array of checks. It might be empty.
 	Checks []*IstioCheck `json:"checks"`
+
+	// Related objects (only validation errors)
+	References []IstioValidationKey
 }
 
 // IstioCheck represents an individual check.
@@ -283,8 +286,22 @@ func (iv IstioValidations) MergeValidations(validations IstioValidations) IstioV
 				v.Checks = append(v.Checks, toAdd)
 			}
 			v.Valid = v.Valid && validation.Valid
+			v.References = append(v.References, validation.References...)
 		}
 	}
+	return iv
+}
+
+func (iv IstioValidations) MergeReferences(validations IstioValidations) IstioValidations {
+	for _, currentValidations := range iv {
+		if currentValidations.References == nil {
+			currentValidations.References = make([]IstioValidationKey, 0, len(validations))
+		}
+		for k := range validations {
+			currentValidations.References = append(currentValidations.References, k)
+		}
+	}
+
 	return iv
 }
 

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -11,6 +11,7 @@ type NamespaceValidations map[string]IstioValidations
 type IstioValidationKey struct {
 	ObjectType string `json:"objectType"`
 	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
 }
 
 // IstioValidations represents a set of IstioValidation grouped by IstioValidationKey.
@@ -216,8 +217,8 @@ func Build(checkId string, path string) IstioCheck {
 	return check
 }
 
-func BuildKey(objectType, name string) IstioValidationKey {
-	return IstioValidationKey{ObjectType: objectType, Name: name}
+func BuildKey(objectType, name, namespace string) IstioValidationKey {
+	return IstioValidationKey{ObjectType: objectType, Namespace: namespace, Name: name}
 }
 
 func CheckMessage(checkId string) string {

--- a/models/istio_validation_test.go
+++ b/models/istio_validation_test.go
@@ -11,12 +11,12 @@ func TestIstioValidationsMarshal(t *testing.T) {
 	assert := assert.New(t)
 
 	validations := IstioValidations{
-		IstioValidationKey{"virtualservice", "foo"}: &IstioValidation{
+		IstioValidationKey{ObjectType: "virtualservice", Name: "foo"}: &IstioValidation{
 			Name:       "foo",
 			ObjectType: "virtualservice",
 			Valid:      true,
 		},
-		IstioValidationKey{"virtualservice", "bar"}: &IstioValidation{
+		IstioValidationKey{ObjectType: "virtualservice", Name: "bar"}: &IstioValidation{
 			Name:       "bar",
 			ObjectType: "virtualservice",
 			Valid:      false,
@@ -36,5 +36,5 @@ func TestIstioValidationKeyMarshal(t *testing.T) {
 	}
 	b, err := json.Marshal(validationKey)
 	assert.NoError(err)
-	assert.Equal(string(b), `{"objectType":"virtualservice","name":"foo"}`)
+	assert.Equal(string(b), `{"objectType":"virtualservice","name":"foo","namespace":""}`)
 }

--- a/models/istio_validation_test.go
+++ b/models/istio_validation_test.go
@@ -23,6 +23,18 @@ func TestIstioValidationsMarshal(t *testing.T) {
 		},
 	}
 	b, err := json.Marshal(validations)
-	assert.Empty(err)
-	assert.Equal(string(b), `{"virtualservice":{"bar":{"name":"bar","objectType":"virtualservice","valid":false,"checks":null},"foo":{"name":"foo","objectType":"virtualservice","valid":true,"checks":null}}}`)
+	assert.NoError(err)
+	assert.Equal(string(b), `{"virtualservice":{"bar":{"name":"bar","objectType":"virtualservice","valid":false,"checks":null,"references":null},"foo":{"name":"foo","objectType":"virtualservice","valid":true,"checks":null,"references":null}}}`)
+}
+
+func TestIstioValidationKeyMarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	validationKey := IstioValidationKey{
+		ObjectType: "virtualservice",
+		Name:       "foo",
+	}
+	b, err := json.Marshal(validationKey)
+	assert.NoError(err)
+	assert.Equal(string(b), `{"objectType":"virtualservice","name":"foo"}`)
 }

--- a/swagger.json
+++ b/swagger.json
@@ -3881,11 +3881,34 @@
           "x-go-name": "ObjectType",
           "example": "virtualservice"
         },
+        "references": {
+          "description": "Related objects (only validation errors)",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IstioValidationKey"
+          },
+          "x-go-name": "References"
+        },
         "valid": {
           "description": "Represents validity of the object: in case of warning, validity remains as true",
           "type": "boolean",
           "x-go-name": "Valid",
           "example": false
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "IstioValidationKey": {
+      "type": "object",
+      "title": "IstioValidationKey is the key value composed of an Istio ObjectType and Name.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "objectType": {
+          "type": "string",
+          "x-go-name": "ObjectType"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"

--- a/swagger.json
+++ b/swagger.json
@@ -3906,6 +3906,10 @@
           "type": "string",
           "x-go-name": "Name"
         },
+        "namespace": {
+          "type": "string",
+          "x-go-name": "Namespace"
+        },
         "objectType": {
           "type": "string",
           "x-go-name": "ObjectType"


### PR DESCRIPTION
** Describe the change **

As described in the issue #1419, certain resources are causing each other validation errors. This change adds links to those other objects which could have caused the validation issue to each other (since we don't know which one the user has incorrectly defined).

This PR includes only a sample for multimatch gateway validations, nothing else so far. Waiting for input first.

Also makes the logic in multi_match_checker a little more sane (instead of relying only on the duplicate removal).

** Issue reference **

Closes issue #1419 

** Backwards incompatible? **

Yes. If we want to take advantage of the feature in the UI, then UI will require changes.
