### PR TITLE
Do not do prefix matching for multi-cluster ServiceEntry

### DIFF
--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -167,7 +167,18 @@ func (a ServiceEntryAppender) getServiceEntry(serviceName string, globalInfo *gr
 		}
 		// handle serviceName prefix (e.g. host = serviceName.namespace.svc.cluster.local)
 		if se.location == "MESH_INTERNAL" {
-			if strings.Split(host, ".")[0] == serviceName {
+			hostSplitted := strings.Split(host, ".")
+
+			if len(hostSplitted) == 3 && hostSplitted[2] == "global" {
+				// If suffix is "global", this node should be a service entry
+				// related to multi-cluster configs. Only exact match should be done, so
+				// skip prefix matching.
+				//
+				// Number of entries == 3 in the host is checked because the host
+				// must be of the form svc.namespace.global for Istio to
+				// work correctly in the multi-cluster/multiple-control-plane scenario.
+				continue
+			} else if hostSplitted[0] == serviceName {
 				return se, true
 			}
 		}


### PR DESCRIPTION
It was assumed that MESH_INTERNAL ServiceEntries refer to services in the local cluster. But when Istio is setup in a multi-cluster scenario, MESH_INTERNAL ServiceEntries are also used to route traffic to services in remote clusters.

ServiceEntries that route traffic to remote clusters must have a hostnames configured of the form remote_svc_name.remote_ns_name.global. I.e. always have three entries and last entry is the static string "global". This helps to clearly differentiate ServiceEntries are referring to local services and the ones that are routing traffic to remote clusters. This changes are implementing this logic.

This fixes #1364, fixes #1365, fixes #1366, fixes #1367