### PR TITLE
[operator] update base ansible image and change to k8s_info task

### DIFF
--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -1,10 +1,5 @@
-FROM quay.io/operator-framework/ansible-operator:v0.10.0
+FROM quay.io/operator-framework/ansible-operator:v0.13.0
 
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
 COPY watches.yaml ${HOME}/watches.yaml
-
-# Add things required by the operator not available in the base ansible operator image
-USER root
-RUN pip install jmespath
-USER 1001

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kiali
 annotations:
   ansible.operator-sdk/reconcile-period: "0s"
+  ansible.operator-sdk/verbosity: "3"
 spec:
 ###################################################################
 # kiali_cr.yaml

--- a/operator/deploy/kiali/kiali_cr_dev.yaml
+++ b/operator/deploy/kiali/kiali_cr_dev.yaml
@@ -2,6 +2,8 @@ apiVersion: kiali.io/v1alpha1
 kind: Kiali
 metadata:
   name: kiali
+  annotations:
+    ansible.operator-sdk/verbosity: "3"
 spec:
   auth:
     strategy: $AUTH_STRATEGY

--- a/operator/deploy/kiali/kiali_cr_dev_servicemesh.yaml
+++ b/operator/deploy/kiali/kiali_cr_dev_servicemesh.yaml
@@ -2,6 +2,8 @@ apiVersion: kiali.io/v1alpha1
 kind: Kiali
 metadata:
   name: kiali
+  annotations:
+    ansible.operator-sdk/verbosity: "3"
 spec:
   auth:
     strategy: "${AUTH_STRATEGY}"

--- a/operator/roles/kiali-deploy/tasks/create-namespace-label.yml
+++ b/operator/roles/kiali-deploy/tasks/create-namespace-label.yml
@@ -6,7 +6,7 @@
     the_labeled_namespace: {}
 
 - name: "Get namespace [{{ the_namespace }}] that is to be labeled"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -26,7 +26,7 @@
   - is_k8s == False
 
 - name: Get information about the operator
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
@@ -610,7 +610,7 @@
 # continue even though it means the monitoring dashboards feature will be disabled.
 
 - name: Wait for Monitoring Dashboards CRD to be ready
-  k8s_facts:
+  k8s_info:
     api_version: apiextensions.k8s.io/v1beta1
     kind: CustomResourceDefinition
     name: monitoringdashboards.monitoring.kiali.io

--- a/operator/roles/kiali-deploy/tasks/openshift/os-oauth.yml
+++ b/operator/roles/kiali-deploy/tasks/openshift/os-oauth.yml
@@ -2,7 +2,7 @@
 
 # Give some time for the route to come up
 - name: Detect Kiali route on OpenShift
-  k8s_facts:
+  k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
     name: kiali

--- a/operator/roles/kiali-deploy/tasks/remove-namespace-label.yml
+++ b/operator/roles/kiali-deploy/tasks/remove-namespace-label.yml
@@ -7,7 +7,7 @@
     the_namespace_label_value: null
 
 - name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/kiali-remove/tasks/remove-namespace-label.yml
+++ b/operator/roles/kiali-remove/tasks/remove-namespace-label.yml
@@ -10,7 +10,7 @@
 
 - name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
   ignore_errors: yes
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/1584
fixes https://github.com/kiali/kiali/issues/2073

Move up to base image of ansible operator SDK 0.13, which also means we need to move from k8s_facts to k8s_info due to deprecation of the former.