### PR TITLE
[operator] allow user to override ingress spec and annotation sections to be able to customize it

### DIFF
--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -214,7 +214,7 @@ spec:
 #    ---
 #    namespace: ""
 #
-# Because an ingress into a cluster can vary wildly in their desired configuration,
+# Because an ingress into a cluster can vary wildly in its desired configuration,
 # this setting provides a way to override complete portions of the ingress resource
 # configuration (Ingress on Kubernetes and Route on OpenShift). It is up to the user
 # to ensure this override YAML configuration is valid and supports the cluster environment

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -214,6 +214,33 @@ spec:
 #    ---
 #    namespace: ""
 #
+# Because an ingress into a cluster can vary wildly in their desired configuration,
+# this setting provides a way to override complete portions of the ingress resource
+# configuration (Ingress on Kubernetes and Route on OpenShift). It is up to the user
+# to ensure this override YAML configuration is valid and supports the cluster environment
+# since the operator will blindly copy this custom configuration into the resource it
+# creates.
+# This setting is not used if deployment.ingress_enabled is set to 'false'.
+# Note that only 'metadata.annotations' and 'spec' is valid and only they will
+# be used to override those same sections in the created resource. You can define
+# either one or both.
+# Example:
+#   override_ingress_yaml:
+#     metadata:
+#       annotations:
+#         nginx.ingress.kubernetes.io/secure-backends: "true"
+#         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+#     spec:
+#       rules:
+#       - http:
+#           paths:
+#           - path: /kiali
+#             backend:
+#               serviceName: kiali
+#               servicePort: 20001
+#    ---
+#    #override_ingress_yaml:
+#
 # Custom annotations to be created on the Kiali pod.
 #    ---
 #    pod_annotations: {}

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -59,6 +59,7 @@ kiali_defaults:
     image_version: ""
     ingress_enabled: true
     namespace: ""
+    #override_ingress_yaml:
     pod_annotations: {}
     priority_class_name: ""
     replicas: 1

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -118,6 +118,15 @@
   - kiali_vars.deployment.resources is defined
   - kiali_vars.deployment.resources | length > 0
 
+- name: Replace snake_case with camelCase in deployment.override_ingress_yaml
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('override_ingress_yaml') %}
+      {{ kiali_vars | combine({'deployment': {'override_ingress_yaml': current_cr.spec.deployment.override_ingress_yaml }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.override_ingress_yaml is defined
+  - kiali_vars.deployment.override_ingress_yaml | length > 0
+
 - name: Print some debug information
   vars:
     msg: |

--- a/operator/roles/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/operator/roles/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -6,13 +6,20 @@ metadata:
   labels:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
+{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
+  {{ kiali_vars.deployment.override_ingress_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% else %}
   annotations:
     # For ingress-nginx versions older than 0.20.0
     # (see: https://github.com/kubernetes/ingress-nginx/issues/3416#issuecomment-438247948)
     nginx.ingress.kubernetes.io/secure-backends: "{{ 'false' if kiali_vars.identity.cert_file == "" else 'true' }}"
     # For ingress-nginx versions 0.20.0 and later
     nginx.ingress.kubernetes.io/backend-protocol: "{{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}"
+{% endif %}
 spec:
+{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.spec is defined %}
+  {{ kiali_vars.deployment.override_ingress_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% else %}
   rules:
   - http:
       paths:
@@ -20,3 +27,4 @@ spec:
         backend:
           serviceName: kiali
           servicePort: {{ kiali_vars.server.port }}
+{% endif %}

--- a/operator/roles/kiali-deploy/templates/openshift/route.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/route.yaml
@@ -6,7 +6,13 @@ metadata:
   labels:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
+{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
+  {{ kiali_vars.deployment.override_ingress_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% endif %}
 spec:
+{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.spec is defined %}
+  {{ kiali_vars.deployment.override_ingress_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% else %}
   tls:
     termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
@@ -14,3 +20,4 @@ spec:
     kind: Service
     targetPort: {{ kiali_vars.server.port }}
     name: kiali
+{% endif %}


### PR DESCRIPTION
fixed #2111 

Because an ingress into a cluster can vary wildly in their desired configuration, a new setting in the Kiali CR is being introduced to allow the user to override complete portions of the ingress resource configuration (Ingress on Kubernetes and Route on OpenShift).

See the new setting in the Kiali CR for an example and the docs commenting the new setting.

For users that use these overrides, they are required to make sure the new configuration is valid - the operator will just blindly copy those settings into the resource - no validation is performed other than the validation the k8s master performs when it applies the new config to the resource.

@tillig can you see if this provides what you need? Based on your comments in the issue, you will want something like this in your Kiali CR:

```
spec:
  deployment:
    override_ingress_yaml:
      metadata:
        annotations:
          kubernetes.io/ingress.class: nginx
      spec:
        tls:
          ...your tls settings...
        rules:
        - host: your.host.here
          http:
            paths:
            - path: /kiali
              backend:
                serviceName: kiali
                servicePort: 20001
```