### PR TITLE
Support canonical_service fields in Istio 1.5+ telemetry

### DIFF
--- a/business/health.go
+++ b/business/health.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
+	"github.com/kiali/kiali/status"
 )
 
 // HealthService deals with fetching health from various sources and convert to kiali model
@@ -256,6 +257,11 @@ func (in *HealthService) getNamespaceWorkloadHealth(namespace string, ws models.
 func fillAppRequestRates(allHealth models.NamespaceAppHealth, rates model.Vector) {
 	lblDest := model.LabelName("destination_app")
 	lblSrc := model.LabelName("source_app")
+	if status.IstioSupportsCanonical() {
+		lblDest = model.LabelName("destination_canonical_service")
+		lblSrc = model.LabelName("source_canonical_service")
+	}
+
 	for _, sample := range rates {
 		name := string(sample.Metric[lblDest])
 		if health, ok := allHealth[name]; ok {

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -24,7 +24,7 @@ var verLabel = "version"
 func init() {
 	if status.IstioSupportsCanonical() {
 		appLabel = "canonical_service"
-		// verLabel = "canonical_revision"  TODO UNCOMMENT WHEN FIELD IS THERE
+		verLabel = "canonical_revision"
 		log.Info("JSHAUGHN DEBUG: supportsCanonical=true")
 	}
 }

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -16,21 +16,21 @@ const (
 )
 
 // version-specific telemetry field names.  Because the istio version can change outside of the kiali pod,
-// these values may change and are therefore re-set on every graph request.  TODO: can we just set these once
-// and potentially require a pod restart
+// these values may change and are therefore re-set on every graph request.
 var appLabel = "app"
 var verLabel = "version"
 
-func init() {
+func setLabels() {
 	if status.IstioSupportsCanonical() {
 		appLabel = "canonical_service"
 		verLabel = "canonical_revision"
-		log.Info("JSHAUGHN DEBUG: supportsCanonical=true")
 	}
 }
 
 // ParseAppenders determines which appenders should run for this graphing request
 func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
+	setLabels()
+
 	requestedAppenders := make(map[string]bool)
 	if !o.Appenders.All {
 		for _, appenderName := range o.Appenders.AppenderNames {

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -8,11 +8,26 @@ import (
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/status"
 )
 
 const (
 	defaultQuantile = 0.95
 )
+
+// version-specific telemetry field names.  Because the istio version can change outside of the kiali pod,
+// these values may change and are therefore re-set on every graph request.  TODO: can we just set these once
+// and potentially require a pod restart
+var appLabel = "app"
+var verLabel = "version"
+
+func init() {
+	if status.IstioSupportsCanonical() {
+		appLabel = "canonical_service"
+		// verLabel = "canonical_revision"  TODO UNCOMMENT WHEN FIELD IS THERE
+		log.Info("JSHAUGHN DEBUG: supportsCanonical=true")
+	}
+}
 
 // ParseAppenders determines which appenders should run for this graphing request
 func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -79,7 +79,7 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
 	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
 	// 1) query for responseTime originating from "unknown" (i.e. the internet)
-	groupBy := "le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status"
+	groupBy := "le,source_workload_namespace,source_workload,source_canonical_service,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_app,destination_version,response_code,grpc_response_status"
 	millisQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v"}[%vs])) by (%s))`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
@@ -190,12 +190,14 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		m := s.Metric
 		lSourceWlNs, sourceWlNsOk := m["source_workload_namespace"]
 		lSourceWl, sourceWlOk := m["source_workload"]
+		lSourceCS, sourceCSOk := m["source_canonical_service"]
 		lSourceApp, sourceAppOk := m["source_app"]
 		lSourceVer, sourceVerOk := m["source_version"]
 		lDestSvcNs, destSvcNsOk := m["destination_service_namespace"]
 		lDestSvcName, destSvcNameOk := m["destination_service_name"]
 		lDestWlNs, destWlNsOk := m["destination_workload_namespace"]
 		lDestWl, destWlOk := m["destination_workload"]
+		lDestCS, destCSOk := m["destination_canonical_service"]
 		lDestApp, destAppOk := m["destination_app"]
 		lDestVer, destVerOk := m["destination_version"]
 		lResponseCode, responseCodeOk := m["response_code"]
@@ -208,15 +210,18 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 
 		sourceWlNs := string(lSourceWlNs)
 		sourceWl := string(lSourceWl)
-		sourceApp := string(lSourceApp)
 		sourceVer := string(lSourceVer)
 		destSvcNs := string(lDestSvcNs)
 		destSvcName := string(lDestSvcName)
 		destWlNs := string(lDestWlNs)
 		destWl := string(lDestWl)
-		destApp := string(lDestApp)
 		destVer := string(lDestVer)
 		responseCode := string(lResponseCode)
+
+		// set app in a backward compatible way
+		sourceApp := util.HandleApp(string(lSourceApp), string(lSourceCS), sourceCSOk)
+		destApp := util.HandleApp(string(lDestApp), string(lDestCS), destCSOk)
+
 		// This was added in istio 1.5, handle in a backward compatible way
 		grpcReponseStatus := "0"
 		if grpcReponseStatusOk {

--- a/graph/telemetry/istio/appender/security_policy.go
+++ b/graph/telemetry/istio/appender/security_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/graph/telemetry/istio/util"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus"
 )
@@ -57,7 +58,7 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 	// 1) query for requests originating from a workload outside the namespace. This may include unnecessary istio
 	//    but we don't want to miss ingressgateway traffic, even if it's not in a requested namespace.  The excess
 	//    traffic will be ignored because it won't map to the trafficMap.
-	groupBy := "source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,connection_security_policy"
+	groupBy := "source_workload_namespace,source_workload,source_canonical_service,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_app,destination_version,connection_security_policy"
 	httpQuery := fmt.Sprintf(`sum(rate(%s{reporter="destination",source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
 		"istio_requests_total",
 		namespace,
@@ -109,12 +110,14 @@ func (a SecurityPolicyAppender) populateSecurityPolicyMap(securityPolicyMap map[
 		m := s.Metric
 		lSourceWlNs, sourceWlNsOk := m["source_workload_namespace"]
 		lSourceWl, sourceWlOk := m["source_workload"]
+		lSourceCS, sourceCSOk := m["source_canonical_service"]
 		lSourceApp, sourceAppOk := m["source_app"]
 		lSourceVer, sourceVerOk := m["source_version"]
 		lDestSvcNs, destSvcNsOk := m["destination_service_namespace"]
 		lDestSvcName, destSvcNameOk := m["destination_service_name"]
 		lDestWlNs, destWlNsOk := m["destination_workload_namespace"]
 		lDestWl, destWlOk := m["destination_workload"]
+		lDestCS, destCSOk := m["destination_canonical_service"]
 		lDestApp, destAppOk := m["destination_app"]
 		lDestVer, destVerOk := m["destination_version"]
 		lCsp, cspOk := m["connection_security_policy"]
@@ -126,15 +129,17 @@ func (a SecurityPolicyAppender) populateSecurityPolicyMap(securityPolicyMap map[
 
 		sourceWlNs := string(lSourceWlNs)
 		sourceWl := string(lSourceWl)
-		sourceApp := string(lSourceApp)
 		sourceVer := string(lSourceVer)
 		destSvcNs := string(lDestSvcNs)
 		destSvcName := string(lDestSvcName)
 		destWlNs := string(lDestWlNs)
 		destWl := string(lDestWl)
-		destApp := string(lDestApp)
 		destVer := string(lDestVer)
 		csp := string(lCsp)
+
+		// set app in a backward compatible way
+		sourceApp := util.HandleApp(string(lSourceApp), string(lSourceCS), sourceCSOk)
+		destApp := util.HandleApp(string(lDestApp), string(lDestCS), destCSOk)
 
 		val := float64(s.Value)
 

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -395,10 +395,10 @@ func handleMisconfiguredLabels(node *graph.Node, app, version string, rate float
 	if isWorkloadNode || isVersionedAppNode {
 		labels := []string{}
 		if node.App != app {
-			labels = append(labels, "app")
+			labels = append(labels, appLabel)
 		}
 		if node.Version != version {
-			labels = append(labels, "version")
+			labels = append(labels, verLabel)
 		}
 		// prefer the labels of an active time series as often the other labels are inactive
 		if len(labels) > 0 {

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -43,7 +43,7 @@ var verLabel = "version"
 func init() {
 	if status.IstioSupportsCanonical() {
 		appLabel = "canonical_service"
-		// verLabel = "canonical_revision"  TODO UNCOMMENT WHEN FIELD IS THERE
+		verLabel = "canonical_revision"
 		log.Info("JSHAUGHN DEBUG: supportsCanonical=true")
 	}
 }

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -35,16 +35,14 @@ import (
 )
 
 // version-specific telemetry field names.  Because the istio version can change outside of the kiali pod,
-// these values may change and are therefore re-set on every graph request.  TODO: can we just set these once
-// and potentially require a pod restart
+// these values may change and are therefore re-set on every graph request.
 var appLabel = "app"
 var verLabel = "version"
 
-func init() {
+func setLabels() {
 	if status.IstioSupportsCanonical() {
 		appLabel = "canonical_service"
 		verLabel = "canonical_revision"
-		log.Info("JSHAUGHN DEBUG: supportsCanonical=true")
 	}
 }
 
@@ -52,6 +50,7 @@ func init() {
 func BuildNamespacesTrafficMap(o graph.TelemetryOptions, client *prometheus.Client, globalInfo *graph.AppenderGlobalInfo) graph.TrafficMap {
 	log.Tracef("Build [%s] graph for [%v] namespaces [%s]", o.GraphType, len(o.Namespaces), o.Namespaces)
 
+	setLabels()
 	appenders := appender.ParseAppenders(o)
 	trafficMap := graph.NewTrafficMap()
 
@@ -433,6 +432,7 @@ func BuildNodeTrafficMap(o graph.TelemetryOptions, client *prometheus.Client, gl
 
 	log.Tracef("Build graph for node [%+v]", n)
 
+	setLabels()
 	appenders := appender.ParseAppenders(o)
 	trafficMap := buildNodeTrafficMap(o.NodeOptions.Namespace, n, o, client)
 

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -57,14 +57,3 @@ func HandleResponseCode(protocol, httpResponseCode string, grpcResponseStatusOk 
 
 	return grpcResponseStatus
 }
-
-// HandleApp returns either the app or the canonical_service.  source_canonical_service and destination_canonical_service
-// were added upstream in Istio 1.5.   source_app and destination_app are the legacy fields.  We support it here in a
-// backward compatible way.  Return canonical_service is set, otherwise app.
-func HandleApp(app, canonicalService string, canonicalServiceOk bool) string {
-	if canonicalServiceOk {
-		return canonicalService
-	}
-
-	return app
-}

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -47,7 +47,7 @@ func HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName stri
 
 // HandleResponseCode returns either the HTTP response code or the GRPC response status.  GRPC response
 // status was added upstream in Istio 1.5 and downstream OSSM 1.1.  We support it here in a backward compatible
-// way.  When protocol is not GRPC, or if the version running dies not supply the GRPC statsus, just return the
+// way.  When protocol is not GRPC, or if the version running does not supply the GRPC status, just return the
 // HTTP code.  Also return the HTTP code In the rare case that protocol is GRPC but the HTTP transport fails. (I
 // have never seen this happen).  Otherwise, return the GRPC status.
 func HandleResponseCode(protocol, httpResponseCode string, grpcResponseStatusOk bool, grpcResponseStatus string) string {
@@ -56,4 +56,15 @@ func HandleResponseCode(protocol, httpResponseCode string, grpcResponseStatusOk 
 	}
 
 	return grpcResponseStatus
+}
+
+// HandleApp returns either the app or the canonical_service.  source_canonical_service and destination_canonical_service
+// were added upstream in Istio 1.5.   source_app and destination_app are the legacy fields.  We support it here in a
+// backward compatible way.  Return canonical_service is set, otherwise app.
+func HandleApp(app, canonicalService string, canonicalServiceOk bool) string {
+	if canonicalServiceOk {
+		return canonicalService
+	}
+
+	return app
 }

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -34,7 +34,7 @@ func buildIstioAggregations(local, remote string) []kmodel.Aggregation {
 	verLabel := "version"
 	if status.IstioSupportsCanonical() {
 		appLabel = "canonical_service"
-		// verLabel = "canonical_revision"  TODO UNCOMMENT WHEN FIELD IS THERE
+		verLabel = "canonical_revision"
 	}
 
 	aggs := []kmodel.Aggregation{

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/kiali/k-charted/kubernetes/v1alpha1"
 	kmodel "github.com/kiali/k-charted/model"
+
+	"github.com/kiali/kiali/status"
 )
 
 // ConvertAggregations converts a k8s aggregations (from MonitoringDashboard k8s resource) into this models aggregations
@@ -28,9 +30,16 @@ func ConvertAggregations(from v1alpha1.MonitoringDashboardSpec) []kmodel.Aggrega
 }
 
 func buildIstioAggregations(local, remote string) []kmodel.Aggregation {
+	appLabel := "app"
+	verLabel := "version"
+	if status.IstioSupportsCanonical() {
+		appLabel = "canonical_service"
+		// verLabel = "canonical_revision"  TODO UNCOMMENT WHEN FIELD IS THERE
+	}
+
 	aggs := []kmodel.Aggregation{
 		{
-			Label:       fmt.Sprintf("%s_version", local),
+			Label:       fmt.Sprintf("%s_%s", local, verLabel),
 			DisplayName: "Local version",
 		},
 	}
@@ -42,17 +51,18 @@ func buildIstioAggregations(local, remote string) []kmodel.Aggregation {
 	}
 	aggs = append(aggs, []kmodel.Aggregation{
 		{
-			Label:       fmt.Sprintf("%s_app", remote),
+			Label:       fmt.Sprintf("%s_%s", remote, appLabel),
 			DisplayName: "Remote app",
 		},
 		{
-			Label:       fmt.Sprintf("%s_version", remote),
+			Label:       fmt.Sprintf("%s_%s", remote, verLabel),
 			DisplayName: "Remote version",
 		},
 		{
 			Label:       "response_code",
 			DisplayName: "Response code",
 		},
+		// TODO: Do we need to aggrgate also on grpc_response_status?
 		{
 			Label:       "response_flags",
 			DisplayName: "Response flags",

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/kiali/kiali/prometheus/internalmetrics"
+	"github.com/kiali/kiali/status"
 )
 
 func getMetrics(api prom_v1.API, q *IstioMetricsQuery) Metrics {
@@ -40,7 +41,11 @@ func buildLabelStrings(q *IstioMetricsQuery) (string, []string) {
 		labels = append(labels, fmt.Sprintf(`%s_workload="%s"`, ref, q.Workload))
 	}
 	if q.App != "" {
-		labels = append(labels, fmt.Sprintf(`%s_app="%s"`, ref, q.App))
+		if status.IstioSupportsCanonical() {
+			labels = append(labels, fmt.Sprintf(`%s_canonical_service="%s"`, ref, q.App))
+		} else {
+			labels = append(labels, fmt.Sprintf(`%s_app="%s"`, ref, q.App))
+		}
 	}
 	if q.RequestProtocol != "" {
 		labels = append(labels, fmt.Sprintf(`request_protocol="%s"`, q.RequestProtocol))

--- a/status/versions.go
+++ b/status/versions.go
@@ -304,7 +304,7 @@ func kubernetesVersion() (*ExternalServiceInfo, error) {
 	return nil, err
 }
 
-// set this one time, it is very unlikely that the istio version will without a kiali pod restart, or if it
+// set this one time, it is very unlikely that the istio version will change without a kiali pod restart, or if it
 // did that that version change will matter, and the kiali pod could be bounced as a workaround.
 var istioSupportsCanonical *bool
 
@@ -319,6 +319,7 @@ func IstioSupportsCanonical() bool {
 	if err != nil {
 		return false
 	}
-	*istioSupportsCanonical = validateVersion(">= 1.5", istioVersion.Version)
+	valid := validateVersion(">= 1.5", istioVersion.Version)
+	istioSupportsCanonical = &valid
 	return *istioSupportsCanonical
 }

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -145,7 +145,7 @@ func TestParseIstioRawVersion(t *testing.T) {
 	}
 }
 
-func TestvalidateVersion(t *testing.T) {
+func TestValidateVersion(t *testing.T) {
 	result := validateVersion(">= 0.7.1", "0.7.1")
 
 	if !result {
@@ -242,7 +242,7 @@ func TestvalidateVersion(t *testing.T) {
 
 	result = validateVersion(">= 1.5", "1.5")
 
-	if result {
+	if !result {
 		t.Errorf("validateVersion was incorrect, got false, want true, 1.5 is >= 1.5")
 	}
 

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -111,9 +111,9 @@ func TestParseIstioRawVersion(t *testing.T) {
 			supported:  false,
 		},
 		{
-			rawVersion: "root@f72e3d3ef3c2-docker.io/1.5-alpha.5c882cd74304ec037d38cd3abdf147cf1c44a392-5c882cd74304ec037d38cd3abdf147cf1c44a392-Clean ",
+			rawVersion: "root@f72e3d3ef3c2-docker.io/1.5-alpha.5c882cd74304ec037d38cd3abdf147cf1c44a392-5c882cd74304ec037d38cd3abdf147cf1c44a392-Clean",
 			name:       "Istio Dev",
-			version:    "1.5 (5c882cd74304ec037d38cd3abdf147cf1c44a392)",
+			version:    "1.5 (dev 5c882cd74304ec037d38cd3abdf147cf1c44a392)",
 			supported:  true,
 		},
 		{

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -111,6 +111,12 @@ func TestParseIstioRawVersion(t *testing.T) {
 			supported:  false,
 		},
 		{
+			rawVersion: "root@f72e3d3ef3c2-docker.io/1.5-alpha.5c882cd74304ec037d38cd3abdf147cf1c44a392-5c882cd74304ec037d38cd3abdf147cf1c44a392-Clean ",
+			name:       "Istio Dev",
+			version:    "1.5 (5c882cd74304ec037d38cd3abdf147cf1c44a392)",
+			supported:  true,
+		},
+		{
 			rawVersion: "some-unknown-version-string",
 			name:       "Unknown Istio Implementation",
 			version:    "some-unknown-version-string",
@@ -139,7 +145,7 @@ func TestParseIstioRawVersion(t *testing.T) {
 	}
 }
 
-func TestValidateVersion(t *testing.T) {
+func TestvalidateVersion(t *testing.T) {
 	result := validateVersion(">= 0.7.1", "0.7.1")
 
 	if !result {
@@ -221,4 +227,29 @@ func TestValidateVersion(t *testing.T) {
 	if !result {
 		t.Errorf("validateVersion was incorrect, got false, want true, 1 is > 0.8.1.1")
 	}
+
+	result = validateVersion("< 1.5", "1.4")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 1.4 is < 1.5")
+	}
+
+	result = validateVersion("< 1.5", "1.4.2")
+
+	if !result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 1.4.2 is < 1.5")
+	}
+
+	result = validateVersion(">= 1.5", "1.5")
+
+	if result {
+		t.Errorf("validateVersion was incorrect, got false, want true, 1.5 is >= 1.5")
+	}
+
+	result = validateVersion("< 1.5", "1.5.2")
+
+	if result {
+		t.Errorf("validateVersion was incorrect, got true, want false, 1.5.2 is > 1.5")
+	}
+
 }


### PR DESCRIPTION
Istio 1.5 introduces` canonical_service` and `canonical_revision` telemetry labels and deprecates `app` and `version`.   This affects graph, metrics and health as they now need to prefer the new labels when the istio version is 1.5+.  This PR introduces the necessary version-specific handling.  When support for the deprecated fields is removed so can be the version-specific handling.  

Also added Istio dev builds as recognized istio versions.

Fixes #2276 
