### PR TITLE
Allow grafana dashboard path without leading slash

### DIFF
--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/kiali/kiali/config"
@@ -76,7 +77,7 @@ func getGrafanaInfo(requestToken string, dashboardSupplier dashboardSupplier) (*
 		}
 		if dashboardPath != "" {
 			dashboard := models.GrafanaDashboardInfo{
-				URL:       externalURL + dashboardPath,
+				URL:       strings.TrimSuffix(externalURL, "/") + "/" + strings.TrimPrefix(dashboardPath, "/"),
 				Name:      dashboardConfig.Name,
 				Variables: dashboardConfig.Variables,
 			}
@@ -132,5 +133,5 @@ func getDashboardPath(basePath, name string, auth *config.Auth, dashboardSupplie
 }
 
 func findDashboard(url, searchPattern string, auth *config.Auth) ([]byte, int, error) {
-	return httputil.HttpGet(url+"/api/search?query="+searchPattern, auth, time.Second*10)
+	return httputil.HttpGet(strings.TrimSuffix(url, "/")+"/api/search?query="+searchPattern, auth, time.Second*10)
 }

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -10,12 +10,6 @@ import (
 	"github.com/kiali/kiali/config"
 )
 
-var dashboard = []map[string]interface{}{
-	map[string]interface{}{
-		"url": "/the_path",
-	},
-}
-
 var dashboardsConfig = []config.GrafanaDashboardConfig{
 	config.GrafanaDashboardConfig{
 		Name: "My Dashboard",
@@ -26,11 +20,19 @@ var anError = map[string]string{
 	"message": "unauthorized",
 }
 
+func genDashboard(path string) []map[string]interface{} {
+	return []map[string]interface{}{
+		map[string]interface{}{
+			"url": path,
+		},
+	}
+}
+
 func TestGetGrafanaInfoDisabled(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Grafana.Enabled = false
 	config.Set(conf)
-	info, code, err := getGrafanaInfo("", buildDashboardSupplier(dashboard, 200, "whatever", t))
+	info, code, err := getGrafanaInfo("", buildDashboardSupplier(genDashboard("/some_path"), 200, "whatever", t))
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusNoContent, code)
 	assert.Nil(t, info)
@@ -41,11 +43,11 @@ func TestGetGrafanaInfoExternal(t *testing.T) {
 	conf.ExternalServices.Grafana.URL = "http://grafana-external:3001"
 	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
 	config.Set(conf)
-	info, code, err := getGrafanaInfo("", buildDashboardSupplier(dashboard, 200, "http://grafana-external:3001", t))
+	info, code, err := getGrafanaInfo("", buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana-external:3001", t))
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
 	assert.Len(t, info.Dashboards, 1)
-	assert.Equal(t, "http://grafana-external:3001/the_path", info.Dashboards[0].URL)
+	assert.Equal(t, "http://grafana-external:3001/some_path", info.Dashboards[0].URL)
 }
 
 func TestGetGrafanaInfoInCluster(t *testing.T) {
@@ -54,10 +56,10 @@ func TestGetGrafanaInfoInCluster(t *testing.T) {
 	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
 	conf.ExternalServices.Grafana.InClusterURL = "http://grafana.istio-system:3001"
 	config.Set(conf)
-	info, code, err := getGrafanaInfo("", buildDashboardSupplier(dashboard, 200, "http://grafana.istio-system:3001", t))
+	info, code, err := getGrafanaInfo("", buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana.istio-system:3001", t))
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
-	assert.Equal(t, "http://grafana-external:3001/the_path", info.Dashboards[0].URL)
+	assert.Equal(t, "http://grafana-external:3001/some_path", info.Dashboards[0].URL)
 }
 
 func TestGetGrafanaInfoGetError(t *testing.T) {
@@ -79,6 +81,30 @@ func TestGetGrafanaInfoInvalidDashboard(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "json: cannot unmarshal")
 	assert.Equal(t, 503, code)
+}
+
+func TestGetGrafanaInfoWithoutLeadingSlashPath(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Grafana.URL = "http://grafana-external:3001"
+	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
+	config.Set(conf)
+	info, code, err := getGrafanaInfo("", buildDashboardSupplier(genDashboard("some_path"), 200, "http://grafana-external:3001", t))
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Len(t, info.Dashboards, 1)
+	assert.Equal(t, "http://grafana-external:3001/some_path", info.Dashboards[0].URL)
+}
+
+func TestGetGrafanaInfoWithTrailingSlashURL(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Grafana.URL = "http://grafana-external:3001/"
+	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
+	config.Set(conf)
+	info, code, err := getGrafanaInfo("", buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana-external:3001/", t))
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Len(t, info.Dashboards, 1)
+	assert.Equal(t, "http://grafana-external:3001/some_path", info.Dashboards[0].URL)
 }
 
 func buildDashboardSupplier(jSon interface{}, code int, expectURL string, t *testing.T) dashboardSupplier {

--- a/status/discover.go
+++ b/status/discover.go
@@ -190,7 +190,7 @@ func DiscoverGrafana() string {
 		return ""
 	}
 	if grafanaConf.URL != "" || grafanaConf.InClusterURL == "" {
-		return strings.TrimSuffix(grafanaConf.URL, "/")
+		return grafanaConf.URL
 	}
 	if appstate.GrafanaDiscoveredURL != "" {
 		return appstate.GrafanaDiscoveredURL
@@ -205,7 +205,7 @@ func DiscoverGrafana() string {
 				if err != nil {
 					log.Debugf("[GRAFANA] URL discovery failed: %v", err)
 				}
-				appstate.GrafanaDiscoveredURL = strings.TrimSuffix(routeURL, "/")
+				appstate.GrafanaDiscoveredURL = routeURL
 			}
 		}
 	}


### PR DESCRIPTION
Usually grafana dashboard path (as returned by grafana API) has a leading slash, but it seems there can be some exceptions (although circumstances are not established)
So make Kiali able to generate links to grafana with or without that leading slash

Closes https://github.com/kiali/kiali/issues/1692
