### PR TITLE
PeerAuthn validations for disabling scenarios

### DIFF
--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -61,6 +61,7 @@ func (in DestinationRulesChecker) runChecks(destinationRule kubernetes.IstioObje
 
 	enabledCheckers := []Checker{
 		destinationrules.DisabledNamespaceWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
+		destinationrules.DisabledMeshWideMTLSChecker{DestinationRule: destinationRule, MeshPeerAuthns: in.MTLSDetails.MeshPeerAuthentications},
 	}
 
 	// Appending validations that only applies to non-autoMTLS meshes

--- a/business/checkers/destinationrules/disabled_meshwide_mtls_checker.go
+++ b/business/checkers/destinationrules/disabled_meshwide_mtls_checker.go
@@ -1,0 +1,28 @@
+package destinationrules
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type DisabledMeshWideMTLSChecker struct {
+	DestinationRule kubernetes.IstioObject
+	MeshPeerAuthns  []kubernetes.IstioObject
+}
+
+func (c DisabledMeshWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	if _, mode := kubernetes.DestinationRuleHasMeshWideMTLSEnabled(c.DestinationRule); mode != "DISABLE" {
+		return validations, true
+	}
+
+	for _, pa := range c.MeshPeerAuthns {
+		if _, mode := kubernetes.PeerAuthnHasMTLSEnabled(pa); mode == "STRICT" {
+			check := models.Build("destinationrules.mtls.meshpolicymtlsenabled", "spec/trafficPolicy/tls/mode")
+			return append(validations, &check), false
+		}
+	}
+
+	return validations, true
+}

--- a/business/checkers/destinationrules/disabled_meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/disabled_meshwide_mtls_checker_test.go
@@ -1,0 +1,86 @@
+package destinationrules
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+)
+
+// Context: DestinationRule at mesh-level disabling mTLS
+// Context: PeerAuthn at mesh-level disabling mTLS
+// It doesn't return any validation
+func TestDestRuleDisabledPeerAuthnDisabled(t *testing.T) {
+	testNoDestRuleDisabledValidations("disabled_meshwide_checker_1.yaml", t)
+}
+
+// Context: DestinationRule at mesh-level disabling mTLS
+// Context: PeerAuthn at mesh-level with permissive mTLS
+// It doesn't return any validation
+func TestDestRuleDisabledPeerAuthnPermissive(t *testing.T) {
+	testNoDestRuleDisabledValidations("disabled_meshwide_checker_4.yaml", t)
+}
+
+// Context: DestinationRule at mesh-level disabling mTLS
+// Context: No PeerAuthentication at mesh-level
+// It doesn't return any validation
+func TestDestRuleDisabledNoPeerAuthn(t *testing.T) {
+	testNoDestRuleDisabledValidations("disabled_meshwide_checker_3.yaml", t)
+}
+
+// Context: DestinationRule at mesh-level disabling mTLS
+// Context: PeerAuthn at mesh-level with STRICT mTLS
+// It returns a validation
+func TestDestRuleDisabledPeerAuthnEnabled(t *testing.T) {
+	testWithDestRuleDisabledValidations("disabled_meshwide_checker_2.yaml", t)
+}
+
+func disabledMeshDestRuleTestPrep(scenario string) ([]*models.IstioCheck, bool, error) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	loader := yamlFixtureLoaderFor(scenario)
+	err := loader.Load()
+
+	validations, valid := DisabledMeshWideMTLSChecker{
+		DestinationRule: loader.GetResource("DestinationRule"),
+		MeshPeerAuthns:  loader.GetResources("PeerAuthentication"),
+	}.Check()
+
+	return validations, valid, err
+}
+
+func testNoDestRuleDisabledValidations(scenario string, t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid, error := disabledMeshDestRuleTestPrep(scenario)
+
+	assert.NoError(error)
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+func testWithDestRuleDisabledValidations(scenario string, t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid, error := disabledMeshDestRuleTestPrep(scenario)
+
+	assert.NoError(error)
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+
+	validation := validations[0]
+	assert.NotNil(validation)
+	assert.Equal(models.ErrorSeverity, validation.Severity)
+	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
+	assert.Equal(models.CheckMessage("destinationrules.mtls.meshpolicymtlsenabled"), validation.Message)
+}
+
+func yamlFixtureLoaderFor(file string) *data.YamlFixtureLoader {
+	path := fmt.Sprintf("../../../tests/data/validations/destinationrules/%s", file)
+	return &data.YamlFixtureLoader{Filename: path}
+}

--- a/business/checkers/peer_authentication_checker.go
+++ b/business/checkers/peer_authentication_checker.go
@@ -43,6 +43,8 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn kubernetes.IstioObject) m
 		if peerAuthn.GetObjectMeta().Namespace == config.Get().IstioNamespace {
 			enabledCheckers = append(enabledCheckers,
 				peerauthentications.MeshMtlsChecker{MeshPolicy: peerAuthn, MTLSDetails: m.MTLSDetails, IsServiceMesh: false})
+			enabledCheckers = append(enabledCheckers,
+				peerauthentications.DisabledMeshWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
 		} else {
 			enabledCheckers = append(enabledCheckers,
 				peerauthentications.NamespaceMtlsChecker{PeerAuthn: peerAuthn, MTLSDetails: m.MTLSDetails})

--- a/business/checkers/peer_authentication_checker.go
+++ b/business/checkers/peer_authentication_checker.go
@@ -36,6 +36,11 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn kubernetes.IstioObject) m
 	var enabledCheckers []Checker
 
 	enabledCheckers = append(enabledCheckers, common.SelectorNoWorkloadFoundChecker(PeerAuthenticationCheckerType, peerAuthn, m.WorkloadList))
+	if peerAuthn.GetObjectMeta().Namespace == config.Get().IstioNamespace {
+		enabledCheckers = append(enabledCheckers, peerauthentications.DisabledMeshWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
+	} else {
+		enabledCheckers = append(enabledCheckers, peerauthentications.DisabledNamespaceWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
+	}
 
 	// MeshWide and NamespaceWide validations are only needed with autoMtls disabled
 	if !m.MTLSDetails.EnabledAutoMtls {
@@ -43,13 +48,9 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn kubernetes.IstioObject) m
 		if peerAuthn.GetObjectMeta().Namespace == config.Get().IstioNamespace {
 			enabledCheckers = append(enabledCheckers,
 				peerauthentications.MeshMtlsChecker{MeshPolicy: peerAuthn, MTLSDetails: m.MTLSDetails, IsServiceMesh: false})
-			enabledCheckers = append(enabledCheckers,
-				peerauthentications.DisabledMeshWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
 		} else {
 			enabledCheckers = append(enabledCheckers,
 				peerauthentications.NamespaceMtlsChecker{PeerAuthn: peerAuthn, MTLSDetails: m.MTLSDetails})
-			enabledCheckers = append(enabledCheckers,
-				peerauthentications.DisabledNamespaceWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
 		}
 	}
 

--- a/business/checkers/peer_authentication_checker.go
+++ b/business/checkers/peer_authentication_checker.go
@@ -46,6 +46,8 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn kubernetes.IstioObject) m
 		} else {
 			enabledCheckers = append(enabledCheckers,
 				peerauthentications.NamespaceMtlsChecker{PeerAuthn: peerAuthn, MTLSDetails: m.MTLSDetails})
+			enabledCheckers = append(enabledCheckers,
+				peerauthentications.DisabledNamespaceWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
 		}
 	}
 

--- a/business/checkers/peerauthentications/disabled_meshwide_checker.go
+++ b/business/checkers/peerauthentications/disabled_meshwide_checker.go
@@ -1,0 +1,29 @@
+package peerauthentications
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type DisabledMeshWideChecker struct {
+	PeerAuthn        kubernetes.IstioObject
+	DestinationRules []kubernetes.IstioObject
+}
+
+func (c DisabledMeshWideChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	// Validation only affects to PeerAuthn disabling mTLS
+	if _, mode := kubernetes.PeerAuthnHasMTLSEnabled(c.PeerAuthn); mode != "DISABLE" {
+		return validations, true
+	}
+
+	for _, dr := range c.DestinationRules {
+		if _, mode := kubernetes.DestinationRuleHasMeshWideMTLSEnabled(dr); mode == "ISTIO_MUTUAL" || mode == "MUTUAL" {
+			check := models.Build("peerauthentications.mtls.disablemeshdestinationrulemissing", "spec/mtls")
+			return append(validations, &check), false
+		}
+	}
+
+	return validations, true
+}

--- a/business/checkers/peerauthentications/disabled_meshwide_checker_test.go
+++ b/business/checkers/peerauthentications/disabled_meshwide_checker_test.go
@@ -1,0 +1,74 @@
+package peerauthentications
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// This validations works only with AutoMTls disabled
+
+// Context: MeshPeerAuthn disabled
+// Context: DestinationRule tls mode disabled
+// It doesn't return any validation
+func TestMeshPeerAuthnDisabledDestRuleDisabled(t *testing.T) {
+	testNoDisabledMeshValidations("disabled_meshwide_checker_1.yaml", t)
+}
+
+// Context: MeshPeerAuthn disabled
+// Context: DestinationRule tls mode ISTIO_MUTUAL
+// It returns a validation
+func TestMeshPeerAuthnDisabledDestRuleEnabled(t *testing.T) {
+	testWithDisabledMeshValidations("disabled_meshwide_checker_2.yaml", t)
+}
+
+// Context: MeshPeerAuthn disabled
+// Context: No Destination Rule at mesh-wide
+// It doesn't return any validation
+func TestMeshPeerAuthnNoDestRule(t *testing.T) {
+	testNoDisabledMeshValidations("disabled_meshwide_checker_3.yaml", t)
+}
+
+func disabledMeshTestPrep(scenario string) ([]*models.IstioCheck, bool, error) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	loader := yamlFixtureLoaderFor(scenario)
+	err := loader.Load()
+
+	validations, valid := DisabledMeshWideChecker{
+		PeerAuthn:        loader.GetResource("PeerAuthentication"),
+		DestinationRules: loader.GetResources("DestinationRule"),
+	}.Check()
+
+	return validations, valid, err
+}
+
+func testNoDisabledMeshValidations(scenario string, t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid, error := disabledMeshTestPrep(scenario)
+
+	assert.NoError(error)
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+func testWithDisabledMeshValidations(scenario string, t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid, error := disabledMeshTestPrep(scenario)
+
+	assert.NoError(error)
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+
+	validation := validations[0]
+	assert.NotNil(validation)
+	assert.Equal(models.ErrorSeverity, validation.Severity)
+	assert.Equal("spec/mtls", validation.Path)
+	assert.Equal(models.CheckMessage("peerauthentications.mtls.disablemeshdestinationrulemissing"), validation.Message)
+}

--- a/business/checkers/peerauthentications/disabled_namespacewide_checker.go
+++ b/business/checkers/peerauthentications/disabled_namespacewide_checker.go
@@ -1,0 +1,35 @@
+package peerauthentications
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type DisabledNamespaceWideChecker struct {
+	PeerAuthn        kubernetes.IstioObject
+	DestinationRules []kubernetes.IstioObject
+}
+
+func (c DisabledNamespaceWideChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	// Validation only affects to PeerAuthn disabling mTLS
+	if _, mode := kubernetes.PeerAuthnHasMTLSEnabled(c.PeerAuthn); mode != "DISABLE" {
+		return validations, true
+	}
+
+	for _, dr := range c.DestinationRules {
+		// If ns-wide Destination Rule enabling mtls found, error found
+		if _, mode := kubernetes.DestinationRuleHasNamespaceWideMTLSEnabled(c.PeerAuthn.GetObjectMeta().Namespace, dr); mode == "ISTIO_MUTUAL" || mode == "MUTUAL" {
+			check := models.Build("peerauthentications.mtls.disabledestinationrulemissing", "spec/mtls")
+			return append(validations, &check), false
+		}
+
+		if _, mode := kubernetes.DestinationRuleHasMeshWideMTLSEnabled(dr); mode == "ISTIO_MUTUAL" || mode == "MUTUAL" {
+			check := models.Build("peerauthentications.mtls.disabledestinationrulemissing", "spec/mtls")
+			return append(validations, &check), false
+		}
+	}
+
+	return validations, true
+}

--- a/business/checkers/peerauthentications/disabled_namespacewide_checker_test.go
+++ b/business/checkers/peerauthentications/disabled_namespacewide_checker_test.go
@@ -1,0 +1,95 @@
+package peerauthentications
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/stretchr/testify/assert"
+)
+
+// This validations works only with AutoMTls disabled
+
+// Context: PeerAuthn disabled
+// Context: DestinationRule tls mode disabled
+// It doesn't return any validation
+func TestPeerAuthnDisabledDestRuleDisabled(t *testing.T) {
+	testNoDisabledNsValidations("disabled_namespacewide_checker_1.yaml", t)
+}
+
+// Context: PeerAuthn disabled
+// Context: DestinationRule tls mode ISTIO_MUTUAL
+// It returns a validation
+func TestPeerAuthnDisabledDestRuleEnabled(t *testing.T) {
+	testWithDisabledNsValidations("disabled_namespacewide_checker_2.yaml", t)
+}
+
+// Context: PeerAuthn disabled
+// Context: Mesh-wide DestinationRule tls mode disabled
+// It doesn't return a validation
+func TestPeerAuthnDisabledMeshWideDestRuleDisabled(t *testing.T) {
+	testNoDisabledNsValidations("disabled_namespacewide_checker_3.yaml", t)
+}
+
+// Context: PeerAuthn disabled
+// Context: Mesh-wide DestinationRule tls mode ISTIO_MUTUAL
+// It returns a validation
+func TestPeerAuthnDisabledMeshWideDestRuleEnabled(t *testing.T) {
+	testWithDisabledNsValidations("disabled_namespacewide_checker_4.yaml", t)
+}
+
+// Context: PeerAuthn disabled
+// Context: No Destination Rule at any level
+// It doesn't return any validation
+func TestPeerAuthnDisabledNoDestRule(t *testing.T) {
+	testNoDisabledNsValidations("disabled_namespacewide_checker_5.yaml", t)
+}
+
+func disabledNamespacetestPrep(scenario string) ([]*models.IstioCheck, bool, error) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	loader := yamlFixtureLoaderFor(scenario)
+	err := loader.Load()
+
+	validations, valid := DisabledNamespaceWideChecker{
+		PeerAuthn:        loader.GetResource("PeerAuthentication"),
+		DestinationRules: loader.GetResources("DestinationRule"),
+	}.Check()
+
+	return validations, valid, err
+}
+
+func testNoDisabledNsValidations(scenario string, t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid, error := disabledNamespacetestPrep(scenario)
+
+	assert.NoError(error)
+	assert.Empty(validations)
+	assert.True(valid)
+}
+
+func testWithDisabledNsValidations(scenario string, t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid, error := disabledNamespacetestPrep(scenario)
+
+	assert.NoError(error)
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, 1)
+
+	validation := validations[0]
+	assert.NotNil(validation)
+	assert.Equal(models.ErrorSeverity, validation.Severity)
+	assert.Equal("spec/mtls", validation.Path)
+	assert.Equal(models.CheckMessage("peerauthentications.mtls.disabledestinationrulemissing"), validation.Message)
+}
+
+func yamlFixtureLoaderFor(file string) *data.YamlFixtureLoader {
+	path := fmt.Sprintf("../../../tests/data/validations/peerauthentications/%s", file)
+	return &data.YamlFixtureLoader{Filename: path}
+}

--- a/business/tls.go
+++ b/business/tls.go
@@ -176,7 +176,7 @@ func (in TLSService) hasPeerAuthnNamespacemTLSDefinition(namespace string) (stri
 	}
 
 	for _, p := range ps {
-		if enabled, mode := kubernetes.PeerAuthnHasMTLSEnabled(p); enabled {
+		if _, mode := kubernetes.PeerAuthnHasMTLSEnabled(p); mode != "" {
 			return mode, nil
 		}
 	}

--- a/kubernetes/istio_details_service.go
+++ b/kubernetes/istio_details_service.go
@@ -1511,13 +1511,12 @@ func PeerAuthnHasMTLSEnabled(peerAuthn IstioObject) (bool, string) {
 		if mtlsMap, ok := mtls.(map[string]interface{}); ok {
 			if modeItf, found := mtlsMap["mode"]; found {
 				if mode, ok := modeItf.(string); ok {
-					return true, mode
+					return mode == "STRICT" || mode == "PERMISSIVE", mode
 				} else {
 					return false, ""
 				}
 			} else {
-				// STRICT when mtls object is empty
-				return false, "PERMISSIVE"
+				return true, "PERMISSIVE"
 			}
 		}
 	}

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -494,8 +494,8 @@ type istioResponse struct {
 
 // GenericIstioObject is a type to test Istio types defined by Istio as a Kubernetes extension.
 type GenericIstioObject struct {
-	meta_v1.TypeMeta   `json:",inline"`
-	meta_v1.ObjectMeta `json:"metadata"`
+	meta_v1.TypeMeta   `json:",inline" yaml:",inline"`
+	meta_v1.ObjectMeta `json:"metadata" yaml:"metadata"`
 	Spec               map[string]interface{} `json:"spec"`
 }
 

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -187,6 +187,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA0504 No matching workload found for PeerAuthentication selector in this namespace",
 		Severity: WarningSeverity,
 	},
+	"peerauthentications.mtls.disabledestinationrulemissing": {
+		Message:  "KIA0502 Destination Rule disabling namespace-wide mTLS is missing",
+		Severity: ErrorSeverity,
+	},
 	"port.name.mismatch": {
 		Message:  "KIA0601 Port name must follow <protocol>[-suffix] form",
 		Severity: ErrorSeverity,

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -191,6 +191,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA0502 Destination Rule disabling namespace-wide mTLS is missing",
 		Severity: ErrorSeverity,
 	},
+	"peerauthentications.mtls.disablemeshdestinationrulemissing": {
+		Message:  "KIA0506 Destination Rule disabling mesh-wide mTLS is missing",
+		Severity: ErrorSeverity,
+	},
 	"port.name.mismatch": {
 		Message:  "KIA0601 Port name must follow <protocol>[-suffix] form",
 		Severity: ErrorSeverity,

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -188,7 +188,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"peerauthentications.mtls.disabledestinationrulemissing": {
-		Message:  "KIA0502 Destination Rule disabling namespace-wide mTLS is missing",
+		Message:  "KIA0505 Destination Rule disabling namespace-wide mTLS is missing",
 		Severity: ErrorSeverity,
 	},
 	"peerauthentications.mtls.disablemeshdestinationrulemissing": {

--- a/tests/data/fiture_loader.go
+++ b/tests/data/fiture_loader.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"bytes"
+	"fmt"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 
@@ -37,6 +38,7 @@ func (l *YamlFixtureLoader) Load() error {
 
 		err = dec.Decode(&resource)
 		if err == nil {
+			resource.Spec = cleanUpStringInterfaceMap(resource.Spec)
 			resources = append(resources, resource)
 		}
 	}
@@ -73,4 +75,45 @@ func (l YamlFixtureLoader) GetResource(kind string) kubernetes.IstioObject {
 		return l.GetResources(kind)[0]
 	}
 	return nil
+}
+
+// Needed due to Yaml.Decode default map type is map[interface{}]interface{}
+// We need to convert it to map[string]interface{} to be compliant with real Istio Objects.
+// Known issue: https://github.com/go-yaml/yaml/issues/139
+
+func cleanUpInterfaceArray(in []interface{}) []interface{} {
+	result := make([]interface{}, len(in))
+	for i, v := range in {
+		result[i] = cleanUpMapValue(v)
+	}
+	return result
+}
+
+func cleanUpInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range in {
+		result[fmt.Sprintf("%v", k)] = cleanUpMapValue(v)
+	}
+	return result
+}
+
+func cleanUpStringInterfaceMap(in map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range in {
+		result[k] = cleanUpMapValue(v)
+	}
+	return result
+}
+
+func cleanUpMapValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanUpInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return cleanUpInterfaceMap(v)
+	case map[string]interface{}:
+		return cleanUpStringInterfaceMap(v)
+	default:
+		return v
+	}
 }

--- a/tests/data/fiture_loader.go
+++ b/tests/data/fiture_loader.go
@@ -1,0 +1,76 @@
+package data
+
+import (
+	"bytes"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
+)
+
+type FixtureLoader interface {
+	Load() error
+	GetResources(kind string) kubernetes.IstioObjectList
+}
+
+type YamlFixtureLoader struct {
+	Filename  string
+	loaded    bool
+	resources map[string][]kubernetes.IstioObject
+}
+
+func (l *YamlFixtureLoader) Load() error {
+	yamlFile, err := ioutil.ReadFile(l.Filename)
+	if err != nil {
+		log.Errorf("Error loading test file: #%v ", err)
+		return err
+	}
+
+	r := bytes.NewReader(yamlFile)
+	dec := yaml.NewDecoder(r)
+
+	var resources []kubernetes.GenericIstioObject
+
+	for err == nil {
+		var resource kubernetes.GenericIstioObject
+
+		err = dec.Decode(&resource)
+		if err == nil {
+			resources = append(resources, resource)
+		}
+	}
+
+	l.sortResources(&kubernetes.GenericIstioObjectList{Items: resources})
+	l.loaded = true
+
+	return nil
+}
+
+func (l *YamlFixtureLoader) sortResources(resources kubernetes.IstioObjectList) {
+	l.resources = map[string][]kubernetes.IstioObject{}
+
+	for _, r := range resources.GetItems() {
+		kind := r.GetObjectKind().GroupVersionKind().Kind
+		if l.resources[kind] == nil {
+			l.resources[kind] = []kubernetes.IstioObject{}
+		}
+
+		l.resources[kind] = append(l.resources[kind], r)
+	}
+}
+
+func (l YamlFixtureLoader) GetResources(kind string) []kubernetes.IstioObject {
+	if !l.loaded {
+		return nil
+	}
+
+	return l.resources[kind]
+}
+
+func (l YamlFixtureLoader) GetResource(kind string) kubernetes.IstioObject {
+	if len(l.GetResources(kind)) > 0 {
+		return l.GetResources(kind)[0]
+	}
+	return nil
+}

--- a/tests/data/fixture_loader_test.go
+++ b/tests/data/fixture_loader_test.go
@@ -1,0 +1,35 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetResources(t *testing.T) {
+	assert := assert.New(t)
+
+	loader := YamlFixtureLoader{Filename: "./loader/basic.yaml"}
+	err := loader.Load()
+
+	assert.NoError(err)
+	assert.NotEmpty(loader)
+
+	rscs := loader.GetResources("PeerAuthentication")
+	assert.Len(rscs, 2)
+
+	rsc := rscs[0]
+	assert.Equal(rsc.GetObjectKind().GroupVersionKind().Kind, "PeerAuthentication")
+	assert.Equal(rsc.GetObjectMeta().Name, "default")
+	assert.Equal(rsc.GetObjectMeta().Namespace, "bookinfo")
+	assert.NotEmpty(rsc.GetSpec())
+
+	rsc = rscs[1]
+	assert.Equal(rsc.GetObjectKind().GroupVersionKind().Kind, "PeerAuthentication")
+	assert.Equal(rsc.GetObjectMeta().Name, "default")
+	assert.Equal(rsc.GetObjectMeta().Namespace, "istio-system")
+	assert.NotEmpty(rsc.GetSpec())
+
+	rscs = loader.GetResources("VirtualService")
+	assert.Len(rscs, 0)
+}

--- a/tests/data/loader/basic.yaml
+++ b/tests/data/loader/basic.yaml
@@ -1,0 +1,17 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  namespace: "bookinfo"
+spec:
+  mtls:
+    mode: PERMISSIVE
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: STRICT

--- a/tests/data/validations/destinationrules/disabled_meshwide_checker_1.yaml
+++ b/tests/data/validations/destinationrules/disabled_meshwide_checker_1.yaml
@@ -1,0 +1,19 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "disable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: DISABLE

--- a/tests/data/validations/destinationrules/disabled_meshwide_checker_2.yaml
+++ b/tests/data/validations/destinationrules/disabled_meshwide_checker_2.yaml
@@ -1,0 +1,19 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "disable-mesh-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: STRICT

--- a/tests/data/validations/destinationrules/disabled_meshwide_checker_3.yaml
+++ b/tests/data/validations/destinationrules/disabled_meshwide_checker_3.yaml
@@ -1,0 +1,22 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "mesh-enable-mtls"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-grafana-mtls"
+  namespace: "bookinfo"
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  mtls:
+    mode: DISABLE

--- a/tests/data/validations/destinationrules/disabled_meshwide_checker_4.yaml
+++ b/tests/data/validations/destinationrules/disabled_meshwide_checker_4.yaml
@@ -1,0 +1,19 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "enable-mesh-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "permissive-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: PERMISSIVE

--- a/tests/data/validations/peerauthentications/disabled_meshwide_checker_1.yaml
+++ b/tests/data/validations/peerauthentications/disabled_meshwide_checker_1.yaml
@@ -1,0 +1,43 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: DISABLE
+---
+kind: "PeerAuthentication"
+apiVersion: "security.istio.io/v1beta1"
+metadata:
+  name: "grafana-ports-mtls-disabled"
+  namespace: "istio-system"
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  portLevelMtls:
+    '3000':
+      mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "disable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "grafana-enable-mtls"
+  namespace: "istio-system"
+spec:
+  host: "grafana.istio-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/data/validations/peerauthentications/disabled_meshwide_checker_2.yaml
+++ b/tests/data/validations/peerauthentications/disabled_meshwide_checker_2.yaml
@@ -1,0 +1,43 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: DISABLE
+---
+kind: "PeerAuthentication"
+apiVersion: "security.istio.io/v1beta1"
+metadata:
+  name: "grafana-ports-mtls-disabled"
+  namespace: "istio-system"
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  portLevelMtls:
+    '3000':
+      mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "enable-mesh-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "grafana-enable-mtls"
+  namespace: "istio-system"
+spec:
+  host: "grafana.istio-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/data/validations/peerauthentications/disabled_meshwide_checker_3.yaml
+++ b/tests/data/validations/peerauthentications/disabled_meshwide_checker_3.yaml
@@ -1,0 +1,19 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "grafana-enable-mtls"
+  namespace: "istio-system"
+spec:
+  host: "grafana.istio-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/tests/data/validations/peerauthentications/disabled_namespacewide_checker_1.yaml
+++ b/tests/data/validations/peerauthentications/disabled_namespacewide_checker_1.yaml
@@ -1,0 +1,30 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mtls-bookinfo"
+  namespace: "bookinfo"
+spec:
+  mtls:
+    mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "disable-mtls-bookinfo"
+  namespace: "bookinfo"
+spec:
+  host: "*.bookinfo.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "details-enable-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "details"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/data/validations/peerauthentications/disabled_namespacewide_checker_2.yaml
+++ b/tests/data/validations/peerauthentications/disabled_namespacewide_checker_2.yaml
@@ -1,0 +1,30 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mtls-bookinfo"
+  namespace: "bookinfo"
+spec:
+  mtls:
+    mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "bookinfo-enable-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "*.bookinfo.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "details-enable-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "details"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/data/validations/peerauthentications/disabled_namespacewide_checker_3.yaml
+++ b/tests/data/validations/peerauthentications/disabled_namespacewide_checker_3.yaml
@@ -1,0 +1,30 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mtls-bookinfo"
+  namespace: "bookinfo"
+spec:
+  mtls:
+    mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "disable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "details-enable-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "details"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/data/validations/peerauthentications/disabled_namespacewide_checker_4.yaml
+++ b/tests/data/validations/peerauthentications/disabled_namespacewide_checker_4.yaml
@@ -1,0 +1,30 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mtls-bookinfo"
+  namespace: "bookinfo"
+spec:
+  mtls:
+    mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "enable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "details-enable-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "details"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/data/validations/peerauthentications/disabled_namespacewide_checker_5.yaml
+++ b/tests/data/validations/peerauthentications/disabled_namespacewide_checker_5.yaml
@@ -1,0 +1,8 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mtls-bookinfo"
+  namespace: "bookinfo"
+spec:
+  mtls:
+    mode: DISABLE

--- a/tests/data/validations/test_asserter.go
+++ b/tests/data/validations/test_asserter.go
@@ -1,0 +1,49 @@
+package validations
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/models"
+	"github.com/stretchr/testify/assert"
+)
+
+type TestAsserter interface {
+	AssertNoValidations()
+	AssertValidationsPresent(int)
+	AssertValidationAt(int, models.SeverityLevel, string, string)
+}
+
+type ValidationTestAsserter struct {
+	T           *testing.T
+	Validations []*models.IstioCheck
+	Valid       bool
+}
+
+func (tb ValidationTestAsserter) AssertNoValidations() {
+	assert := assert.New(tb.T)
+
+	assert.Empty(tb.Validations)
+	assert.True(tb.Valid)
+}
+
+func (tb ValidationTestAsserter) AssertValidationsPresent(count int) {
+	assert := assert.New(tb.T)
+
+	assert.False(tb.Valid)
+	assert.NotEmpty(tb.Validations)
+	assert.Len(tb.Validations, count)
+}
+
+func (tb ValidationTestAsserter) AssertValidationAt(i int, severity models.SeverityLevel, path, message string) {
+	assert := assert.New(tb.T)
+
+	if len(tb.Validations) < i {
+		tb.T.Error("Wrong memory access to validations array")
+	}
+
+	validation := tb.Validations[i]
+	assert.NotNil(validation)
+	assert.Equal(severity, validation.Severity)
+	assert.Equal(path, validation.Path)
+	assert.Equal(models.CheckMessage(message), validation.Message)
+}


### PR DESCRIPTION
Three validations have been included:

- PeerAuthn: Disabling mTLS at namespace level ([steps to reproduce](https://raw.githubusercontent.com/xeviknal/swscore/kiali-2086-2/tests/data/validations/peerauthentications/disabled_namespacewide_checker_2.yaml)) (both autoMtls enabled/disabled)
![Screenshot of Kiali Console (99)](https://user-images.githubusercontent.com/613814/83425393-ec1c9080-a42d-11ea-82f1-4b0ba10db043.png)

- PeerAuthn: Disabling mTLS at mesh-level ([steps to reproduce](https://raw.githubusercontent.com/xeviknal/swscore/kiali-2086-2/tests/data/validations/peerauthentications/disabled_meshwide_checker_2.yaml)) (both autoMtls enabled/disabled)

![Screenshot of Kiali Console (100)](https://user-images.githubusercontent.com/613814/83518787-30b23580-a4db-11ea-83c0-757e1144495f.png)

- DestinationRule: Disabling mTLS at mesh-level ([steps to reproduce](https://raw.githubusercontent.com/xeviknal/swscore/kiali-2086-2/tests/data/validations/destinationrules/disabled_meshwide_checker_2.yaml)) (both autoMtls enabled/disabled)

![Screenshot of Kiali Console (97)](https://user-images.githubusercontent.com/613814/83425107-acee3f80-a42d-11ea-95c4-7fcb680e5ef3.png)

Introduced a mechanism for reduce the high amount of test code we have and also increase better team work with QE.



