### PR TITLE
[hack] move aws-openshift.sh to OpenShift 4.3.0

### DIFF
--- a/hack/aws-openshift.sh
+++ b/hack/aws-openshift.sh
@@ -401,7 +401,7 @@ SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPT_ROOT}
 
 # The default version of OpenShift to be downloaded
-DEFAULT_OPENSHIFT_DOWNLOAD_VERSION="4.2.4"
+DEFAULT_OPENSHIFT_DOWNLOAD_VERSION="4.3.0"
 
 # The default number of worker nodes that should be in the cluster.
 DEFAULT_OPENSHIFT_REQUIRED_WORKER_NODES="4"


### PR DESCRIPTION
OS 4.3.0 is available now. Have the hack script install it by default.

You can still have it use 4.2.4 by passing in `-ov 4.2.4` as a command line argument.