### PR TITLE
Disable LoginToken.SigningKey validation with Anonymous auth strategy

### DIFF
--- a/config/token.go
+++ b/config/token.go
@@ -38,7 +38,7 @@ func GetSigningKey() string {
 	cfg := Get()
 	signKey := cfg.LoginToken.SigningKey
 
-	if len(signKey) == 0 || signKey == "kiali" {
+	if cfg.Auth.Strategy != AuthStrategyAnonymous && (len(signKey) == 0 || signKey == "kiali") {
 		// "kiali" is a well-known signing key reported in a CVE. We ban it's usage.
 		// An empty key is also just not allowed.
 		panic("signing key for login tokens is invalid")

--- a/config/token.go
+++ b/config/token.go
@@ -57,7 +57,7 @@ func ValidateSigningKey(signingKey string, authStrategy string) error {
 	if authStrategy != AuthStrategyAnonymous && (len(signingKey) == 0 || signingKey == "kiali") {
 		// "kiali" is a well-known signing key reported in a CVE. We ban it's usage.
 		// An empty key is also just not allowed.
-		return fmt.Errorf("signing key for login tokens is invalid")
+		return errors.New("signing key for login tokens is invalid")
 	}
 
 	return nil

--- a/kiali.go
+++ b/kiali.go
@@ -217,7 +217,7 @@ func validateConfig() error {
 
 	// Check the signing key for the JWT token is valid
 	signingKey := config.Get().LoginToken.SigningKey
-	if len(signingKey) == 0 || signingKey == "kiali" {
+	if auth.Strategy != config.AuthStrategyAnonymous && (len(signingKey) == 0 || signingKey == "kiali") {
 		// "kiali" is a well-known signing key reported in a CVE. We ban it's usage.
 		// An empty key is also just not allowed.
 		return fmt.Errorf("signing key for login tokens is invalid")

--- a/kiali.go
+++ b/kiali.go
@@ -217,8 +217,8 @@ func validateConfig() error {
 
 	// Check the signing key for the JWT token is valid
 	signingKey := config.Get().LoginToken.SigningKey
-	if config.ValidateSigningKey(signingKey, auth.Strategy) != nil {
-		return fmt.Errorf("signing key for login tokens is invalid")
+	if err := config.ValidateSigningKey(signingKey, auth.Strategy); err != nil {
+		return err
 	}
 
 	return nil

--- a/kiali.go
+++ b/kiali.go
@@ -217,9 +217,7 @@ func validateConfig() error {
 
 	// Check the signing key for the JWT token is valid
 	signingKey := config.Get().LoginToken.SigningKey
-	if auth.Strategy != config.AuthStrategyAnonymous && (len(signingKey) == 0 || signingKey == "kiali") {
-		// "kiali" is a well-known signing key reported in a CVE. We ban it's usage.
-		// An empty key is also just not allowed.
+	if config.ValidateSigningKey(signingKey, auth.Strategy) != nil {
 		return fmt.Errorf("signing key for login tokens is invalid")
 	}
 


### PR DESCRIPTION
** Describe the change **

This disables the validation for `LoginToken.SigningKey` when using the `anonymous` Authentication Strategy. Currently, the value is required and cannot equal `"kiali"` which is not relevant when using an `anonymous` strategy.

** Issue reference **

[Issue](https://github.com/kiali/kiali/issues/2548)([comment](https://github.com/kiali/kiali/issues/2548#issuecomment-610630144))

** Backwards incompatible? **

This change is **not** backwards incompatible. 

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
TBD
