### PR TITLE
VirtualService#Route validation: one route under 100 weight warning

### DIFF
--- a/business/checkers/virtual_service_checker_test.go
+++ b/business/checkers/virtual_service_checker_test.go
@@ -74,8 +74,8 @@ func TestVirtualServiceMixedChecker(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(validation.Name, "reviews-mixed")
 	assert.Equal(validation.ObjectType, "virtualservice")
-	assert.False(validation.Valid)
-	assert.Len(validation.Checks, 3)
+	assert.True(validation.Valid)
+	assert.Len(validation.Checks, 2)
 }
 
 func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
@@ -99,8 +99,8 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(validation.Name, "reviews-mixed")
 	assert.Equal(validation.ObjectType, "virtualservice")
-	assert.False(validation.Valid)
-	assert.Len(validation.Checks, 3)
+	assert.True(validation.Valid)
+	assert.Len(validation.Checks, 2)
 
 	validation, ok = validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "reviews-multiple"}]
 	assert.True(ok)
@@ -121,22 +121,18 @@ func fakeVirtualServices() kubernetes.IstioObject {
 }
 
 func fakeVirtualServicesMultipleChecks() kubernetes.IstioObject {
-
-	validVirtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v4", 55),
-		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v5", 45),
-			data.CreateEmptyVirtualService("reviews-multiple", "bookinfo", []string{}),
-		),
-	).DeepCopyIstioObject()
+	virtualService := data.CreateEmptyVirtualService("reviews-multiple", "bookinfo", []string{})
+	validVirtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 55), virtualService)
+	validVirtualService = data.AddRoutesToVirtualService("tcp", data.CreateRoute("reviews", "v2", 55),
+		validVirtualService).DeepCopyIstioObject()
 	delete(validVirtualService.GetSpec(), "hosts") // this isn't valid, but we mock the original testdata
 
 	return validVirtualService
 }
 
 func fakeVirtualServiceMixedChecker() kubernetes.IstioObject {
-	validVirtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v4", 155),
-		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v2", 45),
-			data.CreateEmptyVirtualService("reviews-mixed", "bookinfo", []string{}),
-		),
+	validVirtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v4", 05),
+		data.CreateEmptyVirtualService("reviews-mixed", "bookinfo", []string{}),
 	).DeepCopyIstioObject()
 	delete(validVirtualService.GetSpec(), "hosts") // this isn't valid, but we mock the original testdata
 

--- a/business/checkers/virtual_services/route_checker.go
+++ b/business/checkers/virtual_services/route_checker.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/intutil"
 )
@@ -68,19 +67,12 @@ func (route RouteChecker) checkRoutesFor(kind string) ([]*models.IstioCheck, boo
 
 			if weight, err := intutil.Convert(destinationWeight["weight"]); err == nil && weight < 100 {
 				valid = true
-				path := fmt.Sprintf("spec/%s[%d]/route/weight", kind, routeIdx)
-				validation := buildValidation("virtualservices.route.singleweight", path)
+				path := fmt.Sprintf("spec/%s[%d]/route[%d]/weight", kind, routeIdx, 0)
+				validation := models.Build("virtualservices.route.singleweight", path)
 				validations = append(validations, &validation)
 			}
 		}
 	}
 
 	return validations, valid
-}
-
-func buildValidation(checkId string, path string) models.IstioCheck {
-	validation := models.Build(checkId, path)
-	log.Infof("%s Galley should be performing this validation but it isn't. "+
-		"Make sure Galley is fully working.", checkId)
-	return validation
 }

--- a/business/checkers/virtual_services/route_checker.go
+++ b/business/checkers/virtual_services/route_checker.go
@@ -35,7 +35,7 @@ func (route RouteChecker) Check() ([]*models.IstioCheck, bool) {
 
 func (route RouteChecker) checkRoutesFor(kind string) ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
-	weightSum, weightCount, valid := 0, 0, true
+	valid := true
 
 	http := route.Route.GetSpec()[kind]
 	if http == nil {
@@ -54,50 +54,22 @@ func (route RouteChecker) checkRoutesFor(kind string) ([]*models.IstioCheck, boo
 			continue
 		}
 
-		weightCount, weightSum = 0, 0
-
 		// Getting a []DestinationWeight
 		destinationWeights := reflect.ValueOf(route["route"])
 		if destinationWeights.Kind() != reflect.Slice {
 			return validations, valid
 		}
 
-		for destWeightIdx := 0; destWeightIdx < destinationWeights.Len(); destWeightIdx++ {
-			destinationWeight, ok := destinationWeights.Index(destWeightIdx).Interface().(map[string]interface{})
+		if destinationWeights.Len() == 1 {
+			destinationWeight, ok := destinationWeights.Index(0).Interface().(map[string]interface{})
 			if !ok || destinationWeight["weight"] == nil {
 				continue
 			}
 
-			weightCount = weightCount + 1
-			weight, err := intutil.Convert(destinationWeight["weight"])
-			if err != nil {
-				valid = false
-				path := fmt.Sprintf("spec/%s[%d]/route[%d]/weight/%s",
-					kind, routeIdx, destWeightIdx, destinationWeight["weight"])
-				validation := buildValidation("virtualservices.route.numericweight", path)
-				validations = append(validations, &validation)
-			}
-
-			if weight > 100 || weight < 0 {
-				valid = false
-				path := fmt.Sprintf("spec/%s[%d]/route[%d]/weight/%d",
-					kind, routeIdx, destWeightIdx, weight)
-				validation := buildValidation("virtualservices.route.weightrange", path)
-				validations = append(validations, &validation)
-			}
-
-			weightSum = weightSum + weight
-		}
-
-		if weightCount > 0 && weightSum != 100 {
-			valid = false
-			path := fmt.Sprintf("spec/%s[%d]/route", kind, routeIdx)
-			validation := buildValidation("virtualservices.route.weightsum", path)
-			validations = append(validations, &validation)
-			if weightCount != destinationWeights.Len() {
-				valid = false
-				path := fmt.Sprintf("spec/%s[%d]/route", kind, routeIdx)
-				validation := buildValidation("virtualservices.route.allweightspresent", path)
+			if weight, err := intutil.Convert(destinationWeight["weight"]); err == nil && weight < 100 {
+				valid = true
+				path := fmt.Sprintf("spec/%s[%d]/route/weight", kind, routeIdx)
+				validation := buildValidation("virtualservices.route.singleweight", path)
 				validations = append(validations, &validation)
 			}
 		}

--- a/business/checkers/virtual_services/route_checker_test.go
+++ b/business/checkers/virtual_services/route_checker_test.go
@@ -34,7 +34,7 @@ func TestServiceMultipleChecks(t *testing.T) {
 	assert.Len(validations, 1)
 	assert.Equal(validations[0].Message, models.CheckMessage("virtualservices.route.singleweight"))
 	assert.Equal(validations[0].Severity, models.WarningSeverity)
-	assert.Equal(validations[0].Path, "spec/http[0]/route/weight")
+	assert.Equal(validations[0].Path, "spec/http[0]/route[0]/weight")
 }
 
 func fakeValidVirtualService() kubernetes.IstioObject {

--- a/business/checkers/virtual_services/route_checker_test.go
+++ b/business/checkers/virtual_services/route_checker_test.go
@@ -10,119 +10,34 @@ import (
 	"github.com/kiali/kiali/tests/data"
 )
 
+// VirtualService has two routes that all the weights sum 100
 func TestServiceWellVirtualServiceValidation(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
-	validations, valid := RouteChecker{fakeIstioObjects()}.Check()
+	validations, valid := RouteChecker{fakeValidVirtualService()}.Check()
 
 	// Well configured object
 	assert.True(valid)
 	assert.Empty(validations)
 }
 
+// VirtualService with one route and a weight between 0 and 100
 func TestServiceMultipleChecks(t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := RouteChecker{fakeMultipleChecks()}.Check()
-
-	// wrong weight'ed route rule
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 2)
-	assert.Equal(validations[0].Message, models.CheckMessage("virtualservices.route.weightrange"))
-	assert.Equal(validations[0].Severity, models.ErrorSeverity)
-	assert.Equal(validations[0].Path, "spec/http[0]/route[1]/weight/145")
-
-	assert.Equal(validations[1].Message, models.CheckMessage("virtualservices.route.weightsum"))
-	assert.Equal(validations[1].Severity, models.ErrorSeverity)
-	assert.Equal(validations[1].Path, "spec/http[0]/route")
-
-}
-
-func TestServiceOver100VirtualService(t *testing.T) {
-	assert := assert.New(t)
-
-	// Setup mocks
-	validations, valid := RouteChecker{fakeOver100VirtualService()}.Check()
-
-	// wrong weight'ed route rule
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 1)
-	assert.Equal(validations[0].Message, models.CheckMessage("virtualservices.route.weightsum"))
-	assert.Equal(validations[0].Severity, models.ErrorSeverity)
-	assert.Equal(validations[0].Path, "spec/http[0]/route")
-}
-
-func TestServiceUnder100VirtualService(t *testing.T) {
-	assert := assert.New(t)
-
-	// Setup mocks
-	validations, valid := RouteChecker{fakeUnder100VirtualService()}.Check()
-
-	// wrong weight'ed route rule
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 1)
-	assert.Equal(validations[0].Message, models.CheckMessage("virtualservices.route.weightsum"))
-	assert.Equal(validations[0].Severity, models.ErrorSeverity)
-	assert.Equal(validations[0].Path, "spec/http[0]/route")
-}
-
-func TestOneRouteWithoutWeight(t *testing.T) {
-	assert := assert.New(t)
-
-	// Setup mocks
-	validations, valid := RouteChecker{fakeOneRouteWithoutWeight()}.Check()
-
-	// wrong weight'ed route rule
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 2)
-
-	assert.Equal(validations[0].Message, models.CheckMessage("virtualservices.route.weightsum"))
-	assert.Equal(validations[0].Severity, models.ErrorSeverity)
-	assert.Equal(validations[0].Path, "spec/http[0]/route")
-
-	assert.Equal(validations[1].Message, models.CheckMessage("virtualservices.route.allweightspresent"))
-	assert.Equal(validations[1].Severity, models.WarningSeverity)
-	assert.Equal(validations[1].Path, "spec/http[0]/route")
-}
-
-func TestSecondHTTPRouteHasNoWeight(t *testing.T) {
-	assert := assert.New(t)
-
-	// Setup mocks
-	validations, valid := RouteChecker{fake2HTTPRoutes()}.Check()
-
-	// wrong weight'ed route rule
-	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 2)
-
-	assert.Equal(validations[0].Message, models.CheckMessage("virtualservices.route.weightsum"))
-	assert.Equal(validations[0].Severity, models.ErrorSeverity)
-	assert.Equal(validations[0].Path, "spec/http[0]/route")
-
-	assert.Equal(validations[1].Message, models.CheckMessage("virtualservices.route.allweightspresent"))
-	assert.Equal(validations[1].Severity, models.WarningSeverity)
-	assert.Equal(validations[1].Path, "spec/http[0]/route")
-}
-
-func TestNoWeightRouteBut100SumUp(t *testing.T) {
-	assert := assert.New(t)
-
-	// Setup mocks
-	validations, valid := RouteChecker{fake2Routes100SumUp()}.Check()
+	validations, valid := RouteChecker{fakeOneRouteUnder100()}.Check()
 
 	// wrong weight'ed route rule
 	assert.True(valid)
-	assert.Empty(validations)
-	assert.Len(validations, 0)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(validations[0].Message, models.CheckMessage("virtualservices.route.singleweight"))
+	assert.Equal(validations[0].Severity, models.WarningSeverity)
+	assert.Equal(validations[0].Path, "spec/http[0]/route/weight")
 }
 
-func fakeIstioObjects() kubernetes.IstioObject {
+func fakeValidVirtualService() kubernetes.IstioObject {
 	validVirtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 55),
 		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 45),
 			data.CreateEmptyVirtualService("reviews-well", "test", []string{"reviews"}),
@@ -132,69 +47,9 @@ func fakeIstioObjects() kubernetes.IstioObject {
 	return validVirtualService
 }
 
-func fakeUnder100VirtualService() kubernetes.IstioObject {
+func fakeOneRouteUnder100() kubernetes.IstioObject {
 	virtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 45),
-		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 45),
-			data.CreateEmptyVirtualService("reviews-100-minus", "test", []string{"reviews"}),
-		),
-	)
-
-	return virtualService
-}
-
-func fakeOver100VirtualService() kubernetes.IstioObject {
-	virtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 55),
-		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 55),
-			data.CreateEmptyVirtualService("reviews-100-plus", "test", []string{"reviews"}),
-		),
-	)
-
-	return virtualService
-}
-
-func fakeMultipleChecks() kubernetes.IstioObject {
-	virtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 145),
-		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 55),
-			data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
-		),
-	)
-
-	return virtualService
-}
-
-func fakeOneRouteWithoutWeight() kubernetes.IstioObject {
-	validVirtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", -1),
-		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 55),
-			data.CreateEmptyVirtualService("reviews-well", "test", []string{"reviews"}),
-		),
-	)
-
-	return validVirtualService
-}
-
-func fake2HTTPRoutes() kubernetes.IstioObject {
-	validVirtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", -1),
-		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 55),
-			data.CreateEmptyVirtualService("reviews-well", "test", []string{"reviews"}),
-		),
-	)
-
-	if routeTypeInterface, found := validVirtualService.GetSpec()["http"]; found {
-		if routeTypeCasted, ok := routeTypeInterface.([]interface{}); ok {
-			duplicateRoute := data.CreateRoute("reviews", "v1", -1)
-			routeTypeCasted = append(routeTypeCasted, duplicateRoute)
-			validVirtualService.GetSpec()["http"] = routeTypeCasted
-		}
-	}
-
-	return validVirtualService
-}
-
-func fake2Routes100SumUp() kubernetes.IstioObject {
-	virtualService := data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", 100),
-		data.AddRoutesToVirtualService("http", data.CreateRoute("reviews", "v1", -10),
-			data.CreateEmptyVirtualService("reviews-100-plus", "test", []string{"reviews"}),
-		),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
 	)
 
 	return virtualService

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -161,20 +161,8 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "VirtualService doesn't define any valid route protocol",
 		Severity: ErrorSeverity,
 	},
-	"virtualservices.route.numericweight": {
-		Message:  "Weight must be a number",
-		Severity: ErrorSeverity,
-	},
-	"virtualservices.route.weightrange": {
-		Message:  "Weight should be between 0 and 100",
-		Severity: ErrorSeverity,
-	},
-	"virtualservices.route.weightsum": {
-		Message:  "Weight sum should be 100",
-		Severity: ErrorSeverity,
-	},
-	"virtualservices.route.allweightspresent": {
-		Message:  "All routes should have weight",
+	"virtualservices.route.singleweight": {
+		Message:  "The weight is assumed to be 100 because there is only one route destination",
 		Severity: WarningSeverity,
 	},
 	"virtualservices.singlehost": {


### PR DESCRIPTION
** Describe the change **
1. Removing all the outdated validations that Galley takes care of.
2. Adding one warning validation for the following scenario:

```yaml
kind: VirtualService
apiVersion: networking.istio.io/v1alpha3
metadata:
  name: reviews
  namespace: bookinfo
spec:
  hosts:
    - reviews
  http:
    - route:
        - destination:
            host: reviews
            subset: v1
          weight: 80
```
This is the scenario where there is only one destinationRouteWeight but there is a weight different to 100. In this case, Istio assumes the weight to be 100. Independently the value set in the weight field.

The validation message is the following:
`The weight is assumed to be 100 because there is only one route destination`

** Issue reference **
Relates to https://github.com/kiali/kiali/issues/1528

** Screeeenshot **
![Screenshot of localhost_8000_api_namespaces_bookinfo_istio_virtualservices_reviews_validate=true](https://user-images.githubusercontent.com/613814/72531503-ea34a500-3871-11ea-8da8-221221897c5c.jpg)

