### PR TITLE
Fix dead node corner case

### DIFF
--- a/graph/telemetry/istio/appender/dead_node.go
+++ b/graph/telemetry/istio/appender/dead_node.go
@@ -102,13 +102,26 @@ func (a DeadNodeAppender) applyDeadNodes(trafficMap graph.TrafficMap, globalInfo
 		return
 	}
 
-	for _, s := range trafficMap {
+	for _, n := range trafficMap {
 		goodEdges := []*graph.Edge{}
-		for _, e := range s.Edges {
+		for _, e := range n.Edges {
 			if _, found := trafficMap[e.Dest.ID]; found {
 				goodEdges = append(goodEdges, e)
 			}
 		}
-		s.Edges = goodEdges
+		n.Edges = goodEdges
+	}
+
+	// now, after removing edges, remove any orphaned nodes (no incoming or outgoing edges)
+	destNodes := graph.NewTrafficMap()
+	for _, n := range trafficMap {
+		for _, e := range n.Edges {
+			destNodes[e.Dest.ID] = e.Dest
+		}
+	}
+	for _, n := range trafficMap {
+		if _, found := destNodes[n.ID]; !found && len(n.Edges) == 0 {
+			delete(trafficMap, n.ID)
+		}
 	}
 }

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -253,3 +253,55 @@ func testTrafficMap() map[string]*graph.Node {
 
 	return trafficMap
 }
+
+func TestDeadNodeIssue2783(t *testing.T) {
+	assert := assert.New(t)
+
+	businessLayer := setupWorkloads()
+	trafficMap := testTrafficMapIssue2783()
+
+	assert.Equal(3, len(trafficMap))
+	aID, _ := graph.Id("testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	aNode, found := trafficMap[aID]
+	assert.Equal(true, found)
+	assert.Equal(1, len(aNode.Edges))
+
+	bSvcID, _ := graph.Id("testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	bSvcNode, found := trafficMap[bSvcID]
+	assert.Equal(true, found)
+	assert.Equal(1, len(bSvcNode.Edges))
+
+	bID, _ := graph.Id("testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	bNode, found := trafficMap[bID]
+	assert.Equal(true, found)
+	assert.Equal(0, len(bNode.Edges))
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	a := DeadNodeAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(0, len(trafficMap))
+}
+
+// testTrafficMapIssue2783() ensures that zero request traffic does not leave behind an injected service node.
+func testTrafficMapIssue2783() map[string]*graph.Node {
+	trafficMap := make(map[string]*graph.Node)
+
+	n0 := graph.NewNode("testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+
+	n1 := graph.NewNode("testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+
+	n2 := graph.NewNode("testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+
+	trafficMap[n0.ID] = &n0
+	trafficMap[n1.ID] = &n1
+	trafficMap[n2.ID] = &n2
+
+	n0.AddEdge(&n1)
+	n1.AddEdge(&n2)
+
+	return trafficMap
+}


### PR DESCRIPTION
The injected service node was not being killed when:
- Service injection on
- Both the source and dest nodes were dead:
  - No traffic between the source and dest
  - No backing workloads for the source and dest

Fixes: #2783 

Before:
![image](https://user-images.githubusercontent.com/2104052/82937818-cccdc100-9f5e-11ea-952b-652b363cdb78.png)

After:
![image](https://user-images.githubusercontent.com/2104052/82937965-0e5e6c00-9f5f-11ea-8342-f13ccda82822.png)
