### PR TITLE
Run Kiali as non-root user

### DIFF
--- a/deploy/docker/Dockerfile-ubi7-minimal
+++ b/deploy/docker/Dockerfile-ubi7-minimal
@@ -11,7 +11,13 @@ COPY kiali $KIALI_HOME/
 
 ADD console $KIALI_HOME/console/
 
-RUN chgrp -R 0 $KIALI_HOME/console && \
+RUN microdnf install -y shadow-utils && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum && \
+    adduser kiali && \
+    chown -R kiali:kiali $KIALI_HOME/console && \
     chmod -R g=u $KIALI_HOME/console
+
+USER kiali
 
 ENTRYPOINT ["/opt/kiali/kiali"]

--- a/deploy/docker/Dockerfile-ubi8-minimal
+++ b/deploy/docker/Dockerfile-ubi8-minimal
@@ -11,7 +11,13 @@ COPY kiali $KIALI_HOME/
 
 ADD console $KIALI_HOME/console/
 
-RUN chgrp -R 0 $KIALI_HOME/console && \
+RUN microdnf install -y shadow-utils && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum && \
+    adduser kiali && \
+    chown -R kiali:kiali $KIALI_HOME/console && \
     chmod -R g=u $KIALI_HOME/console
+
+USER kiali
 
 ENTRYPOINT ["/opt/kiali/kiali"]


### PR DESCRIPTION
To follow container best practices, run Kiali as a regular user by default.

Fixes kiali/kiali#2745