### PR TITLE
KIALI#1605 Update route to redirect http to https

### DIFF
--- a/operator/roles/kiali-deploy/templates/openshift/route.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/route.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   tls:
     termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
   to:
     kind: Service
     targetPort: {{ kiali_vars.server.port }}


### PR DESCRIPTION
**Describe the change**

Updates the route so that if a use enters the url using 'http' it will redirect them to the 'https' endpoint instead.

closes https://github.com/kiali/kiali/issues/1605


