### PR TITLE
Fix overview services health showing inexisting services

### DIFF
--- a/business/health.go
+++ b/business/health.go
@@ -200,12 +200,9 @@ func (in *HealthService) getNamespaceServiceHealth(namespace string, services []
 	lblDestSvc := model.LabelName("destination_service_name")
 	for _, sample := range rates {
 		service := string(sample.Metric[lblDestSvc])
-		health, ok := allHealth[service]
-		if !ok {
-			health = &models.ServiceHealth{Requests: models.NewEmptyRequestHealth()}
-			allHealth[service] = health
+		if health, ok := allHealth[service]; ok {
+			health.Requests.AggregateInbound(sample)
 		}
-		health.Requests.AggregateInbound(sample)
 	}
 
 	return allHealth


### PR DESCRIPTION
It was adding services based on istio metrics in addition to the ones strictly resulting from k8s api

Fixes https://github.com/kiali/kiali/issues/2772
