### PR TITLE
Allow Policy to return an empty array on Istio without Authentication API

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -149,6 +149,11 @@ type IstioClient struct {
 	// See istio_details_service.go#HasSecurityResource() for more details.
 	securityResources *map[string]bool
 
+	// securityResources private variable will check which resources kiali has access to from security.istio.io group
+	// It is represented as a pointer to include the initialization phase.
+	// See istio_details_service.go#HasSecurityResource() for more details.
+	authenticationResources *map[string]bool
+
 	// isMixedDisabled private variable will check if mixed is enabled in the current istio deployment.
 	// It is represented with a pointer to a bool. True if mixer is disabled, false instead
 	isMixerDisabled *bool

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -141,17 +141,17 @@ type IstioClient struct {
 
 	// rbacResources private variable will check which resources kiali has access to from rbac.istio.io group
 	// It is represented as a pointer to include the initialization phase.
-	// See istio_details_service.go#HasRbacResource() for more details.
+	// See istio_details_service.go#hasRbacResource() for more details.
 	rbacResources *map[string]bool
 
 	// securityResources private variable will check which resources kiali has access to from security.istio.io group
 	// It is represented as a pointer to include the initialization phase.
-	// See istio_details_service.go#HasSecurityResource() for more details.
+	// See istio_details_service.go#hasSecurityResource() for more details.
 	securityResources *map[string]bool
 
-	// securityResources private variable will check which resources kiali has access to from security.istio.io group
+	// authenticationResources private variable will check which resources kiali has access to from authentication.istio.io group
 	// It is represented as a pointer to include the initialization phase.
-	// See istio_details_service.go#HasSecurityResource() for more details.
+	// See istio_details_service.go#hasAuthenticationResource() for more details.
 	authenticationResources *map[string]bool
 
 	// isMixedDisabled private variable will check if mixed is enabled in the current istio deployment.


### PR DESCRIPTION
This PR has the responsability to allow Kiali to run into Istio 1.5 and Istio 1.6 without triggering alerts because of the consumption of the Policy CRD.

This is preventing me to implement further features based on Istio 1.6.

The behavior is the following:

On Istio 1.5:
![Screen recording (27)](https://user-images.githubusercontent.com/613814/81077187-f316b880-8eec-11ea-877f-2810483b17c6.gif)

On Istio 1.6:
![Screen recording (26)](https://user-images.githubusercontent.com/613814/81077260-07f34c00-8eed-11ea-8173-6d638aff7f91.gif)

Makes #2727 less ugly. However, I couldn't consider that issue close because this workaround makes the MTLS icons disappear into istio 1.6 (except for the graph).
