### PR TITLE
Update base images when building Kiali containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ swagger-travis: swagger-validate
 ## docker-build-kiali: Build Kiali container image into local docker daemon.
 docker-build-kiali: .prepare-docker-image-files
 	@echo Building container image for Kiali into local docker daemon...
-	docker build -t ${DOCKER_TAG} _output/docker
+	docker build --pull -t ${DOCKER_TAG} _output/docker
 	docker tag ${DOCKER_TAG} ${QUAY_TAG}
 
 ## docker-build-operator: Build Kiali operator container image into local docker daemon.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -71,7 +71,7 @@ help: Makefile
 # Requires operator-sdk - download it from https://github.com/operator-framework/operator-sdk/releases
 operator-build: .ensure-operator-sdk-exists
 	@echo Build operator
-	"${OP_SDK}" build "${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_VERSION}"
+	"${OP_SDK}" build --image-build-args "--pull" "${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_VERSION}"
 
 ## ocp-operator-push: Push the Kiali operator container image to a OCP cluster
 ocp-operator-push:


### PR DESCRIPTION
The UBI7 base images used to build Kiali are, apparently, updated to patch for vulnerabilities, but the machine building the Kiali containers seems to have a "shared" docker daemon which is caching the base images. So, Kiali is being built with the cached base image retrieved at some point of the time.

To fix, adding --pull argument to check and get available updates of the base images at build time.

Although operator base images will also be checked for updates, the base image has a fixed version tag. So, updates are not retrieved. The :latest tag of the base image is the one with the security fixes, but I'm not sure if changing the base image would break the operator. Leaving that for another PR, unless I get the green light to change the base image in this PR.

Fixes #1781.