### PR TITLE
[make] the delete make target should attempt to clean up kiali CR first, then purge.

### DIFF
--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -46,7 +46,7 @@ operator-create: .ensure-operator-repo-exists .prepare-cluster operator-delete .
     --namespace                  "${NAMESPACE}"
 
 ## operator-delete: Remove the Kiali operator resources from the cluster along with Kiali itself
-operator-delete: .ensure-oc-exists kiali-purge
+operator-delete: .ensure-oc-exists kiali-delete kiali-purge
 	@echo Remove Operator
 	${OC} delete --ignore-not-found=true all,sa,deployments,clusterroles,clusterrolebindings,customresourcedefinitions --selector="app=kiali-operator" -n "${OPERATOR_NAMESPACE}"
 	${OC} delete --ignore-not-found=true namespace "${OPERATOR_NAMESPACE}"


### PR DESCRIPTION
Now you can just do `make operator-delete` and you will avoid the finalizer hanging problem.
If you want a fast way to purge it, you can still do `make kiali-purge` as always.