### PR TITLE
Include GRPC failures in Health calculation

### DIFF
--- a/business/health_test.go
+++ b/business/health_test.go
@@ -219,6 +219,26 @@ var (
 		Value:     model.SampleValue(3.5),
 		Timestamp: model.Now(),
 	}
+	sampleReviewsToHttpbinGrpc0 = model.Sample{
+		Metric: model.Metric{
+			"source_service":       "reviews.tutorial.svc.cluster.local",
+			"destination_service":  "httpbin.tutorial.svc.cluster.local",
+			"request_protocol":     "grpc",
+			"grpc_response_status": "0",
+		},
+		Value:     model.SampleValue(5),
+		Timestamp: model.Now(),
+	}
+	sampleReviewsToHttpbinGrpc7 = model.Sample{
+		Metric: model.Metric{
+			"source_service":       "reviews.tutorial.svc.cluster.local",
+			"destination_service":  "httpbin.tutorial.svc.cluster.local",
+			"request_protocol":     "grpc",
+			"grpc_response_status": "7",
+		},
+		Value:     model.SampleValue(3), // should fail, change to 3.5 to succeed
+		Timestamp: model.Now(),
+	}
 	sampleUnknownToHttpbin200 = model.Sample{
 		Metric: model.Metric{
 			"destination_service":      "httpbin.tutorial.svc.cluster.local",
@@ -237,6 +257,28 @@ var (
 			"response_code":            "404",
 		},
 		Value:     model.SampleValue(1.4),
+		Timestamp: model.Now(),
+	}
+	sampleUnknownToHttpbinGrpc0 = model.Sample{
+		Metric: model.Metric{
+			"destination_service":      "httpbin.tutorial.svc.cluster.local",
+			"destination_service_name": "httpbin",
+			"source_service":           "unknown",
+			"request_protocol":         "grpc",
+			"grpc_response_status":     "0",
+		},
+		Value:     model.SampleValue(14),
+		Timestamp: model.Now(),
+	}
+	sampleUnknownToHttpbinGrpc7 = model.Sample{
+		Metric: model.Metric{
+			"destination_service":      "httpbin.tutorial.svc.cluster.local",
+			"destination_service_name": "httpbin",
+			"source_service":           "unknown",
+			"request_protocol":         "grpc",
+			"grpc_response_status":     "7",
+		},
+		Value:     model.SampleValue(2.4), // should fail, change to 1.4 to succeed
 		Timestamp: model.Now(),
 	}
 	sampleUnknownToReviews500 = model.Sample{


### PR DESCRIPTION
Starting is Istio 1.5 GRPC requests will generate request_protocol="grpc" grpc_request_status=<grpcStatus>.  Note that when request_protocol is not "grpc" the additional field is not provided (i.e. not present on the time series).

The health calculation was considering only http errors reported in response_code.  We need to include grpc errors.

Fixes #2457 