### PR TITLE
Add another RC version-string variety

### DIFF
--- a/status/versions.go
+++ b/status/versions.go
@@ -38,7 +38,7 @@ var (
 	ossmVersionExpr           = regexp.MustCompile(`(?:OSSM_|openshift-service-mesh-)([0-9]+\.[0-9]+\.[0-9]+)`)
 	maistraProjectVersionExpr = regexp.MustCompile(`(?:Maistra_|openshift-istio.*-)([0-9]+\.[0-9]+\.[0-9]+)`)
 	istioDevVersionExpr       = regexp.MustCompile(`(\d+\.\d+)-alpha\.([[:alnum:]]+)-.*`)
-	istioRCVersionExpr        = regexp.MustCompile(`(\d+\.\d+.\d+)-((?:alpha|beta|rc)\.\d+)`)
+	istioRCVersionExpr        = regexp.MustCompile(`(\d+\.\d+.\d+)-((?:alpha|beta|rc|RC)\.\d+)`)
 	istioSnapshotVersionExpr  = regexp.MustCompile(`istio-release-([0-9]+\.[0-9]+)(-[0-9]{8})`)
 	istioVersionExpr          = regexp.MustCompile(`([0-9]+\.[0-9]+\.[0-9]+)`)
 )

--- a/status/versions.go
+++ b/status/versions.go
@@ -38,7 +38,7 @@ var (
 	ossmVersionExpr           = regexp.MustCompile(`(?:OSSM_|openshift-service-mesh-)([0-9]+\.[0-9]+\.[0-9]+)`)
 	maistraProjectVersionExpr = regexp.MustCompile(`(?:Maistra_|openshift-istio.*-)([0-9]+\.[0-9]+\.[0-9]+)`)
 	istioDevVersionExpr       = regexp.MustCompile(`(\d+\.\d+)-alpha\.([[:alnum:]]+)-.*`)
-	istioRCVersionExpr        = regexp.MustCompile(`(\d+\.\d+.\d+)-((?:alpha|beta)\.\d+)`)
+	istioRCVersionExpr        = regexp.MustCompile(`(\d+\.\d+.\d+)-((?:alpha|beta|rc)\.\d+)`)
 	istioSnapshotVersionExpr  = regexp.MustCompile(`istio-release-([0-9]+\.[0-9]+)(-[0-9]{8})`)
 	istioVersionExpr          = regexp.MustCompile(`([0-9]+\.[0-9]+\.[0-9]+)`)
 )

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -147,6 +147,12 @@ func TestParseIstioRawVersion(t *testing.T) {
 			supported:  true,
 		},
 		{
+			rawVersion: "root@f72e3d3ef3c2-docker.io/1.6.0-rc.0",
+			name:       "Istio RC",
+			version:    "1.6.0 (rc.0)",
+			supported:  true,
+		},
+		{
 			rawVersion: "some-unknown-version-string",
 			name:       "Unknown Istio Implementation",
 			version:    "some-unknown-version-string",


### PR DESCRIPTION
This adds support for detecting when the running istio version is an RC release like x.x.x-rc.x For example, without this PR running istio-1.6.0-rc.0 wil be reported as:

Istio: 1.6.0

With the PR it will be reported like:

Istio RC: 1.6.0 (rc.0)

Relates to #2754