### PR TITLE
Iter8 v0.1.1 Integration for Kiali

### DIFF
--- a/kubernetes/iter8.go
+++ b/kubernetes/iter8.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,14 +52,12 @@ type Iter8ExperimentSpec struct {
 			MinMax     string `json:"min_max,omitempty"`
 		} `json:"reward,omitempty"`
 	} `json:"analysis,omitempty"`
-	Assessment       string `json:"assessment,omitempty"`
-	Cleanup          string `json:"cleanup,omitempty"`
-	RoutingReference *struct {
-		ApiVersion string `json:"apiVersion,omitempty"`
-		Kind       string `json:"kind,omitempty"`
-		Name       string `json:"name,omitempty"`
-	} `json:"routingReference,omitempty"`
+	Assessment       string                   `json:"assessment,omitempty"`
+	Cleanup          string                   `json:"cleanup,omitempty"`
+	RoutingReference *core_v1.ObjectReference `json:"routingReference,omitempty"`
 }
+
+type Iter8ExperimentAction string
 
 type Iter8ExperimentStatus struct {
 	Conditions []struct {
@@ -136,6 +135,7 @@ type Iter8ExperimentObject struct {
 	Spec               Iter8ExperimentSpec    `json:"spec"`
 	Status             Iter8ExperimentStatus  `json:"status"`
 	Metrics            Iter8ExperimentMetrics `json:"metrics"`
+	Action             Iter8ExperimentAction  `json:"action,omitempty"`
 }
 
 type Iter8ExperimentObjectList struct {
@@ -278,6 +278,7 @@ type Iter8AnalyticMetric struct {
 
 type Iter8ClientInterface interface {
 	CreateIter8Experiment(namespace string, json string) (Iter8Experiment, error)
+	UpdateIter8Experiment(namespace string, name string, json string) (Iter8Experiment, error)
 	DeleteIter8Experiment(namespace string, name string) error
 	GetIter8Experiment(namespace string, name string) (Iter8Experiment, error)
 	GetIter8Experiments(namespace string) ([]Iter8Experiment, error)
@@ -321,6 +322,23 @@ func (in *K8SClient) CreateIter8Experiment(namespace string, json string) (Iter8
 	var err error
 	byteJson := []byte(json)
 	result, err = in.iter8Api.Post().Namespace(namespace).Resource(Iter8Experiments).Body(byteJson).Do().Get()
+	if err != nil {
+		return nil, err
+	}
+	iter8ExperimentObject, ok := result.(*Iter8ExperimentObject)
+	if !ok {
+		return nil, fmt.Errorf("%s doesn't return a Iter8 Experiment object", namespace)
+	}
+	i8 := iter8ExperimentObject.DeepCopyIter8Object()
+	i8.SetTypeMeta(iter8typeMeta)
+	return i8, nil
+}
+
+func (in *K8SClient) UpdateIter8Experiment(namespace string, name string, json string) (Iter8Experiment, error) {
+	var result runtime.Object
+	var err error
+	byteJson := []byte(json)
+	result, err = in.iter8Api.Patch(types.MergePatchType).Namespace(namespace).Resource(Iter8Experiments).SubResource(name).Body(byteJson).Do().Get()
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/kubetest/mock_iter8.go
+++ b/kubernetes/kubetest/mock_iter8.go
@@ -7,6 +7,12 @@ func (o *K8SClientMock) CreateIter8Experiment(namespace string, json string) (ku
 	return args.Get(0).(kubernetes.Iter8Experiment), args.Error(1)
 }
 
+func (o *K8SClientMock) UpdateIter8Experiment(namespace string, name string, json string) (kubernetes.Iter8Experiment, error) {
+	args := o.Called(namespace, name, json)
+	return args.Get(0).(kubernetes.Iter8Experiment), args.Error(1)
+}
+
+
 func (o *K8SClientMock) GetIter8Experiment(namespace string, name string) (kubernetes.Iter8Experiment, error) {
 	args := o.Called(namespace, name)
 	return args.Get(0).(kubernetes.Iter8Experiment), args.Error(1)

--- a/kubernetes/kubetest/mock_iter8.go
+++ b/kubernetes/kubetest/mock_iter8.go
@@ -12,7 +12,6 @@ func (o *K8SClientMock) UpdateIter8Experiment(namespace string, name string, jso
 	return args.Get(0).(kubernetes.Iter8Experiment), args.Error(1)
 }
 
-
 func (o *K8SClientMock) GetIter8Experiment(namespace string, name string) (kubernetes.Iter8Experiment, error) {
 	args := o.Called(namespace, name)
 	return args.Get(0).(kubernetes.Iter8Experiment), args.Error(1)

--- a/models/iter8.go
+++ b/models/iter8.go
@@ -8,6 +8,10 @@ type Iter8Info struct {
 	Enabled bool `json:"enabled"`
 }
 
+type ExperimentAction struct {
+	Action string `json:"action"`
+}
+
 type Iter8ExperimentItem struct {
 	Name                   string   `json:"name"`
 	Phase                  string   `json:"phase"`
@@ -15,8 +19,10 @@ type Iter8ExperimentItem struct {
 	Status                 string   `json:"status"`
 	Baseline               string   `json:"baseline"`
 	BaselinePercentage     int      `json:"baselinePercentage"`
+	BaselineVersion        string   `json:"baselineVersion"`
 	Candidate              string   `json:"candidate"`
 	CandidatePercentage    int      `json:"candidatePercentage"`
+	CandidateVersion       string   `json:"candidateVersion"`
 	Namespace              string   `json:"namespace"`
 	StartedAt              int64    `json:"startedAt"`
 	EndedAt                int64    `json:"endedAt"`
@@ -30,6 +36,7 @@ type Iter8ExperimentDetail struct {
 	CriteriaDetails []Iter8CriteriaDetail `json:"criterias"`
 	TrafficControl  Iter8TrafficControl   `json:"trafficControl"`
 	Permissions     ResourcePermissions   `json:"permissions"`
+	Action          string                `json:"action"`
 }
 
 type Iter8CriteriaDetail struct {
@@ -61,6 +68,7 @@ type Iter8ExperimentSpec struct {
 	Candidate      string              `json:"candidate"`
 	TrafficControl Iter8TrafficControl `json:"trafficControl"`
 	Criterias      []Iter8Criteria     `json:"criterias"`
+	Action         string              `json:"action"`
 }
 
 type Iter8TrafficControl struct {
@@ -92,6 +100,19 @@ type Iter8AnalyticsConfig struct {
 		} `yaml:"auth"`
 		URL string `yaml:"url"`
 	} `yaml:"prometheus"`
+}
+
+func (i *Iter8ExperimentSpec) Parse(iter8Object Iter8ExperimentDetail) {
+	i.Name = iter8Object.ExperimentItem.Name
+	i.Namespace = iter8Object.ExperimentItem.Namespace
+	i.Service = iter8Object.ExperimentItem.TargetService
+	i.Candidate = iter8Object.ExperimentItem.Candidate
+	i.Baseline = iter8Object.ExperimentItem.Baseline
+	i.TrafficControl = iter8Object.TrafficControl
+	i.Criterias = make([]Iter8Criteria, len(iter8Object.CriteriaDetails))
+	for k, c := range iter8Object.CriteriaDetails {
+		i.Criterias[k] = c.Criteria
+	}
 }
 
 func (i *Iter8ExperimentDetail) Parse(iter8Object kubernetes.Iter8Experiment) {

--- a/swagger.json
+++ b/swagger.json
@@ -4333,6 +4333,10 @@
     "Iter8ExperimentDetail": {
       "type": "object",
       "properties": {
+        "action": {
+          "type": "string",
+          "x-go-name": "Action"
+        },
         "criterias": {
           "type": "array",
           "items": {
@@ -4371,6 +4375,10 @@
           "format": "int64",
           "x-go-name": "BaselinePercentage"
         },
+        "baselineVersion": {
+          "type": "string",
+          "x-go-name": "BaselineVersion"
+        },
         "candidate": {
           "type": "string",
           "x-go-name": "Candidate"
@@ -4379,6 +4387,10 @@
           "type": "integer",
           "format": "int64",
           "x-go-name": "CandidatePercentage"
+        },
+        "candidateVersion": {
+          "type": "string",
+          "x-go-name": "CandidateVersion"
         },
         "createdAt": {
           "type": "integer",


### PR DESCRIPTION
** Describe the change **

1. Auto Generate Routing References
2. Change the Kiali-specific CRD facade based on changes for 0.1.1 releases
3. Additional control endpoints - Pause/Resume and Rollforward, Rollback

This issue is created to replace the original Kiali PR 2815 
Refer - [Kiali PR# 2815](https://github.com/kiali/kiali/pull/2815)

** Issue reference **
[Main issue #2007](https://github.com/kiali/kiali/issues/2007)
and 
[Issue #2633](https://github.com/kiali/kiali/issues/2633)

** Changes **
Introduce a new Iter8 Endpoint for update experiment with action.
Change the Iter8 Experiment CRD -- add new field "action"

** UI Changes **
The new action will require changes in the Kiali-UI 

** Changes based on comment in previous PR  2815
1. Fix business/iter8 "CreateIter8Experiment -> UpdateIter8Experiment to collect metrics for this method"
2. Move the GetIter8RoutingPreference out of the Parse() method
3. Use using the IstioConfig API  to get VirtualService and Gateway info ( which enable caching)
4. Use conf.IstioLabels.VersionLabelName instead of hard-coded "version"