### PR TITLE
Support GRPC status codes (#2211)

### DIFF
--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -169,7 +169,7 @@ func mockQuery(api *prometheustest.PromAPIMock, query string, ret *model.Vector)
 
 // mockNamespaceGraph provides the same single-namespace mocks to be used for different graph types
 func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -184,6 +184,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":      "unknown",
@@ -199,6 +200,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -208,7 +210,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 			Metric: q0m1,
 			Value:  50}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -223,13 +225,14 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v1 := model.Vector{
 		&model.Sample{
 			Metric: q1m0,
 			Value:  100}}
 
-	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -244,6 +247,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -259,6 +263,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -274,6 +279,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -334,6 +340,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m7 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -349,6 +356,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m8 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -364,6 +372,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m9 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -394,6 +403,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m11 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -409,6 +419,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m12 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -439,6 +450,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m14 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -454,6 +466,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q2m15 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -763,7 +776,7 @@ func TestWorkloadGraph(t *testing.T) {
 }
 
 func TestAppNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -778,6 +791,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":      "istio-system",
@@ -793,6 +807,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -802,7 +817,7 @@ func TestAppNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -817,6 +832,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -832,6 +848,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -847,6 +864,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -907,6 +925,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m7 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -922,6 +941,7 @@ func TestAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m8 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1033,7 +1053,7 @@ func TestAppNodeGraph(t *testing.T) {
 }
 
 func TestVersionedAppNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage",destination_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_app="productpage",destination_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1048,6 +1068,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":      "istio-system",
@@ -1063,6 +1084,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -1072,7 +1094,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",source_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",source_version="v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1087,6 +1109,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1102,6 +1125,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1117,6 +1141,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1177,6 +1202,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m7 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1192,6 +1218,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m8 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1303,7 +1330,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 }
 
 func TestWorkloadNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1318,6 +1345,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q0m1 := model.Metric{
 		"source_workload_namespace":      "istio-system",
@@ -1333,6 +1361,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
@@ -1342,7 +1371,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1357,6 +1386,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1372,6 +1402,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v2",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1387,6 +1418,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v3",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1447,6 +1479,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m7 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1462,6 +1495,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q1m8 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -1573,10 +1607,10 @@ func TestWorkloadNodeGraph(t *testing.T) {
 }
 
 func TestServiceNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -1591,6 +1625,7 @@ func TestServiceNodeGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v1 := model.Vector{
 		&model.Sample{
@@ -1664,7 +1699,7 @@ func TestServiceNodeGraph(t *testing.T) {
 // - request.host
 // note: appenders still tested in separate unit tests given that they create their own new business/kube clients
 func TestComplexGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1679,16 +1714,17 @@ func TestComplexGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v0 := model.Vector{
 		&model.Sample{
 			Metric: q0m0,
 			Value:  50}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v1 := model.Vector{}
 
-	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v2 := model.Vector{}
 
 	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_flags),0.001)`
@@ -1700,7 +1736,7 @@ func TestComplexGraph(t *testing.T) {
 	q5 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_flags),0.001)`
 	v5 := model.Vector{}
 
-	q6 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q6 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q6m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1715,16 +1751,17 @@ func TestComplexGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "grpc",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v6 := model.Vector{
 		&model.Sample{
 			Metric: q6m0,
 			Value:  50}}
 
-	q7 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q7 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v7 := model.Vector{}
 
-	q8 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q8 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q8m0 := model.Metric{
 		"source_workload_namespace":      "tutorial",
 		"source_workload":                "customer-v1",
@@ -1739,6 +1776,7 @@ func TestComplexGraph(t *testing.T) {
 		"destination_version":            "v1",
 		"request_protocol":               "http",
 		"response_code":                  "200",
+		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	v8 := model.Vector{
 		&model.Sample{
@@ -1754,16 +1792,16 @@ func TestComplexGraph(t *testing.T) {
 	q11 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_flags),0.001)`
 	v11 := model.Vector{}
 
-	q12 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q12 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v12 := model.Vector{}
 
-	q13 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!~"istio-system|istio-telemetry",source_workload!="unknown",destination_service_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q13 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!~"istio-system|istio-telemetry",source_workload!="unknown",destination_service_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v13 := model.Vector{}
 
-	q14 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q14 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v14 := model.Vector{}
 
-	q15 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="istio-system",destination_service_namespace=~"istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,response_flags),0.001)`
+	q15 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="istio-system",destination_service_namespace=~"istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v15 := model.Vector{}
 
 	client, api, _, err := setupMockedWithIstioComponentNamespaces()

--- a/graph/api/testdata/test_complex_graph.expected
+++ b/graph/api/testdata/test_complex_graph.expected
@@ -122,7 +122,7 @@
               "grpcPercentReq": "100.0"
             },
             "responses": {
-              "200": {
+              "0": {
                 "flags": {
                   "-": "100.0"
                 },

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -167,9 +167,9 @@ func addToMetadataGrpc(val float64, code, flags, host string, sourceMetadata, de
 	isHTTPCode := len(code) == 3
 	isErr := false
 	if isHTTPCode {
-		isErr = strings.HasPrefix(code, "4") || strings.HasPrefix(code, "5")
+		isErr = IsHTTPErr(code)
 	} else {
-		isErr = code != "0"
+		isErr = IsGRPCErr(code)
 	}
 	if isErr {
 		addToMetadataValue(destMetadata, grpcInErr, val)
@@ -203,6 +203,16 @@ func addToMetadataTCP(val float64, flags, host string, sourceMetadata, destMetad
 	addToMetadataValue(destMetadata, tcpIn, val)
 	addToMetadataValue(edgeMetadata, tcp, val)
 	addToMetadataResponses(edgeMetadata, tcpResponses, "-", flags, host, val)
+}
+
+// IsHTTPErr return true if code is 4xx or 5xx
+func IsHTTPErr(code string) bool {
+	return strings.HasPrefix(code, "4") || strings.HasPrefix(code, "5")
+}
+
+// IsGRPCErr return true if code != 0
+func IsGRPCErr(code string) bool {
+	return code != "0"
 }
 
 // AddOutgoingEdgeToMetadata updates the source node's outgoing traffic with the outgoing edge traffic value

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -16,11 +16,11 @@ func TestResponseTime(t *testing.T) {
 
 	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
 	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
-	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
+	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
 	q0 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q0Temp, "milliseconds"), fmt.Sprintf(q0Temp, "seconds"))
 	v0 := model.Vector{}
 
-	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
+	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
 	q1 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q1Temp, "milliseconds"), fmt.Sprintf(q1Temp, "seconds"))
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
@@ -32,15 +32,15 @@ func TestResponseTime(t *testing.T) {
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "productpage-v1",
 		"destination_app":                "productpage",
-		"destination_version":            "v1"}
+		"destination_version":            "v1",
+		"response_code":                  "200"}
 	v1 := model.Vector{
 		&model.Sample{
 			Metric: q1m0,
 			Value:  0.010}}
 
-	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace="bookinfo",response_code=~"2[0-9]{2}|^0$"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version))`
+	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
 	q2 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q2Temp, "milliseconds"), fmt.Sprintf(q2Temp, "seconds"))
-	fmt.Printf("QUERY:\n%s", q2)
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -51,7 +51,8 @@ func TestResponseTime(t *testing.T) {
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "reviews-v1",
 		"destination_app":                "reviews",
-		"destination_version":            "v1"}
+		"destination_version":            "v1",
+		"response_code":                  "200"}
 	q2m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -62,7 +63,8 @@ func TestResponseTime(t *testing.T) {
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "reviews-v2",
 		"destination_app":                "reviews",
-		"destination_version":            "v2"}
+		"destination_version":            "v2",
+		"response_code":                  "200"}
 	q2m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
@@ -73,7 +75,8 @@ func TestResponseTime(t *testing.T) {
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "ratings-v1",
 		"destination_app":                "ratings",
-		"destination_version":            "v1"}
+		"destination_version":            "v1",
+		"response_code":                  "200"}
 	q2m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
@@ -84,7 +87,35 @@ func TestResponseTime(t *testing.T) {
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "ratings-v1",
 		"destination_app":                "ratings",
-		"destination_version":            "v1"}
+		"destination_version":            "v1",
+		"response_code":                  "200"}
+	q2m4 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "reviews-v2",
+		"source_app":                     "reviews",
+		"source_version":                 "v2",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service_name":       "ratings",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "ratings-v1",
+		"destination_app":                "ratings",
+		"destination_version":            "v1",
+		"response_code":                  "404", // should get tossed out on HTTP error
+		"grpc_response_status":           "0"}
+	q2m5 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "reviews-v2",
+		"source_app":                     "reviews",
+		"source_version":                 "v2",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service_name":       "ratings",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "ratings-v1",
+		"destination_app":                "ratings",
+		"destination_version":            "v1",
+		"response_code":                  "200",
+		"grpc_response_status":           "1"} // should get tossed out on GRPC error
+
 	v2 := model.Vector{
 		&model.Sample{
 			Metric: q2m0,
@@ -97,7 +128,13 @@ func TestResponseTime(t *testing.T) {
 			Value:  0.030},
 		&model.Sample{
 			Metric: q2m3,
-			Value:  0.030}}
+			Value:  0.030},
+		&model.Sample{
+			Metric: q2m4,
+			Value:  0.001},
+		&model.Sample{
+			Metric: q2m5,
+			Value:  0.001}}
 
 	client, api, err := setupMocked()
 	if err != nil {

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -44,3 +44,16 @@ func HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName stri
 
 	return destSvcNs, destSvcName
 }
+
+// HandleResponseCode returns either the HTTP response code or the GRPC response status.  GRPC response
+// status was added upstream in Istio 1.5 and downstream OSSM 1.1.  We support it here in a backward compatible
+// way.  When protocol is not GRPC, or if the version running dies not supply the GRPC statsus, just return the
+// HTTP code.  Also return the HTTP code In the rare case that protocol is GRPC but the HTTP transport fails. (I
+// have never seen this happen).  Otherwise, return the GRPC status.
+func HandleResponseCode(protocol, httpResponseCode string, grpcResponseStatusOk bool, grpcResponseStatus string) string {
+	if protocol != graph.GRPC.Name || graph.IsHTTPErr(httpResponseCode) || !grpcResponseStatusOk {
+		return httpResponseCode
+	}
+
+	return grpcResponseStatus
+}

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -130,7 +130,7 @@ func (in *Client) FetchRange(metricName, labels, grouping, aggregator string, q 
 
 // FetchRateRange fetches a counter's rate in given range
 func (in *Client) FetchRateRange(metricName, labels, grouping string, q *BaseMetricsQuery) *Metric {
-	return fetchRateRange(in.api, metricName, labels, grouping, q)
+	return fetchRateRange(in.api, metricName, []string{labels}, grouping, q)
 }
 
 // FetchHistogramRange fetches bucketed metric as histogram in given range

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -20,7 +20,7 @@ func getMetrics(api prom_v1.API, q *IstioMetricsQuery) Metrics {
 	return metrics
 }
 
-func buildLabelStrings(q *IstioMetricsQuery) (string, string) {
+func buildLabelStrings(q *IstioMetricsQuery) (string, []string) {
 	labels := []string{fmt.Sprintf(`reporter="%s"`, q.Reporter)}
 	ref := "destination"
 	if q.Direction == "outbound" {
@@ -48,15 +48,26 @@ func buildLabelStrings(q *IstioMetricsQuery) (string, string) {
 
 	full := "{" + strings.Join(labels, ",") + "}"
 
-	labels = append(labels, `response_code=~"[5|4].*"`)
-	errors := "{" + strings.Join(labels, ",") + "}"
+	errors := []string{}
+	protocol := strings.ToLower(q.RequestProtocol)
+	if protocol == "" || protocol == "grpc" {
+		// this is intentionally not `grpc_response_status!="0"`. We need to be backward compatible and
+		// handle the case where grpc_response_status does not exist.  In Prometheus, negative tests on a
+		// non-existent label match everything, but positive tests match nothing. So, we stay positive.
+		grpcLabels := append(labels, `grpc_response_status=~"^[1-9]$|^1[0-6]$"`)
+		errors = append(errors, ("{" + strings.Join(grpcLabels, ",") + "}"))
+	}
+	if protocol == "" || protocol == "http" {
+		httpLabels := append(labels, `response_code=~"^[4-5]\d\d$"`)
+		errors = append(errors, "{"+strings.Join(httpLabels, ",")+"}")
+	}
 
 	return full, errors
 }
 
-func fetchAllMetrics(api prom_v1.API, q *IstioMetricsQuery, labels, labelsError, grouping string) Metrics {
+func fetchAllMetrics(api prom_v1.API, q *IstioMetricsQuery, labels string, labelsError []string, grouping string) Metrics {
 	var wg sync.WaitGroup
-	fetchRate := func(p8sFamilyName string, metric **Metric, lbl string) {
+	fetchRate := func(p8sFamilyName string, metric **Metric, lbl []string) {
 		defer wg.Done()
 		m := fetchRateRange(api, p8sFamilyName, lbl, grouping, &q.BaseMetricsQuery)
 		*metric = m
@@ -122,13 +133,21 @@ func fetchAllMetrics(api prom_v1.API, q *IstioMetricsQuery, labels, labelsError,
 	}
 }
 
-func fetchRateRange(api prom_v1.API, metricName, labels, grouping string, q *BaseMetricsQuery) *Metric {
+func fetchRateRange(api prom_v1.API, metricName string, labels []string, grouping string, q *BaseMetricsQuery) *Metric {
 	var query string
 	// Example: round(sum(rate(my_counter{foo=bar}[5m])) by (baz), 0.001)
-	if grouping == "" {
-		query = fmt.Sprintf("sum(%s(%s%s[%s]))", q.RateFunc, metricName, labels, q.RateInterval)
-	} else {
-		query = fmt.Sprintf("sum(%s(%s%s[%s])) by (%s)", q.RateFunc, metricName, labels, q.RateInterval, grouping)
+	for i, labelsInstance := range labels {
+		if i > 0 {
+			query += " OR "
+		}
+		if grouping == "" {
+			query += fmt.Sprintf("sum(%s(%s%s[%s]))", q.RateFunc, metricName, labelsInstance, q.RateInterval)
+		} else {
+			query += fmt.Sprintf("sum(%s(%s%s[%s])) by (%s)", q.RateFunc, metricName, labelsInstance, q.RateInterval, grouping)
+		}
+	}
+	if len(labels) > 1 {
+		query = fmt.Sprintf("(%s)", query)
 	}
 	query = roundSignificant(query, 0.001)
 	return fetchRange(api, query, q.Range)

--- a/prometheus/metrics_definitions.go
+++ b/prometheus/metrics_definitions.go
@@ -51,9 +51,9 @@ var istioMetrics = []istioMetric{
 	},
 }
 
-func (in *istioMetric) labelsToUse(labels, labelsError string) string {
+func (in *istioMetric) labelsToUse(labels string, labelsError []string) []string {
 	if in.useErrorLabels {
 		return labelsError
 	}
-	return labels
+	return []string{labels}
 }


### PR DESCRIPTION
V1.12/SM1.1 Backport for https://github.com/kiali/kiali/issues/1235

Graph:
- For GRPC requests use grpc_response_status unless there was an HTTP-level failure (i.e. response_code is an HTTP failure code). Kiali only associates one response code with a request, so based on protocol we use one of the two supplied in the telemetry.
- We limit TCP metrics to only successful requests so now we also check for grpc success criteria to our queries.

Metrics/Health:
- To capture error rate when no protocol is specified we need to query separately for HTTP and GRPC errors. Update queries appropriately (pretty ugly now).  In the future we could consider
a refactor that eliminated support for error query and defered the filtering to the client.
- To aggregate errors for health checks we need to include both GRPC and HTTP errors

Prometheus Query Note relevant to backward compatibility: In prom queries a negative operator on a non-existent label matches everything (e.g. bad_label != "0").   A postive operator on a non-existent label matches nothing (e.g. bad_label = "0").
