### PR TITLE
Iter8 fixes after UI end-to-end

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -65,6 +65,7 @@ const (
 	ServiceMeshPolicies    = "servicemeshpolicies"
 	ServiceMeshRbacConfigs = "servicemeshrbacconfigs"
 	AuthorizationPolicies  = "authorizationpolicies"
+	Experiments            = "experiments"
 )
 
 var resourceTypesToAPI = map[string]string{
@@ -87,6 +88,8 @@ var resourceTypesToAPI = map[string]string{
 	ServiceMeshPolicies:    kubernetes.MaistraAuthenticationGroupVersion.Group,
 	ServiceMeshRbacConfigs: kubernetes.MaistraRbacGroupVersion.Group,
 	AuthorizationPolicies:  kubernetes.SecurityGroupVersion.Group,
+	// Externsions
+	Experiments: kubernetes.Iter8GroupVersion.Group,
 }
 
 var apiToVersion = map[string]string{

--- a/business/iter8.go
+++ b/business/iter8.go
@@ -126,10 +126,9 @@ func (in *Iter8Service) ParseJsonForCreate(body []byte) (string, error) {
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      newExperimentSpec.Name,
-			Namespace: newExperimentSpec.Namespace,
 		},
 		Spec:    kubernetes.Iter8ExperimentSpec{},
-		Metrics: nil,
+		Metrics: kubernetes.Iter8ExperimentMetrics{},
 		Status:  kubernetes.Iter8ExperimentStatus{},
 	}
 	object.Spec.TargetService.ApiVersion = "v1"

--- a/business/iter8.go
+++ b/business/iter8.go
@@ -125,7 +125,7 @@ func (in *Iter8Service) ParseJsonForCreate(body []byte) (string, error) {
 			Kind:       "Experiment",
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      newExperimentSpec.Name,
+			Name: newExperimentSpec.Name,
 		},
 		Spec:    kubernetes.Iter8ExperimentSpec{},
 		Metrics: kubernetes.Iter8ExperimentMetrics{},

--- a/handlers/iter8.go
+++ b/handlers/iter8.go
@@ -82,6 +82,7 @@ func Iter8ExperimentUpdate(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
 	}
+	// TODO This is not yet implemented
 	experiment, err := business.Iter8.GetIter8Experiment(namespace, name)
 	if err != nil {
 		handleErrorResponse(w, err)
@@ -99,10 +100,10 @@ func Iter8ExperimentDelete(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
 	}
-	experiment, err := business.Iter8.GetIter8Experiment(namespace, name)
+	err = business.Iter8.DeleteIter8Experiment(namespace, name)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return
 	}
-	RespondWithJSON(w, http.StatusOK, experiment)
+	RespondWithCode(w, http.StatusOK)
 }

--- a/handlers/iter8.go
+++ b/handlers/iter8.go
@@ -59,7 +59,7 @@ func Iter8ExperimentCreate(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
 	}
-	namespace := params["namespaces"]
+	namespace := params["namespace"]
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())

--- a/kubernetes/iter8.go
+++ b/kubernetes/iter8.go
@@ -20,7 +20,10 @@ spec:
 
       # apiVersion of the target service (required)
       # options:
-      #   v1: indicates that the target service is a Kubernetes service
+      #   v1: indicates that the targeconst (
+    Experiments       = "experiments"
+)
+t service is a Kubernetes service
       #   serving.knative.dev/v1alpha1: indicates that the target service is a Knative service
       apiVersion: v1
 
@@ -484,6 +487,7 @@ func (in *Iter8ExperimentObjectList) DeepCopyObject() runtime.Object {
 
 type Iter8ClientInterface interface {
 	CreateIter8Experiment(namespace string, json string) (Iter8Experiment, error)
+	DeleteIter8Experiment(namespace string, name string) error
 	GetIter8Experiment(namespace string, name string) (Iter8Experiment, error)
 	GetIter8Experiments(namespace string) ([]Iter8Experiment, error)
 	IsIter8Api() bool
@@ -548,4 +552,10 @@ func (in *IstioClient) GetIter8Experiments(namespace string) ([]Iter8Experiment,
 		iter8Experiments = append(iter8Experiments, i8)
 	}
 	return iter8Experiments, nil
+}
+
+func (in *IstioClient) DeleteIter8Experiment(namespace string, name string) error {
+	var err error
+	_, err = in.iter8Api.Delete().Namespace(namespace).Resource(iter8experiments).Name(name).Do().Get()
+	return err
 }

--- a/kubernetes/iter8.go
+++ b/kubernetes/iter8.go
@@ -164,37 +164,37 @@ type Iter8ExperimentSpec struct {
 		Baseline   string `json:"baseline"`
 		Candidate  string `json:"candidate"`
 	} `json:"targetService"`
-	RoutingReference struct {
-		ApiVersion string `json:"apiVersion"`
-		Kind       string `json:"kind"`
-		Name       string `json:"name"`
-	} `json:"routingReference"`
+	RoutingReference *struct {
+		ApiVersion string `json:"apiVersion,omitempty"`
+		Kind       string `json:"kind,omitempty"`
+		Name       string `json:"name,omitempty"`
+	} `json:"routingReference,omitempty"`
 	Analysis struct {
-		AnalyticsService string `json:"analyticsService"`
-		GrafanaEndpoint  string `json:"grafanaEndpoint"`
+		AnalyticsService string `json:"analyticsService,omitempty"`
+		GrafanaEndpoint  string `json:"grafanaEndpoint,omitempty"`
 		SuccessCriteria  []struct {
-			MetricName    string  `json:"metricName"`
-			SampleSize    int     `json:"sampleSize"`
-			Tolerance     float64 `json:"tolerance"`
-			ToleranceType string  `json:"toleranceType"`
+			MetricName    string  `json:"metricName,omitempty"`
+			SampleSize    int     `json:"sampleSize,omitempty"`
+			Tolerance     float64 `json:"tolerance,omitempty"`
+			ToleranceType string  `json:"toleranceType,omitempty"`
 			MinMax        struct {
-				Min float64 `json:"min"`
-				Max float64 `json:"max"`
-			} `json:"min_max"`
-			StopOnFailure bool `json:"stopOnFailure"`
-		} `json:"successCriteria"`
-	} `json:"analysis"`
+				Min float64 `json:"min,omitempty"`
+				Max float64 `json:"max,omitempty"`
+			} `json:"min_max,omitempty"`
+			StopOnFailure bool `json:"stopOnFailure,omitempty"`
+		} `json:"successCriteria,omitempty"`
+	} `json:"analysis,omitempty"`
 	TrafficControl struct {
-		Interval             string  `json:"interval"`
-		MaxIterations        int     `json:"maxIterations"`
-		MaxTrafficPercentage float64 `json:"maxTrafficPercentage"`
-		Strategy             string  `json:"strategy"`
-		TrafficStepSize      float64 `json:"trafficStepSize"`
-		Confidence           float64 `json:"confidence"`
-		OnSuccess            string  `json:"onSuccess"`
-	} `json:"trafficControl"`
-	Assessment string `json:"assessment"`
-	Cleanup    string `json:"cleanup"`
+		Interval             string  `json:"interval,omitempty"`
+		MaxIterations        int     `json:"maxIterations,omitempty"`
+		MaxTrafficPercentage float64 `json:"maxTrafficPercentage,omitempty"`
+		Strategy             string  `json:"strategy,omitempty"`
+		TrafficStepSize      float64 `json:"trafficStepSize,omitempty"`
+		Confidence           float64 `json:"confidence,omitempty"`
+		OnSuccess            string  `json:"onSuccess,omitempty"`
+	} `json:"trafficControl,omitempty"`
+	Assessment string `json:"assessment,omitempty"`
+	Cleanup    string `json:"cleanup,omitempty"`
 }
 
 /*
@@ -209,10 +209,10 @@ type Iter8ExperimentSpec struct {
 		  by ($entity_labels)
 */
 type Iter8ExperimentMetrics map[string]struct {
-	AbsentValue        string `json:"absent_value"`
-	IsCounter          bool   `json:"is_counter"`
-	QueryTemplate      string `json:"query_template"`
-	SampleSizeTemplate string `json:"sample_size_template"`
+	AbsentValue        string `json:"absent_value,omitempty"`
+	IsCounter          bool   `json:"is_counter,omitempty"`
+	QueryTemplate      string `json:"query_template,omitempty"`
+	SampleSizeTemplate string `json:"sample_size_template,omitempty"`
 }
 
 /*

--- a/kubernetes/iter8.go
+++ b/kubernetes/iter8.go
@@ -12,153 +12,7 @@ var iter8typeMeta = meta_v1.TypeMeta{
 	APIVersion: ApiIter8Version,
 }
 
-// https://github.com/iter8-tools/docs/blob/master/doc_files/iter8_crd.md
-/*
-spec:
-    # targetService specifies the reference to experiment targets
-    targetService:
-
-      # apiVersion of the target service (required)
-      # options:
-      #   v1: indicates that the targeconst (
-    Experiments       = "experiments"
-)
-t service is a Kubernetes service
-      #   serving.knative.dev/v1alpha1: indicates that the target service is a Knative service
-      apiVersion: v1
-
-      # name of target service (required)
-      # identifies either a Kubernetes service or a Knative service
-      name: reviews
-
-      # the baseline and candidate versions of the target service (required)
-      # for Kubernetes, these two components refer to names of deployments
-      # for Knative, they are names of revisions
-      baseline: reviews-v3
-      candidate: reviews-v5
-
-    # routingReference is a reference to an existing Istio VirtualService (optional)
-    # this should be used only if an Istio VirtualService has already been defined for the target Kubernetes service
-    routingReference:
-      apiversion: networking.istio.io/v1alpha3
-      kind: VirtualService
-      name: reviews-external
-
-    # analysis contains the parameters for configuring the analytics service
-    analysis:
-
-      # analyticsService specifies analytics service endpoint (optional)
-      # default value is http://iter8-analytics.iter8
-      analyticsService: http://iter8-analytics.iter8
-
-      # endpoint to Grafana dashboard (optional)
-      # default is http://localhost:3000
-      grafanaEndpoint: http://localhost:3000
-
-      # successCriteria is a list of criteria for assessing the candidate version (optional)
-      # if the list is empty, the controller will not rely on the analytics service
-      successCriteria:
-
-      # metricName: name of the metric to which this criterion applies (required)
-      # the name should match the name of an iter8 metric or that of a user-defined custom metric
-      # names of metrics supported by iter8 out of the box:
-      #   iter8_latency: mean latency of the service
-      #   iter8_error_rate: mean error rate (~5** HTTP Status codes) of the service
-      #   iter8_error_count: total error count (~5** HTTP Status codes) of the service
-      - metricName: iter8_latency
-
-        # minimum number of data points required to make a decision based on this criterion (optional)
-        # default is 10
-        # Used by the check and increment alogorithm.
-        # Ignored by other algorithms.
-        sampleSize: 100
-
-        # the metric value for the candidate version defining this success criterion (required)
-        # it can be an absolute threshold or one relative to the baseline version, depending on the
-        # attribute toleranceType described next
-        tolerance: 0.2
-
-        # indicates if the tolerance value above should be interpreted as an absolute threshold or
-        # a threshold relative to the baseline (required)
-        # options:
-        #   threshold: the metric value for the candidate must be below the tolerance value above
-        #   delta: the tolerance value above indicates the percentage within which the candidate metric value can deviate
-        # from the baseline metric value
-        toleranceType: threshold
-
-        # The range of possible metric values (optional)
-        # Used by bayesian routing algorithms if available.
-        # Ignored by other algorithms.
-        min_max:
-          # The minimum possible value for the metric
-          min: 0.0
-
-          # The maximum possible value for the metric
-          max: 1.0
-
-        # indicates whether or not the experiment must finish if this criterion is not satisfied (optional)
-        # default is false
-        stopOnFailure: false
-
-    # trafficControl controls the experiment durarion and how the controller should change the traffic split
-    trafficControl:
-
-      # frequency with which the controller calls the analytics service
-      # it corresponds to the duration of each "iteration" of the experiment
-      interval: 30s
-
-      # maximum number of iterations for this experiment (optional)
-      # the duration of an experiment is defined by maxIterations * internal
-      # default is 100
-      maxIterations: 6
-
-      # the maximum traffic percentage to send to the candidate during an experiment (optional)
-      # default is 50
-      maxTrafficPercentage: 80
-
-      # strategy used to analyze the candidate and shift the traffic (optional)
-      # except for the strategy increment_without_check, the analytics service is called
-      # at each iteration and responds with the appropriate traffic split which the controller honors
-      # options:
-      #   check_and_increment
-      #   epsilon_greedy
-      #   posterior_bayesian_routing
-      #   optimistic_bayesian_routing
-      #   increment_without_check: increase traffic to candidate by trafficStepSize at each iteration without calling analytics
-      # default is check_and_increment
-      strategy: check_and_increment
-
-      # the maximum traffic increment per iteration (optional)
-      # default is 2.0
-      trafficStepSize: 20
-
-      # The required confidence in the recommeded traffic split (optional)
-      # default is 0.95
-      # Used by bayesian routing algorithms
-      # Ignored by other algorithms
-      confidence: 0.9
-
-      # determines how the traffic must be split at the end of the experiment (optional)
-      # options:
-      #   baseline: all traffic goes to the baseline version
-      #   candidate: all traffic goes to the candidate version
-      #   both: traffic is split across baseline and candidate
-      # default is candidate
-      onSuccess: candidate
-
-    # a flag that allows the user to terminate an ongoing experiment (optional)
-    # options:
-    #   override_success: terminate the experiment indicating that the candidate succeeded
-    #   override_failure: abort the experiment indicating that the candidate failed
-    # default is the empty string
-    assessment: ""
-
-    # indicates whether or not iter8 should perform a clean-up action at the end of the experiment (optional)
-    # if no action is specified, nothing is done to clean up at the end
-    # if used, the currently supported actions are:
-    #   delete: at the end of the experiment, the version that ends up with no traffic (if any) is deleted
-    cleanup:
-*/
+// Linked with https://github.com/iter8-tools/iter8-controller/blob/master/pkg/apis/iter8/v1alpha1/experiment_types.go
 type Iter8ExperimentSpec struct {
 	TargetService struct {
 		ApiVersion string `json:"apiVersion"`
@@ -167,145 +21,44 @@ type Iter8ExperimentSpec struct {
 		Baseline   string `json:"baseline"`
 		Candidate  string `json:"candidate"`
 	} `json:"targetService"`
-	RoutingReference *struct {
-		ApiVersion string `json:"apiVersion,omitempty"`
-		Kind       string `json:"kind,omitempty"`
-		Name       string `json:"name,omitempty"`
-	} `json:"routingReference,omitempty"`
+	TrafficControl struct {
+		Strategy             string  `json:"strategy,omitempty"`
+		MaxTrafficPercentage float64 `json:"maxTrafficPercentage,omitempty"`
+		TrafficStepSize      float64 `json:"trafficStepSize,omitempty"`
+		Interval             string  `json:"interval,omitempty"`
+		MaxIterations        int     `json:"maxIterations,omitempty"`
+		OnSuccess            string  `json:"onSuccess,omitempty"`
+		Confidence           float64 `json:"confidence,omitempty"`
+	} `json:"trafficControl,omitempty"`
 	Analysis struct {
 		AnalyticsService string `json:"analyticsService,omitempty"`
 		GrafanaEndpoint  string `json:"grafanaEndpoint,omitempty"`
 		SuccessCriteria  []struct {
 			MetricName    string  `json:"metricName,omitempty"`
-			SampleSize    int     `json:"sampleSize,omitempty"`
-			Tolerance     float64 `json:"tolerance,omitempty"`
 			ToleranceType string  `json:"toleranceType,omitempty"`
+			Tolerance     float64 `json:"tolerance,omitempty"`
+			SampleSize    int     `json:"sampleSize,omitempty"`
 			MinMax        struct {
 				Min float64 `json:"min,omitempty"`
 				Max float64 `json:"max,omitempty"`
 			} `json:"min_max,omitempty"`
 			StopOnFailure bool `json:"stopOnFailure,omitempty"`
 		} `json:"successCriteria,omitempty"`
+		Reward *struct {
+			MetricName string `json:"metricName,omitempty"`
+			MinMax     string `json:"min_max,omitempty"`
+		} `json:"reward,omitempty"`
 	} `json:"analysis,omitempty"`
-	TrafficControl struct {
-		Interval             string  `json:"interval,omitempty"`
-		MaxIterations        int     `json:"maxIterations,omitempty"`
-		MaxTrafficPercentage float64 `json:"maxTrafficPercentage,omitempty"`
-		Strategy             string  `json:"strategy,omitempty"`
-		TrafficStepSize      float64 `json:"trafficStepSize,omitempty"`
-		Confidence           float64 `json:"confidence,omitempty"`
-		OnSuccess            string  `json:"onSuccess,omitempty"`
-	} `json:"trafficControl,omitempty"`
-	Assessment string `json:"assessment,omitempty"`
-	Cleanup    string `json:"cleanup,omitempty"`
+	Assessment       string `json:"assessment,omitempty"`
+	Cleanup          string `json:"cleanup,omitempty"`
+	RoutingReference *struct {
+		ApiVersion string `json:"apiVersion,omitempty"`
+		Kind       string `json:"kind,omitempty"`
+		Name       string `json:"name,omitempty"`
+	} `json:"routingReference,omitempty"`
 }
 
-/*
-	metrics:
-	  iter8_latency:
-		absent_value: None
-		is_counter: false
-		query_template: (sum(increase(istio_request_duration_seconds_sum{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str))
-		  by ($entity_labels)) / (sum(increase(istio_request_duration_seconds_count{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str))
-		  by ($entity_labels))
-		sample_size_template: sum(increase(istio_requests_total{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str))
-		  by ($entity_labels)
-*/
-type Iter8ExperimentMetrics map[string]struct {
-	AbsentValue        string `json:"absent_value,omitempty"`
-	IsCounter          bool   `json:"is_counter,omitempty"`
-	QueryTemplate      string `json:"query_template,omitempty"`
-	SampleSizeTemplate string `json:"sample_size_template,omitempty"`
-}
-
-/*
-  status:
-    # the last analysis state
-    analysisState: {}
-
-    # assessment returned from the analytics service
-    assessment:
-      conclusions:
-      - The experiment needs to be aborted
-      - All success criteria were not met
-
-    # list of boolean conditions describing the status of the experiment
-    # for each condition, if the status is "False", the reason field will give detailed explanations
-    # lastTransitionTime records the time when the last change happened to the corresponding condition
-    # when a condition is not set, its status will be "Unknown"
-    conditions:
-
-    # AnalyticsServiceNormal is "True" when the controller can get an interpretable response from the analytics service
-    - lastTransitionTime: "2019-12-20T05:38:37Z"
-      status: "True"
-      type: AnalyticsServiceNormal
-
-    # ExperimentCompleted tells whether the experiment is completed or not
-    - lasv1alpha1.Phase		tTransitionTime: "2019-12-20T05:39:37Z"
-      status: "True"
-      type: ExperimentCompleted
-
-    # ExperimentSucceeded indicates whether the experiment succeeded or not when it is completed
-    - lastTransitionTime: "2019-12-20T05:39:37Z"
-      message: Aborted
-      reason: ExperimentFailed
-      status: "False"
-      type: ExperimentSucceeded
-
-    # MetricsSynced states whether the referenced metrics have been retrieved from the ConfigMap and stored in the metrics section
-    - lastTransitionTime: "2019-12-20T05:38:22Z"
-      status: "True"
-      type: MetricsSynced
-
-    # Ready records the status of the latest-updated condition
-    - lastTransitionTime: "2019-12-20T05:39:37Z"
-      message: Aborted
-      reason: ExperimentFailed
-      status: "False"
-      type: Ready
-
-    # RoutingRulesReady indicates whether the routing rules are successfully created/updated
-    - lastTransitionTime: "2019-12-20T05:38:22Z"
-      tatus: "True"
-      type: RoutingRulesReady
-
-    # TargetsProvided is "True" when both the baseline and the candidate versions of the targetService are detected by the controller; otherwise, missing elements will be shown in the reason field
-    - lastTransitionTime: "2019-12-20T05:38:37Z"
-      status: "True"
-      type: TargetsProvided
-
-    # the current experiment's iteration
-    currentIteration: 2
-
-    # Unix timestamp in milliseconds corresponding to when the experiment started
-    startTimestamp: "1576820317351"
-
-    # Unix timestamp in milliseconds corresponding to when the experiment finished
-    endTimestamp: "1576820377696"
-
-    # The url to he Grafana dashboard pertaining to this experiment
-    grafanaURL: http://localhost:3000/d/eXPEaNnZz/iter8-application-metrics?var-namespace=bookinfo-iter8&var-service=reviews&var-baseline=reviews-v3&var-candidate=reviews-v5&from=1576820317351&to=1576820377696
-
-    # the time when the previous iteration was completed
-    lastIncrementTime: "2019-12-20T05:39:07Z"
-
-    # this is the message to be shown in the STATUS column for the `kubectl` printer, which summarizes the experiment situation
-    message: 'ExperimentFailed: Aborted'
-
-    # the experiment's current phase
-    # values could be: Initializing, Progressing, Pause, Completed
-    phase: Completed
-
-    # the current traffic split
-    trafficSplitPercentage:
-      baseline: 100
-      candidate: 0
-*/
 type Iter8ExperimentStatus struct {
-	AnalysisState map[string]interface{} `json:"analysisState"`
-	Assestment    struct {
-		Conclusions []string `json:"conclusions"`
-	} `json:"assessment"`
 	Conditions []struct {
 		LastTransitionTime string `json:"lastTransitionTime"`
 		Message            string `json:"message"`
@@ -313,17 +66,29 @@ type Iter8ExperimentStatus struct {
 		Status             string `json:"status"`
 		Type               string `json:"type"`
 	} `json:"conditions"`
-	CurrentIteration       int    `json:"currentIteration"`
-	StartTimeStamp         string `json:"startTimestamp"`
-	EndTimestamp           string `json:"endTimestamp"`
-	GrafanaURL             string `json:"grafanaURL"`
-	LastIncrementTime      string `json:"lastIncrementTime"`
-	Message                string `json:"message"`
-	Phase                  string `json:"phase"`
+	CreateTimeStamp   int64                  `json:"createTimestamp"`
+	StartTimeStamp    int64                  `json:"startTimestamp"`
+	EndTimestamp      int64                  `json:"endTimestamp"`
+	LastIncrementTime string                 `json:"lastIncrementTime"`
+	CurrentIteration  int                    `json:"currentIteration"`
+	AnalysisState     map[string]interface{} `json:"analysisState"`
+	GrafanaURL        string                 `json:"grafanaURL"`
+	Assestment        struct {
+		Conclusions []string `json:"conclusions"`
+	} `json:"assessment"`
 	TrafficSplitPercentage struct {
 		Baseline  int `json:"baseline"`
 		Candidate int `json:"candidate"`
 	} `json:"trafficSplitPercentage"`
+	Phase   string `json:"phase"`
+	Message string `json:"message"`
+}
+
+type Iter8ExperimentMetrics map[string]struct {
+	AbsentValue        string `json:"absent_value,omitempty"`
+	IsCounter          bool   `json:"is_counter,omitempty"`
+	QueryTemplate      string `json:"query_template,omitempty"`
+	SampleSizeTemplate string `json:"sample_size_template,omitempty"`
 }
 
 // Iter8Experiment is a dynamic object to map Iter8 Experiments
@@ -331,10 +96,10 @@ type Iter8Experiment interface {
 	runtime.Object
 	GetSpec() Iter8ExperimentSpec
 	SetSpec(Iter8ExperimentSpec)
-	GetMetrics() Iter8ExperimentMetrics
-	SetMetrics(Iter8ExperimentMetrics)
 	GetStatus() Iter8ExperimentStatus
 	SetStatus(Iter8ExperimentStatus)
+	GetMetrics() Iter8ExperimentMetrics
+	SetMetrics(Iter8ExperimentMetrics)
 	GetTypeMeta() meta_v1.TypeMeta
 	SetTypeMeta(meta_v1.TypeMeta)
 	GetObjectMeta() meta_v1.ObjectMeta
@@ -351,8 +116,8 @@ type Iter8ExperimentObject struct {
 	meta_v1.TypeMeta   `json:",inline"`
 	meta_v1.ObjectMeta `json:"metadata"`
 	Spec               Iter8ExperimentSpec    `json:"spec"`
-	Metrics            Iter8ExperimentMetrics `json:"metrics"`
 	Status             Iter8ExperimentStatus  `json:"status"`
+	Metrics            Iter8ExperimentMetrics `json:"metrics"`
 }
 
 type Iter8ExperimentObjectList struct {

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -460,6 +460,11 @@ func (o *K8SClientMock) IsIter8Api() bool {
 	return args.Get(0).(bool)
 }
 
+func (o *K8SClientMock) DeleteIter8Experiment(namespace string, name string) error {
+	args := o.Called(namespace, name)
+	return args.Error(0)
+}
+
 func fakeService(namespace, name string) core_v1.Service {
 	return core_v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{

--- a/make/Makefile.cluster.mk
+++ b/make/Makefile.cluster.mk
@@ -36,7 +36,7 @@
 	@if [ "${CLUSTER_REPO_INTERNAL}" == "" ]; then echo "Cannot determine minikube internal registry hostname."; exit 1; fi
 	@if [ "${CLUSTER_REPO}" == "" ]; then echo "Cannot determine minikube external registry hostname. Make sure minikube is running."; exit 1; fi
 	@echo "Minikube repos: external=[${CLUSTER_REPO}] internal=[${CLUSTER_REPO_INTERNAL}]"
-	@if ! ${MINIKUBE} addons list | grep -q "registry: enabled"; then \
+	@if ! ${MINIKUBE} addons list | grep "registry" | grep "enabled"; then \
 	   echo "Minikube does not have the registry addon enabled. Run 'minikube addons enable registry' in order for the make targets to work."; \
 		exit 1 ;\
 	 fi

--- a/models/iter8.go
+++ b/models/iter8.go
@@ -57,7 +57,7 @@ type Iter8ExperimentSpec struct {
 	Baseline       string              `json:"baseline"`
 	Candidate      string              `json:"candidate"`
 	TrafficControl Iter8TrafficControl `json:"trafficControl"`
-	Criterias      Iter8Criteria       `json:"criterias"`
+	Criterias      []Iter8Criteria       `json:"criterias"`
 }
 
 type Iter8TrafficControl struct {

--- a/models/iter8.go
+++ b/models/iter8.go
@@ -57,7 +57,7 @@ type Iter8ExperimentSpec struct {
 	Baseline       string              `json:"baseline"`
 	Candidate      string              `json:"candidate"`
 	TrafficControl Iter8TrafficControl `json:"trafficControl"`
-	Criterias      []Iter8Criteria       `json:"criterias"`
+	Criterias      []Iter8Criteria     `json:"criterias"`
 }
 
 type Iter8TrafficControl struct {

--- a/models/iter8.go
+++ b/models/iter8.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"strconv"
 	"strings"
 	"time"
 
@@ -112,14 +111,8 @@ func (i *Iter8ExperimentDetail) Parse(iter8Object kubernetes.Iter8Experiment) {
 		TrafficStepSize:      spec.TrafficControl.TrafficStepSize,
 	}
 
-	startTime, _ := strconv.ParseInt(status.StartTimeStamp, 10, 64)
-	startTimeString := time.Unix(0, startTime*int64(1000000)).Format(time.RFC1123)
-	endTimeString := ""
-	if status.EndTimestamp != "" {
-		_endTime, _ := strconv.ParseInt(status.EndTimestamp, 10, 64)
-		endTimeInNano := _endTime * int64(1000000)
-		endTimeString = time.Unix(0, endTimeInNano).Format(time.RFC1123)
-	}
+	startTimeString := time.Unix(0, status.StartTimeStamp*int64(1000000)).Format(time.RFC1123)
+	endTimeString := time.Unix(0, status.EndTimestamp*int64(1000000)).Format(time.RFC1123)
 	targetServiceNamespace := spec.TargetService.Namespace
 	if targetServiceNamespace == "" {
 		targetServiceNamespace = iter8Object.GetObjectMeta().Namespace

--- a/models/iter8.go
+++ b/models/iter8.go
@@ -9,8 +9,7 @@ import (
 )
 
 type Iter8Info struct {
-	Enabled     bool                `json:"enabled"`
-	Permissions ResourcePermissions `json:"permissions"`
+	Enabled bool `json:"enabled"`
 }
 
 type Iter8ExperimentItem struct {
@@ -34,6 +33,7 @@ type Iter8ExperimentDetail struct {
 	ExperimentItem  Iter8ExperimentItem   `json:"experimentItem"`
 	CriteriaDetails []Iter8CriteriaDetail `json:"criterias"`
 	TrafficControl  Iter8TrafficControl   `json:"trafficControl"`
+	Permissions     ResourcePermissions   `json:"permissions"`
 }
 
 type Iter8CriteriaDetail struct {
@@ -63,7 +63,7 @@ type Iter8ExperimentSpec struct {
 type Iter8TrafficControl struct {
 	Algorithm            string  `json:"algorithm"`
 	Interval             string  `json:"interval"`
-	MaxIteration         int     `json:"maxIteration"`
+	MaxIterations        int     `json:"maxIterations"`
 	MaxTrafficPercentage float64 `json:"maxTrafficPercentage"`
 	TrafficStepSize      float64 `json:"trafficStepSize"`
 }
@@ -107,7 +107,7 @@ func (i *Iter8ExperimentDetail) Parse(iter8Object kubernetes.Iter8Experiment) {
 	trafficControl := Iter8TrafficControl{
 		Algorithm:            spec.TrafficControl.Strategy,
 		Interval:             spec.TrafficControl.Interval,
-		MaxIteration:         spec.TrafficControl.MaxIterations,
+		MaxIterations:        spec.TrafficControl.MaxIterations,
 		MaxTrafficPercentage: spec.TrafficControl.MaxTrafficPercentage,
 		TrafficStepSize:      spec.TrafficControl.TrafficStepSize,
 	}

--- a/models/iter8.go
+++ b/models/iter8.go
@@ -111,8 +111,15 @@ func (i *Iter8ExperimentDetail) Parse(iter8Object kubernetes.Iter8Experiment) {
 		TrafficStepSize:      spec.TrafficControl.TrafficStepSize,
 	}
 
-	startTimeString := time.Unix(0, status.StartTimeStamp*int64(1000000)).Format(time.RFC1123)
-	endTimeString := time.Unix(0, status.EndTimestamp*int64(1000000)).Format(time.RFC1123)
+	startTimeString := ""
+	endTimeString := ""
+	if status.StartTimeStamp > 0 {
+		startTimeString = time.Unix(0, status.StartTimeStamp).Format(time.RFC1123)
+	}
+	if status.EndTimestamp > 0 {
+		endTimeString = time.Unix(0, status.EndTimestamp).Format(time.RFC1123)
+	}
+
 	targetServiceNamespace := spec.TargetService.Namespace
 	if targetServiceNamespace == "" {
 		targetServiceNamespace = iter8Object.GetObjectMeta().Namespace

--- a/models/iter8_test.go
+++ b/models/iter8_test.go
@@ -3,8 +3,8 @@ package models
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIter8MarshalForCreate(t *testing.T) {
@@ -32,7 +32,7 @@ func TestIter8MarshalForCreate(t *testing.T) {
 		  "stopOnFailure": false
 		}
 	  ]
-	}`;
+	}`
 
 	experimentBytes := []byte(experimentJson)
 

--- a/models/iter8_test.go
+++ b/models/iter8_test.go
@@ -1,0 +1,41 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"encoding/json"
+)
+
+func TestIter8MarshalForCreate(t *testing.T) {
+	assert := assert.New(t)
+	experimentJson := `{
+	  "name": "reviews-experiment",
+	  "namespace": "default",
+	  "service": "reviews",
+	  "apiversion": "v1",
+	  "baseline": "reviews-v1",
+	  "candidate": "reviews-v2",
+	  "trafficControl": {
+		"algorithm": "check_and_increment",
+		"interval": "30s",
+		"maxIteration": 100,
+		"maxTrafficPercentage": 50,
+		"trafficStepSize": 2
+	  },
+	  "criterias": [
+		{
+		  "metric": "iter8_latency",
+		  "sampleSize": 100,
+		  "tolerance": 0.2,
+		  "toleranceType": "threshold",
+		  "stopOnFailure": false
+		}
+	  ]
+	}`;
+
+	experimentBytes := []byte(experimentJson)
+
+	err := json.Unmarshal(experimentBytes, &Iter8ExperimentSpec{})
+	assert.NoError(err)
+}

--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -272,3 +272,13 @@ rules:
   verbs:
   - get
   - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch

--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -276,9 +276,9 @@ rules:
   resources:
   - experiments
   verbs:
-  - create
-  - delete
+  ${OPERATOR_ROLE_CREATE}
+  ${OPERATOR_ROLE_DELETE}
   - get
   - list
-  - patch
+  ${OPERATOR_ROLE_PATCH}
   - watch

--- a/operator/manifests/kiali-community/1.16.0/kiali.crd.yaml
+++ b/operator/manifests/kiali-community/1.16.0/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-community/1.16.0/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-community/1.16.0/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-community/1.16.0/kiali.v1.16.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/1.16.0/kiali.v1.16.0.clusterserviceversion.yaml
@@ -1,0 +1,582 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.16.0
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.16.0
+    capabilities: Deep Insights
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2020-03-25T00:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "istio-system",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.16.0
+  maturity: stable
+  replaces: kiali-operator.v1.15.1
+  displayName: Kiali Operator
+  description: |-
+    ## About the managed application
+
+    A Microservice Architecture breaks up the monolith into many smaller pieces
+    that are composed together. Patterns to secure the communication between
+    services like fault tolerance (via timeout, retry, circuit breaking, etc.)
+    have come up as well as distributed tracing to be able to see where calls
+    are going.
+
+    A service mesh can now provide these services on a platform level and frees
+    the application writers from those tasks. Routing decisions are done at the
+    mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service
+    mesh topology, to provide visibility into features like circuit breakers,
+    request rates and more. It offers insights about the mesh components at
+    different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift
+    or Ingress on Kubernetes.
+
+    On OpenShift, the default root context path is '/' and on Kubernetes it is
+    '/kiali' though you can change this by configuring the 'web_root' setting in
+    the Kiali CR.
+
+    ## About this Operator
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali
+    Custom Resource (CR), see the file
+    [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.16.0/operator/deploy/kiali/kiali_cr.yaml)
+
+    Note that the Kiali operator can be told to restrict Kiali's access to
+    specific namespaces, or can provide to Kiali cluster-wide access to all
+    namespaces.
+
+    ## Prerequisites for enabling this Operator
+
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio. Note that Istio can come pre-bundled with Kiali
+    (specifically if you installed the Istio demo helm profile or if you
+    installed Istio with the helm option '--set kiali.enabled=true'). If you
+    already have the pre-bundled Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first.
+    You can do this via this command,
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `login`. When using the
+    authentication strategy of `login`, you are required to create a Kubernetes
+    Secret with a `username` and `passphrase` that you want users to provide in
+    order to successfully log into Kiali. Here is an example command you can
+    execute to create such a secret (with a username of `admin` and a passphrase
+    of `admin`),
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    If you wish to use the "ldap" authentication strategy, you must have an LDAP
+    server available and accessible to Kiali.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.16.0
+              annotations:
+                prometheus.io/scrape: "true"
+                prometheus.io/port: "8383"
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.16.0
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.16.0
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: [""]
+          resources:
+          - secrets
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups: [""]
+          resourceNames:
+          - kiali-signing-key
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.istio.io
+          - networking.istio.io
+          - authentication.istio.io
+          - rbac.istio.io
+          - security.istio.io
+          resources: ["*"]
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        - apiGroups: ["iter8.tools"]
+          resources:
+          - experiments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-community/kiali.package.yaml
+++ b/operator/manifests/kiali-community/kiali.package.yaml
@@ -1,7 +1,7 @@
 packageName: kiali
 channels:
 - name: alpha
-  currentCSV: kiali-operator.v1.15.1
+  currentCSV: kiali-operator.v1.16.0
 - name: stable
-  currentCSV: kiali-operator.v1.15.1
+  currentCSV: kiali-operator.v1.16.0
 defaultChannel: stable

--- a/operator/manifests/kiali-upstream/1.16.0/kiali.crd.yaml
+++ b/operator/manifests/kiali-upstream/1.16.0/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-upstream/1.16.0/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-upstream/1.16.0/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-upstream/1.16.0/kiali.v1.16.0.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/1.16.0/kiali.v1.16.0.clusterserviceversion.yaml
@@ -1,0 +1,582 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.16.0
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.16.0
+    capabilities: Deep Insights
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2020-03-25T00:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "default",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.16.0
+  maturity: stable
+  replaces: kiali-operator.v1.15.1
+  displayName: Kiali Operator
+  description: |-
+    ## About the managed application
+
+    A Microservice Architecture breaks up the monolith into many smaller pieces
+    that are composed together. Patterns to secure the communication between
+    services like fault tolerance (via timeout, retry, circuit breaking, etc.)
+    have come up as well as distributed tracing to be able to see where calls
+    are going.
+
+    A service mesh can now provide these services on a platform level and frees
+    the application writers from those tasks. Routing decisions are done at the
+    mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service
+    mesh topology, to provide visibility into features like circuit breakers,
+    request rates and more. It offers insights about the mesh components at
+    different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift
+    or Ingress on Kubernetes.
+
+    On OpenShift, the default root context path is '/' and on Kubernetes it is
+    '/kiali' though you can change this by configuring the 'web_root' setting in
+    the Kiali CR.
+
+    ## About this Operator
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali
+    Custom Resource (CR), see the file
+    [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.16.0/operator/deploy/kiali/kiali_cr.yaml)
+
+    Note that the Kiali operator can be told to restrict Kiali's access to
+    specific namespaces, or can provide to Kiali cluster-wide access to all
+    namespaces.
+
+    ## Prerequisites for enabling this Operator
+
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio. Note that Istio can come pre-bundled with Kiali
+    (specifically if you installed the Istio demo helm profile or if you
+    installed Istio with the helm option '--set kiali.enabled=true'). If you
+    already have the pre-bundled Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first.
+    You can do this via this command,
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `login`. When using the
+    authentication strategy of `login`, you are required to create a Kubernetes
+    Secret with a `username` and `passphrase` that you want users to provide in
+    order to successfully log into Kiali. Here is an example command you can
+    execute to create such a secret (with a username of `admin` and a passphrase
+    of `admin`),
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    If you wish to use the "ldap" authentication strategy, you must have an LDAP
+    server available and accessible to Kiali.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.16.0
+              annotations:
+                prometheus.io/scrape: "true"
+                prometheus.io/port: "8383"
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.16.0
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.16.0
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: [""]
+          resources:
+          - secrets
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups: [""]
+          resourceNames:
+          - kiali-signing-key
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.istio.io
+          - networking.istio.io
+          - authentication.istio.io
+          - rbac.istio.io
+          - security.istio.io
+          resources: ["*"]
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        - apiGroups: ["iter8.tools"]
+          resources:
+          - experiments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-upstream/kiali.package.yaml
+++ b/operator/manifests/kiali-upstream/kiali.package.yaml
@@ -1,7 +1,7 @@
 packageName: kiali
 channels:
 - name: alpha
-  currentCSV: kiali-operator.v1.15.1
+  currentCSV: kiali-operator.v1.16.0
 - name: stable
-  currentCSV: kiali-operator.v1.15.1
+  currentCSV: kiali-operator.v1.16.0
 defaultChannel: stable

--- a/operator/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/operator/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -62,3 +62,9 @@ rules:
   verbs:
   - get
   - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - get
+  - list

--- a/operator/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/operator/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -65,3 +65,13 @@ rules:
   verbs:
   - get
   - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch

--- a/operator/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/operator/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -93,3 +93,9 @@ rules:
   verbs:
   - get
   - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - get
+  - list

--- a/operator/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/operator/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -102,3 +102,13 @@ rules:
   verbs:
   - get
   - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1399,7 +1399,7 @@ func NewRoutes() (r *Routes) {
 		{
 			Name:          "Iter8ExperimentsUpdate",
 			Method:        "PATCH",
-			Pattern:       "/api/iter8/experiments/namespaces/{namespace}/name/{name}",
+			Pattern:       "/api/iter8/namespaces/{namespace}/experiments/{name}",
 			HandlerFunc:   handlers.Iter8ExperimentUpdate,
 			Authenticated: true,
 		},
@@ -1418,7 +1418,7 @@ func NewRoutes() (r *Routes) {
 		{
 			Name:          "Iter8ExperimentDelete",
 			Method:        "DELETE",
-			Pattern:       "/api/iter8/experiments/namespaces/{namespace}/name/{name}",
+			Pattern:       "/api/iter8/namespaces/{namespace}/experiments/{name}",
 			HandlerFunc:   handlers.Iter8ExperimentDelete,
 			Authenticated: true,
 		},

--- a/swagger.json
+++ b/swagger.json
@@ -4330,6 +4330,9 @@
         "experimentItem": {
           "$ref": "#/definitions/Iter8ExperimentItem"
         },
+        "permissions": {
+          "$ref": "#/definitions/ResourcePermissions"
+        },
         "trafficControl": {
           "$ref": "#/definitions/Iter8TrafficControl"
         }
@@ -4406,9 +4409,6 @@
         "enabled": {
           "type": "boolean",
           "x-go-name": "Enabled"
-        },
-        "permissions": {
-          "$ref": "#/definitions/ResourcePermissions"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -4446,10 +4446,10 @@
           "type": "string",
           "x-go-name": "Interval"
         },
-        "maxIteration": {
+        "maxIterations": {
           "type": "integer",
           "format": "int64",
-          "x-go-name": "MaxIteration"
+          "x-go-name": "MaxIterations"
         },
         "maxTrafficPercentage": {
           "type": "number",


### PR DESCRIPTION
More work to consolidate an end-to-end flow for Iter8 extension.

cc @jadeyliu939 
cc @kiali/iter8 

Frontend PR
https://github.com/kiali/kiali-ui/pull/1708

Main work on this PR:
- Avoid to pull Iter8 dependencies
- Create a static model of Iter8 entities to map the CRD. 
- Pros: avoid conflict with dependencies (Iter8 pulls different golang deps versions than Kiali and forces to non desired upgrades).
- Cons: this needs to be maintained on Iter8 changes and some logic (initialization of some default value) should be added.
- Refinements on endpoints and logic.

How to test in minikube:
- Install minikube + bookinfo.
- Install iter8 in minikube:
```
kubectl apply \
    -f https://raw.githubusercontent.com/iter8-tools/iter8-analytics/master/install/kubernetes/iter8-analytics.yaml \
    -f https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/install/iter8-controller.yaml
```
- Enable iter8 extension in kiali config:
```
extensions:
  threescale:
    adapter_name: threescale
    adapter_port: 3333
    adapter_service: threescale-istio-adapter
    enabled: false
  iter8:
    enabled: true
```
- Manually:
-- Check Iter8 list page is enabled.
-- Check an experiment on reviews service can be created using reviews-v1 and reviews-v2.
-- Check that experiment is being updated with the progress.
-- Delete is not yet in implemented (I will remove do not merge when it's implemented).

Note, the goal of this PR (and UI) is to provide a Step 0 status of a very basic end-to-end CRUD.