### PR TITLE
Expose Istio Telemetry Version to Public Config

### DIFF
--- a/handlers/config.go
+++ b/handlers/config.go
@@ -48,6 +48,7 @@ type PublicConfig struct {
 	IstioLabels              config.IstioLabels              `json:"istioLabels,omitempty"`
 	Prometheus               PrometheusConfig                `json:"prometheus,omitempty"`
 	CanonicalMetrics         bool                            `json:"canonicalMetrics"`
+	IsMixerDisabled          bool                            `json:"isMixerDisabled"`
 }
 
 // Config is a REST http.HandlerFunc serving up the Kiali configuration made public to clients.
@@ -77,7 +78,8 @@ func Config(w http.ResponseWriter, r *http.Request) {
 			GlobalScrapeInterval: promConfig.GlobalScrapeInterval,
 			StorageTsdbRetention: promConfig.StorageTsdbRetention,
 		},
-		CanonicalMetrics: 		  status.AreCanonicalMetricsAvailable(),
+		CanonicalMetrics: status.AreCanonicalMetricsAvailable(),
+		IsMixerDisabled:  status.IsMixerDisabled(),
 	}
 
 	RespondWithJSONIndent(w, http.StatusOK, publicConfig)

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -46,9 +46,8 @@ type PublicConfig struct {
 	IstioNamespace           string                          `json:"istioNamespace,omitempty"`
 	IstioComponentNamespaces config.IstioComponentNamespaces `json:"istioComponentNamespaces,omitempty"`
 	IstioLabels              config.IstioLabels              `json:"istioLabels,omitempty"`
+	IstioTelemetryV2         bool                            `json:"istioTelemetryV2"`
 	Prometheus               PrometheusConfig                `json:"prometheus,omitempty"`
-	CanonicalMetrics         bool                            `json:"canonicalMetrics"`
-	IsMixerDisabled          bool                            `json:"isMixerDisabled"`
 }
 
 // Config is a REST http.HandlerFunc serving up the Kiali configuration made public to clients.
@@ -78,8 +77,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 			GlobalScrapeInterval: promConfig.GlobalScrapeInterval,
 			StorageTsdbRetention: promConfig.StorageTsdbRetention,
 		},
-		CanonicalMetrics: status.AreCanonicalMetricsAvailable(),
-		IsMixerDisabled:  status.IsMixerDisabled(),
+		IstioTelemetryV2: status.IsMixerDisabled(),
 	}
 
 	RespondWithJSONIndent(w, http.StatusOK, publicConfig)

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/status"
 )
 
 const (
@@ -46,6 +47,7 @@ type PublicConfig struct {
 	IstioComponentNamespaces config.IstioComponentNamespaces `json:"istioComponentNamespaces,omitempty"`
 	IstioLabels              config.IstioLabels              `json:"istioLabels,omitempty"`
 	Prometheus               PrometheusConfig                `json:"prometheus,omitempty"`
+	CanonicalMetrics         bool                            `json:"canonicalMetrics"`
 }
 
 // Config is a REST http.HandlerFunc serving up the Kiali configuration made public to clients.
@@ -75,6 +77,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 			GlobalScrapeInterval: promConfig.GlobalScrapeInterval,
 			StorageTsdbRetention: promConfig.StorageTsdbRetention,
 		},
+		CanonicalMetrics: 		  status.AreCanonicalMetricsAvailable(),
 	}
 
 	RespondWithJSONIndent(w, http.StatusOK, publicConfig)


### PR DESCRIPTION
This is related to #2633 where extensions may need access from backend/frontend to the CanonicalMetrics flag to check if telemetry is based on v1 or v2 metrics.

This requires a frontend PR.