### PR TITLE
Low down the severity of 'service.deployment.port.mismatch' validation

### DIFF
--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -214,8 +214,8 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: ErrorSeverity,
 	},
 	"service.deployment.port.mismatch": {
-		Message:  "Service port and deployment port do not match",
-		Severity: ErrorSeverity,
+		Message:  "Deployment exposing same port as Service not found",
+		Severity: WarningSeverity,
 	},
 	"validation.unable.cross-namespace": {
 		Message:  "Unable to verify the validity, cross-namespace validation is not supported for this field",


### PR DESCRIPTION
** Describe the change **
Lowing the severity down from error to warning.
Changing the validation message.

** Issue reference **

https://github.com/kiali/kiali/issues/1891#issuecomment-557519775

Closes https://github.com/kiali/kiali/issues/1891