### PR TITLE
Removing deadlock in IstioConfigList

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -133,7 +133,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 		return models.IstioConfigList{}, err
 	}
 
-	errChan := make(chan error, 1)
+	errChan := make(chan error, 18)
 
 	var wg sync.WaitGroup
 	wg.Add(18)


### PR DESCRIPTION
** Describe the change **

Tricky situation. In case there were two or more errors in the goroutines, the channel blocked the execution until the error was read. The problem was that there was a semaphore waiting for all the goroutines to finish. Deadlock. The result of this was a Timeout.
The execution is not blocked after adding a buffered channel of length 18. Each attempt to add will have room and won't block.

Right now, the response is:

![Screenshot of Kiali  istio-system  (9)](https://user-images.githubusercontent.com/613814/69069143-3e640a00-0a26-11ea-9124-08de61622390.jpg)

Then, when the user has permissions for the resource, the list will be displayed. Meaning, we are following the same pattern as before.

** Issue reference **

Closes https://github.com/kiali/kiali/issues/1550
