### PR TITLE
Remove null values from JSON on Create operations

### DIFF
--- a/models/destination_rule.go
+++ b/models/destination_rule.go
@@ -28,9 +28,9 @@ type DestinationRule struct {
 	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
-		Host          interface{} `json:"host"`
+		Host          interface{} `json:"host,omitempty"`
 		TrafficPolicy interface{} `json:"trafficPolicy,omitempty"`
-		Subsets       interface{} `json:"subsets"`
+		Subsets       interface{} `json:"subsets,omitempty"`
 	} `json:"spec"`
 }
 

--- a/models/virtual_service.go
+++ b/models/virtual_service.go
@@ -27,7 +27,7 @@ type VirtualService struct {
 	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
 	Spec     struct {
-		Hosts    interface{} `json:"hosts"`
+		Hosts    interface{} `json:"hosts,omitempty"`
 		Gateways interface{} `json:"gateways,omitempty"`
 		Http     interface{} `json:"http,omitempty"`
 		Tcp      interface{} `json:"tcp,omitempty"`

--- a/util/maps.go
+++ b/util/maps.go
@@ -1,0 +1,14 @@
+package util
+
+func RemoveNilValues(root interface{}) {
+	if mRoot, isMap := root.(map[string]interface{}); isMap {
+		for k, v := range mRoot {
+			if v == nil {
+				delete(mRoot, k)
+			}
+			if leaf, isLeafMap := v.(map[string]interface{}); isLeafMap {
+				RemoveNilValues(leaf)
+			}
+		}
+	}
+}

--- a/util/maps_test.go
+++ b/util/maps_test.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRemoveNilValues(t *testing.T) {
+	vs := map[string]interface{}{
+		"k1": "v1",
+		"k2": nil,
+		"k3": map[string]interface{}{
+			"k3k1": "k3v1",
+			"k3k2": nil,
+			"k3k3": map[string]interface{}{
+				"k3k3k1": "k3k3v1",
+				"k3k3k2": nil,
+				"k3k3k3": "k3k3v3",
+			},
+		},
+	}
+
+	RemoveNilValues(vs)
+
+	_, k2 := vs["k2"]
+	_, k3k2 := (vs["k3"].(map[string]interface{}))["k3k2"]
+	_, k3k3k2 := ((vs["k3"].(map[string]interface{}))["k3k3"].(map[string]interface{}))["k3k3k2"]
+
+	assert.False(t, k2)
+	assert.False(t, k3k2)
+	assert.False(t, k3k3k2)
+
+	_, k1 := vs["k1"]
+	_, k3k1 := (vs["k3"].(map[string]interface{}))["k3k1"]
+	_, k3k3k1 := ((vs["k3"].(map[string]interface{}))["k3k3"].(map[string]interface{}))["k3k3k1"]
+
+	assert.True(t, k1)
+	assert.True(t, k3k1)
+	assert.True(t, k3k3k1)
+}


### PR DESCRIPTION
Fixes #1883 

This is a continuation of #1870. Main issue in Kiali is that our model in backend doesn't map entire types, so Marshall/Unmarshall didn't work in some use cases.

Also, this is not trivial, as empty values are valid when using patches, so UI will continue sending them.
But now with this patch, all JSON on CREATE operations should be cleaned from nil values if whole type is mapped or not.

Note that Golang has not a "omitempty" tag for generic.
