### PR TITLE
E2E - Disable Workloads Test

### DIFF
--- a/tests/e2e/tests/test_kiali_workload_endpoint.py
+++ b/tests/e2e/tests/test_kiali_workload_endpoint.py
@@ -23,7 +23,7 @@ def test_workload_list_endpoint(kiali_client):
           assert workload.get('versionLabel') == True
       assert workload.get('appLabel') == True
 
-def test_diversity_in_workload_list_endpoint(kiali_client):
+def _test_diversity_in_workload_list_endpoint(kiali_client):
   bookinfo_namespace = conftest.get_bookinfo_namespace()
 
   try:


### PR DESCRIPTION
Disabling test_diversity_in_workload_list_endpoint due to pod version no being supported in OCP 4.4.