### PR TITLE
Promote StatefulSet and ReplicaSets to v1 to fix e2e test

### DIFF
--- a/tests/e2e/assets/bookinfo-workloads.yaml
+++ b/tests/e2e/assets/bookinfo-workloads.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: reviews-v4
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v4
   template:
     metadata:
       labels:
@@ -36,12 +40,16 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: reviews-v6
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v6
   template:
     metadata:
       labels:


### PR DESCRIPTION
** Describe the change **

Fixing e2e test about workload diversity. The assets yaml was outdated and seems that in OCP 4.4 the previous versions for StatefulSets and ReplicaSets are going to be unsupported.

@mattmahoneyrh Do that work for you?