### PR TITLE
golden copy of the operator manifests

### DIFF
--- a/operator/manifests/README.adoc
+++ b/operator/manifests/README.adoc
@@ -1,0 +1,316 @@
+== OpenShift Lifecycle Manager manifests
+
+These contain the OpenShift Lifecycle Manager manifest files for the several different OLM deployments.
+
+* link:./kiali-ossm[kiali-ossm]: The official RedHat Kiali distribution which has beeen productized for use with OpenShift Container Platform (aka OCP). This manifest is distributed to customers of RedHat/OCP.
+* link:./kiali-community[kiali-community]: Kiali for use with the community distribution of Kubernetes that powers OCP (aka OKD). This manifest shows up in OKD's Catalog.
+* link:./kiali-upstream[kiali-upstream]: Kiali for use with upstream Kubernetes distributions. This manifest shows up in OperatorHub.io.
+
+=== Testing
+
+To test these manifests, follow the directions at:
+
+* link:https://docs.openshift.com/container-platform/4.1/applications/operators/olm-adding-operators-to-cluster.html#olm-installing-operator-from-operatorhub-using-cli_olm-adding-operators-to-a-cluster[OpenShift docs page]
+* link:https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md#testing-operator-deployment-on-openshift[Operator framework testing page].
+
+If on OKD or OCP, these quick instructions summarize what you have to do. This assumes you have a quay.io account and your current working directory is this parent directory of the manifests. Optionally, you can have `operator-courier` installed.
+
+==== Disable other operator sources
+
+Kiali operator is published in the community and so will appear by default in the OpenShift Catalog. Kiali is also available in OCP installations via the `redhat-operators` OperatorSource. You will need to disable all of the OperatorSources that provide published Kiali operators, otherwise they will conflict with the Kiali operator you are testing.
+
+_OpenShift 4.1 instructions_
+
+Make sure you link:https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusterversion.md[turn off the CVO] so the OperatorHub is not refreshed.
+
+```
+oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-operator
+```
+
+Now remove the OperatorSources for the different out-of-box sources:
+
+```
+oc patch operatorsources community-operators -n openshift-marketplace -p '{"spec":{"unmanaged":true}}' --type=merge
+oc delete operatorsources community-operators -n openshift-marketplace
+
+oc patch operatorsources redhat-operators -n openshift-marketplace -p '{"spec":{"unmanaged":true}}' --type=merge
+oc delete operatorsources redhat-operators -n openshift-marketplace
+```
+
+You can disable all OperatorSources in your cluster via:
+
+```
+for o in $(oc get operatorsources -n openshift-marketplace -o name); do oc patch $o -n openshift-marketplace -p '{"spec":{"unmanaged":true}}' --type=merge ; oc delete $o -n openshift-marketplace ; done
+```
+
+_OpenShift 4.2 instructions_
+
+Disable the OperatorSources through a config object:
+
+```
+cat <<EOF | oc apply -f -
+apiVersion: config.openshift.io/v1
+kind: OperatorHub
+metadata:
+  name: cluster
+  namespace: openshift-marketplace
+spec:
+  disableAllDefaultSources: true
+  sources: [
+    {
+      name: "community-operators",
+      disabled: true
+    },
+    {
+      name: "redhat-operators",
+      disabled: true
+    }
+  ]
+EOF
+```
+
+==== Get your quay.io username and quay.io token
+
+Set the environment variables `QUAY_USERNAME` and `QUAY_TOKEN`. These will be used in subsequent steps. Your quay.io token will look something like this: `basic abcdef123456abcdef==`.
+
+You can set both of these by running the following command:
+
+```
+echo -n 'Your quay.io username: ' \
+  && read QUAY_USERNAME \
+  && echo -n 'Your quay.io password: ' \
+  && export QUAY_TOKEN=$(curl --silent -H "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user":{"username":"'"${QUAY_USERNAME}"'","password":"'"$(read -s PW && echo -n $PW)"'"}}' | sed -E 's/.*\"(basic .*)\".*/\1/')
+```
+
+An alternative to getting your token is through the use of the link:https://raw.githubusercontent.com/operator-framework/operator-courier/master/scripts/get-quay-token[get-quay-token] script provided by operator-courier and store the returned token in the `QUAY_TOKEN` environment variable.
+
+==== Push the Kiali operator manifest bundle to Quay.io
+
+```
+OPERATOR_DIR=kiali-community/ # other manifests here are: kiali-upstream/ and kiali-ossm/
+PACKAGE_NAME=kiali # use kiali-ossm if pushing the OCP manifest found in directory kiali-ossm/
+PACKAGE_VERSION=1.0.0 # unrelated to operator version but you can set this to the highest operator version
+
+curl --silent -H "Content-Type: application/json" -H "Authorization: ${QUAY_TOKEN}" -XPOST "https://quay.io/cnr/api/v1/packages/${QUAY_USERNAME}/${PACKAGE_NAME}" -d '{"release":"'"${PACKAGE_VERSION}"'","media_type":"helm","blob":"'"$(tar cz ${OPERATOR_DIR} | base64 -w 0 | iconv -t utf-8)"'"}'
+```
+
+An alternative is to use `operator-courier`:
+
+```
+operator-courier push "$OPERATOR_DIR" "$QUAY_USERNAME" "$PACKAGE_NAME" "$PACKAGE_VERSION" "$QUAY_TOKEN"
+```
+
+Once this step has been completed, you should see your operator manifest bundle listed in your account's `Applications` tab. If the application has a lock icon, click through to the application and its Settings tab and select to make the application public.
+
+
+===== Push the other Service Mesh manifest bundles to Quay.io
+
+Because we removed the redhat-operators earlier, you will probably want to publish your own copy of the Service Mesh manifest bundles (Service Mesh, Jaeger, ElasticSearch). Run the script code below to do this. Note that this requires link:https://stedolan.github.io/jq/download/[jq] to be installed.
+You do not need to do this if you plan on installing Service Mesh or Istio through some other mechanism other than OLM.
+
+```
+export RH_PACKAGE_NAMESPACE="redhat-operators"
+for op in elasticsearch-operator jaeger-product servicemeshoperator
+do
+  export op
+  OP_RELEASE="$(curl --silent -H "Authorization: ${QUAY_TOKEN}" "https://quay.io/cnr/api/v1/packages?namespace=${RH_PACKAGE_NAMESPACE}" | jq '.[] | select(.name == $ENV.RH_PACKAGE_NAMESPACE + "/" + $ENV.op) | .default' -r)"
+  OP_DIGEST="$(curl --silent -H "Authorization: ${QUAY_TOKEN}" "https://quay.io/cnr/api/v1/packages/${RH_PACKAGE_NAMESPACE}/${op}/${OP_RELEASE}" | jq '.[0].content.digest' -r)"
+  OP_MANIFEST_TARBALL="/tmp/${RH_PACKAGE_NAMESPACE}-${op}-${OP_RELEASE}.tar.gz"
+  echo -n "Retrieving ${OP_MANIFEST_TARBALL} ... "
+  curl --silent -H "Authorization: ${QUAY_TOKEN}" "https://quay.io/cnr/api/v1/packages/${RH_PACKAGE_NAMESPACE}/${op}/blobs/sha256/${OP_DIGEST}" -o "$OP_MANIFEST_TARBALL"
+  echo "Done."
+  echo -n "Uploading ${OP_MANIFEST_TARBALL} ... "
+  curl --silent -H "Content-Type: application/json" -H "Authorization: ${QUAY_TOKEN}" -XPOST "https://quay.io/cnr/api/v1/packages/${QUAY_USERNAME}/${op}" -d '{"release":"'"${OP_RELEASE}"'","media_type":"helm","blob":"'"$(cat ${OP_MANIFEST_TARBALL} | base64 -w 0 | iconv -t utf-8)"'"}'
+done
+```
+
+Once done, your Quay.io account will have its own copies of the Service Mesh operator manifests in your account's `Applications` tab. The first time you do this, the applications will have a lock icon indicating "private" access only - you will need to change them all to allow for public access.
+
+==== Create OperatorSource
+
+Tell OpenShift where your operator bundles are.
+
+```
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: ${QUAY_USERNAME}-operators
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: ${QUAY_USERNAME}
+  displayName: "${QUAY_USERNAME}'s Operators"
+  publisher: "${QUAY_USERNAME}"
+EOF
+```
+
+==== Verify the OperatorSource was processed correctly
+
+```
+oc get operatorsource ${QUAY_USERNAME}-operators -n openshift-marketplace
+```
+
+_At this point, the operator is ready to be installed. You can do so using the OpenShift UI or follow the rest of the instructions here to do it manually via 'oc' commands._
+
+==== Create CatalogSourceConfig to identify the operator to enable on the cluster.
+
+Create the catalog containing all the packages you want to install. If you are installing all of Service Mesh via OLM, you need all the packages listed. If you plan on installing Service Mesh or Istio outside of OLM, just put the Kiali package name
+in the spec.packages setting.
+
+```
+ALL_PACKAGES="${PACKAGE_NAME},elasticsearch-operator,jaeger-product,servicemeshoperator"
+KIALI_OPERATOR_NAMESPACE="openshift-operators"
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: CatalogSourceConfig
+metadata:
+  name: kiali
+  namespace: openshift-marketplace
+spec:
+  targetNamespace: ${KIALI_OPERATOR_NAMESPACE}
+  packages: ${ALL_PACKAGES}
+EOF
+```
+
+==== Create OperatorGroup
+
+Here's some docs on link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/operatorgroups.md[OperatorGroup] resources.
+
+You do not need to do this if your CatalogSourceConfig has a targetNamespace of `openshift-operators`. In that case, the operator will be considered with an InstallMode of AllNamespaces and will watch all namespaces for a Kiali CR.
+
+If you want the operator to watch its own namespace (InstallMode of OwnNamespace), then create an OperatorGroup in the namespace where the operator is to be installed (i.e. in the namespace where the Subscription will be) and set the targetNamespace as the same namespace where the operator is to be installed. Note that targetNamespace is the namespace that will be watched by the operator and can be different from the namespace where the OperatorGroup is (this would be InstallMode of SingleNamespace).
+
+```
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: kiali
+  namespace: ${KIALI_OPERATOR_NAMESPACE}
+spec:
+  targetNamespaces:
+  - ${KIALI_OPERATOR_NAMESPACE}
+EOF
+```
+
+==== Create Subscription to the operator
+
+Create a Subscription to the version of the Kiali operator you want installed/upgraded.
+The namespace where the Subscription is created is the namespace where the operator is installed.
+
+```
+KIALI_VERSION="1.0.0"
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kiali
+  namespace: ${KIALI_OPERATOR_NAMESPACE}
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: ${PACKAGE_NAME}
+  source: kiali
+  sourceNamespace: ${KIALI_OPERATOR_NAMESPACE}
+  startingCSV: kiali-operator.v${KIALI_VERSION}
+EOF
+```
+
+==== Create Subscription to the Service Mesh operators
+
+To install Service Mesh and its other components:
+
+```
+cat <<EOF | oc apply -f -
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: elasticsearch-operator
+  namespace: openshift-operators
+spec:
+  channel: preview
+  installPlanApproval: Automatic
+  name: elasticsearch-operator
+  source: kiali
+  sourceNamespace: ${KIALI_OPERATOR_NAMESPACE}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: jaeger-product
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: jaeger-product
+  source: kiali
+  sourceNamespace: ${KIALI_OPERATOR_NAMESPACE}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+spec:
+  channel: '1.0'
+  installPlanApproval: Automatic
+  name: servicemeshoperator
+  source: kiali
+  sourceNamespace: ${KIALI_OPERATOR_NAMESPACE}
+EOF
+```
+
+==== Define where you want the control plane
+
+```
+CONTROL_PLANE_NAMESPACE="istio-system"
+oc create namespace ${CONTROL_PLANE_NAMESPACE}
+```
+
+==== Create Service Mesh CR
+
+If you want to install Service Mesh, run one of these commands to create the necessary CR.
+
+* If you want Kiali enabled (which will create and manage the Kiali CR under the covers):
+
+```
+oc create -n ${CONTROL_PLANE_NAMESPACE} -f https://raw.githubusercontent.com/Maistra/istio-operator/maistra-1.0/deploy/examples/maistra_v1_servicemeshcontrolplane_cr_full.yaml
+```
+
+* If you want Kiali disabled (which will require you to create and manage the Kiali CR):
+
+```
+oc create -n ${CONTROL_PLANE_NAMESPACE} -f https://raw.githubusercontent.com/Maistra/istio-operator/maistra-1.0/deploy/examples/maistra_v1_servicemeshcontrolplane_cr_minimal.yaml
+```
+
+==== Create Kiali CR
+
+If you are using Service Mesh, it will manage the Kiali CR for you. If you disabled Kiali within Service Mesh (or if you
+are using upstream Istio that is not managing the Kiali CR), then you need to create one to install Kiali:
+
+```
+cat <<EOF | oc apply -f -
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: ${KIALI_OPERATOR_NAMESPACE}
+annotations:
+  ansible.operator-sdk/reconcile-period: "0s"
+spec:
+  deployment:
+    namespace: ${CONTROL_PLANE_NAMESPACE}
+    verbose_mode: "4"
+EOF
+```
+
+==== Upgrade Operator
+
+To upgrade to a new operator, upload a new manifest bundle (with a new package version and new CSV) to quay.io. At this point, you can wait for OLM to refresh (which happens once an hour) or `oc edit` or `oc patch` the OperatorSource and delete its status block, which should immediate force a rescan of quay. You can remove the status block using `oc patch` like this:
+
+```
+oc patch operatorsource ${QUAY_USERNAME}-operators -n openshift-marketplace -p '[{"op":"replace","path":"/status","value":{}}]' --type json
+```

--- a/operator/manifests/kiali-community/0.18.1/kiali.crd.yaml
+++ b/operator/manifests/kiali-community/0.18.1/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-community/0.18.1/kiali.v0.18.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/0.18.1/kiali.v0.18.1.clusterserviceversion.yaml
@@ -1,0 +1,480 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v0.18.1
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v0.18.1
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-04-10T23:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+           },
+           "spec": {
+             "installation_tag": "My Kiali",
+             "deployment": {
+               "view_only_mode": true
+             },
+             "external_services": {
+               "grafana": {
+                 "url": "http://my-grafana-location"
+               },
+               "jaeger": {
+                 "url": "http://my-jaeger-location"
+               },
+               "prometheus": {
+                 "url": "http://my-prometheus-location"
+               }
+             },
+             "server": {
+               "web_root": "/mykiali"
+             }
+           }
+        }
+      ]
+spec:
+  version: 0.18.1
+  maturity: alpha
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See https://www.kiali.io to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/master/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/gettingstarted
+  - name: Features
+    url: https://www.kiali.io/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v0.18.1
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v0.18.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v0.18.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-community/1.1.0/kiali.crd.yaml
+++ b/operator/manifests/kiali-community/1.1.0/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-community/1.1.0/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-community/1.1.0/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-community/1.1.0/kiali.v1.1.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/1.1.0/kiali.v1.1.0.clusterserviceversion.yaml
@@ -1,0 +1,530 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.1.0
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.1.0
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-06-28T20:09:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "istio-system",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.1.0
+  maturity: stable
+  replaces: kiali-operator.v0.18.1
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.1.0/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.1.0
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.1.0
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.1.0
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - sidecars
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-community/1.3.1/kiali.crd.yaml
+++ b/operator/manifests/kiali-community/1.3.1/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-community/1.3.1/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-community/1.3.1/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-community/1.3.1/kiali.v1.3.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/1.3.1/kiali.v1.3.1.clusterserviceversion.yaml
@@ -1,0 +1,555 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.3.1
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.3.1
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-08-12T00:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "istio-system",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.3.1
+  maturity: stable
+  replaces: kiali-operator.v1.1.0
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.3.1/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.3.1
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.3.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.3.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - sidecars
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-community/1.4.2/kiali.crd.yaml
+++ b/operator/manifests/kiali-community/1.4.2/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-community/1.4.2/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-community/1.4.2/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-community/1.4.2/kiali.v1.4.2.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/1.4.2/kiali.v1.4.2.clusterserviceversion.yaml
@@ -1,0 +1,555 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.4.2
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.4.2
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-09-12T00:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "istio-system",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.4.2
+  maturity: stable
+  replaces: kiali-operator.v1.3.1
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.4.2/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.4.2
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.4.2
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.4.2
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - sidecars
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-community/kiali.package.yaml
+++ b/operator/manifests/kiali-community/kiali.package.yaml
@@ -1,0 +1,7 @@
+packageName: kiali
+channels:
+- name: alpha
+  currentCSV: kiali-operator.v1.4.2
+- name: stable
+  currentCSV: kiali-operator.v1.4.2
+defaultChannel: stable

--- a/operator/manifests/kiali-ossm/1.0.5/kiali.crd.yaml
+++ b/operator/manifests/kiali-ossm/1.0.5/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-ossm/1.0.5/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-ossm/1.0.5/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-ossm/1.0.5/kiali.v1.0.5.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-ossm/1.0.5/kiali.v1.0.5.clusterserviceversion.yaml
@@ -1,0 +1,544 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.0.5
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: registry.stage.redhat.io/openshift-service-mesh/kiali-rhel7-operator:1.0.5
+    capabilities: Basic Install
+    support: Red Hat
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-08-12T00:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "istio-system",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.0.5
+  maturity: stable
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.0.0/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Red Hat
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+              version: v1.0.5
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.0.5
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: operator
+                image: registry.stage.redhat.io/openshift-service-mesh/kiali-rhel7-operator:1.0.5
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - sidecars
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-ossm/1.0.6/kiali.crd.yaml
+++ b/operator/manifests/kiali-ossm/1.0.6/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-ossm/1.0.6/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-ossm/1.0.6/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-ossm/1.0.6/kiali.v1.0.6.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-ossm/1.0.6/kiali.v1.0.6.clusterserviceversion.yaml
@@ -1,0 +1,544 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.0.6
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: registry.redhat.io/openshift-service-mesh/kiali-rhel7-operator:1.0.6
+    capabilities: Basic Install
+    support: Red Hat
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-08-12T00:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "istio-system",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.0.6
+  maturity: stable
+  replaces: kiali-operator.v1.0.5
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.0.0/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Red Hat
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.0.6
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: operator
+                image: registry.redhat.io/openshift-service-mesh/kiali-rhel7-operator:1.0.6
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - sidecars
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-ossm/kiali-ossm.package.yaml
+++ b/operator/manifests/kiali-ossm/kiali-ossm.package.yaml
@@ -1,0 +1,5 @@
+packageName: kiali-ossm
+channels:
+- name: stable
+  currentCSV: kiali-operator.v1.0.6
+defaultChannel: stable

--- a/operator/manifests/kiali-upstream/kiali.crd.yaml
+++ b/operator/manifests/kiali-upstream/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-upstream/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-upstream/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-upstream/kiali.package.yaml
+++ b/operator/manifests/kiali-upstream/kiali.package.yaml
@@ -1,0 +1,7 @@
+packageName: kiali
+channels:
+- name: alpha
+  currentCSV: kiali-operator.v1.4.2
+- name: stable
+  currentCSV: kiali-operator.v1.4.2
+defaultChannel: stable

--- a/operator/manifests/kiali-upstream/kiali.v0.18.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/kiali.v0.18.1.clusterserviceversion.yaml
@@ -1,0 +1,481 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v0.18.1
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v0.18.1
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-04-10T23:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+           },
+           "spec": {
+             "installation_tag": "My Kiali",
+             "deployment": {
+               "view_only_mode": true
+             },
+             "external_services": {
+               "grafana": {
+                 "url": "http://my-grafana-location"
+               },
+               "jaeger": {
+                 "url": "http://my-jaeger-location"
+               },
+               "prometheus": {
+                 "url": "http://my-prometheus-location"
+               }
+             },
+             "server": {
+               "web_root": "/mykiali"
+             }
+           }
+        }
+      ]
+spec:
+  version: 0.18.1
+  maturity: alpha
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See https://www.kiali.io to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/master/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/gettingstarted
+  - name: Features
+    url: https://www.kiali.io/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+              version: v0.18.1
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v0.18.1
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v0.18.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v0.18.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-upstream/kiali.v1.1.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/kiali.v1.1.0.clusterserviceversion.yaml
@@ -1,0 +1,536 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.1.0
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.1.0
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-06-28T20:09:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "default",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.1.0
+  maturity: stable
+  replaces: kiali-operator.v0.18.1
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.1.0/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+              version: v1.1.0
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.1.0
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.1.0
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.1.0
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - sidecars
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-upstream/kiali.v1.3.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/kiali.v1.3.1.clusterserviceversion.yaml
@@ -1,0 +1,556 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.3.1
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.3.1
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-08-12T00:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "default",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.3.1
+  maturity: stable
+  replaces: kiali-operator.v1.1.0
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.3.1/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+              version: v1.3.1
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.3.1
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.3.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.3.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - sidecars
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-upstream/kiali.v1.4.2.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/kiali.v1.4.2.clusterserviceversion.yaml
@@ -1,0 +1,555 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.4.2
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.4.2
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2019-09-12T00:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "default",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.4.2
+  maturity: stable
+  replaces: kiali-operator.v1.3.1
+  displayName: Kiali Operator
+  description: |-
+    A Microservice Architecture breaks up the monolith into many smaller pieces that are composed together. Patterns to secure the communication between services like fault tolerance (via timeout, retry, circuit breaking, etc.) have come up as well as distributed tracing to be able to see where calls are going.
+
+    A service mesh can now provide these services on a platform level and frees the application writers from those tasks. Routing decisions are done at the mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service mesh topology, to provide visibility into features like circuit breakers, request rates and more. It offers insights about the mesh components at different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Prerequisites
+
+    Today Kiali works with Istio. So before you install Kiali, you must have already installed Istio. Note that Istio can come pre-bundled with Kiali (specifically if you installed the Istio demo helm profile or if you installed Istio with the helm option '--set kiali.enabled=true'). If you already have the pre-bundled Kiali in your Istio environment and you want to install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first. You can do this via this command:
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the authentication strategy will default to `login`. When using the authentication strategy of `login`, you are required to create a Kubernetes Secret with a `username` and `passphrase` that you want users to provide in order to successfully log into Kiali. Here is an example command you can execute to create such a secret (with a username of `admin` and a passphrase of `admin`):
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali Custom Resource (CR), see the file [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.4.2/operator/deploy/kiali/kiali_cr.yaml)
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift or Ingress on Kubernetes.
+    On OpenShift, the default root context path is '/' and on Kubernetes it is '/kiali' though you can change this by configuring the 'web_root' setting in the Kiali CR.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.4.2
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.4.2
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.4.2
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["config.istio.io"]
+          resources:
+          - adapters
+          - apikeys
+          - bypasses
+          - authorizations
+          - checknothings
+          - circonuses
+          - cloudwatches
+          - deniers
+          - dogstatsds
+          - edges
+          - fluentds
+          - handlers
+          - instances
+          - kubernetesenvs
+          - kuberneteses
+          - listcheckers
+          - listentries
+          - logentries
+          - memquotas
+          - metrics
+          - noops
+          - opas
+          - prometheuses
+          - quotas
+          - quotaspecbindings
+          - quotaspecs
+          - rbacs
+          - redisquotas
+          - reportnothings
+          - rules
+          - signalfxs
+          - solarwindses
+          - stackdrivers
+          - statsds
+          - stdios
+          - templates
+          - tracespans
+          - zipkins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["networking.istio.io"]
+          resources:
+          - destinationrules
+          - gateways
+          - serviceentries
+          - sidecars
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.istio.io"]
+          resources:
+          - meshpolicies
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.istio.io"]
+          resources:
+          - clusterrbacconfigs
+          - rbacconfigs
+          - servicerolebindings
+          - serviceroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator


### PR DESCRIPTION
We have copies of our operator manifests in several different places (the upstream and community github repos, the RH production repo). We need one "golden copy" that we can be sure is the "correct" versions, and are maintained in a single place. We can then copy these over to the appropriate places when the time is right.

This PR also contains a 1.0.6 version of the productized Kiali - this is not published yet but I started it out here for now as we'll need it soon.