### PR TITLE
Enable kiali travis build on arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+arch:
+  - amd64
+  - arm64
+
 go:
 - 1.14
 

--- a/README.adoc
+++ b/README.adoc
@@ -152,7 +152,9 @@ cd ${GOPATH}/src/github.com/kiali/kiali
 make container-build
 ----
 
-On x86_64 machine, this will build both the Kiali and the Kiali operator image. On aarch64 machine, this will only build the Kiali image.
+This will build the Kiali image.
+
+Generated container image will be consistant with the host machine (either x86_64 or aarch64).
 
 === Pushing Kiali operator and Kiali images to your cluster
 

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -103,7 +103,7 @@ dep-update:
 ## swagger-install: Install swagger from github
 swagger-install:
 	@echo "Installing swagger binary to ${GOPATH}/bin..."
-	@curl https://github.com/go-swagger/go-swagger/releases/download/v0.22.0/swagger_linux_amd64 -Lo ${GOPATH}/bin/swagger && chmod +x ${GOPATH}/bin/swagger
+	@curl https://github.com/go-swagger/go-swagger/releases/download/v0.22.0/swagger_linux_${GOARCH} --create-dirs -Lo ${GOPATH}/bin/swagger && chmod +x ${GOPATH}/bin/swagger
 
 ## swagger-validate: Validate that swagger.json is correctly. Runs `swagger validate` internally
 swagger-validate:


### PR DESCRIPTION
** Describe the change **
This commit adds arm64 support for the kiali operator image and enables the travis job on arm64.

Note: Currently just proposing this as a draft PR for comments :))

**WIP (Checklist):**

- [x] The change in `.travis.yml` should be tested.

- [x] The operator binary downloaded from curl should be from the operator-sdk official release instead of the personal repo.

- [x] Discuss the version of operator-sdk with the community (currently their master is v0.16.0 instead of kiali used version v0.10.0).

- [x] The base image of the operator should also use the offical multiarch image instead of current x86_64 one. 

- [x] Update the `README.adoc` wherever possible.

Operator related code was moved to [operator #6](https://github.com/kiali/kiali-operator/pull/6).

Signed-off-by: Henry Wang <Henry.Wang@arm.com>

** Issue reference **

Extended fix of #1091 

** Backwards incompatible? **

No.

** Documentation **

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
If so, please also update README.adoc

Yes, will update the README.adoc in the final version of this patch.