### PR TITLE
report a container version as part of status results

### DIFF
--- a/kiali.go
+++ b/kiali.go
@@ -89,6 +89,7 @@ func main() {
 	status.Put(status.ConsoleVersion, consoleVersion)
 	status.Put(status.CoreVersion, version)
 	status.Put(status.CoreCommitHash, commitHash)
+	status.Put(status.ContainerVersion, determineContainerVersion(version))
 
 	if webRoot := config.Get().Server.WebRoot; webRoot != "/" {
 		updateBaseURL(webRoot)
@@ -240,6 +241,17 @@ func determineConsoleVersion() string {
 		log.Errorf("Failed to determine console version from file [%v]. error=%v", filename, err)
 	}
 	return consoleVersion
+}
+
+// determineContainerVersion will return the version of the image container.
+// It does this by looking at an ENV defined in the Dockerfile when the image is built.
+// If the ENV is not defined, the version is assumed the same as the given default value.
+func determineContainerVersion(defaultVersion string) string {
+	v := os.Getenv("KIALI_CONTAINER_VERSION")
+	if v == "" {
+		return defaultVersion
+	}
+	return v
 }
 
 // configToJS generates env.js file from Kiali config

--- a/status/status.go
+++ b/status/status.go
@@ -2,13 +2,14 @@
 package status
 
 const (
-	name           = "Kiali"
-	ConsoleVersion = name + " console version"
-	CoreVersion    = name + " core version"
-	CoreCommitHash = name + " core commit hash"
-	State          = name + " state"
-	ClusterMTLS    = "Istio mTLS"
-	StateRunning   = "running"
+	name             = "Kiali"
+	ContainerVersion = name + " container version"
+	ConsoleVersion   = name + " console version"
+	CoreVersion      = name + " core version"
+	CoreCommitHash   = name + " core commit hash"
+	State            = name + " state"
+	ClusterMTLS      = "Istio mTLS"
+	StateRunning     = "running"
 )
 
 // StatusInfo statusInfo


### PR DESCRIPTION
fixes #2054 

if KIALI_CONTAINER_VERSION is defined (typically in Dockerfile) then report it that version. Otherwise, assume container and server versions are the same.

related UI PR: https://github.com/kiali/kiali-ui/pull/1587