### PR TITLE
[operator] needs new permissions

### DIFF
--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -123,6 +123,12 @@ rules:
   - update
   - watch
 - apiGroups: ["config.openshift.io"]
+  resources:
+  - clusteroperators
+  verbs:
+  - list
+  - watch
+- apiGroups: ["config.openshift.io"]
   resourceNames:
   - kube-apiserver
   resources:

--- a/operator/manifests/kiali-community/1.13.0/kiali.v1.13.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/1.13.0/kiali.v1.13.0.clusterserviceversion.yaml
@@ -420,6 +420,12 @@ spec:
           - update
           - watch
         - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
           resourceNames:
           - kube-apiserver
           resources:

--- a/operator/manifests/kiali-ossm/1.12.0/kiali.v1.12.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-ossm/1.12.0/kiali.v1.12.0.clusterserviceversion.yaml
@@ -425,6 +425,12 @@ spec:
           - update
           - watch
         - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
           resourceNames:
           - kube-apiserver
           resources:

--- a/operator/manifests/kiali-upstream/1.13.0/kiali.v1.13.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/1.13.0/kiali.v1.13.0.clusterserviceversion.yaml
@@ -420,6 +420,12 @@ spec:
           - update
           - watch
         - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
           resourceNames:
           - kube-apiserver
           resources:


### PR DESCRIPTION
When installing the operator via OLM, we need these permissions. Seems as though then installed via OLM, some caching mechanism is turned on which requires permission to list and watch the objects being queried.

See OSSM-133