### PR TITLE
[hack] temp fix for the 1.0.6 release due to the change of the deployment name

### DIFF
--- a/hack/aws-openshift.sh
+++ b/hack/aws-openshift.sh
@@ -335,7 +335,8 @@ EOM
     done
 
     infomsg "Waiting for operator Deployments to start..."
-    for op in elasticsearch-operator jaeger-operator kiali-operator istio-operator
+    #### TODO: when 1.0.7 is released, flip this back to kiali-operator (remove the "2")
+    for op in elasticsearch-operator jaeger-operator kiali-operator2 istio-operator
     do
       echo -n "Waiting for ${op} to be ready..."
       readyReplicas="0"


### PR DESCRIPTION
we need to revert this when 1.0.7 is released since its deployment name is going back to its original