### PR TITLE
Stop publishing Kiali to DockerHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,7 @@ CONTAINER_NAME ?= ${IMAGE_ORG}/kiali
 CONTAINER_VERSION ?= dev
 
 # These two vars allow Jenkins to override values.
-DOCKER_NAME ?= docker.io/${CONTAINER_NAME}
 QUAY_NAME ?= quay.io/${CONTAINER_NAME}
-
-DOCKER_TAG = ${DOCKER_NAME}:${CONTAINER_VERSION}
 QUAY_TAG = ${QUAY_NAME}:${CONTAINER_VERSION}
 
 # Identifies the Kiali operator container images that will be built

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -22,20 +22,13 @@ Edge-snapshots (or snapshots after merged PRs) are also handled in the Pipeline.
 
 == Finished product
 
-When the release process is complete, a new DockerHub image will be available in the
-link:https://hub.docker.com/r/kiali/kiali/tags/[Kiali Docker Hub repo].
+When the release process is complete, a new container image will be available in the
+link:https://quay.io/repository/kiali/kiali?tab=tags[Kiali Quay.io repository].
 
 == Actions before creating a release
 
 These actions are not performed by the release process. Please, do
 these actions manually before running the release process.
-
-=== Creating a new JIRA issue
-
-If you know that you'll spend a considerable amount of time doing
-the release, create a new issue on
-link:https://issues.jboss.org/browse/KIALI[JIRA] detailing the
-release, and add sub-tasks if necessary.
 
 === Updating Docs
 
@@ -50,59 +43,16 @@ Update the document, and create a PR.
 These actions are not performed by the release process. Please, do
 these actions manually after the release process finishes successfully.
 
-=== Updating JIRA issues
-
-Edit all issues in `Awaiting Release` state with `Fix-Version`:
-
-* Use this query https://issues.jboss.org/issues/?filter=12336798
-* Use Tools>Bulk Change>All XX issue(s)
-* Select all issues and press `Next`
-* `Edit issues`
-* `Change Fix Version/s`>`Add to existing`>Pick the version to release>Unselect `Send mail for this update`>Next>Confirm
-
-Transition all issues to `Released`:
-
-* Use this query https://issues.jboss.org/issues/?filter=12337486
-* Use Tools>Bulk Change>All XX issue(s)
-* Select all issues and press `Next`
-* `Transition issues`
-* `Released`>Next
-* Unselect `Send mail for this update`>Next>Confirm
-
-After that, close the release issues, and then, create a new `Release` in JIRA
-for the next release.
-
-Mark the current version as released, and create a new minor version:
-https://issues.jboss.org/projects/KIALI?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page
-
-=== Notify Istio and Openshift Istio Teams for changes
-
-There are no fixed steps for releasing a new version on the Istio installer,
-each release is kind of different.
-
-This has been done a few times before, so they can be used as references:
-
-* https://github.com/istio/istio/pull/5869
-* https://github.com/istio/istio/pull/5921
-* https://github.com/istio/istio/pull/6192
-* https://github.com/istio/istio/pull/6592
-* https://github.com/istio/istio/pull/6594
-* https://github.com/istio/istio/pull/7042
-* https://github.com/istio/istio/pull/7007
-
-Those PRs cover both the ansible-installer and the helm installer updates.
-
 === Send out notifications
 
 Finally, we just need to send the notifications to create awareness of the new
-release.
+release:
 
-Post an email about the release on our
-link:https://groups.google.com/forum/#!search/kiali-dev[Mailing List].
-
-Send a message on our channel at Freenode, #kiali.
-
-Post a message on our twitter,
+* Post an email about the release on our
+link:https://groups.google.com/forum/#!search/kiali-dev[Mailing List]. This is done
+automatically if you are doing a minor or major release.
+* Send a message on our channel at Freenode, #kiali.
+* Post a message on our twitter,
 link:https://www.twitter.com/KialiProject[@KialiProject]. If you don't know
 who's responsible for the account, ask on IRC.
 
@@ -119,8 +69,8 @@ The Pipeline performs the following actions to do the release:
 * Run tests for back-end and front-end
 * If all tests pass:
 ** The front-end is released to NPM
-** A docker image integrating the back-end and the front-end is built
-   and pushed to DockerHub
+** A container image integrating the back-end and the front-end is built
+   and pushed to Quay.io
 ** Tags for the new releases are created
 ** If a _minor_ release was done, _master_ branches are prepared for the
     next version and a version branches named of the form _vX.Y_ are created
@@ -161,8 +111,8 @@ https://github.com/kiali/kiali[kiali/kiali GitHub repository].
 ** Please, follow the https://github.com/kiali/kiali-ui/blob/master/RELEASING.adoc[releasing guide for the front-end]
 ** You can omit this step if there is no need to release the front-end. Kiali
    will be released using the specified version of the front-end.
-. Login to DockerHub
-** `docker login docker.io`
+. Login to Quay.io
+** `docker login quay.io`
 . Checkout the code that you want to release:
 ** `git checkout branch_to_release` (usually, you should release "master")
 ** Be advised that the release process will commit changes locally.
@@ -198,9 +148,9 @@ don't change the version in the `Makefile`).
 
 === Available options
 
-* The generated Docker image is published to kiali/kiali DockerHub repository.
+* The generated container image is published to kiali/kiali Quay.io repository.
   If you want to publish to another repository:
-** `DOCKER_NAME="{repository}" make -f deploy/jenkins-ci/Makefile release``
+** `QUAY_NAME="{repository}" make -f deploy/jenkins-ci/Makefile release``
 * In _major_, _minor_ or _patch_ mode, the release process updates or creates
   a version branch in the kiali-ui repository (the branch name is like
   "vMAJOR.MINOR"). You can omit the creation of this branch:

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -19,9 +19,6 @@
  *   - UI_GITHUB_URI
  *      defaultValue: git@github.com:kiali/kiali-ui.git
  *      description: SSH Url of the kiali-ui GitHub repository
- *   - DOCKER_NAME
- *      defaultValue: docker.io/kiali/kiali
- *      description: The name of the Docker repository to push the release
  *   - QUAY_NAME
  *      defaultValue: quay.io/kiali/kiali
  *      description: The name of the Quay repository to push the release
@@ -55,7 +52,6 @@ node('kiali-build') {
   def (backendDir, uiDir) = ['src/github.com/kiali/kiali', 'src/github.com/kiali/kiali-ui']
   def (backendMakefile, uiMakefile) = ['deploy/jenkins-ci/Makefile', 'Makefile.jenkins']
   def buildUi = params.SKIP_UI_RELEASE != "y"
-  def dockerTag = ""
   def quayTag = ""
 
   try {
@@ -152,9 +148,8 @@ node('kiali-build') {
       }
 
       stage('Release Kiali to Container Repositories') {
-        withCredentials([usernamePassword(credentialsId: 'kiali-docker', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USER'), usernamePassword(credentialsId: 'kiali-quay', passwordVariable: 'QUAY_PASSWORD', usernameVariable: 'QUAY_USER')]) {
+        withCredentials([usernamePassword(credentialsId: 'kiali-quay', passwordVariable: 'QUAY_PASSWORD', usernameVariable: 'QUAY_USER')]) {
           sh "make -f ${backendMakefile} -C ${backendDir} backend-push-docker"
-          dockerTag = sh(returnStdout: true, script: "sed -rn 's/^VERSION \\?= v(.*)/v\\1/p' ${backendDir}/Makefile").trim()
           quayTag = sh(returnStdout: true, script: "sed -rn 's/^VERSION \\?= v(.*)/v\\1/p' ${backendDir}/Makefile").trim()
         }
       }
@@ -172,9 +167,7 @@ node('kiali-build') {
            build(job: 'kiali-release-notifier',
              parameters: [
                [$class: 'StringParameterValue', value: 'minor', name: 'RELEASE_TYPE'],
-               [$class: 'StringParameterValue', value: "${params.DOCKER_NAME}", name: 'DOCKER_NAME'],
                [$class: 'StringParameterValue', value: "${params.QUAY_NAME}", name: 'QUAY_NAME'],
-               [$class: 'StringParameterValue', value: dockerTag, name: 'DOCKER_TAG'],
                [$class: 'StringParameterValue', value: quayTag, name: 'QUAY_TAG']
              ], wait: false
            )

--- a/deploy/jenkins-ci/Makefile
+++ b/deploy/jenkins-ci/Makefile
@@ -64,7 +64,6 @@ BACKEND_FORK_URI ?= $(shell git config --get remote.origin.url)
 BUILD_TAG ?= prepare-next-version
 BUMP_BRANCH_ID ?= $(BUILD_TAG)
 
-DOCKER_NAME ?= docker.io/kiali/kiali
 QUAY_NAME ?= quay.io/kiali/kiali
 QUAY_OPERATOR_NAME ?= quay.io/kiali/kiali-operator
 
@@ -129,12 +128,6 @@ backend-test:
 	$(MAKE) test-race
 
 backend-push-docker:
-ifdef DOCKER_USER
-ifdef DOCKER_PASSWORD
-	@echo "Logging in to DockerHub..."
-	@docker login -u "$(DOCKER_USER)" -p "$(DOCKER_PASSWORD)" docker.io
-endif
-endif
 ifdef QUAY_USER
 ifdef QUAY_PASSWORD
 	@echo "Logging in to Quay.io..."
@@ -148,10 +141,6 @@ endif
 	  make container-build container-push
 ifneq ($(IS_SNAPSHOT),y)
    # Create or update vX.Y tags (without the patch number)
-   # docker.io/kiali
-	docker tag "$(DOCKER_NAME):$(VERSION_TAG)" "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"
-	docker push "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"
-	docker rmi "$(DOCKER_NAME):v$(BACKEND_VERSION_BRANCH)"
    # quay.io/kiali
 	docker tag "$(QUAY_NAME):$(VERSION_TAG)" "$(QUAY_NAME):v$(BACKEND_VERSION_BRANCH)"
 	docker push "$(QUAY_NAME):v$(BACKEND_VERSION_BRANCH)"
@@ -162,7 +151,6 @@ ifneq ($(IS_SNAPSHOT),y)
 	docker rmi "$(QUAY_OPERATOR_NAME):v$(BACKEND_VERSION_BRANCH)"
 endif
    # Clean-up
-	docker rmi "$(DOCKER_NAME):$(VERSION_TAG)"
 	docker rmi "$(QUAY_NAME):$(VERSION_TAG)"
 	docker rmi "$(QUAY_OPERATOR_NAME):$(VERSION_TAG)"
 

--- a/deploy/jenkins-ci/README.md
+++ b/deploy/jenkins-ci/README.md
@@ -12,7 +12,7 @@
     + [Building a patch release (back-end only)](#building-a-patch-release-back-end-only)
     + [Building a major release](#building-a-major-release)
     + [Building a snapshot release](#building-a-snapshot-release)
-    + [Building an edge/daily release](#building-an-edge-daily-release)
+    + [Building an edge/daily release](#building-an-edgedaily-release)
 * [Recovering and troubleshooting a build](#recovering-and-troubleshooting-a-build)
 * [Making test builds](#making-test-builds)
 * [Developer setup](#developer-setup)
@@ -206,7 +206,7 @@ repositories.
 ## Recovering and troubleshooting a build
 
 The Pipeline is not idempotent, mainly because of all external systems
-that are involved (NPM, repositories, DockerHub, etc.). Nevertheless,
+that are involved (NPM, repositories, Quay.io, etc.). Nevertheless,
 it is possible to re-try a build or do a new build to continue the
 failed one. You first need to figure out at what stage the build failed
 to decide how to proceed.
@@ -239,7 +239,7 @@ the suggested action of the first check that is not OK:
      prepare it for the next release.
    * Retry the build but set parameters SKIP_UI_RELEASE to `y` and UI_VERSION
      to the version of the front-end that got published in NPM.
-1. Are the container images present in DockerHub and Quay.io?
+1. Are the container images present in Quay.io?
    Is the back-end version properly tagged (see https://github.com/kiali/kiali/tags)?
    If not to any of these questions:
    * Retry the build but set parameters SKIP_UI_RELEASE to `y` and UI_VERSION
@@ -262,8 +262,8 @@ It is not possible to simulate a build. However, you can run a build
 against and affecting alternate repositories.
 
 To run test builds you will need your own forks of the Kiali repositories
-and your own DockerHub and Quay.io repositories. You will need to
-setup Jenkins with a GitHub, DockerHub and Quay.io accounts with push
+and your own Quay.io repository. You will need to
+setup Jenkins with a GitHub and Quay.io accounts with push
 privileges to your repositories; see the
 [Setup Jenkins credentials](#setup-jenkins-credentials) of the developer
 setup section to learn more.
@@ -274,8 +274,6 @@ When running the build, set the following parameters:
   `git@github.com:israel-hdez/swscore.git`.
 * UI_GITHUB_URI: Use the SSH url of your Kiali's front-end fork; e.g.
   `git@github.com:israel-hdez/swsui.git`.
-* DOCKER_NAME: Use your own DockerHub repository for Kiali;
-  e.g. `docker.io/edgarhz/kiali`.
 * QUAY_NAME: Use your own Quay.io repository for Kiali;
   e.g. `quay.io/edgarhz/kiali`.
 * QUAY_OPERATOR_NAME: Use your own Quay.io repository for the operator;
@@ -389,14 +387,6 @@ at the left to add these five credentials:
   * Kind: Secret text
   * ID: kiali-npm
   * Secret: An arbitrary string.
-* **DockerHub credentials:** Used to push the Kiali image to
-  DockerHub. For development, use your DockerHub account (it will
-  be safer if you use an account without push rights to the
-  DockerHub Kiali repositories.)
-  * Kind: Username with password
-  * ID: kiali-docker
-  * Username: A valid DockerHub username
-  * Password: A valid DockerHub password
 * **Quay credentials:** Used to push the Kiali image and the
   Kiali operator image to Quay.io. For development, use your
   Quay.io account (it will be safer if you use an account

--- a/deploy/jenkins-ci/jenkins_ref/jobs/kiali-release/config.xml
+++ b/deploy/jenkins-ci/jenkins_ref/jobs/kiali-release/config.xml
@@ -8,7 +8,7 @@
       </jobPropertyDescriptors>
     </org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction>
   </actions>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
@@ -47,12 +47,6 @@ specified, the type of the release will be determined based on the current date.
           <name>UI_GITHUB_URI</name>
           <description>SSH Url of the kiali-ui GitHub repository</description>
           <defaultValue>git@github.com:kiali/kiali-ui.git</defaultValue>
-          <trim>true</trim>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>DOCKER_NAME</name>
-          <description>The name of the Docker repository to push the release</description>
-          <defaultValue>docker.io/kiali/kiali</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
@@ -97,13 +91,13 @@ UI (changes to prepare for next version)</description>
           <name>UI_VERSION</name>
           <description>If you are skipping UI release. Specify the UI version to package, or leave 
 unset to use the version present in the main Makefile (e.g. leave unset for patch releases)</description>
-          <defaultValue></defaultValue>
+          <defaultValue/>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>NPM_CONFIG_REGISTRY</name>
           <description>Registry to use for fetching packages. This is not used for publishing releases. Do not include the trailing slash.</description>
-          <defaultValue></defaultValue>
+          <defaultValue/>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>

--- a/make/Makefile.cluster.mk
+++ b/make/Makefile.cluster.mk
@@ -85,10 +85,10 @@ cluster-build-operator: .prepare-cluster container-build-operator
 cluster-build-kiali: .prepare-cluster container-build-kiali
 ifeq ($(DORP),docker)
 	@echo Re-tag the already built Kiali container image for a remote cluster using docker
-	docker tag ${DOCKER_TAG} ${CLUSTER_KIALI_TAG}
+	docker tag ${QUAY_TAG} ${CLUSTER_KIALI_TAG}
 else
 	@echo Re-tag the already built Kiali container image for a remote cluster using podman
-	podman tag ${DOCKER_TAG} ${CLUSTER_KIALI_TAG}
+	podman tag ${QUAY_TAG} ${CLUSTER_KIALI_TAG}
 endif
 
 ## cluster-build: Builds the images for development with a remote cluster

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -30,12 +30,10 @@
 container-build-kiali: .prepare-kiali-image-files
 ifeq ($(DORP),docker)
 	@echo Building container image for Kiali using docker
-	docker build --pull -t ${DOCKER_TAG} -f ${OUTDIR}/docker/${KIALI_DOCKER_FILE} ${OUTDIR}/docker
-	docker tag ${DOCKER_TAG} ${QUAY_TAG}
+	docker build --pull -t ${QUAY_TAG} -f ${OUTDIR}/docker/${KIALI_DOCKER_FILE} ${OUTDIR}/docker
 else
 	@echo Building container image for Kiali using podman
-	podman build --pull -t ${DOCKER_TAG} -f ${OUTDIR}/docker/${KIALI_DOCKER_FILE} ${OUTDIR}/docker
-	podman tag ${DOCKER_TAG} ${QUAY_TAG}
+	podman build --pull -t ${QUAY_TAG} -f ${OUTDIR}/docker/${KIALI_DOCKER_FILE} ${OUTDIR}/docker
 endif
 
 ## container-build-operator: Build Kiali operator container image.
@@ -62,17 +60,6 @@ else
 	podman push ${QUAY_TAG}
 endif
 
-## container-push-kiali-docker: Pushes the Kiali image to docker hub.
-# TODO when can we stop publishing to docker.io?
-container-push-kiali-docker:
-ifeq ($(DORP),docker)
-	@echo Pushing current image to ${DOCKER_TAG} using docker
-	docker push ${DOCKER_TAG}
-else
-	@echo Pushing current image to ${DOCKER_TAG} using podman
-	podman push ${DOCKER_TAG}
-endif
-
 ## container-push-operator: Pushes the operator image to quay.
 container-push-operator-quay:
 ifeq ($(DORP),docker)
@@ -86,8 +73,8 @@ endif
 ## container-push: Pushes all container images to quay and docker hub.
 # On x86_64 machine, push both kiali and operator images.
 ifeq ($(GOARCH),amd64)
-container-push: container-push-kiali-quay container-push-kiali-docker container-push-operator-quay
+container-push: container-push-kiali-quay container-push-operator-quay
 # On other achitectures, only push kiali image.
 else
-container-push: container-push-kiali-quay container-push-kiali-docker
+container-push: container-push-kiali-quay
 endif


### PR DESCRIPTION
* DockerHub references in main Makefiles are removed
* DockerHub references in Jenkins Pipeline are removed
* DockerHub references in docs are removed

Also, remove some outdated docs.

Fixes kiali/kiali#2615