### PR TITLE
be able to deploy kiali outside istio control plane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,10 @@ OPERATOR_CONTAINER_VERSION ?= ${CONTAINER_VERSION}
 OPERATOR_QUAY_NAME ?= quay.io/${OPERATOR_CONTAINER_NAME}
 OPERATOR_QUAY_TAG = ${OPERATOR_QUAY_NAME}:${OPERATOR_CONTAINER_VERSION}
 
+# Where the control plane is
+ISTIO_NAMESPACE ?= istio-system
 # Declares the namespace/project where the objects are to be deployed.
-NAMESPACE ?= istio-system
+NAMESPACE ?= ${ISTIO_NAMESPACE}
 
 # A default go GOPATH if it isn't user defined
 GOPATH ?= ${HOME}/go

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -42,6 +42,7 @@ operator-create: .ensure-operator-repo-exists .prepare-cluster operator-delete .
     --kiali-image-name           "${CLUSTER_KIALI_INTERNAL_NAME}" \
     --kiali-image-pull-policy    "${KIALI_IMAGE_PULL_POLICY}" \
     --kiali-image-version        "${CONTAINER_VERSION}" \
+    --istio-namespace            "${ISTIO_NAMESPACE}" \
     --namespace                  "${NAMESPACE}"
 
 ## operator-delete: Remove the Kiali operator resources from the cluster along with Kiali itself
@@ -75,6 +76,7 @@ KIALI_EXTERNAL_SERVICES_PASSWORD="$(shell ${OC} get secrets htpasswd -n ${NAMESP
 KIALI_IMAGE_NAME="${CLUSTER_KIALI_INTERNAL_NAME}" \
 KIALI_IMAGE_PULL_POLICY="${KIALI_IMAGE_PULL_POLICY}" \
 KIALI_IMAGE_VERSION="${CONTAINER_VERSION}" \
+ISTIO_NAMESPACE="${ISTIO_NAMESPACE}" \
 NAMESPACE="${NAMESPACE}" \
 ROUTER_HOSTNAME="$(shell ${OC} get $(shell (${OC} get routes -n ${NAMESPACE} -o name 2>/dev/null || echo 'noroute') | head -n 1) -n ${NAMESPACE} -o jsonpath='{.status.ingress[0].routerCanonicalHostname}' 2>/dev/null)" \
 SERVICE_TYPE="${SERVICE_TYPE}" \


### PR DESCRIPTION
This just lets devs deploy kiali outside the control plane namespace via the make targets.

This was needed to test https://github.com/kiali/kiali-operator/pull/34