### PR TITLE
issue 1698 do not log a warning if its expected

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -290,7 +290,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 			} else {
 				// This query can return false if user doesn't have cluster permissions
 				// On this case we log internally the error but we return an empty list
-				log.Warningf("GetMeshPolicies failed during a GetIstioConfigList. Probably Kiali doesn't have cluster permissions. Error: %s", mpErr)
+				checkForbidden("GetMeshPolicies", mpErr, "probably Kiali doesn't have cluster permissions")
 			}
 		}
 	}()
@@ -305,7 +305,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 			} else {
 				// This query can return false if user doesn't have cluster permissions
 				// On this case we log internally the error but we return an empty list
-				log.Warningf("GetClusterRbacConfigs failed during a GetIstioConfigList. Probably Kiali doesn't have cluster permissions. Error: %s", crcErr)
+				checkForbidden("GetClusterRbacConfigs", crcErr, "probably Kiali doesn't have cluster permissions")
 			}
 		}
 	}()

--- a/business/tls.go
+++ b/business/tls.go
@@ -53,14 +53,7 @@ func (in *TLSService) hasMeshPolicyEnabled() (bool, error) {
 		if mps, err = in.k8s.GetMeshPolicies(); err != nil {
 			// This query can return false if Kiali doesn't have cluster permissions
 			// On this case we log internally the error but we return a false with nil
-			// To avoid flooding the logs with this message when it is expected, do not log
-			// the message if we know we do not have cluster role permissions. If we do expect to have
-			// cluster permissions, then something is really wrong and we need to log this message.
-			// We expect to have cluster permissions if accessible namespaces is "**".
-			an := config.Get().Deployment.AccessibleNamespaces
-			if len(an) == 1 && an[0] == "**" {
-				log.Warningf("GetMeshPolicies failed during a TLS validation. You should confirm that Kiali has the proper cluster permissions. Error: %s", err)
-			}
+			checkForbidden("GetMeshPolicies", err, "probably Kiali doesn't have cluster permissions")
 			return false, nil
 		}
 	} else {

--- a/business/tls.go
+++ b/business/tls.go
@@ -53,7 +53,14 @@ func (in *TLSService) hasMeshPolicyEnabled() (bool, error) {
 		if mps, err = in.k8s.GetMeshPolicies(); err != nil {
 			// This query can return false if Kiali doesn't have cluster permissions
 			// On this case we log internally the error but we return a false with nil
-			log.Warningf("GetMeshPolicies failed during a TLS validation. Probably Kiali doesn't have cluster permissions. Error: %s", err)
+			// To avoid flooding the logs with this message when it is expected, do not log
+			// the message if we know we do not have cluster role permissions. If we do expect to have
+			// cluster permissions, then something is really wrong and we need to log this message.
+			// We expect to have cluster permissions if accessible namespaces is "**".
+			an := config.Get().Deployment.AccessibleNamespaces
+			if len(an) == 1 && an[0] == "**" {
+				log.Warningf("GetMeshPolicies failed during a TLS validation. You should confirm that Kiali has the proper cluster permissions. Error: %s", err)
+			}
 			return false, nil
 		}
 	} else {


### PR DESCRIPTION
fixes #1698 

I took the path of least resistance. There should be no need to log this unless we have a cluster role and we know we have a cluster role when accessible namespaces is \*\* (and we know we do not have a cluster role when accessible namespaces is NOT \*\*).

This means it's a very small, localized change. No need to go through a huge change in the operator and adding a config setting to the configmap just to turn off this message - that seems like killing an ant with a sledgehammer.