### PR TITLE
Updating Molecule OLM Tests for Openshift 4.2 and Openshift 4.3

### DIFF
--- a/operator/molecule/olm-test/assets/catalog-sources.yaml
+++ b/operator/molecule/olm-test/assets/catalog-sources.yaml
@@ -1,9 +1,0 @@
-apiVersion: operators.coreos.com/v1
-kind: CatalogSourceConfig
-metadata:
-  name: rhd-workshop-packages
-  namespace: openshift-marketplace
-spec:
-  packages: elasticsearch-operator,jaeger-product,kiali-ossm,servicemeshoperator
-  source: redhat-operators
-  targetNamespace: openshift-operators

--- a/operator/molecule/olm-test/assets/elasticsearch-subscription.yaml
+++ b/operator/molecule/olm-test/assets/elasticsearch-subscription.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: preview
-  source: rhd-workshop-packages
+  source: redhat-operators
   name: elasticsearch-operator
-  sourceNamespace: openshift-operators
+  sourceNamespace: openshift-marketplace

--- a/operator/molecule/olm-test/assets/jaeger-subscription.yaml
+++ b/operator/molecule/olm-test/assets/jaeger-subscription.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: stable
-  source: rhd-workshop-packages
+  source: redhat-operators
   name: jaeger-product
-  sourceNamespace: openshift-operators
+  sourceNamespace: openshift-marketplace

--- a/operator/molecule/olm-test/assets/kiali-subscription.yaml
+++ b/operator/molecule/olm-test/assets/kiali-subscription.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: stable
-  source: rhd-workshop-packages
+  source: redhat-operators
   name: kiali-ossm 
-  sourceNamespace: openshift-operators
+  sourceNamespace: openshift-marketplace

--- a/operator/molecule/olm-test/assets/servicemesh-subscription.yaml
+++ b/operator/molecule/olm-test/assets/servicemesh-subscription.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: "1.0"
-  source: rhd-workshop-packages
+  source: redhat-operators
   name: servicemeshoperator 
-  sourceNamespace: openshift-operators
+  sourceNamespace: openshift-marketplace

--- a/operator/molecule/olm-test/create.yml
+++ b/operator/molecule/olm-test/create.yml
@@ -12,10 +12,6 @@
     with_items:
     - "{{ maistra.cr.control_planes }}"
 
-  - name: Deploy Catalog Sources
-    k8s:
-      definition: "{{ lookup('template', catalog_sources_file_path) }}"
-
   - name: Deploy Elasticsearch Subscription
     k8s:
       definition: "{{ lookup('template', elasticsearch_subscription_path) }}"
@@ -54,9 +50,9 @@
     retries: 2000
     delay: 10
 
-  - name: Pause for 5 minutes to wait Maistra to create Admission Controller via OLM
+  - name: Pause for 2 minutes to wait Maistra to create Admission Controller via OLM
     pause:
-      minutes: 5
+      minutes: 2
     
   - name: Deploy Control Planes
     k8s:

--- a/operator/molecule/olm-test/destroy.yml
+++ b/operator/molecule/olm-test/destroy.yml
@@ -49,11 +49,6 @@
       state: absent
       definition: "{{ lookup('template', kiali_subscription_path) }}"
 
-  - name: Remove Catalog Sources
-    k8s:
-      state: absent
-      definition: "{{ lookup('template', catalog_sources_file_path) }}"
-
   - name: Delete Control Planes Namespaces
     k8s:
       name: "{{ item }}"


### PR DESCRIPTION
## Updating Molecule OLM Test Cases for Openshift 4.2 and Openshift 4.3

- To run this Pull Request:

0. Install Ansible and Molecule (``pip3 install ansible molecule junit-xml openshift --user``)

1. Deploy an Openshift 4.2 or 4.3 clean cluster

2. Login on the Openshift via `oc login`

3. Add more machines, because of this test uses 2 control planes for testing (including multi-tenancy testing) (something like 6 workers should do the work)

4. Run Following Commands if you want to see the full cycle (create-test-destroy):
``cd kiali/operator``
``molecule test -s olm-test``

5. If you don't want to destroy it, run the following commands:
``cd kiali/operator``
``molecule test -s olm-test --destroy never``
