### PR TITLE
Disable Iter8 by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -313,7 +313,7 @@ func NewConfig() (c *Config) {
 				Enabled:        true,
 			},
 			Iter8: Iter8Config{
-				Enabled: true,
+				Enabled: false,
 			},
 		},
 		ExternalServices: ExternalServices{

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -350,6 +350,16 @@ spec:
 #      ---
 #      enabled: false
 #
+# Kiali enabled integration with Iter8 project.
+# If this extension is enabled, Kiali will communicate with Iter8 controller allowing to manage Experiments and review results.
+# Additional documentation https://iter8.tools/
+#    ---
+#    iter8:
+#
+# Flag to indicate if iter8 extension is enabled in Kiali
+#      ---
+#      enabled: false
+#
 
 ##########
 #  ---

--- a/operator/roles/default/kiali-deploy/defaults/main.yml
+++ b/operator/roles/default/kiali-deploy/defaults/main.yml
@@ -77,6 +77,8 @@ kiali_defaults:
       adapter_port: "3333"
       adapter_service: "threescale-istio-adapter"
       enabled: false
+    iter8:
+      enabled: false
 
   external_services:
     grafana:


### PR DESCRIPTION
Disable Iter8 extension by default.
Add it to the kiali CR description and defaults.

cc @jadeyliu939 