### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug :bug:'
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'enhancement :rocket:'
+labels: 'enhancement'
 assignees: ''
 
 ---


### PR DESCRIPTION
Lately, looks like no labels are being added to new issues when using the templates. But issue templates have labels that no longer exist because the emoji was removed some time ago.

Probably, this is the reason behind no labels being added when using the templates. This may fix the problem and we may, again, see the labels automatically added.

Related #1969.