### PR TITLE
Protect against bad source telemetry

### DIFF
--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -220,6 +220,10 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		destVer := string(lDestVer)
 		responseCode := string(lResponseCode)
 
+		if util.IsBadSourceTelemetry(sourceWlNs, sourceWl, sourceApp) {
+			continue
+		}
+
 		// This was added in istio 1.5, handle in a backward compatible way
 		grpcReponseStatus := "0"
 		if grpcReponseStatusOk {
@@ -235,7 +239,7 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		val := float64(s.Value)
 		destSvcNs, destSvcName = util.HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName)
 
-		if util.IsBadTelemetry(destSvc, destSvcName, destWl) {
+		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue
 		}
 

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -231,13 +231,17 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o gra
 		code := string(lCode)
 		flags := string(lFlags)
 
+		if util.IsBadSourceTelemetry(sourceWlNs, sourceWl, sourceApp) {
+			continue
+		}
+
 		// set response code in a backward compatible way
 		code = util.HandleResponseCode(protocol, code, grpcOk, string(lGrpc))
 
 		// handle multicluster requests
 		destSvcNs, destSvcName := util.HandleMultiClusterRequest(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvcName))
 
-		if util.IsBadTelemetry(destSvc, destSvcName, destWl) {
+		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue
 		}
 
@@ -325,10 +329,14 @@ func populateTrafficMapTCP(trafficMap graph.TrafficMap, vector *model.Vector, o 
 		destVer := string(lDestVer)
 		flags := string(lFlags)
 
+		if util.IsBadSourceTelemetry(sourceWlNs, sourceWl, sourceApp) {
+			continue
+		}
+
 		// handle multicluster requests
 		destSvcNs, destSvcName := util.HandleMultiClusterRequest(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvcName))
 
-		if util.IsBadTelemetry(destSvc, destSvcName, destWl) {
+		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue
 		}
 

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -62,12 +62,20 @@ func HandleResponseCode(protocol, httpResponseCode string, grpcResponseStatusOk 
 	return grpcResponseStatus
 }
 
-// IsBadTelemetry tests for known issues in generated telemetry given indicative label values.
+// IsBadSourceTelemetry tests for known issues in generated telemetry given indicative label values.
+// 1) source namespace is provided without workload or app
+// 2) no more conditions known
+func IsBadSourceTelemetry(ns, wl, app string) bool {
+	// case1
+	return graph.IsOK(ns) && !graph.IsOK(wl) && !graph.IsOK(app)
+}
+
+// IsBadDestTelemetry tests for known issues in generated telemetry given indicative label values.
 // 1) During pod lifecycle changes incomplete telemetry may be generated that results in
 //    destSvc == destSvcName and no dest workload, where destSvc[Name] is in the form of an IP address.
 // 2) no more conditions known
-func IsBadTelemetry(destSvc, destSvcName, destWl string) bool {
+func IsBadDestTelemetry(svc, svcName, wl string) bool {
 	// case1
-	failsEqualsTest := (!graph.IsOK(destWl) && graph.IsOK(destSvc) && graph.IsOK(destSvcName) && (destSvc == destSvcName))
-	return failsEqualsTest && badServiceMatcher.MatchString(destSvcName)
+	failsEqualsTest := (!graph.IsOK(wl) && graph.IsOK(svc) && graph.IsOK(svcName) && (svc == svcName))
+	return failsEqualsTest && badServiceMatcher.MatchString(svcName)
 }

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -63,7 +63,7 @@ func HandleResponseCode(protocol, httpResponseCode string, grpcResponseStatusOk 
 }
 
 // IsBadSourceTelemetry tests for known issues in generated telemetry given indicative label values.
-// 1) source namespace is provided without workload or app
+// 1) source namespace is provided with neither workload nor app
 // 2) no more conditions known
 func IsBadSourceTelemetry(ns, wl, app string) bool {
 	// case1

--- a/graph/types.go
+++ b/graph/types.go
@@ -180,14 +180,14 @@ func Id(serviceNamespace, service, workloadNamespace, workload, app, version, gr
 	serviceOk := IsOK(service)
 
 	if !workloadOk && !appOk && !serviceOk {
-		panic(fmt.Sprintf("Failed ID gen: namespace=[%s] workload=[%s] app=[%s] version=[%s] service=[%s] graphType=[%s]", namespace, workload, app, version, service, graphType))
+		panic(fmt.Sprintf("Failed ID gen1: namespace=[%s] workload=[%s] app=[%s] version=[%s] service=[%s] graphType=[%s]", namespace, workload, app, version, service, graphType))
 	}
 
 	// handle workload graph nodes (service graphs are initially processed as workload graphs)
 	if graphType == GraphTypeWorkload || graphType == GraphTypeService {
 		// workload graph nodes are type workload or service
 		if !workloadOk && !serviceOk {
-			panic(fmt.Sprintf("Failed ID gen: namespace=[%s] workload=[%s] app=[%s] version=[%s] service=[%s] graphType=[%s]", namespace, workload, app, version, service, graphType))
+			panic(fmt.Sprintf("Failed ID gen2: namespace=[%s] workload=[%s] app=[%s] version=[%s] service=[%s] graphType=[%s]", namespace, workload, app, version, service, graphType))
 		}
 		if !workloadOk {
 			return fmt.Sprintf("svc_%v_%v", namespace, service), NodeTypeService


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2622

After discussing with the community member in the issue we decided that the problematic telemetry is "bad" telemetry, likely due to a telemetry V2 corner case with reporting or scraping.  I asked in the istio Telemetry working group and they also said it seemed unintended to have source workload set, but with no other source information.

So, this PR adds a filter for telemetry with that signature.

@israel-hdez This is probably just a visual review of the code as we can't easily replicate the problem.  @mattmahoneyrh, the validation is likely just to ensure that bookinfo or any other traffic remains the same as before the PR (basically show that the new filtering doesn't lose any of the existing traffic we expect).