### PR TITLE
[hack] status reports age of cluster

### DIFF
--- a/hack/aws-openshift.sh
+++ b/hack/aws-openshift.sh
@@ -140,6 +140,7 @@ get_status() {
     ${OC} version
     echo "====================================================================="
     echo "Number of worker nodes in cluster: ${OPENSHIFT_WORKER_NODE_COUNT}"
+    echo "Age of cluster: $(${OC} get namespace kube-system --no-headers | tr -s ' ' | cut -d ' ' -f3)"
     echo "====================================================================="
     echo "whoami: $(${OC} whoami)"
     echo "====================================================================="


### PR DESCRIPTION
If your cluster has a maximum lifespan before it gets destroyed, this helps you judge when your cluster will be destroyed. The status can report how old the cluster is - you can use this to determine how much longer you have before the cluster goes away.

@jshaughn asked for this (or something like it).

