### PR TITLE
Improve log messages for 3scale and traces

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -327,7 +327,11 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 	go func() {
 		// Maybe a future jaeger business layer
 		defer wg.Done()
-		eTraces, err = in.businessLayer.Jaeger.GetErrorTraces(namespace, service, interval)
+		var err2 error
+		eTraces, err2 = in.businessLayer.Jaeger.GetErrorTraces(namespace, service, interval)
+		if err2 != nil {
+			errChan <- err2
+		}
 	}()
 
 	wg.Wait()

--- a/handlers/threescale.go
+++ b/handlers/threescale.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
@@ -132,6 +133,12 @@ func ThreeScaleServiceRuleGet(w http.ResponseWriter, r *http.Request) {
 
 	threeScaleRule, err := business.ThreeScale.GetThreeScaleRule(namespace, service)
 	if err != nil {
+		// A NotFound error is a valid business response for this handler, so, we respond the Error but we don't use
+		// handleErrorResponse to avoid unnecessary Error traces in kiali log
+		if errors.IsNotFound(err) {
+			RespondWithError(w, http.StatusNotFound, err.Error())
+			return
+		}
 		handleErrorResponse(w, err)
 		return
 	}

--- a/jaeger/spans.go
+++ b/jaeger/spans.go
@@ -72,7 +72,7 @@ func tracesToSpans(traces []jaegerModels.Trace, service, namespace string) []Spa
 			}
 		}
 	}
-	log.Infof("Found %d spans in the %d traces for service %s", len(spans), len(traces), service)
+	log.Tracef("Found %d spans in the %d traces for service %s", len(spans), len(traces), service)
 	return spans
 }
 


### PR DESCRIPTION
 Fixes #2109 

It doesn't log an error when a 3scale rule is not found, because it's a valid business request, UI is handled correctly, but in backlog it was printing an unnecessary Error trace.

Also, moved to Trace a repetitive log when fetching spans.

