### PR TITLE
[operator] trivial change to manifest created date

### DIFF
--- a/operator/manifests/kiali-community/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-community/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     support: Kiali
     description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
     repository: https://github.com/kiali/kiali
-    createdAt: 2020-03-03T21:51:46Z
+    createdAt: 2020-03-25T00:00:00Z
     alm-examples: |-
       [
         {

--- a/operator/manifests/kiali-upstream/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-upstream/1.15.1/kiali.v1.15.1.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     support: Kiali
     description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
     repository: https://github.com/kiali/kiali
-    createdAt: 2020-03-03T21:51:56Z
+    createdAt: 2020-03-25T00:00:00Z
     alm-examples: |-
       [
         {


### PR DESCRIPTION
This is a trivial change to the community/upstream manifests - changes the created date to indicate the time this release was uploaded to the community repo.