### PR TITLE
Fix wizards for Istio 1.4

### DIFF
--- a/models/destination_rule.go
+++ b/models/destination_rule.go
@@ -29,7 +29,7 @@ type DestinationRule struct {
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Host          interface{} `json:"host"`
-		TrafficPolicy interface{} `json:"trafficPolicy"`
+		TrafficPolicy interface{} `json:"trafficPolicy,omitempty"`
 		Subsets       interface{} `json:"subsets"`
 	} `json:"spec"`
 }

--- a/models/virtual_service.go
+++ b/models/virtual_service.go
@@ -28,11 +28,11 @@ type VirtualService struct {
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
 		Hosts    interface{} `json:"hosts"`
-		Gateways interface{} `json:"gateways"`
-		Http     interface{} `json:"http"`
-		Tcp      interface{} `json:"tcp"`
-		Tls      interface{} `json:"tls"`
-		ExportTo interface{} `json:"exportTo"`
+		Gateways interface{} `json:"gateways,omitempty"`
+		Http     interface{} `json:"http,omitempty"`
+		Tcp      interface{} `json:"tcp,omitempty"`
+		Tls      interface{} `json:"tls,omitempty"`
+		ExportTo interface{} `json:"exportTo,omitempty"`
 	} `json:"spec"`
 }
 


### PR DESCRIPTION
The JSON coming from kiali-ui may not be "cleaned" from unset properties and Istio 1.4 seems to have more strict schemas for its CRDs.

This is ensuring that a "clean" JSON is used. Only CRDs involved in Kiali Wizards are fixed.

Related to kiali/kiali#1838, istio/istio#18558.