### PR TITLE
This change is required to support disconnected installs within OLM environment

### DIFF
--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -162,6 +162,10 @@ spec:
 # Determines which Kiali image to download and install.
 # If you set this to a specific name, you must make sure that image is supported by the operator.
 # If empty, the operator will use a known supported image name.
+# Note that, as a security measure, a cluster admin may have configured the Kiali operator to
+# ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs
+# a single, specific Kiali version, thus this setting may have no effect depending on how the
+# operator itself was configured.
 #    ---
 #    image_name: ""
 #
@@ -182,6 +186,10 @@ spec:
 # If you set this to a specific version (i.e. you do not leave it as the default empty string),
 # you must make sure that image version is supported by the operator.
 # If empty, the operator will use a known supported image version.
+# Note that, as a security measure, a cluster admin may have configured the Kiali operator to
+# ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs
+# a single, specific Kiali version, thus this setting may have no effect depending on how the
+# operator itself was configured.
 #    ---
 #    image_version: ""
 #

--- a/operator/manifests/kiali-ossm/1.0.7/kiali.v1.0.7.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-ossm/1.0.7/kiali.v1.0.7.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     support: Red Hat
     description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
     repository: https://github.com/kiali/kiali
-    createdAt: 2019-XX-XXT00:00:00Z
+    createdAt: 20XX-XX-XXT00:00:00Z
     alm-examples: |-
       [
         {
@@ -76,6 +76,9 @@ spec:
   version: 1.0.7
   maturity: stable
   replaces: kiali-operator.v1.0.6
+  relatedImages:
+  - name: kiali
+    image: registry.redhat.io/openshift-service-mesh/kiali-rhel7:1.0.7
   displayName: Kiali Operator
   description: |-
     ## About the managed application
@@ -286,6 +289,8 @@ spec:
                       fieldPath: metadata.namespace
                 - name: OPERATOR_NAME
                   value: "kiali-operator"
+                - name: KIALI_IMAGE
+                  value: registry.redhat.io/openshift-service-mesh/kiali-rhel7:1.0.7
               volumes:
               - name: runner
                 emptyDir: {}

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -161,10 +161,22 @@ kiali_defaults:
 # These variables are outside of the kiali_defaults. Their values will be
 # auto-detected by the role and are not meant to be set by the user.
 # However, for debugging purposes you can change these.
+
+is_k8s: false
+is_openshift: false
+
 # If supported_image.version is "operator_version" then the version of the
 # operator itself will be assumed, otherwise it can be any valid Kiali
 # version string. If the Kiali CR does not provide an image name or version,
 # supported_image defines the defaults that will be used.
-is_k8s: false
-is_openshift: false
+# A special override to this supported_image default is available by setting an environment
+# variable called KIALI_IMAGE in the operator's Deployment. This environment variable
+# must have a value such as "quay.io/kiali/kiali:v1.0" or "myrepo.io/kiali/kiali@sha256:abcde1234567890".
+# If such an environment variable exists, the value of KIALI_IMAGE overrides not only these defaults
+# but also the deployment.image_[name,version] that might be declared in the Kiali CR.
+# In other words, if you set an environment variable called KIALI_IMAGE in the operator's
+# Deployment then that is the only image the operator will deploy - you cannot tell
+# the operator to install any other Kiali image unless you modify the environment
+# variable's value (or you delete it from the Deployment).
+
 supported_image: {"name": "quay.io/kiali/kiali", "version": "operator_version" }

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -215,6 +215,23 @@
     kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': operator_version if supported_image.version == 'operator_version' else supported_image.version}}, recursive=True) }}"
   when:
   - kiali_vars.deployment.image_version == ""
+- name: Override the image name if the operator was told to install only a very specific image via env var
+  vars:
+    env_kiali_image: "{{ lookup('env', 'KIALI_IMAGE') }}"
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_name': env_kiali_image | regex_replace('(.+):.+', '\\1')}}, recursive=True) }}"
+  when:
+  - env_kiali_image is defined
+  - env_kiali_image != ""
+- name: Override the image version if the operator was told to install only a very specific image via env var
+  vars:
+    env_kiali_image: "{{ lookup('env', 'KIALI_IMAGE') }}"
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': env_kiali_image | regex_replace('.+:(.+)', '\\1')}}, recursive=True) }}"
+  when:
+  - env_kiali_image is defined
+  - env_kiali_image != ""
+
 - name: If image version is latest then we will want to always pull
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_pull_policy': 'Always'}}, recursive=True) }}"


### PR DESCRIPTION
This is backwards compatible. Without a env var KIALI_IMAGE in the operator Deployment,
the behavior is the same as before.
