### PR TITLE
Fixing 2 DR pointing to same host with short name svc.ns

### DIFF
--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -12,6 +12,7 @@ type DestinationRulesChecker struct {
 	DestinationRules []kubernetes.IstioObject
 	MTLSDetails      kubernetes.MTLSDetails
 	ServiceEntries   []kubernetes.IstioObject
+	Namespaces       []models.Namespace
 }
 
 func (in DestinationRulesChecker) Check() models.IstioValidations {
@@ -29,7 +30,7 @@ func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 	seHosts := kubernetes.ServiceEntryHostnames(in.ServiceEntries)
 
 	enabledDRCheckers := []GroupChecker{
-		destinationrules.MultiMatchChecker{DestinationRules: in.DestinationRules, ServiceEntries: seHosts},
+		destinationrules.MultiMatchChecker{Namespaces: in.Namespaces, DestinationRules: in.DestinationRules, ServiceEntries: seHosts},
 		destinationrules.TrafficPolicyChecker{DestinationRules: in.DestinationRules, MTLSDetails: in.MTLSDetails},
 	}
 

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -108,6 +108,29 @@ func TestMultiHostMatchValidShortFormat(t *testing.T) {
 	assert.Nil(validation)
 }
 
+func TestMultiHostMatchValidShortFormatDiffNamespace(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+		data.CreateTestDestinationRule("test", "rule2", "host2.bookinfo"),
+	}
+
+	validations := MultiMatchChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.Unknown, validation.Checks[0].Severity)
+}
+
 func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -59,6 +59,55 @@ func TestMultiHostMatchInvalid(t *testing.T) {
 	assert.Equal("rule1", validation.References[0].Name)
 }
 
+func TestMultiHostMatchInvalidShortFormat(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+		data.CreateTestDestinationRule("test", "rule2", "host1.test"),
+	}
+
+	validations := MultiMatchChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(2, len(validations))
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.Equal(models.CheckMessage("destinationrules.multimatch"), validation.Checks[0].Message)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule1", validation.References[0].Name)
+}
+
+func TestMultiHostMatchValidShortFormat(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+		data.CreateTestDestinationRule("test", "rule2", "host2.test"),
+	}
+
+	validations := MultiMatchChecker{
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.Empty(validations)
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
 func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -235,4 +284,32 @@ func TestMultiServiceEntry(t *testing.T) {
 	}.Check()
 
 	assert.Empty(validations)
+}
+
+func TestMultiServiceEntryInvalid(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	seA := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-a", "test", []string{"api.service_a.com"}))
+
+	drA := data.CreateEmptyDestinationRule("test", "service-a", "api.service_a.com")
+	drB := data.CreateEmptyDestinationRule("test", "service-a2", "api.service_a.com")
+
+	validations := MultiMatchChecker{
+		DestinationRules: []kubernetes.IstioObject{drA, drB},
+		ServiceEntries:   kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{seA}),
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Equal(2, len(validations))
+	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "service-a2"}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.Equal(1, len(validation.Checks))
+
+	assert.Equal(1, len(validation.References)) // Both reviews and reviews2 is faulty
 }

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -120,6 +120,10 @@ func TestMultiHostMatchValidShortFormatDiffNamespace(t *testing.T) {
 	}
 
 	validations := MultiMatchChecker{
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "bookinfo"},
+			models.Namespace{Name: "test"},
+		},
 		DestinationRules: destinationRules,
 	}.Check()
 

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -33,7 +33,7 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 	gatewayNames := kubernetes.GatewayNames(in.GatewaysPerNamespace)
 
 	for _, virtualService := range in.IstioDetails.VirtualServices {
-		validations.MergeValidations(runVirtualServiceCheck(virtualService, in.Namespace, serviceNames, serviceHosts))
+		validations.MergeValidations(runVirtualServiceCheck(virtualService, in.Namespace, serviceNames, serviceHosts, in.Namespaces))
 		validations.MergeValidations(runGatewayCheck(virtualService, gatewayNames))
 	}
 	for _, destinationRule := range in.IstioDetails.DestinationRules {
@@ -47,11 +47,12 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 	return validations
 }
 
-func runVirtualServiceCheck(virtualService kubernetes.IstioObject, namespace string, serviceNames []string, serviceHosts map[string][]string) models.IstioValidations {
+func runVirtualServiceCheck(virtualService kubernetes.IstioObject, namespace string, serviceNames []string, serviceHosts map[string][]string, clusterNamespaces models.Namespaces) models.IstioValidations {
 	key, validations := EmptyValidValidation(virtualService.GetObjectMeta().Name, virtualService.GetObjectMeta().Namespace, VirtualCheckerType)
 
 	result, valid := virtual_services.NoHostChecker{
 		Namespace:         namespace,
+		Namespaces:        clusterNamespaces,
 		ServiceNames:      serviceNames,
 		VirtualService:    virtualService,
 		ServiceEntryHosts: serviceHosts,

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -10,6 +10,7 @@ const VirtualCheckerType = "virtualservice"
 
 type VirtualServiceChecker struct {
 	Namespace        string
+	Namespaces       models.Namespaces
 	DestinationRules []kubernetes.IstioObject
 	VirtualServices  []kubernetes.IstioObject
 }
@@ -43,7 +44,7 @@ func (in VirtualServiceChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	enabledCheckers := []GroupChecker{
-		virtual_services.SingleHostChecker{Namespace: in.Namespace, VirtualServices: in.VirtualServices},
+		virtual_services.SingleHostChecker{Namespace: in.Namespace, Namespaces: in.Namespaces, VirtualServices: in.VirtualServices},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/virtual_service_checker_test.go
+++ b/business/checkers/virtual_service_checker_test.go
@@ -19,7 +19,11 @@ func prepareTestForVirtualService(istioObject kubernetes.IstioObject) models.Ist
 		data.CreateTestDestinationRule("bookinfo", "reviewsrule", "reviews"),
 	}
 
-	virtualServiceChecker := VirtualServiceChecker{"bookinfo", destinationList, istioObjects}
+	virtualServiceChecker := VirtualServiceChecker{
+		Namespace:        "bookinfo",
+		DestinationRules: destinationList,
+		VirtualServices:  istioObjects,
+	}
 
 	return virtualServiceChecker.Check()
 }
@@ -82,8 +86,11 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 		data.CreateTestDestinationRule("bookinfo", "reviewsrule1", "reviews"),
 	}
 
-	virtualServiceChecker := VirtualServiceChecker{"bookinfo",
-		destinationList, fakeVirtualServiceMultipleIstioObjects()}
+	virtualServiceChecker := VirtualServiceChecker{
+		Namespace:        "bookinfo",
+		DestinationRules: destinationList,
+		VirtualServices:  fakeVirtualServiceMultipleIstioObjects(),
+	}
 
 	validations := virtualServiceChecker.Check()
 	assert.NotEmpty(validations)

--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -111,9 +111,9 @@ func (n NoHostChecker) getHost(dHost, namespace, cluster string) kubernetes.Host
 		// Otherwise is considered as a service entry
 		if hParts[1] == namespace || n.Namespaces.Includes(hParts[1]) {
 			return kubernetes.Host{
-				Service:   hParts[0],
-				Namespace: hParts[1],
-				Cluster:   cluster,
+				Service:       hParts[0],
+				Namespace:     hParts[1],
+				Cluster:       cluster,
 				CompleteInput: true,
 			}
 		}

--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -10,6 +10,7 @@ import (
 
 type NoHostChecker struct {
 	Namespace         string
+	Namespaces        models.Namespaces
 	ServiceNames      []string
 	VirtualService    kubernetes.IstioObject
 	ServiceEntryHosts map[string][]string
@@ -34,8 +35,8 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 									if host == "" {
 										continue
 									}
-									if !n.checkDestination(parseHost(destination), protocol) {
-										fqdn := kubernetes.ParseHost(host, n.VirtualService.GetObjectMeta().Namespace, n.VirtualService.GetObjectMeta().ClusterName)
+									if !n.checkDestination(host, protocol) {
+										fqdn := n.getHost(host, n.VirtualService.GetObjectMeta().Namespace, n.VirtualService.GetObjectMeta().ClusterName)
 										path := fmt.Sprintf("spec/%s[%d]/route[%d]/destination/host", protocol, k, i)
 										if fqdn.Namespace != n.VirtualService.GetObjectMeta().Namespace && fqdn.CompleteInput {
 											validation := models.Build("validation.unable.cross-namespace", path)
@@ -80,7 +81,7 @@ func parseHost(destination interface{}) string {
 }
 
 func (n NoHostChecker) checkDestination(sHost, protocol string) bool {
-	fqdn := kubernetes.ParseHost(sHost, n.VirtualService.GetObjectMeta().Namespace, n.VirtualService.GetObjectMeta().ClusterName)
+	fqdn := n.getHost(sHost, n.VirtualService.GetObjectMeta().Namespace, n.VirtualService.GetObjectMeta().ClusterName)
 	if fqdn.Namespace == n.VirtualService.GetObjectMeta().Namespace {
 		// We need to check for namespace equivalent so that two services from different namespaces do not collide
 		for _, service := range n.ServiceNames {
@@ -100,4 +101,23 @@ func (n NoHostChecker) checkDestination(sHost, protocol string) bool {
 		}
 	}
 	return false
+}
+
+func (n NoHostChecker) getHost(dHost, namespace, cluster string) kubernetes.Host {
+	hParts := strings.Split(dHost, ".")
+	// It might be a service entry or a 2-format host specification
+	if len(hParts) == 2 {
+		// It is subject of validation when object is within the namespace
+		// Otherwise is considered as a service entry
+		if hParts[1] == namespace || n.Namespaces.Includes(hParts[1]) {
+			return kubernetes.Host{
+				Service:   hParts[0],
+				Namespace: hParts[1],
+				Cluster:   cluster,
+				CompleteInput: true,
+			}
+		}
+	}
+
+	return kubernetes.ParseHost(dHost, namespace, cluster)
 }

--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -36,7 +36,7 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 										continue
 									}
 									if !n.checkDestination(host, protocol) {
-										fqdn := n.getHost(host, n.VirtualService.GetObjectMeta().Namespace, n.VirtualService.GetObjectMeta().ClusterName)
+										fqdn := kubernetes.GetHost(host, n.VirtualService.GetObjectMeta().Namespace, n.VirtualService.GetObjectMeta().ClusterName, n.Namespaces.GetNames())
 										path := fmt.Sprintf("spec/%s[%d]/route[%d]/destination/host", protocol, k, i)
 										if fqdn.Namespace != n.VirtualService.GetObjectMeta().Namespace && fqdn.CompleteInput {
 											validation := models.Build("validation.unable.cross-namespace", path)
@@ -81,7 +81,7 @@ func parseHost(destination interface{}) string {
 }
 
 func (n NoHostChecker) checkDestination(sHost, protocol string) bool {
-	fqdn := n.getHost(sHost, n.VirtualService.GetObjectMeta().Namespace, n.VirtualService.GetObjectMeta().ClusterName)
+	fqdn := kubernetes.GetHost(sHost, n.VirtualService.GetObjectMeta().Namespace, n.VirtualService.GetObjectMeta().ClusterName, n.Namespaces.GetNames())
 	if fqdn.Namespace == n.VirtualService.GetObjectMeta().Namespace {
 		// We need to check for namespace equivalent so that two services from different namespaces do not collide
 		for _, service := range n.ServiceNames {
@@ -101,23 +101,4 @@ func (n NoHostChecker) checkDestination(sHost, protocol string) bool {
 		}
 	}
 	return false
-}
-
-func (n NoHostChecker) getHost(dHost, namespace, cluster string) kubernetes.Host {
-	hParts := strings.Split(dHost, ".")
-	// It might be a service entry or a 2-format host specification
-	if len(hParts) == 2 {
-		// It is subject of validation when object is within the namespace
-		// Otherwise is considered as a service entry
-		if hParts[1] == namespace || n.Namespaces.Includes(hParts[1]) {
-			return kubernetes.Host{
-				Service:       hParts[0],
-				Namespace:     hParts[1],
-				Cluster:       cluster,
-				CompleteInput: true,
-			}
-		}
-	}
-
-	return kubernetes.ParseHost(dHost, namespace, cluster)
 }

--- a/business/checkers/virtual_services/no_host_checker_test.go
+++ b/business/checkers/virtual_services/no_host_checker_test.go
@@ -87,7 +87,7 @@ func TestInvalidServiceNamespaceFormatHost(t *testing.T) {
 	)
 
 	validations, valid := NoHostChecker{
-		Namespace:      "test-namespace",
+		Namespace: "test-namespace",
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "outside-namespace"},

--- a/business/checkers/virtual_services/no_host_checker_test.go
+++ b/business/checkers/virtual_services/no_host_checker_test.go
@@ -76,6 +76,33 @@ func TestNoValidHost(t *testing.T) {
 	assert.Equal("", validations[0].Path)
 }
 
+func TestInvalidServiceNamespaceFormatHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	virtualService := data.AddRoutesToVirtualService("tcp", data.CreateRoute("reviews.outside-namespace", "v1", -1),
+		data.CreateEmptyVirtualService("reviews", "test", []string{"reviews"}),
+	)
+
+	validations, valid := NoHostChecker{
+		Namespace:      "test-namespace",
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "test"},
+			models.Namespace{Name: "outside-namespace"},
+		},
+		ServiceNames:   []string{"details", "other"},
+		VirtualService: virtualService,
+	}.Check()
+
+	assert.True(valid)
+	assert.NotEmpty(validations)
+	assert.Equal(models.Unknown, validations[0].Severity)
+	assert.Equal(models.CheckMessage("validation.unable.cross-namespace"), validations[0].Message)
+	assert.Equal("spec/tcp[0]/route[0]/destination/host", validations[0].Path)
+}
+
 func TestValidServiceEntryHost(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/virtual_services/single_host_checker.go
+++ b/business/checkers/virtual_services/single_host_checker.go
@@ -2,7 +2,6 @@ package virtual_services
 
 import (
 	"reflect"
-	"strings"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -132,29 +131,10 @@ func (s SingleHostChecker) getHosts(virtualService kubernetes.IstioObject) []kub
 			continue
 		}
 
-		targetHosts = append(targetHosts, s.getHost(hostName, namespace, clusterName))
+		targetHosts = append(targetHosts, kubernetes.GetHost(hostName, namespace, clusterName, s.Namespaces.GetNames()))
 	}
 
 	return targetHosts
-}
-
-func (s SingleHostChecker) getHost(dHost, namespace, cluster string) kubernetes.Host {
-	hParts := strings.Split(dHost, ".")
-	// It might be a service entry or a 2-format host specification
-	if len(hParts) == 2 {
-		// It is subject of validation when object is within the namespace
-		// Otherwise is considered as a service entry
-		if hParts[1] == namespace || s.Namespaces.Includes(hParts[1]) {
-			return kubernetes.Host{
-				Service:       hParts[0],
-				Namespace:     hParts[1],
-				Cluster:       cluster,
-				CompleteInput: true,
-			}
-		}
-	}
-
-	return kubernetes.ParseHost(dHost, namespace, cluster)
 }
 
 func hasGateways(virtualService *kubernetes.IstioObject) bool {

--- a/business/checkers/virtual_services/single_host_checker_test.go
+++ b/business/checkers/virtual_services/single_host_checker_test.go
@@ -154,6 +154,101 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 	emptyValidationTest(t, validations)
 }
 
+func TestRepeatingSVCNSHost(t *testing.T) {
+	vss := []kubernetes.IstioObject{
+		buildVirtualService("virtual-1", "reviews.bookinfo"),
+		buildVirtualService("virtual-2", "reviews.bookinfo"),
+	}
+	validations := SingleHostChecker{
+		Namespace: "bookinfo",
+		Namespaces: models.Namespaces{
+			{Name: "bookinfo"},
+		},
+		VirtualServices: vss,
+	}.Check()
+
+	presentValidationTest(t, validations, "virtual-1")
+	presentValidationTest(t, validations, "virtual-2")
+
+	vss = []kubernetes.IstioObject{
+		buildVirtualService("virtual-1", "reviews"),
+		buildVirtualService("virtual-2", "reviews.bookinfo"),
+	}
+	validations = SingleHostChecker{
+		Namespace: "bookinfo",
+		Namespaces: models.Namespaces{
+			{Name: "bookinfo"},
+		},
+		VirtualServices: vss,
+	}.Check()
+
+	presentValidationTest(t, validations, "virtual-1")
+	presentValidationTest(t, validations, "virtual-2")
+
+	vss = []kubernetes.IstioObject{
+		buildVirtualService("virtual-1", "reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "reviews.bookinfo"),
+		buildVirtualServiceWithGateway("virtual-3", "reviews", "bookinfo-gateway-auto"),
+	}
+	validations = SingleHostChecker{
+		Namespace: "bookinfo",
+		Namespaces: models.Namespaces{
+			{Name: "bookinfo"},
+		},
+		VirtualServices: vss,
+	}.Check()
+
+	presentValidationTest(t, validations, "virtual-1")
+	presentValidationTest(t, validations, "virtual-2")
+
+	vss = []kubernetes.IstioObject{
+		buildVirtualService("virtual-1", "*.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "reviews.bookinfo"),
+	}
+	validations = SingleHostChecker{
+		Namespace: "bookinfo",
+		Namespaces: models.Namespaces{
+			{Name: "bookinfo"},
+		},
+		VirtualServices: vss,
+	}.Check()
+
+	presentValidationTest(t, validations, "virtual-1")
+	presentValidationTest(t, validations, "virtual-2")
+
+	vss = []kubernetes.IstioObject{
+		buildVirtualService("virtual-1", "reviews"),
+		buildVirtualService("virtual-2", "details.bookinfo"),
+	}
+	validations = SingleHostChecker{
+		Namespace: "bookinfo",
+		Namespaces: models.Namespaces{
+			{Name: "bookinfo"},
+		},
+		VirtualServices: vss,
+	}.Check()
+
+	noObjectValidationTest(t, validations, "virtual-1")
+	noObjectValidationTest(t, validations, "virtual-2")
+	emptyValidationTest(t, validations)
+
+	vss = []kubernetes.IstioObject{
+		buildVirtualService("virtual-1", "reviews.bookinfo.svc.cluster.local"),
+		buildVirtualService("virtual-2", "details.bookinfo"),
+	}
+	validations = SingleHostChecker{
+		Namespace: "bookinfo",
+		Namespaces: models.Namespaces{
+			{Name: "bookinfo"},
+		},
+		VirtualServices: vss,
+	}.Check()
+
+	noObjectValidationTest(t, validations, "virtual-1")
+	noObjectValidationTest(t, validations, "virtual-2")
+	emptyValidationTest(t, validations)
+}
+
 func TestRepeatingFQDNHost(t *testing.T) {
 	vss := []kubernetes.IstioObject{
 		buildVirtualService("virtual-1", "reviews.bookinfo.svc.cluster.local"),

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -108,7 +108,7 @@ func (in *IstioValidationsService) getServiceCheckers(namespace string, services
 func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioDetails kubernetes.IstioDetails, services []core_v1.Service, workloads models.WorkloadList, gatewaysPerNamespace [][]kubernetes.IstioObject, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace) []ObjectChecker {
 	return []ObjectChecker{
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails},
-		checkers.VirtualServiceChecker{Namespace: namespace, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices},
+		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices},
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads},
 		checkers.MeshPolicyChecker{MeshPolicies: mtlsDetails.MeshPolicies, MTLSDetails: mtlsDetails},
@@ -162,7 +162,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 			checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads},
 		}
 	case VirtualServices:
-		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}
+		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}
 		objectCheckers = []ObjectChecker{noServiceChecker, virtualServiceChecker}
 	case DestinationRules:
 		destinationRulesChecker := checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -107,7 +107,7 @@ func (in *IstioValidationsService) getServiceCheckers(namespace string, services
 
 func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioDetails kubernetes.IstioDetails, services []core_v1.Service, workloads models.WorkloadList, gatewaysPerNamespace [][]kubernetes.IstioObject, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace) []ObjectChecker {
 	return []ObjectChecker{
-		checkers.NoServiceChecker{Namespace: namespace, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails},
+		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails},
 		checkers.VirtualServiceChecker{Namespace: namespace, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices},
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads},
@@ -154,7 +154,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	go in.fetchAuthorizationDetails(&rbacDetails, namespace, errChan, &wg)
 	wg.Wait()
 
-	noServiceChecker := checkers.NoServiceChecker{Namespace: namespace, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails}
+	noServiceChecker := checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails}
 
 	switch objectType {
 	case Gateways:

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -26,6 +26,8 @@ type Namespace struct {
 	CreationTimestamp time.Time `json:"-"`
 }
 
+type Namespaces []Namespace
+
 func CastNamespaceCollection(ns []core_v1.Namespace) []Namespace {
 	namespaces := make([]Namespace, len(ns))
 	for i, item := range ns {
@@ -58,4 +60,13 @@ func CastProject(p osproject_v1.Project) Namespace {
 	namespace.CreationTimestamp = p.CreationTimestamp.Time
 
 	return namespace
+}
+
+func (nss Namespaces) Includes(namespace string) bool {
+	for _, ns := range nss {
+		if ns.Name == namespace {
+			return true
+		}
+	}
+	return false
 }

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -70,3 +70,11 @@ func (nss Namespaces) Includes(namespace string) bool {
 	}
 	return false
 }
+
+func (nss Namespaces) GetNames() []string {
+	names := make([]string, len(nss))
+	for _, ns := range nss {
+		names = append(names, ns.Name)
+	}
+	return names
+}


### PR DESCRIPTION
** Describe the change **

Give support to 'service.namespace' support to DestinationRules and VirtualServices.
Fixes #1892 and also give extra support to #1884 (adds a unknown validation when refers to another namespace).

This is the list of the validations that now supports the `service.namespace` format:

# VirtualService

1. DestinationWeight on route doesn't have a valid service (host not found)
https://kiali.io/documentation/validations/#_destinationweight_on_route_doesn_t_have_a_valid_service_host_not_found
NoHostChecker

2. Subset not found
https://kiali.io/documentation/validations/#_subset_not_found
SubsetPresenceChecker

3. More than one Virtual Service for same host
https://kiali.io/documentation/validations/#_more_than_one_virtual_service_for_same_host
SingleHostChecker

# DestinationRules

1. This host has no matching entry in the service registry (service, workload or service entries)
https://kiali.io/documentation/validations/#_this_host_has_no_matching_entry_in_the_service_registry_service_workload_or_service_entries
NoDestinationChecker

2. More than one DestinationRules for the same host subset combination
https://kiali.io/documentation/validations/#_more_than_one_destination_rule_for_the_same_host_subset_combination
MultiMatchChecker


** Issue reference **

Closes https://github.com/kiali/kiali/issues/1892

** Backwards incompatible? **

yes
