### PR TITLE
getting ready for operator phase 2

### DIFF
--- a/operator/deploy/deploy-kiali-operator.sh
+++ b/operator/deploy/deploy-kiali-operator.sh
@@ -157,7 +157,9 @@
 #
 # KIALI_IMAGE_NAME
 #    Determines which image of Kiali to download and install.
-#    Default: "kiali/kiali"
+#    If you set this, you must make sure that image is supported by the operator.
+#    If left empty (the default), the operator will use a known supported image.
+#    Default: ""
 #
 # KIALI_IMAGE_PULL_POLICY
 #    The Kubernetes pull policy for the Kiali deployment.
@@ -169,9 +171,11 @@
 #    This can be set to "latest" in which case the latest image is installed (which may or
 #    may not be a released version of Kiali). This is normally for developer use only.
 #    This can be set to "lastrelease" in which case the last Kiali release is installed.
-#    Otherwise, you can set to this any valid Kiali version (such as "v0.12").
+#    Otherwise, you can set this to any valid Kiali version (such as "v1.0").
 #    NOTE: If this is set to "latest" then the KIALI_IMAGE_PULL_POLICY will be "Always".
-#    Default: "lastrelease"
+#    If you set this, you must make sure that image is supported by the operator.
+#    If left empty (the default), the operator will use a known supported image.
+#    Default: ""
 #
 # ISTIO_NAMESPACE
 #    The namespace where Istio is installed. If empty, assumes the value of NAMESPACE.
@@ -401,14 +405,16 @@ Valid options for Kiali installation (if Kiali is to be installed):
       Default: ""
   -kin|--kiali-image-name
       Determines which image of Kiali to download and install.
-      Default: "kiali/kiali"
+      If left empty (the default), the operator will use a known supported image.
+      Default: ""
   -kipp|--kiali-image-pull-policy
       The Kubernetes pull policy for the Kiali deployment.
       Default: "IfNotPresent"
   -kiv|--kiali-image-version
       Determines which version of Kiali to install.
       Can be a version string or "latest" or "lastrelease".
-      Default: "lastrelease"
+      If left empty (the default), the operator will use a known supported image.
+      Default: ""
   -in|--istio-namespace
       The namespace where Istio is installed.
       If empty, assumes the value of the namespace option.
@@ -644,7 +650,7 @@ fi
 # If asking for the last release of Kiali (which is the default), then pick up the latest release.
 # Note that you could ask for "latest" - that would pick up the current image built from master.
 if [ "${OPERATOR_INSTALL_KIALI}" == "true" ]; then
-  if [ "${KIALI_IMAGE_VERSION:-lastrelease}" == "lastrelease" ]; then
+  if [ "${KIALI_IMAGE_VERSION}" == "lastrelease" ]; then
     resolve_latest_kiali_release
     echo "Will use the last Kiali release: ${kiali_version_we_want}"
     KIALI_IMAGE_VERSION=${kiali_version_we_want}

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -160,8 +160,10 @@ spec:
 #      pod_anti: {}
 #
 # Determines which Kiali image to download and install.
+# If you set this to a specific name, you must make sure that image is supported by the operator.
+# If empty, the operator will use a known supported image name.
 #    ---
-#    image_name: "quay.io/kiali/kiali"
+#    image_name: ""
 #
 # The Kubernetes pull policy for the Kiali deployment.
 # This is overridden to be "Always" if image_version is set to "latest".
@@ -175,10 +177,13 @@ spec:
 # Determines which version of Kiali to install.
 # Choose "lastrelease" to use the last Kiali release.
 # Choose "latest" to use the latest image (which may or may not be a released version of Kiali).
-# Otherwise, you can set this to any valid Kiali version (such as "v0.12").
+# Otherwise, you can set this to any valid Kiali version (such as "v1.0").
 # Note that if this is set to "latest" then the image_pull_policy will be "Always".
+# If you set this to a specific version (i.e. you do not leave it as the default empty string),
+# you must make sure that image version is supported by the operator.
+# If empty, the operator will use a known supported image version.
 #    ---
-#    image_version: "lastrelease"
+#    image_version: ""
 #
 # Determines if the Kiali endpoint should be exposed externally.
 # If true, an Ingress will be created if on Kubernetes or a Route if on OpenShift.

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -45,6 +45,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: OPERATOR_NAME
           value: "kiali-operator"
       volumes:

--- a/operator/manifests/README.adoc
+++ b/operator/manifests/README.adoc
@@ -30,17 +30,15 @@ oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-o
 Now remove the OperatorSources for the different out-of-box sources:
 
 ```
-oc patch operatorsources community-operators -n openshift-marketplace -p '{"spec":{"unmanaged":true}}' --type=merge
+oc delete operatorsources certified-operators -n openshift-marketplace
 oc delete operatorsources community-operators -n openshift-marketplace
-
-oc patch operatorsources redhat-operators -n openshift-marketplace -p '{"spec":{"unmanaged":true}}' --type=merge
 oc delete operatorsources redhat-operators -n openshift-marketplace
 ```
 
 You can disable all OperatorSources in your cluster via:
 
 ```
-for o in $(oc get operatorsources -n openshift-marketplace -o name); do oc patch $o -n openshift-marketplace -p '{"spec":{"unmanaged":true}}' --type=merge ; oc delete $o -n openshift-marketplace ; done
+for o in $(oc get operatorsources -n openshift-marketplace -o name); do oc delete $o -n openshift-marketplace ; done
 ```
 
 _OpenShift 4.2 instructions_
@@ -57,6 +55,10 @@ metadata:
 spec:
   disableAllDefaultSources: true
   sources: [
+    {
+      name: "certified-operators",
+      disabled: true
+    },
     {
       name: "community-operators",
       disabled: true

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -51,10 +51,10 @@ kiali_defaults:
       node: {}
       pod: {}
       pod_anti: {}
-    image_name: "quay.io/kiali/kiali"
+    image_name: ""
     image_pull_policy: "IfNotPresent"
     image_pull_secrets: []
-    image_version: "lastrelease"
+    image_version: ""
     ingress_enabled: true
     namespace: "istio-system"
     secret_name: "kiali"
@@ -146,6 +146,7 @@ kiali_defaults:
 
 # These variables are outside of the kiali_defaults. Their values will be
 # auto-detected by the role and are not meant to be set by the user.
-# However, for debugging purposes you can force one of these to true.
+# However, for debugging purposes you can change these.
 is_k8s: false
 is_openshift: false
+supported_image: {"name": "quay.io/kiali/kiali", "version": "v1.4" }

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -147,6 +147,10 @@ kiali_defaults:
 # These variables are outside of the kiali_defaults. Their values will be
 # auto-detected by the role and are not meant to be set by the user.
 # However, for debugging purposes you can change these.
+# If supported_image.version is "operator_version" then the version of the
+# operator itself will be assumed, otherwise it can be any valid Kiali
+# version string. If the Kiali CR does not provide an image name or version,
+# supported_image defines the defaults that will be used.
 is_k8s: false
 is_openshift: false
-supported_image: {"name": "quay.io/kiali/kiali", "version": "v1.4" }
+supported_image: {"name": "quay.io/kiali/kiali", "version": "operator_version" }

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -181,6 +181,16 @@
   when:
   - kiali_vars.identity.private_key_file is not defined
 
+- name: Default the image name to a known supported image.
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_name': supported_image.name}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.image_name == ""
+- name: Default the image version to a known supported image.
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': supported_image.version}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.image_version == ""
 - name: If image version is latest then we will want to always pull
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_pull_policy': 'Always'}}, recursive=True) }}"

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -25,6 +25,30 @@
   - is_openshift == False
   - is_k8s == False
 
+- name: Get information about the operator
+  k8s_facts:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+    name: "{{ lookup('env', 'POD_NAME') }}"
+  register: operator_pod_raw
+  ignore_errors: yes
+- name: Determine the version of the operator based on the version label
+  set_fact:
+    operator_version: "{{ operator_pod_raw.resources[0].metadata.labels.version }}"
+  when:
+  - operator_pod_raw is defined
+  - operator_pod_raw.resources[0] is defined
+  - operator_pod_raw.resources[0].metadata is defined
+  - operator_pod_raw.resources[0].metadata.labels is defined
+  - operator_pod_raw.resources[0].metadata.labels.version is defined
+- set_fact:
+    operator_version: "unknown"
+  when:
+  - operator_version is not defined
+- debug:
+    msg: "OPERATOR VERSION: [{{ operator_version }}]"
+
 # Because we are passing through some yaml directly to Kubernetes resources, we have to retain the camelCase keys.
 # All CR parameters are converted to snake_case, but the original yaml is found in the special _kiali_io_kiali param.
 # We need to copy that original yaml into our vars where appropriate to keep the camelCase.
@@ -188,7 +212,7 @@
   - kiali_vars.deployment.image_name == ""
 - name: Default the image version to a known supported image.
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': supported_image.version}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': operator_version if supported_image.version == 'operator_version' else supported_image.version}}, recursive=True) }}"
   when:
   - kiali_vars.deployment.image_version == ""
 - name: If image version is latest then we will want to always pull

--- a/operator/roles/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -11,7 +11,6 @@ spec:
   selector:
     matchLabels:
       app: kiali
-      version: {{ kiali_vars.deployment.version_label }}
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/operator/roles/kiali-deploy/templates/openshift/deployment.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/deployment.yaml
@@ -11,7 +11,6 @@ spec:
   selector:
     matchLabels:
       app: kiali
-      version: {{ kiali_vars.deployment.version_label }}
   template:
     metadata:
       name: kiali


### PR DESCRIPTION
fixes #1618 

This will be work to see the operator work with OLM as a "phase 2" operator (meaning seamless upgrades).

Phases are part of the maturity model as described [here](https://github.com/operator-framework/operatorhub-docs/blob/master/building-operators/building-operators/types-of-operators.md#operator-maturity-model) and [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.png)