### PR TITLE
[hack] update crc to 1.7

### DIFF
--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -235,10 +235,10 @@ SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPT_ROOT}
 
 # The default version of the crc tool to be downloaded
-DEFAULT_CRC_DOWNLOAD_VERSION="1.6.0"
+DEFAULT_CRC_DOWNLOAD_VERSION="1.7.0"
 
 # The default version of the crc bundle - this is typically the version included with the CRC download
-DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.3.0"
+DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.3.1"
 
 # The default virtual CPUs assigned to the CRC VM (CRC requires a minimum of 4)
 DEFAULT_CRC_CPUS="4"


### PR DESCRIPTION
move to the latest CRC 1.7.0. This starts up a OpenShift 4.3.1 cluster.