### PR TITLE
Implement token authentication

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,10 +39,12 @@ const (
 	AuthStrategyLogin     = "login"
 	AuthStrategyAnonymous = "anonymous"
 	AuthStrategyLDAP      = "ldap"
+	AuthStrategyToken     = "token"
 
 	TokenCookieName             = "kiali-token"
 	AuthStrategyOpenshiftIssuer = "kiali-openshift"
 	AuthStrategyLoginIssuer     = "kiali-login"
+	AuthStrategyTokenIssuer     = "kiali-token"
 
 	// These constants are used for external services auth (Prometheus, Grafana ...) ; not for Kiali auth
 	AuthTypeBasic  = "basic"

--- a/config/token.go
+++ b/config/token.go
@@ -79,13 +79,16 @@ func GetTokenClaimsIfValid(tokenString string) (*IanaClaims, error) {
 		cfg := Get()
 		claims := token.Claims.(*IanaClaims)
 
-		if claims.Issuer != AuthStrategyLoginIssuer && claims.Issuer != AuthStrategyOpenshiftIssuer {
+		if claims.Issuer != AuthStrategyLoginIssuer && claims.Issuer != AuthStrategyOpenshiftIssuer && claims.Issuer != AuthStrategyTokenIssuer {
 			return nil, errors.New("token has invalid issuer (auth strategy)")
 		}
 		if claims.Issuer == AuthStrategyLoginIssuer && cfg.Auth.Strategy != AuthStrategyLogin {
 			return nil, errors.New("token is invalid because of authentication strategy mismatch")
 		}
 		if claims.Issuer == AuthStrategyOpenshiftIssuer && cfg.Auth.Strategy != AuthStrategyOpenshift {
+			return nil, errors.New("token is invalid because of authentication strategy mismatch")
+		}
+		if claims.Issuer == AuthStrategyTokenIssuer && cfg.Auth.Strategy != AuthStrategyToken {
 			return nil, errors.New("token is invalid because of authentication strategy mismatch")
 		}
 

--- a/operator/deploy/deploy-kiali-operator.sh
+++ b/operator/deploy/deploy-kiali-operator.sh
@@ -123,8 +123,12 @@
 #    Determines what authentication strategy to use.
 #    Choose "login" to use a username and password.
 #    Choose "anonymous" to allow full access to Kiali without requiring any credentials.
+#    Choose "token" to allow access to Kiali using service account tokens, which controls
+#     access based on RBAC roles assigned to the service account.
 #    Choose "openshift" to use the OpenShift OAuth login which controls access
-#    based on the individual's RBAC roles in OpenShift.
+#     based on the individual's RBAC roles in OpenShift.
+#    Choose "ldap" to enable LDAP based authentication. There are additional configurations for
+#     LDAP auth strategy that are required. See below for the additional LDAP configuration section.
 #    Default: "openshift" (when using OpenShift), "login" (when using Kubernetes)
 #
 # CREDENTIALS_CREATE_SECRET
@@ -383,7 +387,7 @@ Valid options for Kiali installation (if Kiali is to be installed):
       Default: "^((?!(istio-operator|kube.*|openshift.*|ibm.*|kiali-operator)).)*$"
   -as|--auth-strategy
       Determines what authentication strategy to use.
-      Valid values are "login", "anonymous", and "openshift"
+      Valid values are "login", "anonymous", "token", "ldap" and "openshift"
       Default: "openshift" (when using OpenShift), "login" (when using Kubernetes)
   -ccs|--credentials-create-secret
       When "true" a secret will be created with the credentials provided to this script.
@@ -462,13 +466,13 @@ CLIENT_EXE=$(which istiooc 2>/dev/null || which oc 2>/dev/null)
 if [ "$?" == "0" ]; then
   echo "Using 'oc' located here: ${CLIENT_EXE}"
   _AUTH_STRATEGY_DEFAULT="openshift"
-  _AUTH_STRATEGY_PROMPT="Choose a login strategy of either 'login', 'openshift' or 'anonymous'. Use 'anonymous' at your own risk. [${_AUTH_STRATEGY_DEFAULT}]: "
+  _AUTH_STRATEGY_PROMPT="Choose a login strategy of either 'login', 'openshift', 'token', 'ldap' or 'anonymous'. Use 'anonymous' at your own risk. [${_AUTH_STRATEGY_DEFAULT}]: "
 else
   CLIENT_EXE=$(which kubectl 2>/dev/null)
   if [ "$?" == "0" ]; then
     echo "Using 'kubectl' located here: ${CLIENT_EXE}"
     _AUTH_STRATEGY_DEFAULT="login"
-    _AUTH_STRATEGY_PROMPT="Choose a login strategy of either 'login' or 'anonymous'. Use 'anonymous' at your own risk. [${_AUTH_STRATEGY_DEFAULT}]: "
+    _AUTH_STRATEGY_PROMPT="Choose a login strategy of either 'login', 'token', 'ldap' or 'anonymous'. Use 'anonymous' at your own risk. [${_AUTH_STRATEGY_DEFAULT}]: "
   else
     echo "ERROR: You do not have 'oc' or 'kubectl' in your PATH. Please install it and retry."
     exit 1
@@ -942,8 +946,8 @@ if [ "${AUTH_STRATEGY}" == "" ]; then
 fi
 
 # Verify the AUTH_STRATEGY is a proper known value
-if [ "${AUTH_STRATEGY}" != "login" ] && [ "${AUTH_STRATEGY}" != "openshift" ] && [ "${AUTH_STRATEGY}" != "anonymous" ]; then
-  echo "ERROR: unknown AUTH_STRATEGY [$AUTH_STRATEGY] must be either 'login', 'openshift' or 'anonymous'"
+if [ "${AUTH_STRATEGY}" != "login" ] && [ "${AUTH_STRATEGY}" != "openshift" ] && [ "${AUTH_STRATEGY}" != "anonymous" ] && [ "${AUTH_STRATEGY}" != "token" ] && [ "${AUTH_STRATEGY}" != "ldap" ]; then
+  echo "ERROR: unknown AUTH_STRATEGY [$AUTH_STRATEGY] must be either 'login', 'openshift', 'token', 'ldap' or 'anonymous'"
   exit 1
 fi
 

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -94,7 +94,7 @@ spec:
 #  auth:
 #
 # Determines what authentication strategy to use when users log into Kiali.
-# Options are "login", "anonymous", "openshift", "token".
+# Options are "login", "anonymous", "openshift", "token", "ldap".
 # Choose "login" to use a username and password that will be stored in a secret.
 # Choose "anonymous" to allow full access to Kiali without requiring any credentials.
 # Choose "token" to allow access to Kiali using service account tokens, which controls

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -94,13 +94,18 @@ spec:
 #  auth:
 #
 # Determines what authentication strategy to use when users log into Kiali.
-# Options are "login", "anonymous", "openshift".
+# Options are "login", "anonymous", "openshift", "token".
 # Choose "login" to use a username and password that will be stored in a secret.
 # Choose "anonymous" to allow full access to Kiali without requiring any credentials.
+# Choose "token" to allow access to Kiali using service account tokens, which controls
+#  access based on RBAC roles assigned to the service account.
 # Choose "openshift" to use the OpenShift OAuth login which controls access based on
-# the individual's  RBAC roles in OpenShift. Not valid for non-OpenShift environments.
+#  the individual's  RBAC roles in OpenShift. Not valid for non-OpenShift environments.
 # Choose "ldap" to enable LDAP based authentication. There are additional configurations for
-# LDAP auth strategy that are required. See below for the additional LDAP configuration section.
+#  LDAP auth strategy that are required. See below for the additional LDAP configuration section.
+# When empty, its value will default to "openshift" on OpenShift and "login" on Kubernetes.
+#    ---
+#    strategy: ""
 #    ---
 #    ldap:
 #      ldap_base: ""
@@ -122,10 +127,6 @@ spec:
 #      ldap_use_ssl: false
 #      ldap_user_filter: "(cn=%s)"
 #      ldap_user_id_key: "cn"
-#
-# When empty, its value will default to "openshift" on OpenShift and "login" on Kubernetes.
-#    ---
-#    strategy: ""
 
 ##########
 #  ---

--- a/operator/molecule/asserts/token-test/assert-token-access.yml
+++ b/operator/molecule/asserts/token-test/assert-token-access.yml
@@ -1,0 +1,64 @@
+# Wait for Kiali to be running and accepting requests.
+- import_tasks: ../common/wait_for_kiali_running.yml
+
+# Assert that we can access Kiali console login screen that does not need authentication
+- name: Get the console login screen from Kiali
+  uri:
+    url: "{{ kiali_base_url }}/console"
+    validate_certs: false
+
+# Try to access Kiali api endpoint that requires authentication (should return 401)
+- name: Attempt unauthorized access to api endpoint
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces"
+    status_code: 401
+    validate_certs: false
+
+# Try to log in with invalid token credentials
+- name: Attempt login with invalid token credentials
+  uri:
+    url: "{{ kiali_base_url }}/api/authenticate"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      token: invalid
+    status_code: 401
+    return_content: yes
+    validate_certs: false
+  register: kiali_output
+
+# Log in with good token credentials
+- name: Log in with good token credentials
+  uri:
+    url: "{{ kiali_base_url }}/api/authenticate"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      token: "{{ test_token }}"
+    return_content: yes
+    validate_certs: false
+  register: kiali_output
+- name: Assert that we were able to authenticate our token
+  assert:
+    that:
+    - kiali_output.json.token is defined
+    - kiali_output.json.token != ""
+    - kiali_output.json.username is defined
+    - kiali_output.json.username != ""
+- set_fact:
+    login_bearer_token: "Bearer {{ kiali_output.json.token }}"
+
+# With the login token, make a request to that same endpoint that requires authentication (should now return 200)
+- name: Make authorized access to api endpoint
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces"
+    headers:
+      Authorization: "{{ login_bearer_token }}"
+    return_content: yes
+    status_code: 200
+    validate_certs: false
+  register: kiali_output
+- name: Assert that we got json back
+  assert:
+    that:
+    - kiali_output.json is defined

--- a/operator/molecule/token-test/molecule.yml
+++ b/operator/molecule/token-test/molecule.yml
@@ -1,0 +1,46 @@
+---
+dependency:
+  name: galaxy
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+  inventory:
+    group_vars:
+      all:
+        kiali_operator_assets_path : "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/kiali-cr.yaml"
+        cr_namespace: kiali-operator
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          install_namespace: istio-system
+          accessible_namespaces: ["**"]
+          auth_strategy: token
+          operator_namespace: kiali-operator
+          operator_image_name: quay.io/kiali/kiali-operator
+          operator_version: latest
+          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
+          #operator_version: dev
+          operator_watch_namespace: kiali-operator
+          operator_clusterrolebindings: "- clusterrolebindings"
+          operator_clusterroles: "- clusterroles"
+          image_name: quay.io/kiali/kiali
+          image_version: latest
+          #image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali
+          #image_version: dev
+          image_pull_policy: Always
+scenario:
+  name: token-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/operator/molecule/token-test/playbook.yml
+++ b/operator/molecule/token-test/playbook.yml
@@ -1,0 +1,18 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  # prepare the test token
+  - import_tasks: prepare-token.yml
+    vars:
+      sa_namespace: "{{ istio.control_plane_namespace }}"
+
+  # test Kiali access via token
+  - import_tasks: ../asserts/token-test/assert-token-access.yml
+    vars:
+      test_token: "{{ test_token }}"

--- a/operator/molecule/token-test/prepare-token.yml
+++ b/operator/molecule/token-test/prepare-token.yml
@@ -1,0 +1,25 @@
+# This will obtain a namespace's default service account token that will be used to login for this test
+
+- name: Get default service account from namespace [{{ sa_namespace }}]
+  k8s_facts:
+    api_version: v1
+    kind: ServiceAccount
+    name: default
+    namespace: "{{ sa_namespace }}"
+  register: sa_default
+
+- name: Determine the name of the secret that contains the token
+  set_fact:
+    test_token_secret_name: "{{ sa_default.resources[0].secrets | selectattr('name', 'match', 'default-token-.*') | map(attribute='name') | list | first }}"
+
+- name: Get secret [{{ test_token_secret_name }}] containing the service account token
+  k8s_facts:
+    api_version: v1
+    kind: Secret
+    name: "{{ test_token_secret_name }}"
+    namespace: "{{ sa_namespace }}"
+  register: test_token_secret
+
+- name: Extract the service account token from the secret
+  set_fact:
+    test_token: "{{ test_token_secret.resources[0].data.token | b64decode }}"

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -264,21 +264,23 @@
     msg: "AUTH STRATEGY={{ kiali_vars.auth.strategy }}"
 - name: Confirm auth strategy is valid for OpenShift environments
   fail:
-    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login', 'openshift', 'ldap' or 'anonymous'"
+    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login', 'openshift', 'ldap', 'token' or 'anonymous'"
   when:
   - is_openshift == True
   - kiali_vars.auth.strategy != 'login'
   - kiali_vars.auth.strategy != 'anonymous'
   - kiali_vars.auth.strategy != 'openshift'
   - kiali_vars.auth.strategy != 'ldap'
+  - kiali_vars.auth.strategy != 'token'
 - name: Confirm auth strategy is valid for Kubernetes environments
   fail:
-    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login', 'ldap' or 'anonymous'"
+    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login', 'ldap', 'token' or 'anonymous'"
   when:
   - is_k8s == True
   - kiali_vars.auth.strategy != 'login'
   - kiali_vars.auth.strategy != 'anonymous'
   - kiali_vars.auth.strategy != 'ldap'
+  - kiali_vars.auth.strategy != 'token'
 - name: Confirm ldap configuration when auth strategy is 'ldap'
   fail:
     msg: "Invalid configuration for LDAP! The mandatory parameters should be provided like `ldap_host', 'ldap_port', 'ldap_bind_dn', and 'ldap_base'"


### PR DESCRIPTION
This is adding a login mechanism inspired on the [kubernetes dashboard login view](https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/README.md#login-view).

Instead of providing a username and a password, Kiali asks for a token. The provided token is meant to be a service account token and Kiali will use it during the session of the user to make calls to the cluster API.

By using the provided token to make calls to the cluster API, the cluster's RBAC mechanisms takes effect and write actions in Kiali can be limited using Roles and RoleBindings.

Currently, in Kubernetes, there is a limitation: the resulting _accessible namespaces_ given the Kiali ConfigMap should all be, at least, readable via the kiali-viewer role. Kiali will fail if a user logs in using a token that does not have read privileges in, at least, one of the "accessible namespaces". This limitation is because the Kubernetes API always returns all namespaces regardless if the user does not have access to any of the resources on it. In contrast, in OpenShift Kiali takes advantage of the Projects API which truncates the list to the readable namespaces.

Despite the limitation with Kubernetes, the new Token auth mechanism allows to login with privileges to modify the cluster, or to login in view mode by taking advantage of the cluster RBAC.

See also kiali/kiali-ui#1572

Related #1139