### PR TITLE
Fail faster: validate swagger first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ install:
 script:
   - if [ ! -z "$(gofmt -l ${GO_FILES})" ]; then echo "These files need to be formatted:" "$(gofmt -l ${GO_FILES})";echo "Diff files:"; gofmt -d ${GO_FILES}; exit 1; fi # Gofmt Linter
   - make lint
-  - make clean build test-race
   - make swagger-travis
+  - make clean build test-race


### PR DESCRIPTION
I've found myself many times forgetting to update the swagger files. And many times, I realized right after switching to another context. I propose to validate the swagger files as faster as possible to prevent that context switch. Like we do with the linting.