### PR TITLE
Configurable thresholds for error rates

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -343,6 +343,10 @@ spec:
 For now, only REST APIs have their spec displayed but we are working to support gRpc and GraphQL soon.
 A live console to test your APIs directly with Kiali is also being worked on.
 
+=== Configure ThresholdHealths
+
+If you want to customize ThresholdHealth in Kiali, follow this documentation link:./models/threshold/Threshold.adoc[documentation].
+
 === Customize API docs annotations
 
 You can configure Kiali to use your own annotation names with the Kiali CR

--- a/business/apps.go
+++ b/business/apps.go
@@ -64,18 +64,9 @@ func (in *AppService) GetAppList(namespace string) (models.AppList, error) {
 	}
 
 	for keyApp, valueApp := range apps {
-		appItem := &models.AppListItem{
-			Name:         keyApp,
-			IstioSidecar: true,
-		}
-		labels := make(map[string][]string)
-		for _, srv := range valueApp.Services {
-			joinMap(labels, srv.Labels)
-		}
-		for _, wrk := range valueApp.Workloads {
-			joinMap(labels, wrk.Labels)
-		}
-		appItem.Labels = buildFinalLabels(labels)
+		appItem := &models.AppListItem{Name: keyApp}
+		appItem.IstioSidecar = true
+		appItem.Labels = getLabelsApp(valueApp.Workloads, valueApp.Services)
 		for _, w := range valueApp.Workloads {
 			if appItem.IstioSidecar = w.IstioSidecar; !appItem.IstioSidecar {
 				break
@@ -227,4 +218,15 @@ func fetchNamespaceApps(layer *Layer, namespace string, appName string) (namespa
 	}
 
 	return castAppDetails(services, ws), nil
+}
+
+func getLabelsApp(workloads models.Workloads, services []core_v1.Service) map[string]string {
+	var labels = make(map[string][]string)
+	for _, srv := range services {
+		joinMap(labels, srv.Labels)
+	}
+	for _, wrk := range workloads {
+		joinMap(labels, wrk.Labels)
+	}
+	return buildFinalLabels(labels)
 }

--- a/business/health.go
+++ b/business/health.go
@@ -296,7 +296,7 @@ func (in *HealthService) getServiceRequestsHealth(namespace, service, rateInterv
 	for _, sample := range inbound {
 		rqHealth.AggregateInbound(sample)
 	}
-	return rqHealth, generateThreshold(inbound, namespace, service, "service", srv.Service.Labels), err
+	return rqHealth, generateThreshold(inbound, model.Vector{}, namespace, service, "service", srv.Service.Labels), err
 }
 
 func (in *HealthService) getAppRequestsHealth(namespace, app, rateInterval string, queryTime time.Time) (models.RequestHealth, []models.Threshold, error) {
@@ -309,7 +309,7 @@ func (in *HealthService) getAppRequestsHealth(namespace, app, rateInterval strin
 	for _, sample := range outbound {
 		rqHealth.AggregateOutbound(sample)
 	}
-	return rqHealth, generateThreshold(inbound, namespace, app, "app", getLabelsApp(appInfo[app].Workloads, appInfo[app].Services)), err
+	return rqHealth, generateThreshold(inbound, outbound, namespace, app, "app", getLabelsApp(appInfo[app].Workloads, appInfo[app].Services)), err
 }
 
 func (in *HealthService) getWorkloadRequestsHealth(namespace, workload, rateInterval string, queryTime time.Time) (models.RequestHealth, []models.Threshold, error) {
@@ -322,7 +322,7 @@ func (in *HealthService) getWorkloadRequestsHealth(namespace, workload, rateInte
 	for _, sample := range outbound {
 		rqHealth.AggregateOutbound(sample)
 	}
-	return rqHealth, generateThreshold(inbound, namespace, workload, "workload", wInfo.Labels), err
+	return rqHealth, generateThreshold(inbound, outbound, namespace, workload, "workload", wInfo.Labels), err
 }
 
 func castWorkloadStatuses(ws models.Workloads) []models.WorkloadStatus {
@@ -339,9 +339,9 @@ func castWorkloadStatuses(ws models.Workloads) []models.WorkloadStatus {
 	return statuses
 }
 
-func generateThreshold(requests model.Vector, ns string, srv string, kind string, labels map[string]string) models.Thresholds {
+func generateThreshold(inbound model.Vector, outbound model.Vector, ns string, srv string, kind string, labels map[string]string) models.Thresholds {
 	thAlerts := threshold.FilterBy(config.Get().ThresholdsHealth, ns, srv, kind, labels)
 	thresholds := models.Thresholds{}
-	thresholds.Parse(thAlerts, &requests, "service")
+	thresholds.Parse(thAlerts, &inbound, &outbound)
 	return thresholds
 }

--- a/config/config.go
+++ b/config/config.go
@@ -288,18 +288,19 @@ type ThresholdHealth struct {
 }
 
 type ThresholdCheck struct {
-	Rule       string          `yaml:"rule"`
-	Kind       string          `yaml:"kind"`
-	Label      string          `yaml:"label"`
-	Filter     ThresholdFilter `yaml:"filter,omitempty"`
-	Expression string          `yaml:"exp"`
-	Alert      string          `yaml:"alert"`
+	Rule        string          `yaml:"rule"`
+	Kind        string          `yaml:"kind"`
+	RequestType string          `yaml:"request_type"`
+	Label       string          `yaml:"label"`
+	Filter      ThresholdFilter `yaml:"filter,omitempty"`
+	Expression  string          `yaml:"expression"`
+	Alert       string          `yaml:"alert"`
 }
 
 type ThresholdFilter struct {
 	Regex       string                `yaml:"regex,omitempty"`
 	LabelFilter *ThresholdLabelFilter `yaml:"label_filter,omitempty"`
-	OptProm     *ThresholdLabelFilter `yaml:"prom_filter,omitempty"`
+	OptProm     *ThresholdLabelFilter `yaml:"opt_prom,omitempty"`
 }
 
 type ThresholdLabelFilter struct {

--- a/config/config.go
+++ b/config/config.go
@@ -281,6 +281,33 @@ type DeploymentConfig struct {
 // defaults to the namespace configured for IstioNamespace (which itself defaults to 'istio-system').
 type IstioComponentNamespaces map[string]string
 
+// Threshold configuration
+type ThresholdHealth struct {
+	Namespace       string           `yaml:"namespace"`
+	ThresholdChecks []ThresholdCheck `yaml:"threshold_checks"`
+}
+
+type ThresholdCheck struct {
+	Rule       string          `yaml:"rule"`
+	Kind       string          `yaml:"kind"`
+	Label      string          `yaml:"label"`
+	Filter     ThresholdFilter `yaml:"filter,omitempty"`
+	Expression string          `yaml:"exp"`
+	Alert      string          `yaml:"alert"`
+}
+
+type ThresholdFilter struct {
+	Regex       string                `yaml:"regex,omitempty"`
+	LabelFilter *ThresholdLabelFilter `yaml:"label_filter,omitempty"`
+	OptProm     *ThresholdLabelFilter `yaml:"prom_filter,omitempty"`
+}
+
+type ThresholdLabelFilter struct {
+	LabelFilter *[]ThresholdLabelFilter `yaml:"label_filter,omitempty"`
+	Labels      map[string]string       `yaml:"labels,omitempty"`
+	Operation   string                  `yaml:"operation,omitempty"`
+}
+
 // Config defines full YAML configuration.
 type Config struct {
 	AdditionalDisplayDetails []AdditionalDisplayItem  `yaml:"additional_display_details,omitempty"`
@@ -298,6 +325,7 @@ type Config struct {
 	KubernetesConfig         KubernetesConfig         `yaml:"kubernetes_config,omitempty"`
 	LoginToken               LoginToken               `yaml:"login_token,omitempty"`
 	Server                   Server                   `yaml:",omitempty"`
+	ThresholdsHealth         []ThresholdHealth        `yaml:"thresholds_health,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -407,6 +435,7 @@ func NewConfig() (c *Config) {
 			WebRoot:                    "/",
 			WebSchema:                  "",
 		},
+		ThresholdsHealth: []ThresholdHealth{},
 	}
 
 	return

--- a/models/health.go
+++ b/models/health.go
@@ -17,13 +17,15 @@ type NamespaceWorkloadHealth map[string]*WorkloadHealth
 
 // ServiceHealth contains aggregated health from various sources, for a given service
 type ServiceHealth struct {
-	Requests RequestHealth `json:"requests"`
+	Requests   RequestHealth `json:"requests"`
+	Thresholds []Threshold   `json:"thresholds"`
 }
 
 // AppHealth contains aggregated health from various sources, for a given app
 type AppHealth struct {
 	WorkloadStatuses []WorkloadStatus `json:"workloadStatuses"`
 	Requests         RequestHealth    `json:"requests"`
+	Thresholds       []Threshold      `json:"thresholds"`
 }
 
 var (
@@ -40,6 +42,7 @@ func EmptyAppHealth() AppHealth {
 	return AppHealth{
 		WorkloadStatuses: []WorkloadStatus{},
 		Requests:         NewEmptyRequestHealth(),
+		Thresholds:       []Threshold{},
 	}
 }
 
@@ -54,6 +57,7 @@ func EmptyServiceHealth() ServiceHealth {
 type WorkloadHealth struct {
 	WorkloadStatus WorkloadStatus `json:"workloadStatus"`
 	Requests       RequestHealth  `json:"requests"`
+	Thresholds     []Threshold    `json:"thresholds"`
 }
 
 // WorkloadStatus gives

--- a/models/threshold.go
+++ b/models/threshold.go
@@ -1,0 +1,51 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models/threshold"
+)
+
+type Thresholds []Threshold
+
+// Customize Thresholds error rates
+type Threshold struct {
+	Percent int    `json:"percent"`
+	Rule    string `json:"rule"`
+	Alert   string `json:"alert"`
+}
+
+func (in *Thresholds) Parse(ths []config.ThresholdCheck, sample *model.Vector, kind string) {
+	for _, th := range ths {
+		newTh := Threshold{}
+		error := newTh.Parse(th, sample)
+		if error == nil {
+			*in = append(*in, newTh)
+		}
+	}
+}
+
+func (in *Threshold) Parse(th config.ThresholdCheck, sample *model.Vector) error {
+	count, total, err := threshold.CountBy(sample, th)
+
+	if err != nil {
+		return errors.New("Not Alert")
+	}
+	var calculation = (count * 100 / total)
+	err, op, percent := threshold.CheckRule(th.Rule)
+	if err != nil {
+		return errors.New("Not Alert")
+	}
+	if threshold.Compare(calculation, op, percent) {
+		in.Alert = th.Alert
+		in.Percent = count * 100 / total
+		in.Rule = fmt.Sprintf("[%s] Alert requests where %s are %d%% , rule defined %s", th.Alert, th.Expression, calculation, th.Rule)
+		return nil
+	}
+
+	return errors.New("Not Alert")
+}

--- a/models/threshold/Threshold.adoc
+++ b/models/threshold/Threshold.adoc
@@ -1,0 +1,83 @@
+= ThresholdHealth
+:toc: macro
+:toc-title:
+
+== Introduction
+
+Kiali provides a customize configuration for ThresholdAlert from requests in your environment.
+
+== Table of contents
+
+toc::[]
+
+== Configuration
+
+[source,yaml]
+----
+thresholds_health:
+  - namespace: "bookinfo"
+    threshold_checks:
+      - rule: ">20"
+        kind: "all"
+        label: "response_code"
+        filter:
+          reg: "views"
+          label_filter:
+            labels:
+              - app: "^details$"
+                version: "^v1$"
+            operation: "and"
+        expression: "400>x"
+        alert: "warning"
+----
+
+- *namespace*: Namespace to apply the ThresholdHealth
+- *theshold_checks*: List of Checks for that namespace
+  * *rule*: The expression to match.(In the sample the selected requests must be greater than the 20%)
+  * *kind*: Resources to apply. Options (`service`, `workload`, `app`, `all`/`""`)
+  * *label*: Label of request in Prometheus that we want to have the ThresholdHealth
+  * *filter*: Options for filter requests
+    ** *reg*: Regex that the `name` of the resource must match
+    ** *label_filter*: Filter by labels of the resource (See <<LabelFilter and PromFilter configuration>>)
+    ** *prom_filter*: Filter requests by prometheus label (See <<LabelFilter and PromFilter configuration>>)
+  * *expression*: The condition for requests for `label` (In example, requests where `response_code` is greater than `400`)
+  * *alert*: The alert that we want to show in the UI. (The message in UI will be [`alert`] `format message provided by kiali`. Options should be something like `INFO`, `WARNING` ....)
+
+
+=== Filter configuration
+
+We can filter the Threshold by:
+
+- Regex: Match the resource name by this regex
+- LabelFilter: Filter by labels of the resource
+- PromFilter: Filter by Prometheus Labels of each request
+
+
+==== LabelFilter and PromFilter configuration
+
+LabelFilter and PromFilter work with Regex patterns (https://www.w3schools.com/jsref/jsref_obj_regexp.asp[Some docs about]).
+
+So if we want to match exactly the name we must to set the value to `^name$` otherwise kiali will match the label value with the regex that you set.
+
+Kiali provide an option to set the operation of filter, `and`/`or` (`and` by default)so the filter support find requests with some complex options.
+
+For example if we want to filter by (app:details || app:reviews) && (version:v1 || project:backendProjectA)
+
+[source,yaml]
+----
+label_filter:
+    operation: "and"
+    label_filter:
+      - labels:
+        - app: "(details|reviews)"
+      - labels:
+        - version: "^v1$"
+          project: "backendProjectA$"
+        operation: "or"
+
+----
+ * *operation*: Operation `and`/`or` to apply to filter (Default: `and`)
+ * *label_filter*: SubObject for complexes filters
+ * *labels*: List of labels to apply like `key`: `regular expr` (This must be empty if we have a label_filter defined.)
+
+The same way kiali provide the filter for Prometheus Labels in requests.

--- a/models/threshold/filter.go
+++ b/models/threshold/filter.go
@@ -1,0 +1,160 @@
+package threshold
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/kiali/kiali/config"
+)
+
+/*
+	FilterRequests
+    Filter the requests by Prometheus options set in ThresholdCheck/Filter
+      - sample => Requests from Prometheus
+      - check => ThresholdCheck to apply to requests
+    Return
+      - result => Request that match the prometheus Filter
+*/
+func FilterRequests(sample *model.Vector, check config.ThresholdCheck) (result *model.Vector) {
+	if check.Filter.OptProm != nil {
+		result := model.Vector{}
+		for _, request := range *sample {
+			if FilterByLabel(*check.Filter.OptProm, request.Metric) {
+				result = append(result, request)
+			}
+		}
+		return &result
+	}
+	return sample
+}
+
+/*
+     FilterBy
+     Filter a list of ThresholdCheck that match with the ns, resource, kind of resource and labels of resource
+		 - configs => The list of ThresholdHealth to filter
+		 - ns => namespace of resource
+		 - resource => name of resource
+		 - kind => Type of resource (workload, service, app...)
+		 - labels => labels of resource
+	Return
+         - ret => List of ThresholdCheck that match the filter options
+*/
+func FilterBy(configs []config.ThresholdHealth, ns string, resource string, kind string, labels map[string]string) (ret []config.ThresholdCheck) {
+	thresHoldToApply := []config.ThresholdCheck{}
+	for _, conf := range configs {
+		if checkIfKind(conf.Namespace, ns) {
+			// We can apply this alert to the namespace
+			for _, alert := range conf.ThresholdChecks {
+				/*
+					Check if Kind match the resource
+					Check if match labels
+					Check if there is a regex and apply the resource name
+				*/
+				if checkIfKind(alert.Kind, kind) && FilterByLabel(*alert.Filter.LabelFilter, labels) && checkIfRegex(alert.Filter.Regex, resource) {
+					thresHoldToApply = append(thresHoldToApply, alert)
+				}
+
+			}
+		}
+	}
+
+	return thresHoldToApply
+}
+
+/*
+	FilterByLabel the interface (Metrics or map)
+		- filter => ThresholdLabelFilter to match
+        - sample => interface to match
+    Return
+ 		- bool => true if match the filter, otherwise false
+
+*/
+func FilterByLabel(filter config.ThresholdLabelFilter, sample interface{}) bool {
+	isAnd := true
+	if filter.Operation != "" {
+		isAnd = filter.Operation == "and"
+	}
+	if filter.LabelFilter == nil {
+		return FilterByORAndLabel(isAnd, filter.Labels, sample)
+	}
+	andResult := true
+	orResult := false
+	for _, v := range *filter.LabelFilter {
+		if FilterByLabel(v, sample) {
+			orResult = true
+		} else {
+			andResult = false
+		}
+		if (isAnd && !andResult) || (!isAnd && orResult) {
+			return isAnd
+		}
+	}
+	if isAnd {
+		return andResult
+	}
+	return orResult
+}
+
+/*
+	FilterByORAndLabel
+		- and => true if operator is and, false if is or
+        - labels => labels to filter
+        - sample =>  interface (Metrics or map) to match
+    Return
+ 		- bool => true if match the labels with and/or operation for sample, otherwise false
+
+*/
+func FilterByORAndLabel(and bool, labels map[string]string, sample interface{}) bool {
+	isOr := false
+	isAnd := true
+	for k, v := range labels {
+		regex := GetRegex(v)
+		err, _ := CheckExpr(sample.(map[string]string)[k], *regex)
+		// Check if apply for OR/AND operation
+		if err == nil {
+			isOr = true
+		} else {
+			isAnd = false
+		}
+		// Break in condition case to avoid continue
+		if (and && !isAnd) || (!and && isOr) {
+			return and
+		}
+	}
+	// Return if apply with the operator param provided
+	if and {
+		return isAnd
+	}
+	return isOr
+}
+
+// Check if match kind of resource
+func checkIfKind(filter string, kind string) bool {
+	if strings.Contains(filter, kind) || filter == "**" || filter == "" {
+		return true
+	}
+	return false
+}
+
+// Check if match labels of resource
+func checkIfLabels(filter map[string]string, labels map[string]string) bool {
+	for k, v := range filter {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// Check if match regex
+func checkIfRegex(regex string, resource string) bool {
+	if regex != "" {
+		reg := regexp.MustCompile(regex)
+		if !reg.MatchString(resource) {
+			return false
+		}
+	}
+	return true
+}

--- a/models/threshold/filter_test.go
+++ b/models/threshold/filter_test.go
@@ -1,0 +1,166 @@
+package threshold
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+)
+
+var ns = "bookinfo"
+var resource = "details-v1"
+var labels = map[string]string{"app": "details", "version": "v1"}
+var kind = "workload"
+
+var configs = []config.ThresholdHealth{
+	{
+		Namespace: "bookinfo",
+		ThresholdChecks: []config.ThresholdCheck{
+			{
+				Rule:       ">20",
+				Kind:       "**",
+				Label:      "response_code",
+				Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"app": "details"}}},
+				Expression: "400<x<500",
+				Alert:      "Warning-bookinfo->20",
+			},
+			{
+				Rule:       ">90",
+				Kind:       "service",
+				Label:      "response_code",
+				Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"app": "reviews"}}},
+				Expression: "x<=200",
+				Alert:      "Warning-bookinfo->90",
+			},
+			{
+				Rule:       ">90",
+				Kind:       "workload",
+				Label:      "response_code",
+				Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"version": "v1"}}, Regex: "tails"},
+				Expression: "x<=200",
+				Alert:      "Warning-bookinfo->90",
+			},
+			{
+				Rule:       ">60",
+				Kind:       "service",
+				Label:      "response_code",
+				Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"app": "details"}}},
+				Expression: "x<400",
+				Alert:      "Warning-bookinfo->60",
+			},
+		},
+	},
+	{
+		Namespace: "**",
+		ThresholdChecks: []config.ThresholdCheck{
+			{
+				Rule:       ">20",
+				Kind:       "**",
+				Label:      "response_code",
+				Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"app": "details"}}},
+				Expression: "400<x<500",
+				Alert:      "Warning-**->20",
+			},
+			{
+				Rule:       ">90",
+				Kind:       "service",
+				Label:      "response_code",
+				Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"app": "reviews"}}},
+				Expression: "x<=200",
+				Alert:      "Warning-**->90",
+			},
+			{
+				Rule:       ">60",
+				Kind:       "workload",
+				Label:      "response_code",
+				Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"app": "details"}}},
+				Expression: "x<400",
+				Alert:      "Warning-**->60",
+			},
+		},
+	},
+	{
+		Namespace: "istio-system",
+		ThresholdChecks: []config.ThresholdCheck{
+			{
+				Rule:       ">20",
+				Kind:       "**",
+				Label:      "response_code",
+				Expression: "400<x<500",
+				Alert:      "Warning-istio-system",
+			},
+		},
+	},
+}
+
+func TestFilterBy(t *testing.T) {
+	ns := "bookinfo"
+	resource := "details"
+	expected := []config.ThresholdCheck{
+		{
+			Rule:       ">20",
+			Kind:       "**",
+			Label:      "response_code",
+			Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"app": "details"}}},
+			Expression: "400<x<500",
+			Alert:      "Warning-bookinfo->20",
+		},
+		{
+			Rule:       ">90",
+			Kind:       "workload",
+			Label:      "response_code",
+			Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"version": "^v1$"}}, Regex: "tails"},
+			Expression: "x<=200",
+			Alert:      "Warning-bookinfo->90",
+		},
+		{
+			Rule:       ">20",
+			Kind:       "**",
+			Label:      "response_code",
+			Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"app": "details"}}},
+			Expression: "400<x<500",
+			Alert:      "Warning-**->20",
+		},
+		{
+			Rule:       ">60",
+			Kind:       "workload",
+			Label:      "response_code",
+			Filter:     config.ThresholdFilter{LabelFilter: &config.ThresholdLabelFilter{Labels: map[string]string{"app": "details"}}},
+			Expression: "x<400",
+			Alert:      "Warning-**->60",
+		},
+	}
+
+	result := FilterBy(configs, ns, resource, kind, labels)
+
+	for k, v := range expected {
+		assert.Equal(t, v.Label, result[k].Label)
+		assert.Equal(t, v.Alert, result[k].Alert)
+		assert.Equal(t, v.Kind, result[k].Kind)
+		assert.Equal(t, v.Rule, result[k].Rule)
+		assert.Equal(t, v.Expression, result[k].Expression)
+	}
+}
+
+func TestCheckIfKind(t *testing.T) {
+	assert.Equal(t, checkIfKind("**", ns), true)
+	assert.Equal(t, checkIfKind("", ns), true)
+	assert.Equal(t, checkIfKind("bookinfo", ns), true)
+	assert.Equal(t, checkIfKind("bookinfo,istio-system", ns), true)
+	assert.Equal(t, checkIfKind("istio-system", ns), false)
+}
+
+func TestCheckIfLabels(t *testing.T) {
+	assert.Equal(t, checkIfLabels(map[string]string{"app": "details"}, labels), true)
+	assert.Equal(t, checkIfLabels(map[string]string{}, labels), true)
+	assert.Equal(t, checkIfLabels(map[string]string{"app": "reviews"}, labels), false)
+	assert.Equal(t, checkIfLabels(labels, labels), true)
+}
+
+func TestCheckIfRegex(t *testing.T) {
+	assert.Equal(t, checkIfRegex("v1", resource), true)
+	assert.Equal(t, checkIfRegex("details", resource), true)
+	assert.Equal(t, checkIfRegex("reviews", resource), false)
+	assert.Equal(t, checkIfRegex("tails", resource), true)
+}

--- a/models/threshold/helper.go
+++ b/models/threshold/helper.go
@@ -1,0 +1,30 @@
+package threshold
+
+// Clean empty values in array
+func delete_empty(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
+}
+
+//Compare given A value, operator and B value
+func Compare(valueA int, operator string, valueB int) bool {
+	switch operator {
+	case ">":
+		return valueA > valueB
+	case ">=":
+		return valueA >= valueB
+	case "<=":
+		return valueA <= valueB
+	case "<":
+		return valueA < valueB
+	case "!=":
+		return valueA != valueB
+	default:
+		return valueA == valueB
+	}
+}

--- a/models/threshold/helper_test.go
+++ b/models/threshold/helper_test.go
@@ -1,0 +1,28 @@
+package threshold
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompare(t *testing.T) {
+	assert.Equal(t, Compare(200, "<", 400), true)
+	assert.Equal(t, Compare(200, "<=", 400), true)
+	assert.Equal(t, Compare(200, "<=", 200), true)
+	assert.Equal(t, Compare(200, "==", 200), true)
+	assert.Equal(t, Compare(200, "!=", 400), true)
+	assert.Equal(t, Compare(200, ">=", 200), true)
+
+	assert.Equal(t, Compare(200, "!=", 200), false)
+	assert.Equal(t, Compare(200, "==", 300), false)
+	assert.Equal(t, Compare(200, ">=", 300), false)
+	assert.Equal(t, Compare(200, ">", 300), false)
+	assert.Equal(t, Compare(400, "<=", 300), false)
+	assert.Equal(t, Compare(400, "<", 300), false)
+	assert.Equal(t, Compare(400, "<", 400), false)
+}
+
+func TestDeleteEmpty(t *testing.T) {
+	assert.Equal(t, delete_empty([]string{"a", "", "c"}), []string{"a", "c"})
+}

--- a/models/threshold/labelsHelper.go
+++ b/models/threshold/labelsHelper.go
@@ -1,36 +1,25 @@
 package threshold
 
 import (
-	"errors"
 	"github.com/prometheus/common/model"
-	"strconv"
 
 	"github.com/kiali/kiali/config"
 )
 
-func CountBy(sample *model.Vector, alert config.ThresholdCheck) (count int, total int, err error) {
-	filterSample := FilterRequests(sample, alert)
-	switch alert.Label {
-	case "response_code":
-		return countByResponseCode(filterSample, alert)
-	default:
-		return countByOtherCode(filterSample, alert)
-	}
-}
-
 /*
-  Group Request by Other Code
+  Group Request by label
 
 	Return:
 		- Count: Number of requests that apply the filter
 		- Total: Number of requests
 */
-func countByOtherCode(requests *model.Vector, ThAlert config.ThresholdCheck) (count int, total int, err error) {
-	regex := GetRegex(ThAlert.Expression)
+func CountBy(requests *model.Vector, check config.ThresholdCheck) (count int, total int, err error) {
+	filterSample := FilterRequests(requests, check)
+	regex := GetRegex(check.Expression)
 	count = 0
-	total = len(*requests)
-	for _, req := range *requests {
-		if val, ok := req.Metric[model.LabelName(ThAlert.Label)]; ok {
+	total = len(*filterSample)
+	for _, req := range *filterSample {
+		if val, ok := req.Metric[model.LabelName(check.Label)]; ok {
 			err, _ := CheckExpr(string(val), *regex)
 			if err == nil {
 				count += 1
@@ -40,83 +29,4 @@ func countByOtherCode(requests *model.Vector, ThAlert config.ThresholdCheck) (co
 		}
 	}
 	return count, total, nil
-}
-
-/*
-  Group Request by ResponseCode
-
-	Return:
-		- Count: Number of requests that apply the filter
-		- Total: Number of requests
-*/
-func countByResponseCode(requests *model.Vector, ThAlert config.ThresholdCheck) (count int, total int, err error) {
-	err, steps := CheckExpr(ThAlert.Expression, *responseCodeRegex)
-	count = -1
-	total = -1
-	if err != nil {
-		return -1, -1, err
-	}
-	if CheckVariable(ThAlert.Expression, 1) {
-		requestsByStatus, total := groupBy(requests, ThAlert.Label)
-		// Check the expression cases
-		if len(steps) == 4 {
-			// Case nnn < X
-			num := 0
-			firstCode := false
-			// Check if case the code to compare is before operator or after
-			if num, err = strconv.Atoi(steps[1]); err == nil {
-				firstCode = true
-			} else if num, err = strconv.Atoi(steps[3]); err != nil {
-			} else if num, err = strconv.Atoi(steps[3]); err != nil {
-				err = errors.New("Regular Expression not match with an integer")
-				return -1, -1, err
-			}
-			count = 0
-			for code, c := range requestsByStatus {
-				if (firstCode && Compare(num, steps[2], code)) ||
-					(!firstCode && Compare(code, steps[2], num)) {
-					count += c
-				}
-			}
-		} else if len(steps) == 6 {
-			// Case nnn < X < yyy
-			numA, errA := strconv.Atoi(steps[1])
-			numB, errB := strconv.Atoi(steps[5])
-			if errA == nil && errB == nil {
-				count = 0
-				for code, c := range requestsByStatus {
-					if Compare(numA, steps[2], code) &&
-						Compare(code, steps[4], numB) {
-						count += c
-					}
-				}
-			} else {
-				err = errors.New("Regular Expression not match with an integer")
-				return -1, -1, err
-			}
-
-		}
-		return count, total, err
-	}
-	err = errors.New("No variable X in expression " + ThAlert.Expression)
-	return -1, -1, err
-}
-
-/*
-	Group requests by a specific metric.
-	Return:
-		- Map with key the possible values and Value the number of times that this value is in requests
-*/
-func groupBy(requests *model.Vector, label string) (map[int]int, int) {
-	result := map[int]int{}
-	for _, sample := range *requests {
-		stcode, _ := strconv.Atoi(string(sample.Metric[model.LabelName(label)]))
-		if _, ok := result[stcode]; ok {
-			//do something here
-			result[stcode] += 1
-		} else {
-			result[stcode] = 1
-		}
-	}
-	return result, len(*requests)
 }

--- a/models/threshold/labelsHelper.go
+++ b/models/threshold/labelsHelper.go
@@ -1,0 +1,122 @@
+package threshold
+
+import (
+	"errors"
+	"github.com/prometheus/common/model"
+	"strconv"
+
+	"github.com/kiali/kiali/config"
+)
+
+func CountBy(sample *model.Vector, alert config.ThresholdCheck) (count int, total int, err error) {
+	filterSample := FilterRequests(sample, alert)
+	switch alert.Label {
+	case "response_code":
+		return countByResponseCode(filterSample, alert)
+	default:
+		return countByOtherCode(filterSample, alert)
+	}
+}
+
+/*
+  Group Request by Other Code
+
+	Return:
+		- Count: Number of requests that apply the filter
+		- Total: Number of requests
+*/
+func countByOtherCode(requests *model.Vector, ThAlert config.ThresholdCheck) (count int, total int, err error) {
+	regex := GetRegex(ThAlert.Expression)
+	count = 0
+	total = len(*requests)
+	for _, req := range *requests {
+		if val, ok := req.Metric[model.LabelName(ThAlert.Label)]; ok {
+			err, _ := CheckExpr(string(val), *regex)
+			if err == nil {
+				count += 1
+			}
+		} else {
+			return -1, -1, err
+		}
+	}
+	return count, total, nil
+}
+
+/*
+  Group Request by ResponseCode
+
+	Return:
+		- Count: Number of requests that apply the filter
+		- Total: Number of requests
+*/
+func countByResponseCode(requests *model.Vector, ThAlert config.ThresholdCheck) (count int, total int, err error) {
+	err, steps := CheckExpr(ThAlert.Expression, *responseCodeRegex)
+	count = -1
+	total = -1
+	if err != nil {
+		return -1, -1, err
+	}
+	if CheckVariable(ThAlert.Expression, 1) {
+		requestsByStatus, total := groupBy(requests, ThAlert.Label)
+		// Check the expression cases
+		if len(steps) == 4 {
+			// Case nnn < X
+			num := 0
+			firstCode := false
+			// Check if case the code to compare is before operator or after
+			if num, err = strconv.Atoi(steps[1]); err == nil {
+				firstCode = true
+			} else if num, err = strconv.Atoi(steps[3]); err != nil {
+			} else if num, err = strconv.Atoi(steps[3]); err != nil {
+				err = errors.New("Regular Expression not match with an integer")
+				return -1, -1, err
+			}
+			count = 0
+			for code, c := range requestsByStatus {
+				if (firstCode && Compare(num, steps[2], code)) ||
+					(!firstCode && Compare(code, steps[2], num)) {
+					count += c
+				}
+			}
+		} else if len(steps) == 6 {
+			// Case nnn < X < yyy
+			numA, errA := strconv.Atoi(steps[1])
+			numB, errB := strconv.Atoi(steps[5])
+			if errA == nil && errB == nil {
+				count = 0
+				for code, c := range requestsByStatus {
+					if Compare(numA, steps[2], code) &&
+						Compare(code, steps[4], numB) {
+						count += c
+					}
+				}
+			} else {
+				err = errors.New("Regular Expression not match with an integer")
+				return -1, -1, err
+			}
+
+		}
+		return count, total, err
+	}
+	err = errors.New("No variable X in expression " + ThAlert.Expression)
+	return -1, -1, err
+}
+
+/*
+	Group requests by a specific metric.
+	Return:
+		- Map with key the possible values and Value the number of times that this value is in requests
+*/
+func groupBy(requests *model.Vector, label string) (map[int]int, int) {
+	result := map[int]int{}
+	for _, sample := range *requests {
+		stcode, _ := strconv.Atoi(string(sample.Metric[model.LabelName(label)]))
+		if _, ok := result[stcode]; ok {
+			//do something here
+			result[stcode] += 1
+		} else {
+			result[stcode] = 1
+		}
+	}
+	return result, len(*requests)
+}

--- a/models/threshold/labelsHelper_test.go
+++ b/models/threshold/labelsHelper_test.go
@@ -1,0 +1,64 @@
+package threshold
+
+import (
+	"github.com/kiali/kiali/config"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupBy(t *testing.T) {
+
+	requests := model.Vector{
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "300"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "200"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "300"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "200"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
+	}
+
+	result, total := groupBy(&requests, "response_code")
+	assert.Equal(t, result, map[int]int{400: 3, 300: 2, 200: 2})
+	assert.Equal(t, total, 7)
+}
+
+func TestCountByResponseCode(t *testing.T) {
+
+	requests := model.Vector{
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "300"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "200"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "300"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "200"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
+	}
+
+	count, total, err := countByResponseCode(&requests, config.ThresholdCheck{Rule: "", Kind: "", Label: "response_code", Expression: "x>300"})
+	assert.Equal(t, count, 3)
+	assert.Equal(t, total, 7)
+	assert.Equal(t, err, nil)
+
+}
+
+func TestCountByOtherCode(t *testing.T) {
+
+	requests := model.Vector{
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"destination_service_name": "reviews"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"destination_service_name": "productpage"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"destination_service_name": "reviews"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"destination_service_name": "details"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"destination_service_name": "productpage-v2"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"destination_service_name": "productpage-v1"}},
+		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"destination_service_name": "reviews"}},
+	}
+
+	count, total, err := countByOtherCode(&requests, config.ThresholdCheck{Rule: "", Kind: "", Label: "destination_service_name", Expression: "^productpage-v([0-9])"})
+	assert.Equal(t, count, 2)
+	assert.Equal(t, total, 7)
+	assert.Equal(t, err, nil)
+
+}

--- a/models/threshold/labelsHelper_test.go
+++ b/models/threshold/labelsHelper_test.go
@@ -8,42 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGroupBy(t *testing.T) {
-
-	requests := model.Vector{
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "300"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "200"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "300"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "200"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
-	}
-
-	result, total := groupBy(&requests, "response_code")
-	assert.Equal(t, result, map[int]int{400: 3, 300: 2, 200: 2})
-	assert.Equal(t, total, 7)
-}
-
-func TestCountByResponseCode(t *testing.T) {
-
-	requests := model.Vector{
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "300"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "200"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "300"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "200"}},
-		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"response_code": "400"}},
-	}
-
-	count, total, err := countByResponseCode(&requests, config.ThresholdCheck{Rule: "", Kind: "", Label: "response_code", Expression: "x>300"})
-	assert.Equal(t, count, 3)
-	assert.Equal(t, total, 7)
-	assert.Equal(t, err, nil)
-
-}
-
 func TestCountByOtherCode(t *testing.T) {
 
 	requests := model.Vector{
@@ -56,7 +20,7 @@ func TestCountByOtherCode(t *testing.T) {
 		&model.Sample{Metric: map[model.LabelName]model.LabelValue{"destination_service_name": "reviews"}},
 	}
 
-	count, total, err := countByOtherCode(&requests, config.ThresholdCheck{Rule: "", Kind: "", Label: "destination_service_name", Expression: "^productpage-v([0-9])"})
+	count, total, err := CountBy(&requests, config.ThresholdCheck{Rule: "", Kind: "", Label: "destination_service_name", Expression: "^productpage-v([0-9])"})
 	assert.Equal(t, count, 2)
 	assert.Equal(t, total, 7)
 	assert.Equal(t, err, nil)

--- a/models/threshold/regex.go
+++ b/models/threshold/regex.go
@@ -1,0 +1,77 @@
+package threshold
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+var ruleRegex = regexp.MustCompile(`^(<|>|<=|>=|==|!=)?([0-9]+)$`)
+
+// Check if variable
+var checkX = regexp.MustCompile(`x|X`)
+
+/*
+ Regex forresponse_code
+*/
+
+var responseCodeRegex = regexp.MustCompile(`^(x|X|[0-9]+)(<|>|<=|>=|==|!=)(x|X|[0-9]+)(<|>|<=|>=|==|!=)?(x|X|[0-9]+)?$`)
+
+/*
+	Check the Rule expression
+	Return
+		- err: Error if not match
+		- op: the operation string ">","<" ....
+		- percent: the integer to check
+*/
+func CheckRule(expr string) (err error, op string, percent int) {
+	steps := delete_empty(ruleRegex.FindStringSubmatch(expr))
+	if ruleRegex.MatchString(expr) {
+		op = "=="
+		auxPercent := steps[1]
+		if len(steps) == 3 {
+			op = steps[1]
+			auxPercent = steps[2]
+		}
+		if percent, err := strconv.Atoi(auxPercent); err == nil {
+			return nil, op, percent
+		}
+		return fmt.Errorf("Error percent %s is not an integer", auxPercent), "", -1
+	}
+	return fmt.Errorf("Error %s not match %s", expr, ruleRegex), "", -1
+}
+
+/*
+	Return the regex for a given string
+*/
+func GetRegex(expr string) *regexp.Regexp {
+	return regexp.MustCompile(expr)
+}
+
+/*
+	Check if expression match with a regex
+	Return:
+		- error: Error if not match
+		- []string: An array of strings with results.
+*/
+func CheckExpr(expr string, regex regexp.Regexp) (error, []string) {
+	steps := delete_empty(regex.FindStringSubmatch(expr))
+	// The Expression match the regex and there is only a X|x
+	if regex.MatchString(expr) {
+		return nil, steps
+	}
+	return fmt.Errorf("Error %s not match %s", expr, regex.String()), []string{}
+}
+
+/*
+	Check If a expression have a variable x|X for response_code case
+		expr: string with expression
+		n: number of times that the expression should be in the string (1)
+
+*/
+func CheckVariable(expr string, n int) bool {
+	if checkX.MatchString(expr) && len(checkX.FindAllStringIndex(expr, -1)) == n {
+		return true
+	}
+	return false
+}

--- a/models/threshold/regex.go
+++ b/models/threshold/regex.go
@@ -8,15 +8,6 @@ import (
 
 var ruleRegex = regexp.MustCompile(`^(<|>|<=|>=|==|!=)?([0-9]+)$`)
 
-// Check if variable
-var checkX = regexp.MustCompile(`x|X`)
-
-/*
- Regex forresponse_code
-*/
-
-var responseCodeRegex = regexp.MustCompile(`^(x|X|[0-9]+)(<|>|<=|>=|==|!=)(x|X|[0-9]+)(<|>|<=|>=|==|!=)?(x|X|[0-9]+)?$`)
-
 /*
 	Check the Rule expression
 	Return
@@ -56,22 +47,8 @@ func GetRegex(expr string) *regexp.Regexp {
 */
 func CheckExpr(expr string, regex regexp.Regexp) (error, []string) {
 	steps := delete_empty(regex.FindStringSubmatch(expr))
-	// The Expression match the regex and there is only a X|x
 	if regex.MatchString(expr) {
 		return nil, steps
 	}
 	return fmt.Errorf("Error %s not match %s", expr, regex.String()), []string{}
-}
-
-/*
-	Check If a expression have a variable x|X for response_code case
-		expr: string with expression
-		n: number of times that the expression should be in the string (1)
-
-*/
-func CheckVariable(expr string, n int) bool {
-	if checkX.MatchString(expr) && len(checkX.FindAllStringIndex(expr, -1)) == n {
-		return true
-	}
-	return false
 }

--- a/models/threshold/regex_test.go
+++ b/models/threshold/regex_test.go
@@ -8,59 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var batteryCheckExpr = map[string][]string{
-	"x<300":      []string{"x<300", "x", "<", "300"},
-	"300<=X":     []string{"300<=X", "300", "<=", "X"},
-	"200<=x<300": []string{"200<=x<300", "200", "<=", "x", "<", "300"},
-	"x==300":     []string{"x==300", "x", "==", "300"},
-	"x!=400":     []string{"x!=400", "x", "!=", "400"},
-	"x>=200":     []string{"x>=200", "x", ">=", "200"},
-}
-
-var errBatteryCheckExpr = []string{
-	"asda", "<Z", "X<200<Z", "300-X<200",
-}
-
-func TestCheckExpr(t *testing.T) {
-
-	for k, v := range batteryCheckExpr {
-		error, result := CheckExpr(k, *responseCodeRegex)
-		assert.Equal(t, error, nil)
-		assert.Equal(t, result, v)
-	}
-	error, result := CheckExpr("x<300", *responseCodeRegex)
-	assert.Equal(t, error, nil)
-	assert.Equal(t, result, []string{"x<300", "x", "<", "300"})
-
-	for _, v := range errBatteryCheckExpr {
-		_, result := CheckExpr(v, *responseCodeRegex)
-		//assert.Equal(t,error.Error(),fmt.Sprintf("Error %s not match %s",v, *responseCodeRegex.String()))
-		assert.Equal(t, result, []string{})
-	}
-}
-
-var batteryCheckVariable = []string{
-	"x<300", "300>X",
-}
-
-var errBatteryCheckVariable = []string{
-	"asda", "<Z",
-}
-
-func TestCheckVariable(t *testing.T) {
-	for _, v := range batteryCheckVariable {
-		result := CheckVariable(v, 1)
-		assert.Equal(t, true, result)
-	}
-	result := CheckVariable("x<300<X", 2)
-	assert.Equal(t, true, result)
-
-	for _, v := range errBatteryCheckVariable {
-		result := CheckVariable(v, 1)
-		assert.Equal(t, false, result)
-	}
-}
-
 var batteryCheckRule = map[string][]string{
 	"<20":  []string{"<", "20"},
 	">=30": []string{">=", "30"},

--- a/models/threshold/regex_test.go
+++ b/models/threshold/regex_test.go
@@ -1,0 +1,97 @@
+package threshold
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var batteryCheckExpr = map[string][]string{
+	"x<300":      []string{"x<300", "x", "<", "300"},
+	"300<=X":     []string{"300<=X", "300", "<=", "X"},
+	"200<=x<300": []string{"200<=x<300", "200", "<=", "x", "<", "300"},
+	"x==300":     []string{"x==300", "x", "==", "300"},
+	"x!=400":     []string{"x!=400", "x", "!=", "400"},
+	"x>=200":     []string{"x>=200", "x", ">=", "200"},
+}
+
+var errBatteryCheckExpr = []string{
+	"asda", "<Z", "X<200<Z", "300-X<200",
+}
+
+func TestCheckExpr(t *testing.T) {
+
+	for k, v := range batteryCheckExpr {
+		error, result := CheckExpr(k, *responseCodeRegex)
+		assert.Equal(t, error, nil)
+		assert.Equal(t, result, v)
+	}
+	error, result := CheckExpr("x<300", *responseCodeRegex)
+	assert.Equal(t, error, nil)
+	assert.Equal(t, result, []string{"x<300", "x", "<", "300"})
+
+	for _, v := range errBatteryCheckExpr {
+		_, result := CheckExpr(v, *responseCodeRegex)
+		//assert.Equal(t,error.Error(),fmt.Sprintf("Error %s not match %s",v, *responseCodeRegex.String()))
+		assert.Equal(t, result, []string{})
+	}
+}
+
+var batteryCheckVariable = []string{
+	"x<300", "300>X",
+}
+
+var errBatteryCheckVariable = []string{
+	"asda", "<Z",
+}
+
+func TestCheckVariable(t *testing.T) {
+	for _, v := range batteryCheckVariable {
+		result := CheckVariable(v, 1)
+		assert.Equal(t, true, result)
+	}
+	result := CheckVariable("x<300<X", 2)
+	assert.Equal(t, true, result)
+
+	for _, v := range errBatteryCheckVariable {
+		result := CheckVariable(v, 1)
+		assert.Equal(t, false, result)
+	}
+}
+
+var batteryCheckRule = map[string][]string{
+	"<20":  []string{"<", "20"},
+	">=30": []string{">=", "30"},
+}
+
+var errBatteryCheckRule = []string{
+	"asda", "<Z",
+}
+
+func TestCheckRule(t *testing.T) {
+
+	for k, v := range batteryCheckRule {
+		error, op, percent := CheckRule(k)
+		assert.Equal(t, v[0], op)
+		percentExp, _ := strconv.Atoi(v[1])
+		assert.Equal(t, percentExp, percent)
+		assert.Equal(t, nil, error)
+	}
+
+	for _, v := range errBatteryCheckRule {
+		err, op, percent := CheckRule(v)
+		assert.Equal(t, "", op)
+		assert.Equal(t, -1, percent)
+		assert.Equal(t, fmt.Errorf("Error %s not match %s", v, ruleRegex), err)
+	}
+
+	//Error conversion to int
+	rule := ">=a"
+	err, op, percent := CheckRule(rule)
+	assert.Equal(t, "", op)
+	assert.Equal(t, -1, percent)
+	//assert.Equal(t,error.Error(),fmt.Sprintf("Error %s not match %s",v, *responseCodeRegex.String()))
+	assert.Equal(t, fmt.Errorf("Error %s not match %s", rule, ruleRegex), err)
+}

--- a/models/threshold/vectorSampleMock.go
+++ b/models/threshold/vectorSampleMock.go
@@ -1,0 +1,54 @@
+package threshold
+
+import "github.com/prometheus/common/model"
+
+var Requests = model.Vector{
+	&model.Sample{
+		Metric: map[model.LabelName]model.LabelValue{
+			"connection_security_policy":     "none",
+			"destination_app":                "details",
+			"destination_principal":          "unknown",
+			"destination_service":            "details.bookinfo.svc.cluster.local",
+			"destination_service_name":       "details",
+			"destination_service_namespace":  "bookinfo",
+			"destination_version":            "v1",
+			"destination_workload":           "details-v1",
+			"destination_workload_namespace": "bookinfo",
+			"instance":                       "10.129.2.20:42422",
+			"job":                            "istio-mesh",
+			"reporter":                       "destination",
+			"request_protocol":               "http",
+			"response_code":                  "400",
+			"response_flags":                 "-",
+			"source_app":                     "productpage",
+			"source_principal":               "unknown",
+			"source_version":                 "v1",
+			"source_workload":                "productpage-v1",
+			"source_workload_namespace":      "bookinfo",
+		},
+	},
+	&model.Sample{
+		Metric: map[model.LabelName]model.LabelValue{
+			"connection_security_policy":     "none",
+			"destination_app":                "details",
+			"destination_principal":          "unknown",
+			"destination_service":            "details.bookinfo.svc.cluster.local",
+			"destination_service_name":       "reviews",
+			"destination_service_namespace":  "bookinfo",
+			"destination_version":            "v1",
+			"destination_workload":           "details-v1",
+			"destination_workload_namespace": "bookinfo",
+			"instance":                       "10.129.2.20:42422",
+			"job":                            "istio-mesh",
+			"reporter":                       "destination",
+			"request_protocol":               "http",
+			"response_code":                  "100",
+			"response_flags":                 "-",
+			"source_app":                     "productpage",
+			"source_principal":               "unknown",
+			"source_version":                 "v1",
+			"source_workload":                "productpage-v1",
+			"source_workload_namespace":      "bookinfo",
+		},
+	},
+}

--- a/models/threshold_test.go
+++ b/models/threshold_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"github.com/prometheus/common/model"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,42 +13,45 @@ import (
 
 var thresholdConfResponseCode = []config.ThresholdCheck{
 	{
-		Rule:       ">20",
-		Kind:       "service",
-		Label:      "response_code",
-		Expression: "x>=200",
-		Alert:      "warning",
+		Rule:        ">20",
+		Kind:        "service",
+		RequestType: "inbound",
+		Label:       "response_code",
+		Expression:  "x>=200",
+		Alert:       "warning",
 	},
 }
 
 var thresholdConfOther = []config.ThresholdCheck{
 	{
-		Rule:       ">20",
-		Kind:       "service",
-		Label:      "destination_service_name",
-		Expression: "^reviews$",
-		Alert:      "warning",
+		Rule:        ">20",
+		Kind:        "service",
+		RequestType: "inbound",
+		Label:       "destination_service_name",
+		Expression:  "^reviews$",
+		Alert:       "warning",
 	},
 }
 
 var thresholdConfOtherWrongRegex = []config.ThresholdCheck{
 	{
-		Rule:       ">20",
-		Kind:       "service",
-		Label:      "destination_service_name",
-		Expression: "^rev23iews$",
-		Alert:      "warning",
+		Rule:        ">20",
+		Kind:        "service",
+		RequestType: "inbound",
+		Label:       "destination_service_name",
+		Expression:  "^rev23iews$",
+		Alert:       "warning",
 	},
 }
 
 func TestParse(t *testing.T) {
 	thresholds := Thresholds{}
-	thresholds.Parse(thresholdConfResponseCode, &threshold.Requests, "service")
+	thresholds.Parse(thresholdConfResponseCode, &threshold.Requests, &model.Vector{})
 	calculation := (1 * 100 / len(threshold.Requests))
 	thresholdsResult := Thresholds{
 		{
 			Percent: 50,
-			Rule:    fmt.Sprintf("[%s] Alert requests where %s are %d%% , rule defined %s", thresholdConfResponseCode[0].Alert, thresholdConfResponseCode[0].Expression, calculation, thresholdConfResponseCode[0].Rule),
+			Rule:    fmt.Sprintf("[%s][%s] Alert requests where %s are %d%% , rule defined %s", thresholdConfResponseCode[0].Alert, thresholdConfResponseCode[0].RequestType, thresholdConfResponseCode[0].Expression, calculation, thresholdConfResponseCode[0].Rule),
 			Alert:   thresholdConfResponseCode[0].Alert,
 		},
 	}
@@ -56,11 +60,11 @@ func TestParse(t *testing.T) {
 	// other property
 
 	thresholds = Thresholds{}
-	thresholds.Parse(thresholdConfOther, &threshold.Requests, "service")
+	thresholds.Parse(thresholdConfOther, &threshold.Requests, &model.Vector{})
 	thresholdsResult = Thresholds{
 		{
 			Percent: 50,
-			Rule:    fmt.Sprintf("[%s] Alert requests where %s are %d%% , rule defined %s", thresholdConfOther[0].Alert, thresholdConfOther[0].Expression, calculation, thresholdConfOther[0].Rule),
+			Rule:    fmt.Sprintf("[%s][%s] Alert requests where %s are %d%% , rule defined %s", thresholdConfOther[0].Alert, thresholdConfResponseCode[0].RequestType, thresholdConfOther[0].Expression, calculation, thresholdConfOther[0].Rule),
 			Alert:   thresholdConfResponseCode[0].Alert,
 		},
 	}
@@ -69,7 +73,7 @@ func TestParse(t *testing.T) {
 	// other property with wrong regex
 
 	thresholds = Thresholds{}
-	thresholds.Parse(thresholdConfOtherWrongRegex, &threshold.Requests, "service")
+	thresholds.Parse(thresholdConfOtherWrongRegex, &threshold.Requests, &model.Vector{})
 	thresholdsResult = Thresholds{}
 	assert.Equal(t, thresholdsResult, thresholds)
 

--- a/models/threshold_test.go
+++ b/models/threshold_test.go
@@ -17,7 +17,7 @@ var thresholdConfResponseCode = []config.ThresholdCheck{
 		Kind:        "service",
 		RequestType: "inbound",
 		Label:       "response_code",
-		Expression:  "x>=200",
+		Expression:  "400",
 		Alert:       "warning",
 	},
 }

--- a/models/threshold_test.go
+++ b/models/threshold_test.go
@@ -1,0 +1,76 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models/threshold"
+)
+
+var thresholdConfResponseCode = []config.ThresholdCheck{
+	{
+		Rule:       ">20",
+		Kind:       "service",
+		Label:      "response_code",
+		Expression: "x>=200",
+		Alert:      "warning",
+	},
+}
+
+var thresholdConfOther = []config.ThresholdCheck{
+	{
+		Rule:       ">20",
+		Kind:       "service",
+		Label:      "destination_service_name",
+		Expression: "^reviews$",
+		Alert:      "warning",
+	},
+}
+
+var thresholdConfOtherWrongRegex = []config.ThresholdCheck{
+	{
+		Rule:       ">20",
+		Kind:       "service",
+		Label:      "destination_service_name",
+		Expression: "^rev23iews$",
+		Alert:      "warning",
+	},
+}
+
+func TestParse(t *testing.T) {
+	thresholds := Thresholds{}
+	thresholds.Parse(thresholdConfResponseCode, &threshold.Requests, "service")
+	calculation := (1 * 100 / len(threshold.Requests))
+	thresholdsResult := Thresholds{
+		{
+			Percent: 50,
+			Rule:    fmt.Sprintf("[%s] Alert requests where %s are %d%% , rule defined %s", thresholdConfResponseCode[0].Alert, thresholdConfResponseCode[0].Expression, calculation, thresholdConfResponseCode[0].Rule),
+			Alert:   thresholdConfResponseCode[0].Alert,
+		},
+	}
+	assert.Equal(t, thresholdsResult, thresholds)
+
+	// other property
+
+	thresholds = Thresholds{}
+	thresholds.Parse(thresholdConfOther, &threshold.Requests, "service")
+	thresholdsResult = Thresholds{
+		{
+			Percent: 50,
+			Rule:    fmt.Sprintf("[%s] Alert requests where %s are %d%% , rule defined %s", thresholdConfOther[0].Alert, thresholdConfOther[0].Expression, calculation, thresholdConfOther[0].Rule),
+			Alert:   thresholdConfResponseCode[0].Alert,
+		},
+	}
+	assert.Equal(t, thresholdsResult, thresholds)
+
+	// other property with wrong regex
+
+	thresholds = Thresholds{}
+	thresholds.Parse(thresholdConfOtherWrongRegex, &threshold.Requests, "service")
+	thresholdsResult = Thresholds{}
+	assert.Equal(t, thresholdsResult, thresholds)
+
+}

--- a/swagger.json
+++ b/swagger.json
@@ -5909,6 +5909,13 @@
       "properties": {
         "requests": {
           "$ref": "#/definitions/RequestHealth"
+        },
+        "thresholds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Threshold"
+          },
+          "x-go-name": "Thresholds"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -6474,6 +6481,26 @@
         "threeScaleHandlerName": {
           "type": "string",
           "x-go-name": "ThreeScaleHandlerName"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "Threshold": {
+      "description": "Customize Thresholds error rates",
+      "type": "object",
+      "properties": {
+        "alert": {
+          "type": "string",
+          "x-go-name": "Alert"
+        },
+        "percent": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Percent"
+        },
+        "rule": {
+          "type": "string",
+          "x-go-name": "Rule"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"

--- a/swagger.json
+++ b/swagger.json
@@ -3745,6 +3745,13 @@
         "requests": {
           "$ref": "#/definitions/RequestHealth"
         },
+        "thresholds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Threshold"
+          },
+          "x-go-name": "Thresholds"
+        },
         "workloadStatuses": {
           "type": "array",
           "items": {
@@ -6717,6 +6724,13 @@
       "properties": {
         "requests": {
           "$ref": "#/definitions/RequestHealth"
+        },
+        "thresholds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Threshold"
+          },
+          "x-go-name": "Thresholds"
         },
         "workloadStatus": {
           "$ref": "#/definitions/WorkloadStatus"


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/1424

Actual Config sample

```yaml
thresholds_health:
  - namespace: bookinfo
    threshold_checks:
      - rule: ">20"
        kind: "all"
        label: "response_code"
        filter:
          - regex: "views"
            label_filter:
              - labels:
                    app: "details"
                    version: "v1"
                operation: "and"
            prom_filter:
              - labels:
                    destination_service: "reviews"
        exp: "400>x"
        alert: "warning"
```

- Namespace is the ns to apply: 
  - We can set this value to "**" or "" to set all or a list of namespaces "bookinfo,istio-system"

For each alert

- rule => When I want more than a x% (>, >=, <=, <, == or !=)
- Kind can be "**" or ""(all) | "services" | "workloads" | "apps" or list "services,workloads"
- metric: metric to check in prometheus, by default response_code
- filter(optional) =>
  - We can filter by a reg for resource name
  - labels that the resource has
  - Working in optProm => filter by a parameter of metric promethus like destination_source: "reviews-v2"
- expression => status code operation than  (x<400 , 400>x, 300<x<400)
- alert => kind of alert

Example:

Warning alert when in the Last X minutes of user the requests with status code > 400 are more than 20%


PR Docs: https://github.com/aljesusg/kiali/blob/improve_configuration_custom/models/threshold/Threshold.adoc




