### PR TITLE
Support GRPC status codes

### DIFF
--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -169,7 +169,7 @@ func mockQuery(api *prometheustest.PromAPIMock, query string, ret *model.Vector)
 
 // mockNamespaceGraph provides the same single-namespace mocks to be used for different graph types
 func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -184,6 +184,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":      "unknown",
@@ -199,6 +200,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -208,7 +210,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 			Metric: q0m1,
 			Value:  50}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -223,13 +225,14 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v1 := model.Vector{
 		&model.Sample{
 			Metric: q1m0,
 			Value:  100}}
 
-	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -244,6 +247,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -259,6 +263,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -274,6 +279,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -334,6 +340,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m7 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -349,6 +356,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m8 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -364,6 +372,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m9 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -394,6 +403,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m11 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -409,6 +419,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m12 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -439,6 +450,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m14 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -454,6 +466,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m15 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -763,7 +776,7 @@ func TestWorkloadGraph(t *testing.T) {
 }
 
 func TestAppNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -778,6 +791,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":      "istio-system",
@@ -793,6 +807,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -802,7 +817,7 @@ func TestAppNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -817,6 +832,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -832,6 +848,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -847,6 +864,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -907,6 +925,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m7 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -922,6 +941,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m8 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1033,7 +1053,7 @@ func TestAppNodeGraph(t *testing.T) {
 }
 
 func TestVersionedAppNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage",destination_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage",destination_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1048,6 +1068,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":      "istio-system",
@@ -1063,6 +1084,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -1072,7 +1094,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",source_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",source_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1087,6 +1109,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1102,6 +1125,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1117,6 +1141,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1177,6 +1202,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m7 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1192,6 +1218,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m8 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1303,7 +1330,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 }
 
 func TestWorkloadNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1318,6 +1345,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":      "istio-system",
@@ -1333,6 +1361,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -1342,7 +1371,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1357,6 +1386,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1372,6 +1402,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1387,6 +1418,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1447,6 +1479,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m7 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1462,6 +1495,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m8 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1573,10 +1607,10 @@ func TestWorkloadNodeGraph(t *testing.T) {
 }
 
 func TestServiceNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -1591,6 +1625,7 @@ func TestServiceNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v1 := model.Vector{
 		&model.Sample{
@@ -1664,7 +1699,7 @@ func TestServiceNodeGraph(t *testing.T) {
 // - request.host
 // note: appenders still tested in separate unit tests given that they create their own new business/kube clients
 func TestComplexGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1679,16 +1714,17 @@ func TestComplexGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
 			Metric: q0m0,
 			Value:  50}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v1 := model.Vector{}
 
-	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v2 := model.Vector{}
 
 	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_flags),0.001)`
@@ -1700,7 +1736,7 @@ func TestComplexGraph(t *testing.T) {
 	q5 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_flags),0.001)`
 	v5 := model.Vector{}
 
-	q6 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q6 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q6m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1715,16 +1751,17 @@ func TestComplexGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "grpc",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v6 := model.Vector{
 		&model.Sample{
 			Metric: q6m0,
 			Value:  50}}
 
-	q7 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q7 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v7 := model.Vector{}
 
-	q8 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q8 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q8m0 := model.Metric{
 		"source_workload_namespace":      "tutorial",
 		"source_workload":                "customer-v1",
@@ -1739,6 +1776,7 @@ func TestComplexGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v8 := model.Vector{
 		&model.Sample{
@@ -1754,16 +1792,16 @@ func TestComplexGraph(t *testing.T) {
 	q11 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_flags),0.001)`
 	v11 := model.Vector{}
 
-	q12 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q12 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v12 := model.Vector{}
 
-	q13 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!~"istio-system|istio-telemetry",source_workload!="unknown",destination_service_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q13 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!~"istio-system|istio-telemetry",source_workload!="unknown",destination_service_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v13 := model.Vector{}
 
-	q14 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q14 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v14 := model.Vector{}
 
-	q15 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="istio-system",destination_service_namespace=~"istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q15 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="istio-system",destination_service_namespace=~"istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v15 := model.Vector{}
 
 	client, api, _, err := setupMockedWithIstioComponentNamespaces()

--- a/graph/api/testdata/test_complex_graph.expected
+++ b/graph/api/testdata/test_complex_graph.expected
@@ -122,7 +122,7 @@
               "grpcPercentReq": "100.0"
             },
             "responses": {
-              "200": {
+              "0": {
                 "flags": {
                   "-": "100.0"
                 },

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -167,9 +167,9 @@ func addToMetadataGrpc(val float64, code, flags, host string, sourceMetadata, de
 	isHTTPCode := len(code) == 3
 	isErr := false
 	if isHTTPCode {
-		isErr = strings.HasPrefix(code, "4") || strings.HasPrefix(code, "5")
+		isErr = IsHTTPErr(code)
 	} else {
-		isErr = code != "0"
+		isErr = IsGRPCErr(code)
 	}
 	if isErr {
 		addToMetadataValue(destMetadata, grpcInErr, val)
@@ -203,6 +203,16 @@ func addToMetadataTCP(val float64, flags, host string, sourceMetadata, destMetad
 	addToMetadataValue(destMetadata, tcpIn, val)
 	addToMetadataValue(edgeMetadata, tcp, val)
 	addToMetadataResponses(edgeMetadata, tcpResponses, "-", flags, host, val)
+}
+
+// IsHTTPErr return true if code is 4xx or 5xx
+func IsHTTPErr(code string) bool {
+	return strings.HasPrefix(code, "4") || strings.HasPrefix(code, "5")
+}
+
+// IsGRPCErr return true if code != 0
+func IsGRPCErr(code string) bool {
+	return code != "0"
 }
 
 // AddOutgoingEdgeToMetadata updates the source node's outgoing traffic with the outgoing edge traffic value

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -75,18 +75,18 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
 	// 1) query for responseTime originating from "unknown" (i.e. the internet)
 	groupBy := "le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version"
-	millisQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v",response_code=~"%s"}[%vs])) by (%s))`,
+	millisQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
 		namespace,
-		"2[0-9]{2}|^0$",         // must match success for all expected protocols
+		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	secondsQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v",response_code=~"%s"}[%vs])) by (%s))`,
+	secondsQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_seconds_bucket",
 		namespace,
-		"2[0-9]{2}|^0$",         // must match success for all expected protocols
+		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
 	query := fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
@@ -105,22 +105,22 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 			sourceWorkloadQuery = fmt.Sprintf(`source_workload_namespace!~"%s|%s"`, namespace, excludedIstioRegex)
 		}
 	}
-	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v",response_code=~"%s"}[%vs])) by (%s))`,
+	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
 		reporter,
 		sourceWorkloadQuery,
 		namespace,
-		"2[0-9]{2}|^0$",         // must match success for all expected protocols
+		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v",response_code=~"%s"}[%vs])) by (%s))`,
+	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_seconds_bucket",
 		reporter,
 		sourceWorkloadQuery,
 		namespace,
-		"2[0-9]{2}|^0$",         // must match success for all expected protocols
+		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
 	query = fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
@@ -128,18 +128,18 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	a.populateResponseTimeMap(responseTimeMap, &outVector)
 
 	// 3) query for responseTime originating from a workload inside of the namespace
-	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v",response_code=~"%s"}[%vs])) by (%s))`,
+	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
 		namespace,
-		"2[0-9]{2}|^0$",         // must match success for all expected protocols
+		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v",response_code=~"%s"}[%vs])) by (%s))`,
+	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_seconds_bucket",
 		namespace,
-		"2[0-9]{2}|^0$",         // must match success for all expected protocols
+		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
 	query = fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
@@ -152,20 +152,20 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 		istioNamespacesRegex := strings.Join(getIstioNamespaces(a.Namespaces), "|")
 
 		// 3a) supplemental query for istio-to-istio traffic
-		millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload_namespace="%s",destination_service_namespace=~"%s",response_code=~"%s"}[%vs])) by (%s))`,
+		millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload_namespace="%s",destination_service_namespace=~"%s",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
 			quantile,
 			"istio_request_duration_milliseconds_bucket",
 			namespace,
 			istioNamespacesRegex,
-			"2[0-9]{2}|^0$",         // must match success for all expected protocols
+			"2[0-9]{2}$",
 			int(duration.Seconds()), // range duration for the query
 			groupBy)
-		secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload_namespace="%s",destination_service_namespace=~"%s",response_code=~"%s"}[%vs])) by (%s))`,
+		secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload_namespace="%s",destination_service_namespace=~"%s",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
 			quantile,
 			"istio_request_duration_seconds_bucket",
 			namespace,
 			istioNamespacesRegex,
-			"2[0-9]{2}|^0$",         // must match success for all expected protocols
+			"2[0-9]{2}$",
 			int(duration.Seconds()), // range duration for the query
 			groupBy)
 		query = fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -3,6 +3,7 @@ package appender
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,6 +19,10 @@ import (
 const (
 	// ResponseTimeAppenderName uniquely identifies the appender: responseTime
 	ResponseTimeAppenderName = "responseTime"
+)
+
+var (
+	regexpHTTPFailure, _ = regexp.Compile(`^[4|5]\d\d$`)
 )
 
 // ResponseTimeAppender is responsible for adding responseTime information to the graph. ResponseTime
@@ -74,19 +79,17 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
 	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
 	// 1) query for responseTime originating from "unknown" (i.e. the internet)
-	groupBy := "le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version"
-	millisQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
+	groupBy := "le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status"
+	millisQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
 		namespace,
-		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	secondsQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
+	secondsQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_seconds_bucket",
 		namespace,
-		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
 	query := fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
@@ -105,22 +108,20 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 			sourceWorkloadQuery = fmt.Sprintf(`source_workload_namespace!~"%s|%s"`, namespace, excludedIstioRegex)
 		}
 	}
-	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
+	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
 		reporter,
 		sourceWorkloadQuery,
 		namespace,
-		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
+	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_seconds_bucket",
 		reporter,
 		sourceWorkloadQuery,
 		namespace,
-		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
 	query = fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
@@ -128,18 +129,16 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	a.populateResponseTimeMap(responseTimeMap, &outVector)
 
 	// 3) query for responseTime originating from a workload inside of the namespace
-	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
+	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
 		namespace,
-		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
+	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_seconds_bucket",
 		namespace,
-		"2[0-9]{2}$",
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
 	query = fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
@@ -152,20 +151,18 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 		istioNamespacesRegex := strings.Join(getIstioNamespaces(a.Namespaces), "|")
 
 		// 3a) supplemental query for istio-to-istio traffic
-		millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload_namespace="%s",destination_service_namespace=~"%s",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
+		millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload_namespace="%s",destination_service_namespace=~"%s"}[%vs])) by (%s))`,
 			quantile,
 			"istio_request_duration_milliseconds_bucket",
 			namespace,
 			istioNamespacesRegex,
-			"2[0-9]{2}$",
 			int(duration.Seconds()), // range duration for the query
 			groupBy)
-		secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload_namespace="%s",destination_service_namespace=~"%s",response_code=~"%s",grpc_response_status="0"}[%vs])) by (%s))`,
+		secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload_namespace="%s",destination_service_namespace=~"%s"}[%vs])) by (%s))`,
 			quantile,
 			"istio_request_duration_seconds_bucket",
 			namespace,
 			istioNamespacesRegex,
-			"2[0-9]{2}$",
 			int(duration.Seconds()), // range duration for the query
 			groupBy)
 		query = fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
@@ -201,7 +198,10 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		lDestWl, destWlOk := m["destination_workload"]
 		lDestApp, destAppOk := m["destination_app"]
 		lDestVer, destVerOk := m["destination_version"]
-		if !sourceWlNsOk || !sourceWlOk || !sourceAppOk || !sourceVerOk || !destSvcNsOk || !destSvcNameOk || !destWlNsOk || !destWlOk || !destAppOk || !destVerOk {
+		lResponseCode, responseCodeOk := m["response_code"]
+		lGrpcResponseStatus, grpcReponseStatusOk := m["grpc_response_status"]
+
+		if !sourceWlNsOk || !sourceWlOk || !sourceAppOk || !sourceVerOk || !destSvcNsOk || !destSvcNameOk || !destWlNsOk || !destWlOk || !destAppOk || !destVerOk || !responseCodeOk {
 			log.Warningf("Skipping %v, missing expected labels", m.String())
 			continue
 		}
@@ -216,6 +216,18 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		destWl := string(lDestWl)
 		destApp := string(lDestApp)
 		destVer := string(lDestVer)
+		responseCode := string(lResponseCode)
+		// This was added in istio 1.5, handle in a backward compatible way
+		grpcReponseStatus := "0"
+		if grpcReponseStatusOk {
+			grpcReponseStatus = string(lGrpcResponseStatus)
+		}
+
+		// Only valid requests contribute to response time so as not to skew RT when a failed request returns immediately
+		// TODO: Note, we can do this filtering in the queries when and if all supported Istio versions provide grpc_response_status
+		if grpcReponseStatus != "0" || regexpHTTPFailure.MatchString(responseCode) {
+			continue
+		}
 
 		val := float64(s.Value)
 		destSvcNs, destSvcName = util.HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName)

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -16,11 +16,11 @@ func TestResponseTime(t *testing.T) {
 
 	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
 	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
-	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
+	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",response_code=~"2[0-9]{2}$",grpc_response_status="0"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
 	q0 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q0Temp, "milliseconds"), fmt.Sprintf(q0Temp, "seconds"))
 	v0 := model.Vector{}
 
-	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
+	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo",response_code=~"2[0-9]{2}$",grpc_response_status="0"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
 	q1 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q1Temp, "milliseconds"), fmt.Sprintf(q1Temp, "seconds"))
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
@@ -38,7 +38,7 @@ func TestResponseTime(t *testing.T) {
 			Metric: q1m0,
 			Value:  0.010}}
 
-	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
+	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace="bookinfo",response_code=~"2[0-9]{2}$",grpc_response_status="0"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
 	q2 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q2Temp, "milliseconds"), fmt.Sprintf(q2Temp, "seconds"))
 	fmt.Printf("QUERY:\n%s", q2)
 	q2m0 := model.Metric{

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -44,3 +44,16 @@ func HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName stri
 
 	return destSvcNs, destSvcName
 }
+
+// HandleResponseCode returns either the HTTP response code or the GRPC response status.  GRPC response
+// status was added upstream in Istio 1.5 and downstream OSSM 1.1.  We support it here in a backward compatible
+// way.  When protocol is not GRPC, or if the version running dies not supply the GRPC statsus, just return the
+// HTTP code.  Also return the HTTP code In the rare case that protocol is GRPC but the HTTP transport fails. (I
+// have never seen this happen).  Otherwise, return the GRPC status.
+func HandleResponseCode(protocol, httpResponseCode string, grpcResponseStatusOk bool, grpcResponseStatus string) string {
+	if protocol != graph.GRPC.Name || graph.IsHTTPErr(httpResponseCode) || !grpcResponseStatusOk {
+		return httpResponseCode
+	}
+
+	return grpcResponseStatus
+}

--- a/models/health.go
+++ b/models/health.go
@@ -28,7 +28,7 @@ type AppHealth struct {
 
 // errorCodeRegexp is a regex pattern to match HTTP errors (4xx, 5xx) or GRPC errors (1-16)
 var (
-	errorCodeRegexp, _ = regexp.Compile("^[4-5][0-9]{2}$|^[1-9]$|^1[0-6]$")
+	errorCodeRegexp, _ = regexp.Compile(`^[4-5]\d\d$|^[1-9]$|^1[0-6]$`)
 )
 
 func NewEmptyRequestHealth() RequestHealth {

--- a/models/health.go
+++ b/models/health.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"regexp"
+
 	"github.com/prometheus/common/model"
 )
 
@@ -23,6 +25,11 @@ type AppHealth struct {
 	WorkloadStatuses []WorkloadStatus `json:"workloadStatuses"`
 	Requests         RequestHealth    `json:"requests"`
 }
+
+// errorCodeRegexp is a regex pattern to match HTTP errors (4xx, 5xx) or GRPC errors (1-16)
+var (
+	errorCodeRegexp, _ = regexp.Compile("^[4-5][0-9]{2}$|^[1-9]$|^1[0-6]$")
+)
 
 func NewEmptyRequestHealth() RequestHealth {
 	return RequestHealth{ErrorRatio: -1, InboundErrorRatio: -1, OutboundErrorRatio: -1}
@@ -102,8 +109,8 @@ func (in *RequestHealth) updateGlobalErrorRatio() {
 
 func aggregate(sample *model.Sample, requestRate, errorRate, errorRatio *float64) {
 	*requestRate += float64(sample.Value)
-	responseCode := sample.Metric["response_code"][0]
-	if responseCode == '5' || responseCode == '4' {
+	responseCode := sample.Metric["response_code"]
+	if errorCodeRegexp.MatchString(string(responseCode)) {
 		*errorRate += float64(sample.Value)
 	}
 	if *requestRate == 0 {

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -130,7 +130,7 @@ func (in *Client) FetchRange(metricName, labels, grouping, aggregator string, q 
 
 // FetchRateRange fetches a counter's rate in given range
 func (in *Client) FetchRateRange(metricName, labels, grouping string, q *BaseMetricsQuery) *Metric {
-	return fetchRateRange(in.api, metricName, labels, grouping, q)
+	return fetchRateRange(in.api, metricName, []string{labels}, grouping, q)
 }
 
 // FetchHistogramRange fetches bucketed metric as histogram in given range

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -147,7 +147,6 @@ func fetchRateRange(api prom_v1.API, metricName string, labels []string, groupin
 		query = fmt.Sprintf("(%s)", query)
 	}
 	query = roundSignificant(query, 0.001)
-	fmt.Println("QUERY:\n" + query)
 	return fetchRange(api, query, q.Range)
 }
 

--- a/prometheus/metrics_definitions.go
+++ b/prometheus/metrics_definitions.go
@@ -51,9 +51,9 @@ var istioMetrics = []istioMetric{
 	},
 }
 
-func (in *istioMetric) labelsToUse(labels, labelsError string) string {
+func (in *istioMetric) labelsToUse(labels string, labelsError []string) []string {
 	if in.useErrorLabels {
 		return labelsError
 	}
-	return labels
+	return []string{labels}
 }

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -55,7 +55,7 @@ func TestGetServiceMetrics(t *testing.T) {
 	}
 
 	mockWithRange(api, expectedRange, round(`sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]))`), 2.5)
-	mockWithRange(api, expectedRange, roundErrs(`sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",grpc_response_status!="0"}[5m])) OR sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",response_code=~"[5|4].*"}[5m]))`), 4.5)
+	mockWithRange(api, expectedRange, roundErrs(`sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",response_code=~"^[4-5]\d\d$"}[5m]))`), 4.5)
 	mockWithRange(api, expectedRange, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]))`), 11)
 	mockWithRange(api, expectedRange, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]))`), 13)
 	mockHistogram(api, "istio_request_bytes", `{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.7)
@@ -101,7 +101,7 @@ func TestGetAppMetrics(t *testing.T) {
 		return
 	}
 	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 1.5)
-	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",grpc_response_status!="0"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",response_code=~"[5|4].*"}[5m]))`), 3.5)
+	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",response_code=~"^[4-5]\d\d$"}[5m]))`), 3.5)
 	mockRange(api, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 10)
 	mockRange(api, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 12)
 	mockHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]`, 0.35, 0.2, 0.3, 0.4)
@@ -236,7 +236,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 		return
 	}
 	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 1.5)
-	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",grpc_response_status!="0"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",response_code=~"[5|4].*"}[5m]))`), 3.5)
+	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",response_code=~"^[4-5]\d\d$"}[5m]))`), 3.5)
 	mockRange(api, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 10)
 	mockRange(api, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 12)
 	mockHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.4)

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -101,7 +101,7 @@ func TestGetAppMetrics(t *testing.T) {
 		return
 	}
 	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 1.5)
-	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",response_code=~"[5|4].*"}[5m]))`), 3.5)
+	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",grpc_response_status!="0"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",response_code=~"[5|4].*"}[5m]))`), 3.5)
 	mockRange(api, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 10)
 	mockRange(api, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 12)
 	mockHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]`, 0.35, 0.2, 0.3, 0.4)
@@ -236,7 +236,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 		return
 	}
 	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 1.5)
-	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",response_code=~"[5|4].*"}[5m]))`), 3.5)
+	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",grpc_response_status!="0"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",response_code=~"[5|4].*"}[5m]))`), 3.5)
 	mockRange(api, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 10)
 	mockRange(api, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 12)
 	mockHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.4)

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -29,6 +29,10 @@ func round(q string) string {
 	return fmt.Sprintf("round(%s, 0.001000) > 0.001000 or %s", q, q)
 }
 
+func roundErrs(q string) string {
+	return fmt.Sprintf("round((%s), 0.001000) > 0.001000 or (%s)", q, q)
+}
+
 func TestGetServiceMetrics(t *testing.T) {
 	client, api, err := setupMocked()
 	if err != nil {
@@ -50,14 +54,14 @@ func TestGetServiceMetrics(t *testing.T) {
 		Step:  q.Step,
 	}
 
-	mockWithRange(api, expectedRange, round("sum(rate(istio_requests_total{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]))"), 2.5)
-	mockWithRange(api, expectedRange, round("sum(rate(istio_requests_total{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m]))"), 4.5)
-	mockWithRange(api, expectedRange, round("sum(rate(istio_tcp_received_bytes_total{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]))"), 11)
-	mockWithRange(api, expectedRange, round("sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]))"), 13)
-	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.7)
-	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
-	mockHistogram(api, "istio_request_duration_milliseconds", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.8)
-	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",destination_service_name=\"productpage\",destination_service_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.9)
+	mockWithRange(api, expectedRange, round(`sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]))`), 2.5)
+	mockWithRange(api, expectedRange, roundErrs(`sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",grpc_response_status!="0"}[5m])) OR sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",response_code=~"[5|4].*"}[5m]))`), 4.5)
+	mockWithRange(api, expectedRange, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]))`), 11)
+	mockWithRange(api, expectedRange, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]))`), 13)
+	mockHistogram(api, "istio_request_bytes", `{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.7)
+	mockHistogram(api, "istio_request_duration_seconds", `{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.8)
+	mockHistogram(api, "istio_request_duration_milliseconds", `{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.8)
+	mockHistogram(api, "istio_response_bytes", `{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.9)
 
 	// Test that range and rate interval are changed when needed (namespace bounds)
 	metrics := client.GetMetrics(&q)
@@ -96,14 +100,14 @@ func TestGetAppMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, round("sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]))"), 1.5)
-	mockRange(api, round("sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\",response_code=~\"[5|4].*\"}[5m]))"), 3.5)
-	mockRange(api, round("sum(rate(istio_tcp_received_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]))"), 10)
-	mockRange(api, round("sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]))"), 12)
-	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.5)
-	mockHistogram(api, "istio_request_duration_milliseconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.5)
-	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.6)
+	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 1.5)
+	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",response_code=~"[5|4].*"}[5m]))`), 3.5)
+	mockRange(api, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 10)
+	mockRange(api, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 12)
+	mockHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]`, 0.35, 0.2, 0.3, 0.4)
+	mockHistogram(api, "istio_request_duration_seconds", `{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]`, 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_request_duration_milliseconds", `{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]`, 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_response_bytes", `{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]`, 0.35, 0.2, 0.3, 0.6)
 	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
@@ -150,8 +154,8 @@ func TestGetFilteredAppMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, round("sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]))"), 1.5)
-	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]", 0.35, 0.2, 0.3, 0.4)
+	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 1.5)
+	mockHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]`, 0.35, 0.2, 0.3, 0.4)
 	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
@@ -175,7 +179,7 @@ func TestGetAppMetricsInstantRates(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, round("sum(irate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[1m]))"), 1.5)
+	mockRange(api, round(`sum(irate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[1m]))`), 1.5)
 	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
@@ -198,8 +202,8 @@ func TestGetAppMetricsUnavailable(t *testing.T) {
 		return
 	}
 	// Mock everything to return empty data
-	mockEmptyRange(api, round("sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]))"))
-	mockEmptyHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\",source_app=\"productpage\"}[5m]")
+	mockEmptyRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`))
+	mockEmptyHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]`)
 	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 		App:       "productpage",
@@ -231,14 +235,14 @@ func TestGetNamespaceMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	mockRange(api, round("sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]))"), 1.5)
-	mockRange(api, round("sum(rate(istio_requests_total{reporter=\"source\",source_workload_namespace=\"bookinfo\",response_code=~\"[5|4].*\"}[5m]))"), 3.5)
-	mockRange(api, round("sum(rate(istio_tcp_received_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]))"), 10)
-	mockRange(api, round("sum(rate(istio_tcp_sent_bytes_total{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]))"), 12)
-	mockHistogram(api, "istio_request_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_duration_seconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
-	mockHistogram(api, "istio_request_duration_milliseconds", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.5)
-	mockHistogram(api, "istio_response_bytes", "{reporter=\"source\",source_workload_namespace=\"bookinfo\"}[5m]", 0.35, 0.2, 0.3, 0.6)
+	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 1.5)
+	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",response_code=~"[5|4].*"}[5m]))`), 3.5)
+	mockRange(api, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 10)
+	mockRange(api, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 12)
+	mockHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.4)
+	mockHistogram(api, "istio_request_duration_seconds", `{reporter="source",source_workload_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_request_duration_milliseconds", `{reporter="source",source_workload_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.5)
+	mockHistogram(api, "istio_response_bytes", `{reporter="source",source_workload_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.6)
 	q := prometheus.IstioMetricsQuery{
 		Namespace: "bookinfo",
 	}
@@ -405,7 +409,7 @@ func mockQueryRange(api *PromAPIMock, query string, ret *model.Matrix) {
 		"QueryRange",
 		mock.AnythingOfType("*context.emptyCtx"),
 		query,
-		mock.AnythingOfType("v1.Range")).
+		mock.AnythingOfType(`v1.Range`)).
 		Return(*ret, nil)
 }
 


### PR DESCRIPTION
In Istio 1.5 (likely) and SM 1.1 (definite) GRPC status codes will be reported for requests using protocol="grpc".  We had partially coded for this in the graph but the code assumed that the GRPC code would be set in the existing response_code telemetry field.  Because Istio was afraid that existing consuming code may assume response_code contains only HTTP codes, it elected to add a new field, grpc_response_status.  See https://github.com/istio/istio/pull/20036 for more.

Although this protects existing consumer code it also makes it more difficult to add support as consumers now need to deal with two, protocol-specific, fields.

In this PR the graph code deals with it by basically setting our existing response code field with the appropriate protocol-specific code in the telemetry.  In that way most code stays the same.

In metrics things are little complicated because we support queries that fetch all error time-series.  That results in the need for OR queries, or a post-query merge of data.  Merge is hard so this PR opts for the OR logic, which does produce some longer/more-complicated query strings.  In Health we aggregate errors and so the code now uses a regex pattern to capture both HTTP and GRPC error codes.

Fixes #1235 