### PR TITLE
Allow Policies and MeshPolicies still be displayed into Istio 1.5

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -182,6 +182,10 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	case Adapters:
 		// Validations on Adapters are not yet in place
 		// TODO Support subtypes
+	case Policies:
+		// Still supporting Policy Objects
+	case MeshPolicies:
+		// Still supporting MeshPolicies
 	case QuotaSpecs:
 		// Validations on QuotaSpecs are not yet in place
 	case QuotaSpecBindings:


### PR DESCRIPTION
Previous review removed those two statements from the switch.
I think we should include this into 1.18
Fixes https://github.com/kiali/kiali/issues/2812