### PR TITLE
WIP - Batch namespace health operations in a single call

### DIFF
--- a/models/health.go
+++ b/models/health.go
@@ -4,6 +4,9 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+// NamespacesHealth is an alias of map of namespace x NamespaceHealth
+type NamespacesHealth map[string]*NamespaceHealth
+
 // NamespaceAppHealth is an alias of map of app name x health
 type NamespaceAppHealth map[string]*AppHealth
 
@@ -16,6 +19,13 @@ type NamespaceWorkloadHealth map[string]*WorkloadHealth
 // ServiceHealth contains aggregated health from various sources, for a given service
 type ServiceHealth struct {
 	Requests RequestHealth `json:"requests"`
+}
+
+// NamespaceHealth contains aggregated health from various sources, for a given namespace
+type NamespaceHealth struct {
+	NamespaceAppHealth      *NamespaceAppHealth      `json:"namespaceAppHealth"`
+	NamespaceServiceHealth  *NamespaceServiceHealth  `json:"namespaceServiceHealth"`
+	NamespaceWorkloadHealth *NamespaceWorkloadHealth `json:"namespaceWorkloadHealth"`
 }
 
 // AppHealth contains aggregated health from various sources, for a given app

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -793,6 +793,26 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceHealth,
 			true,
 		},
+		// swagger:route GET /namespaces/health services serviceHealth
+		// ---
+		// Get health associated to resources specified in body request
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      200: batchHealthResponse
+		//      500: internalError
+		//
+		{
+			"Health",
+			"GET",
+			"/api/namespaces/health",
+			handlers.MultiNamespaceHealth,
+			true,
+		},
 		// swagger:route GET /mesh/tls tls meshTls
 		// ---
 		// Get TLS status for the whole mesh


### PR DESCRIPTION
** Describe the change **

Batches the health operations in a single call, to avoid multiple calls for each health type (workload, service, app)

 @cfcosta is this what you had in mind?

This PoC uses GET, but we should probably move to POST to avoid hitting limits on the URL.

I was running some tests, and there are pro's and con's about this approach.

All the tests were run on my local minikube cluster, so maybe someone else should take a look

For a single namespace, there wasn't any noticeable speed gain, it was about the same time, i suppose it has something to do with the persistent connections (`connection: keep-alive`)
For 3 namespaces, times was about the same, but there was an increase in the download size, as a single result gets compressed and tiny separate results do not.
The downside of this is that if there is a namespace with 1 workload; the result reach the UI faster without the batch, as the batch has to wait for every other health result to be finished.

Perhaps a web socket would be a better fit for this kind of optimizations?

Closes #1637
