### PR TITLE
Refresh namespace level cache

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -712,7 +712,7 @@ func (in *IstioConfigService) DeleteIstioConfigDetail(api, namespace, resourceTy
 
 	// Cache is stopped after a Create/Update/Delete operation to force a refresh
 	if kialiCache != nil && err == nil {
-		kialiCache.Stop()
+		kialiCache.RefreshNamespace(namespace)
 	}
 	return err
 }
@@ -811,7 +811,7 @@ func (in *IstioConfigService) modifyIstioConfigDetail(api, namespace, resourceTy
 	}
 	// Cache is stopped after a Create/Update/Delete operation to force a refresh
 	if kialiCache != nil && err == nil {
-		kialiCache.Stop()
+		kialiCache.RefreshNamespace(namespace)
 	}
 	return istioConfigDetail, err
 

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -25,6 +25,9 @@ type (
 		// Control methods
 		// Check if a namespace is listed to be cached; if yes, creates a cache for that namespace
 		CheckNamespace(namespace string) bool
+
+		// Clear a namespace's cache
+		RefreshNamespace(namespace string)
 		// Stop all caches
 		Stop()
 
@@ -176,6 +179,14 @@ func (c *kialiCacheImpl) CheckNamespace(namespace string) bool {
 		return c.createCache(namespace)
 	}
 	return c.isKubernetesSynced(namespace) && c.isIstioSynced(namespace)
+}
+
+// RefreshNamespace will delete the specific namespace's cache and create a new one.
+func (c *kialiCacheImpl) RefreshNamespace(namespace string) {
+	defer c.cacheLock.Unlock()
+	c.cacheLock.Lock()
+	delete(c.nsCache, namespace)
+	c.createCache(namespace)
 }
 
 func (c *kialiCacheImpl) Stop() {


### PR DESCRIPTION
This PR adds a method `RefreshNamespace` in `KialiCache` providing a way to clear the cache only in a specific namespace.

When updating istio object, caches from all namespaces will be refreshed. It takes 10s+ to finish this job when the number of namespaces is more than 50.

This PR is to solve this problem as it is not necessary to refresh all caches.
