### PR TITLE
[hack] support 1.6 as well as 1.5 - mtls options changed

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -239,6 +239,14 @@ if [[ "${CLIENT_EXE}" = *"oc" ]]; then
   else
     CNI_OPTIONS="--set components.cni.enabled=true --set components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/etc/cni/multus/net.d --set values.cni.chained=false --set values.cni.cniConfFileName=istio-cni.conf --set values.sidecarInjectorWebhook.injectedAnnotations.k8s\.v1\.cni\.cncf\.io/networks=istio-cni"
     TELEMETRY_OPTIONS="--set components.telemetry.k8s.resources.requests.memory=100Mi --set components.telemetry.k8s.resources.requests.cpu=50m"
+
+    # Istio 1.5 used global.mtls.auto, 1.6 renamed it
+    if ${ISTIOCTL} --remote=false version | grep -q "1\.5" ; then
+      MTLS_OPTIONS="--set values.global.mtls.auto=${MTLS}"
+    else
+      MTLS_OPTIONS="--set values.meshConfig.enableAutoMtls=${MTLS}"
+    fi
+    MTLS_OPTIONS="${MTLS_OPTIONS} --set values.global.controlPlaneSecurityEnabled=${MTLS}"
   fi
 fi
 
@@ -288,8 +296,7 @@ for s in \
    "${_KIALI_TAG_ARG}" \
    "--set addonComponents.tracing.enabled=${DASHBOARDS_ENABLED}" \
    "--set addonComponents.grafana.enabled=${DASHBOARDS_ENABLED}" \
-   "--set values.meshConfig.enableAutoMtls=${MTLS}" \
-   "--set values.global.controlPlaneSecurityEnabled=${MTLS}" \
+   "${MTLS_OPTIONS}" \
    "--set values.gateways.istio-egressgateway.enabled=${ISTIO_EGRESSGATEWAY_ENABLED}" \
    "${CNI_OPTIONS}" \
    "${TELEMETRY_OPTIONS}" \


### PR DESCRIPTION
We still want the hack script to support 1.5. This uses the proper mtls setting for 1.6 but retains the same one used in 1.5.