### PR TITLE
[operator] 1.0.12 was released, so 1.12.6 now replaces that version

### DIFF
--- a/operator/manifests/kiali-ossm/1.12.6/kiali.v1.12.6.clusterserviceversion.yaml
+++ b/operator/manifests/kiali-ossm/1.12.6/kiali.v1.12.6.clusterserviceversion.yaml
@@ -75,7 +75,7 @@ metadata:
 spec:
   version: 1.12.6
   maturity: stable
-  replaces: kiali-operator.v1.0.11
+  replaces: kiali-operator.v1.0.12
   relatedImages:
   - name: kiali
     image: registry.redhat.io/openshift-service-mesh/kiali-rhel7:1.12.6


### PR DESCRIPTION
now that 1.0.12 was released, 1.12.6 replaces it