### PR TITLE
Filter API with AccessibleNamespaces

### DIFF
--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
+	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -18,10 +19,8 @@ import (
 
 func setupAppService(k8s *kubetest.K8SClientMock) AppService {
 	prom := new(prometheustest.PromClientMock)
-	layer := Layer{
-		k8s: k8s,
-	}
-	return AppService{k8s: k8s, prom: prom, businessLayer: &layer}
+	layer := NewWithBackends(k8s, prom)
+	return AppService{k8s: k8s, prom: prom, businessLayer: layer}
 }
 
 func TestGetAppListFromDeployments(t *testing.T) {
@@ -33,6 +32,8 @@ func TestGetAppListFromDeployments(t *testing.T) {
 	k8s := new(kubetest.K8SClientMock)
 	// Auxiliar fake* tests defined in workload_test.go
 	k8s.On("IsOpenShift").Return(true)
+	// Not needed a result, just to not send an error to test this usecase
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDeployments(), nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -60,6 +61,7 @@ func TestGetAppFromDeployments(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDeployments(), nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -92,6 +94,7 @@ func TestGetAppListFromReplicaSets(t *testing.T) {
 	k8s := new(kubetest.K8SClientMock)
 	// Auxiliar fake* tests defined in workload_test.go
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeReplicaSets(), nil)
@@ -119,6 +122,7 @@ func TestGetAppFromReplicaSets(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeReplicaSets(), nil)

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -73,6 +73,7 @@ func mockWorkLoadService(k8s *kubetest.K8SClientMock) WorkloadService {
 func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(false)
+	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
 	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("GetGateways", "test", mock.AnythingOfType("string")).Return(getGateway("first"), nil)
 	k8s.On("GetGateways", "test2", mock.AnythingOfType("string")).Return(getGateway("second"), nil)

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	core_v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes/kubetest"
@@ -17,9 +18,11 @@ func TestServiceListParsing(t *testing.T) {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.MockServices("Namespace", []string{"reviews", "httpbin"})
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(kubetest.FakePodList(), nil)
+	k8s.On("IsOpenShift").Return(false)
+	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
 	conf := config.NewConfig()
 	config.Set(conf)
-	svc := SvcService{k8s: k8s}
+	svc := SvcService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil)}
 
 	serviceList, _ := svc.GetServiceList("Namespace")
 

--- a/business/tls.go
+++ b/business/tls.go
@@ -109,11 +109,9 @@ func (in *TLSService) getAllDestinationRules(namespaces []string) ([]kubernetes.
 			var drs []kubernetes.IstioObject
 			var err error
 			// Check if namespace is cached
+			// Namespace access is checked in the upper call
 			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.DestinationRuleType) && kialiCache.CheckNamespace(ns) {
-				// Cache uses Kiali ServiceAccount, check if user can access to the namespace
-				if _, err = in.businessLayer.Namespace.GetNamespace(ns); err == nil {
-					drs, err = kialiCache.GetIstioResources(kubernetes.DestinationRuleType, ns)
-				}
+				drs, err = kialiCache.GetIstioResources(kubernetes.DestinationRuleType, ns)
 			} else {
 				drs, err = in.k8s.GetDestinationRules(ns, "")
 			}

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -166,6 +166,12 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 
 	ws := models.Workloads{}
 
+	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
+	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
+	if _, err := layer.Namespace.GetNamespace(namespace); err != nil {
+		return nil, err
+	}
+
 	wg := sync.WaitGroup{}
 	wg.Add(8)
 	errChan := make(chan error, 8)
@@ -173,6 +179,8 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 	go func() {
 		defer wg.Done()
 		var err error
+		// Check if namespace is cached
+		// Namespace access is checked in the upper caller
 		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
 			pods, err = kialiCache.GetPods(namespace, labelSelector)
 		} else {
@@ -188,11 +196,9 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		defer wg.Done()
 		var err error
 		// Check if namespace is cached
+		// Namespace access is checked in the upper caller
 		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
-			// Cache uses Kiali ServiceAccount, check if user can access to the namespace
-			if _, err = layer.Namespace.GetNamespace(namespace); err == nil {
-				dep, err = kialiCache.GetDeployments(namespace)
-			}
+			dep, err = kialiCache.GetDeployments(namespace)
 		} else {
 			dep, err = layer.k8s.GetDeployments(namespace)
 		}
@@ -206,11 +212,9 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		defer wg.Done()
 		var err error
 		// Check if namespace is cached
+		// Namespace access is checked in the upper caller
 		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
-			// Cache uses Kiali ServiceAccount, check if user can access to the namespace
-			if _, err = layer.Namespace.GetNamespace(namespace); err == nil {
-				repset, err = kialiCache.GetReplicaSets(namespace)
-			}
+			repset, err = kialiCache.GetReplicaSets(namespace)
 		} else {
 			repset, err = layer.k8s.GetReplicaSets(namespace)
 		}
@@ -646,6 +650,12 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string) (*models
 		Services: models.Services{},
 	}
 
+	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
+	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
+	if _, err := layer.Namespace.GetNamespace(namespace); err != nil {
+		return nil, err
+	}
+
 	wg := sync.WaitGroup{}
 	wg.Add(8)
 	errChan := make(chan error, 8)
@@ -654,12 +664,9 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string) (*models
 		defer wg.Done()
 		var err error
 		// Check if namespace is cached
+		// Namespace access is checked in the upper call
 		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
-			// Cache uses Kiali ServiceAccount, check if user can access to the namespace
-			if _, err = layer.Namespace.GetNamespace(namespace); err == nil {
-				pods, err = kialiCache.GetPods(namespace, "")
-			}
-
+			pods, err = kialiCache.GetPods(namespace, "")
 		} else {
 			pods, err = layer.k8s.GetPods(namespace, "")
 		}
@@ -673,11 +680,9 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string) (*models
 		defer wg.Done()
 		var err error
 		// Check if namespace is cached
+		// Namespace access is checked in the upper call
 		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
-			// Cache uses Kiali ServiceAccount, check if user can access to the namespace
-			if _, err = layer.Namespace.GetNamespace(namespace); err == nil {
-				dep, err = kialiCache.GetDeployment(namespace, workloadName)
-			}
+			dep, err = kialiCache.GetDeployment(namespace, workloadName)
 		} else {
 			dep, err = layer.k8s.GetDeployment(namespace, workloadName)
 		}
@@ -695,11 +700,9 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string) (*models
 		defer wg.Done()
 		var err error
 		// Check if namespace is cached
+		// Namespace access is checked in the upper call
 		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
-			// Cache uses Kiali ServiceAccount, check if user can access to the namespace
-			if _, err = layer.Namespace.GetNamespace(namespace); err == nil {
-				repset, err = kialiCache.GetReplicaSets(namespace)
-			}
+			repset, err = kialiCache.GetReplicaSets(namespace)
 		} else {
 			repset, err = layer.k8s.GetReplicaSets(namespace)
 		}

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
+	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -33,6 +34,7 @@ func TestGetWorkloadListFromDeployments(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDeployments(), nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -74,6 +76,7 @@ func TestGetWorkloadListFromReplicaSets(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeReplicaSets(), nil)
@@ -113,6 +116,7 @@ func TestGetWorkloadListFromReplicationControllers(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -153,6 +157,7 @@ func TestGetWorkloadListFromDeploymentConfigs(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDeploymentConfigs(), nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -193,6 +198,7 @@ func TestGetWorkloadListFromStatefulSets(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -233,6 +239,7 @@ func TestGetWorkloadListFromDepRCPod(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDepSyncedWithRS(), nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeRSSyncedWithPods(), nil)
@@ -264,6 +271,7 @@ func TestGetWorkloadListFromPod(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -295,6 +303,7 @@ func TestGetWorkloadListFromPods(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -332,6 +341,7 @@ func TestGetWorkloadFromDeployment(t *testing.T) {
 	notfound := errors.NewNotFound(gr, "not found")
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployment", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&FakeDepSyncedWithRS()[0], nil)
 	k8s.On("GetDeploymentConfig", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&osapps_v1.DeploymentConfig{}, notfound)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -364,6 +374,7 @@ func TestGetWorkloadFromPods(t *testing.T) {
 	notfound := errors.NewNotFound(gr, "not found")
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployment", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&apps_v1.Deployment{}, notfound)
 	k8s.On("GetDeploymentConfig", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&osapps_v1.DeploymentConfig{}, notfound)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
@@ -442,6 +453,7 @@ func TestDuplicatedControllers(t *testing.T) {
 	// Setup mocks
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDuplicatedDeployments(), nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDuplicatedReplicaSets(), nil)

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
+	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -20,7 +21,10 @@ import (
 
 func setupWorkloads() *business.Layer {
 	k8s := kubetest.NewK8SClientMock()
+	conf := config.NewConfig()
+	config.Set(conf)
 
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string")).Return([]apps_v1.Deployment{
 		apps_v1.Deployment{

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -3,6 +3,7 @@ package appender
 import (
 	"testing"
 
+	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	core_v1 "k8s.io/api/core/v1"
@@ -57,6 +58,7 @@ func TestCBAll(t *testing.T) {
 			"trafficPolicy": map[string]interface{}{"connectionPool": true},
 		},
 	}
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{
 		dRule.DeepCopyIstioObject(),
 	}, nil)
@@ -118,6 +120,7 @@ func TestCBSubset(t *testing.T) {
 			},
 		},
 	}
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{
 		dRule.DeepCopyIstioObject(),
 	}, nil)
@@ -186,6 +189,7 @@ func TestVS(t *testing.T) {
 			},
 		},
 	}
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), "").Return([]kubernetes.IstioObject{}, nil)
 	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Endpoints{}, nil)
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{core_v1.Service{}}, nil)

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +42,7 @@ func setupServiceEntries() *business.Layer {
 		},
 	}
 
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetServiceEntries", mock.AnythingOfType("string")).Return([]kubernetes.IstioObject{
 		&externalSE,
 		&internalSE},
@@ -246,6 +248,7 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 		},
 	}
 
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetServiceEntries", mock.AnythingOfType("string")).Return([]kubernetes.IstioObject{
 		&remoteSE},
 		nil)

--- a/graph/telemetry/istio/appender/sidecars_check_test.go
+++ b/graph/telemetry/istio/appender/sidecars_check_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
+	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -201,6 +202,7 @@ func buildFakeWorkloadPodsNoSidecar() []core_v1.Pod {
 func setupSidecarsCheckWorkloads(deployments []apps_v1.Deployment, pods []core_v1.Pod) *business.Layer {
 	k8s := kubetest.NewK8SClientMock()
 
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string")).Return(deployments, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 	osapps_v1 "github.com/openshift/api/apps/v1"
+	osproject_v1 "github.com/openshift/api/project/v1"
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -199,6 +200,7 @@ func TestAppsEndpoint(t *testing.T) {
 	ts, k8s, _ := setupAppListEndpoint()
 	defer ts.Close()
 
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(business.FakeDeployments(), nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
@@ -227,6 +229,7 @@ func TestAppDetailsEndpoint(t *testing.T) {
 	ts, k8s, _ := setupAppListEndpoint()
 	defer ts.Close()
 
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(business.FakeDeployments(), nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -53,6 +53,7 @@ func TestWorkloadsEndpoint(t *testing.T) {
 	ts, k8s, _ := setupWorkloadList()
 	defer ts.Close()
 
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(business.FakeDepSyncedWithRS(), nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(business.FakeRSSyncedWithPods(), nil)
 	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)

--- a/kubernetes/cache/namespaces.go
+++ b/kubernetes/cache/namespaces.go
@@ -1,9 +1,10 @@
 package cache
 
 import (
+	"time"
+
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
-	"time"
 )
 
 type (


### PR DESCRIPTION
This PR address two things:

- GetNamespaces() is filtered by AccessibleNamespaces, so API should be consistency, if Kiali has no visibility of a given namespace, rest of the API should skip it.
- There was an inconsistency in the cache/non cache use case.

There is no a "Security" flaw, as in any case, Kiali API is protected by RBAC (in OpenShift using the users's token, in Kubernetes, using the ServiceAccount).

Closes #1831 