### PR TITLE
[operator] fix molecule tests so they use the route and LoadBalancer

### DIFF
--- a/operator/molecule/common/tasks.yml
+++ b/operator/molecule/common/tasks.yml
@@ -46,21 +46,15 @@
     - app = kiali
   register: kiali_service
 
-- name: Get cluster node IP that can be used to communicate to cluster services
+- name: Get Kiali Route
   k8s_facts:
-    api_version: v1
-    kind: Node
-  register: cluster_node
-- set_fact:
-    cluster_node_ip: "{{ cluster_node | json_query('resources[0].status.addresses[?type==`InternalIP`].address') | join() }}"
-    kiali_port: "{{ kiali_service | json_query('resources[0].spec.ports[?name==`tcp`].nodePort') | join() }}"
-- set_fact:
-    kiali_base_url: "https://{{ cluster_node_ip }}:{{ kiali_port }}"
-  when:
-  - kiali_service.resources[0].spec.type == 'NodePort'
-- debug:
-    msg: "This test does not have kiali_base_url set because the kiali service is not of type NodePort"
-  when:
-  - kiali_service.resources[0].spec.type != 'NodePort'
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: "{{ istio.control_plane_namespace }}"
+    label_selectors:
+    - app = kiali
+  register: kiali_route
 
-
+- name: Set Kiali's Route URL
+  set_fact:
+    kiali_base_url: "https://{{ kiali_route.resources[0].spec.host }}"

--- a/operator/molecule/ldap-test/ldap-service.yaml
+++ b/operator/molecule/ldap-test/ldap-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: ldap
   name: ldap-service
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
     - name: ldap-port
       targetPort: ldap-port

--- a/operator/molecule/ldap-test/prepare-ldap.yml
+++ b/operator/molecule/ldap-test/prepare-ldap.yml
@@ -42,9 +42,15 @@
   register: ldap_service
 
 - set_fact:
-    external_ldap_host: "{{ cluster_node_ip }}"
-    external_ldap_port: "{{ ldap_service | json_query('resources[0].spec.ports[?name==`ldap-port`].nodePort') | join() }}"
-    external_ldap_port_ssl: "{{ ldap_service | json_query('resources[0].spec.ports[?name==`ssl-ldap-port`].nodePort') | join() }}"
+    external_ldap_host: "{{ ldap_service.resources[0].status.loadBalancer.ingress[0].hostname }}"
+    external_ldap_port: "389"
+    external_ldap_port_ssl: "636"
+
+- name: Wait for the LoadBalancer to provide the endpoint for the LDAP service which takes a long time
+  wait_for:
+    host: "{{ external_ldap_host }}"
+    port: "{{ external_ldap_port }}"
+    timeout: 300
 
 - name: Make sure we have a parent entry for users (this tests unsecure LDAP access)
   ldap_entry:


### PR DESCRIPTION
fixes #1832 

The molecule tests will fail on an AWS cluster due to the way the kiali_base_url was being defined.  The LDAP test also failed because the LDAP service type was incompatible with running on a remote AWS cluster.

This fixes it to use the Kiali Route, which should always be there.
This makes the LDAP service of type "LoadBalancer" and the test uses the external load balancer URL.

Because of the use of Route, this means the molecule tests will only run on OpenShift clusters (which I think we assumed anyway, but I just wanted to point this out).

@gbaufake I'm running tests over here myself, but you might want to review this and run those e2e/olm tests you have.