### PR TITLE
Supporting setting more than one user credential at once (for web login)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -125,16 +125,16 @@ var rwMutex sync.RWMutex
 
 // Server configuration
 type Server struct {
-	Address                    string               `yaml:",omitempty"`
-	AuditLog                   bool                 `yaml:"audit_log,omitempty"`
-	CORSAllowAll               bool                 `yaml:"cors_allow_all,omitempty"`
-	Credentials                security.Credentials `yaml:",omitempty"`
-	GzipEnabled                bool                 `yaml:"gzip_enabled,omitempty"`
-	MetricsEnabled             bool                 `yaml:"metrics_enabled,omitempty"`
-	MetricsPort                int                  `yaml:"metrics_port,omitempty"`
-	Port                       int                  `yaml:",omitempty"`
-	StaticContentRootDirectory string               `yaml:"static_content_root_directory,omitempty"`
-	WebRoot                    string               `yaml:"web_root,omitempty"`
+	Address                    string                  `yaml:",omitempty"`
+	AuditLog                   bool                    `yaml:"audit_log,omitempty"`
+	CORSAllowAll               bool                    `yaml:"cors_allow_all,omitempty"`
+	Credentials                security.CredentialList `yaml:",omitempty"`
+	GzipEnabled                bool                    `yaml:"gzip_enabled,omitempty"`
+	MetricsEnabled             bool                    `yaml:"metrics_enabled,omitempty"`
+	MetricsPort                int                     `yaml:"metrics_port,omitempty"`
+	Port                       int                     `yaml:",omitempty"`
+	StaticContentRootDirectory string                  `yaml:"static_content_root_directory,omitempty"`
+	WebRoot                    string                  `yaml:"web_root,omitempty"`
 }
 
 // Auth provides authentication data for external services
@@ -325,10 +325,10 @@ func NewConfig() (c *Config) {
 
 	c.Server.Address = strings.TrimSpace(getDefaultString(EnvServerAddress, ""))
 	c.Server.Port = getDefaultInt(EnvServerPort, 20000)
-	c.Server.Credentials = security.Credentials{
+	c.Server.Credentials = []security.Credentials{{
 		Username:   getDefaultStringFromFile(LoginSecretUsername, ""),
 		Passphrase: getDefaultStringFromFile(LoginSecretPassphrase, ""),
-	}
+	}}
 
 	c.Server.WebRoot = strings.TrimSpace(getDefaultString(EnvWebRoot, "/"))
 	c.Server.StaticContentRootDirectory = strings.TrimSpace(getDefaultString(EnvServerStaticContentRootDirectory, "/opt/kiali/console"))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -228,10 +228,7 @@ func TestError(t *testing.T) {
 func TestMarshalUnmarshalCredentials(t *testing.T) {
 	testConf := Config{
 		Server: Server{
-			Credentials: security.Credentials{
-				Username:   "foo",
-				Passphrase: "bar",
-			},
+			Credentials: security.CredentialList{security.Credentials{Username: "foo", Passphrase: "bar"}},
 		},
 	}
 
@@ -246,19 +243,19 @@ func TestMarshalUnmarshalCredentials(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to unmarshal: %v", err)
 	}
-	if conf.Server.Credentials.Username != "foo" {
-		t.Errorf("Failed to unmarshal username credentials:\n%v", conf)
+
+	user := conf.Server.Credentials[0]
+
+	if user.Username != "foo" {
+		t.Errorf("Failed to unmarshal username credentials:\n%v", user)
 	}
-	if conf.Server.Credentials.Passphrase != "bar" {
-		t.Errorf("Failed to unmarshal password credentials:\n%v", conf)
+	if user.Passphrase != "bar" {
+		t.Errorf("Failed to unmarshal password credentials:\n%v", user)
 	}
 
 	testConf = Config{
 		Server: Server{
-			Credentials: security.Credentials{
-				Username:   "",
-				Passphrase: "",
-			},
+			Credentials: security.CredentialList{security.Credentials{Username: "", Passphrase: ""}},
 		},
 	}
 
@@ -270,10 +267,11 @@ func TestMarshalUnmarshalCredentials(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to unmarshal: %v", err)
 	}
-	if conf.Server.Credentials.Username != "" {
+	user = conf.Server.Credentials[0]
+	if user.Username != "" {
 		t.Errorf("Failed to unmarshal empty username credentials:\n%v", conf)
 	}
-	if conf.Server.Credentials.Passphrase != "" {
+	if user.Passphrase != "" {
 		t.Errorf("Failed to unmarshal empty password credentials:\n%v", conf)
 	}
 }

--- a/config/security/config_security_test.go
+++ b/config/security/config_security_test.go
@@ -2,7 +2,38 @@ package security
 
 import (
 	"testing"
+
+	"gopkg.in/yaml.v2"
 )
+
+func TestValidateCollection(t *testing.T) {
+	list := CredentialList{Credentials{Username: "foo", Passphrase: "bar"}}
+	creds, err := list.ValidateCredentials()
+
+	if err != nil {
+		t.Errorf("Failed to validate credential list: %v", err)
+	} else {
+		if creds.Username != "foo" || creds.Passphrase != "bar" {
+			t.Errorf("Validated credentials has wrong data: %v", creds)
+		}
+	}
+}
+
+func TestUnmarshalCollection(t *testing.T) {
+	var res CredentialList
+
+	input := "- username: foo\n  password: foo"
+
+	if err := yaml.Unmarshal([]byte(input), &res); err != nil {
+		t.Errorf("Raised error %v when parsing credential list", err)
+	}
+
+	input = "username: foo\npassword: foo"
+
+	if err := yaml.Unmarshal([]byte(input), &res); err != nil {
+		t.Errorf("Raised error %v when parsing credential list", err)
+	}
+}
 
 func TestValidateCredentials(t *testing.T) {
 	creds := &Credentials{}

--- a/hack/istio/download-istio.sh
+++ b/hack/istio/download-istio.sh
@@ -23,27 +23,29 @@ ISTIO_VERSION=
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
-    -iv|--istio-version)
-      ISTIO_VERSION="$2"
-      shift;shift
-      ;;
-    -o|--output)
-      OUTPUT_DIR="$2"
-      shift;shift
-      ;;
-    -h|--help)
-      cat <<HELPMSG
+  -iv | --istio-version)
+    ISTIO_VERSION="$2"
+    shift
+    shift
+    ;;
+  -o | --output)
+    OUTPUT_DIR="$2"
+    shift
+    shift
+    ;;
+  -h | --help)
+    cat <<HELPMSG
 Valid command line arguments:
   -iv|--istio-version <#.#.#>: Version of Istio to download. (default will be the latest version)
   -o|--output <dir> : Output directory where Istio is (or will be downloaded to if it doesn't exist).
   -h|--help : This message.
 HELPMSG
-      exit 1
-      ;;
-    *)
-      echo "Unknown argument [$key]. Aborting."
-      exit 1
-      ;;
+    exit 1
+    ;;
+  *)
+    echo "Unknown argument [$key]. Aborting."
+    exit 1
+    ;;
   esac
 done
 
@@ -56,21 +58,21 @@ OUTPUT_DIR="$(pwd)" # remove the .. references
 echo "Output Directory: ${OUTPUT_DIR}"
 
 if [ -z "${ISTIO_VERSION}" ]; then
-   VERSION_WE_WANT=$(curl https://api.github.com/repos/istio/istio/releases/latest 2> /dev/null |\
-         grep  "tag_name" | \
-         sed -e 's/.*://' -e 's/ *"//' -e 's/",//')
-   echo "Will use the latest Istio version: $VERSION_WE_WANT"
+  VERSION_WE_WANT=$(curl https://api.github.com/repos/istio/istio/releases/latest 2>/dev/null |
+    grep "tag_name" |
+    sed -e 's/.*://' -e 's/ *"//' -e 's/",//')
+  echo "Will use the latest Istio version: $VERSION_WE_WANT"
 else
-   VERSION_WE_WANT="${ISTIO_VERSION}"
-   echo "Will use a specific Istio version: $VERSION_WE_WANT"
+  VERSION_WE_WANT="${ISTIO_VERSION}"
+  echo "Will use a specific Istio version: $VERSION_WE_WANT"
 fi
 
 # See if Istio is downloaded; if not, get it now.
 echo "Will look for Istio here: ${OUTPUT_DIR}/istio-${VERSION_WE_WANT}"
 if [ ! -d "./istio-${VERSION_WE_WANT}" ]; then
-   echo "Cannot find Istio ${VERSION_WE_WANT} - will download it now..."
-   export ISTIO_VERSION
-   curl -L https://git.io/getLatestIstio | sh -
+  echo "Cannot find Istio ${VERSION_WE_WANT} - will download it now..."
+  export ISTIO_VERSION
+  curl -L https://git.io/getLatestIstio | sh -
 fi
 
 cd "./istio-${VERSION_WE_WANT}/"
@@ -80,6 +82,8 @@ if [ -x "${ISTIO_DIR}/bin/istioctl" ]; then
   ISTIOCTL="${ISTIO_DIR}/bin/istioctl"
   ${ISTIOCTL} version
   echo "istioctl is found here: ${ISTIO_DIR}/bin/istioctl"
+
+  exit 0
 else
   echo "WARNING: istioctl is NOT found at ${ISTIO_DIR}/bin/istioctl"
   exit 1

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -68,12 +68,8 @@ type TokenResponse struct {
 func checkKialiCredentials(r *http.Request) string {
 	conf := config.Get()
 
-	if conf.Server.Credentials.Username == "" || conf.Server.Credentials.Passphrase == "" {
-		return ""
-	}
-
 	u, p, ok := r.BasicAuth()
-	if ok && conf.Server.Credentials.Username == u && conf.Server.Credentials.Passphrase == p {
+	if ok && conf.Server.Credentials.Validate(u, p) {
 		return u
 	}
 
@@ -111,7 +107,8 @@ func performKialiAuthentication(w http.ResponseWriter, r *http.Request) bool {
 
 		if len(user) == 0 {
 			conf := config.Get()
-			if conf.Server.Credentials.Username == "" && conf.Server.Credentials.Passphrase == "" {
+
+			if len(conf.Server.Credentials) == 0 {
 				log.Error("Credentials are missing. Create a secret. Please refer to the documentation for more details.")
 				RespondWithCode(w, missingSecretStatusCode) // our specific error code that indicates to the client that we are missing the secret
 				return false
@@ -318,7 +315,7 @@ func checkKialiSession(w http.ResponseWriter, r *http.Request) int {
 		user := checkKialiCredentials(r)
 		if len(user) == 0 {
 			conf := config.Get()
-			if conf.Server.Credentials.Username == "" && conf.Server.Credentials.Passphrase == "" {
+			if len(conf.Server.Credentials) == 0 {
 				log.Error("Credentials are missing. Create a secret. Please refer to the documentation for more details.")
 				return missingSecretStatusCode // our specific error code that indicates to the client that we are missing the secret
 			} else {
@@ -463,7 +460,7 @@ func AuthenticationInfo(w http.ResponseWriter, r *http.Request) {
 		response.LogoutEndpoint = metadata.LogoutEndpoint
 		response.LogoutRedirect = metadata.LogoutRedirect
 	case config.AuthStrategyLogin:
-		if conf.Server.Credentials.Username == "" && conf.Server.Credentials.Passphrase == "" {
+		if len(conf.Server.Credentials) == 0 {
 			response.SecretMissing = true
 		}
 	}

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -2,15 +2,17 @@ package handlers
 
 import (
 	"encoding/json"
-	"github.com/dgrijalva/jwt-go"
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/util"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/config/security"
+	"github.com/kiali/kiali/util"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestStrategyLoginAuthentication checks that a user with no active
@@ -18,8 +20,7 @@ import (
 func TestStrategyLoginAuthentication(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
-	cfg.Server.Credentials.Username = "foo"
-	cfg.Server.Credentials.Passphrase = "bar"
+	cfg.Server.Credentials = security.CredentialList{security.Credentials{Username: "foo", Passphrase: "bar"}}
 	config.Set(cfg)
 
 	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -49,8 +50,7 @@ func TestStrategyLoginAuthentication(t *testing.T) {
 func TestStrategyLoginFails(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
-	cfg.Server.Credentials.Username = "foo"
-	cfg.Server.Credentials.Passphrase = "bar"
+	cfg.Server.Credentials = security.CredentialList{security.Credentials{Username: "foo", Passphrase: "bar"}}
 	config.Set(cfg)
 
 	// Check wrong user
@@ -85,8 +85,7 @@ func TestStrategyLoginExtend(t *testing.T) {
 
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
-	cfg.Server.Credentials.Username = "foo"
-	cfg.Server.Credentials.Passphrase = "bar"
+	cfg.Server.Credentials = security.CredentialList{security.Credentials{Username: "foo", Passphrase: "bar"}}
 	config.Set(cfg)
 
 	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -167,8 +166,7 @@ func TestLogout(t *testing.T) {
 func TestMissingSecretFlagPresent(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
-	cfg.Server.Credentials.Username = ""
-	cfg.Server.Credentials.Passphrase = ""
+	cfg.Server.Credentials = security.CredentialList{}
 	config.Set(cfg)
 
 	request := httptest.NewRequest("GET", "http://kiali/api/auth/info", nil)
@@ -192,8 +190,7 @@ func TestMissingSecretFlagPresent(t *testing.T) {
 func TestMissingSecretFlagAbsent(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
-	cfg.Server.Credentials.Username = "foo"
-	cfg.Server.Credentials.Passphrase = "bar"
+	cfg.Server.Credentials = security.CredentialList{security.Credentials{Username: "foo", Passphrase: "bar"}}
 	config.Set(cfg)
 
 	request := httptest.NewRequest("GET", "http://kiali/api/auth/info", nil)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -49,8 +49,7 @@ func TestRootContextPath(t *testing.T) {
 	conf.Server.Address = testHostname
 	conf.Server.Port = testPort
 	conf.Server.StaticContentRootDirectory = tmpDir
-	conf.Server.Credentials.Username = "unused"
-	conf.Server.Credentials.Passphrase = "unused"
+	conf.Server.Credentials = security.CredentialList{security.Credentials{Username: "unused", Passphrase: "unused"}}
 	conf.Auth.Strategy = "anonymous"
 
 	serverURL := fmt.Sprintf("http://%v", testServerHostPort)
@@ -108,8 +107,7 @@ func TestAnonymousMode(t *testing.T) {
 	conf.Server.Address = testHostname
 	conf.Server.Port = testPort
 	conf.Server.StaticContentRootDirectory = tmpDir
-	conf.Server.Credentials.Username = "unused"
-	conf.Server.Credentials.Passphrase = "unused"
+	conf.Server.Credentials = security.CredentialList{security.Credentials{Username: "unused", Passphrase: "unused"}}
 	conf.Auth.Strategy = "anonymous"
 
 	serverURL := fmt.Sprintf("http://%v", testServerHostPort)
@@ -190,8 +188,7 @@ func TestSecureComm(t *testing.T) {
 	conf.Server.Address = testHostname
 	conf.Server.Port = testPort
 	conf.Server.StaticContentRootDirectory = tmpDir
-	conf.Server.Credentials.Username = authorizedUsername
-	conf.Server.Credentials.Passphrase = authorizedPassword
+	conf.Server.Credentials = security.CredentialList{security.Credentials{Username: authorizedUsername, Passphrase: authorizedPassword}}
 	conf.Server.MetricsEnabled = true
 	conf.Server.MetricsPort = testMetricsPort
 	conf.Auth.Strategy = "login"


### PR DESCRIPTION
Part of #1139.

This PR enables the users to create more than one weblogin user, by using an array instead of an object for the user. It does not break backwards compatibility.

To create multiple users, change the secret as such:

```diff
--- before.yml  2019-09-30 11:12:22.214379071 -0300
+++ after.yml   2019-09-30 11:12:37.007582588 -0300
@@ -1,7 +1,9 @@
 apiVersion: v1
 data:
-  passphrase: YWRtaW4=
-  username: YWRtaW4=
+  - passphrase: YWRtaW4=
+    username: YWRtaW4=
+  - passphrase: YWRtaW4=
+    username: YWRtaW4=
 kind: Secret
 metadata:
   creationTimestamp: "2019-09-30T14:11:45Z"
```

Obviously all the users should have different passwords ;)

### How to test?

- Install kiali as expected.
- Create a secret with more than one user.
- Log in with both users.
- Both should work.