### PR TITLE
jenkins generation of all-in-one operator deployment yaml

### DIFF
--- a/deploy/jenkins-ci/Dockerfile
+++ b/deploy/jenkins-ci/Dockerfile
@@ -56,6 +56,8 @@ RUN set -eux; \
     # Install tools: build tools, gosu, docker-cli \
     apt-get -qq update; \
     apt-get install --no-install-recommends -qq build-essential gosu docker-ce-cli; \
+    # Install some things to support generating operator all-in-one yaml (gettext-base has 'envsubst') \
+    apt-get -qq install gettext-base; \
     # Create Docker group \
     groupadd -r docker; \
     usermod -aG docker jenkins; \

--- a/deploy/jenkins-ci/Makefile.operator.jenkins
+++ b/deploy/jenkins-ci/Makefile.operator.jenkins
@@ -90,6 +90,11 @@ operator-build-release:
 	sed -i -r 's/^VERSION \?= v.*/VERSION \?= $(OPERATOR_VERSION_TO_RELEASE)/' Makefile
 	OPERATOR_QUAY_NAME="$(QUAY_OPERATOR_NAME)" \
 	  $(MAKE) clean build
+ifneq ($(IS_SNAPSHOT),y)
+	OPERATOR_IMAGE_VERSION="$(OPERATOR_VERSION_TO_RELEASE)" \
+	  $(MAKE) generate-all-in-one
+	cp _output/kiali-operator-all-in-one.yaml deploy/
+endif
 
 operator-push-quay:
 ifdef QUAY_USER
@@ -114,6 +119,7 @@ endif
 operator-push-version-tag:
 ifeq ($(PUSH_GITHUB_TAG),y)
 	git add Makefile
+	git add deploy/kiali-operator-all-in-one.yaml
 	git commit -m "Release $(OPERATOR_VERSION)"
 	git push $(OPERATOR_GITHUB_URI) $$(git rev-parse HEAD):refs/tags/$(VERSION_TAG)
 ifdef GH_TOKEN
@@ -156,8 +162,12 @@ endif
 operator-prepare-master-next-version:
 	# Only minor releases require to prepare the master branch for the next release
 ifeq ($(RELEASE_TYPE),minor)
+	OPERATOR_IMAGE_VERSION="latest" \
+	  $(MAKE) generate-all-in-one
+	cp _output/kiali-operator-all-in-one.yaml deploy/
 	sed -i -r "s/^VERSION \?= (.*)/VERSION \?= v$(OPERATOR_BUMPED_VERSION)-SNAPSHOT/" Makefile
 	git add Makefile
+	git add deploy/kiali-operator-all-in-one.yaml
 	git commit -m "Prepare for next version"
 	# First, try to push directly to master
 	git push $(OPERATOR_GITHUB_URI) $$(git rev-parse HEAD):refs/heads/$(OPERATOR_MAIN_BRANCH) || touch pr_needed.txt


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/2674
This goes with https://github.com/kiali/kiali-operator/pull/28

This generates the all-in-one yaml and commits it to the deploy/ directory.

This all-in-one yaml should only be used for those that do not have nor wish to use Operator Lifecycle Manager to install and manage the Kiali operator installation.