### PR TITLE
KIALI-1804 Remove false positive coming from . chars in RegExps

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -136,12 +136,17 @@ func (m MultiMatchChecker) findMatch(host Host) (bool, []Host) {
 			current := strings.ToLower(strings.Replace(host.Hostname, "*", ".*", -1))
 			previous := strings.ToLower(strings.Replace(h.Hostname, "*", ".*", -1))
 
+			// Escaping dot chars for RegExp. Dot char means all possible chars.
+			// This protects this validation to false positive for (api-dev.example.com and api.dev.example.com)
+			escapedCurrent := strings.Replace(host.Hostname, ".", "\\.", -1)
+			escapedPrevious := strings.Replace(h.Hostname, ".", "\\.", -1)
+
 			// We anchor the beginning and end of the string when it's
 			// to be used as a regex, so that we don't get spurious
 			// substring matches, e.g., "example.com" matching
 			// "foo.example.com".
-			currentRegexp := strings.Join([]string{"^", current, "$"}, "")
-			previousRegexp := strings.Join([]string{"^", previous, "$"}, "")
+			currentRegexp := strings.Join([]string{"^", escapedCurrent, "$"}, "")
+			previousRegexp := strings.Join([]string{"^", escapedPrevious, "$"}, "")
 
 			if regexp.MustCompile(currentRegexp).MatchString(previous) ||
 				regexp.MustCompile(previousRegexp).MatchString(current) {

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -61,6 +61,31 @@ func TestCaseMatching(t *testing.T) {
 	assert.True(validation.Valid)
 }
 
+func TestDashSubdomainMatching(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer(
+		[]string{
+			"api.dev.example.com",
+			"api-dev.example.com",
+		}, 80, "http", "http"),
+
+		data.CreateEmptyGateway("foxxed", "test", map[string]string{
+			"app": "canidae",
+		}))
+
+	gws := [][]kubernetes.IstioObject{{gwObject}}
+
+	validations := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.Empty(validations)
+}
+
 func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)


### PR DESCRIPTION
Closes https://github.com/kiali/kiali/issues/1804

Before:

![](https://user-images.githubusercontent.com/751681/66844932-7b446900-ef6f-11e9-8f0a-035dde75ee6a.png)


After:
![Screenshot of Kiali Console (74)](https://user-images.githubusercontent.com/613814/66912557-14788b80-f013-11e9-9773-967009a8dcb8.jpg)