### PR TITLE
fix guess url for default port 

### DIFF
--- a/util/httputil/http_util_test.go
+++ b/util/httputil/http_util_test.go
@@ -71,6 +71,15 @@ func TestGuessKialiURLReadsHostPortFromHostAttr(t *testing.T) {
 	assert.Equal(t, "https://example.com:901/custom/kiali", guessedUrl)
 }
 
+func TestGuessKialiURLReadsHostPortFromHostAttrDefault(t *testing.T) {
+	request := setupAndCreateRequest()
+	request.URL.Host = "example.com"
+	request.Host = "example.com"
+	guessedUrl := GuessKialiURL(request)
+
+	assert.Equal(t, "https://example.com/custom/kiali", guessedUrl)
+}
+
 func TestGuessKialiURLOmitsStandardPlainHttpPort(t *testing.T) {
 	// See reference: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html#x-forwarded-port
 


### PR DESCRIPTION
** Describe the change **

We met this problem when we connect kiali web from the service(the service ip is accessible out of k8s cluster). 
We use openid auth strategy. 
As the kiali service port is 80, we connect kiali by `http://1.1.1.1`, then the browser will redirect to openid login page; After the user login, the browser will redirect to `http://1.1.1.1:20001`, which should be `http://1.1.1.1`.

We check the func `GuessKialiURL` and find this maybe a bug. 
If the http request uses default port(80, 443) both in url and in host header, the func `GuessKialiURL` will use `cfg.Server.WebFQDN`, which maybe 20001.

So we add a step to check if it is a default port, if so, use default port instead.

Look forward to your response :)

** Issue reference **
NA

* Please, provide the link to the GitHub issue here.
NA

** Backwards incompatible? **
None

** Documentation **
NA

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
If so, please also update README.adoc
NA