### PR TITLE
Fixes Iter8 literal in config to please ansible operator

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -162,7 +162,7 @@ type Iter8Config struct {
 // New add-on/extension configuration should create a specif config and be located under this
 type Extensions struct {
 	ThreeScale ThreeScaleConfig `yaml:"threescale,omitempty"`
-	Iter8      Iter8Config      `yaml:"iter8,omitempty"`
+	Iter8      Iter8Config      `yaml:"iter_8,omitempty"`
 }
 
 // ExternalServices holds configurations for other systems that Kiali depends on


### PR DESCRIPTION
I won't refactor all code, just the mapping into the yaml.

Fixes https://github.com/kiali/kiali/issues/2711

Note, this requires a PR on the operator side (on the way).