### PR TITLE
Add some special handling of PassthroughCluster service

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -355,7 +355,7 @@ func (in *SvcService) getServiceDefinition(namespace, service string) (svc *core
 // GetServiceDefinitionList returns service definitions for the namespace (the service object only), no istio or runtime information
 func (in *SvcService) GetServiceDefinitionList(namespace string) (*models.ServiceDefinitionList, error) {
 	var err error
-	promtimer := internalmetrics.GetGoFunctionMetric("business", "SvcService", "GetServiceList")
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "SvcService", "GetServiceDefinitionList")
 	defer promtimer.ObserveNow(&err)
 
 	var svcs []core_v1.Service

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -13,20 +13,21 @@ func NewMetadata() Metadata {
 
 // Metadata keys to be used instead of literal strings
 const (
-	DestServices    MetadataKey = "destServices"
-	HasCB           MetadataKey = "hasCB"
-	HasMissingSC    MetadataKey = "hasMissingSC"
-	HasVS           MetadataKey = "hasVS"
-	IsDead          MetadataKey = "isDead"
-	IsInaccessible  MetadataKey = "isInaccessible"
-	IsMisconfigured MetadataKey = "isMisconfigured"
-	IsMTLS          MetadataKey = "isMTLS"
-	IsOutside       MetadataKey = "isOutside"
-	IsRoot          MetadataKey = "isRoot"
-	IsServiceEntry  MetadataKey = "isServiceEntry"
-	IsUnused        MetadataKey = "isUnused"
-	ProtocolKey     MetadataKey = "protocol"
-	ResponseTime    MetadataKey = "responseTime"
+	DestServices         MetadataKey = "destServices"
+	HasCB                MetadataKey = "hasCB"
+	HasMissingSC         MetadataKey = "hasMissingSC"
+	HasVS                MetadataKey = "hasVS"
+	IsDead               MetadataKey = "isDead"
+	IsInaccessible       MetadataKey = "isInaccessible"
+	IsMisconfigured      MetadataKey = "isMisconfigured"
+	IsMTLS               MetadataKey = "isMTLS"
+	IsOutside            MetadataKey = "isOutside"
+	IsPassthroughCluster MetadataKey = "isPassthroughCluster"
+	IsRoot               MetadataKey = "isRoot"
+	IsServiceEntry       MetadataKey = "isServiceEntry"
+	IsUnused             MetadataKey = "isUnused"
+	ProtocolKey          MetadataKey = "protocol"
+	ResponseTime         MetadataKey = "responseTime"
 )
 
 // DestServicesMetadata key=Service.Key()

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kiali/kiali/log"
 )
 
-// constanst usable by any protocol
+// constants usable by any protocol
 const (
 	requestsPerSecond = "requests per second"
 	rps               = "rps"

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -110,8 +110,9 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 }
 
 const (
-	serviceEntryHostsKey = "serviceEntryHosts" // global vendor info
-	workloadListKey      = "workloadList"      // namespace vendor info
+	serviceDefinitionListKey = "serviceDefinitionListKey" // namespace vendor info
+	serviceEntryHostsKey     = "serviceEntryHosts"        // global vendor info
+	workloadListKey          = "workloadList"             // namespace vendor info
 )
 
 type serviceEntry struct {
@@ -130,6 +131,13 @@ func (seh serviceEntryHosts) addHost(host string, se *serviceEntry) {
 		log.Warningf("Same host [%s] found in ServiceEntry [%s] and [%s]", host, existingSe.name, se.name)
 	}
 	seh[host] = se
+}
+
+func getServiceDefinitionList(ni *graph.AppenderNamespaceInfo) *models.ServiceDefinitionList {
+	if sdl, ok := ni.Vendor[serviceDefinitionListKey]; ok {
+		return sdl.(*models.ServiceDefinitionList)
+	}
+	return nil
 }
 
 func getServiceEntryHosts(gi *graph.AppenderGlobalInfo) (serviceEntryHosts, bool) {

--- a/graph/telemetry/istio/appender/dead_node.go
+++ b/graph/telemetry/istio/appender/dead_node.go
@@ -50,6 +50,11 @@ func (a DeadNodeAppender) applyDeadNodes(trafficMap graph.TrafficMap, globalInfo
 				continue
 			}
 
+			// A service node that is the PassthroughCluster is never considered dead
+			if _, ok := n.Metadata[graph.IsPassthroughCluster]; ok {
+				continue
+			}
+
 			// a service node with no incoming error traffic and no outgoing edges, is dead.
 			// Incoming non-error traffic can not raise the dead because it is caused by an
 			// edge case (pod life-cycle change) that we don't want to see.

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -61,7 +61,7 @@ func TestCBAll(t *testing.T) {
 		dRule.DeepCopyIstioObject(),
 	}, nil)
 	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Endpoints{}, nil)
-	k8s.On("GetService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Service{}, nil)
+	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{core_v1.Service{}}, nil)
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{}, nil)
 
 	businessLayer := business.NewWithBackends(k8s, nil)
@@ -122,7 +122,7 @@ func TestCBSubset(t *testing.T) {
 		dRule.DeepCopyIstioObject(),
 	}, nil)
 	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Endpoints{}, nil)
-	k8s.On("GetService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Service{}, nil)
+	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{core_v1.Service{}}, nil)
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{}, nil)
 
 	businessLayer := business.NewWithBackends(k8s, nil)
@@ -140,15 +140,12 @@ func TestCBSubset(t *testing.T) {
 	assert.Equal(nil, trafficMap[svcNodeId].Metadata[graph.HasVS])
 	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasVS])
 
-	globalInfo := graph.AppenderGlobalInfo{
-		Business: businessLayer,
-	}
-	namespaceInfo := graph.AppenderNamespaceInfo{
-		Namespace: "testNamespace",
-	}
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
 	a := IstioAppender{}
-	a.AppendGraph(trafficMap, &globalInfo, &namespaceInfo)
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
 
 	assert.Equal(6, len(trafficMap))
 	assert.Equal(true, trafficMap[appNodeId].Metadata[graph.HasCB])
@@ -191,7 +188,7 @@ func TestVS(t *testing.T) {
 	}
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{}, nil)
 	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Endpoints{}, nil)
-	k8s.On("GetService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Service{}, nil)
+	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{core_v1.Service{}}, nil)
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{
 		vService.DeepCopyIstioObject(),
 	}, nil)
@@ -212,15 +209,12 @@ func TestVS(t *testing.T) {
 	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasVS])
 	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
 
-	globalInfo := graph.AppenderGlobalInfo{
-		Business: businessLayer,
-	}
-	namespaceInfo := graph.AppenderNamespaceInfo{
-		Namespace: "testNamespace",
-	}
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
 	a := IstioAppender{}
-	a.AppendGraph(trafficMap, &globalInfo, &namespaceInfo)
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
 
 	assert.Equal(6, len(trafficMap))
 	assert.Equal(nil, trafficMap[appNodeId].Metadata[graph.HasCB])

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -65,6 +65,10 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 		if n.NodeType != graph.NodeTypeService {
 			continue
 		}
+		// PassthroughCluster is not a service entry (nor a defined service)
+		if n.Metadata[graph.IsPassthroughCluster] == true {
+			continue
+		}
 		// a serviceEntry has at most one outgoing edge, to an egress gateway. (note: it may be that it
 		// can only lead to "istio-egressgateway" but at the time of writing we're not sure, and so don't
 		// want to hardcode that assumption.)

--- a/graph/telemetry/istio/appender/unused_node_test.go
+++ b/graph/telemetry/istio/appender/unused_node_test.go
@@ -190,23 +190,31 @@ func TestVersionWithNoTrafficScenario(t *testing.T) {
 	assert.Equal(nil, recommendationV1.Metadata[graph.IsUnused])
 }
 
-func mockServices(a UnusedNodeAppender) []models.ServiceOverview {
+func mockServices(a UnusedNodeAppender) []models.ServiceDetails {
 	if !(a.GraphType == graph.GraphTypeService || a.InjectServiceNodes) {
-		return []models.ServiceOverview{}
+		return []models.ServiceDetails{}
 	}
 
-	return []models.ServiceOverview{
+	return []models.ServiceDetails{
 		{
-			Name: "customer",
+			Service: models.Service{
+				Name: "customer",
+			},
 		},
 		{
-			Name: "preference",
+			Service: models.Service{
+				Name: "preference",
+			},
 		},
 		{
-			Name: "recommendation",
+			Service: models.Service{
+				Name: "recommendation",
+			},
 		},
 		{
-			Name: "recommendation",
+			Service: models.Service{
+				Name: "recommendation",
+			},
 		},
 	}
 }

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -109,6 +109,8 @@ func markOutsideOrInaccessible(trafficMap graph.TrafficMap, o graph.TelemetryOpt
 		case graph.NodeTypeService:
 			if n.Namespace == graph.Unknown && n.Service == graph.Unknown {
 				n.Metadata[graph.IsInaccessible] = true
+			} else if n.Metadata[graph.IsPassthroughCluster] == true {
+				n.Metadata[graph.IsInaccessible] = true
 			} else {
 				if isOutside(n, o.Namespaces) {
 					n.Metadata[graph.IsOutside] = true

--- a/graph/types.go
+++ b/graph/types.go
@@ -18,6 +18,8 @@ const (
 	NodeTypeWorkload      string = "workload"
 	TF                    string = "2006-01-02 15:04:05" // TF is the TimeFormat for timestamps
 	Unknown               string = "unknown"             // Istio unknown label value
+	// private
+	passthroughCluster string = "PassthroughCluster"
 )
 
 type Node struct {
@@ -88,6 +90,8 @@ func NewNode(serviceNamespace, service, workloadNamespace, workload, app, versio
 }
 
 func NewNodeExplicit(id, namespace, workload, app, version, service, nodeType, graphType string) Node {
+	metadata := make(Metadata)
+
 	// trim unnecessary fields
 	switch nodeType {
 	case NodeTypeWorkload:
@@ -113,6 +117,10 @@ func NewNodeExplicit(id, namespace, workload, app, version, service, nodeType, g
 		app = ""
 		workload = ""
 		version = ""
+
+		if service == passthroughCluster {
+			metadata[IsPassthroughCluster] = true
+		}
 	}
 
 	return Node{
@@ -124,7 +132,7 @@ func NewNodeExplicit(id, namespace, workload, app, version, service, nodeType, g
 		Version:   version,
 		Service:   service,
 		Edges:     []*Edge{},
-		Metadata:  make(Metadata),
+		Metadata:  metadata,
 	}
 }
 

--- a/models/service.go
+++ b/models/service.go
@@ -31,6 +31,11 @@ type ServiceList struct {
 	Validations IstioValidations  `json:"validations"`
 }
 
+type ServiceDefinitionList struct {
+	Namespace          Namespace        `json:"namespace"`
+	ServiceDefinitions []ServiceDetails `json:"serviceDefinitions"`
+}
+
 type ServiceDetails struct {
 	Service          Service           `json:"service"`
 	IstioSidecar     bool              `json:"istioSidecar"`


### PR DESCRIPTION
Istio 1.3 includes PassthroughCluster telemetry.  This is a special
"service" that acts as default ServiceEntry when ALLOW_ANY external
traffic is configured (the default).  It does not correlate to an
actual Service defined in k8s, as such it needs special handling.

- mark the PC service with IsPassthroughCluster = true in the node metadata
- service entry appender: don't try and determine if PC is a service entry
- istio details appender: don't try and fetch service definition
  - as part of this I added GetServiceDefinitionList to the business.Svc API. This
    replaces 1 round-trip per service node with 1 call for all service nodes
    (per namespace). Moreover, this lighter-weight method also replaced the
    call to getServices in the unused_node appender.  By adding it to the appender
    namespace cache the results are use by both appenders. So, it's reduced now to
    1 call for both appenders (per namespace in the graph).

cc @cfcosta , I threw in a perf enhancement as part of this new istio 1.3, that should make you happy :)  Feel free to review if you like.

#1569