### PR TITLE
Re-label telemetry destination_service={*.global} to hostname only

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -114,6 +114,10 @@ const (
 	LoginSecretPassphrase = "/kiali-secret/passphrase"
 )
 
+const (
+	IstioMultiClusterHostSuffix = "global"
+)
+
 // Global configuration for the application.
 var configuration Config
 var rwMutex sync.RWMutex

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -169,7 +170,7 @@ func (a ServiceEntryAppender) getServiceEntry(serviceName string, globalInfo *gr
 		if se.location == "MESH_INTERNAL" {
 			hostSplitted := strings.Split(host, ".")
 
-			if len(hostSplitted) == 3 && hostSplitted[2] == "global" {
+			if len(hostSplitted) == 3 && hostSplitted[2] == config.IstioMultiClusterHostSuffix {
 				// If suffix is "global", this node should be a service entry
 				// related to multi-cluster configs. Only exact match should be done, so
 				// skip prefix matching.

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -387,24 +387,7 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o gra
 		flags := string(lFlags)
 
 		val := float64(s.Value)
-
-		destSvcNameEntries := strings.Split(destSvcName, ".")
-		if sourceWlNs == graph.Unknown && sourceWl == graph.Unknown &&
-			len(destSvcNameEntries) == 3 && destSvcNameEntries[2] == config.IstioMultiClusterHostSuffix {
-			// For multi-cluster setup, if "we are" the DESTINATION cluster of traffic,
-			// the destination_service_name label will contain the
-			// hostname that the source cluster requested. Since we know that the requested hostname
-			// has the form "svc_name.ns_name.global", we can truncate the destSvcName to the
-			// prefix to correctly unify svc nodes. This way, the graph will show only one "svc_name" node
-			// instead of duplicating and having one "svc_name" and one "svc_name.ns_name.global" node which,
-			// in practice, are same.
-			//
-			// This is done only if source workload is "unknown" which is what is recorded in telemetry
-			// when traffic is coming from a remote cluster. If source workload IS known,
-			// then, traffic is most-likely going to a ServiceEntry and being routed out of the cluster (i.e.
-			// the "source cluster" case). That case is handled in the service_entry.go file.
-			destSvcName = destSvcNameEntries[0]
-		}
+		destSvcName = handleMultiClusterServiceName(sourceWlNs, sourceWl, destSvcName)
 
 		if o.InjectServiceNodes {
 			// don't inject a service node if the dest node is already a service node.  Also, we can't inject if destSvcName is not set.
@@ -487,24 +470,7 @@ func populateTrafficMapTcp(trafficMap graph.TrafficMap, vector *model.Vector, o 
 		flags := string(lFlags)
 
 		val := float64(s.Value)
-
-		destSvcNameEntries := strings.Split(destSvcName, ".")
-		if sourceWlNs == graph.Unknown && sourceWl == graph.Unknown &&
-			len(destSvcNameEntries) == 3 && destSvcNameEntries[2] == config.IstioMultiClusterHostSuffix {
-			// For multi-cluster setup, if "we are" the DESTINATION cluster of traffic,
-			// the destination_service_name label will contain the
-			// hostname that the source cluster requested. Since we know that the requested hostname
-			// has the form "svc_name.ns_name.global", we can truncate the destSvcName to the
-			// prefix to correctly unify svc nodes. This way, the graph will show only one "svc_name" node
-			// instead of duplicating and having one "svc_name" and one "svc_name.ns_name.global" node which,
-			// in practice, are same.
-			//
-			// This is done only if source workload is "unknown" which is what is recorded in telemetry
-			// when traffic is coming from a remote cluster. If source workload IS known,
-			// then, traffic is most-likely going to a ServiceEntry and being routed out of the cluster (i.e.
-			// the "source cluster" case). That case is handled in the service_entry.go file.
-			destSvcName = destSvcNameEntries[0]
-		}
+		destSvcName = handleMultiClusterServiceName(sourceWlNs, sourceWl, destSvcName)
 
 		if o.InjectServiceNodes {
 			// don't inject a service node if the dest node is already a service node.  Also, we can't inject if destSvcName is not set.
@@ -901,4 +867,31 @@ func promQuery(query string, queryTime time.Time, api prom_v1.API) model.Vector 
 	}
 
 	return nil
+}
+
+// handleMultiClusterServiceName resolves the right name for the destination svc
+// given a multi-cluster setup.
+//
+// For multi-cluster setup, if "we are" the DESTINATION cluster of traffic,
+// the destination_service_name label will contain the
+// hostname that the source cluster requested. Since we know that the requested hostname
+// has the form "svc_name.ns_name.global", we can truncate the destSvcName to the
+// prefix to correctly unify svc nodes. This way, the graph will show only one "svc_name" node
+// instead of duplicating and having one "svc_name" and one "svc_name.ns_name.global" node which,
+// in practice, are same.
+//
+// This is done only if source workload is "unknown" which is what is recorded in telemetry
+// when traffic is coming from a remote cluster. If source workload IS known,
+// then, traffic is most-likely going to a ServiceEntry and being routed out of the cluster (i.e.
+// the "source cluster" case). That case is handled in the service_entry.go file.
+func handleMultiClusterServiceName(sourceWlNs, sourceWl, destSvcName string) string {
+	if sourceWlNs == graph.Unknown && sourceWl == graph.Unknown {
+		destSvcNameEntries := strings.Split(destSvcName, ".")
+
+		if len(destSvcNameEntries) == 3 && destSvcNameEntries[2] == config.IstioMultiClusterHostSuffix {
+			destSvcName = destSvcNameEntries[0]
+		}
+	}
+
+	return destSvcName
 }

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -388,6 +388,24 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o gra
 
 		val := float64(s.Value)
 
+		destSvcNameEntries := strings.Split(destSvcName, ".")
+		if sourceWlNs == graph.Unknown && sourceWl == graph.Unknown &&
+			len(destSvcNameEntries) == 3 && destSvcNameEntries[2] == config.IstioMultiClusterHostSuffix {
+			// For multi-cluster setup, if "we are" the DESTINATION cluster of traffic,
+			// the destination_service_name label will contain the
+			// hostname that the source cluster requested. Since we know that the requested hostname
+			// has the form "svc_name.ns_name.global", we can truncate the destSvcName to the
+			// prefix to correctly unify svc nodes. This way, the graph will show only one "svc_name" node
+			// instead of duplicating and having one "svc_name" and one "svc_name.ns_name.global" node which,
+			// in practice, are same.
+			//
+			// This is done only if source workload is "unknown" which is what is recorded in telemetry
+			// when traffic is coming from a remote cluster. If source workload IS known,
+			// then, traffic is most-likely going to a ServiceEntry and being routed out of the cluster (i.e.
+			// the "source cluster" case). That case is handled in the service_entry.go file.
+			destSvcName = destSvcNameEntries[0]
+		}
+
 		if o.InjectServiceNodes {
 			// don't inject a service node if the dest node is already a service node.  Also, we can't inject if destSvcName is not set.
 			destSvcNameOk = graph.IsOK(destSvcName)
@@ -469,6 +487,24 @@ func populateTrafficMapTcp(trafficMap graph.TrafficMap, vector *model.Vector, o 
 		flags := string(lFlags)
 
 		val := float64(s.Value)
+
+		destSvcNameEntries := strings.Split(destSvcName, ".")
+		if sourceWlNs == graph.Unknown && sourceWl == graph.Unknown &&
+			len(destSvcNameEntries) == 3 && destSvcNameEntries[2] == config.IstioMultiClusterHostSuffix {
+			// For multi-cluster setup, if "we are" the DESTINATION cluster of traffic,
+			// the destination_service_name label will contain the
+			// hostname that the source cluster requested. Since we know that the requested hostname
+			// has the form "svc_name.ns_name.global", we can truncate the destSvcName to the
+			// prefix to correctly unify svc nodes. This way, the graph will show only one "svc_name" node
+			// instead of duplicating and having one "svc_name" and one "svc_name.ns_name.global" node which,
+			// in practice, are same.
+			//
+			// This is done only if source workload is "unknown" which is what is recorded in telemetry
+			// when traffic is coming from a remote cluster. If source workload IS known,
+			// then, traffic is most-likely going to a ServiceEntry and being routed out of the cluster (i.e.
+			// the "source cluster" case). That case is handled in the service_entry.go file.
+			destSvcName = destSvcNameEntries[0]
+		}
 
 		if o.InjectServiceNodes {
 			// don't inject a service node if the dest node is already a service node.  Also, we can't inject if destSvcName is not set.


### PR DESCRIPTION
In a multi-cluster scenario, in the cluster that is the destination of
the traffic, Istio will record telemetry with
destination_service="svc.namespace.global". This was generating a graph
with dummy service nodes labeled with "svc.namespace.global". These
represent the same "svc" kubernetes services without any suffix.

This changes perform some renaming to generate a traffic map that will
lead to proper unified service nodes.

Resolves #1481.

BEFORE:

![image](https://user-images.githubusercontent.com/23639005/64055005-896d3000-cb4f-11e9-83e5-1f07a13b60b0.png)

AFTER:

![image](https://user-images.githubusercontent.com/23639005/64054974-63e02680-cb4f-11e9-8905-11fbedaa1717.png)
