### PR TITLE
Don't use "login" strategy in when deploying in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ OPERATOR_INSTALL_KIALI ?= false
 # When installing Kiali to a remote cluster via make, here are some configuration settings for it.
 ACCESSIBLE_NAMESPACES ?= **
 ifneq ($(CLUSTER_TYPE),openshift)
-AUTH_STRATEGY ?= login
+AUTH_STRATEGY ?= anonymous
 else
 AUTH_STRATEGY ?= openshift
 endif


### PR DESCRIPTION
As part of kiali/kiali#2862, stop using "login" strategy in the
Makefiles.