### PR TITLE
pilot is gone, default the version endpoint to the new istiod

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -329,7 +329,7 @@ func NewConfig() (c *Config) {
 				IstioStatusEnabled:     true,
 				IstioIdentityDomain:    "svc.cluster.local",
 				IstioSidecarAnnotation: "sidecar.istio.io/status",
-				UrlServiceVersion:      "http://istio-pilot:8080/version",
+				UrlServiceVersion:      "http://istiod:15014/version",
 			},
 			Prometheus: PrometheusConfig{
 				Auth: Auth{


### PR DESCRIPTION
this doesn't really address https://github.com/kiali/kiali/issues/2754 but it does need to be incorporated. The default version endpoint should be the one in istiod that was introduced in 1.6.

Note that this default doesn't really come into  play under normal circumstances - the operator will always set it and so do the upstream istio helm chart, so this default isn't used. It will only be used during tests or if you remove the setting from the configmap manually. but it is good to change it since that pilot endpoint is now gone since istio 1.6