### PR TITLE
fix makefile so it works with servicemesh deployments

### DIFF
--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -70,7 +70,7 @@ endif
 	cat ${KIALI_CR_FILE} | \
 ACCESSIBLE_NAMESPACES="${ACCESSIBLE_NAMESPACES}" \
 AUTH_STRATEGY="${AUTH_STRATEGY}" \
-KIALI_EXTERNAL_SERVICES_PASSWORD="$(shell ${OC} get secrets htpasswd -n ${NAMESPACE} -o jsonpath='{.data.rawPassword}' 2>/dev/null || echo '' | base64 --decode)" \
+KIALI_EXTERNAL_SERVICES_PASSWORD="$(shell ${OC} get secrets htpasswd -n ${NAMESPACE} -o jsonpath='{.data.rawPassword}' 2>/dev/null | base64 --decode)" \
 KIALI_IMAGE_NAME="${CLUSTER_KIALI_INTERNAL_NAME}" \
 KIALI_IMAGE_PULL_POLICY="${KIALI_IMAGE_PULL_POLICY}" \
 KIALI_IMAGE_VERSION="${CONTAINER_VERSION}" \


### PR DESCRIPTION
I don't know why this is behaving differently for me now, but all of a sudden this isn't working like it was.

But if I remove the `echo ''` , it will still work because the base64 decode will return an empty string on error or if the secret doesn't exist (which happens on non-ServiceMesh environs). This env var isn't used anyway for non-SM environs so it shouldn't matter anyway. It just needs to be correct when you have ServiceMesh installed (and in that case the secret will exist so that command should succeed).