### PR TITLE
update makefile to support building and deploying to other non-minikube/non-OS clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,11 @@ GO_BUILD_ENVVARS = \
 # Determine if we should use Docker OR Podman - value must be one of "docker" or "podman"
 DORP ?= docker
 
-# Set this to true if you want images to be tagged/pushed for minikube as opposed to OpenShift/AWS
-IS_MINIKUBE ?= false
+# Set this to 'minikube' if you want images to be tagged/pushed for minikube as opposed to OpenShift/AWS. Set to 'local' if the image should not be pushed to any remote cluster (requires the cluster to be able to pull from your local image repository).
+CLUSTER_TYPE ?= openshift
 
 # Find the client executable (either oc or kubectl). If minikube, only look for kubectl.
-ifeq ($(IS_MINIKUBE),true)
+ifeq ($(CLUSTER_TYPE),minikube)
 OC ?= $(shell which kubectl 2>/dev/null || echo "MISSING-KUBECTL-FROM-PATH")
 else
 OC ?= $(shell which oc 2>/dev/null || which kubectl 2>/dev/null || echo "MISSING-OC/KUBECTL-FROM-PATH")
@@ -87,7 +87,7 @@ OPERATOR_INSTALL_KIALI ?= false
 
 # When installing Kiali to a remote cluster via make, here are some configuration settings for it.
 ACCESSIBLE_NAMESPACES ?= **
-ifeq ($(IS_MINIKUBE),true)
+ifneq ($(CLUSTER_TYPE),openshift)
 AUTH_STRATEGY ?= login
 else
 AUTH_STRATEGY ?= openshift

--- a/README.adoc
+++ b/README.adoc
@@ -133,7 +133,9 @@ Before deploying and running Kiali, you must first install and deploy link:https
 
 By default, the make targets used to push and deploy Kiali images will assume you have an OpenShift 4.x cluster installed and running and that `oc` is found in your $PATH.
 
-If you wish to push and deploy Kiali to an installed and running Kubernetes (via Minikube) environment, pass the environment variable `IS_MINIKUBE=true` to the `make` commands and make sure `kubectl` is found in your $PATH.
+If you wish to push and deploy Kiali to an installed and running Kubernetes (via Minikube) environment, pass the environment variable `CLUSTER_TYPE=minikube` to the `make` commands and make sure `kubectl` is found in your $PATH.
+
+If you have neither minikube nor a remote OpenShift cluster, you can pass the environment variable `CLUSTER_TYPE=local` to the `make` commands and make sure you have either `oc` or `kubectl` in your $PATH. This requires your Kubernetes cluster to be able to pull from your local image repository.
 
 In order to deploy on Minikube using the below instructions, and to be able to access the deployed services, you must ensure you have the Registry and Ingress addons. To do this, ensure you run `minikube addons enable registry` and `minikube addons enable ingress` and add `kiali` as a hostname in your `/etc/hosts` via something like this command: `echo "$(minikube ip) kiali" | sudo tee -a /etc/hosts`
 

--- a/make/Makefile.cluster.mk
+++ b/make/Makefile.cluster.mk
@@ -41,10 +41,22 @@
 		exit 1 ;\
 	 fi
 
-ifeq ($(IS_MINIKUBE),true)
+.prepare-local: .ensure-oc-exists
+	@$(eval CLUSTER_KIALI_INTERNAL_NAME ?= ${CONTAINER_NAME})
+	@$(eval CLUSTER_KIALI_TAG ?= ${CONTAINER_NAME}:${CONTAINER_VERSION})
+	@$(eval CLUSTER_OPERATOR_INTERNAL_NAME ?= ${OPERATOR_CONTAINER_NAME})
+	@$(eval CLUSTER_OPERATOR_TAG ?= ${OPERATOR_CONTAINER_NAME}:${OPERATOR_CONTAINER_VERSION})
+
+ifeq ($(CLUSTER_TYPE),minikube)
 .prepare-cluster: .prepare-minikube
-else
+else ifeq ($(CLUSTER_TYPE),openshift)
 .prepare-cluster: .prepare-ocp
+else ifeq ($(CLUSTER_TYPE),local)
+.prepare-cluster: .prepare-local
+else
+.prepare-cluster:
+	@echo "ERROR: unknown CLUSTER_TYPE [${CLUSTER_TYPE}] - must be one of: openshift, minikube, local"
+	@exit 1
 endif
 
 ## cluster-build-operator: Builds the operator image for development with a remote cluster


### PR DESCRIPTION
fixes #2101 

If you do not have a minikube or remote openshift cluster, you can build and deploy using the  `CLUSTER_TYPE=local` env var. like this:

`CLUSTER_TYPE=local make container-build operator-create kiali-create`

This assumes the cluster can pull from your local repository.