### PR TITLE
Implementing edge aggregation for nodes "talking" to a ServiceEntry

### DIFF
--- a/graph/api/api.go
+++ b/graph/api/api.go
@@ -19,7 +19,6 @@ func GraphNamespaces(business *business.Layer, o graph.Options) (code int, confi
 	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer(o.GetGraphKind(), o.TelemetryOptions.GraphType, o.InjectServiceNodes)
 	defer promtimer.ObserveDuration()
 
-	var trafficMap graph.TrafficMap
 	switch o.TelemetryVendor {
 	case graph.VendorIstio:
 		prom, err := prometheus.NewClient()
@@ -30,7 +29,7 @@ func GraphNamespaces(business *business.Layer, o graph.Options) (code int, confi
 	}
 
 	// update metrics
-	internalmetrics.SetGraphNodes(o.GetGraphKind(), o.TelemetryOptions.GraphType, o.InjectServiceNodes, len(trafficMap))
+	internalmetrics.SetGraphNodes(o.GetGraphKind(), o.TelemetryOptions.GraphType, o.InjectServiceNodes, 0)
 
 	return code, config
 }
@@ -58,7 +57,6 @@ func GraphNode(business *business.Layer, o graph.Options) (code int, config inte
 	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer(o.GetGraphKind(), o.TelemetryOptions.GraphType, o.InjectServiceNodes)
 	defer promtimer.ObserveDuration()
 
-	var trafficMap graph.TrafficMap
 	switch o.TelemetryVendor {
 	case graph.VendorIstio:
 		prom, err := prometheus.NewClient()
@@ -68,7 +66,7 @@ func GraphNode(business *business.Layer, o graph.Options) (code int, config inte
 		graph.Error(fmt.Sprintf("TelemetryVendor [%s] not supported", o.TelemetryVendor))
 	}
 	// update metrics
-	internalmetrics.SetGraphNodes(o.GetGraphKind(), o.TelemetryOptions.GraphType, o.InjectServiceNodes, len(trafficMap))
+	internalmetrics.SetGraphNodes(o.GetGraphKind(), o.TelemetryOptions.GraphType, o.InjectServiceNodes, 0)
 
 	return code, config
 }

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -232,7 +232,7 @@ func AggregateNodeTraffic(node, aggregateNode *Node) {
 // AggregateEdgeTraffic is for aggregating edge traffic when reducing multiple edges into one edge (e.g.
 // when generating service graph from workload graph, or aggregating serviceEntry nodes).
 func AggregateEdgeTraffic(edge, aggregateEdge *Edge) {
-	protocol, ok := edge.Metadata["protocol"]
+	protocol, ok := edge.Metadata[ProtocolKey]
 	if !ok {
 		return
 	}

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -56,6 +56,33 @@ func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInf
 	a.applyServiceEntries(trafficMap, globalInfo, namespaceInfo)
 }
 
+// aggregateEdges identifies edges that are going from <node> to <serviceEntryNode> and
+// aggregates them in only one edge per protocol. This ensures that the traffic map
+// will comply with the assumption/rule of one edge per protocol between any two nodes.
+func aggregateEdges(node *graph.Node, serviceEntryNode *graph.Node) {
+	edgesToAggregate := make(map[string][]*graph.Edge)
+	bound := 0
+	for _, edge := range node.Edges {
+		if edge.Dest == serviceEntryNode {
+			protocol := edge.Metadata[graph.ProtocolKey].(string)
+			edgesToAggregate[protocol] = append(edgesToAggregate[protocol], edge)
+		} else {
+			// Manipulating the slice as in this StackOverflow post: https://stackoverflow.com/a/20551116
+			node.Edges[bound] = edge
+			bound++
+		}
+	}
+	node.Edges = node.Edges[:bound]
+	// Add aggregated edge
+	for protocol, edges := range edgesToAggregate {
+		aggregatedEdge := node.AddEdge(serviceEntryNode)
+		aggregatedEdge.Metadata[graph.ProtocolKey] = protocol
+		for _, e := range edges {
+			graph.AggregateEdgeTraffic(e, aggregatedEdge)
+		}
+	}
+}
+
 func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	// a map of "se-service" nodes to the "se-aggregate" information
 	seMap := make(map[*serviceEntry][]*graph.Node)
@@ -108,6 +135,12 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 						edge.Dest = &serviceEntryNode
 					}
 				}
+
+				// If there is more than one doomed node, edges leading to the new aggregated node must
+				// also be aggregated per source and protocol.
+				if len(seServiceNodes) > 1 {
+					aggregateEdges(n, &serviceEntryNode)
+				}
 			}
 			// redirect/aggregate edges leading from the doomed se-service node [to an egress gateway]
 			for _, doomedEdge := range doomedSeServiceNode.Edges {
@@ -127,36 +160,6 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 			delete(trafficMap, doomedSeServiceNode.ID)
 		}
 		trafficMap[serviceEntryNode.ID] = &serviceEntryNode
-
-		// If there is more than one doomed node, edges leading to the new aggregated node must
-		// also be aggregated per source and protocol.
-		if len(seServiceNodes) > 1 {
-			for _, n := range trafficMap {
-				// Get the edges that need to be aggregated and remove them from the node.
-				edgesToAggregate := make(map[string][]*graph.Edge) // This is per protocol.
-				bound := 0
-				for _, edge := range n.Edges {
-					if edge.Dest == &serviceEntryNode {
-						protocol := edge.Metadata[graph.ProtocolKey].(string)
-						edgesToAggregate[protocol] = append(edgesToAggregate[protocol], edge)
-					} else {
-						// Manipulating the slice as in this StackOverflow post: https://stackoverflow.com/a/20551116
-						n.Edges[bound] = edge
-						bound++
-					}
-				}
-				n.Edges = n.Edges[:bound]
-
-				// Add aggregated edge
-				for protocol, edges := range edgesToAggregate {
-					aggregatedEdge := n.AddEdge(&serviceEntryNode)
-					aggregatedEdge.Metadata[graph.ProtocolKey] = protocol
-					for _, e := range edges {
-						graph.AggregateEdgeTraffic(e, aggregatedEdge)
-					}
-				}
-			}
-		}
 	}
 }
 

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -108,13 +108,13 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	trafficMap[n6.ID] = &n6
 	trafficMap[n7.ID] = &n7
 
-	n0.AddEdge(&n1)
-	n1.AddEdge(&n2)
-	n2.AddEdge(&n3)
-	n2.AddEdge(&n4)
-	n2.AddEdge(&n5)
-	n2.AddEdge(&n6)
-	n2.AddEdge(&n7)
+	n0.AddEdge(&n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n1.AddEdge(&n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(&n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(&n4).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(&n5).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(&n6).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(&n7).Metadata[graph.ProtocolKey] = graph.TCP.Name
 
 	return trafficMap
 }
@@ -202,7 +202,7 @@ func TestServiceEntry(t *testing.T) {
 	notSEAppID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
-	assert.Equal(5, len(notSEAppNode.Edges))
+	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
 	externalSEServiceEntryID, _ := graph.Id("testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)


### PR DESCRIPTION
One Istio ServiceEntry can have several hostnames in its definition, leading to an initial traffic map with one service node for each hostname in the SE. The service_entry appender was correctly reducing the service nodes into one ServiceEntry node, but edges were only being re-bounded leading to the possibility of multiple edges between the same source node and destination SE node.

This is adding a protocol-aware edge aggregation to remove redundant edges. It's also adding the protocol-awareness for the SE-to-Egress case.

Fixes #1752.