### PR TITLE
Reorganize config for extensions

### DIFF
--- a/business/threescale.go
+++ b/business/threescale.go
@@ -314,8 +314,8 @@ func getThreeScaleRuleDetails(rule kubernetes.IstioObject) string {
 						if handler, handlerFound := actionCast["handler"]; handlerFound {
 							if handlerCast, handlerString := handler.(string); handlerString {
 								suffix := "." + conf.IstioNamespace
-								if strings.HasSuffix(handlerCast, "." + conf.IstioNamespace) {
-									threeScaleHandlerName = handlerCast[0:len(handlerCast) - len(suffix)]
+								if strings.HasSuffix(handlerCast, "."+conf.IstioNamespace) {
+									threeScaleHandlerName = handlerCast[0 : len(handlerCast)-len(suffix)]
 								}
 							}
 						}

--- a/business/threescale.go
+++ b/business/threescale.go
@@ -303,6 +303,7 @@ func (in *ThreeScaleService) DeleteThreeScaleHandler(handlerName string) (models
 }
 
 func getThreeScaleRuleDetails(rule kubernetes.IstioObject) string {
+	conf := config.Get()
 	threeScaleHandlerName := ""
 	if rule.GetSpec() != nil {
 		if actions, actionsFound := rule.GetSpec()["actions"]; actionsFound {
@@ -312,8 +313,9 @@ func getThreeScaleRuleDetails(rule kubernetes.IstioObject) string {
 					if actionCast, actionInterface := action.(map[string]interface{}); actionInterface {
 						if handler, handlerFound := actionCast["handler"]; handlerFound {
 							if handlerCast, handlerString := handler.(string); handlerString {
-								if i := strings.Index(handlerCast, "."); i > -1 {
-									threeScaleHandlerName = handlerCast[:i]
+								suffix := "." + conf.IstioNamespace
+								if strings.HasSuffix(handlerCast, "." + conf.IstioNamespace) {
+									threeScaleHandlerName = handlerCast[0:len(handlerCast) - len(suffix)]
 								}
 							}
 						}

--- a/business/threescale.go
+++ b/business/threescale.go
@@ -30,7 +30,7 @@ func (in *ThreeScaleService) GetThreeScaleInfo() (models.ThreeScaleInfo, error) 
 	defer promtimer.ObserveNow(&err)
 
 	conf := config.Get()
-	_, err2 := in.k8s.GetAdapter(conf.IstioNamespace, "adapters", conf.ExternalServices.ThreeScale.AdapterName)
+	_, err2 := in.k8s.GetAdapter(conf.IstioNamespace, "adapters", conf.Extensions.ThreeScale.AdapterName)
 	if err2 != nil {
 		if errors.IsNotFound(err2) {
 			return models.ThreeScaleInfo{}, nil
@@ -134,14 +134,14 @@ func generateJsonHandlerInstance(handler models.ThreeScaleHandler) (string, stri
 			},
 		},
 		Spec: map[string]interface{}{
-			"adapter": conf.ExternalServices.ThreeScale.AdapterName,
+			"adapter": conf.Extensions.ThreeScale.AdapterName,
 			"params": map[string]interface{}{
 				"service_id":   handler.ServiceId,
 				"system_url":   handler.SystemUrl,
 				"access_token": handler.AccessToken,
 			},
 			"connection": map[string]interface{}{
-				"address": conf.ExternalServices.ThreeScale.AdapterService + ":" + conf.ExternalServices.ThreeScale.AdapterPort,
+				"address": conf.Extensions.ThreeScale.AdapterService + ":" + conf.Extensions.ThreeScale.AdapterPort,
 			},
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -148,6 +148,13 @@ type ThreeScaleConfig struct {
 	AdapterName    string `yaml:"adapter_name"`
 	AdapterPort    string `yaml:"adapter_port"`
 	AdapterService string `yaml:"adapter_service"`
+	Enabled        bool   `yaml:"enabled"`
+}
+
+// Extensions struct describes configuration for Kiali add-ons (extensions)
+// New add-on/extension configuration should create a specif config and be located under this
+type Extensions struct {
+	ThreeScale ThreeScaleConfig `yaml:"threescale,omitempty"`
 }
 
 // ExternalServices holds configurations for other systems that Kiali depends on
@@ -155,7 +162,6 @@ type ExternalServices struct {
 	Grafana    GrafanaConfig    `yaml:"grafana,omitempty"`
 	Istio      IstioConfig      `yaml:"istio,omitempty"`
 	Prometheus PrometheusConfig `yaml:"prometheus,omitempty"`
-	ThreeScale ThreeScaleConfig `yaml:"threescale,omitempty"`
 	Tracing    TracingConfig    `yaml:"tracing,omitempty"`
 }
 
@@ -268,6 +274,7 @@ type Config struct {
 	ApiDocumentation         ApiDocumentation         `yaml:"apidocs,omitempty"`
 	Auth                     AuthConfig               `yaml:"auth,omitempty"`
 	Deployment               DeploymentConfig         `yaml:"deployment,omitempty"`
+	Extensions               Extensions               `yaml:"extensions,omitempty"`
 	ExternalServices         ExternalServices         `yaml:"external_services,omitempty"`
 	Identity                 security.Identity        `yaml:",omitempty"`
 	InCluster                bool                     `yaml:"in_cluster,omitempty"`
@@ -309,6 +316,14 @@ func NewConfig() (c *Config) {
 			AccessibleNamespaces: []string{"**"},
 			Namespace:            "istio-system",
 		},
+		Extensions: Extensions{
+			ThreeScale: ThreeScaleConfig{
+				AdapterName:    "threescale",
+				AdapterPort:    "3333",
+				AdapterService: "threescale-istio-adapter",
+				Enabled:        false,
+			},
+		},
 		ExternalServices: ExternalServices{
 			Grafana: GrafanaConfig{
 				Auth: Auth{
@@ -327,11 +342,6 @@ func NewConfig() (c *Config) {
 				},
 				CustomMetricsURL: "http://prometheus.istio-system:9090",
 				URL:              "http://prometheus.istio-system:9090",
-			},
-			ThreeScale: ThreeScaleConfig{
-				AdapterName:    "threescale",
-				AdapterPort:    "3333",
-				AdapterService: "threescale-istio-adapter",
 			},
 			Tracing: TracingConfig{
 				Auth: Auth{

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -17,6 +17,14 @@ const (
 	defaultPrometheusGlobalScrapeInterval = 15 // seconds
 )
 
+type ThreeScaleConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
+type Extensions struct {
+	ThreeScale ThreeScaleConfig `json:"threescale,omitempty"`
+}
+
 // PrometheusConfig holds actual Prometheus configuration that is useful to Kiali.
 // All durations are in seconds.
 type PrometheusConfig struct {
@@ -27,6 +35,7 @@ type PrometheusConfig struct {
 // PublicConfig is a subset of Kiali configuration that can be exposed to clients to
 // help them interact with the system.
 type PublicConfig struct {
+	Extensions               Extensions                      `json:"extensions,omitempty"`
 	InstallationTag          string                          `json:"installationTag,omitempty"`
 	IstioIdentityDomain      string                          `json:"istioIdentityDomain,omitempty"`
 	IstioNamespace           string                          `json:"istioNamespace,omitempty"`
@@ -44,6 +53,11 @@ func Config(w http.ResponseWriter, r *http.Request) {
 	promConfig := getPrometheusConfig()
 	config := config.Get()
 	publicConfig := PublicConfig{
+		Extensions: Extensions{
+			ThreeScale: ThreeScaleConfig{
+				Enabled: config.Extensions.ThreeScale.Enabled,
+			},
+		},
 		InstallationTag:          config.InstallationTag,
 		IstioIdentityDomain:      config.ExternalServices.Istio.IstioIdentityDomain,
 		IstioNamespace:           config.IstioNamespace,

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -298,6 +298,34 @@ spec:
 
 ##########
 #  ---
+#  extensions:
+#
+# Kiali enables integration with 3scale API management solution.
+# If this extension is enabled, Kiali will communicate with 3scale Istio adapter allowing to manage 3scale handlers
+# and link 3scale handler with services.
+# Additional documentation https://github.com/3scale/3scale-istio-adapter
+#    ---
+#    threescale:
+#
+# Istio 3scale adapters name. Istio handlers for 3scale are created pointing to this adapter.
+#      ---
+#      adapter_name: "threescale"
+#
+# Istio 3scale adapter port. Istio handlers will use this param as part of the address to connect with the adapter.
+#      ---
+#      adapter_port: "3333"
+#
+# Istio 3scale adapter service. Istio handlers will use this param as part of the address to connect with the adapter.
+#      ---
+#      adapter_service: "threescale-istio-adapter"
+#
+# Flag to indicate if 3scale extension is enabled in Kiali.
+#      ---
+#      enabled: false
+#
+
+##########
+#  ---
 #  external_services:
 #
 # Note about sensitive values in the external_services "auth" sections:

--- a/operator/roles/kiali-deploy/defaults/main.yml
+++ b/operator/roles/kiali-deploy/defaults/main.yml
@@ -71,6 +71,13 @@ kiali_defaults:
     version_label: ""
     view_only_mode: false
 
+  extensions:
+    threescale:
+      adapter_name: "threescale"
+      adapter_port: "3333"
+      adapter_service: "threescale-istio-adapter"
+      enabled: false
+
   external_services:
     grafana:
       auth:

--- a/operator/roles/kiali-deploy/vars/main.yml
+++ b/operator/roles/kiali-deploy/vars/main.yml
@@ -52,6 +52,13 @@ kiali_vars:
     {{ kiali_defaults.deployment }}
     {%- endif -%}
 
+  extensions: |
+    {%- if extensions is defined and extensions is iterable -%}
+    {{ kiali_defaults.extensions | combine((extensions | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.extensions }}
+    {%- endif -%}
+
   external_services: |
     {%- if external_services is defined and external_services is iterable -%}
     {{ kiali_defaults.external_services | combine((external_services | stripnone), recursive=True) }}


### PR DESCRIPTION
This is a WIP to re-organize the Kiali extensions/add-on.
At the moment, Kiali only has one feature that fits this cagegory: integration with 3scale Istio Adapter [1].

This PR starts to refactor configuration for this feature, only changed the private/public config, handlers/business layers are not touched, that can be do in following iterations.

Not this PR would require UI changes, so it's still in draft.

Fixes #2146 

[1] https://github.com/3scale/3scale-istio-adapter