### PR TITLE
Add Istio Components Status

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -26,7 +26,7 @@ type ComponentStatus struct {
 	// required: true
 	Status string `json:"status"`
 
-	// When true, the component is part of istio core. Otherwise, it is an addon
+	// When true, the component is necessary for Istio to function. Otherwise, it is an addon
 	//
 	// example:  true
 	// required: true
@@ -41,42 +41,89 @@ const (
 	NotFound  string = "NotFound"
 )
 
-// List of workloads part of a Istio deployment and if whether it is mandatory or not
-var components = map[string]bool{
-	// Core components, mandatory
-	"istio-egressgateway":  true,
-	"istio-ingressgateway": true,
-	"istiod":               true,
-	// Addon components, not mandatory
-	// Kiali not included.
-	"grafana":    false,
-	"jaeger":     false,
-	"prometheus": false,
+// List of workloads part of a Istio deployment and if whether it is mandatory or not.
+// It follows the default profile
+var components = map[string]map[string]bool{
+	"monolith": {
+		"istio-egressgateway":  false,
+		"istio-ingressgateway": true,
+		"istiod":               true,
+		"grafana":              false,
+		"istio-tracing":        false,
+		"prometheus":           true,
+	},
+	"mixer": {
+		"istio-citadel":          true,
+		"istio-egressgateway":    false,
+		"istio-galley":           true,
+		"istio-ingressgateway":   true,
+		"istio-pilot":            true,
+		"istio-policy":           true,
+		"istio-sidecar-injector": true,
+		"istio-telemetry":        true,
+		"grafana":                false,
+		"istio-tracing":          false,
+		"prometheus":             true,
+	},
 }
 
 func (iss *IstioStatusService) GetStatus() (IstioComponentStatus, error) {
-	isc := IstioComponentStatus{}
-
 	if !config.Get().ExternalServices.Istio.IstioStatusEnabled {
-		return isc, nil
+		return IstioComponentStatus{}, nil
 	}
-
-	cf := map[string]bool{}
 
 	// Fetching workloads from control plane namespace
 	ds, error := iss.k8s.GetDeployments(config.Get().IstioNamespace)
 	if error != nil {
-		return isc, error
+		return IstioComponentStatus{}, error
 	}
 
-	// Map workloads there by app name
+	arch := iss.detectArchitecture(ds)
+	if arch != "monolith" && arch != "mixer" {
+		return IstioComponentStatus{}, nil
+	}
+
+	return iss.getStatusOf(arch, ds)
+}
+
+func (iss *IstioStatusService) detectArchitecture(ds []apps_v1.Deployment) string {
+	monArch := false
+	mixArch := false
+
 	for _, d := range ds {
-		appName := d.Labels[config.Get().IstioLabels.AppLabelName]
+		appName := d.Name
 		if appName == "" {
 			continue
 		}
 
-		isCore, found := components[appName]
+		monArch = monArch || appName == "istiod"
+		mixArch = mixArch || appName == "istio-pilot"
+	}
+
+	arch := "notfound"
+	if monArch && !mixArch {
+		arch = "monolith"
+	} else if !monArch && mixArch {
+		arch = "mixer"
+	} else if monArch && mixArch {
+		arch = "multiple"
+	}
+
+	return arch
+}
+
+func (iss *IstioStatusService) getStatusOf(arch string, ds []apps_v1.Deployment) (IstioComponentStatus, error) {
+	isc := IstioComponentStatus{}
+	cf := map[string]bool{}
+
+	// Map workloads there by app name
+	for _, d := range ds {
+		appName := d.Name
+		if appName == "" {
+			continue
+		}
+
+		isCore, found := components[arch][appName]
 		if !found {
 			continue
 		}
@@ -84,17 +131,19 @@ func (iss *IstioStatusService) GetStatus() (IstioComponentStatus, error) {
 		// Component found
 		cf[appName] = true
 
-		// Check status
-		isc = append(isc, ComponentStatus{
-			Name:   appName,
-			Status: GetDeploymentStatus(d),
-			IsCore: isCore,
-		},
-		)
+		if status := GetDeploymentStatus(d); status != Healthy {
+			// Check status
+			isc = append(isc, ComponentStatus{
+				Name:   appName,
+				Status: status,
+				IsCore: isCore,
+			},
+			)
+		}
 	}
 
 	// Add missing deployments
-	for comp, isCore := range components {
+	for comp, isCore := range components[arch] {
 		if _, found := cf[comp]; !found {
 			isc = append(isc, ComponentStatus{
 				Name:   comp,

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -1,0 +1,116 @@
+package business
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+)
+
+// SvcService deals with fetching istio/kubernetes services related content and convert to kiali model
+type IstioStatusService struct {
+	k8s kubernetes.IstioClientInterface
+}
+
+type Status string
+type ComponentName string
+type IsCoreComponent bool
+type ComponentStatus struct {
+	// The status of a Istio component
+	//
+	// example:  Not Found
+	// required: true
+	Status Status `json:"status"`
+
+	// When true, the component is part of istio core. Otherwise, it is an addon
+	//
+	// example:  true
+	// required: true
+	IsCore IsCoreComponent `json:"is_core"`
+}
+
+type IstioComponentStatus map[ComponentName]ComponentStatus
+
+const (
+	NotFound   Status = "Not Found"
+	NotRunning Status = "Not Running"
+	Running    Status = "Running"
+)
+
+var PhaseStatusMap = map[v1.PodPhase]Status{
+	v1.PodFailed:    NotRunning,
+	v1.PodPending:   NotRunning,
+	v1.PodSucceeded: NotRunning,
+	v1.PodUnknown:   NotRunning,
+	v1.PodRunning:   Running,
+}
+
+// List of workloads part of a Istio deployment and if whether it is mandatory or not
+var components = map[ComponentName]IsCoreComponent{
+	// Core components, mandatory
+	"istio-egressgateway":  true,
+	"istio-ingressgateway": true,
+	"istiod":               true,
+	// Addon components, not mandatory
+	// Kiali not included.
+	"grafana":    false,
+	"jaeger":     false,
+	"prometheus": false,
+}
+
+func (iss *IstioStatusService) GetStatus() (IstioComponentStatus, error) {
+	isc := IstioComponentStatus{}
+
+	// Fetching workloads from control plane namespace
+	pods, error := iss.k8s.GetPods(config.Get().IstioNamespace, "")
+	if error != nil {
+		return isc, error
+	}
+
+	// Map workloads there by app name
+	for _, pod := range pods {
+		appName := ComponentName(pod.Labels[config.Get().IstioLabels.AppLabelName])
+		if appName == "" {
+			continue
+		}
+
+		isCore, found := components[appName]
+		if !found {
+			continue
+		}
+
+		if s, ok := GetPodStatus(pod); ok {
+			if cs, found := isc[appName]; found {
+				s = healthiest(s, cs.Status)
+			}
+			isc[appName] = ComponentStatus{Status: s, IsCore: isCore}
+		}
+	}
+
+	// Add missing pods
+	for comp, isCore := range components {
+		if _, found := isc[comp]; !found {
+			isc[comp] = ComponentStatus{
+				Status: NotFound,
+				IsCore: isCore,
+			}
+		}
+	}
+
+	return isc, nil
+}
+
+func GetPodStatus(pod v1.Pod) (Status, bool) {
+	status, ok := PhaseStatusMap[pod.Status.Phase]
+	return status, ok
+}
+
+func healthiest(a, b Status) Status {
+	if a == Running && b != Running {
+		return a
+	} else if a == NotRunning && b != Running {
+		return a
+	} else {
+		return b
+	}
+}

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -101,8 +101,23 @@ func (iss *IstioStatusService) GetStatus() (IstioComponentStatus, error) {
 }
 
 func GetPodStatus(pod v1.Pod) (Status, bool) {
-	status, ok := PhaseStatusMap[pod.Status.Phase]
+	status, ok := Running, true
+
+	if areContainersReady(pod) {
+		status, ok = PhaseStatusMap[pod.Status.Phase]
+	} else {
+		status, ok = NotRunning, true
+	}
+
 	return status, ok
+}
+
+func areContainersReady(pod v1.Pod) bool {
+	cr := true
+	for _, cs := range pod.Status.ContainerStatuses {
+		cr = cr && cs.Ready
+	}
+	return cr
 }
 
 func healthiest(a, b Status) Status {

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -56,6 +56,11 @@ var components = map[string]bool{
 
 func (iss *IstioStatusService) GetStatus() (IstioComponentStatus, error) {
 	isc := IstioComponentStatus{}
+
+	if !config.Get().ExternalServices.Istio.IstioStatusEnabled {
+		return isc, nil
+	}
+
 	cf := map[string]bool{}
 
 	// Fetching workloads from control plane namespace

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -66,7 +66,7 @@ func TestComponentRunning(t *testing.T) {
 	assert.Equal(Healthy, status)
 }
 
-func TestAllComp(t *testing.T) {
+func TestMonolithComp(t *testing.T) {
 	assert := assert.New(t)
 
 	conf := config.NewConfig()
@@ -84,12 +84,58 @@ func TestAllComp(t *testing.T) {
 
 	icsl, error := iss.GetStatus()
 	assert.NoError(error)
-	assertComponent(assert, icsl, "istio-egressgateway", Healthy, true)
 	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, true)
-	assertComponent(assert, icsl, "istiod", Healthy, true)
 	assertComponent(assert, icsl, "grafana", Unhealthy, false)
-	assertComponent(assert, icsl, "jaeger", Unhealthy, false)
-	assertComponent(assert, icsl, "prometheus", NotFound, false)
+	assertComponent(assert, icsl, "istio-tracing", Unhealthy, false)
+	assertComponent(assert, icsl, "prometheus", NotFound, true)
+
+	// Don't return healthy deployments
+	assertComponent(assert, icsl, "istio-egressgateway", Healthy, false)
+	assertComponent(assert, icsl, "istiod", Healthy, true)
+
+	// Don't return status of mixer deployment
+	assertNotPresent(assert, icsl, "istio-citadel")
+	assertNotPresent(assert, icsl, "istio-galley")
+	assertNotPresent(assert, icsl, "istio-pilot")
+	assertNotPresent(assert, icsl, "istio-policy")
+	assertNotPresent(assert, icsl, "istio-telemetry")
+}
+
+func TestMixerComp(t *testing.T) {
+	assert := assert.New(t)
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	pods := []apps_v1.Deployment{
+		fakeDeploymentWithStatus("istio-citadel", map[string]string{"app": "citadel", "istio": "citadel"}, healthyStatus),
+		fakeDeploymentWithStatus("istio-egressgateway", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, healthyStatus),
+		fakeDeploymentWithStatus("istio-pilot", map[string]string{"app": "pilot", "istio": "pilot"}, healthyStatus),
+		fakeDeploymentWithStatus("grafana", map[string]string{"app": "grafana"}, unhealthyStatus),
+		fakeDeploymentWithStatus("istio-tracing", map[string]string{"app": "jaeger"}, unhealthyStatus),
+	}
+
+	k8s := mockDeploymentCall(pods)
+	iss := IstioStatusService{k8s: k8s}
+
+	icsl, error := iss.GetStatus()
+	assert.NoError(error)
+	assertComponent(assert, icsl, "istio-galley", NotFound, true)
+	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, true)
+	assertComponent(assert, icsl, "istio-policy", NotFound, true)
+	assertComponent(assert, icsl, "istio-sidecar-injection", NotFound, true)
+	assertComponent(assert, icsl, "istio-telemetry", NotFound, true)
+	assertComponent(assert, icsl, "grafana", Unhealthy, false)
+	assertComponent(assert, icsl, "istio-tracing", Unhealthy, false)
+	assertComponent(assert, icsl, "prometheus", NotFound, true)
+
+	// Don't return healthy deployments
+	assertNotPresent(assert, icsl, "istio-citadel")
+	assertNotPresent(assert, icsl, "istio-egressgateway")
+	assertNotPresent(assert, icsl, "istio-pilot")
+
+	// Don't return status of mixer deployment
+	assertNotPresent(assert, icsl, "istiod")
 }
 
 func assertComponent(assert *assert.Assertions, icsl IstioComponentStatus, name string, status string, isCore bool) {
@@ -97,6 +143,14 @@ func assertComponent(assert *assert.Assertions, icsl IstioComponentStatus, name 
 		if ics.Name == name {
 			assert.Equal(status, ics.Status)
 			assert.Equal(isCore, ics.IsCore)
+		}
+	}
+}
+
+func assertNotPresent(assert *assert.Assertions, icsl IstioComponentStatus, name string) {
+	for _, ics := range icsl {
+		if ics.Name == name {
+			assert.NotEqual(name, ics.Name)
 		}
 	}
 }

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -1,0 +1,121 @@
+package business
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+)
+
+func TestComponentNotRunning(t *testing.T) {
+	assert := assert.New(t)
+
+	phases := []v1.PodPhase{
+		v1.PodFailed,
+		v1.PodPending,
+		v1.PodSucceeded,
+		v1.PodUnknown,
+	}
+
+	for _, phase := range phases {
+		status, ok := GetPodStatus(fakePodWithPhase(phase))
+		assert.True(ok)
+		assert.Equal(NotRunning, status)
+	}
+}
+
+func TestComponentRunning(t *testing.T) {
+	assert := assert.New(t)
+
+	status, ok := GetPodStatus(fakePodWithPhase(v1.PodRunning))
+	assert.True(ok)
+	assert.Equal(Running, status)
+}
+
+func fakePodWithPhase(phase v1.PodPhase) v1.Pod {
+	return kubetest.FakePod(
+		"grafana-19hhhj",
+		map[string]string{"app": "grafana"},
+		phase,
+	)
+}
+
+func TestAllComp(t *testing.T) {
+	assert := assert.New(t)
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	pods := []v1.Pod{
+		kubetest.FakePod("istio-egressgateway-122hjbhq", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, v1.PodRunning),
+		kubetest.FakePod("istiod-1jna99", map[string]string{"app": "istiod", "istio": "pilot"}, v1.PodRunning),
+		kubetest.FakePod("grafana-982jjh", map[string]string{"app": "grafana"}, v1.PodFailed),
+		kubetest.FakePod("istio-tracing-847ajj", map[string]string{"app": "jaeger"}, v1.PodPending),
+	}
+
+	k8s := mockPodsCall(pods)
+	iss := IstioStatusService{k8s: k8s}
+
+	icsl, error := iss.GetStatus()
+	assert.NoError(error)
+	assert.Equal(Running, icsl["istio-egressgateway"].Status)
+	assert.Equal(IsCoreComponent(true), icsl["istio-egressgateway"].IsCore)
+	assert.Equal(NotFound, icsl["istio-ingressgateway"].Status)
+	assert.Equal(IsCoreComponent(true), icsl["istio-ingressgateway"].IsCore)
+	assert.Equal(Running, icsl["istiod"].Status)
+	assert.Equal(IsCoreComponent(true), icsl["istiod"].IsCore)
+	assert.Equal(NotRunning, icsl["grafana"].Status)
+	assert.Equal(IsCoreComponent(false), icsl["grafana"].IsCore)
+	assert.Equal(NotRunning, icsl["jaeger"].Status)
+	assert.Equal(IsCoreComponent(false), icsl["jaeger"].IsCore)
+	assert.Equal(NotFound, icsl["prometheus"].Status)
+	assert.Equal(IsCoreComponent(false), icsl["prometheus"].IsCore)
+}
+
+func TestMultiplePod(t *testing.T) {
+	assert := assert.New(t)
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	pods := []v1.Pod{
+		kubetest.FakePod("istio-egressgateway-122hjbhq", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, v1.PodRunning),
+		kubetest.FakePod("istio-egressgateway-jh88j880", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, v1.PodFailed),
+	}
+
+	k8s := mockPodsCall(pods)
+	iss := IstioStatusService{k8s: k8s}
+
+	icsl, error := iss.GetStatus()
+	assert.NoError(error)
+	assert.Equal(Running, icsl["istio-egressgateway"].Status)
+	assert.Equal(IsCoreComponent(true), icsl["istio-egressgateway"].IsCore)
+}
+
+func TestStatusHealthier(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(Running, healthiest(Running, Running))
+	assert.Equal(Running, healthiest(Running, NotRunning))
+	assert.Equal(Running, healthiest(Running, NotFound))
+
+	assert.Equal(Running, healthiest(NotRunning, Running))
+	assert.Equal(NotRunning, healthiest(NotRunning, NotRunning))
+	assert.Equal(NotRunning, healthiest(NotRunning, NotFound))
+
+	assert.Equal(Running, healthiest(NotFound, Running))
+	assert.Equal(NotRunning, healthiest(NotFound, NotRunning))
+	assert.Equal(NotFound, healthiest(NotFound, NotFound))
+}
+
+// Setup K8S api call to fetch Pods
+func mockPodsCall(pods []v1.Pod) *kubetest.K8SClientMock {
+	k8s := new(kubetest.K8SClientMock)
+	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(pods, nil)
+
+	return k8s
+}

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -92,11 +92,11 @@ func TestAllComp(t *testing.T) {
 	assertComponent(assert, icsl, "prometheus", NotFound, false)
 }
 
-func assertComponent(assert *assert.Assertions, icsl IstioComponentStatus, name string, status Status, isCore bool) {
+func assertComponent(assert *assert.Assertions, icsl IstioComponentStatus, name string, status string, isCore bool) {
 	for _, ics := range icsl {
-		if ics.Name == ComponentName(name) {
+		if ics.Name == name {
 			assert.Equal(status, ics.Status)
-			assert.Equal(IsCoreComponent(isCore), ics.IsCore)
+			assert.Equal(isCore, ics.IsCore)
 		}
 	}
 }

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -5,43 +5,65 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	v1 "k8s.io/api/core/v1"
+	apps_v1 "k8s.io/api/apps/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
+var healthyStatus = apps_v1.DeploymentStatus{
+	Replicas:            2,
+	AvailableReplicas:   2,
+	UnavailableReplicas: 0,
+}
+
+var unhealthyStatus = apps_v1.DeploymentStatus{
+	Replicas:            2,
+	AvailableReplicas:   1,
+	UnavailableReplicas: 1,
+}
+
 func TestComponentNotRunning(t *testing.T) {
 	assert := assert.New(t)
 
-	phases := []v1.PodPhase{
-		v1.PodFailed,
-		v1.PodPending,
-		v1.PodSucceeded,
-		v1.PodUnknown,
+	dss := []apps_v1.DeploymentStatus{
+		{
+			Replicas:            3,
+			AvailableReplicas:   2,
+			UnavailableReplicas: 1,
+		},
+		{
+			Replicas:            1,
+			AvailableReplicas:   0,
+			UnavailableReplicas: 0,
+		},
 	}
 
-	for _, phase := range phases {
-		status, ok := GetPodStatus(fakePodWithPhase(phase))
-		assert.True(ok)
-		assert.Equal(NotRunning, status)
+	for _, ds := range dss {
+		assert.Equal(Unhealthy, GetDeploymentStatus(
+			fakeDeploymentWithStatus(
+				"istio-egressgateway",
+				map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"},
+				ds,
+			)))
 	}
 }
 
 func TestComponentRunning(t *testing.T) {
 	assert := assert.New(t)
 
-	status, ok := GetPodStatus(fakePodWithPhase(v1.PodRunning))
-	assert.True(ok)
-	assert.Equal(Running, status)
-}
-
-func fakePodWithPhase(phase v1.PodPhase) v1.Pod {
-	return kubetest.FakePod(
-		"grafana-19hhhj",
-		map[string]string{"app": "grafana"},
-		phase,
+	status := GetDeploymentStatus(fakeDeploymentWithStatus(
+		"istio-egressgateway",
+		map[string]string{"app": "istio-egressgateway"},
+		apps_v1.DeploymentStatus{
+			Replicas:            2,
+			AvailableReplicas:   2,
+			UnavailableReplicas: 0,
+		}),
 	)
+
+	assert.Equal(Healthy, status)
 }
 
 func TestAllComp(t *testing.T) {
@@ -50,157 +72,52 @@ func TestAllComp(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	pods := []v1.Pod{
-		kubetest.FakePod("istio-egressgateway-122hjbhq", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, v1.PodRunning),
-		kubetest.FakePod("istiod-1jna99", map[string]string{"app": "istiod", "istio": "pilot"}, v1.PodRunning),
-		kubetest.FakePod("grafana-982jjh", map[string]string{"app": "grafana"}, v1.PodFailed),
-		kubetest.FakePod("istio-tracing-847ajj", map[string]string{"app": "jaeger"}, v1.PodPending),
+	pods := []apps_v1.Deployment{
+		fakeDeploymentWithStatus("istio-egressgateway", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, healthyStatus),
+		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
+		fakeDeploymentWithStatus("grafana", map[string]string{"app": "grafana"}, unhealthyStatus),
+		fakeDeploymentWithStatus("istio-tracing", map[string]string{"app": "jaeger"}, unhealthyStatus),
 	}
 
-	k8s := mockPodsCall(pods)
+	k8s := mockDeploymentCall(pods)
 	iss := IstioStatusService{k8s: k8s}
 
 	icsl, error := iss.GetStatus()
 	assert.NoError(error)
-	assert.Equal(Running, icsl["istio-egressgateway"].Status)
-	assert.Equal(IsCoreComponent(true), icsl["istio-egressgateway"].IsCore)
-	assert.Equal(NotFound, icsl["istio-ingressgateway"].Status)
-	assert.Equal(IsCoreComponent(true), icsl["istio-ingressgateway"].IsCore)
-	assert.Equal(Running, icsl["istiod"].Status)
-	assert.Equal(IsCoreComponent(true), icsl["istiod"].IsCore)
-	assert.Equal(NotRunning, icsl["grafana"].Status)
-	assert.Equal(IsCoreComponent(false), icsl["grafana"].IsCore)
-	assert.Equal(NotRunning, icsl["jaeger"].Status)
-	assert.Equal(IsCoreComponent(false), icsl["jaeger"].IsCore)
-	assert.Equal(NotFound, icsl["prometheus"].Status)
-	assert.Equal(IsCoreComponent(false), icsl["prometheus"].IsCore)
+	assertComponent(assert, icsl, "istio-egressgateway", Healthy, true)
+	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, true)
+	assertComponent(assert, icsl, "istiod", Healthy, true)
+	assertComponent(assert, icsl, "grafana", Unhealthy, false)
+	assertComponent(assert, icsl, "jaeger", Unhealthy, false)
+	assertComponent(assert, icsl, "prometheus", NotFound, false)
 }
 
-func TestMultiplePod(t *testing.T) {
-	assert := assert.New(t)
-
-	conf := config.NewConfig()
-	config.Set(conf)
-
-	pods := []v1.Pod{
-		kubetest.FakePod("istio-egressgateway-122hjbhq", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, v1.PodRunning),
-		kubetest.FakePod("istio-egressgateway-jh88j880", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, v1.PodFailed),
+func assertComponent(assert *assert.Assertions, icsl IstioComponentStatus, name string, status Status, isCore bool) {
+	for _, ics := range icsl {
+		if ics.Name == ComponentName(name) {
+			assert.Equal(status, ics.Status)
+			assert.Equal(IsCoreComponent(isCore), ics.IsCore)
+		}
 	}
-
-	k8s := mockPodsCall(pods)
-	iss := IstioStatusService{k8s: k8s}
-
-	icsl, error := iss.GetStatus()
-	assert.NoError(error)
-	assert.Equal(Running, icsl["istio-egressgateway"].Status)
-	assert.Equal(IsCoreComponent(true), icsl["istio-egressgateway"].IsCore)
-}
-
-func TestContainerStatus(t *testing.T) {
-	assert := assert.New(t)
-
-	conf := config.NewConfig()
-	config.Set(conf)
-
-	pods := []v1.Pod{
-		kubetest.FakePodWithContainers(
-			"istio-egressgateway-122hjbhq",
-			map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"},
-			v1.PodRunning,
-			[]v1.ContainerStatus{
-				{
-					Name:  "istio-egressgateway",
-					Ready: false,
-				},
-				{
-					Name:  "istio-egress-2",
-					Ready: true,
-				},
-			},
-		),
-		kubetest.FakePodWithContainers(
-			"istiod-1jna99",
-			map[string]string{"app": "istiod", "istio": "pilot"},
-			v1.PodRunning,
-			[]v1.ContainerStatus{
-				{
-					Name:  "istiod",
-					Ready: true,
-				},
-				{
-					Name:  "istiod",
-					Ready: true,
-				},
-			},
-		),
-		kubetest.FakePodWithContainers(
-			"istio-tracing-847ajj",
-			map[string]string{"app": "jaeger"},
-			v1.PodRunning,
-			[]v1.ContainerStatus{
-				{
-					Name:  "istio-tracing",
-					Ready: true,
-				},
-			},
-		),
-		kubetest.FakePodWithContainers(
-			"grafana-982jjh",
-			map[string]string{"app": "grafana"},
-			v1.PodRunning,
-			[]v1.ContainerStatus{
-				{
-					Name:  "grafana",
-					Ready: false,
-				},
-			},
-		),
-		kubetest.FakePodWithContainers(
-			"prometheus-982jjh",
-			map[string]string{"app": "prometheus"},
-			v1.PodPending,
-			[]v1.ContainerStatus{
-				{
-					Name:  "prometheus",
-					Ready: true,
-				},
-			},
-		),
-	}
-
-	k8s := mockPodsCall(pods)
-	iss := IstioStatusService{k8s: k8s}
-
-	icsl, error := iss.GetStatus()
-	assert.NoError(error)
-	assert.Equal(NotRunning, icsl["istio-egressgateway"].Status)
-	assert.Equal(Running, icsl["istiod"].Status)
-	assert.Equal(Running, icsl["jaeger"].Status)
-	assert.Equal(NotRunning, icsl["grafana"].Status)
-	assert.Equal(NotRunning, icsl["prometheus"].Status)
-	assert.Equal(NotFound, icsl["istio-ingressgateway"].Status)
-}
-
-func TestStatusHealthier(t *testing.T) {
-	assert := assert.New(t)
-
-	assert.Equal(Running, healthiest(Running, Running))
-	assert.Equal(Running, healthiest(Running, NotRunning))
-	assert.Equal(Running, healthiest(Running, NotFound))
-
-	assert.Equal(Running, healthiest(NotRunning, Running))
-	assert.Equal(NotRunning, healthiest(NotRunning, NotRunning))
-	assert.Equal(NotRunning, healthiest(NotRunning, NotFound))
-
-	assert.Equal(Running, healthiest(NotFound, Running))
-	assert.Equal(NotRunning, healthiest(NotFound, NotRunning))
-	assert.Equal(NotFound, healthiest(NotFound, NotFound))
 }
 
 // Setup K8S api call to fetch Pods
-func mockPodsCall(pods []v1.Pod) *kubetest.K8SClientMock {
+func mockDeploymentCall(deployments []apps_v1.Deployment) *kubetest.K8SClientMock {
 	k8s := new(kubetest.K8SClientMock)
-	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(pods, nil)
+	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(deployments, nil)
 
 	return k8s
+}
+
+func fakeDeploymentWithStatus(name string, labels map[string]string, status apps_v1.DeploymentStatus) apps_v1.Deployment {
+	return apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: status,
+		Spec: apps_v1.DeploymentSpec{
+			Replicas: &status.Replicas,
+			Selector: &meta_v1.LabelSelector{
+				MatchLabels: labels}}}
 }

--- a/business/layer.go
+++ b/business/layer.go
@@ -26,6 +26,7 @@ type Layer struct {
 	TLS            TLSService
 	ThreeScale     ThreeScaleService
 	Iter8          Iter8Service
+	IstioStatus    IstioStatusService
 }
 
 // Global clientfactory and prometheus clients.
@@ -114,6 +115,7 @@ func NewWithBackends(k8s kubernetes.IstioClientInterface, prom prometheus.Client
 	temporaryLayer.TLS = TLSService{k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.ThreeScale = ThreeScaleService{k8s: k8s}
 	temporaryLayer.Iter8 = Iter8Service{k8s: k8s, businessLayer: temporaryLayer}
+	temporaryLayer.IstioStatus = IstioStatusService{k8s: k8s}
 
 	return temporaryLayer
 }

--- a/config/config.go
+++ b/config/config.go
@@ -140,6 +140,7 @@ type TracingConfig struct {
 
 // IstioConfig describes configuration used for istio links
 type IstioConfig struct {
+	IstioStatusEnabled     bool   `yaml:"istio_status_enabled,omitempty"`
 	IstioIdentityDomain    string `yaml:"istio_identity_domain,omitempty"`
 	IstioSidecarAnnotation string `yaml:"istio_sidecar_annotation,omitempty"`
 	UrlServiceVersion      string `yaml:"url_service_version"`
@@ -325,6 +326,7 @@ func NewConfig() (c *Config) {
 				Enabled: true,
 			},
 			Istio: IstioConfig{
+				IstioStatusEnabled:     true,
 				IstioIdentityDomain:    "svc.cluster.local",
 				IstioSidecarAnnotation: "sidecar.istio.io/status",
 				UrlServiceVersion:      "http://istio-pilot:8080/version",

--- a/doc.go
+++ b/doc.go
@@ -4,6 +4,7 @@ import (
 	jaegerModels "github.com/jaegertracing/jaeger/model/json"
 
 	"github.com/kiali/k-charted/model"
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph/config/cytoscape"
 	"github.com/kiali/kiali/handlers"
 	"github.com/kiali/kiali/jaeger"
@@ -696,4 +697,11 @@ type Iter8ExperimentsGetDetailResponse struct {
 type Iter8ExperimentsResponnse struct {
 	// in: body
 	Body []models.Iter8ExperimentItem
+}
+
+// Return a list of Istio components along its status
+// swagger:response istioStatusResponse
+type IstioStatusResponse struct {
+	// in: body
+	Body business.IstioComponentStatus
 }

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -40,6 +40,7 @@ type PrometheusConfig struct {
 type PublicConfig struct {
 	Extensions               Extensions                      `json:"extensions,omitempty"`
 	InstallationTag          string                          `json:"installationTag,omitempty"`
+	IstioStatusEnabled       bool                            `json:"istioStatusEnabled,omitempty"`
 	IstioIdentityDomain      string                          `json:"istioIdentityDomain,omitempty"`
 	IstioNamespace           string                          `json:"istioNamespace,omitempty"`
 	IstioComponentNamespaces config.IstioComponentNamespaces `json:"istioComponentNamespaces,omitempty"`
@@ -65,6 +66,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 		InstallationTag:          config.InstallationTag,
+		IstioStatusEnabled:       config.ExternalServices.Istio.IstioStatusEnabled,
 		IstioIdentityDomain:      config.ExternalServices.Istio.IstioIdentityDomain,
 		IstioNamespace:           config.IstioNamespace,
 		IstioComponentNamespaces: config.IstioComponentNamespaces,

--- a/handlers/istio_status.go
+++ b/handlers/istio_status.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"net/http"
+)
+
+// IstioStatus returns a list of istio components and its status
+func IstioStatus(w http.ResponseWriter, r *http.Request) {
+	// Get business layer
+	business, err := getBusiness(r)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+		return
+	}
+
+	istioStatus, err := business.IstioStatus.GetStatus()
+	if err != nil {
+		handleErrorResponse(w, err)
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, istioStatus)
+}

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -105,6 +105,7 @@ type IstioClientInterface interface {
 	GetVirtualServices(namespace string, serviceName string) ([]IstioObject, error)
 	IsMaistraApi() bool
 	IsOpenShift() bool
+	IsMixerDisabled() bool
 	UpdateIstioObject(api, namespace, resourceType, name, jsonPatch string) (IstioObject, error)
 	Iter8ClientInterface
 }
@@ -147,6 +148,10 @@ type IstioClient struct {
 	// It is represented as a pointer to include the initialization phase.
 	// See istio_details_service.go#HasSecurityResource() for more details.
 	securityResources *map[string]bool
+
+	// isMixedDisabled private variable will check if mixed is enabled in the current istio deployment.
+	// It is represented with a pointer to a bool. True if mixer is disabled, false instead
+	isMixerDisabled *bool
 }
 
 // GetK8sApi returns the clientset referencing all K8s rest clients

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -2,10 +2,13 @@ package kubernetes
 
 import (
 	"bytes"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	osroutes_v1 "github.com/openshift/api/route/v1"
+	"gopkg.in/yaml.v2"
 	apps_v1 "k8s.io/api/apps/v1"
 	auth_v1 "k8s.io/api/authorization/v1"
 	batch_v1 "k8s.io/api/batch/v1"
@@ -18,6 +21,12 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes/scheme"
 )
+
+const IstioConfigmapName = "istio"
+
+type istioMeshConfig struct {
+	DisableMixerHttpReports bool `yaml:"disableMixerHttpReports,omitempty"`
+}
 
 // GetConfigMap fetches and returns the specified ConfigMap definition
 // from the cluster
@@ -355,4 +364,40 @@ func (in *IstioClient) GetSelfSubjectAccessReview(namespace, api, resourceType s
 		}
 	}
 	return result, err
+}
+
+func (in *IstioClient) IsMixerDisabled() bool {
+	if in.isMixerDisabled != nil {
+		return *in.isMixerDisabled
+	}
+
+	cfg := config.Get()
+	istioConfig, err := in.GetConfigMap(cfg.IstioNamespace, IstioConfigmapName)
+	if err != nil {
+		log.Warningf("IsMixerDisabled: Cannot retrieve Istio ConfigMap.")
+		return true
+	}
+
+	meshConfigYaml, ok := istioConfig.Data["mesh"]
+	log.Tracef("meshConfig: %v", meshConfigYaml)
+	if !ok {
+		log.Warningf("IsMixerDisabled: Cannot find Istio mesh configuration.")
+		return true
+	}
+
+	meshConfig := istioMeshConfig{}
+	err = yaml.Unmarshal([]byte(meshConfigYaml), &meshConfig)
+	if err != nil {
+		log.Warningf("IsMixerDisabled: Cannot read Istio mesh configuration.")
+		return true
+	}
+
+	log.Infof("IsMixerDisabled: %t", meshConfig.DisableMixerHttpReports)
+
+	// References:
+	//   * https://github.com/istio/api/pull/1112
+	//   * https://github.com/istio/istio/pull/17695
+	//   * https://github.com/istio/istio/issues/15935
+	in.isMixerDisabled = &meshConfig.DisableMixerHttpReports
+	return *in.isMixerDisabled
 }

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -528,6 +528,19 @@ func FakePod(name string, labels map[string]string, podPhase core_v1.PodPhase) c
 	}
 }
 
+func FakePodWithContainers(name string, labels map[string]string, podPhase core_v1.PodPhase, containerStatuses []core_v1.ContainerStatus) core_v1.Pod {
+	return core_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: core_v1.PodStatus{
+			Phase:             podPhase,
+			ContainerStatuses: containerStatuses,
+		},
+	}
+}
+
 func FakePodList() []core_v1.Pod {
 	return []core_v1.Pod{
 		{

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -516,6 +516,18 @@ func FakePodListWithoutSidecar() []core_v1.Pod {
 	}
 }
 
+func FakePod(name string, labels map[string]string, podPhase core_v1.PodPhase) core_v1.Pod {
+	return core_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: core_v1.PodStatus{
+			Phase: podPhase,
+		},
+	}
+}
+
 func FakePodList() []core_v1.Pod {
 	return []core_v1.Pod{
 		{

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -470,6 +470,11 @@ func (o *K8SClientMock) DeleteIter8Experiment(namespace string, name string) err
 	return args.Error(0)
 }
 
+func (o *K8SClientMock) IsMixerDisabled() bool {
+	args := o.Called()
+	return args.Get(0).(bool)
+}
+
 func fakeService(namespace, name string) core_v1.Service {
 	return core_v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -940,6 +940,27 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceTls,
 			true,
 		},
+		// swagger:route GET /istio/status status istioStatus
+		// ---
+		// Get the status of each components needed in the control plane
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      200: istioStatusResponse
+		//      400: badRequestError
+		//      500: internalError
+		//
+		{
+			"IstioStatus",
+			"GET",
+			"/api/istio/status",
+			handlers.IstioStatus,
+			true,
+		},
 		// swagger:route GET /namespaces/graph graphs graphNamespaces
 		// ---
 		// The backing JSON for a namespaces graph.

--- a/swagger.json
+++ b/swagger.json
@@ -221,31 +221,6 @@
         }
       }
     },
-    "/iter8/experiments": {
-      "get": {
-        "description": "User can define a comman separated list of namespaces.",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "iter8"
-        ],
-        "summary": "Endpoint to fetch iter8 experiments for all namespaces user have access.",
-        "operationId": "iter8Experiments",
-        "responses": {
-          "200": {
-            "$ref": "#/responses/iter8ExperimentsResponse"
-          },
-          "500": {
-            "$ref": "#/responses/internalError"
-          }
-        }
-      }
-    },
     "/istio/status": {
       "get": {
         "description": "Get the status of each components needed in the control plane",
@@ -266,6 +241,31 @@
           },
           "400": {
             "$ref": "#/responses/badRequestError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/iter8/experiments": {
+      "get": {
+        "description": "User can define a comman separated list of namespaces.",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "iter8"
+        ],
+        "summary": "Endpoint to fetch iter8 experiments for all namespaces user have access.",
+        "operationId": "iter8Experiments",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/iter8ExperimentsResponse"
           },
           "500": {
             "$ref": "#/responses/internalError"
@@ -3777,6 +3777,11 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
+    "CauseType": {
+      "description": "CauseType is a machine readable value providing more detail about what\noccurred in a status response. An operation may have multiple causes for a\nstatus (whether Failure or Success).",
+      "type": "string",
+      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
+    },
     "Chart": {
       "description": "Chart is the model representing a custom chart, transformed from charts in MonitoringDashboard k8s resource",
       "type": "object",
@@ -3882,15 +3887,28 @@
     "ComponentStatus": {
       "type": "object",
       "required": [
+        "name",
         "status",
         "is_core"
       ],
       "properties": {
         "is_core": {
-          "$ref": "#/definitions/IsCoreComponent"
+          "description": "When true, the component is part of istio core. Otherwise, it is an addon",
+          "type": "boolean",
+          "x-go-name": "IsCore",
+          "example": true
+        },
+        "name": {
+          "description": "The app label value of the Istio component",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "istiod"
         },
         "status": {
-          "$ref": "#/definitions/Status"
+          "description": "The status of a Istio component",
+          "type": "string",
+          "x-go-name": "Status",
+          "example": "Not Found"
         }
       },
       "x-go-package": "github.com/kiali/kiali/business"
@@ -4143,10 +4161,6 @@
       },
       "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
     },
-    "IsCoreComponent": {
-      "type": "boolean",
-      "x-go-package": "github.com/kiali/kiali/business"
-    },
     "IstioCheck": {
       "type": "object",
       "title": "IstioCheck represents an individual check.",
@@ -4174,8 +4188,8 @@
       "x-go-package": "github.com/kiali/kiali/models"
     },
     "IstioComponentStatus": {
-      "type": "object",
-      "additionalProperties": {
+      "type": "array",
+      "items": {
         "$ref": "#/definitions/ComponentStatus"
       },
       "x-go-package": "github.com/kiali/kiali/business"
@@ -6144,8 +6158,117 @@
       "x-go-package": "github.com/kiali/kiali/vendor/github.com/jaegertracing/jaeger/model/json"
     },
     "Status": {
-      "type": "string",
-      "x-go-package": "github.com/kiali/kiali/business"
+      "type": "object",
+      "title": "Status is a return value for calls that don't return other objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "code": {
+          "description": "Suggested HTTP return code for this status, 0 if not set.\n+optional",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "Code"
+        },
+        "continue": {
+          "description": "continue may be set if the user set a limit on the number of items returned, and indicates that\nthe server has more data available. The value is opaque and may be used to issue another request\nto the endpoint that served this list to retrieve the next set of available objects. Continuing a\nconsistent list may not be possible if the server configuration has changed or more than a few\nminutes have passed. The resourceVersion field returned when using this continue value will be\nidentical to the value in the first response, unless you have received this token from an error\nmessage.",
+          "type": "string",
+          "x-go-name": "Continue"
+        },
+        "details": {
+          "$ref": "#/definitions/StatusDetails"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "message": {
+          "description": "A human-readable description of the status of this operation.\n+optional",
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "reason": {
+          "$ref": "#/definitions/StatusReason"
+        },
+        "resourceVersion": {
+          "description": "String that identifies the server's internal version of this object that\ncan be used by clients to determine when objects have changed.\nValue must be treated as opaque by clients and passed unmodified back to the server.\nPopulated by the system.\nRead-only.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency\n+optional",
+          "type": "string",
+          "x-go-name": "ResourceVersion"
+        },
+        "selfLink": {
+          "description": "selfLink is a URL representing this object.\nPopulated by the system.\nRead-only.\n+optional",
+          "type": "string",
+          "x-go-name": "SelfLink"
+        },
+        "status": {
+          "description": "Status of the operation.\nOne of: \"Success\" or \"Failure\".\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status\n+optional",
+          "type": "string",
+          "x-go-name": "Status"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
+    },
+    "StatusCause": {
+      "description": "StatusCause provides more information about an api.Status failure, including\ncases when multiple errors are encountered.",
+      "type": "object",
+      "properties": {
+        "field": {
+          "description": "The field of the resource that has caused this error, as named by its JSON\nserialization. May include dot and postfix notation for nested attributes.\nArrays are zero-indexed.  Fields may appear more than once in an array of\ncauses due to fields having multiple errors.\nOptional.\n\nExamples:\n\"name\" - the field \"name\" on the current resource\n\"items[0].name\" - the field \"name\" on the first array entry in \"items\"\n+optional",
+          "type": "string",
+          "x-go-name": "Field"
+        },
+        "message": {
+          "description": "A human-readable description of the cause of the error.  This field may be\npresented as-is to a reader.\n+optional",
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "reason": {
+          "$ref": "#/definitions/CauseType"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
+    },
+    "StatusDetails": {
+      "description": "StatusDetails is a set of additional properties that MAY be set by the\nserver to provide additional information about a response. The Reason\nfield of a Status object defines what attributes will be set. Clients\nmust ignore fields that do not match the defined type of each attribute,\nand should assume that any attribute may be empty, invalid, or under\ndefined.",
+      "type": "object",
+      "properties": {
+        "causes": {
+          "description": "The Causes array includes more details associated with the StatusReason\nfailure. Not all StatusReasons may provide detailed causes.\n+optional",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StatusCause"
+          },
+          "x-go-name": "Causes"
+        },
+        "group": {
+          "description": "The group attribute of the resource associated with the status StatusReason.\n+optional",
+          "type": "string",
+          "x-go-name": "Group"
+        },
+        "kind": {
+          "description": "The kind attribute of the resource associated with the status StatusReason.\nOn some operations may differ from the requested resource Kind.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "name": {
+          "description": "The name attribute of the resource associated with the status StatusReason\n(when there is a single name which can be described).\n+optional",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "retryAfterSeconds": {
+          "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate\nthe client must take an alternate action - for those errors this field may indicate how long to wait\nbefore taking the alternate action.\n+optional",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "RetryAfterSeconds"
+        },
+        "uid": {
+          "$ref": "#/definitions/UID"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
     },
     "StatusInfo": {
       "description": "This is used for returning a response of Kiali Status",
@@ -6183,6 +6306,11 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/status"
+    },
+    "StatusReason": {
+      "description": "StatusReason is an enumeration of possible failure causes.  Each StatusReason\nmust map to a single HTTP status code, but multiple reasons may map\nto the same HTTP status code.\nTODO: move to apiserver",
+      "type": "string",
+      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
     },
     "ThreeScaleHandler": {
       "description": "ThreeScaleHAndler represents the minimal info that a user needs to know from the UI to link a service with 3Scale site",

--- a/swagger.json
+++ b/swagger.json
@@ -4188,25 +4188,9 @@
       "x-go-package": "github.com/kiali/kiali/models"
     },
     "IstioComponentStatus": {
-      "type": "object",
-      "required": [
-        "list"
-      ],
-      "properties": {
-        "list": {
-          "description": "List of each istio deployment status",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ComponentStatus"
-          },
-          "x-go-name": "List"
-        },
-        "message": {
-          "description": "Message regarding the Istio architecture: monolith, mixer-based, multiple or none",
-          "type": "string",
-          "x-go-name": "Message",
-          "example": "Istio status disabled: multiple pilots found"
-        }
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ComponentStatus"
       },
       "x-go-package": "github.com/kiali/kiali/business"
     },

--- a/swagger.json
+++ b/swagger.json
@@ -3893,7 +3893,7 @@
       ],
       "properties": {
         "is_core": {
-          "description": "When true, the component is part of istio core. Otherwise, it is an addon",
+          "description": "When true, the component is necessary for Istio to function. Otherwise, it is an addon",
           "type": "boolean",
           "x-go-name": "IsCore",
           "example": true
@@ -3902,7 +3902,7 @@
           "description": "The app label value of the Istio component",
           "type": "string",
           "x-go-name": "Name",
-          "example": "istiod"
+          "example": "istio-ingressgateway"
         },
         "status": {
           "description": "The status of a Istio component",
@@ -4188,9 +4188,25 @@
       "x-go-package": "github.com/kiali/kiali/models"
     },
     "IstioComponentStatus": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/ComponentStatus"
+      "type": "object",
+      "required": [
+        "list"
+      ],
+      "properties": {
+        "list": {
+          "description": "List of each istio deployment status",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ComponentStatus"
+          },
+          "x-go-name": "List"
+        },
+        "message": {
+          "description": "Message regarding the Istio architecture: monolith, mixer-based, multiple or none",
+          "type": "string",
+          "x-go-name": "Message",
+          "example": "Istio status disabled: multiple pilots found"
+        }
       },
       "x-go-package": "github.com/kiali/kiali/business"
     },

--- a/swagger.json
+++ b/swagger.json
@@ -246,6 +246,33 @@
         }
       }
     },
+    "/istio/status": {
+      "get": {
+        "description": "Get the status of each components needed in the control plane",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "status"
+        ],
+        "operationId": "istioStatus",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/istioStatusResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
     "/iter8/experiments/namespaces/{namespace}/name/{name}": {
       "delete": {
         "description": "Endpoint to delete   iter8 experiments",
@@ -3750,11 +3777,6 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
-    "CauseType": {
-      "description": "CauseType is a machine readable value providing more detail about what\noccurred in a status response. An operation may have multiple causes for a\nstatus (whether Failure or Success).",
-      "type": "string",
-      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
-    },
     "Chart": {
       "description": "Chart is the model representing a custom chart, transformed from charts in MonitoringDashboard k8s resource",
       "type": "object",
@@ -3856,6 +3878,22 @@
         "$ref": "#/definitions/ClusterRbacConfig"
       },
       "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "ComponentStatus": {
+      "type": "object",
+      "required": [
+        "status",
+        "is_core"
+      ],
+      "properties": {
+        "is_core": {
+          "$ref": "#/definitions/IsCoreComponent"
+        },
+        "status": {
+          "$ref": "#/definitions/Status"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/business"
     },
     "Config": {
       "type": "object",
@@ -4105,6 +4143,10 @@
       },
       "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
     },
+    "IsCoreComponent": {
+      "type": "boolean",
+      "x-go-package": "github.com/kiali/kiali/business"
+    },
     "IstioCheck": {
       "type": "object",
       "title": "IstioCheck represents an individual check.",
@@ -4130,6 +4172,13 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "IstioComponentStatus": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ComponentStatus"
+      },
+      "x-go-package": "github.com/kiali/kiali/business"
     },
     "IstioConfigDetails": {
       "type": "object",
@@ -6095,117 +6144,8 @@
       "x-go-package": "github.com/kiali/kiali/vendor/github.com/jaegertracing/jaeger/model/json"
     },
     "Status": {
-      "type": "object",
-      "title": "Status is a return value for calls that don't return other objects.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources\n+optional",
-          "type": "string",
-          "x-go-name": "APIVersion"
-        },
-        "code": {
-          "description": "Suggested HTTP return code for this status, 0 if not set.\n+optional",
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "Code"
-        },
-        "continue": {
-          "description": "continue may be set if the user set a limit on the number of items returned, and indicates that\nthe server has more data available. The value is opaque and may be used to issue another request\nto the endpoint that served this list to retrieve the next set of available objects. Continuing a\nconsistent list may not be possible if the server configuration has changed or more than a few\nminutes have passed. The resourceVersion field returned when using this continue value will be\nidentical to the value in the first response, unless you have received this token from an error\nmessage.",
-          "type": "string",
-          "x-go-name": "Continue"
-        },
-        "details": {
-          "$ref": "#/definitions/StatusDetails"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
-          "type": "string",
-          "x-go-name": "Kind"
-        },
-        "message": {
-          "description": "A human-readable description of the status of this operation.\n+optional",
-          "type": "string",
-          "x-go-name": "Message"
-        },
-        "reason": {
-          "$ref": "#/definitions/StatusReason"
-        },
-        "resourceVersion": {
-          "description": "String that identifies the server's internal version of this object that\ncan be used by clients to determine when objects have changed.\nValue must be treated as opaque by clients and passed unmodified back to the server.\nPopulated by the system.\nRead-only.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency\n+optional",
-          "type": "string",
-          "x-go-name": "ResourceVersion"
-        },
-        "selfLink": {
-          "description": "selfLink is a URL representing this object.\nPopulated by the system.\nRead-only.\n+optional",
-          "type": "string",
-          "x-go-name": "SelfLink"
-        },
-        "status": {
-          "description": "Status of the operation.\nOne of: \"Success\" or \"Failure\".\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status\n+optional",
-          "type": "string",
-          "x-go-name": "Status"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
-    },
-    "StatusCause": {
-      "description": "StatusCause provides more information about an api.Status failure, including\ncases when multiple errors are encountered.",
-      "type": "object",
-      "properties": {
-        "field": {
-          "description": "The field of the resource that has caused this error, as named by its JSON\nserialization. May include dot and postfix notation for nested attributes.\nArrays are zero-indexed.  Fields may appear more than once in an array of\ncauses due to fields having multiple errors.\nOptional.\n\nExamples:\n\"name\" - the field \"name\" on the current resource\n\"items[0].name\" - the field \"name\" on the first array entry in \"items\"\n+optional",
-          "type": "string",
-          "x-go-name": "Field"
-        },
-        "message": {
-          "description": "A human-readable description of the cause of the error.  This field may be\npresented as-is to a reader.\n+optional",
-          "type": "string",
-          "x-go-name": "Message"
-        },
-        "reason": {
-          "$ref": "#/definitions/CauseType"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
-    },
-    "StatusDetails": {
-      "description": "StatusDetails is a set of additional properties that MAY be set by the\nserver to provide additional information about a response. The Reason\nfield of a Status object defines what attributes will be set. Clients\nmust ignore fields that do not match the defined type of each attribute,\nand should assume that any attribute may be empty, invalid, or under\ndefined.",
-      "type": "object",
-      "properties": {
-        "causes": {
-          "description": "The Causes array includes more details associated with the StatusReason\nfailure. Not all StatusReasons may provide detailed causes.\n+optional",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/StatusCause"
-          },
-          "x-go-name": "Causes"
-        },
-        "group": {
-          "description": "The group attribute of the resource associated with the status StatusReason.\n+optional",
-          "type": "string",
-          "x-go-name": "Group"
-        },
-        "kind": {
-          "description": "The kind attribute of the resource associated with the status StatusReason.\nOn some operations may differ from the requested resource Kind.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
-          "type": "string",
-          "x-go-name": "Kind"
-        },
-        "name": {
-          "description": "The name attribute of the resource associated with the status StatusReason\n(when there is a single name which can be described).\n+optional",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "retryAfterSeconds": {
-          "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate\nthe client must take an alternate action - for those errors this field may indicate how long to wait\nbefore taking the alternate action.\n+optional",
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "RetryAfterSeconds"
-        },
-        "uid": {
-          "$ref": "#/definitions/UID"
-        }
-      },
-      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
+      "type": "string",
+      "x-go-package": "github.com/kiali/kiali/business"
     },
     "StatusInfo": {
       "description": "This is used for returning a response of Kiali Status",
@@ -6243,11 +6183,6 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/status"
-    },
-    "StatusReason": {
-      "description": "StatusReason is an enumeration of possible failure causes.  Each StatusReason\nmust map to a single HTTP status code, but multiple reasons may map\nto the same HTTP status code.\nTODO: move to apiserver",
-      "type": "string",
-      "x-go-package": "github.com/kiali/kiali/vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
     },
     "ThreeScaleHandler": {
       "description": "ThreeScaleHAndler represents the minimal info that a user needs to know from the UI to link a service with 3Scale site",
@@ -7162,6 +7097,12 @@
       "description": "Return caller permissions per namespace and Istio Config type",
       "schema": {
         "$ref": "#/definitions/IstioConfigPermissions"
+      }
+    },
+    "istioStatusResponse": {
+      "description": "Return a list of Istio components along its status",
+      "schema": {
+        "$ref": "#/definitions/IstioComponentStatus"
       }
     },
     "iter8ExperimentGetDetailResponse": {


### PR DESCRIPTION
This PR adds a new endpoint that returns the status of each component of Istio. For each components it returns if it is a core component and whether it is Unhealthy or Not Found.

Unhealthy => The component has missing pods
Not Found => There isn't any deployment in that namespace for that component.

Healthy deployments aren't returned.

#### List of components along its severity:
**warning**: means that if a component is not found or unhealthy, the UI will show a warning symbol.
**error**: if the component is not found or unhealthy, it will show an error symbol.

monolith (demo profile from > 1.5):
```
		"istio-egressgateway":  warning,
		"istio-ingressgateway": error,
		"istiod":               error,
		"grafana":              warning,
		"istio-tracing":        warning,
		"prometheus":           error,
``` 

mixer-base installation (tipically < 1.5):

```
		"istio-citadel":          error,
		"istio-egressgateway":    warning,
		"istio-galley":           error,
		"istio-ingressgateway":   error,
		"istio-pilot":            error,
		"istio-policy":           error,
		"istio-sidecar-injector": error,
		"istio-telemetry":        error,
		"grafana":                warning,
		"istio-tracing":          warning,
		"prometheus":             error,
```

![Screenshot of localhost_20001_kiali_api_istio_status (1)](https://user-images.githubusercontent.com/613814/80132416-ed8bab00-859b-11ea-837f-d7ab46653518.png)

This PR supports mixer-based istio installations (pilot, citadel, telemetry,...) and monolith base Istio installation (istiod, ingress, egress).

If Grafana or Tracing is disabled, the components are not considered to check the status.

Needs https://github.com/kiali/kiali-ui/pull/1733