### PR TITLE
Virtual Service: support to partially QDN in gateways

### DIFF
--- a/business/checkers/virtual_services/no_gateway_checker.go
+++ b/business/checkers/virtual_services/no_gateway_checker.go
@@ -2,7 +2,6 @@ package virtual_services
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -36,17 +35,7 @@ func (s NoGatewayChecker) ValidateVirtualServiceGateways(spec map[string]interfa
 					if gate == "mesh" {
 						continue GatewaySearch
 					}
-					var hostname string
-					if strings.Contains(gate, "/") {
-						parts := strings.Split(gate, "/")
-						hostname = kubernetes.Host{
-							Service:   parts[1],
-							Namespace: parts[0],
-							Cluster:   clusterName,
-						}.String()
-					} else {
-						hostname = kubernetes.ParseHost(gate, namespace, clusterName).String()
-					}
+					hostname := kubernetes.ParseGatewayAsHost(gate, namespace, clusterName).String()
 					for gw := range s.GatewayNames {
 						if found := kubernetes.FilterByHost(hostname, gw, namespace); found {
 							continue GatewaySearch

--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -70,6 +70,28 @@ func TestFoundGateway(t *testing.T) {
 	assert.Empty(validations)
 }
 
+func TestFoundGatewayTwoPartNaming(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	virtualService := data.AddGatewaysToVirtualService([]string{"my-gateway.test", "mesh"}, data.CreateVirtualService())
+	gatewayNames := kubernetes.GatewayNames([][]kubernetes.IstioObject{
+		{
+			data.CreateEmptyGateway("my-gateway", "test", make(map[string]string)),
+		},
+	})
+
+	checker := NoGatewayChecker{
+		VirtualService: virtualService,
+		GatewayNames:   gatewayNames,
+	}
+
+	validations, valid := checker.Check()
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
 func TestFQDNFoundGateway(t *testing.T) {
 	assert := assert.New(t)
 

--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -89,7 +89,9 @@ func TestFoundGatewayTwoPartNaming(t *testing.T) {
 
 	validations, valid := checker.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(models.Unknown, validations[0].Severity)
+	assert.Equal(models.CheckMessage("virtualservices.gateway.oldnomenclature"), validations[0].Message)
 }
 
 func TestFQDNFoundGateway(t *testing.T) {
@@ -112,7 +114,9 @@ func TestFQDNFoundGateway(t *testing.T) {
 
 	validations, valid := checker.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(models.Unknown, validations[0].Severity)
+	assert.Equal(models.CheckMessage("virtualservices.gateway.oldnomenclature"), validations[0].Message)
 }
 
 func TestFQDNFoundOtherNamespaceGateway(t *testing.T) {
@@ -136,7 +140,9 @@ func TestFQDNFoundOtherNamespaceGateway(t *testing.T) {
 
 	validations, valid := checker.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Len(validations, 1)
+	assert.Equal(models.Unknown, validations[0].Severity)
+	assert.Equal(models.CheckMessage("virtualservices.gateway.oldnomenclature"), validations[0].Message)
 }
 
 func TestNewIstioGatewayNameFormat(t *testing.T) {

--- a/business/checkers/virtual_services/subset_presence_checker.go
+++ b/business/checkers/virtual_services/subset_presence_checker.go
@@ -47,10 +47,6 @@ func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
 			for destWeightIdx := 0; destWeightIdx < destinationWeights.Len(); destWeightIdx++ {
 				destinationWeight, ok := destinationWeights.Index(destWeightIdx).Interface().(map[string]interface{})
 				if !ok || destinationWeight["destination"] == nil {
-					valid = false
-					path := fmt.Sprintf("spec/%s[%d]/route[%d]", protocol, routeIdx, destWeightIdx)
-					validation := models.Build("virtualservices.subsetpresent.destinationmandatory", path)
-					validations = append(validations, &validation)
 					continue
 				}
 

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -143,3 +143,31 @@ func HasMatchingServiceEntries(service string, serviceEntries map[string][]strin
 
 	return false
 }
+
+func ParseGatewayAsHost(gateway, currentNamespace, currentCluster string) Host {
+	host := Host{
+		Service:   gateway,
+		Namespace: currentNamespace,
+		Cluster:   currentCluster,
+		CompleteInput: true,
+	}
+
+	if strings.Contains(gateway, ".") {
+		parts := strings.Split(gateway, ".")
+		host.Service = parts[0]
+
+		if len(parts) > 1 {
+			host.Namespace = parts[1]
+
+			if len(parts) > 2 {
+				host.Cluster = strings.Join(parts[2:], ".")
+			}
+		}
+	} else if strings.Contains(gateway, "/") {
+		parts := strings.Split(gateway, "/")
+		host.Namespace = parts[0]
+		host.Service = parts[1]
+	}
+
+	return host
+}

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -146,9 +146,9 @@ func HasMatchingServiceEntries(service string, serviceEntries map[string][]strin
 
 func ParseGatewayAsHost(gateway, currentNamespace, currentCluster string) Host {
 	host := Host{
-		Service:   gateway,
-		Namespace: currentNamespace,
-		Cluster:   currentCluster,
+		Service:       gateway,
+		Namespace:     currentNamespace,
+		Cluster:       currentCluster,
 		CompleteInput: true,
 	}
 

--- a/kubernetes/host_test.go
+++ b/kubernetes/host_test.go
@@ -1,0 +1,23 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+)
+
+func TestGatewayAsHost(t *testing.T) {
+	assert := assert.New(t)
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert.Equal("mygateway.bookinfo.svc.cluster.local", ParseGatewayAsHost("mygateway", "bookinfo", "svc.cluster.local").String())
+	assert.Equal("mygateway.bookinfo.svc.cluster.local", ParseGatewayAsHost("bookinfo/mygateway", "bookinfo", "svc.cluster.local").String())
+	assert.Equal("mygateway.istio-system.svc.cluster.local", ParseGatewayAsHost("istio-system/mygateway", "bookinfo", "svc.cluster.local").String())
+	assert.Equal("mygateway.bookinfo.svc.cluster.local", ParseGatewayAsHost("mygateway.bookinfo", "bookinfo", "svc.cluster.local").String())
+	assert.Equal("mygateway.bookinfo.svc.cluster.local", ParseGatewayAsHost("mygateway.bookinfo", "bookinfo", "svc.cluster.local").String())
+	assert.Equal("mygateway.bookinfo.svc.cluster.local", ParseGatewayAsHost("mygateway.bookinfo.svc.cluster.local", "bookinfo", "svc.cluster.local").String())
+}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -148,7 +148,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: ErrorSeverity,
 	},
 	"destinationrules.mtls.meshpolicymtlsenabled": {
-		Message:  "KIA0208 PeerAuthentication enabling mTLS found, permissive policy is needed",
+		Message:  "KIA0208 PeerAuthentication enabling mTLS found, permissive mode needed",
 		Severity: ErrorSeverity,
 	},
 	"destinationrules.mtls.servicemeshpolicymissing": {
@@ -224,7 +224,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"virtualservices.gateway.oldnomenclature": {
-		Message:  "KIA1109 Preferred nomenclature: <gateway namespace>/<gateway name>",
+		Message:  "KIA1108 Preferred nomenclature: <gateway namespace>/<gateway name>",
 		Severity: Unknown,
 	},
 	"virtualservices.nohost.hostnotfound": {
@@ -254,10 +254,6 @@ var checkDescriptors = map[string]IstioCheck{
 	"virtualservices.subsetpresent.subsetnotfound": {
 		Message:  "KIA1107 Subset not found",
 		Severity: WarningSeverity,
-	},
-	"virtualservices.subsetpresent.destinationmandatory": {
-		Message:  "KIA1108 Destination field is mandatory",
-		Severity: ErrorSeverity,
 	},
 	"validation.unable.cross-namespace": {
 		Message:  "KIA0001 Unable to verify the validity, cross-namespace validation is not supported for this field",

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -223,6 +223,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA1006 Global default sidecar should not have workloadSelector",
 		Severity: WarningSeverity,
 	},
+	"virtualservices.gateway.oldnomenclature": {
+		Message:  "KIA1109 Preferred nomenclature: <gateway namespace>/<gateway name>",
+		Severity: Unknown,
+	},
 	"virtualservices.nohost.hostnotfound": {
 		Message:  "KIA1101 DestinationWeight on route doesn't have a valid service (host not found)",
 		Severity: ErrorSeverity,


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2698

It also adds a new validation regarding the nomenclature used for referring a gateway.
The FQDN and PQDN are no longer supported. Istio suggests to use `<namespace>/<gateway name>` format.

Needs a documentation PR: https://github.com/kiali/kiali.io/pull/235


![Screenshot of Kiali Console (71)](https://user-images.githubusercontent.com/613814/82232382-dc318680-992e-11ea-8adf-6d1df28d0ec2.png)

![Screenshot of Kiali Console (70)](https://user-images.githubusercontent.com/613814/82232408-e0f63a80-992e-11ea-9fa6-27b8d9a30b8c.png)

![Screenshot of Kiali Console (69)](https://user-images.githubusercontent.com/613814/82232393-ddfb4a00-992e-11ea-8d18-871de19acdf0.png)
