### PR TITLE
Protect networking and config .istio.io APIs in backend queries

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -145,6 +145,16 @@ type IstioClient struct {
 	// See iter8.go#IsIter8Api() for more details
 	isIter8Api *bool
 
+	// networkingResources private variable will check which resources kiali has access to from networking.istio.io group
+	// It is represented as a pointer to include the initialization phase.
+	// See istio_details_service.go#hasNetworkingResource() for more details.
+	networkingResources *map[string]bool
+
+	// configResources private variable will check which resources kiali has access to from config.istio.io group
+	// It is represented as a pointer to include the initialization phase.
+	// See istio_details_service.go#hasConfigResource() for more details.
+	configResources *map[string]bool
+
 	// rbacResources private variable will check which resources kiali has access to from rbac.istio.io group
 	// It is represented as a pointer to include the initialization phase.
 	// See istio_details_service.go#hasRbacResource() for more details.

--- a/kubernetes/istio_rules_service.go
+++ b/kubernetes/istio_rules_service.go
@@ -10,6 +10,11 @@ import (
 
 // GetIstioRules returns a list of mixer rules for a given namespace.
 func (in *IstioClient) GetIstioRules(namespace string, labelSelector string) ([]IstioObject, error) {
+	// In case rules aren't present on Istio, return empty array.
+	if !in.hasConfigResource(rules) {
+		return []IstioObject{}, nil
+	}
+
 	result, err := in.istioConfigApi.Get().Namespace(namespace).Resource(rules).Param("labelSelector", labelSelector).Do().Get()
 	if err != nil {
 		return nil, err
@@ -66,6 +71,7 @@ func (in *IstioClient) GetTemplate(namespace, templateType, templateName string)
 }
 
 func (in *IstioClient) getAdaptersTemplates(namespace string, itemType string, pluralsMap map[string]string, labelSelector string) ([]IstioObject, error) {
+	// getAdaptersTemplates is already protected on cases a template doesn't exist
 	resultsChan := make(chan istioResponse)
 	for name, plural := range pluralsMap {
 		go func(name, plural string) {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2748

It adds additional check on GetList methods to return empty results on deprecated APIs.

Note, this is a workaround, once Istio 1.6 removes the old deprecated APIs I think we should remove them as well.

No need to make Kiali backward compatible with all versions