### PR TITLE
Separate jaeger queries and kiali tracing queries

### DIFF
--- a/business/jaeger.go
+++ b/business/jaeger.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/kiali/kiali/jaeger"
+	"github.com/kiali/kiali/models"
 )
 
 type JaegerLoader = func() (jaeger.ClientInterface, error)
@@ -25,15 +26,15 @@ func (in *JaegerService) client() (jaeger.ClientInterface, error) {
 	return in.jaeger, in.loaderErr
 }
 
-func (in *JaegerService) GetJaegerSpans(namespace, service, startMicros, endMicros string) ([]jaeger.Span, error) {
+func (in *JaegerService) GetJaegerSpans(ns, srv string, query models.TracingQuery) ([]jaeger.Span, error) {
 	client, err := in.client()
 	if err != nil {
 		return nil, err
 	}
-	return client.GetSpans(namespace, service, startMicros, endMicros)
+	return client.GetSpans(ns, srv, query)
 }
 
-func (in *JaegerService) GetJaegerTraces(ns string, srv string, query string) (traces *jaeger.JaegerResponse, err error) {
+func (in *JaegerService) GetJaegerTraces(ns, srv string, query models.TracingQuery) (traces *jaeger.JaegerResponse, err error) {
 	client, err := in.client()
 	if err != nil {
 		return nil, err

--- a/jaeger/client.go
+++ b/jaeger/client.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/httputil"
 )
 
 // ClientInterface for mocks (only mocked function are necessary here)
 type ClientInterface interface {
-	GetSpans(namespace, service, startMicros, endMicros string) ([]Span, error)
-	GetTraces(namespace string, service string, rawQuery string) (traces *JaegerResponse, err error)
+	GetSpans(ns, srv string, query models.TracingQuery) ([]Span, error)
+	GetTraces(ns, srv string, query models.TracingQuery) (traces *JaegerResponse, err error)
 	GetTraceDetail(traceId string) (*JaegerSingleTrace, error)
 	GetErrorTraces(ns, srv string, duration time.Duration) (errorTraces int, err error)
 }
@@ -58,15 +59,15 @@ func NewClient(token string) (*Client, error) {
 
 // GetSpans fetches Jaeger traces of a service and extract related spans
 // Returns (spans, error)
-func (in *Client) GetSpans(namespace, service, startMicros, endMicros string) ([]Span, error) {
-	return getSpans(in.client, in.endpoint, namespace, service, startMicros, endMicros)
+func (in *Client) GetSpans(ns, srv string, query models.TracingQuery) ([]Span, error) {
+	return getSpans(in.client, in.endpoint, ns, srv, query)
 }
 
 // GetTraces Jaeger to fetch traces of a service
 // requests for traces of a service
 // Returns (traces, code, error)
-func (in *Client) GetTraces(namespace string, service string, rawQuery string) (traces *JaegerResponse, err error) {
-	return getTraces(in.client, in.endpoint, namespace, service, rawQuery)
+func (in *Client) GetTraces(ns, srv string, query models.TracingQuery) (traces *JaegerResponse, err error) {
+	return getTraces(in.client, in.endpoint, ns, srv, query)
 }
 
 // GetTraceDetail jaeger to fetch a specific trace

--- a/jaeger/traces.go
+++ b/jaeger/traces.go
@@ -10,23 +10,13 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/models"
 )
 
-func getTraces(client http.Client, endpoint *url.URL, namespace string, service string, rawQuery string) (response *JaegerResponse, err error) {
-	u := endpoint
-	queryService := service
-	if config.Get().ExternalServices.Tracing.NamespaceSelector && namespace != config.Get().IstioNamespace {
-		queryService = fmt.Sprintf("%s.%s", service, namespace)
-	}
-	u.Path = path.Join(u.Path, "/api/traces")
-	q, err := url.ParseQuery(rawQuery)
-	if err != nil {
-		log.Errorf("Jaeger parse query error: %s", err)
-		return
-	}
-	q.Add("service", queryService)
-	u.RawQuery = q.Encode()
-	return queryTraces(client, u)
+func getTraces(client http.Client, endpoint *url.URL, namespace, service string, query models.TracingQuery) (response *JaegerResponse, err error) {
+	endpoint.Path = path.Join(endpoint.Path, "/api/traces")
+	prepareQuery(endpoint, namespace, service, query)
+	return queryTraces(client, endpoint)
 }
 
 func getTraceDetail(client http.Client, endpoint *url.URL, traceID string) (*JaegerSingleTrace, error) {

--- a/models/tracing.go
+++ b/models/tracing.go
@@ -7,3 +7,11 @@ type JaegerInfo struct {
 	NamespaceSelector    bool     `json:"namespaceSelector"`
 	WhiteListIstioSystem []string `json:"whiteListIstioSystem"`
 }
+
+type TracingQuery struct {
+	StartMicros string `json:"startMicros"`
+	EndMicros   string `json:"endMicros"`
+	Tags        string `json:"tags"`
+	MinDuration string `json:"minDuration"`
+	Limit       int    `json:"limit"`
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -478,7 +478,7 @@ func NewRoutes() (r *Routes) {
 			"TracesList",
 			"GET",
 			"/api/namespaces/{namespace}/services/{service}/traces",
-			handlers.TraceServiceDetails,
+			handlers.TracesList,
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/services/{service}/errortraces traces errorTraces


### PR DESCRIPTION
Using TracingQuery when kiali is queried, decoupled from jaeger query API.
Share more code between spans.go and traces.go

Fixes https://github.com/kiali/kiali/issues/2732

Frontend PR required: https://github.com/kiali/kiali-ui/pull/1810
