### PR TITLE
Backport Kiali#2483

### DIFF
--- a/graph/api/testdata/test_service_graph.expected
+++ b/graph/api/testdata/test_service_graph.expected
@@ -20,8 +20,7 @@
             {
               "protocol": "http",
               "rates": {
-                "httpIn": "20.00",
-                "httpOut": "20.00"
+                "httpIn": "20.00"
               }
             }
           ],
@@ -48,8 +47,7 @@
                 "httpIn": "80.00",
                 "httpIn3xx": "20.00",
                 "httpIn4xx": "20.00",
-                "httpIn5xx": "20.00",
-                "httpOut": "80.00"
+                "httpIn5xx": "20.00"
               }
             }
           ]
@@ -72,7 +70,13 @@
               "protocol": "http",
               "rates": {
                 "httpIn": "170.00",
-                "httpOut": "170.00"
+                "httpOut": "160.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpOut": "31.00"
               }
             }
           ]
@@ -95,8 +99,7 @@
               "protocol": "http",
               "rates": {
                 "httpIn": "60.00",
-                "httpIn5xx": "20.00",
-                "httpOut": "60.00"
+                "httpIn5xx": "20.00"
               }
             }
           ]
@@ -119,7 +122,7 @@
               "protocol": "http",
               "rates": {
                 "httpIn": "100.00",
-                "httpOut": "100.00"
+                "httpOut": "124.00"
               }
             }
           ]
@@ -141,8 +144,7 @@
             {
               "protocol": "tcp",
               "rates": {
-                "tcpIn": "581.00",
-                "tcpOut": "581.00"
+                "tcpIn": "581.00"
               }
             }
           ]
@@ -206,7 +208,7 @@
             {
               "protocol": "http",
               "rates": {
-                "httpOut": "100.00"
+                "httpOut": "50.00"
               }
             },
             {
@@ -354,7 +356,7 @@
             "protocol": "http",
             "rates": {
               "http": "50.00",
-              "httpPercentReq": "50.0"
+              "httpPercentReq": "100.0"
             },
             "responses": {
               "200": {
@@ -450,7 +452,7 @@
               "http": "4.00",
               "http4xx": "4.00",
               "httpPercentErr": "100.0",
-              "httpPercentReq": "5.4"
+              "httpPercentReq": "3.2"
             },
             "responses": {
               "404": {
@@ -474,7 +476,7 @@
             "protocol": "http",
             "rates": {
               "http": "20.00",
-              "httpPercentReq": "27.0"
+              "httpPercentReq": "16.1"
             },
             "responses": {
               "200": {
@@ -498,7 +500,7 @@
             "protocol": "http",
             "rates": {
               "http": "40.00",
-              "httpPercentReq": "80.0"
+              "httpPercentReq": "32.3"
             },
             "responses": {
               "200": {
@@ -524,7 +526,7 @@
               "http": "60.00",
               "http5xx": "20.00",
               "httpPercentErr": "33.3",
-              "httpPercentReq": "120.0"
+              "httpPercentReq": "48.4"
             },
             "responses": {
               "200": {

--- a/graph/protocol.go
+++ b/graph/protocol.go
@@ -228,6 +228,13 @@ func AddOutgoingEdgeToMetadata(sourceMetadata, edgeMetadata Metadata) {
 	}
 }
 
+// ResetOutgoingMetadata sets outgoing traffic to zero. This is useful for some graph type manipulations.
+func ResetOutgoingMetadata(sourceMetadata Metadata) {
+	delete(sourceMetadata, grpcOut)
+	delete(sourceMetadata, httpOut)
+	delete(sourceMetadata, tcpOut)
+}
+
 // AggregateNodeTraffic adds all <nodeMetadata> values (for all protocols) into aggregateNodeMetadata.
 func AggregateNodeTraffic(node, aggregateNode *Node) {
 	for _, protocol := range Protocols {


### PR DESCRIPTION
When building Service service graph ensure outgoing metrics reflect onl traffic from edges reflected in the final graph.

Backport: #2483 