### PR TITLE
Sidecar in istio ns shouldn't have workloadSelector

### DIFF
--- a/business/checkers/sidecars/egress_listener_checker_test.go
+++ b/business/checkers/sidecars/egress_listener_checker_test.go
@@ -106,7 +106,7 @@ func TestEgressServiceNotFound(t *testing.T) {
 }
 
 func sidecarWithHosts(hl []interface{}) kubernetes.IstioObject {
-	return data.AddHostsToSidecar(hl, data.CreateSidecar("sidecar"))
+	return data.AddHostsToSidecar(hl, data.CreateSidecar("sidecar", "bookinfo"))
 }
 
 func fakeServices(serviceNames []string) []core_v1.Service {

--- a/business/checkers/sidecars/global_checker.go
+++ b/business/checkers/sidecars/global_checker.go
@@ -13,7 +13,6 @@ type GlobalChecker struct {
 func (gc GlobalChecker) Check() ([]*models.IstioCheck, bool) {
 	checks, valid := make([]*models.IstioCheck, 0), true
 
-
 	if !config.IsIstioNamespace(gc.Sidecar.GetObjectMeta().Namespace) {
 		return checks, valid
 	}

--- a/business/checkers/sidecars/global_checker.go
+++ b/business/checkers/sidecars/global_checker.go
@@ -1,0 +1,27 @@
+package sidecars
+
+import (
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type GlobalChecker struct {
+	Sidecar kubernetes.IstioObject
+}
+
+func (gc GlobalChecker) Check() ([]*models.IstioCheck, bool) {
+	checks, valid := make([]*models.IstioCheck, 0), true
+
+
+	if !config.IsIstioNamespace(gc.Sidecar.GetObjectMeta().Namespace) {
+		return checks, valid
+	}
+
+	if gc.Sidecar.HasWorkloadSelectorLabels() {
+		check := models.Build("sidecar.global.selector", "spec/workloadSelector")
+		checks = append(checks, &check)
+	}
+
+	return checks, valid
+}

--- a/business/checkers/sidecars/global_checker_test.go
+++ b/business/checkers/sidecars/global_checker_test.go
@@ -1,0 +1,74 @@
+package sidecars
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+func TestSidecarWithoutSelectorOutOfControlPlane(t *testing.T) {
+	assert := assert.New(t)
+	config.Set(config.NewConfig())
+
+	validations, valid := GlobalChecker{
+		Sidecar: data.CreateSidecar("sidecar1", "bookinfo"),
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+
+func TestSidecarWithoutSelectorInControlPlane(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	validations, valid := GlobalChecker{
+		Sidecar: data.CreateSidecar("sidecar1", conf.IstioNamespace),
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+func TestSidecarWithSelectorOutOfControlPlane(t *testing.T) {
+	assert := assert.New(t)
+	config.Set(config.NewConfig())
+
+	validations, valid := GlobalChecker{
+		Sidecar: data.AddSelectorToSidecar(map[string]interface{}{
+				"labels": map[string]interface{}{
+					"app": "reviews",
+				},
+			}, data.CreateSidecar("sidecar1", "bookinfo")),
+	}.Check()
+
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+func TestSidecarWithSelectorInControlPlane(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	validations, valid := GlobalChecker{
+		Sidecar: data.AddSelectorToSidecar(map[string]interface{}{
+				"labels": map[string]interface{}{
+					"app": "reviews",
+				},
+			}, data.CreateSidecar("sidecar1", conf.IstioNamespace)),
+	}.Check()
+
+	assert.NotEmpty(validations)
+	assert.True(valid)
+
+	assert.Len(validations, 1)
+	assert.Equal(models.WarningSeverity, validations[0].Severity)
+	assert.Equal(models.CheckMessage("sidecar.global.selector"), validations[0].Message)
+}

--- a/business/checkers/sidecars/global_checker_test.go
+++ b/business/checkers/sidecars/global_checker_test.go
@@ -22,7 +22,6 @@ func TestSidecarWithoutSelectorOutOfControlPlane(t *testing.T) {
 	assert.True(valid)
 }
 
-
 func TestSidecarWithoutSelectorInControlPlane(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()
@@ -42,10 +41,10 @@ func TestSidecarWithSelectorOutOfControlPlane(t *testing.T) {
 
 	validations, valid := GlobalChecker{
 		Sidecar: data.AddSelectorToSidecar(map[string]interface{}{
-				"labels": map[string]interface{}{
-					"app": "reviews",
-				},
-			}, data.CreateSidecar("sidecar1", "bookinfo")),
+			"labels": map[string]interface{}{
+				"app": "reviews",
+			},
+		}, data.CreateSidecar("sidecar1", "bookinfo")),
 	}.Check()
 
 	assert.Empty(validations)
@@ -59,10 +58,10 @@ func TestSidecarWithSelectorInControlPlane(t *testing.T) {
 
 	validations, valid := GlobalChecker{
 		Sidecar: data.AddSelectorToSidecar(map[string]interface{}{
-				"labels": map[string]interface{}{
-					"app": "reviews",
-				},
-			}, data.CreateSidecar("sidecar1", conf.IstioNamespace)),
+			"labels": map[string]interface{}{
+				"app": "reviews",
+			},
+		}, data.CreateSidecar("sidecar1", conf.IstioNamespace)),
 	}.Check()
 
 	assert.NotEmpty(validations)

--- a/business/checkers/sidecars/multi_match_checker.go
+++ b/business/checkers/sidecars/multi_match_checker.go
@@ -51,19 +51,7 @@ func (m MultiMatchChecker) selectorLessSidecars() []KeyWithIndex {
 	swi := make([]KeyWithIndex, 0, len(m.Sidecars))
 
 	for i, s := range m.Sidecars {
-		add := false
-
-		if ws, found := s.GetSpec()["workloadSelector"]; found {
-			if wsCasted, ok := ws.(map[string]interface{}); ok {
-				if _, found := wsCasted["labels"]; !found {
-					add = true
-				}
-			}
-		} else {
-			add = true
-		}
-
-		if add {
+		if !s.HasWorkloadSelectorLabels() {
 			swi = append(swi, KeyWithIndex{
 				Index: i,
 				Key: &models.IstioValidationKey{

--- a/business/checkers/sidecars/multi_match_checker_test.go
+++ b/business/checkers/sidecars/multi_match_checker_test.go
@@ -20,12 +20,12 @@ func TestTwoSidecarsWithSelector(t *testing.T) {
 				"labels": map[string]interface{}{
 					"app": "reviews",
 				},
-			}, data.CreateSidecar("sidecar1")),
+			}, data.CreateSidecar("sidecar1", "bookinfo")),
 			data.AddSelectorToSidecar(map[string]interface{}{
 				"labels": map[string]interface{}{
 					"app": "details",
 				},
-			}, data.CreateSidecar("sidecar2")),
+			}, data.CreateSidecar("sidecar2", "bookinfo")),
 		},
 	}.Check()
 
@@ -36,8 +36,8 @@ func TestTwoSidecarsWithoutSelector(t *testing.T) {
 	validations := MultiMatchChecker{
 		WorkloadList: workloadList(),
 		Sidecars: []kubernetes.IstioObject{
-			data.CreateSidecar("sidecar1"),
-			data.CreateSidecar("sidecar2"),
+			data.CreateSidecar("sidecar1", "bookinfo"),
+			data.CreateSidecar("sidecar2", "bookinfo"),
 		},
 	}.Check()
 

--- a/business/checkers/sidecars/workload_selector_checker_test.go
+++ b/business/checkers/sidecars/workload_selector_checker_test.go
@@ -49,7 +49,7 @@ func TestWorkloadNotFound(t *testing.T) {
 
 func workloadSelectorSidecar(name string, selector map[string]interface{}) kubernetes.IstioObject {
 	workloadSelector := map[string]interface{}{"labels": selector}
-	return data.AddSelectorToSidecar(workloadSelector, data.CreateSidecar(name))
+	return data.AddSelectorToSidecar(workloadSelector, data.CreateSidecar(name, "bookinfo"))
 }
 
 func testFailureWithWorkloadList(assert *assert.Assertions, selector map[string]interface{}) {

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -59,6 +59,7 @@ func (s SidecarChecker) runChecks(sidecar kubernetes.IstioObject) models.IstioVa
 	enabledCheckers := []Checker{
 		sidecars.WorkloadSelectorChecker{Sidecar: sidecar, WorkloadList: s.WorkloadList},
 		sidecars.EgressHostChecker{Sidecar: sidecar, Services: s.Services, ServiceEntries: serviceHosts},
+		sidecars.GlobalChecker{Sidecar: sidecar},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -396,6 +396,7 @@ type IstioObject interface {
 	GetObjectMeta() meta_v1.ObjectMeta
 	SetObjectMeta(meta_v1.ObjectMeta)
 	DeepCopyIstioObject() IstioObject
+	HasWorkloadSelectorLabels() bool
 }
 
 // IstioObjectList is a k8s wrapper interface for list config objects.
@@ -496,6 +497,20 @@ func (in *GenericIstioObject) GetObjectMeta() meta_v1.ObjectMeta {
 // SetObjectMeta for a wrapper
 func (in *GenericIstioObject) SetObjectMeta(metadata meta_v1.ObjectMeta) {
 	in.ObjectMeta = metadata
+}
+
+func (in *GenericIstioObject) HasWorkloadSelectorLabels() bool {
+	hwsl := false
+
+	if ws, found := in.GetSpec()["workloadSelector"]; found {
+		if wsCasted, ok := ws.(map[string]interface{}); ok {
+			if _, found := wsCasted["labels"]; found {
+				hwsl = true
+			}
+		}
+	}
+
+	return hwsl
 }
 
 // GetItems from a wrapper

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -219,6 +219,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA1005 More than one Sidecar applied to the same workload",
 		Severity: ErrorSeverity,
 	},
+	"sidecar.global.selector": {
+		Message:  "KIA1006 Global default sidecar should not have workloadSelector",
+		Severity: WarningSeverity,
+	},
 	"virtualservices.nohost.hostnotfound": {
 		Message:  "KIA1101 DestinationWeight on route doesn't have a valid service (host not found)",
 		Severity: ErrorSeverity,

--- a/tests/data/sidecar_data.go
+++ b/tests/data/sidecar_data.go
@@ -6,11 +6,11 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 )
 
-func CreateSidecar(name string) kubernetes.IstioObject {
+func CreateSidecar(name string, namespace string) kubernetes.IstioObject {
 	return (&kubernetes.GenericIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:        name,
-			Namespace:   "bookinfo",
+			Namespace:   namespace,
 			ClusterName: "svc.cluster.local",
 		},
 		Spec: map[string]interface{}{},


### PR DESCRIPTION
** Describe the change **
Sidecars placed in istio namespace will be defaulted to all sidecars in the mesh that don't have any sidecar applied to. 

** Issue reference **

https://github.com/kiali/kiali/issues/1541

** Documentation **
![Screenshot of Kiali Console (25)](https://user-images.githubusercontent.com/613814/77168289-df87cd80-6ab7-11ea-9a3f-31508352e3ea.png)

