### PR TITLE
[makefile] be able to tell molecule docker where to find kubeconfig

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -175,6 +175,7 @@ endif
 ifeq ($(MOLECULE_DESTROY_NEVER),true)
 MOLECULE_DESTROY_NEVER_ARG = --destroy never
 endif
+MOLECULE_KUBECONFIG ?= ${HOME}/.kube/config
 
 .molecule-docker-build-if-needed:
 	@if [ "$(shell docker image ls -q kiali-molecule:latest 2>/dev/null || echo -n "")" == "" ]; then \
@@ -187,8 +188,8 @@ molecule-docker-build:
 
 ## molecule-test: Runs Molecule tests using the Molecule docker image
 molecule-test: .molecule-docker-build-if-needed
-	docker run --rm -it -v "${PWD}":/tmp/$(basename "${PWD}"):ro -v "${HOME}/.kube":/root/.kube:ro -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") --network="host" --add-host="api.crc.testing:192.168.130.11" kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name ${MOLECULE_SCENARIO}
+	docker run --rm -it -v "${PWD}":/tmp/$(basename "${PWD}"):ro -v "${MOLECULE_KUBECONFIG}":/root/.kube/config:ro -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") --network="host" --add-host="api.crc.testing:192.168.130.11" kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name ${MOLECULE_SCENARIO}
 
 ## molecule-test-all: Runs all Molecule tests using the Molecule docker image
 molecule-test-all: .molecule-docker-build-if-needed
-	docker run --rm -it -v "${PWD}":/tmp/$(basename "${PWD}"):ro -v "${HOME}/.kube":/root/.kube:ro -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") --network="host" --add-host="api.crc.testing:192.168.130.11" kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --all
+	docker run --rm -it -v "${PWD}":/tmp/$(basename "${PWD}"):ro -v "${MOLECULE_KUBECONFIG}":/root/.kube/config:ro -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") --network="host" --add-host="api.crc.testing:192.168.130.11" kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --all


### PR DESCRIPTION
This is to support local, CRC, and AWS cluster deployments. You can set `MOLECULE_KUBECONFIG` and that config file will be passed to the docker run... default is the usual `$HOME/.kube/config`.