### PR TITLE
Fix rest.Config use https when incluster is false

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -198,7 +198,7 @@ func ConfigClient() (*rest.Config, error) {
 	}
 	return &rest.Config{
 		// TODO: switch to using cluster DNS.
-		Host:  "http://" + net.JoinHostPort(host, port),
+		Host:  "https://" + net.JoinHostPort(host, port),
 		QPS:   kialiConfig.Get().KubernetesConfig.QPS,
 		Burst: kialiConfig.Get().KubernetesConfig.Burst,
 	}, nil


### PR DESCRIPTION
** Describe the change **

use https instead of http

** Issue reference **

None

** Backwards incompatible? **

- Is your change introducing backwards incompatible changes?

no

** Documentation **

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
If so, please also update README.adoc
