### PR TITLE
Allow minikube hack script to set different minikube profile

### DIFF
--- a/hack/k8s-minikube.sh
+++ b/hack/k8s-minikube.sh
@@ -23,6 +23,7 @@ DEFAULT_K8S_DISK="40g"
 DEFAULT_K8S_DRIVER="virtualbox"
 DEFAULT_K8S_MEMORY="16384"
 DEFAULT_K8S_VERSION="v1.14.2"
+DEFAULT_MINIKUBE_PROFILE="minikube"
 
 debug() {
   if [ "$_VERBOSE" == "true" ]; then
@@ -154,6 +155,10 @@ while [[ $# -gt 0 ]]; do
       K8S_VERSION="$2"
       shift;shift
       ;;
+    -mp|--minikube-profile)
+      MINIKUBE_PROFILE="$2"
+      shift;shift
+      ;;
     -v|--verbose)
       _VERBOSE=true
       shift
@@ -184,6 +189,10 @@ Valid options:
       The version of Kubernetes to start.
       Only used for the 'up' command.
       Default: ${DEFAULT_K8S_VERSION}
+  -mp|--minikube-profile
+      The profile which minikube will be started with.
+      Only used for the 'up' command.
+      Default: ${DEFAULT_MINIKUBE_PROFILE}
   -v|--verbose
       Enable logging of debug messages from this script.
 
@@ -217,12 +226,14 @@ K8S_DISK=${K8S_DISK:-${DEFAULT_K8S_DISK}}
 K8S_DRIVER=${K8S_DRIVER:-${DEFAULT_K8S_DRIVER}}
 K8S_VERSION=${K8S_VERSION:-${DEFAULT_K8S_VERSION}}
 K8S_MEMORY=${K8S_MEMORY:-${DEFAULT_K8S_MEMORY}}
+MINIKUBE_PROFILE=${MINIKUBE_PROFILE:-${DEFAULT_MINIKUBE_PROFILE}}
 
 debug "K8S_CPU=$K8S_CPU"
 debug "K8S_DISK=$K8S_DISK"
 debug "K8S_DRIVER=$K8S_DRIVER"
 debug "K8S_MEMORY=$K8S_MEMORY"
 debug "K8S_VERSION=$K8S_VERSION"
+debug "MINIKUBE_PROFILE=$MINIKUBE_PROFILE"
 
 # If minikube is not in PATH, abort.
 if ! which minikube > /dev/null 2>&1 ; then
@@ -235,7 +246,7 @@ debug "minikube is located at $(which minikube)"
 
 if [ "$_CMD" = "up" ]; then
   echo 'Starting minikube...'
-  minikube start --cpus=${K8S_CPU} --memory=${K8S_MEMORY} --disk-size=${K8S_DISK} --vm-driver=${K8S_DRIVER} --kubernetes-version=${K8S_VERSION}
+  minikube start --cpus=${K8S_CPU} --memory=${K8S_MEMORY} --disk-size=${K8S_DISK} --vm-driver=${K8S_DRIVER} --kubernetes-version=${K8S_VERSION} -p ${MINIKUBE_PROFILE}
   echo 'Enabling the ingress addon'
   minikube addons enable ingress
   echo 'Enabling the image registry'


### PR DESCRIPTION
I've recently needed the option of keeping multiple minikube instances alive. I've done so usign the minikube `profile` feature.

This PR allows users can start new clusters with a specific profile. You only need to add either the `mp` or `minikube-profile` param.

`./k8s-minikube.sh up -kdr kvm2 -mp kiali-1287 -v`

Once the minikube is up, you'll see the new profile:
```
$ minikube profile
kiali-1287
```