### PR TITLE
Adding port-naming-validation for service with sidecar

### DIFF
--- a/business/checkers/service_checker.go
+++ b/business/checkers/service_checker.go
@@ -1,10 +1,12 @@
 package checkers
 
 import (
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/kiali/kiali/business/checkers/services"
 	"github.com/kiali/kiali/models"
-	apps_v1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
 )
 
 const ServiceCheckerType = "service"
@@ -12,6 +14,7 @@ const ServiceCheckerType = "service"
 type ServiceChecker struct {
 	Services    []v1.Service
 	Deployments []apps_v1.Deployment
+	Pods        []core_v1.Pod
 }
 
 func (sc ServiceChecker) Check() models.IstioValidations {
@@ -28,7 +31,7 @@ func (sc ServiceChecker) runSingleChecks(service v1.Service) models.IstioValidat
 	key, validations := EmptyValidValidation(service.GetObjectMeta().GetName(), service.GetObjectMeta().GetNamespace(), ServiceCheckerType)
 
 	enabledCheckers := []Checker{
-		services.PortMappingChecker{Service: service, Deployments: sc.Deployments},
+		services.PortMappingChecker{Service: service, Deployments: sc.Deployments, Pods: sc.Pods},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -4,36 +4,48 @@ import (
 	"fmt"
 	"strings"
 
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
-	apps_v1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 type PortMappingChecker struct {
 	Service     v1.Service
 	Deployments []apps_v1.Deployment
+	Pods        []core_v1.Pod
 }
 
 func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
-	for portIndex, sp := range p.Service.Spec.Ports {
-		if strings.ToLower(string(sp.Protocol)) == "udp" {
-			continue
-		} else if !kubernetes.MatchPortNameWithValidProtocols(sp.Name) {
-			validation := models.Build("port.name.mismatch", fmt.Sprintf("spec/ports[%d]", portIndex))
-			validations = append(validations, &validation)
+	// Check Port naming for services in the service mesh
+	if p.hasMatchingPodsWithSidecar(p.Service) {
+		for portIndex, sp := range p.Service.Spec.Ports {
+			if strings.ToLower(string(sp.Protocol)) == "udp" {
+				continue
+			} else if !kubernetes.MatchPortNameWithValidProtocols(sp.Name) {
+				validation := models.Build("port.name.mismatch", fmt.Sprintf("spec/ports[%d]", portIndex))
+				validations = append(validations, &validation)
+			}
 		}
 	}
+
 	if deployment := p.findMatchingDeployment(p.Service.Spec.Selector); deployment != nil {
 		p.matchPorts(&p.Service, deployment, &validations)
 	}
 
 	return validations, len(validations) == 0
+}
+
+func (p PortMappingChecker) hasMatchingPodsWithSidecar(service v1.Service) bool {
+	sPods := models.Pods{}
+	sPods.Parse(kubernetes.FilterPodsForService(&service, p.Pods))
+	return sPods.HasIstioSidecar()
 }
 
 func (p PortMappingChecker) findMatchingDeployment(selectors map[string]string) *apps_v1.Deployment {

--- a/business/services.go
+++ b/business/services.go
@@ -111,7 +111,7 @@ func (in *SvcService) GetServiceList(namespace string) (*models.ServiceList, err
 func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []core_v1.Service, pods []core_v1.Pod, deployments []apps_v1.Deployment) *models.ServiceList {
 	services := make([]models.ServiceOverview, len(svcs))
 	conf := config.Get()
-	validations := in.getServiceValidations(svcs, deployments)
+	validations := in.getServiceValidations(svcs, deployments, pods)
 	// Convert each k8s service into our model
 	for i, item := range svcs {
 		sPods := kubernetes.FilterPodsForService(&item, pods)
@@ -441,10 +441,11 @@ func (in *SvcService) GetServiceDefinitionList(namespace string) (*models.Servic
 	return &sdl, nil
 }
 
-func (in *SvcService) getServiceValidations(services []core_v1.Service, deployments []apps_v1.Deployment) models.IstioValidations {
+func (in *SvcService) getServiceValidations(services []core_v1.Service, deployments []apps_v1.Deployment, pods []core_v1.Pod) models.IstioValidations {
 	validations := checkers.ServiceChecker{
 		Services:    services,
 		Deployments: deployments,
+		Pods:        pods,
 	}.Check()
 
 	return validations


### PR DESCRIPTION
** Describe the change **
Don't run the port name pattern validation for services out of the service mesh (without sidecar).

** Issue reference **
https://github.com/kiali/kiali/issues/1891
