### PR TITLE
[operator] replace k8s_facts with k8s_info

### DIFF
--- a/operator/molecule/asserts/roles-test/ro_clusterrole_asserts.yml
+++ b/operator/molecule/asserts/roles-test/ro_clusterrole_asserts.yml
@@ -1,5 +1,5 @@
 - name: Get cluster roles
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: ClusterRole
    name: kiali-viewer
@@ -11,7 +11,7 @@
     fail_msg: "The kiali-viewer cluster role does not exist"
 
 - name: Get cluster role binding
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: ClusterRoleBinding
    name: kiali

--- a/operator/molecule/asserts/roles-test/ro_role_asserts.yml
+++ b/operator/molecule/asserts/roles-test/ro_role_asserts.yml
@@ -1,5 +1,5 @@
 - name: Get roles
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: Role
    namespace: "{{ item[0] }}"
@@ -16,7 +16,7 @@
   - "{{ roles.results }}"
 
 - name: Get role binding
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: RoleBinding
    namespace: "{{ item[0] }}"

--- a/operator/molecule/asserts/roles-test/rw_clusterrole_asserts.yml
+++ b/operator/molecule/asserts/roles-test/rw_clusterrole_asserts.yml
@@ -1,5 +1,5 @@
 - name: Get cluster roles
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: ClusterRole
    name: kiali
@@ -11,7 +11,7 @@
     fail_msg: "The kiali cluster role does not exist"
 
 - name: Get cluster role binding
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: ClusterRoleBinding
    name: kiali

--- a/operator/molecule/asserts/roles-test/rw_role_asserts.yml
+++ b/operator/molecule/asserts/roles-test/rw_role_asserts.yml
@@ -1,5 +1,5 @@
 - name: Get roles
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: Role
    namespace: "{{ item[0] }}"
@@ -16,7 +16,7 @@
   - "{{ roles.results }}"
 
 - name: Get role binding
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: RoleBinding
    namespace: "{{ item[0] }}"

--- a/operator/molecule/common/tasks.yml
+++ b/operator/molecule/common/tasks.yml
@@ -3,7 +3,7 @@
     kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
 
 - name: Get Kiali Operator Pod
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ kiali.operator_namespace }}"
@@ -12,7 +12,7 @@
   register: kiali_operator_pod
 
 - name: Get Kiali Pod
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ kiali.install_namespace }}"
@@ -29,7 +29,7 @@
     kiali_configmap: "{{ kiali_configmap.data['config.yaml'] | from_yaml }}"
 
 - name: Get Kiali Deployment
-  k8s_facts:
+  k8s_info:
     api_version: apps/v1
     kind: Deployment
     namespace: "{{ kiali.install_namespace }}"
@@ -38,7 +38,7 @@
   register: kiali_deployment
 
 - name: Get Kiali Service
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Service
     namespace: "{{ kiali.install_namespace }}"
@@ -47,7 +47,7 @@
   register: kiali_service
 
 - name: Get Kiali Route
-  k8s_facts:
+  k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
     namespace: "{{ kiali.install_namespace }}"

--- a/operator/molecule/common/wait_for_kiali_cr_changes.yml
+++ b/operator/molecule/common/wait_for_kiali_cr_changes.yml
@@ -1,5 +1,5 @@
 - name: Wait for changes to take effect
-  k8s_facts:
+  k8s_info:
     api_version: kiali.io/v1alpha1
     kind: Kiali
     name: "{{ custom_resource.metadata.name }}"

--- a/operator/molecule/common/wait_for_kiali_running.yml
+++ b/operator/molecule/common/wait_for_kiali_running.yml
@@ -1,5 +1,5 @@
 - name: Asserting that Kiali Pod exists and there is only one
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ kiali.install_namespace }}"

--- a/operator/molecule/default/destroy.yml
+++ b/operator/molecule/default/destroy.yml
@@ -43,7 +43,7 @@
 
   # Wait for the last things to be removed (which are the configmap and monitoring dashboards). This avoids the namespace-stuck-problem.
   - name: Wait for Kiali ConfigMap to be uninstalled
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: ConfigMap
       namespace: "{{ kiali.install_namespace }}"
@@ -55,7 +55,7 @@
     delay: 5
 
   - name: Wait for Kiali MonitoringDashboards to be uninstalled
-    k8s_facts:
+    k8s_info:
       api_version: monitoring.kiali.io/v1alpha1
       kind: MonitoringDashboard
       namespace: "{{ kiali.install_namespace }}"

--- a/operator/molecule/default/prepare.yml
+++ b/operator/molecule/default/prepare.yml
@@ -55,7 +55,7 @@
       definition: "{{ lookup('template', cr_file_path) }}"
 
   - name: Asserting that Kiali is Deployed
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Deployment
       namespace: "{{ kiali.install_namespace }}"

--- a/operator/molecule/ldap-test/prepare-ldap.yml
+++ b/operator/molecule/ldap-test/prepare-ldap.yml
@@ -21,7 +21,7 @@
     definition: "{{ lookup('template', ldap.service_file_path) }}"
 
 - name: Asserting that LDAP is Deployed
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Deployment
     namespace: "{{ ldap.namespace }}"
@@ -33,7 +33,7 @@
   delay: 5
 
 - name: Get the LDAP Service
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Service
     namespace: "{{ ldap.namespace }}"

--- a/operator/molecule/maistra-e2e-test/create.yml
+++ b/operator/molecule/maistra-e2e-test/create.yml
@@ -72,7 +72,7 @@
       definition: "{{ lookup('template', maistra_operator_file_path) }}"
 
   - name: Asserting that Maistra Operator is deployed
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Deployment
       namespace: "{{ operators.maistra.namespace }}"
@@ -94,7 +94,7 @@
     - "{{ maistra.cr.control_planes }}"
 
   - name: Asserting that Kialis are Deployed
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Deployment
       namespace: "{{ item }}"

--- a/operator/molecule/maistra-e2e-test/destroy.yml
+++ b/operator/molecule/maistra-e2e-test/destroy.yml
@@ -17,7 +17,7 @@
     - "{{ maistra.cr.control_planes }}"
 
   - name: Wait for ServiceMeshControlPlane to be uninstalled
-    k8s_facts:
+    k8s_info:
       api_version: maistra.io/v1
       kind: ServiceMeshControlPlane
       namespace: "{{ item }}"
@@ -58,7 +58,7 @@
       operator: "{{ operator | combine({'metadata':{'namespace': operators.kiali.namespace }}, recursive=True)   }}"
 
   - name: Wait for Kiali MonitoringDashboards to be uninstalled
-    k8s_facts:
+    k8s_info:
       api_version: monitoring.kiali.io/v1alpha1
       kind: MonitoringDashboard
       namespace: "{{ item }}"

--- a/operator/molecule/maistra-e2e-test/tests/tasks.yml
+++ b/operator/molecule/maistra-e2e-test/tests/tasks.yml
@@ -1,5 +1,5 @@
 - name: Get Kiali Operator Pod
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ operators.kiali.namespace }}"
@@ -8,7 +8,7 @@
   register: kiali_operator_pod
 
 - name: Get Kiali Pod
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ item }}"
@@ -19,7 +19,7 @@
   - "{{ maistra.cr.control_planes }}"
 
 - name: Get Kiali Configmap
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: ConfigMap
     namespace: "{{ item }}"
@@ -30,7 +30,7 @@
   
 
 - name: Get Service Mesh MemberRolls
-  k8s_facts:
+  k8s_info:
     api_version: maistra.io/v1
     kind: ServiceMeshMemberRoll
     namespace: "{{ item }}"
@@ -40,7 +40,7 @@
   - "{{ maistra.cr.control_planes }}"
 
 - name: Get Service Mesh Control Planes
-  k8s_facts:
+  k8s_info:
     api_version: maistra.io/v1
     kind: ServiceMeshControlPlane
     namespace: "{{ item }}"
@@ -69,7 +69,7 @@
 
 
 - name: Get Kiali Roles
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: Role
    namespace: "{{ item[0] }}"
@@ -81,7 +81,7 @@
 
 
 - name: Get Kiali Role Bindings
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: RoleBinding
    namespace: "{{ item[0] }}"

--- a/operator/molecule/olm-test/create.yml
+++ b/operator/molecule/olm-test/create.yml
@@ -29,7 +29,7 @@
       definition: "{{ lookup('template', kiali_subscription_path) }}"
 
   - name: Asserting that Kiali Operator is deployed via OLM
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Deployment
       namespace: "openshift-operators"
@@ -40,7 +40,7 @@
     delay: 10
 
   - name: Asserting that Maistra Operator is deployed via OLM
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Deployment
       namespace: "openshift-operators"
@@ -62,7 +62,7 @@
     - "{{ maistra.cr.control_planes }}"
 
   - name: Asserting that Kialis are Deployed via OLM
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Deployment
       namespace: "{{ item }}"

--- a/operator/molecule/olm-test/destroy.yml
+++ b/operator/molecule/olm-test/destroy.yml
@@ -17,7 +17,7 @@
     - "{{ maistra.cr.control_planes }}"
 
   - name: Wait for ServiceMeshControlPlane to be uninstalled
-    k8s_facts:
+    k8s_info:
       api_version: maistra.io/v1
       kind: ServiceMeshControlPlane
       namespace: "{{ item }}"

--- a/operator/molecule/olm-test/tests/tasks.yml
+++ b/operator/molecule/olm-test/tests/tasks.yml
@@ -1,5 +1,5 @@
 - name: Get Kiali Operator Pod
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "openshift-operators"
@@ -8,7 +8,7 @@
   register: kiali_operator_pod
 
 - name: Get Kiali Pod
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ item }}"
@@ -19,7 +19,7 @@
   - "{{ maistra.cr.control_planes }}"
 
 - name: Get Kiali Configmap
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: ConfigMap
     namespace: "{{ item }}"
@@ -30,7 +30,7 @@
   
 
 - name: Get Service Mesh MemberRolls
-  k8s_facts:
+  k8s_info:
     api_version: maistra.io/v1
     kind: ServiceMeshMemberRoll
     namespace: "{{ item }}"
@@ -40,7 +40,7 @@
   - "{{ maistra.cr.control_planes }}"
 
 - name: Get Service Mesh Control Planes
-  k8s_facts:
+  k8s_info:
     api_version: maistra.io/v1
     kind: ServiceMeshControlPlane
     namespace: "{{ item }}"
@@ -69,7 +69,7 @@
 
 
 - name: Get Kiali Roles
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: Role
    namespace: "{{ item[0] }}"
@@ -81,7 +81,7 @@
 
 
 - name: Get Kiali Role Bindings
-  k8s_facts:
+  k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: RoleBinding
    namespace: "{{ item[0] }}"

--- a/operator/molecule/os-console-links-test/playbook.yml
+++ b/operator/molecule/os-console-links-test/playbook.yml
@@ -12,7 +12,7 @@
 
   # Test that console links are correct for accessible namespaces of **
   - name: Get app link
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-app-{{ kiali.install_namespace }}"
@@ -54,25 +54,25 @@
 
   # Test that console links are correct across namespaces
   - name: Get app link
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-app-{{ kiali.install_namespace }}"
     register: applink
   - name: Get links from consolelinks1
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-namespace-consolelinks1"
     register: consolelinks1
   - name: Get links from consolelinks2
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-namespace-consolelinks2"
     register: consolelinks2
   - name: Get links from noconsolelinks
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-namespace-noconsolelinks"
@@ -106,25 +106,25 @@
 
   # Test that console links are correct - note we removed a namespace from accessible_namespaces so the link should be gone
   - name: Get app link
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-app-{{ kiali.install_namespace }}"
     register: applink
   - name: Get links from consolelinks1
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-namespace-consolelinks1"
     register: consolelinks1
   - name: Get links from consolelinks2
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-namespace-consolelinks2"
     register: consolelinks2
   - name: Get links from noconsolelinks
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-namespace-noconsolelinks"
@@ -153,25 +153,25 @@
 
   # Test that console links are correct across namespaces
   - name: Get app link
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-app-{{ kiali.install_namespace }}"
     register: applink
   - name: Get links from consolelinks1
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-namespace-consolelinks1"
     register: consolelinks1
   - name: Get links from consolelinks2
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-namespace-consolelinks2"
     register: consolelinks2
   - name: Get links from noconsolelinks
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       name: "kiali-namespace-noconsolelinks"
@@ -199,7 +199,7 @@
       name: "{{ custom_resource.metadata.name }}"
 
   - name: Confirm all the Console Links got deleted
-    k8s_facts:
+    k8s_info:
       api_version: console.openshift.io/v1
       kind: ConsoleLink
       label_selectors:

--- a/operator/molecule/token-test/prepare-token.yml
+++ b/operator/molecule/token-test/prepare-token.yml
@@ -1,7 +1,7 @@
 # This will obtain a namespace's default service account token that will be used to login for this test
 
 - name: Get default service account from namespace [{{ sa_namespace }}]
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: ServiceAccount
     name: default
@@ -13,7 +13,7 @@
     test_token_secret_name: "{{ sa_default.resources[0].secrets | selectattr('name', 'match', 'default-token-.*') | map(attribute='name') | list | first }}"
 
 - name: Get secret [{{ test_token_secret_name }}] containing the service account token
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Secret
     name: "{{ test_token_secret_name }}"

--- a/operator/roles/default/kiali-deploy/tasks/create-namespace-label.yml
+++ b/operator/roles/default/kiali-deploy/tasks/create-namespace-label.yml
@@ -6,7 +6,7 @@
     the_labeled_namespace: {}
 
 - name: "Get namespace [{{ the_namespace }}] that is to be labeled"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/default/kiali-deploy/tasks/main.yml
+++ b/operator/roles/default/kiali-deploy/tasks/main.yml
@@ -44,7 +44,7 @@
     is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
 
 - name: Get information about the operator
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
@@ -636,7 +636,7 @@
 # continue even though it means the monitoring dashboards feature will be disabled.
 
 - name: Wait for Monitoring Dashboards CRD to be ready
-  k8s_facts:
+  k8s_info:
     api_version: apiextensions.k8s.io/v1beta1
     kind: CustomResourceDefinition
     name: monitoringdashboards.monitoring.kiali.io

--- a/operator/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/operator/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -3,7 +3,7 @@
 # Give some time for the route to come up
 
 - name: Detect Kiali route on OpenShift
-  k8s_facts:
+  k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
     name: kiali

--- a/operator/roles/default/kiali-deploy/tasks/remove-namespace-label.yml
+++ b/operator/roles/default/kiali-deploy/tasks/remove-namespace-label.yml
@@ -7,7 +7,7 @@
     the_namespace_label_value: null
 
 - name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/default/kiali-remove/tasks/remove-namespace-label.yml
+++ b/operator/roles/default/kiali-remove/tasks/remove-namespace-label.yml
@@ -10,7 +10,7 @@
 
 - name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
   ignore_errors: yes
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/v1.0/kiali-deploy/tasks/create-namespace-label.yml
+++ b/operator/roles/v1.0/kiali-deploy/tasks/create-namespace-label.yml
@@ -6,7 +6,7 @@
     the_labeled_namespace: {}
 
 - name: "Get namespace [{{ the_namespace }}] that is to be labeled"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/v1.0/kiali-deploy/tasks/main.yml
+++ b/operator/roles/v1.0/kiali-deploy/tasks/main.yml
@@ -400,7 +400,7 @@
 # continue even though it means the monitoring dashboards feature will be disabled.
 
 - name: Wait for Monitoring Dashboards CRD to be ready
-  k8s_facts:
+  k8s_info:
     api_version: apiextensions.k8s.io/v1beta1
     kind: CustomResourceDefinition
     name: monitoringdashboards.monitoring.kiali.io

--- a/operator/roles/v1.0/kiali-deploy/tasks/openshift/os-oauth.yml
+++ b/operator/roles/v1.0/kiali-deploy/tasks/openshift/os-oauth.yml
@@ -2,7 +2,7 @@
 
 # Give some time for the route to come up
 - name: Detect Kiali route on OpenShift
-  k8s_facts:
+  k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
     name: kiali

--- a/operator/roles/v1.0/kiali-deploy/tasks/remove-namespace-label.yml
+++ b/operator/roles/v1.0/kiali-deploy/tasks/remove-namespace-label.yml
@@ -7,7 +7,7 @@
     the_namespace_label_value: null
 
 - name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/v1.0/kiali-remove/tasks/remove-namespace-label.yml
+++ b/operator/roles/v1.0/kiali-remove/tasks/remove-namespace-label.yml
@@ -10,7 +10,7 @@
 
 - name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
   ignore_errors: yes
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/v1.12/kiali-deploy/tasks/create-namespace-label.yml
+++ b/operator/roles/v1.12/kiali-deploy/tasks/create-namespace-label.yml
@@ -6,7 +6,7 @@
     the_labeled_namespace: {}
 
 - name: "Get namespace [{{ the_namespace }}] that is to be labeled"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/operator/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -44,7 +44,7 @@
     is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
 
 - name: Get information about the operator
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
@@ -636,7 +636,7 @@
 # continue even though it means the monitoring dashboards feature will be disabled.
 
 - name: Wait for Monitoring Dashboards CRD to be ready
-  k8s_facts:
+  k8s_info:
     api_version: apiextensions.k8s.io/v1beta1
     kind: CustomResourceDefinition
     name: monitoringdashboards.monitoring.kiali.io

--- a/operator/roles/v1.12/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/operator/roles/v1.12/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -3,7 +3,7 @@
 # Give some time for the route to come up
 
 - name: Detect Kiali route on OpenShift
-  k8s_facts:
+  k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
     name: kiali

--- a/operator/roles/v1.12/kiali-deploy/tasks/remove-namespace-label.yml
+++ b/operator/roles/v1.12/kiali-deploy/tasks/remove-namespace-label.yml
@@ -7,7 +7,7 @@
     the_namespace_label_value: null
 
 - name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"

--- a/operator/roles/v1.12/kiali-remove/tasks/remove-namespace-label.yml
+++ b/operator/roles/v1.12/kiali-remove/tasks/remove-namespace-label.yml
@@ -10,7 +10,7 @@
 
 - name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
   ignore_errors: yes
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ the_namespace }}"


### PR DESCRIPTION
fixes #2073
Latest ansible base image is using a version of ansible where k8s_facts is deprecated. Requires a simple search-n-replaceof `k8s_facts` with the new `k8s_info`.