### PR TITLE
Enable cache, fetch StatefulSets by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -345,11 +345,11 @@ func NewConfig() (c *Config) {
 		KubernetesConfig: KubernetesConfig{
 			Burst:                       200,
 			CacheDuration:               5 * 60,
-			CacheEnabled:                false,
+			CacheEnabled:                true,
 			CacheIstioTypes:             []string{"DestinationRule", "Gateway", "ServiceEntry", "VirtualService"},
 			CacheNamespaces:             []string{},
 			CacheTokenNamespaceDuration: 10,
-			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController", "StatefulSet"},
+			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},
 			QPS:                         175,
 		},
 		LoginToken: LoginToken{

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -539,7 +539,7 @@ spec:
 #
 # Flag to use a Kubernetes cache for watching changes and updating pods and controllers data asynchronously.
 #    ---
-#    cache_enabled: false
+#    cache_enabled: true
 #
 # Kiali can cache VirtualService,DestinationRule,Gateway and ServiceEntry Istio resources if they are present
 # on this list of Istio types. Other Istio types are not yet supported.
@@ -570,7 +570,6 @@ spec:
 #    - "DeploymentConfig"
 #    - "Job"
 #    - "ReplicationController"
-#    - "StatefulSet"
 #
 # The QPS value of the Kubernetes client.
 #    ---

--- a/operator/roles/default/kiali-deploy/defaults/main.yml
+++ b/operator/roles/default/kiali-deploy/defaults/main.yml
@@ -141,7 +141,7 @@ kiali_defaults:
   kubernetes_config:
     burst: 200
     cache_duration: 300
-    cache_enabled: false
+    cache_enabled: true
     cache_istio_types:
     - "DestinationRule"
     - "Gateway"
@@ -154,7 +154,6 @@ kiali_defaults:
     - "DeploymentConfig"
     - "Job"
     - "ReplicationController"
-    - "StatefulSet"
     qps: 175
 
   login_token:


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2253

Screenshot showing stateful sets in workloads list:

![Capture d’écran de 2020-03-02 17-47-40](https://user-images.githubusercontent.com/2153442/75697893-066b9480-5cae-11ea-96e2-56df24bda92f.png)
