### PR TITLE
Moving to go version 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
-# sudo: required
-#
-# services:
-# - docker
-
 language: go
 
 go:
-- 1.12.13
+- 1.14
 
 notifications:
   irc:
@@ -31,8 +26,6 @@ env:
 install:
  - make swagger-install
  - make lint-install
-#- make dep-install
-#- make dep-update
 
 script:
   - if [ ! -z "$(gofmt -l ${GO_FILES})" ]; then echo "These files need to be formatted:" "$(gofmt -l ${GO_FILES})";echo "Diff files:"; gofmt -d ${GO_FILES}; exit 1; fi # Gofmt Linter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,16 +23,13 @@ are:
 * Kiali-UI : UI part, written in Typescript, using the React framework.
 
 Bug tracking happens centrally for both repositories.
-Please open an issue before you make a change. 
-If you have an account at 
-[JBoss JIRA](http://issues.jboss.org/browse/KIALI), use this to open the issue.
-Otherwise open the issue on GitHub
+Before you make a change, please [open an issue in GitHub](https://github.com/kiali/kiali/issues/new/choose). 
 
 ### Good first issues
 
 If you are new to contributing to Kiali and want to pick some easier tasks to 
-get accustomed to the code base, you can pick issues that are marked _good first issue_
-on GitHub or from [this Jira query](https://issues.jboss.org/issues/?filter=12336706).
+get accustomed to the code base, you can pick [issues that are marked _good first issue_
+on GitHub](https://github.com/kiali/kiali/labels/good%20first%20issue).
 
 ### Discussing changes
 
@@ -51,11 +48,12 @@ See the [Backend Style Guide](./STYLE_GUIDE.adoc) and the [Frontend Style Guide]
 
 Once the issue has been agreed upon and developed, you can send a pull-request. 
 
-The pull-request needs to contain a link to the issue. 
-Also for issues that come from Jira, the issue number must be present in the
-pull-request header like e.g.
+The pull-request should have a detailed explanation of the changes that you are doing.
+If you worked on a GitHub issue, please provide the link as part of the description.
 
-    KIALI-0815 Bump go version to 1.9
+If your changes have impact on the front-end, an image showing the changed screen will be
+very helpful to understand your changes. If possible, provide a screenshot before the change
+and another one after the change. 
 
 The pull-request template will help you here.
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.12.13
+GO_VERSION_KIALI = 1.14
 
 # Identifies the Kiali container image that will be built.
 IMAGE_ORG ?= kiali

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,7 @@ _Please describe what the code change is about_
 
 ** Issue reference **
 
-* If this is a fix for a JIRA, please put JIRA-reference in the PR title like _`KIALI-7 New icons`_ (Jira-id, one space, description)
-* If this is a fix for a GH-issue, please link it here
+* Please, provide the link to the GitHub issue here.
 
 ** Backwards incompatible? **
 

--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ See the link:./LICENSE[LICENSE file].
 These build instructions assume you have the following installed on your system: (1) link:http://golang.org/doc/install[Go Programming Language], (2) link:http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[git], (3) link:https://docs.docker.com/installation/[Docker] or link:https://podman.io[Podman], and (4) make. If you are using `podman` instead of `docker`, pass the environment variable `DORP=podman` when executing `make`. To run Kiali in a cluster after you build it, it is assumed you have a running OpenShift or Minikube environment available to you.
 
 [NOTE]
-Currently, Kiali releases are built using Go 1.12.13. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.12.13 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
+Currently, Kiali releases are built using Go 1.14. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.14 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
 
 To build Kiali:
 

--- a/deploy/jenkins-ci/Dockerfile
+++ b/deploy/jenkins-ci/Dockerfile
@@ -25,21 +25,21 @@ COPY bin/entrypoint.sh /usr/local/bin/
 
 RUN set -eux; \
     # Install golang \
-    curl -fsSL https://dl.google.com/go/go1.12.13.linux-amd64.tar.gz -o go.tar.gz; \
+    curl -fsSL https://dl.google.com/go/go1.14.linux-amd64.tar.gz -o go.tar.gz; \
     tar -C /usr/local -zxf go.tar.gz; \
     rm go.tar.gz; \
     # Add Yarn repository \
     # curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
     # echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
     # Install NodeJs \
-    curl -fsSL https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-x64.tar.xz -o node.tar.xz; \
+    curl -fsSL https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-x64.tar.xz -o node.tar.xz; \
     mkdir -p /usr/local/lib/nodejs; \
     tar -xJf node.tar.xz -C /usr/local/lib/nodejs; \
     rm node.tar.xz; \
     # Install Yarn \
     curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import; \
-    curl -fsSL https://yarnpkg.com/downloads/1.16.0/yarn-v1.16.0.tar.gz.asc -o yarn.tar.gz.asc; \
-    curl -fsSL https://yarnpkg.com/downloads/1.16.0/yarn-v1.16.0.tar.gz -o yarn.tar.gz; \
+    curl -fsSL https://yarnpkg.com/downloads/1.22.4/yarn-v1.22.4.tar.gz.asc -o yarn.tar.gz.asc; \
+    curl -fsSL https://yarnpkg.com/downloads/1.22.4/yarn-v1.22.4.tar.gz -o yarn.tar.gz; \
     gpg --verify yarn.tar.gz.asc; \
     tar -C /usr/local -zxf yarn.tar.gz; \
     rm yarn.tar.gz yarn.tar.gz.asc; \
@@ -68,7 +68,7 @@ RUN set -eux; \
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Adjust PATH to include tools: golang, nodejs, yarn
-ENV PATH "/usr/local/lib/nodejs/node-v10.17.0-linux-x64/bin:/usr/local/yarn-v1.16.0/bin:/usr/local/go/bin:$PATH"
+ENV PATH "/usr/local/lib/nodejs/node-v10.19.0-linux-x64/bin:/usr/local/yarn-v1.22.4/bin:/usr/local/go/bin:$PATH"
 
 # Skip Jenkins setup wizard
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -103,7 +103,7 @@ dep-update:
 ## swagger-install: Install swagger from github
 swagger-install:
 	@echo "Installing swagger binary to ${GOPATH}/bin..."
-	@curl https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64 -Lo ${GOPATH}/bin/swagger && chmod +x ${GOPATH}/bin/swagger
+	@curl https://github.com/go-swagger/go-swagger/releases/download/v0.22.0/swagger_linux_amd64 -Lo ${GOPATH}/bin/swagger && chmod +x ${GOPATH}/bin/swagger
 
 ## swagger-validate: Validate that swagger.json is correctly. Runs `swagger validate` internally
 swagger-validate:
@@ -132,7 +132,7 @@ swagger-travis: swagger-validate
 
 ## lint-install: Installs golangci-lint
 lint-install:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(${GO} env GOPATH)/bin v1.21.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(${GO} env GOPATH)/bin v1.23.8
 
 ## lint: Runs golangci-lint
 # doc.go is ommited for linting, because it generates lots of warnings.

--- a/swagger.json
+++ b/swagger.json
@@ -3804,14 +3804,6 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
-    "Histogram": {
-      "description": "Histogram contains Metric objects for several histogram-kind statistics",
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/Metric"
-      },
-      "x-go-package": "github.com/kiali/kiali/prometheus"
-    },
     "Initializer": {
       "type": "object",
       "title": "Initializer is information about an initializer that has not yet completed.",
@@ -4325,7 +4317,10 @@
         "histograms": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/Histogram"
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/Metric"
+            }
           },
           "x-go-name": "Histograms"
         },
@@ -5888,6 +5883,10 @@
       "type": "object",
       "properties": {
         "processes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Process"
+          },
           "x-go-name": "Processes"
         },
         "spans": {


### PR DESCRIPTION
* Change the version used in TravisCI
* Move to Swagger 0.22.0, because 0.19 has issues with go1.14
* Move to golangci 1.23.8 to stay up to date
* Change texts related to the go version in README.adoc
* Change minimum required go version in Makefile
* Bump versions in deploy/jenkins-ci/Dockerfile
* Updating some outdated texts from CONTRIBUTING.md and PULL_REQUEST_TEMPLATE.md files

Fixes https://github.com/kiali/kiali/issues/2490