### PR TITLE
Fix issue when pulling "request_error_count" metrics

### DIFF
--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -58,7 +58,7 @@ func buildLabelStrings(q *IstioMetricsQuery) (string, []string) {
 		errors = append(errors, ("{" + strings.Join(grpcLabels, ",") + "}"))
 	}
 	if protocol == "" || protocol == "http" {
-		httpLabels := append(labels, `response_code=~"^[4-5]\d\d$"`)
+		httpLabels := append(labels, `response_code=~"^[4-5]\\d\\d$"`)
 		errors = append(errors, "{"+strings.Join(httpLabels, ",")+"}")
 	}
 

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -55,7 +55,7 @@ func TestGetServiceMetrics(t *testing.T) {
 	}
 
 	mockWithRange(api, expectedRange, round(`sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]))`), 2.5)
-	mockWithRange(api, expectedRange, roundErrs(`sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",response_code=~"^[4-5]\d\d$"}[5m]))`), 4.5)
+	mockWithRange(api, expectedRange, roundErrs(`sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo",response_code=~"^[4-5]\\d\\d$"}[5m]))`), 4.5)
 	mockWithRange(api, expectedRange, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]))`), 11)
 	mockWithRange(api, expectedRange, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]))`), 13)
 	mockHistogram(api, "istio_request_bytes", `{reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.7)
@@ -101,7 +101,7 @@ func TestGetAppMetrics(t *testing.T) {
 		return
 	}
 	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 1.5)
-	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",response_code=~"^[4-5]\d\d$"}[5m]))`), 3.5)
+	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage",response_code=~"^[4-5]\\d\\d$"}[5m]))`), 3.5)
 	mockRange(api, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 10)
 	mockRange(api, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]))`), 12)
 	mockHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo",source_app="productpage"}[5m]`, 0.35, 0.2, 0.3, 0.4)
@@ -236,7 +236,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 		return
 	}
 	mockRange(api, round(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 1.5)
-	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",response_code=~"^[4-5]\d\d$"}[5m]))`), 3.5)
+	mockRange(api, roundErrs(`sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",response_code=~"^[4-5]\\d\\d$"}[5m]))`), 3.5)
 	mockRange(api, round(`sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 10)
 	mockRange(api, round(`sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"}[5m]))`), 12)
 	mockHistogram(api, "istio_request_bytes", `{reporter="source",source_workload_namespace="bookinfo"}[5m]`, 0.35, 0.2, 0.3, 0.4)


### PR DESCRIPTION
Fixes an unfortunate prom/regex issue introduced with the nre grpc_request_status handling for Istio 1.5.

Fixes https://github.com/kiali/kiali/issues/2242
