### PR TITLE
[operator] do not create consolelinks if not supported on the openshift version

### DIFF
--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -122,6 +122,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: ["config.openshift.io"]
+  resourceNames:
+  - kube-apiserver
+  resources:
+  - clusteroperators
+  verbs:
+  - get
 - apiGroups: ["console.openshift.io"]
   resources:
   - consolelinks

--- a/operator/manifests/kiali-community/1.13.0/kiali.v1.13.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/1.13.0/kiali.v1.13.0.clusterserviceversion.yaml
@@ -419,6 +419,13 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
         - apiGroups: ["console.openshift.io"]
           resources:
           - consolelinks

--- a/operator/manifests/kiali-ossm/1.1.0/kiali.v1.1.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-ossm/1.1.0/kiali.v1.1.0.clusterserviceversion.yaml
@@ -424,6 +424,13 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
         - apiGroups: ["console.openshift.io"]
           resources:
           - consolelinks

--- a/operator/manifests/kiali-upstream/1.13.0/kiali.v1.13.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/1.13.0/kiali.v1.13.0.clusterserviceversion.yaml
@@ -419,6 +419,13 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
         - apiGroups: ["console.openshift.io"]
           resources:
           - consolelinks

--- a/operator/roles/kiali-deploy/tasks/main.yml
+++ b/operator/roles/kiali-deploy/tasks/main.yml
@@ -16,6 +16,23 @@
   - is_openshift == False
   - is_k8s == False
 
+- name: Determine the OpenShift version
+  k8s_facts:
+    api_version: config.openshift.io/v1
+    kind: ClusterOperator
+    name: kube-apiserver
+  register: kube_apiserver_cluster_op_raw
+  when:
+  - is_openshift == True
+- set_fact:
+    openshift_version: "{{ kube_apiserver_cluster_op_raw.resources[0] | json_query(ri_query) | join }}"
+    k8s_version: "{{ kube_apiserver_cluster_op_raw.resources[0] | json_query(ka_query) | join }}"
+  vars:
+    ri_query: "status.versions[?name == 'raw-internal'].version"
+    ka_query: "status.versions[?name == 'kube-apiserver'].version"
+  when:
+  - kube_apiserver_cluster_op_raw is defined
+
 - name: Determine the Istio implementation
   set_fact:
     is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"

--- a/operator/roles/kiali-deploy/templates/openshift/console-links.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/console-links.yaml
@@ -10,8 +10,7 @@ spec:
   href: {{ kiali_route_url }}
   location: ApplicationMenu
   text: Kiali
-####### FIX THIS IF-STATEMENT WITH AN EXPRESSION THAT RETURNS TRUE IF THE VERSION STRING IS 4.3 AND HIGHER ######
-{% if openshift_version >= 4.3 %}
+{% if openshift_version is version('4.3', '>=') %}
 {% for namespace in namespaces %}
 ---
 apiVersion: console.openshift.io/v1

--- a/operator/roles/kiali-deploy/templates/openshift/console-links.yaml
+++ b/operator/roles/kiali-deploy/templates/openshift/console-links.yaml
@@ -10,6 +10,8 @@ spec:
   href: {{ kiali_route_url }}
   location: ApplicationMenu
   text: Kiali
+####### FIX THIS IF-STATEMENT WITH AN EXPRESSION THAT RETURNS TRUE IF THE VERSION STRING IS 4.3 AND HIGHER ######
+{% if openshift_version >= 4.3 %}
 {% for namespace in namespaces %}
 ---
 apiVersion: console.openshift.io/v1
@@ -28,3 +30,4 @@ spec:
     namespaces:
     - {{ namespace }}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/2136

Need to not create consolelinks if not supported on the openshift version we are on.