### PR TITLE
[hack] only check if we are on OpenShift after the client-exe variable is determined

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -27,11 +27,6 @@ DASHBOARDS_ENABLED="false"
 ISTIO_EGRESSGATEWAY_ENABLED="true"
 CONFIG_PROFILE="default" # see "istioctl profile list" for valid values. See: https://istio.io/docs/setup/additional-setup/config-profiles/
 
-# If OpenShift, install CNI
-if [[ "${CLIENT_EXE}" = *"oc" ]]; then
-  CNI_OPTIONS="--set cni.enabled=true --set cni.components.cni.enabled=true --set cni.components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/var/run/multus/cni/net.d"
-fi
-
 # process command line args
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -194,6 +189,11 @@ if [ "${CLIENT_EXE}" = "" ]; then
     echo "ERROR: You must install the cluster client ${CLIENT_EXE_NAME} in your PATH before you can continue."
     exit 1
   fi
+fi
+
+# If OpenShift, install CNI
+if [[ "${CLIENT_EXE}" = *"oc" ]]; then
+  CNI_OPTIONS="--set cni.enabled=true --set cni.components.cni.enabled=true --set cni.components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/var/run/multus/cni/net.d"
 fi
 
 if [ "${ISTIO_DIR}" == "" ]; then


### PR DESCRIPTION
This fixes the problem that was reported here: https://github.com/kiali/kiali/pull/2029