### PR TITLE
Set url jaeger default to empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -340,6 +340,7 @@ func NewConfig() (c *Config) {
 				Enabled:           true,
 				NamespaceSelector: true,
 				InClusterURL:      "http://tracing.istio-system/jaeger",
+				URL:               "",
 			},
 		},
 		IstioLabels: IstioLabels{


### PR DESCRIPTION
Set in the configuration default jaeger Url to empty to avoid that user not set this value.