### PR TITLE
Remove RBAC limitation from the token authentication

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -98,7 +98,14 @@ func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
 		if queryAllNamespaces {
 			nss, err := in.k8s.GetNamespaces(labelSelector)
 			if err != nil {
-				return nil, err
+				// Fallback to using the Kiali service account, if needed
+				if errors.IsForbidden(err) {
+					if nss, err = in.getNamespacesUsingKialiSA(labelSelector, err); err != nil {
+						return nil, err
+					}
+				} else {
+					return nil, err
+				}
 			}
 			namespaces = models.CastNamespaceCollection(nss)
 		} else {
@@ -106,10 +113,13 @@ func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
 			for _, ans := range accessibleNamespaces {
 				k8sNs, err := in.k8s.GetNamespace(ans)
 				if err != nil {
-					// If a namespace is not found, then we skip it from the list of namespaces
 					if errors.IsNotFound(err) {
+						// If a namespace is not found, then we skip it from the list of namespaces
 						log.Warningf("Kiali has an accessible namespace [%s] which doesn't exist", ans)
-					} else {
+					} else if !errors.IsForbidden(err) {
+						// Also, if namespace isn't readable, skip it.
+
+						// ...but if for some reason error is not "forbidden", abort and return the error.
 						return nil, err
 					}
 				} else {
@@ -208,4 +218,59 @@ func (in *NamespaceService) GetNamespace(namespace string) (*models.Namespace, e
 		}
 	}
 	return &result, nil
+}
+
+func (in *NamespaceService) getNamespacesUsingKialiSA(labelSelector string, forwardedError error) ([]core_v1.Namespace, error) {
+	// Check if we already are using the Kiali ServiceAccount token. If we do, no need to do further processing, since
+	// this would just circle back to the same results.
+	if kialiToken, err := kubernetes.GetKialiToken(); err != nil {
+		return nil, err
+	} else if in.k8s.GetToken() == kialiToken {
+		return nil, forwardedError
+	}
+
+	// Let's get the namespaces list using the Kiali Service Account
+	nss, err := getNamespacesForKialiSA(labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only take namespaces where the user has privileges
+	var namespaces []core_v1.Namespace
+	for _, item := range nss {
+		if _, getNsErr := in.k8s.GetNamespace(item.Name); getNsErr == nil {
+			// Namespace is accessible
+			namespaces = append(namespaces, item)
+		} else if !errors.IsForbidden(getNsErr) {
+			// Since the returned error is NOT "forbidden", something bad happened
+			return nil, getNsErr
+		}
+	}
+
+	// Return the list of namespaces where the user has the 'get namespace' read privilege.
+	return namespaces, nil
+}
+
+func getNamespacesForKialiSA(labelSelector string) ([]core_v1.Namespace, error) {
+	clientFactory, err := kubernetes.GetClientFactory()
+	if err != nil {
+		return nil, err
+	}
+
+	kialiToken, err := kubernetes.GetKialiToken()
+	if err != nil {
+		return nil, err
+	}
+
+	k8s, err := clientFactory.GetClient(kialiToken)
+	if err != nil {
+		return nil, err
+	}
+
+	nss, err := k8s.GetNamespaces(labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	return nss, nil
 }

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -228,9 +228,15 @@ func performTokenAuthentication(w http.ResponseWriter, r *http.Request) bool {
 
 	// Using the namespaces API to check if token is valid. In Kubernetes, the version API seems to allow
 	// anonymous access, so it's not feasible to use the version API for token verification.
-	_, err = business.Namespace.GetNamespaces()
+	nsList, err := business.Namespace.GetNamespaces()
 	if err != nil {
 		RespondWithDetailedError(w, http.StatusUnauthorized, "Token is not valid or is expired", err.Error())
+		return false
+	}
+
+	// If namespace list is empty, return unauthorized error
+	if len(nsList) == 0 {
+		RespondWithError(w, http.StatusUnauthorized, "Not enough privileges to login")
 		return false
 	}
 


### PR DESCRIPTION
This is for plain Kubernetes environments, where the Projects API is not available. There was a RBAC limitation where Kiali was requiring read access to all Kiali accessible namespaces in order for users to be able to login.

This tries to circumvent the RBAC limiation by using the Kiali Service Account. Certainly, this is assuming that the Kiali ServiceAccount is present and has the `get namespaces` privilege. We are already assuming the presence of Kiali ServiceAccount with other sets of permissions for the following features:

* Kiali's cache
* Discovery of prometheus
* Discovery of Grafana
* Check what version of Istio's Telemetry is enabled

So, the assumption of the presence of the Kiali ServiceAccount and it's usage may not be too bad. Installation through Kiali Operator is currently creating the SA, at least with read-only privileges. Anyway, if the Kiali ServiceAccount is missing, or not properly mounted, or it doesn't have the assumed privileges, these changes should still fail gracefully.

Fixes kiali/kiali#2728