### PR TITLE
Support request_duration_milliseconds for latency reporting in mixer-less telemetry

### DIFF
--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -70,6 +70,8 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	responseTimeMap := make(map[string]float64)
 
 	// query prometheus for the responseTime info in three queries:
+	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
+	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
 	// 1) query for responseTime originating from "unknown" (i.e. the internet)
 	groupBy := "le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version"
 	millisQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v",response_code=~"%s"}[%vs])) by (%s))`,

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -17,11 +17,11 @@ func TestResponseTime(t *testing.T) {
 	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
 	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
 	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
-	q0 := fmt.Sprintf(`round((((%s > 0) / 1000) OR (%s > 0)),0.001)`, fmt.Sprintf(q0Temp, "milliseconds"), fmt.Sprintf(q0Temp, "seconds"))
+	q0 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q0Temp, "milliseconds"), fmt.Sprintf(q0Temp, "seconds"))
 	v0 := model.Vector{}
 
 	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
-	q1 := fmt.Sprintf(`round((((%s > 0) / 1000) OR (%s > 0)),0.001)`, fmt.Sprintf(q1Temp, "milliseconds"), fmt.Sprintf(q1Temp, "seconds"))
+	q1 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q1Temp, "milliseconds"), fmt.Sprintf(q1Temp, "seconds"))
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -39,7 +39,7 @@ func TestResponseTime(t *testing.T) {
 			Value:  0.010}}
 
 	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
-	q2 := fmt.Sprintf(`round((((%s > 0) / 1000) OR (%s > 0)),0.001)`, fmt.Sprintf(q2Temp, "milliseconds"), fmt.Sprintf(q2Temp, "seconds"))
+	q2 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q2Temp, "milliseconds"), fmt.Sprintf(q2Temp, "seconds"))
 	fmt.Printf("QUERY:\n%s", q2)
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -144,7 +144,7 @@ func TestResponseTime(t *testing.T) {
 	assert.Equal("productpage", productpageService.Service)
 	assert.Equal(nil, productpageService.Metadata[graph.ResponseTime])
 	assert.Equal(1, len(productpageService.Edges))
-	assert.Equal(10.0, productpageService.Edges[0].Metadata[graph.ResponseTime])
+	assert.Equal(0.01, productpageService.Edges[0].Metadata[graph.ResponseTime])
 
 	productpage := productpageService.Edges[0].Dest
 	assert.Equal("productpage", productpage.App)
@@ -159,8 +159,8 @@ func TestResponseTime(t *testing.T) {
 	assert.Equal("reviews", reviewsService.Service)
 	assert.Equal(nil, reviewsService.Metadata[graph.ResponseTime])
 	assert.Equal(2, len(reviewsService.Edges))
-	assert.Equal(20.0, reviewsService.Edges[0].Metadata[graph.ResponseTime])
-	assert.Equal(20.0, reviewsService.Edges[1].Metadata[graph.ResponseTime])
+	assert.Equal(0.02, reviewsService.Edges[0].Metadata[graph.ResponseTime])
+	assert.Equal(0.02, reviewsService.Edges[1].Metadata[graph.ResponseTime])
 
 	reviews1 := reviewsService.Edges[0].Dest
 	assert.Equal("reviews", reviews1.App)
@@ -175,7 +175,7 @@ func TestResponseTime(t *testing.T) {
 	assert.Equal("ratings", ratingsService.Service)
 	assert.Equal(nil, ratingsService.Metadata[graph.ResponseTime])
 	assert.Equal(1, len(ratingsService.Edges))
-	assert.Equal(30.0, ratingsService.Edges[0].Metadata[graph.ResponseTime])
+	assert.Equal(0.03, ratingsService.Edges[0].Metadata[graph.ResponseTime])
 
 	reviews2 := reviewsService.Edges[1].Dest
 	assert.Equal("reviews", reviews2.App)

--- a/prometheus/metrics_definitions.go
+++ b/prometheus/metrics_definitions.go
@@ -25,6 +25,11 @@ var istioMetrics = []istioMetric{
 		isHisto:   true,
 	},
 	istioMetric{
+		kialiName: "request_duration_millis",
+		istioName: "istio_request_duration_milliseconds",
+		isHisto:   true,
+	},
+	istioMetric{
 		kialiName: "request_size",
 		istioName: "istio_request_bytes",
 		isHisto:   true,

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -56,13 +56,14 @@ func TestGetServiceMetrics(t *testing.T) {
 	mockWithRange(api, expectedRange, round("sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]))"), 13)
 	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
 	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
+	mockHistogram(api, "istio_request_duration_milliseconds", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
 	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
 
 	// Test that range and rate interval are changed when needed (namespace bounds)
 	metrics := client.GetMetrics(&q)
 
 	assert.Equal(t, 4, len(metrics.Metrics), "Should have 4 simple metrics")
-	assert.Equal(t, 3, len(metrics.Histograms), "Should have 3 histograms")
+	assert.Equal(t, 4, len(metrics.Histograms), "Should have 4 histograms")
 	rqCountIn := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountIn)
 	rqErrorCountIn := metrics.Metrics["request_error_count"]
@@ -71,6 +72,8 @@ func TestGetServiceMetrics(t *testing.T) {
 	assert.NotNil(t, rqSizeIn)
 	rqDurationIn := metrics.Histograms["request_duration"]
 	assert.NotNil(t, rqDurationIn)
+	rqDurationMillisIn := metrics.Histograms["request_duration_millis"]
+	assert.NotNil(t, rqDurationMillisIn)
 	rsSizeIn := metrics.Histograms["response_size"]
 	assert.NotNil(t, rsSizeIn)
 	tcpRecIn := metrics.Metrics["tcp_received"]
@@ -99,6 +102,7 @@ func TestGetAppMetrics(t *testing.T) {
 	mockRange(api, round("sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]))"), 12)
 	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.4)
 	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_request_duration_milliseconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.5)
 	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.6)
 	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
@@ -110,7 +114,7 @@ func TestGetAppMetrics(t *testing.T) {
 	metrics := client.GetMetrics(&q)
 
 	assert.Equal(t, 4, len(metrics.Metrics), "Should have 4 simple metrics")
-	assert.Equal(t, 3, len(metrics.Histograms), "Should have 3 histograms")
+	assert.Equal(t, 4, len(metrics.Histograms), "Should have 4 histograms")
 	rqCountIn := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountIn)
 	rqErrorCountIn := metrics.Metrics["request_error_count"]
@@ -119,6 +123,8 @@ func TestGetAppMetrics(t *testing.T) {
 	assert.NotNil(t, rqSizeIn)
 	rqDurationIn := metrics.Histograms["request_duration"]
 	assert.NotNil(t, rqDurationIn)
+	rqDurationMillisIn := metrics.Histograms["request_duration_millis"]
+	assert.NotNil(t, rqDurationMillisIn)
 	rsSizeIn := metrics.Histograms["response_size"]
 	assert.NotNil(t, rsSizeIn)
 	tcpRecIn := metrics.Metrics["tcp_received"]
@@ -231,6 +237,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	mockRange(api, round("sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]))"), 12)
 	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
 	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_request_duration_milliseconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
 	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
 	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
@@ -241,7 +248,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	metrics := client.GetMetrics(&q)
 
 	assert.Equal(t, 4, len(metrics.Metrics), "Should have 4 simple metrics")
-	assert.Equal(t, 3, len(metrics.Histograms), "Should have 3 histograms")
+	assert.Equal(t, 4, len(metrics.Histograms), "Should have 4 histograms")
 	rqCountOut := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountOut)
 	rqErrorCountOut := metrics.Metrics["request_error_count"]
@@ -250,6 +257,8 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	assert.NotNil(t, rqSizeOut)
 	rqDurationOut := metrics.Histograms["request_duration"]
 	assert.NotNil(t, rqDurationOut)
+	rqDurationMillisOut := metrics.Histograms["request_duration_millis"]
+	assert.NotNil(t, rqDurationMillisOut)
 	rsSizeOut := metrics.Histograms["response_size"]
 	assert.NotNil(t, rsSizeOut)
 	tcpRecOut := metrics.Metrics["tcp_received"]


### PR DESCRIPTION
Istio 1.3.0 experimental introduces mixer-less telemetry.  In this new approach latency is reported via
a new metric: request_duration_milliseconds, as opposed to what has has been done with request_duration (in seconds).

I'm not aware of a way to drive off config to know which will be in service for a time period, so until the legacy metric is removed we need to support both.  This makes for some sort-of-hacky code. 
 In the graph's response time appender we solved it mainly in the prom queries (this is the way Istio itself is doing it).  But the metrics code is table-driven/generic and so it's handled in a different way, based on determining which metric actually returns valid data.

See relevant Istio issue here: https://github.com/istio/istio/issues/16799.

I'm not really asking reviewers to run the code with mixer-less, rather to ensure no regression using the existing telemetry.  This mainly means that the detail charts should work as expected, as should the graph side panel sparklines for edges, and of course the response time edge labels.

@jotak If you could take a look at the metrics part it would be appreciated.

https://github.com/kiali/kiali/issues/1694

UI PR: https://github.com/kiali/kiali-ui/pull/1436