### PR TITLE
Fix error: Kiali cache doesn't support sidecars

### DIFF
--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -80,19 +80,21 @@ func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 	k8s.On("GetNamespaces").Return(fakeNamespaces(), nil)
 	mockWorkLoadService(k8s)
 	k8s.On("GetDestinationRules", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().DestinationRules, nil)
-	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails(), nil)
+	k8s.On("GetSidecars", mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().Sidecars, nil)
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return(fakeCombinedServices([]string{""}), nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDepSyncedWithRS(), nil)
 	k8s.On("GetMeshPolicies", mock.AnythingOfType("string")).Return(fakeMeshPolicies(), nil)
 	k8s.On("GetPolicies", mock.AnythingOfType("string")).Return(fakePolicies(), nil)
 	k8s.On("GetAuthorizationDetails", mock.AnythingOfType("string")).Return(&kubernetes.RBACDetails{}, nil)
+	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().VirtualServices, nil)
+	k8s.On("GetServiceEntries", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().ServiceEntries, nil)
 
 	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
 }
 
 func mockCombinedValidationService(istioObjects *kubernetes.IstioDetails, services []string, podList *core_v1.PodList) IstioValidationsService {
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetIstioDetails", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(istioObjects, nil)
+	k8s.On("GetSidecars", mock.AnythingOfType("string")).Return(istioObjects.Sidecars, nil)
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return(fakeCombinedServices(services), nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDepSyncedWithRS(), nil)
 	k8s.On("GetVirtualServices", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakeCombinedIstioDetails().VirtualServices, nil)

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -52,7 +52,6 @@ type IstioClientInterface interface {
 	GetEndpoints(namespace string, serviceName string) (*core_v1.Endpoints, error)
 	GetGateway(namespace string, gateway string) (IstioObject, error)
 	GetGateways(namespace string) ([]IstioObject, error)
-	GetIstioDetails(namespace string, serviceName string) (*IstioDetails, error)
 	GetIstioRule(namespace string, istiorule string) (IstioObject, error)
 	GetIstioRules(namespace string, labelSelector string) ([]IstioObject, error)
 	GetJobs(namespace string) ([]batch_v1.Job, error)

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -171,11 +171,6 @@ func (o *K8SClientMock) GetGateway(namespace string, gateway string) (kubernetes
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)
 }
 
-func (o *K8SClientMock) GetIstioDetails(namespace string, serviceName string) (*kubernetes.IstioDetails, error) {
-	args := o.Called(namespace, serviceName)
-	return args.Get(0).(*kubernetes.IstioDetails), args.Error(1)
-}
-
 func (o *K8SClientMock) GetIstioRule(namespace string, istiorule string) (kubernetes.IstioObject, error) {
 	args := o.Called(namespace, istiorule)
 	return args.Get(0).(kubernetes.IstioObject), args.Error(1)


### PR DESCRIPTION
Need to change the logic in istio_validations, as istio objects can be part or not of cache, we need to fetch types, in cache or not, one by one and not all at the same time.

In the end, some logic in kubernetes package is moved to business package.

Fixes https://github.com/kiali/kiali/issues/2488
