### PR TITLE
2770 server should not allow TLS 1.1 or lower (#2782)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 
@@ -40,9 +41,15 @@ func NewServer() *Server {
 	http.DefaultServeMux = mux
 	http.Handle("/", handler)
 
+	// Clients must use TLS 1.2 or higher
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
 	// create the server definition that will handle both console and api server traffic
 	httpServer := &http.Server{
-		Addr: fmt.Sprintf("%v:%v", conf.Server.Address, conf.Server.Port),
+		Addr:      fmt.Sprintf("%v:%v", conf.Server.Address, conf.Server.Port),
+		TLSConfig: tlsConfig,
 	}
 
 	// return our new Server

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -289,6 +289,27 @@ func TestSecureComm(t *testing.T) {
 	if _, err = getRequestResults(t, httpClient, apiURL, noCredentials); err != nil {
 		t.Fatalf("Failed: Basic API URL shouldn't have failed with no credentials: %v", err)
 	}
+
+	// Make sure the server rejects anything trying to use TLS 1.1 or under
+	httpConfigTLS11 := httpClientConfig{
+		Identity: &security.Identity{
+			CertFile:       testClientCertFile,
+			PrivateKeyFile: testClientKeyFile,
+		},
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS10,
+			MaxVersion:         tls.VersionTLS11,
+		},
+	}
+	httpClientTLS11, err := httpConfigTLS11.buildHTTPClient()
+	if err != nil {
+		t.Fatalf("Failed to create http client with TLS 1.1")
+	}
+	if _, err = getRequestResults(t, httpClientTLS11, apiURLWithAuthentication, basicCredentials); err == nil {
+		t.Fatalf("Failed: Should not have been able to use TLS 1.1")
+	}
+
 }
 
 func TestConfigureGzipHandler(t *testing.T) {


### PR DESCRIPTION
fixes #https://github.com/kiali/kiali/issues/2770
backport of https://github.com/kiali/kiali/pull/2782