### PR TITLE
V1.12: Add GRPC status as dashboards available aggregation/filters

### DIFF
--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -32,7 +32,7 @@ func TestGetIstioDashboard(t *testing.T) {
 
 	assert.Nil(err)
 	assert.Equal("Inbound Metrics", dashboard.Title)
-	assert.Len(dashboard.Aggregations, 5)
+	assert.Len(dashboard.Aggregations, 6)
 	assert.Equal("Local version", dashboard.Aggregations[0].DisplayName)
 	assert.Equal("destination_version", dashboard.Aggregations[0].Label)
 	assert.Equal("Remote app", dashboard.Aggregations[1].DisplayName)

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -54,6 +54,10 @@ func buildIstioAggregations(local, remote string) []kmodel.Aggregation {
 			DisplayName: "Response code",
 		},
 		{
+			Label:       "grpc_response_status",
+			DisplayName: "GRPC status",
+		},
+		{
 			Label:       "response_flags",
 			DisplayName: "Response flags",
 		},

--- a/models/dashboards_test.go
+++ b/models/dashboards_test.go
@@ -13,11 +13,12 @@ func TestPrepareIstioDashboard(t *testing.T) {
 	dashboard := PrepareIstioDashboard("Outbound", "source", "destination")
 
 	assert.Equal(dashboard.Title, "Outbound Metrics")
-	assert.Len(dashboard.Aggregations, 6)
+	assert.Len(dashboard.Aggregations, 7)
 	assert.Equal(model.Aggregation{Label: "source_version", DisplayName: "Local version"}, dashboard.Aggregations[0])
 	assert.Equal(model.Aggregation{Label: "destination_service_name", DisplayName: "Remote service"}, dashboard.Aggregations[1])
 	assert.Equal(model.Aggregation{Label: "destination_app", DisplayName: "Remote app"}, dashboard.Aggregations[2])
 	assert.Equal(model.Aggregation{Label: "destination_version", DisplayName: "Remote version"}, dashboard.Aggregations[3])
 	assert.Equal(model.Aggregation{Label: "response_code", DisplayName: "Response code"}, dashboard.Aggregations[4])
-	assert.Equal(model.Aggregation{Label: "response_flags", DisplayName: "Response flags"}, dashboard.Aggregations[5])
+	assert.Equal(model.Aggregation{Label: "grpc_response_status", DisplayName: "GRPC status"}, dashboard.Aggregations[5])
+	assert.Equal(model.Aggregation{Label: "response_flags", DisplayName: "Response flags"}, dashboard.Aggregations[6])
 }


### PR DESCRIPTION
Backports https://github.com/kiali/kiali/issues/2485

@pbajjuri20 You should now see the "GRPC Status" option in Metric Settings:

![image](https://user-images.githubusercontent.com/2104052/77678591-c70c2d00-6f67-11ea-814a-bd8ba41f903a.png)
