### PR TITLE
Optimize image build steps

### DIFF
--- a/deploy/docker/Dockerfile-ubi7-minimal
+++ b/deploy/docker/Dockerfile-ubi7-minimal
@@ -7,15 +7,16 @@ ENV KIALI_HOME=/opt/kiali \
 
 WORKDIR $KIALI_HOME
 
+RUN microdnf install -y shadow-utils && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum && \
+    adduser kiali
+
 COPY kiali $KIALI_HOME/
 
 ADD console $KIALI_HOME/console/
 
-RUN microdnf install -y shadow-utils && \
-    microdnf clean all && \
-    rm -rf /var/cache/yum && \
-    adduser kiali && \
-    chown -R kiali:kiali $KIALI_HOME/console && \
+RUN chown -R kiali:kiali $KIALI_HOME/console && \
     chmod -R g=u $KIALI_HOME/console
 
 USER kiali

--- a/deploy/docker/Dockerfile-ubi8-minimal
+++ b/deploy/docker/Dockerfile-ubi8-minimal
@@ -7,15 +7,16 @@ ENV KIALI_HOME=/opt/kiali \
 
 WORKDIR $KIALI_HOME
 
+RUN microdnf install -y shadow-utils && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum && \
+    adduser kiali
+
 COPY kiali $KIALI_HOME/
 
 ADD console $KIALI_HOME/console/
 
-RUN microdnf install -y shadow-utils && \
-    microdnf clean all && \
-    rm -rf /var/cache/yum && \
-    adduser kiali && \
-    chown -R kiali:kiali $KIALI_HOME/console && \
+RUN chown -R kiali:kiali $KIALI_HOME/console && \
     chmod -R g=u $KIALI_HOME/console
 
 USER kiali


### PR DESCRIPTION
Run microdnf stuff prior to copying Kiali sources to speed up dev builds (uses cache)

---
I noticed that build time is longer than usual, and it's because new build steps were added to install some packages. But they can be cached for dev builds if put prior to copying kiali sources.

*Before change* build was (stops using cache from step 5):

```
STEP 1: FROM registry.access.redhat.com/ubi7-minimal
STEP 2: LABEL maintainer="kiali-dev@googlegroups.com"
--> Using cache c29dec6be71fc9e9874dcdd544d7a8b9a9a61f18738eead82497bd6f66097b02
STEP 3: ENV KIALI_HOME=/opt/kiali     PATH=$KIALI_HOME:$PATH
--> Using cache a52dd6a83921ee3d8b3efd8b95431b4cecc2b20a58f814ed985f5b7b569be2f6
STEP 4: WORKDIR $KIALI_HOME
--> Using cache 36bb6bd62e5414a0815872b099203fd0e817d8045133f97734cc0d657674b18d
STEP 5: COPY kiali $KIALI_HOME/
--> aff523b2cab
STEP 6: ADD console $KIALI_HOME/console/
--> 67ebce65720
STEP 7: RUN microdnf install -y shadow-utils &&     microdnf clean all &&     rm -rf /var/cache/yum &&     adduser kiali &&     chown -R kiali:kiali $KIALI_HOME/console &&     chmod -R g=u $KIALI_HOME/console

(microdnf:2): librhsm-WARNING **: 11:24:07.315: Found 0 entitlement certificates

(microdnf:2): librhsm-WARNING **: 11:24:07.322: Found 0 entitlement certificates
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
Transaction: 3 packages
ustr-1.0.4-16.el7.x86_64 (ubi-7)
shadow-utils-2:4.6-5.el7.x86_64 (ubi-7)
libsemanage-2.5-14.el7.x86_64 (ubi-7)
Downloading packages...
Running transaction test...
Installing: ustr;1.0.4-16.el7;x86_64;ubi-7
Installing: libsemanage;2.5-14.el7;x86_64;ubi-7
Installing: shadow-utils;2:4.6-5.el7;x86_64;ubi-7
Complete.

(microdnf:65): librhsm-WARNING **: 11:24:22.700: Found 0 entitlement certificates

(microdnf:65): librhsm-WARNING **: 11:24:22.702: Found 0 entitlement certificates
Complete.
--> a9609163ca9
STEP 8: USER kiali
--> 82eb0bdc920
STEP 9: ENTRYPOINT ["/opt/kiali/kiali"]
STEP 10: COMMIT quay.io/kiali/kiali:dev
--> 8f9600f19eb
```

*After change* build is (stops using cache from step 6):

```
STEP 1: FROM registry.access.redhat.com/ubi7-minimal
STEP 2: LABEL maintainer="kiali-dev@googlegroups.com"
--> Using cache c29dec6be71fc9e9874dcdd544d7a8b9a9a61f18738eead82497bd6f66097b02
STEP 3: ENV KIALI_HOME=/opt/kiali     PATH=$KIALI_HOME:$PATH
--> Using cache a52dd6a83921ee3d8b3efd8b95431b4cecc2b20a58f814ed985f5b7b569be2f6
STEP 4: WORKDIR $KIALI_HOME
--> Using cache 36bb6bd62e5414a0815872b099203fd0e817d8045133f97734cc0d657674b18d
STEP 5: RUN microdnf install -y shadow-utils &&     microdnf clean all &&     rm -rf /var/cache/yum &&     adduser kiali
--> Using cache 914f5b1ede69b06fe57a51e89a42d08390e960f2f6e904736a1cd17e15f81e60
STEP 6: COPY kiali $KIALI_HOME/
--> a6e04498365
STEP 7: ADD console $KIALI_HOME/console/
--> 6b72ecff64c
STEP 8: RUN chown -R kiali:kiali $KIALI_HOME/console &&     chmod -R g=u $KIALI_HOME/console
--> fca9b72b522
STEP 9: USER kiali
--> 79cc2b36d2a
STEP 10: ENTRYPOINT ["/opt/kiali/kiali"]
STEP 11: COMMIT quay.io/kiali/kiali:dev
--> 99b9ef5c5a2
```
