### PR TITLE
Strict and permissive modes can enable/disable TLS status at ns-level

### DIFF
--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -279,7 +279,7 @@ func TestNamespaceHasMTLSEnabled(t *testing.T) {
 	testNamespaceScenario(MTLSEnabled, []kubernetes.IstioObject{}, ps, true, t)
 }
 
-func TestNamespaceHasPolicyDisabled(t *testing.T) {
+func TestNamespaceHasPeerAuthnDisabled(t *testing.T) {
 	ps := fakePeerAuthnWithMtlsMode("default", "bookinfo", "DISABLE")
 	drs := []kubernetes.IstioObject{
 		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
@@ -287,7 +287,7 @@ func TestNamespaceHasPolicyDisabled(t *testing.T) {
 	}
 	testNamespaceScenario(MTLSPartiallyEnabled, drs, ps, false, t)
 	testNamespaceScenario(MTLSPartiallyEnabled, drs, ps, true, t)
-	testNamespaceScenario(MTLSPartiallyEnabled, []kubernetes.IstioObject{}, ps, true, t)
+	testNamespaceScenario(MTLSDisabled, []kubernetes.IstioObject{}, ps, true, t)
 }
 
 func TestNamespaceHasDestinationRuleDisabled(t *testing.T) {
@@ -320,8 +320,32 @@ func TestNamespaceHasNoDestinationRulesNoPolicy(t *testing.T) {
 	testNamespaceScenario(MTLSNotEnabled, []kubernetes.IstioObject{}, ps, true, t)
 }
 
-func TestNamespaceHasMTLSDisabled(t *testing.T) {
+func TestNamespaceHasPermissivePeerAuthDisableDestRule(t *testing.T) {
 	ps := fakePermissivePeerAuthn("default", "bookinfo")
+	drs := []kubernetes.IstioObject{
+		data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local")),
+	}
+
+	testNamespaceScenario(MTLSPartiallyEnabled, drs, ps, false, t)
+	testNamespaceScenario(MTLSPartiallyEnabled, drs, ps, true, t)
+	testNamespaceScenario(MTLSPartiallyEnabled, []kubernetes.IstioObject{}, ps, true, t)
+}
+
+func TestNamespaceHasPermissivePeerAuthStrictDestRule(t *testing.T) {
+	ps := fakePermissivePeerAuthn("default", "bookinfo")
+	drs := []kubernetes.IstioObject{
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "strict-mtls", "*.bookinfo.svc.cluster.local")),
+	}
+
+	testNamespaceScenario(MTLSPartiallyEnabled, drs, ps, false, t)
+	testNamespaceScenario(MTLSPartiallyEnabled, drs, ps, true, t)
+	testNamespaceScenario(MTLSPartiallyEnabled, []kubernetes.IstioObject{}, ps, true, t)
+}
+
+func TestNamespaceHasMTLSDisabled(t *testing.T) {
+	ps := fakePeerAuthnWithMtlsMode("default", "bookinfo", "DISABLE")
 	drs := []kubernetes.IstioObject{
 		data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
 			data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local")),
@@ -329,19 +353,19 @@ func TestNamespaceHasMTLSDisabled(t *testing.T) {
 
 	testNamespaceScenario(MTLSDisabled, drs, ps, false, t)
 	testNamespaceScenario(MTLSDisabled, drs, ps, true, t)
-	testNamespaceScenario(MTLSEnabled, []kubernetes.IstioObject{}, ps, true, t)
+	testNamespaceScenario(MTLSDisabled, []kubernetes.IstioObject{}, ps, true, t)
 }
 
-func TestNamespaceHasSimpleTls(t *testing.T) {
-	ps := fakePermissivePeerAuthn("default", "bookinfo")
+func TestNamespaceHasPeerAuthnDisabledMtlsDestRule(t *testing.T) {
+	ps := fakePeerAuthnWithMtlsMode("default", "bookinfo", "DISABLE")
 	drs := []kubernetes.IstioObject{
-		data.AddTrafficPolicyToDestinationRule(data.CreateSimpleTLSTrafficPolicyForDestinationRules(),
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 			data.CreateEmptyDestinationRule("bookinfo", "disable-mtls", "*.bookinfo.svc.cluster.local")),
 	}
 
-	testNamespaceScenario(MTLSDisabled, drs, ps, false, t)
-	testNamespaceScenario(MTLSDisabled, drs, ps, true, t)
-	testNamespaceScenario(MTLSEnabled, []kubernetes.IstioObject{}, ps, true, t)
+	testNamespaceScenario(MTLSPartiallyEnabled, drs, ps, false, t)
+	testNamespaceScenario(MTLSPartiallyEnabled, drs, ps, true, t)
+	testNamespaceScenario(MTLSDisabled, []kubernetes.IstioObject{}, ps, true, t)
 }
 
 func TestNamespaceHasDestinationRuleEnabledDifferentNs(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2819

The status is the following:

|PeerAuthn | DR |  | No AutoMtls | AutoMtls |
|-------------- | ----- | - | --------------- | ---------------- |
| STRICT | empty | | Partially Enabled | Enabled |
| STRICT | ISTIO_MUTUAL | | Enabled | Enabled |
| STRICT | DISABLE | | Partially Enabled | Partially Enabled |
| PERMISSIVE | empty | | Partially Enabled | Partially Enabled |
| PERMISSIVE | ISTIO_MUTUAL | | Partially Enabled | Partially Enabled |
| PERMISSIVE | DISABLE | | Partially Enabled | Partially Enabled |
| DISABLE | empty | | Partially Enabled | Disabled |
| DISABLE | ISTIO_MUTUAL | | Partially Enabled | Partially Enabled |
| DISABLE | DISABLE | | Disabled | Disabled |

The `enabled status` implies a lock into namespace card within the overview.
The `disabled status` implies no lock into overview.
The `partially enabled` implies a hollow lock into overview.

This script should help the task of trying all the scenarios: [nswide-mtls-walkthough.sh](https://github.com/xeviknal/istio-lab/blob/master/nswide-mtls/TLSstatus/walkthrough.sh)