### PR TITLE
Disabled Namespace validation: Expects PeerAuthn not to be STRICT

### DIFF
--- a/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go
+++ b/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go
@@ -24,7 +24,7 @@ func (m DisabledNamespaceWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 		if enabled, mode := kubernetes.PeerAuthnHasMTLSEnabled(mp); enabled {
 			// If PeerAuthn has mTLS enabled in STRICT mode
 			// traffic going through DestinationRule won't work
-			if mode != "PERMISSIVE" {
+			if mode == "STRICT" {
 				check := models.Build("destinationrules.mtls.policymtlsenabled", "spec/trafficPolicy/tls/mode")
 				return append(validations, &check), false
 			} else {

--- a/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
@@ -32,6 +32,26 @@ func TestDRNSWideDisablingTLSPolicyPermissive(t *testing.T) {
 }
 
 // Context: DestinationRule ns-wide disabling mTLS connections
+// Context: PeerAuthn ns-wide in disable mode
+// It doesn't return any validation
+func TestDRNSWideDisablingTLSPolicyDisable(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		PeerAuthentications: []kubernetes.IstioObject{
+			data.CreateEmptyPeerAuthentication("default", "bookinfo", data.CreateMTLS("DISABLE")),
+		},
+	}
+
+	testNoDisabledMtlsValidationsFound(t, destinationRule, mTlsDetails, false)
+	testNoDisabledMtlsValidationsFound(t, destinationRule, mTlsDetails, true)
+}
+
+// Context: DestinationRule ns-wide disabling mTLS connections
 // Context: PeerAuthn ns-wide in permissive mode
 // Context: Does have a MeshPolicy in strict mode
 // It doesn't return any validation


### PR DESCRIPTION
Fixing the following scenario:

- PeerAuthentication disabling mtls for the whole namespace (mode = DISABLE or PERMISSIVE)
- Destination Rule disabling mTLS for a whole namespace (mode = DISABLE)
- Validation appears into DR. It shouldn't.

Before:

![Screenshot of Kiali Console (83)](https://user-images.githubusercontent.com/613814/82590899-c924ed80-9b9e-11ea-86ce-6e0716047c39.png)

![Screenshot of Kiali Console (84)](https://user-images.githubusercontent.com/613814/82591196-451f3580-9b9f-11ea-9b47-a34cdfb13479.png)

After:

![Screenshot of Kiali Console (85)](https://user-images.githubusercontent.com/613814/82591308-713ab680-9b9f-11ea-8b40-14a6f4bc2f3f.png)

![Screenshot of Kiali Console (84)](https://user-images.githubusercontent.com/613814/82591196-451f3580-9b9f-11ea-9b47-a34cdfb13479.png)

