### PR TITLE
Removing the null metrics and histogram tags from response of service dashboard

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -126,9 +126,13 @@ func (in *DashboardsService) GetIstioDashboard(params prometheus.IstioMetricsQue
 		newChart := chartTpl.Chart
 		if metric, ok := metrics.Metrics[chartTpl.refName]; ok {
 			newChart.Metric = models.ConvertMatrix(metric.Matrix)
+		} else {
+			newChart.Metric = []*kmodel.SampleStream{}
 		}
 		if histo, ok := metrics.Histograms[chartTpl.refName]; ok {
 			newChart.Histogram = models.ConvertHistogram(histo)
+		} else {
+			newChart.Histogram = map[string][]*kmodel.SampleStream{}
 		}
 		dashboard.Charts = append(dashboard.Charts, newChart)
 	}

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
+	kmodel "github.com/kiali/k-charted/model"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
@@ -41,8 +42,8 @@ func TestGetIstioDashboard(t *testing.T) {
 	assert.Equal("Request volume", dashboard.Charts[0].Name)
 	assert.Equal("Request duration", dashboard.Charts[1].Name)
 	assert.Equal("TCP sent", dashboard.Charts[5].Name)
-	assert.Nil(dashboard.Charts[0].Histogram)
-	assert.Nil(dashboard.Charts[1].Metric)
+	assert.Equal(map[string][]*kmodel.SampleStream{}, dashboard.Charts[0].Histogram)
+	assert.Equal([]*kmodel.SampleStream{}, dashboard.Charts[1].Metric)
 	assert.Equal(float64(10), dashboard.Charts[0].Metric[0].Values[0].Value)
 	assert.Equal(float64(20), dashboard.Charts[1].Histogram["avg"][0].Values[0].Value)
 	assert.Equal(float64(13), dashboard.Charts[5].Metric[0].Values[0].Value)


### PR DESCRIPTION
Removing the null metrics and histogram tags from response of /api/namespaces/{namespace}/services/{service}/dashboard.

** Describe the change **

_Please describe what the code change is about_
We were getting the `metrics: null` and  `metrics: []` in the response of `/api/namespaces/{namespace}/services/{service}/dashboard` api. Making it consistent - making sure that we consistently have `metrics: []` and `"histogram": {}`

** Issue reference **

* If this is a fix for a JIRA, please put JIRA-reference in the PR title like _`KIALI-7 New icons`_ (Jira-id, one space, description)
* If this is a fix for a GH-issue, please link it here

** Backwards incompatible? **

- Is your change introducing backwards incompatible changes?

_describe the changes if appropriate_

** Documentation **

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
No