### PR TITLE
[hack] don't expose kiali if it wasn't installed

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -321,7 +321,9 @@ else
   # Do some OpenShift specific things
   if [[ "${CLIENT_EXE}" = *"oc" ]]; then
     ${CLIENT_EXE} -n ${NAMESPACE} expose svc/istio-ingressgateway --port=http2
-    ${CLIENT_EXE} -n ${NAMESPACE} expose svc/kiali
+    if [ "${KIALI_ENABLED}" == "true" ]; then
+      ${CLIENT_EXE} -n ${NAMESPACE} expose svc/kiali
+    fi
     ${CLIENT_EXE} -n ${NAMESPACE} expose svc/prometheus
 
     echo "===== IMPORTANT ====="


### PR DESCRIPTION
Minor change to the hack script that installs istio.

If it does not install kiali, then it should not create the kiali route. Otherwise, the script spits out an error that might be alarming: 

```
Error from server (NotFound): services "kiali" not found
```

This PR just skips the route creation if kiali wasn't enabled.