### PR TITLE
[hack] fix up some things for minikube that are broken

### DIFF
--- a/make/Makefile.cluster.mk
+++ b/make/Makefile.cluster.mk
@@ -78,19 +78,29 @@ cluster-status: .prepare-cluster
 	@echo "Cluster nodes:"
 	@for n in $(shell ${OC} get nodes -o name); do echo "Node=[$${n}]" "CPUs=[$$(${OC} get $${n} -o jsonpath='{.status.capacity.cpu}')] Memory=[$$(${OC} get $${n} -o jsonpath='{.status.capacity.memory}')]"; done
 	@echo "================================================================="
+ifeq ($(CLUSTER_TYPE),openshift)
 	@echo "Console URL: $(shell ${OC} get console cluster -o jsonpath='{.status.consoleURL}' 2>/dev/null)"
 	@echo "API Server:  $(shell ${OC} whoami --show-server 2>/dev/null)"
 	@echo "================================================================="
+else ifeq ($(CLUSTER_TYPE),minikube)
+	@echo "Console URL: Run 'minikube dashboard' to access the UI console"
+	@echo "================================================================="
+endif
 	@echo "Kiali image as seen from inside the cluster:       ${CLUSTER_KIALI_INTERNAL_NAME}"
 	@echo "Kiali image that will be pushed to the cluster:    ${CLUSTER_KIALI_TAG}"
 	@echo "Operator image as seen from inside the cluster:    ${CLUSTER_OPERATOR_INTERNAL_NAME}"
 	@echo "Operator image that will be pushed to the cluster: ${CLUSTER_OPERATOR_TAG}"
 	@echo "================================================================="
-	@if [[ "${OC}" = *"oc" ]]; then echo "${OC} whoami -c"; ${OC} whoami -c; echo "================================================================="; fi
+ifeq ($(CLUSTER_TYPE),openshift)
+	@echo "oc whoami -c: $(shell ${OC} whoami -c 2>/dev/null)"
+	@echo "================================================================="
 ifeq ($(DORP),docker)
-	@if [[ "${OC}" = *"oc" ]]; then echo "Image Registry login: docker login -u $(shell ${OC} whoami | tr -d ':')" '-p $$(oc whoami -t)' "${CLUSTER_REPO}"; echo "================================================================="; fi
+	@echo "Image Registry login: docker login -u $(shell ${OC} whoami | tr -d ':')" '-p $$(oc whoami -t)' "${CLUSTER_REPO}"
+	@echo "================================================================="
 else
-	@if [[ "${OC}" = *"oc" ]]; then echo "Image Registry login: podman login --tls-verify=false -u $(shell ${OC} whoami | tr -d ':')" '-p $$(oc whoami -t)' "${CLUSTER_REPO}"; echo "================================================================="; fi
+	@echo "Image Registry login: podman login --tls-verify=false -u $(shell ${OC} whoami | tr -d ':')" '-p $$(oc whoami -t)' "${CLUSTER_REPO}"
+	@echo "================================================================="
+endif
 endif
 
 ## cluster-add-users: Add two users to an OpenShift cluster - kiali (cluster admin) and johndoe (no additional permissions)

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -93,8 +93,10 @@ kiali-delete: .ensure-oc-exists secret-delete
 kiali-purge: .ensure-oc-exists
 	@echo Purge Kiali resources
 	${OC} patch kiali kiali -n "${OPERATOR_WATCH_NAMESPACE}" -p '{"metadata":{"finalizers": []}}' --type=merge ; true
-	${OC} delete --ignore-not-found=true all,secrets,sa,templates,configmaps,deployments,roles,rolebindings,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n "${NAMESPACE}"
+	${OC} delete --ignore-not-found=true all,secrets,sa,configmaps,deployments,roles,rolebindings,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n "${NAMESPACE}"
+ifeq ($(CLUSTER_TYPE),openshift)
 	${OC} delete --ignore-not-found=true oauthclients.oauth.openshift.io,consolelinks.console.openshift.io --selector="app=kiali" -n "${NAMESPACE}" ; true
+endif
 
 ## kiali-reload-image: Refreshing the Kiali pod by deleting it which forces a redeployment
 kiali-reload-image: .ensure-oc-exists


### PR DESCRIPTION
1. need to specify insecure registry when starting minikube now
2. default to the most stable release of k8s
3. make should not try to delete templates (k8s doesn't have that type and we don't use templates anymore anyway)
4. make should only try to delete openshift resources when cluster type is openshift
5. xdg-open is deprecated; use gio open now