### PR TITLE
AutoEnableMTLS by default is true

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -516,7 +516,7 @@ func (in *IstioValidationsService) fetchNonLocalmTLSConfigs(mtlsDetails *kuberne
 		if err != nil {
 			errChan <- err
 		} else {
-			details.EnabledAutoMtls = icm.EnableAutoMtls
+			details.EnabledAutoMtls = icm.GetEnableAutoMtls()
 		}
 	}(mtlsDetails)
 

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -65,7 +65,7 @@ func mockWorkLoadService(k8s *kubetest.K8SClientMock) WorkloadService {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakePods().Items, nil)
-	k8s.On("GetIstioConfigMap").Return(&kubernetes.IstioMeshConfig{EnableAutoMtls: true}, nil)
+	k8s.On("GetIstioConfigMap").Return(&kubernetes.IstioMeshConfig{}, nil)
 
 	svc := setupWorkloadService(k8s)
 	return svc

--- a/business/tls.go
+++ b/business/tls.go
@@ -265,5 +265,5 @@ func (in TLSService) hasAutoMTLSEnabled() bool {
 		return true
 	}
 
-	return mc.EnableAutoMtls
+	return mc.GetEnableAutoMtls()
 }

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -437,7 +437,7 @@ type IstioObjectList interface {
 }
 
 type IstioMeshConfig struct {
-	DisableMixerHttpReports bool `yaml:"disableMixerHttpReports,omitempty"`
+	DisableMixerHttpReports bool  `yaml:"disableMixerHttpReports,omitempty"`
 	EnableAutoMtls          *bool `yaml:"enableAutoMtls,omitempty"`
 }
 

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -438,7 +438,7 @@ type IstioObjectList interface {
 
 type IstioMeshConfig struct {
 	DisableMixerHttpReports bool `yaml:"disableMixerHttpReports,omitempty"`
-	EnableAutoMtls          bool `yaml:"enableAutoMtls,omitempty"`
+	EnableAutoMtls          *bool `yaml:"enableAutoMtls,omitempty"`
 }
 
 // ServiceList holds list of services, pods and deployments
@@ -640,4 +640,11 @@ func (in *GenericIstioObjectList) DeepCopyObject() runtime.Object {
 		return c
 	}
 	return nil
+}
+
+func (imc IstioMeshConfig) GetEnableAutoMtls() bool {
+	if imc.EnableAutoMtls == nil {
+		return true
+	}
+	return *imc.EnableAutoMtls
 }


### PR DESCRIPTION
I've detected a change from 1.6-beta.0 to beta.1. The Istio config map no longer includes the 'enableAutoMtls' field in the default installation. It means that they defaults to true.

My previous deployment defaulted to false.
This PR includes this default to true when the flag is not present.