### PR TITLE
OSSM-103 change the name of the operator deployment. OLM should see t…

### DIFF
--- a/operator/manifests/kiali-ossm/1.0.6/kiali.v1.0.6.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-ossm/1.0.6/kiali.v1.0.6.clusterserviceversion.yaml
@@ -212,7 +212,7 @@ spec:
     strategy: deployment
     spec:
       deployments:
-      - name: kiali-operator
+      - name: kiali-operator2
         spec:
           replicas: 1
           selector:


### PR DESCRIPTION
I talked to the OLM guys.  They said changing the name of the operator deployment in the CSV will cause OLM to destroy and re-create the deployment, thus avoiding that update error.