### PR TITLE
Allow customized links to Grafana

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -157,10 +157,23 @@ type PrometheusConfig struct {
 // GrafanaConfig describes configuration used for Grafana links
 type GrafanaConfig struct {
 	// Enable or disable Grafana support in Kiali
-	Enabled      bool   `yaml:"enabled"`
-	InClusterURL string `yaml:"in_cluster_url"`
-	URL          string `yaml:"url"`
-	Auth         Auth   `yaml:"auth"`
+	Enabled      bool                     `yaml:"enabled"`
+	InClusterURL string                   `yaml:"in_cluster_url"`
+	URL          string                   `yaml:"url"`
+	Auth         Auth                     `yaml:"auth"`
+	Dashboards   []GrafanaDashboardConfig `yaml:"dashboards"`
+}
+
+type GrafanaDashboardConfig struct {
+	Name      string                 `yaml:"name"`
+	Variables GrafanaVariablesConfig `yaml:"variables"`
+}
+
+type GrafanaVariablesConfig struct {
+	Namespace string `yaml:"namespace" json:"namespace,omitempty"`
+	App       string `yaml:"app" json:"app,omitempty"`
+	Service   string `yaml:"service" json:"service,omitempty"`
+	Workload  string `yaml:"workload" json:"workload,omitempty"`
 }
 
 // TracingConfig describes configuration used for tracing links

--- a/models/grafana_info.go
+++ b/models/grafana_info.go
@@ -1,8 +1,14 @@
 package models
 
+import "github.com/kiali/kiali/config"
+
 // GrafanaInfo provides information to access Grafana dashboards
 type GrafanaInfo struct {
-	URL                   string `json:"url"`
-	ServiceDashboardPath  string `json:"serviceDashboardPath"`
-	WorkloadDashboardPath string `json:"workloadDashboardPath"`
+	Dashboards []GrafanaDashboardInfo `json:"dashboards"`
+}
+
+type GrafanaDashboardInfo struct {
+	URL       string                        `json:"url"`
+	Name      string                        `json:"name"`
+	Variables config.GrafanaVariablesConfig `json:"variables"`
 }

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -243,6 +243,13 @@ spec:
 #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Grafana,
 #       and auth.token config is ignored then.
 #   username: Username to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
+# dashboards: A list of Grafana dashboards that Kiali can link to. Each item contains:
+#   name: The name of the dashboard in Grafana
+#   variables:
+#     app: The name of a variable that holds the app name, if used in that dashboard (else it must be omitted)
+#     namespace: The name of a variable that holds the namespace, if used in that dashboard (else it must be omitted)
+#     service: The name of a variable that holds the service name, if used in that dashboard (else it must be omitted)
+#     workload: The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)
 # enabled: When true, Grafana support will be enabled in Kiali.
 # in_cluster_url: Set URL for in-cluster access. Example: "http://grafana.istio-system:3000".
 # url: The URL that Kiali uses when integrating with Grafana. This URL must be accessible to clients external to
@@ -257,6 +264,15 @@ spec:
 #        type: "none"
 #        use_kiali_token: false
 #        username: ""
+#      dashboards:
+#      - name: "Istio Service Dashboard"
+#        variables:
+#          namespace: "var-namespace"
+#          service: "var-service"
+#      - name: "Istio Workload Dashboard"
+#        variables:
+#          namespace: "var-namespace"
+#          workload: "var-workload"
 #      enabled: true
 #      in_cluster_url: "http://grafana.istio-system:3000"
 #      url: ""

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -74,6 +74,15 @@ kiali_defaults:
         type: "none"
         use_kiali_token: false
         username: ""
+      dashboards:
+      - name: "Istio Service Dashboard"
+        variables:
+          namespace: "var-namespace"
+          service: "var-service"
+      - name: "Istio Workload Dashboard"
+        variables:
+          namespace: "var-namespace"
+          workload: "var-workload"
       enabled: true
       in_cluster_url: ""
       url: ""

--- a/swagger.json
+++ b/swagger.json
@@ -3591,24 +3591,58 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
-    "GrafanaInfo": {
-      "description": "GrafanaInfo provides information to access Grafana dashboards",
+    "GrafanaDashboardInfo": {
       "type": "object",
       "properties": {
-        "serviceDashboardPath": {
+        "name": {
           "type": "string",
-          "x-go-name": "ServiceDashboardPath"
+          "x-go-name": "Name"
         },
         "url": {
           "type": "string",
           "x-go-name": "URL"
         },
-        "workloadDashboardPath": {
-          "type": "string",
-          "x-go-name": "WorkloadDashboardPath"
+        "variables": {
+          "$ref": "#/definitions/GrafanaVariablesConfig"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "GrafanaInfo": {
+      "description": "GrafanaInfo provides information to access Grafana dashboards",
+      "type": "object",
+      "properties": {
+        "dashboards": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GrafanaDashboardInfo"
+          },
+          "x-go-name": "Dashboards"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "GrafanaVariablesConfig": {
+      "type": "object",
+      "properties": {
+        "app": {
+          "type": "string",
+          "x-go-name": "App"
+        },
+        "namespace": {
+          "type": "string",
+          "x-go-name": "Namespace"
+        },
+        "service": {
+          "type": "string",
+          "x-go-name": "Service"
+        },
+        "workload": {
+          "type": "string",
+          "x-go-name": "Workload"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/config"
     },
     "Histogram": {
       "description": "Histogram contains Metric objects for several histogram-kind statistics",


### PR DESCRIPTION
- Any number of dashboards can be defined
- Now we can also have links on "app" in addition to "workload" and "service"
- No change to the nominal case: default Istio dashboards for Workload and Service are still accessible same way as before

Frontend PR: https://github.com/kiali/kiali-ui/pull/1419

Closes https://github.com/kiali/kiali/issues/1268
