### PR TITLE
Validation: multiple sidecars pointing to one workload

### DIFF
--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -125,7 +125,7 @@ func (n NoDestinationChecker) hasMatchingService(host kubernetes.Host, itemNames
 
 	if localNs == itemNamespace {
 		// Check Workloads
-		if matches := kubernetes.HasMatchingWorkloads(localSvc, models.GetLabels(n.WorkloadList.Workloads)); matches {
+		if matches := kubernetes.HasMatchingWorkloads(localSvc, n.WorkloadList.GetLabels()); matches {
 			return matches
 		}
 

--- a/business/checkers/sidecars/multi_match_checker.go
+++ b/business/checkers/sidecars/multi_match_checker.go
@@ -1,6 +1,8 @@
 package sidecars
 
 import (
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -8,7 +10,8 @@ import (
 const SidecarCheckerType = "sidecar"
 
 type MultiMatchChecker struct {
-	Sidecars []kubernetes.IstioObject
+	Sidecars     []kubernetes.IstioObject
+	WorkloadList models.WorkloadList
 }
 
 type KeyWithIndex struct {
@@ -16,9 +19,32 @@ type KeyWithIndex struct {
 	Key   *models.IstioValidationKey
 }
 
+type ReferenceMap map[models.IstioValidationKey][]models.IstioValidationKey
+
+func (ws ReferenceMap) Add(wk, sk models.IstioValidationKey) {
+	ws[wk] = append(ws[wk], sk)
+}
+
+func (ws ReferenceMap) Get(wk models.IstioValidationKey) []models.IstioValidationKey {
+	return ws[wk]
+}
+
+func (ws ReferenceMap) HasMultipleReferences(wk models.IstioValidationKey) bool {
+	return len(ws.Get(wk)) > 1
+}
+
 func (m MultiMatchChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	validations.MergeValidations(m.analyzeSelectorLessSidecars())
+	validations.MergeValidations(m.analyzeSelectorSidecars())
+
+	return validations
+}
+
+func (m MultiMatchChecker) analyzeSelectorLessSidecars() models.IstioValidations {
 	swi := m.selectorLessSidecars()
-	return buildSidecarValidations(swi)
+	return buildSelectorLessSidecarValidations(swi)
 }
 
 func (m MultiMatchChecker) selectorLessSidecars() []KeyWithIndex {
@@ -52,7 +78,7 @@ func (m MultiMatchChecker) selectorLessSidecars() []KeyWithIndex {
 	return swi
 }
 
-func buildSidecarValidations(sidecars []KeyWithIndex) models.IstioValidations {
+func buildSelectorLessSidecarValidations(sidecars []KeyWithIndex) models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	if len(sidecars) < 2 {
@@ -61,7 +87,7 @@ func buildSidecarValidations(sidecars []KeyWithIndex) models.IstioValidations {
 
 	for _, sidecarWithIndex := range sidecars {
 		references := extractReferences(sidecarWithIndex.Index, sidecars)
-		checks := models.Build("sidecar.multimatch", "spec/workloadSelector")
+		checks := models.Build("sidecar.multimatch.selectorless", "spec/workloadSelector")
 		validations.MergeValidations(
 			models.IstioValidations{
 				*sidecarWithIndex.Key: &models.IstioValidation{
@@ -94,4 +120,111 @@ func extractReferences(index int, sidecars []KeyWithIndex) []models.IstioValidat
 	}
 
 	return references
+}
+
+func (m MultiMatchChecker) analyzeSelectorSidecars() models.IstioValidations {
+	sidecars := m.multiMatchSidecars()
+	return m.buildSidecarValidations(sidecars)
+}
+
+func (m MultiMatchChecker) multiMatchSidecars() ReferenceMap {
+	workloadSidecars := ReferenceMap{}
+
+	for _, s := range m.Sidecars {
+		sidecarKey := models.BuildKey(SidecarCheckerType, s.GetObjectMeta().Name, s.GetObjectMeta().Namespace)
+
+		selector := labels.SelectorFromSet(labels.Set(getWorkloadSelectorLabels(s)))
+		if selector.Empty() {
+			continue
+		}
+
+		for _, w := range m.WorkloadList.Workloads {
+			if !selector.Matches(labels.Set(w.Labels)) {
+				continue
+			}
+
+			workloadKey := models.BuildKey(w.Type, w.Name, m.WorkloadList.Namespace.Name)
+			workloadSidecars.Add(workloadKey, sidecarKey)
+		}
+	}
+
+	return workloadSidecars
+}
+
+func (m MultiMatchChecker) buildSidecarValidations(workloadSidecar ReferenceMap) models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for wk, scs := range workloadSidecar {
+		if !workloadSidecar.HasMultipleReferences(wk) {
+			continue
+		}
+
+		validations.MergeValidations(buildMultipleSidecarsValidation(scs))
+	}
+
+	return validations
+}
+
+func buildMultipleSidecarsValidation(scs []models.IstioValidationKey) models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for i, sck := range scs {
+		// Remove validation sidecar from references
+		refs := make([]models.IstioValidationKey, 0, len(scs)-1)
+		refs = append(refs, scs[:i]...)
+		if len(scs) > i {
+			refs = append(refs, scs[i+1:]...)
+		}
+
+		checks := models.Build("sidecar.multimatch.selector", "spec/workloadSelector")
+		validation := models.IstioValidations{
+			sck: &models.IstioValidation{
+				Name:       sck.Name,
+				ObjectType: SidecarCheckerType,
+				Valid:      false,
+				References: refs,
+				Checks: []*models.IstioCheck{
+					&checks,
+				},
+			},
+		}
+
+		validations.MergeValidations(validation)
+	}
+
+	return validations
+}
+
+func getWorkloadSelectorLabels(s kubernetes.IstioObject) map[string]string {
+	ws, found := s.GetSpec()["workloadSelector"]
+	if !found {
+		return nil
+	}
+
+	wsCasted, ok := ws.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	labels, found := wsCasted["labels"]
+	if !found {
+		return nil
+	}
+
+	labCast, ok := labels.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	labs := map[string]string{}
+	for i, k := range labCast {
+		val, ok := k.(string)
+		if !ok {
+			continue
+		}
+
+		labs[i] = val
+	}
+
+	return labs
 }

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -31,7 +31,7 @@ func (s SidecarChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	enabledDRCheckers := []GroupChecker{
-		sidecars.MultiMatchChecker{Sidecars: s.Sidecars},
+		sidecars.MultiMatchChecker{Sidecars: s.Sidecars, WorkloadList: s.WorkloadList},
 	}
 
 	for _, checker := range enabledDRCheckers {

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
 )
@@ -103,12 +104,12 @@ func ParseTwoPartHost(host Host) (string, string) {
 	return localSvc, localNs
 }
 
-func HasMatchingWorkloads(service string, workloadList []map[string]string) bool {
+func HasMatchingWorkloads(service string, workloadList []labels.Set) bool {
 	appLabel := config.Get().IstioLabels.AppLabelName
 
 	// Check Workloads
 	for _, wl := range workloadList {
-		if service == wl[appLabel] {
+		if service == wl.Get(appLabel) {
 			return true
 		}
 	}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -203,7 +203,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA1001 No matching workload found for authorization policy selector in this namespace",
 		Severity: WarningSeverity,
 	},
-	"sidecar.multimatch": {
+	"sidecar.multimatch.selectorless": {
 		Message:  "KIA1002 More than one selector-less Sidecar in the same namespace",
 		Severity: ErrorSeverity,
 	},
@@ -214,6 +214,10 @@ var checkDescriptors = map[string]IstioCheck{
 	"sidecar.egress.servicenotfound": {
 		Message:  "KIA1004 This host has no matching entry in the service registry",
 		Severity: WarningSeverity,
+	},
+	"sidecar.multimatch.selector": {
+		Message:  "KIA1003 More than one Sidecar applied to the same workload",
+		Severity: ErrorSeverity,
 	},
 	"virtualservices.nohost.hostnotfound": {
 		Message:  "KIA1101 DestinationWeight on route doesn't have a valid service (host not found)",

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -216,7 +216,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"sidecar.multimatch.selector": {
-		Message:  "KIA1003 More than one Sidecar applied to the same workload",
+		Message:  "KIA1005 More than one Sidecar applied to the same workload",
 		Severity: ErrorSeverity,
 	},
 	"virtualservices.nohost.hostnotfound": {

--- a/models/workload.go
+++ b/models/workload.go
@@ -8,6 +8,7 @@ import (
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
 )
@@ -310,10 +311,10 @@ func (workload *Workload) HasIstioSidecar() bool {
 	return workload.Pods.HasIstioSidecar()
 }
 
-func GetLabels(wl []WorkloadListItem) []map[string]string {
-	wLabels := make([]map[string]string, 0, len(wl))
-	for _, wl := range wl {
-		wLabels = append(wLabels, wl.Labels)
+func (wl WorkloadList) GetLabels() []labels.Set {
+	wLabels := make([]labels.Set, 0, len(wl.Workloads))
+	for _, w := range wl.Workloads {
+		wLabels = append(wLabels, labels.Set(w.Labels))
 	}
 	return wLabels
 }


### PR DESCRIPTION
** Describe the change **
Adding validation that checks whether multiple sidecars are pointing to the same workloads or not.
Istio says:

> The behavior of the system is undefined if two or more Sidecar resources with a workload selector select the same workload instance.

![Screenshot of Kiali Console (39)](https://user-images.githubusercontent.com/613814/76398117-98456280-637c-11ea-91f8-12bb54667e97.png)

Test yaml demo:
https://github.com/xeviknal/istio-lab/blob/master/sidecars-examples/multimatch-deployment.yaml
