### PR TITLE
Adding new validation: same subset in different route destination

### DIFF
--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -169,6 +169,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "The weight is assumed to be 100 because there is only one route destination",
 		Severity: WarningSeverity,
 	},
+	"virtualservices.route.repeatedsubset": {
+		Message:  "This subset is already referenced in another route destination",
+		Severity: WarningSeverity,
+	},
 	"virtualservices.singlehost": {
 		Message:  "More than one Virtual Service for same host",
 		Severity: WarningSeverity,


### PR DESCRIPTION
** Describe the change **
Adding new validation for VirtualServices. When there are two destination routes referencing to the same subset. 

![Screenshot of Kiali Console (3)](https://user-images.githubusercontent.com/613814/73770648-08106e00-477d-11ea-9b45-4917af01b0d6.png)

** Issue reference **
Fixes https://github.com/kiali/kiali/issues/1515