### PR TITLE
Sidecar validations: no matching workloads and multi sidecar match

### DIFF
--- a/business/checkers/sidecars/multi_match_checker.go
+++ b/business/checkers/sidecars/multi_match_checker.go
@@ -1,0 +1,92 @@
+package sidecars
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+const SidecarCheckerType = "sidecar"
+
+type MultiMatchChecker struct {
+	Sidecars []kubernetes.IstioObject
+}
+
+type KeyWithIndex struct {
+	Index int
+	Key   *models.IstioValidationKey
+}
+
+func (m MultiMatchChecker) Check() models.IstioValidations {
+	swi := m.selectorLessSidecars()
+	return buildSidecarValidations(swi)
+}
+
+func (m MultiMatchChecker) selectorLessSidecars() []KeyWithIndex {
+	swi := make([]KeyWithIndex, 0, len(m.Sidecars))
+
+	for i, s := range m.Sidecars {
+		add := false
+
+		if ws, found := s.GetSpec()["workloadSelector"]; found {
+			if wsCasted, ok := ws.(map[string]interface{}); ok {
+				if _, found := wsCasted["labels"]; !found {
+					add = true
+				}
+			}
+		} else {
+			add = true
+		}
+
+		if add {
+			swi = append(swi, KeyWithIndex{
+				Index: i,
+				Key: &models.IstioValidationKey{
+					Name:       s.GetObjectMeta().Name,
+					Namespace:  s.GetObjectMeta().Namespace,
+					ObjectType: SidecarCheckerType,
+				},
+			},
+			)
+		}
+	}
+	return swi
+}
+
+func buildSidecarValidations(sidecars []KeyWithIndex) models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	if len(sidecars) < 2 {
+		return validations
+	}
+
+	for _, sidecarWithIndex := range sidecars {
+		sidecarIndex := sidecarWithIndex.Index
+		sidecarKey := sidecarWithIndex.Key
+		references := extractReferences(append(sidecars[:sidecarIndex], sidecars[sidecarIndex+1:]...))
+		checks := models.Build("sidecar.multimatch", "spec/workloadSelector")
+		validations.MergeValidations(
+			models.IstioValidations{
+				*sidecarWithIndex.Key: &models.IstioValidation{
+					Name:       sidecarKey.Name,
+					ObjectType: sidecarKey.ObjectType,
+					Valid:      false,
+					References: references,
+					Checks: []*models.IstioCheck{
+						&checks,
+					},
+				},
+			},
+		)
+	}
+	return validations
+}
+
+func extractReferences(withIndex []KeyWithIndex) []models.IstioValidationKey {
+	references := make([]models.IstioValidationKey, 0, len(withIndex))
+
+	for _, wi := range withIndex {
+		references = append(references, *wi.Key)
+	}
+
+	return references
+}

--- a/business/checkers/sidecars/multi_match_checker_test.go
+++ b/business/checkers/sidecars/multi_match_checker_test.go
@@ -1,0 +1,55 @@
+package sidecars
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+func TestTwoSidecarsWithSelector(t *testing.T) {
+	assert := assert.New(t)
+
+	validations := MultiMatchChecker{
+		Sidecars: []kubernetes.IstioObject{
+			data.AddSelectorToSidecar(map[string]interface{}{
+				"labels": map[string] interface{}{
+					"app": "reviews",
+				},
+			}, data.CreateSidecar("sidecar1")),
+			data.AddSelectorToSidecar(map[string]interface{}{
+				"labels": map[string] interface{}{
+					"app": "details",
+				},
+			}, data.CreateSidecar("sidecar2")),
+		},
+	}.Check()
+
+	assert.Empty(validations)
+}
+
+func TestTwoSidecarsWithoutSelector(t *testing.T) {
+	assert := assert.New(t)
+
+	validations := MultiMatchChecker{
+		Sidecars: []kubernetes.IstioObject{
+			data.CreateSidecar("sidecar1"),
+			data.CreateSidecar("sidecar2"),
+		},
+	}.Check()
+
+	assert.NotEmpty(validations)
+	items := []string{"sidecar1", "sidecar2"}
+	for _, item := range items {
+		validation, ok := validations[models.IstioValidationKey{ObjectType: "sidecar", Namespace: "bookinfo", Name: item}]
+		assert.True(ok)
+		assert.False(validation.Valid)
+		assert.NotEmpty(validation.Checks)
+		assert.Equal(models.ErrorSeverity, validation.Checks[0].Severity)
+		assert.Equal(models.CheckMessage("sidecar.multimatch"), validation.Checks[0].Message)
+		assert.Len(validation.References, 1)
+	}
+}

--- a/business/checkers/sidecars/workload_selector_checker.go
+++ b/business/checkers/sidecars/workload_selector_checker.go
@@ -1,0 +1,47 @@
+package sidecars
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type WorkloadSelectorChecker struct {
+	Sidecar      kubernetes.IstioObject
+	WorkloadList models.WorkloadList
+}
+
+func (wsc WorkloadSelectorChecker) Check() ([]*models.IstioCheck, bool) {
+	checks, valid := make([]*models.IstioCheck, 0), true
+	if selectorSpec, found := wsc.Sidecar.GetSpec()["workloadSelector"]; found {
+		if ml, ok := selectorSpec.(map[string]interface{}); ok {
+			if matchLabels, found := ml["labels"]; found {
+				if selectors, ok := matchLabels.(map[string]interface{}); ok {
+					labelSelectors := make(map[string]string, len(selectors))
+					for k, v := range selectors {
+						labelSelectors[k] = v.(string)
+					}
+					if !wsc.hasMatchingWorkload(labelSelectors) {
+						check := models.Build("sidecar.selector.workloadnotfound", "spec/workloadSelector/labels")
+						checks = append(checks, &check)
+					}
+				}
+			}
+		}
+
+	}
+	return checks, valid
+}
+
+func (wsc WorkloadSelectorChecker) hasMatchingWorkload(labelSelector map[string]string) bool {
+	selector := labels.SelectorFromSet(labels.Set(labelSelector))
+
+	for _, wl := range wsc.WorkloadList.Workloads {
+		wlLabelSet := labels.Set(wl.Labels)
+		if selector.Matches(wlLabelSet) {
+			return true
+		}
+	}
+	return false
+}

--- a/business/checkers/sidecars/workload_selector_checker_test.go
+++ b/business/checkers/sidecars/workload_selector_checker_test.go
@@ -48,7 +48,8 @@ func TestWorkloadNotFound(t *testing.T) {
 }
 
 func workloadSelectorSidecar(selector map[string]interface{}) kubernetes.IstioObject {
-	return data.CreateSidecar(selector)
+	workloadSelector := map[string]interface{}{"labels": selector}
+	return data.AddSelectorToSidecar(workloadSelector, data.CreateSidecar("sidecar"))
 }
 
 func testFailureWithWorkloadList(assert *assert.Assertions, selector map[string]interface{}) {

--- a/business/checkers/sidecars/workload_selector_checker_test.go
+++ b/business/checkers/sidecars/workload_selector_checker_test.go
@@ -1,0 +1,78 @@
+package sidecars
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+func TestPresentWorkloads(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := WorkloadSelectorChecker{
+		WorkloadList: workloadList(),
+		Sidecar: workloadSelectorSidecar(map[string]interface{}{
+			"app":     "details",
+			"version": "v1",
+		}),
+	}.Check()
+
+	// Well configured object
+	assert.True(valid)
+	assert.Empty(validations)
+
+	validations, valid = WorkloadSelectorChecker{
+		WorkloadList: workloadList(),
+		Sidecar: workloadSelectorSidecar(map[string]interface{}{
+			"app": "details",
+		}),
+	}.Check()
+
+	// Well configured object
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestWorkloadNotFound(t *testing.T) {
+	assert := assert.New(t)
+	testFailureWithWorkloadList(assert, map[string]interface{}{"app": "wrong", "version": "v1"})
+	testFailureWithWorkloadList(assert, map[string]interface{}{"app": "details", "version": "wrong"})
+	testFailureWithWorkloadList(assert, map[string]interface{}{"app": "wrong"})
+	testFailureWithEmptyWorkloadList(assert, map[string]interface{}{"app": "wrong", "version": "v1"})
+	testFailureWithEmptyWorkloadList(assert, map[string]interface{}{"app": "details", "version": "wrong"})
+	testFailureWithEmptyWorkloadList(assert, map[string]interface{}{"app": "wrong"})
+}
+
+func workloadSelectorSidecar(selector map[string]interface{}) kubernetes.IstioObject {
+	return data.CreateSidecar(selector)
+}
+
+func testFailureWithWorkloadList(assert *assert.Assertions, selector map[string]interface{}) {
+	testFailure(assert, selector, workloadList())
+}
+
+func testFailureWithEmptyWorkloadList(assert *assert.Assertions, selector map[string]interface{}) {
+	testFailure(assert, selector, data.CreateWorkloadList("test", models.WorkloadListItem{}))
+}
+
+func testFailure(assert *assert.Assertions, selector map[string]interface{}, wl models.WorkloadList) {
+	validations, valid := WorkloadSelectorChecker{
+		WorkloadList: wl,
+		Sidecar:      workloadSelectorSidecar(selector),
+	}.Check()
+
+	assert.True(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(validations[0].Message, models.CheckMessage("sidecar.selector.workloadnotfound"))
+	assert.Equal(validations[0].Severity, models.WarningSeverity)
+	assert.Equal(validations[0].Path, "spec/workloadSelector/labels")
+}
+
+func workloadList() models.WorkloadList {
+	return data.CreateWorkloadList("test", data.CreateWorkloadListItem("details", map[string]string{"app": "details", "version": "v1"}))
+}

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -17,6 +17,29 @@ type SidecarChecker struct {
 func (s SidecarChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
+	validations = validations.MergeValidations(s.runIndividualChecks())
+	validations = validations.MergeValidations(s.runGroupChecks())
+
+	return validations
+}
+
+func (s SidecarChecker) runGroupChecks() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	enabledDRCheckers := []GroupChecker{
+		sidecars.MultiMatchChecker{Sidecars: s.Sidecars},
+	}
+
+	for _, checker := range enabledDRCheckers {
+		validations = validations.MergeValidations(checker.Check())
+	}
+
+	return validations
+}
+
+func (s SidecarChecker) runIndividualChecks() models.IstioValidations {
+	validations := models.IstioValidations{}
+
 	for _, sidecar := range s.Sidecars {
 		validations.MergeValidations(s.runChecks(sidecar))
 	}

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -1,0 +1,42 @@
+package checkers
+
+import (
+	"github.com/kiali/kiali/business/checkers/sidecars"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+const SidecarCheckerType = "sidecar"
+
+type SidecarChecker struct {
+	Sidecars     []kubernetes.IstioObject
+	Namespaces   models.Namespaces
+	WorkloadList models.WorkloadList
+}
+
+func (s SidecarChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, sidecar := range s.Sidecars {
+		validations.MergeValidations(s.runChecks(sidecar))
+	}
+
+	return validations
+}
+
+func (s SidecarChecker) runChecks(sidecar kubernetes.IstioObject) models.IstioValidations {
+	policyName := sidecar.GetObjectMeta().Name
+	key, rrValidation := EmptyValidValidation(policyName, sidecar.GetObjectMeta().Namespace, SidecarCheckerType)
+
+	enabledCheckers := []Checker{
+		sidecars.WorkloadSelectorChecker{Sidecar: sidecar, WorkloadList: s.WorkloadList},
+	}
+
+	for _, checker := range enabledCheckers {
+		checks, validChecker := checker.Check()
+		rrValidation.Checks = append(rrValidation.Checks, checks...)
+		rrValidation.Valid = rrValidation.Valid && validChecker
+	}
+
+	return models.IstioValidations{key: rrValidation}
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -117,6 +117,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
 		checkers.ServiceRoleBindChecker{RBACDetails: rbacDetails},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, WorkloadList: workloads},
+		checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces, WorkloadList: workloads},
 	}
 }
 
@@ -199,7 +200,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	case RbacConfigs:
 		// Validations on RbacConfigs are not yet in place
 	case Sidecars:
-		// Validations on Sidecars are not yet in place
+		sidecarsChecker := checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces, WorkloadList: workloads}
+		objectCheckers = []ObjectChecker{sidecarsChecker}
 	case AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
 			Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, WorkloadList: workloads}
@@ -408,6 +410,9 @@ func (in *IstioValidationsService) fetchDetails(rValue *kubernetes.IstioDetails,
 			}
 			if err == nil {
 				istioDetails.Gateways, err = kialiCache.GetIstioResources("Gateway", namespace)
+			}
+			if err == nil {
+				istioDetails.Sidecars, err = kialiCache.GetIstioResources("Sidecar", namespace)
 			}
 		} else {
 			istioDetails, err = in.k8s.GetIstioDetails(namespace, "")

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -28,17 +28,19 @@ var (
 func (in *IstioClient) GetIstioDetails(namespace string, serviceName string) (*IstioDetails, error) {
 
 	wg := sync.WaitGroup{}
-	errChan := make(chan error, 4)
+	errChan := make(chan error, 5)
 
 	istioDetails := IstioDetails{}
 	vss := make([]IstioObject, 0)
 	drs := make([]IstioObject, 0)
 	gws := make([]IstioObject, 0)
 	ses := make([]IstioObject, 0)
+	scs := make([]IstioObject, 0)
 
-	wg.Add(4)
+	wg.Add(5)
 	go fetchNoEntry(&ses, namespace, in.GetServiceEntries, &wg, errChan)
 	go fetchNoEntry(&gws, namespace, in.GetGateways, &wg, errChan)
+	go fetchNoEntry(&scs, namespace, in.GetSidecars, &wg, errChan)
 	go fetch(&vss, namespace, serviceName, in.GetVirtualServices, &wg, errChan)
 	go fetch(&drs, namespace, serviceName, in.GetDestinationRules, &wg, errChan)
 	wg.Wait()
@@ -53,6 +55,7 @@ func (in *IstioClient) GetIstioDetails(namespace string, serviceName string) (*I
 	istioDetails.DestinationRules = drs
 	istioDetails.Gateways = gws
 	istioDetails.ServiceEntries = ses
+	istioDetails.Sidecars = scs
 
 	return &istioDetails, nil
 }

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -403,6 +403,7 @@ type IstioDetails struct {
 	DestinationRules []IstioObject `json:"destinationrules"`
 	ServiceEntries   []IstioObject `json:"serviceentries"`
 	Gateways         []IstioObject `json:"gateways"`
+	Sidecars         []IstioObject `json:"sidecars"`
 }
 
 // MTLSDetails is a wrapper to group all Istio objects related to non-local mTLS configurations

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -99,6 +99,7 @@ var ObjectTypeSingular = map[string]string{
 	"servicerolebindings":   "servicerolebinding",
 	"clusterrbacconfigs":    "clusterrbacconfig",
 	"authorizationpolicies": "authorizationpolicy",
+	"sidecars":              "sidecar",
 }
 
 var checkDescriptors = map[string]IstioCheck{

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -198,36 +198,40 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA0903 ServiceRole does not exists in this namespace",
 		Severity: ErrorSeverity,
 	},
+	"sidecar.selector.workloadnotfound": {
+		Message:  "KIA1001 No matching workload found for authorization policy selector in this namespace",
+		Severity: WarningSeverity,
+	},
 	"virtualservices.nohost.hostnotfound": {
-		Message:  "KIA1001 DestinationWeight on route doesn't have a valid service (host not found)",
+		Message:  "KIA1101 DestinationWeight on route doesn't have a valid service (host not found)",
 		Severity: ErrorSeverity,
 	},
 	"virtualservices.nogateway": {
-		Message:  "KIA1002 VirtualService is pointing to a non-existent gateway",
+		Message:  "KIA1102 VirtualService is pointing to a non-existent gateway",
 		Severity: ErrorSeverity,
 	},
 	"virtualservices.nohost.invalidprotocol": {
-		Message:  "KIA1003 VirtualService doesn't define any valid route protocol",
+		Message:  "KIA1103 VirtualService doesn't define any valid route protocol",
 		Severity: ErrorSeverity,
 	},
 	"virtualservices.route.singleweight": {
-		Message:  "KIA1004 The weight is assumed to be 100 because there is only one route destination",
+		Message:  "KIA1104 The weight is assumed to be 100 because there is only one route destination",
 		Severity: WarningSeverity,
 	},
 	"virtualservices.route.repeatedsubset": {
-		Message:  "KIA1005 This subset is already referenced in another route destination",
+		Message:  "KIA1105 This subset is already referenced in another route destination",
 		Severity: WarningSeverity,
 	},
 	"virtualservices.singlehost": {
-		Message:  "KIA1006 More than one Virtual Service for same host",
+		Message:  "KIA1106 More than one Virtual Service for same host",
 		Severity: WarningSeverity,
 	},
 	"virtualservices.subsetpresent.subsetnotfound": {
-		Message:  "KIA1007 Subset not found",
+		Message:  "KIA1107 Subset not found",
 		Severity: WarningSeverity,
 	},
 	"virtualservices.subsetpresent.destinationmandatory": {
-		Message:  "KIA1008 Destination field is mandatory",
+		Message:  "KIA1108 Destination field is mandatory",
 		Severity: ErrorSeverity,
 	},
 	"validation.unable.cross-namespace": {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -203,6 +203,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA1001 No matching workload found for authorization policy selector in this namespace",
 		Severity: WarningSeverity,
 	},
+	"sidecar.multimatch": {
+		Message:  "KIA1002 More than one selector-less Sidecar in the same namespace",
+		Severity: ErrorSeverity,
+	},
 	"virtualservices.nohost.hostnotfound": {
 		Message:  "KIA1101 DestinationWeight on route doesn't have a valid service (host not found)",
 		Severity: ErrorSeverity,

--- a/tests/data/sidecar_data.go
+++ b/tests/data/sidecar_data.go
@@ -6,16 +6,17 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 )
 
-func CreateSidecar(selector map[string]interface{}) kubernetes.IstioObject {
+func CreateSidecar(name string) kubernetes.IstioObject {
 	return (&kubernetes.GenericIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      "auth-policy",
+			Name:      name,
 			Namespace: "bookinfo",
 		},
-		Spec: map[string]interface{}{
-			"workloadSelector": map[string]interface{}{
-				"labels": selector,
-			},
-		},
+		Spec: map[string]interface{}{},
 	}).DeepCopyIstioObject()
+}
+
+func AddSelectorToSidecar(selector map[string]interface{}, gw kubernetes.IstioObject) kubernetes.IstioObject {
+	gw.GetSpec()["workloadSelector"] = selector
+	return gw
 }

--- a/tests/data/sidecar_data.go
+++ b/tests/data/sidecar_data.go
@@ -1,0 +1,21 @@
+package data
+
+import (
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+func CreateSidecar(selector map[string]interface{}) kubernetes.IstioObject {
+	return (&kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "auth-policy",
+			Namespace: "bookinfo",
+		},
+		Spec: map[string]interface{}{
+			"workloadSelector": map[string]interface{}{
+				"labels": selector,
+			},
+		},
+	}).DeepCopyIstioObject()
+}


### PR DESCRIPTION
** Describe the change **
Add validations for sidecar resources.

1. There are workloads with the provided labels in the workloadSelector field.
2. There aren't two sidecars in the same namespace without workloadSelector.

Requires to merge quick one in the frontend: https://github.com/kiali/kiali-ui/pull/1679

Next validation will come. Splitting https://github.com/kiali/kiali/issues/1541 for better review.
1.
![Screenshot of Kiali Console (26)](https://user-images.githubusercontent.com/613814/75886922-4acf6f80-5e29-11ea-981c-7967941b1f70.png)

2. 
![Screenshot of Kiali Console (22)](https://user-images.githubusercontent.com/613814/75692155-690c6280-5ca5-11ea-8239-7f0daea7366d.png)



