### PR TITLE
Endpoint [...]/traces/{traceID} returns single trace

### DIFF
--- a/business/jaeger.go
+++ b/business/jaeger.go
@@ -41,7 +41,7 @@ func (in *JaegerService) GetJaegerTraces(ns string, srv string, query string) (t
 	return client.GetTraces(ns, srv, query)
 }
 
-func (in *JaegerService) GetJaegerTraceDetail(traceID string) (trace *jaeger.JaegerResponse, err error) {
+func (in *JaegerService) GetJaegerTraceDetail(traceID string) (trace *jaeger.JaegerSingleTrace, err error) {
 	client, err := in.client()
 	if err != nil {
 		return nil, err

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -82,12 +82,12 @@ func TraceDetails(w http.ResponseWriter, r *http.Request) {
 	}
 	params := mux.Vars(r)
 	traceID := params["traceID"]
-	traces, err := business.Jaeger.GetJaegerTraceDetail(traceID)
+	trace, err := business.Jaeger.GetJaegerTraceDetail(traceID)
 	if err != nil {
 		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
-	RespondWithJSON(w, http.StatusOK, traces)
+	RespondWithJSON(w, http.StatusOK, trace)
 }
 
 // ServiceSpans is the API handler to fetch Jaeger spans of a specific service

--- a/jaeger/client.go
+++ b/jaeger/client.go
@@ -15,7 +15,7 @@ import (
 type ClientInterface interface {
 	GetSpans(namespace, service, startMicros, endMicros string) ([]Span, error)
 	GetTraces(namespace string, service string, rawQuery string) (traces *JaegerResponse, err error)
-	GetTraceDetail(traceId string) (trace *JaegerResponse, err error)
+	GetTraceDetail(traceId string) (*JaegerSingleTrace, error)
 	GetErrorTraces(ns, srv string, duration time.Duration) (errorTraces int, err error)
 }
 
@@ -72,7 +72,7 @@ func (in *Client) GetTraces(namespace string, service string, rawQuery string) (
 // GetTraceDetail jaeger to fetch a specific trace
 // requests for a specific trace detail
 //  Returns (traces, code, error)
-func (in *Client) GetTraceDetail(traceId string) (trace *JaegerResponse, err error) {
+func (in *Client) GetTraceDetail(traceId string) (*JaegerSingleTrace, error) {
 	return getTraceDetail(in.client, in.endpoint, traceId)
 }
 

--- a/jaeger/traces.go
+++ b/jaeger/traces.go
@@ -29,10 +29,20 @@ func getTraces(client http.Client, endpoint *url.URL, namespace string, service 
 	return queryTraces(client, u)
 }
 
-func getTraceDetail(client http.Client, endpoint *url.URL, traceID string) (response *JaegerResponse, err error) {
+func getTraceDetail(client http.Client, endpoint *url.URL, traceID string) (*JaegerSingleTrace, error) {
 	u := endpoint
 	u.Path = path.Join(u.Path, "/api/traces/"+traceID)
-	return queryTraces(client, u)
+	response, err := queryTraces(client, u)
+	if err != nil {
+		return nil, err
+	}
+	if len(response.Data) == 0 {
+		return &JaegerSingleTrace{Errors: response.Errors}, nil
+	}
+	return &JaegerSingleTrace{
+		Data:   response.Data[0],
+		Errors: response.Errors,
+	}, nil
 }
 
 func getErrorTraces(client http.Client, endpoint *url.URL, namespace, service string, duration time.Duration) (errorTraces int, err error) {

--- a/jaeger/types.go
+++ b/jaeger/types.go
@@ -18,3 +18,8 @@ type JaegerResponse struct {
 	Data   []jaegerModels.Trace `json:"data"`
 	Errors []structuredError    `json:"errors"`
 }
+
+type JaegerSingleTrace struct {
+	Data   jaegerModels.Trace `json:"data"`
+	Errors []structuredError  `json:"errors"`
+}


### PR DESCRIPTION
Endpoint to fetch a trace by traceID was returning an array, make it returning a single object instead
This simplifies usage on UI.

Required frontend PR: https://github.com/kiali/kiali-ui/pull/1800
