### PR TITLE
1567 Add apidoc for kiali and use path for relative paths

### DIFF
--- a/handlers/apidocumentation.go
+++ b/handlers/apidocumentation.go
@@ -15,7 +15,7 @@ func ServiceApiDocumentation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	vars := mux.Vars(r)
-	apidoc, err := business.Svc.GetServiceApiDocumentation(vars["namespace"], vars["service"])
+	apidoc, err := business.Svc.GetServiceApiDocumentation(vars["namespace"], vars["service"], vars["lpath"])
 	handleApiDocumentationResponse(w, apidoc, err)
 }
 

--- a/models/service.go
+++ b/models/service.go
@@ -66,8 +66,8 @@ type Service struct {
 }
 
 type ApiDocumentation struct {
-	Type    string `json:"type,omitempty"`
-	HasSpec bool   `json:"hasSpec,omitempty"`
+	Type string `json:"type,omitempty"`
+	Path string `json:"path,omitempty"`
 }
 
 func (ss *Services) Parse(services []core_v1.Service) {

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -421,7 +421,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceDetails,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/services/{service}/apispec services serviceApiDocumentation
+		// swagger:route GET /namespaces/{namespace}/services/{service}/apispec/{lpath:.*} services serviceApiDocumentation
 		// ---
 		// Get api spec associated to the given service. This is just a proxy to the url of the service serving the spec
 		//
@@ -435,7 +435,7 @@ func NewRoutes() (r *Routes) {
 		{
 			"ServiceApiDocumentation",
 			"GET",
-			"/api/namespaces/{namespace}/services/{service}/apispec",
+			"/api/namespaces/{namespace}/services/{service}/apispec/{lpath:.*}",
 			handlers.ServiceApiDocumentation,
 			true,
 		},

--- a/swagger.json
+++ b/swagger.json
@@ -1846,7 +1846,7 @@
         }
       }
     },
-    "/namespaces/{namespace}/services/{service}/apispec": {
+    "/namespaces/{namespace}/services/{service}/apispec/{lpath:.*}": {
       "get": {
         "description": "Get api spec associated to the given service. This is just a proxy to the url of the service serving the spec",
         "schemes": [
@@ -3224,9 +3224,9 @@
     "ApiDocumentation": {
       "type": "object",
       "properties": {
-        "hasSpec": {
-          "type": "boolean",
-          "x-go-name": "HasSpec"
+        "path": {
+          "type": "string",
+          "x-go-name": "Path"
         },
         "type": {
           "type": "string",


### PR DESCRIPTION
** Describe the change **

- Add default apidoc for Kiali reading the file
- Use path from UI so relative calls are working

** Issue reference **

https://github.com/kiali/kiali/issues/1567

** Backwards incompatible? **

No, but it relies  on UI branch

** Documentation **

No