### PR TITLE
bookinfo hack script: add bookinfo-ratings-v2 service account for OS

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -124,11 +124,13 @@ if [[ "$CLIENT_EXE" = *"oc" ]]; then
   $CLIENT_EXE adm policy add-scc-to-user anyuid -z bookinfo-details -n ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user anyuid -z bookinfo-productpage -n ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user anyuid -z bookinfo-ratings -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user anyuid -z bookinfo-ratings-v2 -n ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user anyuid -z bookinfo-reviews -n ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user privileged -z default -n ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user privileged -z bookinfo-details -n ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user privileged -z bookinfo-productpage -n ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user privileged -z bookinfo-ratings -n ${NAMESPACE}
+  $CLIENT_EXE adm policy add-scc-to-user privileged -z bookinfo-ratings-v2 -n ${NAMESPACE}
   $CLIENT_EXE adm policy add-scc-to-user privileged -z bookinfo-reviews -n ${NAMESPACE}
 else
   $CLIENT_EXE create namespace ${NAMESPACE}


### PR DESCRIPTION
the --mongo option installs ratings-v2, but it uses an additional service account: bookinfo-ratings-v2.

@jmazzitelli please sanity check.