### PR TITLE
Add Sidecar egress host validation

### DIFF
--- a/business/checkers/sidecars/egress_listener_checker.go
+++ b/business/checkers/sidecars/egress_listener_checker.go
@@ -1,0 +1,155 @@
+package sidecars
+
+import (
+	"fmt"
+	"strings"
+
+	core_v1 "k8s.io/api/core/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type EgressHostChecker struct {
+	Sidecar        kubernetes.IstioObject
+	ServiceEntries map[string][]string
+	Services       []core_v1.Service
+}
+
+type HostWithIndex struct {
+	Index int
+	Hosts []interface{}
+}
+
+func (elc EgressHostChecker) Check() ([]*models.IstioCheck, bool) {
+	checks, valid := make([]*models.IstioCheck, 0), true
+	hosts, ok := elc.getHosts()
+	if !ok {
+		return checks, valid
+	}
+
+	for i, hwi := range hosts {
+		for j, h := range hwi.Hosts {
+			host, ok := h.(string)
+			if !ok {
+				continue
+			}
+
+			check, hv := elc.validateHost(host, i, j)
+			checks = append(checks, check...)
+			valid = valid && hv
+		}
+	}
+
+	return checks, valid
+}
+
+func (elc EgressHostChecker) getHosts() ([]HostWithIndex, bool) {
+	er, found := elc.Sidecar.GetSpec()["egress"]
+	if !found {
+		return nil, found
+	}
+
+	el, ok := er.([]interface{})
+	if !ok {
+		return nil, found
+	}
+
+	hl := make([]HostWithIndex, 0, len(el))
+	for i, ei := range el {
+		ec, ok := ei.(map[string]interface{})
+		if !ok {
+			return nil, ok
+		}
+
+		hr, found := ec["hosts"]
+		if !found {
+			return nil, ok
+		}
+
+		hc, ok := hr.([]interface{})
+		if !ok {
+			return nil, ok
+		}
+
+		hwi := HostWithIndex{
+			Index: i,
+			Hosts: hc,
+		}
+
+		hl = append(hl, hwi)
+	}
+
+	return hl, true
+}
+
+func (elc EgressHostChecker) validateHost(host string, egrIdx, hostIdx int) ([]*models.IstioCheck, bool) {
+	checks := make([]*models.IstioCheck, 0)
+	ins := config.Get().IstioNamespace
+	sns := elc.Sidecar.GetObjectMeta().Namespace
+
+	hostNs, dnsName, valid := getHostComponents(host)
+	if !valid {
+		return append(checks, buildCheck("sidecar.egress.invalidhostformat", egrIdx, hostIdx)), false
+	}
+
+	// Don't show any validation for common scenarios like */*, ~/* and ./*
+	if (hostNs == "*" || hostNs == "~" || hostNs == ".") && dnsName == "*" {
+		return checks, true
+	}
+
+	// Show cross-namespace validation
+	// when namespace is different to both istio control plane or sidecar namespace
+	if hostNs != ins && hostNs != sns && hostNs != "." {
+		return append(checks, buildCheck("validation.unable.cross-namespace", egrIdx, hostIdx)), true
+	}
+
+	// Lookup services when ns is . or sidecar namespace
+	if hostNs == sns || hostNs == "." {
+		// namespace/* is a valid scenario
+		if dnsName == "*" {
+			return checks, true
+		}
+
+		// Parse the dnsName to a kubernetes Host
+		fqdn := kubernetes.ParseHost(dnsName, sns, elc.Sidecar.GetObjectMeta().ClusterName)
+		if fqdn.Namespace != sns && fqdn.Namespace != "" {
+			return append(checks, buildCheck("validation.unable.cross-namespace", egrIdx, hostIdx)), true
+		}
+
+		// Lookup for matching services
+		if !elc.HasMatchingService(fqdn, sns) {
+			checks = append(checks, buildCheck("sidecar.egress.servicenotfound", egrIdx, hostIdx))
+		}
+	}
+
+	return checks, true
+}
+
+func (elc EgressHostChecker) HasMatchingService(host kubernetes.Host, itemNamespace string) bool {
+	if strings.HasPrefix(host.Service, "*") {
+		return true
+	}
+
+	if kubernetes.HasMatchingServices(host.Service, elc.Services) {
+		return true
+	}
+
+	return kubernetes.HasMatchingServiceEntries(host.Service, elc.ServiceEntries)
+}
+
+func getHostComponents(host string) (string, string, bool) {
+	hParts := strings.Split(host, "/")
+
+	if len(hParts) != 2 {
+		return "", "", false
+	}
+
+	return hParts[0], hParts[1], true
+}
+
+func buildCheck(code string, egrIdx, hostIdx int) *models.IstioCheck {
+	check := models.Build(code, fmt.Sprintf("spec/egress[%d]/hosts[%d]", egrIdx, hostIdx))
+	return &check
+}

--- a/business/checkers/sidecars/egress_listener_checker_test.go
+++ b/business/checkers/sidecars/egress_listener_checker_test.go
@@ -1,0 +1,134 @@
+package sidecars
+
+import (
+	"fmt"
+	"testing"
+
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEgressHostFormatCorrect(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := EgressHostChecker{
+		Services:       fakeServices([]string{"details", "reviews"}),
+		ServiceEntries: kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{data.CreateExternalServiceEntry()}),
+		Sidecar: sidecarWithHosts([]interface{}{
+			"*/*",
+			"~/*",
+			"./*",
+			"./reviews.bookinfo.svc.cluster.local",
+			"./*.bookinfo.svc.cluster.com",
+			"./wikipedia.org",
+			"bookinfo/*",
+			"bookinfo/*.bookinfo.svc.cluster.local",
+			"bookinfo/reviews.bookinfo.svc.cluster.local",
+			"bookinfo/wikipedia.org",
+		}),
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+func TestEgressHostCrossNamespace(t *testing.T) {
+	assert := assert.New(t)
+
+	hosts := []interface{}{
+		"*/*.example.com",
+		"*/www.example.com",
+		"*/example.prod.svc.cluster.local",
+		"~/*.example.com",
+		"~/www.example.com",
+		"~/example.prod.svc.cluster.local",
+		"bookinfo/reviews.bogus.svc.cluster.local",
+		"bookinfo/*.bogus.svc.cluster.local",
+	}
+
+	validations, valid := EgressHostChecker{
+		Sidecar: sidecarWithHosts(hosts),
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Len(validations, len(hosts))
+	assert.True(valid)
+
+	for i, c := range validations {
+		assert.Equal(models.Unknown, c.Severity)
+		assert.Equal(fmt.Sprintf("spec/egress[0]/hosts[%d]", i), c.Path)
+		assert.Equal(models.CheckMessage("validation.unable.cross-namespace"), c.Message)
+	}
+}
+
+func TestEgressInvalidHostFormat(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := EgressHostChecker{
+		Sidecar: sidecarWithHosts([]interface{}{
+			"no-dash-used",
+		}),
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+	assert.False(valid)
+
+	assert.Equal(models.ErrorSeverity, validations[0].Severity)
+	assert.Equal("spec/egress[0]/hosts[0]", validations[0].Path)
+	assert.Equal(models.CheckMessage("sidecar.egress.invalidhostformat"), validations[0].Message)
+}
+
+func TestEgressServiceNotFound(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := EgressHostChecker{
+		Sidecar: sidecarWithHosts([]interface{}{
+			"bookinfo/boggus.bookinfo.svc.cluster.local",
+			"bookinfo/boggus.org",
+		}),
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.Len(validations, 2)
+	assert.True(valid)
+
+	for i, c := range validations {
+		assert.Equal(models.WarningSeverity, c.Severity)
+		assert.Equal(fmt.Sprintf("spec/egress[0]/hosts[%d]", i), c.Path)
+		assert.Equal(models.CheckMessage("sidecar.egress.servicenotfound"), c.Message)
+	}
+}
+
+func sidecarWithHosts(hl []interface{}) kubernetes.IstioObject {
+	return data.AddHostsToSidecar(hl, data.CreateSidecar("sidecar"))
+}
+
+func fakeServices(serviceNames []string) []core_v1.Service {
+	services := make([]core_v1.Service, 0, len(serviceNames))
+
+	for _, sName := range serviceNames {
+		service := core_v1.Service{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      sName,
+				Namespace: "bookinfo",
+				Labels: map[string]string{
+					"app":     sName,
+					"version": "v1"}},
+			Spec: core_v1.ServiceSpec{
+				ClusterIP: "fromservice",
+				Type:      "ClusterIP",
+				Selector:  map[string]string{"app": sName},
+			},
+		}
+
+		services = append(services, service)
+	}
+
+	return services
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -117,7 +117,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
 		checkers.ServiceRoleBindChecker{RBACDetails: rbacDetails},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, WorkloadList: workloads},
-		checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces, WorkloadList: workloads},
+		checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces, WorkloadList: workloads, Services: services, ServiceEntries: istioDetails.ServiceEntries},
 	}
 }
 
@@ -200,7 +200,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	case RbacConfigs:
 		// Validations on RbacConfigs are not yet in place
 	case Sidecars:
-		sidecarsChecker := checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces, WorkloadList: workloads}
+		sidecarsChecker := checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces,
+			WorkloadList: workloads, Services: services, ServiceEntries: istioDetails.ServiceEntries}
 		objectCheckers = []ObjectChecker{sidecarsChecker}
 	case AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -207,6 +207,14 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA1002 More than one selector-less Sidecar in the same namespace",
 		Severity: ErrorSeverity,
 	},
+	"sidecar.egress.invalidhostformat": {
+		Message:  "KIA1003 Invalid host format. 'namespace/dnsName' format expected",
+		Severity: ErrorSeverity,
+	},
+	"sidecar.egress.servicenotfound": {
+		Message:  "KIA1004 This host has no matching entry in the service registry",
+		Severity: WarningSeverity,
+	},
 	"virtualservices.nohost.hostnotfound": {
 		Message:  "KIA1101 DestinationWeight on route doesn't have a valid service (host not found)",
 		Severity: ErrorSeverity,

--- a/tests/data/sidecar_data.go
+++ b/tests/data/sidecar_data.go
@@ -9,14 +9,26 @@ import (
 func CreateSidecar(name string) kubernetes.IstioObject {
 	return (&kubernetes.GenericIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      name,
-			Namespace: "bookinfo",
+			Name:        name,
+			Namespace:   "bookinfo",
+			ClusterName: "svc.cluster.local",
 		},
 		Spec: map[string]interface{}{},
 	}).DeepCopyIstioObject()
 }
 
-func AddSelectorToSidecar(selector map[string]interface{}, gw kubernetes.IstioObject) kubernetes.IstioObject {
-	gw.GetSpec()["workloadSelector"] = selector
-	return gw
+func AddSelectorToSidecar(selector map[string]interface{}, sc kubernetes.IstioObject) kubernetes.IstioObject {
+	sc.GetSpec()["workloadSelector"] = selector
+	return sc
+}
+
+func AddHostsToSidecar(hl []interface{}, sc kubernetes.IstioObject) kubernetes.IstioObject {
+	fullEgress := []interface{}{
+		map[string]interface{}{
+			"hosts": hl,
+		},
+	}
+
+	sc.GetSpec()["egress"] = fullEgress
+	return sc
 }


### PR DESCRIPTION
** Describe the change **
Add validation to egress host field[1].

Each field is a string formatted like this: "namespace/fqdn". In the namespace there can be 4 different values: *, ~, ., namespace name.

*/*, ~/*, ./* are always valid scenarios.
ns/*, ns/*.ns.svc.cluster.local and ns/svc.ns.svc.cluster.local are valid when ns = sidecar namespace. Otherwise, cross-ns validation is shown.

ns/*.ns2.svc.cluster.local and ns/svc.ns2.svc.cluster.local is not a valid scenario unless ns = ns2. The service references is in another namespace. cross-ns validation is shown.

ServiceEntries are taken into account.

1. Check if the host is present in the namespace: 
![Screenshot of Kiali Console (32)](https://user-images.githubusercontent.com/613814/76207198-9bfeab00-61fd-11ea-87fd-bac4108e67e7.png)

2. Warns user that the host is in another namespace. kiali can cover this scenario
![Screenshot of Kiali Console (33)](https://user-images.githubusercontent.com/613814/76207782-b6855400-61fe-11ea-8d5c-d230e5fc8754.png)


See the exact spec for this field:
[1] https://istio.io/docs/reference/config/networking/sidecar/#IstioEgressListener


** Issue reference **
https://github.com/kiali/kiali/issues/1541

Bug detected: https://github.com/kiali/kiali/issues/2492