### PR TITLE
Make Sprint #33 four weeks long

### DIFF
--- a/deploy/jenkins-ci/bin/determine-release-type.sh
+++ b/deploy/jenkins-ci/bin/determine-release-type.sh
@@ -13,10 +13,12 @@
 # - "snapshot.1": if it's determined that a snapshot
 #     release should be built (specifically, the second
 #     snapshot of the sprint.
+# - "snapshot.2": for some sprints with longer duration.
 #
 # The reference date (base date) can be set in the
 # environment variable BASE_DATE. By default, it is the
-# last day of Kiali Sprint #14.
+# last day of Kiali Sprint #14. Starting at end of Sprint #33,
+# BASE_DATE is the last day of Sprint #33.
 #
 # Both NOW_DATE and BASE_DATE should be given in seconds
 # since EPOCH. It is assumed that this script is run weekly
@@ -26,6 +28,13 @@
 BASE_DATE=${BASE_DATE:-$(date -d '2018-11-30' '+%s')}
 NOW_DATE=${NOW_DATE:-$(date -d 'now' '+%s')}
 
+# At end of Sprint #33, we use it's last day as the base date
+cond=$(date -d '2020-01-10' '+%s')
+if [ $NOW_DATE -ge $cond ];
+then
+  BASE_DATE=$cond
+fi
+
 # Transitional calculations
 DATE_DIFF=$(( $NOW_DATE - $BASE_DATE ))
 DAYS_ELAPSED=$(( $DATE_DIFF / (24*60*60) ))
@@ -33,6 +42,13 @@ WEEKS_ELAPSED=$(( $DAYS_ELAPSED / 7))
 
 # This value will be used to determine the type of the release
 WEEKS_MOD3=$(( $WEEKS_ELAPSED % 3 ))
+
+# Sprint #33 is 4 weeks long. Return 'snapshot.2' between Jan 3rd and Jan 9th
+if [ $NOW_DATE -ge $(date -d '2020-01-03' '+%s') ] && [ $NOW_DATE -lt $(date -d '2020-01-10' '+%s') ];
+then
+  echo 'snapshot.2'
+  exit 0
+fi
 
 case $WEEKS_MOD3 in
   0)


### PR DESCRIPTION
Tested with:
```
% NOW_DATE=$(date -d '2019-12-13' '+%s') ./determine-release-type.sh
minor

% NOW_DATE=$(date -d '2019-12-20' '+%s') ./determine-release-type.sh
snapshot.0

% NOW_DATE=$(date -d '2019-12-21' '+%s') ./determine-release-type.sh
snapshot.0

% NOW_DATE=$(date -d '2019-12-27' '+%s') ./determine-release-type.sh
snapshot.1

% NOW_DATE=$(date -d '2019-12-28' '+%s') ./determine-release-type.sh
snapshot.1

% NOW_DATE=$(date -d '2020-01-03' '+%s') ./determine-release-type.sh
snapshot.2

% NOW_DATE=$(date -d '2020-01-04' '+%s') ./determine-release-type.sh
snapshot.2

% NOW_DATE=$(date -d '2020-01-10' '+%s') ./determine-release-type.sh
minor

% NOW_DATE=$(date -d '2020-01-11' '+%s') ./determine-release-type.sh
minor

% NOW_DATE=$(date -d '2020-01-17' '+%s') ./determine-release-type.sh
snapshot.0

% NOW_DATE=$(date -d '2020-01-24' '+%s') ./determine-release-type.sh
snapshot.1

% NOW_DATE=$(date -d '2020-01-31' '+%s') ./determine-release-type.sh
minor

% NOW_DATE=$(date -d '2020-02-7' '+%s') ./determine-release-type.sh
snapshot.0
```