### PR TITLE
Adding workload checker for AuthPolicy

### DIFF
--- a/business/checkers/authorization/namespace_method_checker_test.go
+++ b/business/checkers/authorization/namespace_method_checker_test.go
@@ -66,10 +66,12 @@ func TestToMethodWrongHTTP(t *testing.T) {
 
 func sourceNamespaceAuthPolicy(nss []interface{}) kubernetes.IstioObject {
 	methods := []interface{}{"GET", "PUT", "PATCH"}
-	return data.CreateAuthorizationPolicy(nss, methods)
+	selector := map[string]interface{}{"app": "details"}
+	return data.CreateAuthorizationPolicy(nss, methods, selector)
 }
 
 func toMethodsAuthPolicy(methods []interface{}) kubernetes.IstioObject {
 	nss := []interface{}{"bookinfo"}
-	return data.CreateAuthorizationPolicy(nss, methods)
+	selector := map[string]interface{}{"app": "details"}
+	return data.CreateAuthorizationPolicy(nss, methods, selector)
 }

--- a/business/checkers/authorization/workload_selector_checker.go
+++ b/business/checkers/authorization/workload_selector_checker.go
@@ -1,0 +1,47 @@
+package authorization
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type WorkloadSelectorChecker struct {
+	AuthorizationPolicy kubernetes.IstioObject
+	WorkloadList        models.WorkloadList
+}
+
+func (wsc WorkloadSelectorChecker) Check() ([]*models.IstioCheck, bool) {
+	checks, valid := make([]*models.IstioCheck, 0), true
+	if selectorSpec, found := wsc.AuthorizationPolicy.GetSpec()["selector"]; found {
+		if ml, ok := selectorSpec.(map[string]interface{}); ok {
+			if matchLabels, found := ml["matchLabels"]; found {
+				if selectors, ok := matchLabels.(map[string]interface{}); ok {
+					labelSelectors := make(map[string]string, len(selectors))
+					for k, v := range selectors {
+						labelSelectors[k] = v.(string)
+					}
+					if !wsc.hasMatchingWorkload(labelSelectors) {
+						check := models.Build("authorizationpolicy.selector.workloadnotfound", "spec/selector")
+						checks = append(checks, &check)
+					}
+				}
+			}
+		}
+
+	}
+	return checks, valid
+}
+
+func (wsc WorkloadSelectorChecker) hasMatchingWorkload(labelSelector map[string]string) bool {
+	selector := labels.SelectorFromSet(labels.Set(labelSelector))
+
+	for _, wl := range wsc.WorkloadList.Workloads {
+		wlLabelSet := labels.Set(wl.Labels)
+		if selector.Matches(wlLabelSet) {
+			return true
+		}
+	}
+	return false
+}

--- a/business/checkers/authorization/workload_selector_checker_test.go
+++ b/business/checkers/authorization/workload_selector_checker_test.go
@@ -1,12 +1,13 @@
 package authorization
 
 import (
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/tests/data"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
 )
 
 func TestPresentWorkloads(t *testing.T) {

--- a/business/checkers/authorization/workload_selector_checker_test.go
+++ b/business/checkers/authorization/workload_selector_checker_test.go
@@ -1,0 +1,79 @@
+package authorization
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPresentWorkloads(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := WorkloadSelectorChecker{
+		WorkloadList: workloadList(),
+		AuthorizationPolicy: workloadSelectorAuthPolicy(map[string]interface{}{
+			"app":     "details",
+			"version": "v1",
+		}),
+	}.Check()
+
+	// Well configured object
+	assert.True(valid)
+	assert.Empty(validations)
+
+	validations, valid = WorkloadSelectorChecker{
+		WorkloadList: workloadList(),
+		AuthorizationPolicy: workloadSelectorAuthPolicy(map[string]interface{}{
+			"app": "details",
+		}),
+	}.Check()
+
+	// Well configured object
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestWorkloadNotFound(t *testing.T) {
+	assert := assert.New(t)
+	testFailureWithWorkloadList(assert, map[string]interface{}{"app": "wrong", "version": "v1"})
+	testFailureWithWorkloadList(assert, map[string]interface{}{"app": "details", "version": "wrong"})
+	testFailureWithWorkloadList(assert, map[string]interface{}{"app": "wrong"})
+	testFailureWithEmptyWorkloadList(assert, map[string]interface{}{"app": "wrong", "version": "v1"})
+	testFailureWithEmptyWorkloadList(assert, map[string]interface{}{"app": "details", "version": "wrong"})
+	testFailureWithEmptyWorkloadList(assert, map[string]interface{}{"app": "wrong"})
+}
+
+func workloadSelectorAuthPolicy(selector map[string]interface{}) kubernetes.IstioObject {
+	methods := []interface{}{"GET", "PUT", "PATCH"}
+	nss := []interface{}{"bookinfo"}
+	return data.CreateAuthorizationPolicy(nss, methods, selector)
+}
+
+func testFailureWithWorkloadList(assert *assert.Assertions, selector map[string]interface{}) {
+	testFailure(assert, selector, workloadList())
+}
+
+func testFailureWithEmptyWorkloadList(assert *assert.Assertions, selector map[string]interface{}) {
+	testFailure(assert, selector, data.CreateWorkloadList("test", models.WorkloadListItem{}))
+}
+
+func testFailure(assert *assert.Assertions, selector map[string]interface{}, wl models.WorkloadList) {
+	validations, valid := WorkloadSelectorChecker{
+		WorkloadList:        wl,
+		AuthorizationPolicy: workloadSelectorAuthPolicy(selector),
+	}.Check()
+
+	assert.True(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(validations[0].Message, models.CheckMessage("authorizationpolicy.selector.workloadnotfound"))
+	assert.Equal(validations[0].Severity, models.WarningSeverity)
+	assert.Equal(validations[0].Path, "spec/selector")
+}
+
+func workloadList() models.WorkloadList {
+	return data.CreateWorkloadList("test", data.CreateWorkloadListItem("details", map[string]string{"app": "details", "version": "v1"}))
+}

--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -11,6 +11,7 @@ const AuthorizationPolicyCheckerType = "authorizationpolicy"
 type AuthorizationPolicyChecker struct {
 	AuthorizationPolicies []kubernetes.IstioObject
 	Namespaces            models.Namespaces
+	WorkloadList          models.WorkloadList
 }
 
 func (a AuthorizationPolicyChecker) Check() models.IstioValidations {
@@ -30,6 +31,7 @@ func (a AuthorizationPolicyChecker) runChecks(authPolicy kubernetes.IstioObject)
 
 	enabledCheckers := []Checker{
 		authorization.NamespaceMethodChecker{AuthorizationPolicy: authPolicy, Namespaces: a.Namespaces.GetNames()},
+		authorization.WorkloadSelectorChecker{AuthorizationPolicy: authPolicy, WorkloadList: a.WorkloadList},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -116,7 +116,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.PolicyChecker{Policies: mtlsDetails.Policies, MTLSDetails: mtlsDetails},
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
 		checkers.ServiceRoleBindChecker{RBACDetails: rbacDetails},
-		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespaces: namespaces},
+		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespaces: namespaces, WorkloadList: workloads},
 	}
 }
 
@@ -201,7 +201,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	case Sidecars:
 		// Validations on Sidecars are not yet in place
 	case AuthorizationPolicies:
-		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespaces: namespaces}
+		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespaces: namespaces, WorkloadList: workloads}
 		objectCheckers = []ObjectChecker{authPoliciesChecker}
 	case ServiceRoles:
 		objectCheckers = []ObjectChecker{noServiceChecker}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -110,6 +110,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "Only HTTP methods and fully-qualified gRPC names are allowed",
 		Severity: WarningSeverity,
 	},
+	"authorizationpolicy.selector.workloadnotfound": {
+		Message:  "No matching workload found for authorization policy selector in this namespace",
+		Severity: WarningSeverity,
+	},
 	"destinationrules.multimatch": {
 		Message:  "More than one DestinationRules for the same host subset combination",
 		Severity: WarningSeverity,

--- a/tests/data/authorization_policy_data.go
+++ b/tests/data/authorization_policy_data.go
@@ -6,17 +6,15 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 )
 
-func CreateAuthorizationPolicy(sourceNamespaces, operationMethods []interface{}) kubernetes.IstioObject {
+func CreateAuthorizationPolicy(sourceNamespaces, operationMethods []interface{}, selector map[string]interface{}) kubernetes.IstioObject {
 	return (&kubernetes.GenericIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "auth-policy",
 			Namespace: "bookinfo",
 		},
 		Spec: map[string]interface{}{
-			"selector": []interface{}{
-				map[string]interface{}{
-					"app": "ratings",
-				},
+			"selector": map[string]interface{}{
+				"matchLabels": selector,
 			},
 			"rules": []interface{}{
 				map[string]interface{}{


### PR DESCRIPTION
Adding validation for selector matchLabels on AuthorizationPolicy objects.
This is as part of https://github.com/kiali/kiali/issues/2081
Documentation PR: https://github.com/kiali/kiali.io/pull/204

When there is a workload with those labels:
![Screenshot of Kiali Console (14)](https://user-images.githubusercontent.com/613814/74523814-2402d500-4f1e-11ea-8bc7-8b0d01f8c048.png)

When the AuthorizationPolicy has no selector, there's no warning either.
![Screenshot of Kiali Console (17)](https://user-images.githubusercontent.com/613814/74523943-688e7080-4f1e-11ea-9aaa-ccdbceb3b676.png)

When the AuthPolicy related to a non-existing workload:
![Screenshot of Kiali Console (16)](https://user-images.githubusercontent.com/613814/74523873-43016700-4f1e-11ea-9e7a-9c4b11cb52eb.png)

