### PR TITLE
[hack] ignore version warnings

### DIFF
--- a/hack/aws-openshift.sh
+++ b/hack/aws-openshift.sh
@@ -417,6 +417,9 @@ DEFAULT_CONTROL_PLANE_NAMESPACE="istio-system"
 # Default namespace where bookinfo is to be installed
 DEFAULT_BOOKINFO_NAMESPACE="bookinfo"
 
+# Temporarily ignore the version check by default since the current installer/client releases do not report correct versions
+IGNORE_VERSION_CHECK="true"
+
 # process command line args to override environment
 _CMD=""
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
for now, hack script will ignore version warnings since openshift installer/client releases do not report the expected versions.

This also bumps up to OS 4.2.8
