### PR TITLE
Move to Go1.12.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-sudo: required
-
-services:
-- docker
+# sudo: required
+#
+# services:
+# - docker
 
 language: go
 
 go:
-- 1.12.1
+- 1.13.4
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@
 language: go
 
 go:
-- 1.13.4
+- 1.12.13
 
 notifications:
   irc:

--- a/Makefile
+++ b/Makefile
@@ -342,4 +342,4 @@ lint-install:
 ## lint: Runs golangci-lint
 # doc.go is ommited for linting, because it generates lots of warnings.
 lint:
-	GL_DEBUG=linters_output GOPACKAGESPRINTGOLISTERRORS=1 golangci-lint run -v --skip-files "doc\.go" --tests
+	golangci-lint run --skip-files "doc\.go" --tests --timeout 5m

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,10 @@ CONSOLE_LOCAL_DIR ?= ../../../../../kiali-ui
 # The default is the VERSION itself.
 VERSION_LABEL ?= ${VERSION}
 
-# The minimum Go version that must be used to build the app.
-GO_VERSION_KIALI = 1.8.3
+# The go commands and the minimum Go version that must be used to build the app.
+GO ?= go
+GOFMT ?= $(shell eval $$(${GO} env); echo $$GOROOT)/bin/gofmt
+GO_VERSION_KIALI = 1.13.4
 
 # Identifies the container image that will be built and deployed.
 IMAGE_ORG ?= kiali
@@ -78,52 +80,52 @@ git-init:
 
 ## go-check: Check if the go version installed is supported by Kiali
 go-check:
-	@hack/check_go_version.sh "${GO_VERSION_KIALI}"
+	@GO=${GO} hack/check_go_version.sh "${GO_VERSION_KIALI}"
 
 ## build: Runs `make go-check` internally and build Kiali binary
 build: go-check
 	@echo Building...
-	${GO_BUILD_ENVVARS} go build \
+	${GO_BUILD_ENVVARS} ${GO} build \
 		-o ${GOPATH}/bin/kiali -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
 ## install: Install missing dependencies. Runs `go install` internally
 install:
 	@echo Installing...
-	${GO_BUILD_ENVVARS} go install \
+	${GO_BUILD_ENVVARS} ${GO} install \
 		-ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
 ## format: Format all the files excluding vendor. Runs `gofmt` internally
 format:
 	@# Exclude more paths find . \( -path './vendor' -o -path <new_path_to_exclude> \) -prune -o -type f -iname '*.go' -print
 	@for gofile in $$(find . -path './vendor' -prune -o -type f -iname '*.go' -print); do \
-			gofmt -w $$gofile; \
+			${GOFMT} -w $$gofile; \
 	done
 
 ## build-system-test: Building executable for system tests with code coverage enabled
 build-system-test:
 	@echo Building executable for system tests with code coverage enabled
-	go test -c -covermode=count -coverpkg $(shell go list ./... | grep -v test |  awk -vORS=, "{ print $$1 }" | sed "s/,$$//") \
+	${GO} test -c -covermode=count -coverpkg $(shell ${GO} list ./... | grep -v test |  awk -vORS=, "{ print $$1 }" | sed "s/,$$//") \
 	  -o ${GOPATH}/bin/kiali -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
 ## build-test: Run tests and installing test dependencies, excluding third party tests under vendor. Runs `go test -i` internally
 build-test:
 	@echo Building and installing test dependencies to help speed up test runs.
-	go test -i $(shell go list ./... | grep -v -e /vendor/)
+	${GO} test -i $(shell ${GO} list ./... | grep -v -e /vendor/)
 
 ## test: Run tests, excluding third party tests under vendor. Runs `go test` internally
 test:
 	@echo Running tests, excluding third party tests under vendor
-	go test $(shell go list ./... | grep -v -e /vendor/)
+	${GO} test $(shell ${GO} list ./... | grep -v -e /vendor/)
 
 ## test-debug: Run tests in debug mode, excluding third party tests under vendor. Runs `go test -v` internally
 test-debug:
 	@echo Running tests in debug mode, excluding third party tests under vendor
-	go test -v $(shell go list ./... | grep -v -e /vendor/)
+	${GO} test -v $(shell ${GO} list ./... | grep -v -e /vendor/)
 
 ## test-race: Run tests with race detection, excluding third party tests under vendor. Runs `go test -race` internally
 test-race:
 	@echo Running tests with race detection, excluding third party tests under vendor
-	go test -race $(shell go list ./... | grep -v -e /vendor/)
+	${GO} test -race $(shell ${GO} list ./... | grep -v -e /vendor/)
 
 ## test-e2e-setup: Setup Python environment for running test suite
 test-e2e-setup:
@@ -251,7 +253,7 @@ operator-create: docker-build-operator
 	IMAGE_ORG=${IMAGE_ORG} OPERATOR_IMAGE_VERSION=${CONTAINER_VERSION} "$(MAKE)" -C operator operator-create
 
 .ensure-oc-exists:
-	@$(eval OC ?= $(shell which oc 2>/dev/null || which istiooc 2>/dev/null || which kubectl))
+	@$(eval OC ?= $(shell which oc 2>/dev/null || which kubectl))
 
 .ensure-operator-is-running: .ensure-oc-exists
 	@${OC} get pods -l app=kiali-operator -n kiali-operator 2>/dev/null | grep "^kiali-operator.*Running" > /dev/null ;\

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ dep-update:
 ## swagger-install: Install swagger from github
 swagger-install:
 	@echo "Installing swagger binary to ${GOPATH}/bin..."
-	@curl https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64 -Lo ${GOPATH}/bin/swagger && chmod +x ${GOPATH}/bin/swagger
+	@curl https://github.com/go-swagger/go-swagger/releases/download/v0.21.0/swagger_linux_amd64 -Lo ${GOPATH}/bin/swagger && chmod +x ${GOPATH}/bin/swagger
 
 ## swagger-validate: Validate that swagger.json is correctly. Runs `swagger validate` internally
 swagger-validate:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.13.4
+GO_VERSION_KIALI = 1.12.13
 
 # Identifies the container image that will be built and deployed.
 IMAGE_ORG ?= kiali
@@ -166,7 +166,7 @@ dep-update:
 ## swagger-install: Install swagger from github
 swagger-install:
 	@echo "Installing swagger binary to ${GOPATH}/bin..."
-	@curl https://github.com/go-swagger/go-swagger/releases/download/v0.21.0/swagger_linux_amd64 -Lo ${GOPATH}/bin/swagger && chmod +x ${GOPATH}/bin/swagger
+	@curl https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64 -Lo ${GOPATH}/bin/swagger && chmod +x ${GOPATH}/bin/swagger
 
 ## swagger-validate: Validate that swagger.json is correctly. Runs `swagger validate` internally
 swagger-validate:
@@ -342,4 +342,4 @@ lint-install:
 ## lint: Runs golangci-lint
 # doc.go is ommited for linting, because it generates lots of warnings.
 lint:
-	golangci-lint run --skip-files "doc\.go" --tests
+	GL_DEBUG=linters_output GOPACKAGESPRINTGOLISTERRORS=1 golangci-lint run -v --skip-files "doc\.go" --tests

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ VERSION_LABEL ?= ${VERSION}
 
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
-GOFMT ?= $(shell eval $$(${GO} env); echo $$GOROOT)/bin/gofmt
+GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
 GO_VERSION_KIALI = 1.13.4
 
 # Identifies the container image that will be built and deployed.
@@ -337,7 +337,7 @@ ocp-kiali-create: .prepare-ocp-vars openshift-undeploy
 
 ## lint-install: Installs golangci-lint
 lint-install:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $$(go env GOPATH)/bin v1.17.1
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(${GO} env GOPATH)/bin v1.21.0
 
 ## lint: Runs golangci-lint
 # doc.go is ommited for linting, because it generates lots of warnings.

--- a/README.adoc
+++ b/README.adoc
@@ -82,7 +82,7 @@ See the link:./LICENSE[LICENSE file].
 These build instructions assume you have the following installed on your system: (1) link:http://golang.org/doc/install[Go Programming Language], (2) link:http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[git], (3) link:https://docs.docker.com/installation/[Docker], and (4) make. To run Kiali on OpenShift after you build it, it is assumed you have a running OpenShift environment available to you. If you do not, you can find a set of link:#setting-up-openshift[instructions on how to set up OpenShift below]. To run Kiali on Kubernetes after you built it, it is assumed you have a running Kubernetes environment available to you.
 
 [NOTE]
-Currently, Kiali releases are built using Go 1.12.13. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.13.4 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
+Currently, Kiali releases are built using Go 1.12.13. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.12.13 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
 
 To build Kiali:
 

--- a/README.adoc
+++ b/README.adoc
@@ -79,7 +79,10 @@ See the link:./LICENSE[LICENSE file].
 == Building
 
 [NOTE]
-These build instructions assume you have the following installed on your system: (1) link:http://golang.org/doc/install[Go Programming Language] which must be at least version 1.8.3, (2) link:http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[git], (3) link:https://docs.docker.com/installation/[Docker], and (4) make. To run Kiali on OpenShift after you build it, it is assumed you have a running OpenShift environment available to you. If you do not, you can find a set of link:#setting-up-openshift[instructions on how to set up OpenShift below]. To run Kiali on Kubernetes after you built it, it is assumed you have a running Kubernetes environment available to you.
+These build instructions assume you have the following installed on your system: (1) link:http://golang.org/doc/install[Go Programming Language], (2) link:http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[git], (3) link:https://docs.docker.com/installation/[Docker], and (4) make. To run Kiali on OpenShift after you build it, it is assumed you have a running OpenShift environment available to you. If you do not, you can find a set of link:#setting-up-openshift[instructions on how to set up OpenShift below]. To run Kiali on Kubernetes after you built it, it is assumed you have a running Kubernetes environment available to you.
+
+[NOTE]
+Currently, Kiali releases are built using Go 1.13.4. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.13.4 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
 
 To build Kiali:
 
@@ -156,10 +159,10 @@ This builds the Kiali operator image, too.
 ==== Deploying Kiali operator and Kiali to OpenShift
 
 [NOTE]
-Before deploying and running Kiali, you must first install and deploy link:https://istio.io[Istio]. *Required Istio Version: 1.1*. There are a few places that you can reference in order to learn how to do this. We recommend using link:https://maistra.io/docs/getting_started/[Maistra] but you can use the link:https://istio.io/docs/setup/kubernetes/install[upstream Istio instructions] making sure to follow the link:https://istio.io/docs/setup/kubernetes/prepare/platform-setup/openshift/[OpenShift preparation steps].
+Before deploying and running Kiali, you must first install and deploy link:https://istio.io[Istio]. There are a few places that you can reference in order to learn how to do this. We recommend using link:https://maistra.io/docs/installation/[Maistra] which is a variant of Istio. If you choose to use Istio, make sure to follow the link:https://istio.io/docs/setup/platform-setup/openshift/[OpenShift preparation steps]. Also, check the link:https://kiali.io/documentation/getting-started/#_kiali_version_requirements[version requirements] on our website to read notes about Istio and Maistra compatibility.
 
 [NOTE]
-The following make targets assume that either the `oc` command or the Maistra `istiooc` command is available in the user's PATH and that the user is logged in.
+The following make targets assume that the `oc` command is available in the user's PATH and that the user is logged in.
 
 [NOTE]
 The Makefile used in these commands is the link:./operator/Makefile[Operator Makefile] in the link:./operator[operator] directory. The legacy make targets in the main Makefile are still there for those developers that are used to using them - those legacy targets simply delegate to the Operator Makefile now.
@@ -526,20 +529,7 @@ In the provided Kubernetes templates, SSL is turned on by default. If you want t
 
 == Contributing
 
-See the link:./CONTRIBUTING.md[Contribution Guide].
+First, check the link:https://kiali.io/contribute[Contribute section in our web site], which provides a brief introduction on contributing, how to report issues and request features, and how to reach us.
 
-=== Talk to us
+If you would like to make code contributions, please also check the link:./CONTRIBUTING.md[Contribution Guide] as a starting point.
 
-Ask questions on the Kiali IRC channel (_#kiali_ on freenode) or the Google Groups: link:++https://groups.google.com/forum/#!forum/kiali-users++[kiali-users] or link:++https://groups.google.com/forum/#!forum/kiali-dev++[kiali-dev].
-
-=== Issue tracking
-
-The Kiali team is using link:https://issues.jboss.org/browse/KIALI[JIRA] for issue tracking. 
-If you do not have a JIRA account, you can also https://github.com/kiali/kiali/issues[open issues here on GitHub] (we are monitoring this as well) for any bugs or problems you encounter or to suggest new features.
-
-When you are looking for issues to get started, you can use this https://issues.jboss.org/issues/?filter=12336706[JIRA query for good first issues].
-If you pick one from the list, please let us know by the above mentioned means.
-
-=== Code Style Guide
-
-See the link:./STYLE_GUIDE.adoc[Backend Style Guide] and the link:https://github.com/kiali/kiali-ui/blob/master/STYLE_GUIDE.adoc[Frontend Style Guide].

--- a/README.adoc
+++ b/README.adoc
@@ -82,7 +82,7 @@ See the link:./LICENSE[LICENSE file].
 These build instructions assume you have the following installed on your system: (1) link:http://golang.org/doc/install[Go Programming Language], (2) link:http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[git], (3) link:https://docs.docker.com/installation/[Docker], and (4) make. To run Kiali on OpenShift after you build it, it is assumed you have a running OpenShift environment available to you. If you do not, you can find a set of link:#setting-up-openshift[instructions on how to set up OpenShift below]. To run Kiali on Kubernetes after you built it, it is assumed you have a running Kubernetes environment available to you.
 
 [NOTE]
-Currently, Kiali releases are built using Go 1.13.4. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.13.4 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
+Currently, Kiali releases are built using Go 1.12.13. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.13.4 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
 
 To build Kiali:
 

--- a/hack/check_go_version.sh
+++ b/hack/check_go_version.sh
@@ -9,6 +9,7 @@
 #
 
 USAGE="$0 GO_MIN_VERSION"
+GO=${GO:-go}
 
 die() {
     printf >&2 "fatal: %s\n" "$@"
@@ -75,12 +76,12 @@ check_at_least_version() {
 
 # Check that the go binary exist and is in the path
 
-type go >/dev/null 2>&1 || die_upgrade "go is not installed or not in the PATH!"
+type $GO >/dev/null 2>&1 || die_upgrade "$GO is not installed or not in the PATH!"
 
 # Check the go binary version
 
-VERS_STR=$(go version 2>&1) || die "'go version' failed with output: $VERS_STR"
+VERS_STR=$($GO version 2>&1) || die "'$GO version' failed with output: $VERS_STR"
 
-GO_CUR_VERSION=$(expr "$VERS_STR" : ".*go version go\([^ ]*\) .*") || die "Invalid 'go version' output: $VERS_STR"
+GO_CUR_VERSION=$(expr "$VERS_STR" : ".*go version go\([^ ]*\) .*") || die "Invalid '$GO version' output: $VERS_STR"
 
-check_at_least_version "$GO_MIN_VERSION" "$GO_CUR_VERSION" "go"
+check_at_least_version "$GO_MIN_VERSION" "$GO_CUR_VERSION" "$GO"

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -69,16 +69,16 @@ func handlePanic(w http.ResponseWriter) {
 	code := http.StatusInternalServerError
 	if r := recover(); r != nil {
 		var message string
-		switch r.(type) {
+		switch err := r.(type) {
 		case string:
-			message = r.(string)
+			message = err
 		case error:
-			message = r.(error).Error()
+			message = err.Error()
 		case func() string:
-			message = r.(func() string)()
+			message = err()
 		case graph.Response:
-			message = r.(graph.Response).Message
-			code = r.(graph.Response).Code
+			message = err.Message
+			code = err.Code
 		default:
 			message = fmt.Sprintf("%v", r)
 		}

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -29,8 +29,8 @@ NAMESPACE ?= istio-system
 SERVICE_TYPE ?= ClusterIP
 VERBOSE_MODE ?= 3
 
-# Find the client executable (either istiooc or oc or kubectl)
-OC ?= $(shell which oc 2>/dev/null || which istiooc 2>/dev/null || which kubectl 2>/dev/null || echo "MISSING-OC/KUBECTL-FROM-PATH")
+# Find the client executable (either oc or kubectl)
+OC ?= $(shell which oc 2>/dev/null || which kubectl 2>/dev/null || echo "MISSING-OC/KUBECTL-FROM-PATH")
 
 # Determine if Maistra/Service Mesh is deployed. If not, assume we are working with upstream Istio implementation.
 IS_MAISTRA ?= $(shell if ${OC} get namespace ${NAMESPACE} -o jsonpath='{.metadata.labels}' 2>/dev/null | grep -q maistra ; then echo "true" ; else echo "false" ; fi)

--- a/util/intutil/convert.go
+++ b/util/intutil/convert.go
@@ -5,17 +5,17 @@ import "errors"
 func Convert(subject interface{}) (int, error) {
 	var result int
 
-	switch subject.(type) {
+	switch typedSubject := subject.(type) {
 	case uint64:
-		result = int(subject.(uint64))
+		result = int(typedSubject)
 	case int64:
-		result = int(subject.(int64))
+		result = int(typedSubject)
 	case int32:
-		result = int(subject.(int32))
+		result = int(typedSubject)
 	case uint32:
-		result = int(subject.(uint32))
+		result = int(typedSubject)
 	case int:
-		result = subject.(int)
+		result = typedSubject
 	default:
 		return 0, errors.New("it is not a numeric input")
 	}


### PR DESCRIPTION
With these changes, Makefiles will ask for a minimum go version of 1.12.13. Additionally, the Makefile is changed so that it's possible to specify the go binary using an environment variable; ex: `GO=go1.13.4 make build`. This is useful if user has installed several go version (see https://golang.org/doc/install#extra_versions).

This also is:
* removing references to istiooc, because it's no longer supported in Maistra;
* a quick README.md cleanup;

Fixes #1970.