### PR TITLE
ObjectCount has to count valid objects

### DIFF
--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -335,8 +335,8 @@ func (summary *IstioValidationSummary) mergeSummaries(cs []*IstioCheck) {
 		} else if c.Severity == WarningSeverity {
 			summary.Warnings += 1
 		}
-		summary.ObjectCount += 1
 	}
+	summary.ObjectCount += 1
 }
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
** Describe the change **
The namespaces that have istio config objects that are correct (no validations present) weren't presented with the green tick icon. It was because `objectCount` was 0. ObjectCount should count also the valid istio objects.

Fixes https://github.com/kiali/kiali/issues/2210

It remembers me the rocket which explode because of a lack of protection of an integer overflow: https://en.wikipedia.org/wiki/Cluster_(spacecraft)