### PR TITLE
Fix jaeger security v1.0

### DIFF
--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -77,6 +77,6 @@ func getErrorTracesFromJaeger(namespace string, service string, requestToken str
 }
 
 func GetJaegerInternalURL(path string) (*url.URL, error) {
-	return url.Parse(fmt.Sprintf("http://%s.%s:%d%s%s", appstate.JaegerConfig.Service,
+	return url.Parse(fmt.Sprintf("https://%s.%s:%d%s%s", appstate.JaegerConfig.Service,
 		appstate.JaegerConfig.Namespace, appstate.JaegerConfig.Port, appstate.JaegerConfig.Path, path))
 }

--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -77,6 +77,6 @@ func getErrorTracesFromJaeger(namespace string, service string, requestToken str
 }
 
 func GetJaegerInternalURL(path string) (*url.URL, error) {
-	return url.Parse(fmt.Sprintf("https://%s.%s:%d%s%s", appstate.JaegerConfig.Service,
+	return url.Parse(fmt.Sprintf("https://%s.%s.svc:%d%s%s", appstate.JaegerConfig.Service,
 		appstate.JaegerConfig.Namespace, appstate.JaegerConfig.Port, appstate.JaegerConfig.Path, path))
 }


### PR DESCRIPTION
Fix #1626 

Working with 
```yaml
tracing:
        auth:
          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
          insecure_skip_verify: false
          password: ta2NF3MxwKENIoG/X6HU5kSIdEPb3iF2IxujK2K3UhYJmo9cOq62duZTiliSyHoS/AtTY2l5ZNV9PnRxlCRsPGNYPa0BeAMB5rRwP7R8/D9PxzulRVd7Av8Y490r8BcRyOipQwYdPxhQMjNKKWo1KLgGpzOwEvGIT3nzZ5hAR70j1qWlYezlxuykteW5TB86BqQhfNgUrpu4Z0z6zFZvO+aIL+JC7Uv5bXb1SUbjmw7dCLENMobdZt2o+/XrXKt5zvuZKpXF6UIozLpi2tO05SjjupKL+y7Pq7D0MPKShqxCD8l87Q91fYeOX4v7CmpUUIubRnmyMJ5rIQz9Wvr4
          token: ''
          type: basic
          use_kiali_token: false
          username: internal
        enabled: true
        namespace: istio-system.svc
        port: 443
        service: jaeger-query
        url: https://jaeger-istio-system.apps.ocp4-kqe1.maistra.upshift.redhat.com
```