### PR TITLE
[hack] move to OpenShift 4.4.3 in aws hack script

### DIFF
--- a/hack/aws-openshift.sh
+++ b/hack/aws-openshift.sh
@@ -295,7 +295,7 @@ SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPT_ROOT}
 
 # The default version of OpenShift to be downloaded
-DEFAULT_OPENSHIFT_DOWNLOAD_VERSION="4.4.0"
+DEFAULT_OPENSHIFT_DOWNLOAD_VERSION="4.4.3"
 
 # The default path under mirror.openshift.com/pub/openshift-v4 where the version downloads are found
 DEFAULT_OCP_URL_PATH="ocp"


### PR DESCRIPTION
Looks like OpenShift 4.4 is already up to patch level 3 - have the hack script use it (I tested it, and it does install and start up).