### PR TITLE
Small tweaks while fetching grafana info

### DIFF
--- a/business/jaeger_helper.go
+++ b/business/jaeger_helper.go
@@ -58,9 +58,8 @@ func getErrorTracesFromJaeger(namespace string, service string, requestToken str
 			q.Set("tags", "{\"error\":\"true\"}")
 
 			u.RawQuery = q.Encode()
-			timeout := time.Duration(1000 * time.Millisecond)
 
-			body, code, reqError := httputil.HttpGet(u.String(), &auth, timeout)
+			body, code, reqError := httputil.HttpGet(u.String(), &auth, time.Second)
 			if reqError != nil {
 				log.Errorf("Error fetching Jaeger Error Traces (%d): %s", code, reqError)
 				return -1, reqError

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -74,11 +74,11 @@ func getGrafanaInfo(requestToken string, dashboardSupplier dashboardSupplier) (*
 	// Call Grafana REST API to get dashboard urls
 	serviceDashboardPath, err := getDashboardPath(apiURL, serviceDashboardPattern, &auth, dashboardSupplier)
 	if err != nil {
-		return nil, http.StatusInternalServerError, err
+		return nil, http.StatusServiceUnavailable, err
 	}
 	workloadDashboardPath, err := getDashboardPath(apiURL, workloadDashboardPattern, &auth, dashboardSupplier)
 	if err != nil {
-		return nil, http.StatusInternalServerError, err
+		return nil, http.StatusServiceUnavailable, err
 	}
 
 	grafanaInfo := models.GrafanaInfo{
@@ -129,5 +129,5 @@ func getDashboardPath(url, searchPattern string, auth *config.Auth, dashboardSup
 }
 
 func findDashboard(url, searchPattern string, auth *config.Auth) ([]byte, int, error) {
-	return httputil.HttpGet(url+"/api/search?query="+searchPattern, auth, time.Second*30)
+	return httputil.HttpGet(url+"/api/search?query="+searchPattern, auth, time.Second*10)
 }

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -59,7 +59,7 @@ func TestGetGrafanaInfoGetError(t *testing.T) {
 	config.Set(conf)
 	_, code, err := getGrafanaInfo("", buildDashboardSupplier(anError, 401, "http://grafana-external:3001", t))
 	assert.Equal(t, "error from Grafana (401): unauthorized", err.Error())
-	assert.Equal(t, 500, code)
+	assert.Equal(t, 503, code)
 }
 
 func TestGetGrafanaInfoInvalidDashboard(t *testing.T) {
@@ -69,7 +69,7 @@ func TestGetGrafanaInfoInvalidDashboard(t *testing.T) {
 	_, code, err := getGrafanaInfo("", buildDashboardSupplier("unexpected response", 200, "http://grafana-external:3001", t))
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "json: cannot unmarshal")
-	assert.Equal(t, 500, code)
+	assert.Equal(t, 503, code)
 }
 
 func buildDashboardSupplier(jSon interface{}, code int, expectURL string, t *testing.T) dashboardSupplier {


### PR DESCRIPTION
- In case of error from Grafana, return "ServiceNotAvailable" rather than "InternalServerError" (as Kiali is still OK)
- Decrease timeout from 30s to 10s
- (minor) simplify code while providing duration in jaeger helper

This is related to https://github.com/kiali/kiali/issues/1562 but can be merged independently
