### PR TITLE
Create an Envoy dashboard with a few metrics

### DIFF
--- a/operator/roles/kiali-deploy/templates/dashboards/envoy.yaml
+++ b/operator/roles/kiali-deploy/templates/dashboards/envoy.yaml
@@ -1,0 +1,49 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: envoy
+spec:
+  title: Envoy Metrics
+#  discoverOn: "envoy_server_uptime"
+  items:
+  - chart:
+      name: "Pods uptime"
+      spans: 4
+      metricName: "envoy_server_uptime"
+      dataType: "raw"
+  - chart:
+      name: "Allocated memory"
+      unit: "bytes"
+      spans: 4
+      metricName: "envoy_server_memory_allocated"
+      dataType: "raw"
+      min: 0
+  - chart:
+      name: "Heap size"
+      unit: "bytes"
+      spans: 4
+      metricName: "envoy_server_memory_heap_size"
+      dataType: "raw"
+      min: 0
+  - chart:
+      name: "Upstream active connections"
+      spans: 6
+      metricName: "envoy_cluster_upstream_cx_active"
+      dataType: "raw"
+  - chart:
+      name: "Upstream total requests"
+      spans: 6
+      metricName: "envoy_cluster_upstream_rq_total"
+      unit: "rps"
+      dataType: "rate"
+  - chart:
+      name: "Downstream active connections"
+      spans: 6
+      metricName: "envoy_listener_downstream_cx_active"
+      dataType: "raw"
+  - chart:
+      name: "Downstream HTTP requests"
+      spans: 6
+      metricName: "envoy_listener_http_downstream_rq"
+      unit: "rps"
+      dataType: "rate"


### PR DESCRIPTION
It is disabled by default. To enable, we need to annotate pods (`kiali.io/runtimes: envoy`) or uncomment the "discoverOn" line in this dashboard.

Note that some charts require additional metrics from "listener" to be enabled on pods.
See https://istio.io/docs/ops/telemetry/envoy-stats/

E.g. of annotation: `sidecar.istio.io/statsInclusionPrefixes: cluster_manager,listener_manager,listener`

Closes https://github.com/kiali/kiali/issues/1453
