### PR TITLE
Fixes for CVE-2020-1764 and CVE-2020-1762

### DIFF
--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -10,8 +10,6 @@ import (
 	"net/url"
 	"strings"
 
-	kube "k8s.io/client-go/kubernetes"
-
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 )
@@ -118,30 +116,6 @@ func getOAuthAuthorizationServer() (*OAuthAuthorizationServer, error) {
 	}
 
 	return server, nil
-}
-
-func (in *OpenshiftOAuthService) ValidateToken(token string) error {
-	k8sConfig, err := kubernetes.ConfigClient()
-
-	if err != nil {
-		return fmt.Errorf("could not connect to Openshift: %v", err)
-	}
-
-	k8sConfig.BearerToken = token
-
-	k8s, err := kube.NewForConfig(k8sConfig)
-
-	if err != nil {
-		return fmt.Errorf("could not get Openshift cluster config: %v", err)
-	}
-
-	_, err = k8s.Discovery().ServerVersion()
-
-	if err != nil {
-		return fmt.Errorf("could not get info from Openshift: %v", err)
-	}
-
-	return nil
 }
 
 func (in *OpenshiftOAuthService) GetUserInfo(token string) (*OAuthUser, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -172,7 +172,7 @@ type ExternalServices struct {
 	Tracing    TracingConfig    `yaml:"tracing,omitempty"`
 }
 
-// LoginToken holds config used in token-based authentication
+// LoginToken holds config used for generating the Kiali session tokens.
 type LoginToken struct {
 	ExpirationSeconds int64  `yaml:"expiration_seconds,omitempty"`
 	SigningKey        string `yaml:"signing_key,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ const (
 	AuthStrategyOpenshiftIssuer = "kiali-openshift"
 	AuthStrategyLoginIssuer     = "kiali-login"
 	AuthStrategyTokenIssuer     = "kiali-token"
+	AuthStrategyLDAPIssuer      = "kiali-ldap"
 
 	// These constants are used for external services auth (Prometheus, Grafana ...) ; not for Kiali auth
 	AuthTypeBasic  = "basic"

--- a/config/token.go
+++ b/config/token.go
@@ -38,6 +38,12 @@ func GetSigningKey() string {
 	cfg := Get()
 	signKey := cfg.LoginToken.SigningKey
 
+	if len(signKey) == 0 || signKey == "kiali" {
+		// "kiali" is a well-known signing key reported in a CVE. We ban it's usage.
+		// An empty key is also just not allowed.
+		panic("signing key for login tokens is invalid")
+	}
+
 	if cfg.Auth.Strategy == AuthStrategyLogin {
 		// If we are using "login" strategy, let's combine the login passphrase
 		// and the token signing key to form a new signing key. This way, if

--- a/config/token.go
+++ b/config/token.go
@@ -25,13 +25,28 @@ type TokenGenerated struct {
 
 func GetSignedTokenString(claims jwt.Claims) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	ss, err := token.SignedString([]byte(Get().LoginToken.SigningKey))
+	ss, err := token.SignedString([]byte(GetSigningKey()))
 
 	if err != nil {
 		return "", err
 	}
 
 	return ss, nil
+}
+
+func GetSigningKey() string {
+	cfg := Get()
+	signKey := cfg.LoginToken.SigningKey
+
+	if cfg.Auth.Strategy == AuthStrategyLogin {
+		// If we are using "login" strategy, let's combine the login passphrase
+		// and the token signing key to form a new signing key. This way, if
+		// either the login passphrase or the signing key is changed, active
+		// sessions will be invalidated.
+		signKey = fmt.Sprintf("%s+%s", signKey, cfg.Server.Credentials.Passphrase)
+	}
+
+	return signKey
 }
 
 // GenerateToken generates a signed token with an expiration of <ExpirationSeconds> seconds
@@ -65,7 +80,7 @@ func ValidateToken(tokenString string) (string, error) {
 
 func GetTokenClaimsIfValid(tokenString string) (*IanaClaims, error) {
 	token, err := jwt.ParseWithClaims(tokenString, &IanaClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return []byte(Get().LoginToken.SigningKey), nil
+		return []byte(GetSigningKey()), nil
 	})
 	if err != nil {
 		return nil, err
@@ -90,6 +105,17 @@ func GetTokenClaimsIfValid(tokenString string) (*IanaClaims, error) {
 		}
 		if claims.Issuer == AuthStrategyTokenIssuer && cfg.Auth.Strategy != AuthStrategyToken {
 			return nil, errors.New("token is invalid because of authentication strategy mismatch")
+		}
+
+		// A token with no expiration claim is invalid for Kiali
+		if claims.ExpiresAt == 0 {
+			return nil, errors.New("token is invalid because expiration claim is missing")
+		}
+
+		// If auth strategy is login and the subject claim does not match the username in the Kiali secret,
+		// the token is invalid.
+		if cfg.Auth.Strategy == AuthStrategyLogin && claims.Subject != cfg.Server.Credentials.Username {
+			return nil, errors.New("username has changed")
 		}
 
 		return token.Claims.(*IanaClaims), nil

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -425,6 +425,12 @@ func checkTokenSession(w http.ResponseWriter, r *http.Request) (int, string) {
 	if claims, err := config.GetTokenClaimsIfValid(tokenString); err != nil {
 		log.Warningf("Token is invalid: %s", err.Error())
 	} else {
+		// Session ID claim must be present
+		if len(claims.SessionId) == 0 {
+			log.Warning("Token is invalid: sid claim is required")
+			return http.StatusUnauthorized, ""
+		}
+
 		business, err := business.Get(claims.SessionId)
 		if err != nil {
 			log.Warning("Could not get the business layer : ", err)

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -172,12 +172,6 @@ func performOpenshiftAuthentication(w http.ResponseWriter, r *http.Request) bool
 		return false
 	}
 
-	err = business.OpenshiftOAuth.ValidateToken(token)
-	if err != nil {
-		RespondWithDetailedError(w, http.StatusUnauthorized, "Token is not valid or is expired.", err.Error())
-		return false
-	}
-
 	user, err := business.OpenshiftOAuth.GetUserInfo(token)
 	if err != nil {
 		RespondWithDetailedError(w, http.StatusUnauthorized, "Token is not valid or is expired.", err.Error())
@@ -284,13 +278,19 @@ func checkOpenshiftSession(w http.ResponseWriter, r *http.Request) (int, string)
 	if claims, err := config.GetTokenClaimsIfValid(tokenString); err != nil {
 		log.Warningf("Token is invalid: %s", err.Error())
 	} else {
+		// Session ID claim must be present
+		if len(claims.SessionId) == 0 {
+			log.Warning("Token is invalid: sid claim is required")
+			return http.StatusUnauthorized, ""
+		}
+
 		business, err := business.Get(claims.SessionId)
 		if err != nil {
 			log.Warning("Could not get the business layer : ", err)
 			return http.StatusInternalServerError, ""
 		}
 
-		err = business.OpenshiftOAuth.ValidateToken(claims.SessionId)
+		_, err = business.OpenshiftOAuth.GetUserInfo(claims.SessionId)
 		if err == nil {
 			// Internal header used to propagate the subject of the request for audit purposes
 			r.Header.Add("Kiali-User", claims.Subject)

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -20,7 +20,7 @@ import (
 type dummyHandler struct {
 }
 
-func (t dummyHandler) ServeHTTP(http.ResponseWriter, *http.Request) { }
+func (t dummyHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
 
 // TestStrategyLoginAuthentication checks that a user with no active
 // session is logged in successfully
@@ -117,7 +117,7 @@ func TestStrategyLoginInvalidSignature(t *testing.T) {
 	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(60)) // 1 minute expiration from now
 	customClaims := config.IanaClaims{
 		StandardClaims: jwt.StandardClaims{
-			Subject:   "foo",    // We use the "foo" user which should be valid
+			Subject:   "foo", // We use the "foo" user which should be valid
 			ExpiresAt: timeExpire.Unix(),
 			Issuer:    config.AuthStrategyLoginIssuer,
 		},
@@ -185,7 +185,7 @@ func TestStrategyLoginValidatesExpiration(t *testing.T) {
 	}
 
 	// Let's create a valid but expired token.
-	timeExpire := util.Clock.Now().Add(- time.Second * time.Duration(1)) // Expiration time is one second in the past
+	timeExpire := util.Clock.Now().Add(-time.Second * time.Duration(1)) // Expiration time is one second in the past
 	customClaims := config.IanaClaims{
 		StandardClaims: jwt.StandardClaims{
 			Subject:   "foo",
@@ -399,9 +399,9 @@ func TestStrategyLoginMissingExpiration(t *testing.T) {
 	// Let's create a valid token that does not expire.
 	customClaims := config.IanaClaims{
 		StandardClaims: jwt.StandardClaims{
-			 Subject:   "foo",
+			Subject: "foo",
 			// ExpiresAt: timeExpire.Unix(),
-			Issuer:    config.AuthStrategyLoginIssuer,
+			Issuer: config.AuthStrategyLoginIssuer,
 		},
 	}
 

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -3,16 +3,18 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/util"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/util"
+	"github.com/stretchr/testify/assert"
 )
 
 type dummyHandler struct {
@@ -23,8 +25,10 @@ func (t dummyHandler) ServeHTTP(http.ResponseWriter, *http.Request) { }
 // TestStrategyLoginAuthentication checks that a user with no active
 // session is logged in successfully
 func TestStrategyLoginAuthentication(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.LoginToken.SigningKey = util.RandomString(10)
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "bar"
 	config.Set(cfg)
@@ -65,8 +69,10 @@ func TestStrategyLoginAuthentication(t *testing.T) {
 // rejected as a valid authentication
 func TestStrategyLoginInvalidSignature(t *testing.T) {
 	// Set some config values to a known state
+	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.LoginToken.SigningKey = util.RandomString(10)
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "bar"
 	config.Set(cfg)
@@ -163,8 +169,10 @@ func TestStrategyLoginInvalidSignature(t *testing.T) {
 // of this, the Kiali backend must check the expiration Claim of the JWT token.
 func TestStrategyLoginValidatesExpiration(t *testing.T) {
 	// Set some config values to a known state
+	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.LoginToken.SigningKey = util.RandomString(10)
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "bar"
 	config.Set(cfg)
@@ -216,8 +224,10 @@ func TestStrategyLoginValidatesExpiration(t *testing.T) {
 // changes the Kiali configuration.
 func TestStrategyLoginValidatesUserChange(t *testing.T) {
 	// Set some config values to a known state
+	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.LoginToken.SigningKey = util.RandomString(10)
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "bar"
 	config.Set(cfg)
@@ -268,8 +278,10 @@ func TestStrategyLoginValidatesUserChange(t *testing.T) {
 // to the Kiali configuration
 func TestStrategyLoginValidatesPasswordChange(t *testing.T) {
 	// Set some config values to a known state
+	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.LoginToken.SigningKey = util.RandomString(10)
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "bar"
 	config.Set(cfg)
@@ -294,7 +306,6 @@ func TestStrategyLoginValidatesPasswordChange(t *testing.T) {
 
 	// OK, authentication succeeded and we have a token.
 	// Let's change the passphrase for logging into Kiali.
-	cfg = config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "newValue"
@@ -324,8 +335,10 @@ func TestStrategyLoginValidatesPasswordChange(t *testing.T) {
 // that the username field is populated in the Kiali auth token.
 func TestStrategyLoginMissingUser(t *testing.T) {
 	// Set some config values to a known state
+	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.LoginToken.SigningKey = util.RandomString(10)
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "bar"
 	config.Set(cfg)
@@ -375,8 +388,10 @@ func TestStrategyLoginMissingUser(t *testing.T) {
 // that the expiration date claim is populated in the Kiali auth token.
 func TestStrategyLoginMissingExpiration(t *testing.T) {
 	// Set some config values to a known state
+	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.LoginToken.SigningKey = util.RandomString(10)
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "bar"
 	config.Set(cfg)
@@ -453,8 +468,10 @@ func TestStrategyLoginExtend(t *testing.T) {
 		return util.Clock.Now()
 	}
 
+	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.LoginToken.SigningKey = util.RandomString(10)
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "bar"
 	config.Set(cfg)
@@ -499,8 +516,10 @@ func TestStrategyLoginRejectStaleExtension(t *testing.T) {
 		return util.Clock.Now()
 	}
 
+	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.LoginToken.SigningKey = util.RandomString(10)
 	cfg.Server.Credentials.Username = "foo"
 	cfg.Server.Credentials.Passphrase = "bar"
 	config.Set(cfg)

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/util"
@@ -9,9 +10,15 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
+
+type dummyHandler struct {
+}
+
+func (t dummyHandler) ServeHTTP(http.ResponseWriter, *http.Request) { }
 
 // TestStrategyLoginAuthentication checks that a user with no active
 // session is logged in successfully
@@ -42,6 +49,359 @@ func TestStrategyLoginAuthentication(t *testing.T) {
 
 	assert.NotEmpty(t, cookie.Value)
 	assert.Equal(t, clockTime.Add(time.Second*time.Duration(cfg.LoginToken.ExpirationSeconds)), cookie.Expires)
+}
+
+// TestStrategyLoginInvalidSignature checks that an altered JWT token is
+// rejected as a valid authentication
+func TestStrategyLoginInvalidSignature(t *testing.T) {
+	// Set some config values to a known state
+	cfg := config.NewConfig()
+	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.Server.Credentials.Username = "foo"
+	cfg.Server.Credentials.Passphrase = "bar"
+	config.Set(cfg)
+
+	// Mock the clock
+	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+	jwt.TimeFunc = func() time.Time {
+		return util.Clock.Now()
+	}
+
+	// First go through authentication to get a kiali cookie.
+	authRequest := httptest.NewRequest("GET", "http://kiali/api/authenticate", nil)
+	authRequest.SetBasicAuth("foo", "bar")
+
+	responseRecorder := httptest.NewRecorder()
+	Authenticate(responseRecorder, authRequest)
+	response := responseRecorder.Result()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Len(t, response.Cookies(), 1)
+
+	// Decode the JWT token in the cookie
+	cookie := response.Cookies()[0]
+	assert.Equal(t, config.TokenCookieName, cookie.Name)
+
+	token, err := jwt.ParseWithClaims(cookie.Value, &config.IanaClaims{}, func(token *jwt.Token) (interface{}, error) {
+		return []byte(config.Get().LoginToken.SigningKey), nil
+	})
+
+	assert.Nil(t, err)
+	assert.True(t, token.Valid) // Sanity check. The token should always be valid.
+
+	// Get the raw token
+	tokenString := token.Raw
+
+	// OK, authentication succeeded and we have a token.
+	// Let's create a hacked token with a mutated payload. The header and signature of the
+	// token will be kept unchanged.
+
+	// Build custom claims
+	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(60)) // 1 minute expiration from now
+	customClaims := config.IanaClaims{
+		StandardClaims: jwt.StandardClaims{
+			Subject:   "foo",    // We use the "foo" user which should be valid
+			ExpiresAt: timeExpire.Unix(),
+			Issuer:    config.AuthStrategyLoginIssuer,
+		},
+	}
+
+	// Get JSON string of our customized claims
+	jsonValue, err := json.Marshal(customClaims)
+	assert.Nil(t, err)
+
+	// Hack the token.
+	tokenEntries := strings.Split(tokenString, ".")
+	tokenEntries[1] = jwt.EncodeSegment(jsonValue) // Second entry is the payload
+	tokenString = strings.Join(tokenEntries, ".")
+
+	// Now that we have a "hacked" token with a new expiration date, lets
+	// use it to invoke the authentication handler (which is invoked on all protected endpoints).
+
+	// Build the request with the cookie
+	maliciousRequest := httptest.NewRequest("GET", "http://kiali/api/foo", nil)
+	hackedCookie := http.Cookie{
+		Name:  config.TokenCookieName,
+		Value: tokenString,
+	}
+	maliciousRequest.AddCookie(&hackedCookie)
+
+	// Setup authentication handler
+	authenticationHandler, _ := NewAuthenticationHandler()
+	handler := authenticationHandler.Handle(new(dummyHandler))
+
+	// Run the malicious request
+	maliciousResponseRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(maliciousResponseRecorder, maliciousRequest)
+	hackedResponse := maliciousResponseRecorder.Result()
+
+	// Server should return an unauthorized response code.
+	// Body should be the text explanation of the HTTP error
+	body, _ := ioutil.ReadAll(hackedResponse.Body)
+	assert.Equal(t, http.StatusUnauthorized, hackedResponse.StatusCode)
+	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
+}
+
+// TestStrategyLoginValidUser checks that the Kiali back-end is
+// correctly checking the expiration time of the Kiali token.
+//
+// Assuming that a malicious user has stolen the Kiali token of a user,
+// that user may use it to make requests to the Kiali API. The expiration
+// date of the token and the browser's cookie should be in sync. But a malicious
+// user may want to create his own cookie and use with the stolen token. Because
+// of this, the Kiali backend must check the expiration Claim of the JWT token.
+func TestStrategyLoginValidatesExpiration(t *testing.T) {
+	// Set some config values to a known state
+	cfg := config.NewConfig()
+	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.Server.Credentials.Username = "foo"
+	cfg.Server.Credentials.Passphrase = "bar"
+	config.Set(cfg)
+
+	// Mock the clock
+	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+	jwt.TimeFunc = func() time.Time {
+		return util.Clock.Now()
+	}
+
+	// Let's create a valid but expired token.
+	timeExpire := util.Clock.Now().Add(- time.Second * time.Duration(1)) // Expiration time is one second in the past
+	customClaims := config.IanaClaims{
+		StandardClaims: jwt.StandardClaims{
+			Subject:   "foo",
+			ExpiresAt: timeExpire.Unix(),
+			Issuer:    config.AuthStrategyLoginIssuer,
+		},
+	}
+
+	token, _ := config.GetSignedTokenString(customClaims)
+
+	// Let's simulate a request with the expired token
+	request := httptest.NewRequest("GET", "http://kiali/api/foo", nil)
+	cookie := http.Cookie{
+		Name:  config.TokenCookieName,
+		Value: token,
+	}
+	request.AddCookie(&cookie)
+
+	authenticationHandler, _ := NewAuthenticationHandler()
+	handler := authenticationHandler.Handle(new(dummyHandler))
+
+	responseRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(responseRecorder, request)
+	response := responseRecorder.Result()
+
+	// Server should return an unauthorized response code.
+	// Body should be the text explanation of the HTTP error
+	body, _ := ioutil.ReadAll(response.Body)
+	assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
+}
+
+// TestStrategyLoginValidatesUserChange checks that the Kiali back-end is verifying that
+// the user specified in a Kiali token matches to the user in the configuration.
+// This is for a scenario where logged in users should be kicked if an administrator
+// changes the Kiali configuration.
+func TestStrategyLoginValidatesUserChange(t *testing.T) {
+	// Set some config values to a known state
+	cfg := config.NewConfig()
+	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.Server.Credentials.Username = "foo"
+	cfg.Server.Credentials.Passphrase = "bar"
+	config.Set(cfg)
+
+	// Mock the clock
+	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+	jwt.TimeFunc = func() time.Time {
+		return util.Clock.Now()
+	}
+
+	// Let's create a valid token with a user not matching the one from the config.
+	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(1))
+	customClaims := config.IanaClaims{
+		StandardClaims: jwt.StandardClaims{
+			Subject:   "dummy", // wrong user
+			ExpiresAt: timeExpire.Unix(),
+			Issuer:    config.AuthStrategyLoginIssuer,
+		},
+	}
+
+	token, _ := config.GetSignedTokenString(customClaims)
+
+	// Let's simulate a request
+	request := httptest.NewRequest("GET", "http://kiali/api/foo", nil)
+	cookie := http.Cookie{
+		Name:  config.TokenCookieName,
+		Value: token,
+	}
+	request.AddCookie(&cookie)
+
+	authenticationHandler, _ := NewAuthenticationHandler()
+	handler := authenticationHandler.Handle(new(dummyHandler))
+
+	responseRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(responseRecorder, request)
+	response := responseRecorder.Result()
+
+	// Server should return an unauthorized response code.
+	// Body should be the text explanation of the HTTP error
+	body, _ := ioutil.ReadAll(response.Body)
+	assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
+}
+
+// TestStrategyLoginValidatesPasswordChange checks that the Kiali back-end is verifying that
+// session of currently logged in users are terminated if a password change is made
+// to the Kiali configuration
+func TestStrategyLoginValidatesPasswordChange(t *testing.T) {
+	// Set some config values to a known state
+	cfg := config.NewConfig()
+	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.Server.Credentials.Username = "foo"
+	cfg.Server.Credentials.Passphrase = "bar"
+	config.Set(cfg)
+
+	// Mock the clock
+	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+	jwt.TimeFunc = func() time.Time {
+		return util.Clock.Now()
+	}
+
+	// First go through authentication to get a kiali cookie.
+	authRequest := httptest.NewRequest("GET", "http://kiali/api/authenticate", nil)
+	authRequest.SetBasicAuth("foo", "bar")
+
+	authResponseRecorder := httptest.NewRecorder()
+	Authenticate(authResponseRecorder, authRequest)
+	authResponse := authResponseRecorder.Result()
+
+	assert.Equal(t, http.StatusOK, authResponse.StatusCode)
+	assert.Len(t, authResponse.Cookies(), 1)
+
+	// OK, authentication succeeded and we have a token.
+	// Let's change the passphrase for logging into Kiali.
+	cfg = config.NewConfig()
+	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.Server.Credentials.Username = "foo"
+	cfg.Server.Credentials.Passphrase = "newValue"
+	config.Set(cfg)
+
+	// Make a request using the Kiali token generated with the old credentials.
+	request := httptest.NewRequest("GET", "http://kiali/api/foo", nil)
+	request.AddCookie(authResponse.Cookies()[0])
+
+	// Setup authentication handler
+	authenticationHandler, _ := NewAuthenticationHandler()
+	handler := authenticationHandler.Handle(new(dummyHandler))
+
+	// Run the request
+	responseRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(responseRecorder, request)
+	response := responseRecorder.Result()
+
+	// Server should return an unauthorized authResponse code.
+	// Body should be the text explanation of the HTTP error
+	body, _ := ioutil.ReadAll(response.Body)
+	assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
+}
+
+// TestStrategyLoginMissingUser checks that the Kiali back-end is ensuring
+// that the username field is populated in the Kiali auth token.
+func TestStrategyLoginMissingUser(t *testing.T) {
+	// Set some config values to a known state
+	cfg := config.NewConfig()
+	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.Server.Credentials.Username = "foo"
+	cfg.Server.Credentials.Passphrase = "bar"
+	config.Set(cfg)
+
+	// Mock the clock
+	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+	jwt.TimeFunc = func() time.Time {
+		return util.Clock.Now()
+	}
+
+	// Let's create a valid token without subject.
+	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(1))
+	customClaims := config.IanaClaims{
+		StandardClaims: jwt.StandardClaims{
+			// Subject:   "foo",
+			ExpiresAt: timeExpire.Unix(),
+			Issuer:    config.AuthStrategyLoginIssuer,
+		},
+	}
+
+	token, _ := config.GetSignedTokenString(customClaims)
+
+	// Let's simulate a request
+	request := httptest.NewRequest("GET", "http://kiali/api/foo", nil)
+	cookie := http.Cookie{
+		Name:  config.TokenCookieName,
+		Value: token,
+	}
+	request.AddCookie(&cookie)
+
+	authenticationHandler, _ := NewAuthenticationHandler()
+	handler := authenticationHandler.Handle(new(dummyHandler))
+
+	responseRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(responseRecorder, request)
+	response := responseRecorder.Result()
+
+	// Server should return an unauthorized response code.
+	// Body should be the text explanation of the HTTP error
+	body, _ := ioutil.ReadAll(response.Body)
+	assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
+}
+
+// TestStrategyLoginMissingExpiration checks that the Kiali back-end is ensuring
+// that the expiration date claim is populated in the Kiali auth token.
+func TestStrategyLoginMissingExpiration(t *testing.T) {
+	// Set some config values to a known state
+	cfg := config.NewConfig()
+	cfg.Auth.Strategy = config.AuthStrategyLogin
+	cfg.Server.Credentials.Username = "foo"
+	cfg.Server.Credentials.Passphrase = "bar"
+	config.Set(cfg)
+
+	// Let's create a valid token that does not expire.
+	customClaims := config.IanaClaims{
+		StandardClaims: jwt.StandardClaims{
+			 Subject:   "foo",
+			// ExpiresAt: timeExpire.Unix(),
+			Issuer:    config.AuthStrategyLoginIssuer,
+		},
+	}
+
+	token, _ := config.GetSignedTokenString(customClaims)
+
+	// Let's simulate a request
+	request := httptest.NewRequest("GET", "http://kiali/api/foo", nil)
+	cookie := http.Cookie{
+		Name:  config.TokenCookieName,
+		Value: token,
+	}
+	request.AddCookie(&cookie)
+
+	authenticationHandler, _ := NewAuthenticationHandler()
+	handler := authenticationHandler.Handle(new(dummyHandler))
+
+	responseRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(responseRecorder, request)
+	response := responseRecorder.Result()
+
+	// Server should return an unauthorized response code.
+	// Body should be the text explanation of the HTTP error
+	body, _ := ioutil.ReadAll(response.Body)
+	assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
 }
 
 // TestStrategyLoginFails checks that a login attempt is

--- a/kiali.go
+++ b/kiali.go
@@ -215,6 +215,14 @@ func validateConfig() error {
 		return fmt.Errorf("Auth strategy is LDAP but there is no LDAP configuration")
 	}
 
+	// Check the signing key for the JWT token is valid
+	signingKey := config.Get().LoginToken.SigningKey
+	if len(signingKey) == 0 || signingKey == "kiali" {
+		// "kiali" is a well-known signing key reported in a CVE. We ban it's usage.
+		// An empty key is also just not allowed.
+		return fmt.Errorf("signing key for login tokens is invalid")
+	}
+
 	return nil
 }
 

--- a/kiali_test.go
+++ b/kiali_test.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/util"
 )
 
 func TestValidateWebRoot(t *testing.T) {
 	// create a base config that we know is valid
+	rand.Seed(time.Now().UnixNano())
 	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = util.RandomString(10)
 	conf.Server.StaticContentRootDirectory = "."
 	conf.Auth.Strategy = "anonymous"
 

--- a/ldap/models.go
+++ b/ldap/models.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"fmt"
+	"github.com/kiali/kiali/config"
 	"time"
 )
 
@@ -26,6 +27,7 @@ type JWTClaimsJSON struct {
 	Username string   `json:"username"`
 	Expiry   int      `json:"exp"`
 	Groups   []string `json:"groups"`
+	Issuer    string  `json:"iss,omitempty"`
 }
 
 // Valid so that JWTClaimsJSON satisfies the jwt.Claims interface
@@ -41,6 +43,9 @@ func (c *JWTClaimsJSON) Valid() error {
 	}
 	if c.Iat > int(time.Now().Unix()+int64(time.Second)) {
 		return fmt.Errorf("Token is from the future")
+	}
+	if c.Issuer != config.AuthStrategyLDAPIssuer {
+		return fmt.Errorf("token is invalid because of authentication strategy mismatch")
 	}
 	return nil
 }

--- a/ldap/models.go
+++ b/ldap/models.go
@@ -27,7 +27,7 @@ type JWTClaimsJSON struct {
 	Username string   `json:"username"`
 	Expiry   int      `json:"exp"`
 	Groups   []string `json:"groups"`
-	Issuer    string  `json:"iss,omitempty"`
+	Issuer   string   `json:"iss,omitempty"`
 }
 
 // Valid so that JWTClaimsJSON satisfies the jwt.Claims interface

--- a/operator/deploy/kiali/kiali_cr.yaml
+++ b/operator/deploy/kiali/kiali_cr.yaml
@@ -604,8 +604,10 @@ spec:
 # value in a secret. If you store this signing key value in a secret, you
 # must indicate what key in what secret by setting this value to a string
 # in the form of "secret:<secretName>:<secretKey>"
+# If left as an empty string, a secret with a random signing key will be
+# generated for you.
 #    ---
-#    signing_key: "kiali"
+#    signing_key: ""
 
 ##########
 #  ---

--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -32,6 +32,23 @@ rules:
   - get
   - list
   - patch
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups: [""]
+  resourceNames:
+  - kiali-signing-key
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups: ["apps"]
   resources:
   - deployments

--- a/operator/deploy/role.yaml
+++ b/operator/deploy/role.yaml
@@ -37,6 +37,8 @@ rules:
   - secrets
   verbs:
   - create
+  - list
+  - watch
 - apiGroups: [""]
   resourceNames:
   - kiali-signing-key

--- a/operator/manifests/kiali-community/1.15.1/kiali.crd.yaml
+++ b/operator/manifests/kiali-community/1.15.1/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-community/1.15.1/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-community/1.15.1/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-community/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
@@ -334,6 +334,8 @@ spec:
           - secrets
           verbs:
           - create
+          - list
+          - watch
         - apiGroups: [""]
           resourceNames:
           - kiali-signing-key

--- a/operator/manifests/kiali-community/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
@@ -1,0 +1,570 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.15.1
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.15.1
+    capabilities: Deep Insights
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2020-03-03T21:51:46Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "istio-system",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.15.1
+  maturity: stable
+  replaces: kiali-operator.v1.13.0
+  displayName: Kiali Operator
+  description: |-
+    ## About the managed application
+
+    A Microservice Architecture breaks up the monolith into many smaller pieces
+    that are composed together. Patterns to secure the communication between
+    services like fault tolerance (via timeout, retry, circuit breaking, etc.)
+    have come up as well as distributed tracing to be able to see where calls
+    are going.
+
+    A service mesh can now provide these services on a platform level and frees
+    the application writers from those tasks. Routing decisions are done at the
+    mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service
+    mesh topology, to provide visibility into features like circuit breakers,
+    request rates and more. It offers insights about the mesh components at
+    different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift
+    or Ingress on Kubernetes.
+
+    On OpenShift, the default root context path is '/' and on Kubernetes it is
+    '/kiali' though you can change this by configuring the 'web_root' setting in
+    the Kiali CR.
+
+    ## About this Operator
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali
+    Custom Resource (CR), see the file
+    [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.15.1/operator/deploy/kiali/kiali_cr.yaml)
+
+    Note that the Kiali operator can be told to restrict Kiali's access to
+    specific namespaces, or can provide to Kiali cluster-wide access to all
+    namespaces.
+
+    ## Prerequisites for enabling this Operator
+
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio. Note that Istio can come pre-bundled with Kiali
+    (specifically if you installed the Istio demo helm profile or if you
+    installed Istio with the helm option '--set kiali.enabled=true'). If you
+    already have the pre-bundled Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first.
+    You can do this via this command,
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `login`. When using the
+    authentication strategy of `login`, you are required to create a Kubernetes
+    Secret with a `username` and `passphrase` that you want users to provide in
+    order to successfully log into Kiali. Here is an example command you can
+    execute to create such a secret (with a username of `admin` and a passphrase
+    of `admin`),
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    If you wish to use the "ldap" authentication strategy, you must have an LDAP
+    server available and accessible to Kiali.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.15.1
+              annotations:
+                prometheus.io/scrape: "true"
+                prometheus.io/port: "8383"
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.15.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.15.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: [""]
+          resources:
+          - secrets
+          verbs:
+          - create
+        - apiGroups: [""]
+          resourceNames:
+          - kiali-signing-key
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.istio.io
+          - networking.istio.io
+          - authentication.istio.io
+          - rbac.istio.io
+          - security.istio.io
+          resources: ["*"]
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-community/kiali.package.yaml
+++ b/operator/manifests/kiali-community/kiali.package.yaml
@@ -1,7 +1,7 @@
 packageName: kiali
 channels:
 - name: alpha
-  currentCSV: kiali-operator.v1.13.0
+  currentCSV: kiali-operator.v1.15.1
 - name: stable
-  currentCSV: kiali-operator.v1.13.0
+  currentCSV: kiali-operator.v1.15.1
 defaultChannel: stable

--- a/operator/manifests/kiali-upstream/1.15.1/kiali.crd.yaml
+++ b/operator/manifests/kiali-upstream/1.15.1/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/operator/manifests/kiali-upstream/1.15.1/kiali.monitoringdashboards.crd.yaml
+++ b/operator/manifests/kiali-upstream/1.15.1/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/operator/manifests/kiali-upstream/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
@@ -1,0 +1,570 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.15.1
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.15.1
+    capabilities: Deep Insights
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2020-03-03T21:51:56Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "default",
+              "verbose_mode": "4",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.15.1
+  maturity: stable
+  replaces: kiali-operator.v1.13.0
+  displayName: Kiali Operator
+  description: |-
+    ## About the managed application
+
+    A Microservice Architecture breaks up the monolith into many smaller pieces
+    that are composed together. Patterns to secure the communication between
+    services like fault tolerance (via timeout, retry, circuit breaking, etc.)
+    have come up as well as distributed tracing to be able to see where calls
+    are going.
+
+    A service mesh can now provide these services on a platform level and frees
+    the application writers from those tasks. Routing decisions are done at the
+    mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service
+    mesh topology, to provide visibility into features like circuit breakers,
+    request rates and more. It offers insights about the mesh components at
+    different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift
+    or Ingress on Kubernetes.
+
+    On OpenShift, the default root context path is '/' and on Kubernetes it is
+    '/kiali' though you can change this by configuring the 'web_root' setting in
+    the Kiali CR.
+
+    ## About this Operator
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali
+    Custom Resource (CR), see the file
+    [kiali_cr.yaml](https://github.com/kiali/kiali/blob/v1.15.1/operator/deploy/kiali/kiali_cr.yaml)
+
+    Note that the Kiali operator can be told to restrict Kiali's access to
+    specific namespaces, or can provide to Kiali cluster-wide access to all
+    namespaces.
+
+    ## Prerequisites for enabling this Operator
+
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio. Note that Istio can come pre-bundled with Kiali
+    (specifically if you installed the Istio demo helm profile or if you
+    installed Istio with the helm option '--set kiali.enabled=true'). If you
+    already have the pre-bundled Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first.
+    You can do this via this command,
+
+        kubectl delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n istio-system
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `login`. When using the
+    authentication strategy of `login`, you are required to create a Kubernetes
+    Secret with a `username` and `passphrase` that you want users to provide in
+    order to successfully log into Kiali. Here is an example command you can
+    execute to create such a secret (with a username of `admin` and a passphrase
+    of `admin`),
+
+        kubectl create secret generic kiali -n istio-system --from-literal "username=admin" --from-literal "passphrase=admin"
+
+    If you wish to use the "ldap" authentication strategy, you must have an LDAP
+    server available and accessible to Kiali.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Getting Started Guide
+    url: https://www.kiali.io/documentation/getting-started/
+  - name: Features
+    url: https://www.kiali.io/documentation/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Choose 'login' to use a username and passphrase as defined in a Secret. Choose 'anonymous' to allow full access to Kiali without requiring credentials (use this at your own risk). Choose 'openshift' if on OpenShift to use the OpenShift OAuth login which controls access based on the individual's OpenShift RBAC roles. Default: openshift (when deployed in OpenShift); login (when deployed in Kubernetes)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Secret Name
+        description: "If Kiali is configured with auth.strategy 'login', an admin must create a Secret with credentials ('username' and 'passphrase') which will be used to authenticate users logging into Kiali. This setting defines the name of that secret. Default: kiali"
+        path: deployment.secret_name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Secret'
+      - displayName: Verbose Mode
+        description: "Determines the priority levels of log messages Kiali will output. Typical values are '3' for INFO and higher priority messages, '4' for DEBUG and higher priority messages (this makes the logs more noisy). Default: 3"
+        path: deployment.verbose_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                version: v1.15.1
+              annotations:
+                prometheus.io/scrape: "true"
+                prometheus.io/port: "8383"
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: ansible
+                command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/kiali/kiali-operator:v1.15.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.15.1
+                imagePullPolicy: "IfNotPresent"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_NAME
+                  value: "kiali-operator"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: [""]
+          resources:
+          - secrets
+          verbs:
+          - create
+        - apiGroups: [""]
+          resourceNames:
+          - kiali-signing-key
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.istio.io
+          - networking.istio.io
+          - authentication.istio.io
+          - rbac.istio.io
+          - security.istio.io
+          resources: ["*"]
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        serviceAccountName: kiali-operator

--- a/operator/manifests/kiali-upstream/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
@@ -334,6 +334,8 @@ spec:
           - secrets
           verbs:
           - create
+          - list
+          - watch
         - apiGroups: [""]
           resourceNames:
           - kiali-signing-key

--- a/operator/manifests/kiali-upstream/kiali.package.yaml
+++ b/operator/manifests/kiali-upstream/kiali.package.yaml
@@ -1,7 +1,7 @@
 packageName: kiali
 channels:
 - name: alpha
-  currentCSV: kiali-operator.v1.13.0
+  currentCSV: kiali-operator.v1.15.1
 - name: stable
-  currentCSV: kiali-operator.v1.13.0
+  currentCSV: kiali-operator.v1.15.1
 defaultChannel: stable

--- a/operator/roles/default/kiali-deploy/defaults/main.yml
+++ b/operator/roles/default/kiali-deploy/defaults/main.yml
@@ -162,7 +162,7 @@ kiali_defaults:
 
   login_token:
     expiration_seconds: 86400
-    signing_key: "kiali"
+    signing_key: ""
 
   server:
     address: ""

--- a/operator/roles/default/kiali-deploy/tasks/main.yml
+++ b/operator/roles/default/kiali-deploy/tasks/main.yml
@@ -437,6 +437,31 @@
   # this regex is not 100% accurate, but we want to at least catch obvious errors
   - kiali_vars.api.namespaces.label_selector is not regex('^[a-zA-Z0-9/_.-]+=[a-zA-Z0-9_.-]+$')
 
+# Prepare a random signing key if one needs to be generated
+
+- name: Create secret to store a random signing key
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: kiali-signing-key
+        namespace: "{{ kiali_vars.deployment.namespace }}"
+        labels:
+          app: kiali
+          version: "{{ kiali_vars.deployment.version_label }}"
+      type: Opaque
+      data:
+        key: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}"
+  when:
+  - kiali_vars.login_token.signing_key == ""
+- name: Point signing key to the generated secret
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'login_token': {'signing_key': 'secret:kiali-signing-key:key'}}, recursive=True) }}"
+  when:
+  - kiali_vars.login_token.signing_key == ""
+
 # Prepare any additional environment variables that need to be defined in the deployment
 
 - set_fact:

--- a/operator/roles/default/kiali-remove/tasks/main.yml
+++ b/operator/roles/default/kiali-remove/tasks/main.yml
@@ -137,6 +137,7 @@
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali', api_version='v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
   loop_control:
     loop_var: k8s_item
 

--- a/operator/roles/v1.0/kiali-deploy/defaults/main.yml
+++ b/operator/roles/v1.0/kiali-deploy/defaults/main.yml
@@ -99,7 +99,7 @@ kiali_defaults:
     cache_duration: 300000000
 
   login_token:
-    signing_key: "kiali"
+    signing_key: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}"
     expiration_seconds: 86400
 
   server:

--- a/operator/roles/v1.0/kiali-remove/tasks/main.yml
+++ b/operator/roles/v1.0/kiali-remove/tasks/main.yml
@@ -137,6 +137,7 @@
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali', api_version='v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
   loop_control:
     loop_var: k8s_item
 

--- a/operator/roles/v1.12/kiali-deploy/defaults/main.yml
+++ b/operator/roles/v1.12/kiali-deploy/defaults/main.yml
@@ -160,7 +160,7 @@ kiali_defaults:
 
   login_token:
     expiration_seconds: 86400
-    signing_key: "kiali"
+    signing_key: ""
 
   server:
     address: ""

--- a/operator/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/operator/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -428,6 +428,31 @@
   # this regex is not 100% accurate, but we want to at least catch obvious errors
   - kiali_vars.api.namespaces.label_selector is not regex('^[a-zA-Z0-9/_.-]+=[a-zA-Z0-9_.-]+$')
 
+# Prepare a random signing key if one needs to be generated
+
+- name: Create secret to store a random signing key
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: kiali-signing-key
+        namespace: "{{ kiali_vars.deployment.namespace }}"
+        labels:
+          app: kiali
+          version: "{{ kiali_vars.deployment.version_label }}"
+      type: Opaque
+      data:
+        key: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}"
+  when:
+  - kiali_vars.login_token.signing_key == ""
+- name: Point signing key to the generated secret
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'login_token': {'signing_key': 'secret:kiali-signing-key:key'}}, recursive=True) }}"
+  when:
+  - kiali_vars.login_token.signing_key == ""
+
 # Prepare any additional environment variables that need to be defined in the deployment
 
 - set_fact:

--- a/operator/roles/v1.12/kiali-remove/tasks/main.yml
+++ b/operator/roles/v1.12/kiali-remove/tasks/main.yml
@@ -137,6 +137,7 @@
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali', api_version='v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
   loop_control:
     loop_var: k8s_item
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	rnd "math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -44,7 +45,9 @@ func TestRootContextPath(t *testing.T) {
 	testServerHostPort := fmt.Sprintf("%v:%v", testHostname, testPort)
 	testCustomRoot := "/customroot"
 
+	rnd.Seed(time.Now().UnixNano())
 	conf := new(config.Config)
+	conf.LoginToken.SigningKey = util.RandomString(10)
 	conf.Server.WebRoot = testCustomRoot
 	conf.Server.Address = testHostname
 	conf.Server.Port = testPort
@@ -184,9 +187,11 @@ func TestSecureComm(t *testing.T) {
 	defer os.Remove(testClientCertFile)
 	defer os.Remove(testClientKeyFile)
 
+	rnd.Seed(time.Now().UnixNano())
 	conf := new(config.Config)
 	conf.Identity.CertFile = testServerCertFile
 	conf.Identity.PrivateKeyFile = testServerKeyFile
+	conf.LoginToken.SigningKey = util.RandomString(10)
 	conf.Server.Address = testHostname
 	conf.Server.Port = testPort
 	conf.Server.StaticContentRootDirectory = tmpDir

--- a/util/random.go
+++ b/util/random.go
@@ -1,0 +1,17 @@
+package util
+
+import "math/rand"
+
+// RandomString generates a random string of length n. Before calling this function, you should call
+// rand.Seed() to initialize the default source.
+//
+// Found at https://ispycode.com/Blog/golang/2016-10/How-to-generate-a-random-string-of-a-fixed-length
+func RandomString(n int) string {
+	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}


### PR DESCRIPTION

Bringing to master fixes for bulleting [KIALI-SECURITY-001](https://kiali.io/news/security-bulletins/kiali-security-001/)

---

* [operator] generate random signing key by default
* Strengthen security of Kiali session with some additional validations

---

This is fixing some issues around authentication mechanisms.

For **all** auth strategies: 
* All sessions are invalidated if the signing key is changed
* If subject and/or expiration claims are missing in the Kiali token, the token is rejected and user is treated as not logged in.
* Usage of empty signing key (which provides no security) and *kiali* signing key (which is a well-known key) are now banned. Kiali server won't start and/or will panic if these keys are configured.

For **login** auth strategy:
* All sessions will be invalidated if username and/or passphrase are changed (mismatch between configured username/password and the data from the token)
* Add tests validation the behavior of this strategy.

For **openshift** auth strategy:
* Require presence of sid claim in the Kiali token
* Do proper validation of the OpenShift session token
  * Looks like ValidateToken method in openshift_oauth.go source is using endpoints of the cluster API which are unprotected. So, the session token was being ignored by the cluster API effectively meaning that the token wasn't being validated. This was allowing malicious requests to be processed by Kiali.
  * Removing that ValidateToken method and using GetUserInfo as a replacement.

For **token** auth strategy:
* Require presence of sid claim in the Kiali token

For **ldap** auth strategy:
* Add the "issuer" claim in the token, and require it when validating it on every request.

