### PR TITLE
Remove aggressive filtering of bad telemetry from DeadNodeAppender

### DIFF
--- a/graph/telemetry/istio/appender/dead_node.go
+++ b/graph/telemetry/istio/appender/dead_node.go
@@ -40,40 +40,7 @@ func (a DeadNodeAppender) applyDeadNodes(trafficMap graph.TrafficMap, globalInfo
 	for id, n := range trafficMap {
 		switch n.NodeType {
 		case graph.NodeTypeService:
-			// a service node with outgoing edges is never considered dead (or egress)
-			if len(n.Edges) > 0 {
-				continue
-			}
-
-			// A service node that is a service entry is never considered dead
-			if _, ok := n.Metadata[graph.IsServiceEntry]; ok {
-				continue
-			}
-
-			// A service node that is an Istio egress cluster is never considered dead
-			if _, ok := n.Metadata[graph.IsEgressCluster]; ok {
-				continue
-			}
-
-			// a service node with no incoming error traffic and no outgoing edges, is dead.
-			// Incoming non-error traffic can not raise the dead because it is caused by an
-			// edge case (pod life-cycle change) that we don't want to see.
-			isDead := true
-		ServiceCase:
-			for _, p := range graph.Protocols {
-				for _, r := range p.NodeRates {
-					if r.IsErr {
-						if errRate, hasErrRate := n.Metadata[r.Name]; hasErrRate && errRate.(float64) > 0 {
-							isDead = false
-							break ServiceCase
-						}
-					}
-				}
-			}
-			if isDead {
-				delete(trafficMap, id)
-				numRemoved++
-			}
+			continue
 		default:
 			// a node with traffic is not dead, skip
 			isDead := true

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -132,14 +132,14 @@ func TestDeadNode(t *testing.T) {
 	a := DeadNodeAppender{}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
 
-	assert.Equal(9, len(trafficMap))
+	assert.Equal(10, len(trafficMap))
 
 	_, found = trafficMap[unknownId]
 	assert.Equal(false, found)
 
 	ingressNode, found = trafficMap[ingressId]
 	assert.Equal(true, found)
-	assert.Equal(8, len(ingressNode.Edges))
+	assert.Equal(9, len(ingressNode.Edges))
 
 	assert.Equal("testPodsWithTraffic-v1", ingressNode.Edges[0].Dest.Workload)
 	assert.Equal("testPodsNoTraffic-v1", ingressNode.Edges[1].Dest.Workload)

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -16,11 +16,11 @@ func TestResponseTime(t *testing.T) {
 
 	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
 	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
-	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
+	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
 	q0 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q0Temp, "milliseconds"), fmt.Sprintf(q0Temp, "seconds"))
 	v0 := model.Vector{}
 
-	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
+	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
 	q1 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q1Temp, "milliseconds"), fmt.Sprintf(q1Temp, "seconds"))
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
@@ -28,6 +28,7 @@ func TestResponseTime(t *testing.T) {
 		"source_app":                     "ingressgateway",
 		"source_version":                 model.LabelValue(graph.Unknown),
 		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "productpage-v1",
@@ -39,7 +40,7 @@ func TestResponseTime(t *testing.T) {
 			Metric: q1m0,
 			Value:  0.010}}
 
-	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
+	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
 	q2 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q2Temp, "milliseconds"), fmt.Sprintf(q2Temp, "seconds"))
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
@@ -47,6 +48,7 @@ func TestResponseTime(t *testing.T) {
 		"source_app":                     "productpage",
 		"source_version":                 "v1",
 		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "reviews-v1",
@@ -59,6 +61,7 @@ func TestResponseTime(t *testing.T) {
 		"source_app":                     "productpage",
 		"source_version":                 "v1",
 		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "reviews-v2",
@@ -71,6 +74,7 @@ func TestResponseTime(t *testing.T) {
 		"source_app":                     "reviews",
 		"source_version":                 "v1",
 		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "ratings-v1",
@@ -83,6 +87,7 @@ func TestResponseTime(t *testing.T) {
 		"source_app":                     "reviews",
 		"source_version":                 "v2",
 		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "ratings-v1",
@@ -95,6 +100,7 @@ func TestResponseTime(t *testing.T) {
 		"source_app":                     "reviews",
 		"source_version":                 "v2",
 		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "ratings-v1",
@@ -108,6 +114,7 @@ func TestResponseTime(t *testing.T) {
 		"source_app":                     "reviews",
 		"source_version":                 "v2",
 		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
 		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "ratings-v1",

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -237,6 +237,10 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o gra
 		// handle multicluster requests
 		destSvcNs, destSvcName := util.HandleMultiClusterRequest(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvcName))
 
+		if util.IsBadTelemetry(destSvc, destSvcName, destWl) {
+			continue
+		}
+
 		// make code more readable by setting "host" because "destSvc" holds destination.service.host | request.host | "unknown"
 		host := destSvc
 
@@ -321,7 +325,12 @@ func populateTrafficMapTCP(trafficMap graph.TrafficMap, vector *model.Vector, o 
 		destVer := string(lDestVer)
 		flags := string(lFlags)
 
+		// handle multicluster requests
 		destSvcNs, destSvcName := util.HandleMultiClusterRequest(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvcName))
+
+		if util.IsBadTelemetry(destSvc, destSvcName, destWl) {
+			continue
+		}
 
 		// make code more readable by setting "host" because "destSvc" holds destination.service.host | "unknown"
 		host := destSvc

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -57,3 +57,11 @@ func HandleResponseCode(protocol, httpResponseCode string, grpcResponseStatusOk 
 
 	return grpcResponseStatus
 }
+
+// IsBadTelemetry tests for known issues in generated telemetry given indicative label values.
+// 1) During pod lifecycle changes incomplete telemetry may be generated that results in
+//    destSvc == destSvcName and no dest workload
+// 2) no more conditions known
+func IsBadTelemetry(destSvc, destSvcName, destWl string) bool {
+	return (!graph.IsOK(destWl) && graph.IsOK(destSvc) && graph.IsOK(destSvcName) && (destSvc == destSvcName))
+}


### PR DESCRIPTION
Remove aggressive filtering of bad telemetry from DeadNodeAppender because it was also removing good telemetry for headless services.  Instead, filter unwanted telemetry immediately when building the TrafficMap.

This change is based on the discussion in https://github.com/kiali/kiali-ui/pull/1680

Fixes #976

@jotak Try out this change and see how it affects the Kafka situation.