### PR TITLE
Prevent "Failed ID gen" error in the graph

### DIFF
--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -225,15 +225,15 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 			continue
 		}
 
-		if a.InjectServiceNodes {
-			// don't inject a service node if the dest node is already a service node.  Also, we can't inject if destSvcName is not set.
+		// don't inject a service node if destSvcName is not set or the dest node is already a service node.
+		inject := false
+		if a.InjectServiceNodes && graph.IsOK(destSvcName) {
 			_, destNodeType := graph.Id(destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType)
-			if destSvcNameOk && destNodeType != graph.NodeTypeService {
-				// Do not set response time on the incoming edge, we can't validly aggregate response times of the outgoing edges (kiali-2297)
-				a.addResponseTime(responseTimeMap, val, destSvcNs, destSvcName, "", "", "", destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
-			} else {
-				a.addResponseTime(responseTimeMap, val, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
-			}
+			inject = (graph.NodeTypeService != destNodeType)
+		}
+		if inject {
+			// Do not set response time on the incoming edge, we can't validly aggregate response times of the outgoing edges (kiali-2297)
+			a.addResponseTime(responseTimeMap, val, destSvcNs, destSvcName, "", "", "", destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
 		} else {
 			a.addResponseTime(responseTimeMap, val, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
 		}

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -219,16 +219,15 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o gra
 		val := float64(s.Value)
 		destSvcNs, destSvcName = util.HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName)
 
-		if o.InjectServiceNodes {
-			// don't inject a service node if the dest node is already a service node.  Also, we can't inject if destSvcName is not set.
-			destSvcNameOk = graph.IsOK(destSvcName)
+		// don't inject a service node if destSvcName is not set or the dest node is already a service node.
+		inject := false
+		if o.InjectServiceNodes && graph.IsOK(destSvcName) {
 			_, destNodeType := graph.Id(destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o.GraphType)
-			if destSvcNameOk && destNodeType != graph.NodeTypeService {
-				addTraffic(trafficMap, val, protocol, code, flags, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, "", "", "", "", o)
-				addTraffic(trafficMap, val, protocol, code, flags, destSvcNs, destSvcName, "", "", "", destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o)
-			} else {
-				addTraffic(trafficMap, val, protocol, code, flags, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o)
-			}
+			inject = (graph.NodeTypeService != destNodeType)
+		}
+		if inject {
+			addTraffic(trafficMap, val, protocol, code, flags, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, "", "", "", "", o)
+			addTraffic(trafficMap, val, protocol, code, flags, destSvcNs, destSvcName, "", "", "", destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o)
 		} else {
 			addTraffic(trafficMap, val, protocol, code, flags, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o)
 		}
@@ -302,16 +301,15 @@ func populateTrafficMapTcp(trafficMap graph.TrafficMap, vector *model.Vector, o 
 		val := float64(s.Value)
 		destSvcNs, destSvcName = util.HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName)
 
-		if o.InjectServiceNodes {
-			// don't inject a service node if the dest node is already a service node.  Also, we can't inject if destSvcName is not set.
-			destSvcNameOk = graph.IsOK(destSvcName)
+		// don't inject a service node if destSvcName is not set or the dest node is already a service node.
+		inject := false
+		if o.InjectServiceNodes && graph.IsOK(destSvcName) {
 			_, destNodeType := graph.Id(destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o.GraphType)
-			if destSvcNameOk && destNodeType != graph.NodeTypeService {
-				addTcpTraffic(trafficMap, val, flags, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, "", "", "", "", o)
-				addTcpTraffic(trafficMap, val, flags, destSvcNs, destSvcName, "", "", "", destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o)
-			} else {
-				addTcpTraffic(trafficMap, val, flags, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o)
-			}
+			inject = (graph.NodeTypeService != destNodeType)
+		}
+		if inject {
+			addTcpTraffic(trafficMap, val, flags, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, "", "", "", "", o)
+			addTcpTraffic(trafficMap, val, flags, destSvcNs, destSvcName, "", "", "", destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o)
 		} else {
 			addTcpTraffic(trafficMap, val, flags, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o)
 		}


### PR DESCRIPTION
Some expanded querying for TCP security policy info revealed a weakness in
protecting against invalid service injection when generating the graph.  Update
base graph generation, as well as response_time and security_policy appenders,
with enhanced guards. Prevent node ID generation unless destSvcName is set.

Fixes #1731
