### PR TITLE
Bump k-charted 0.6.0 final (no change)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577
 	github.com/jaegertracing/jaeger v1.15.1
 	github.com/jtblin/go-ldap-client v0.0.0-20161205001958-ad9f2ea47a83
-	github.com/kiali/k-charted v0.6.0-rc5
+	github.com/kiali/k-charted v0.6.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/openshift/api v0.0.0-20200221181648-8ce0047d664f
 	github.com/prometheus/client_golang v0.9.4

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/jtblin/go-ldap-client v0.0.0-20161205001958-ad9f2ea47a83/go.mod h1:+0
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kiali/k-charted v0.6.0-rc5 h1:6iqV0X2m3jcSPifpYg8p+ImKDkVnfJAOwdFkIOitnp4=
 github.com/kiali/k-charted v0.6.0-rc5/go.mod h1:EHpndpTT3uB6Q8lbyDf+Yiv/L7nIiV5XIVsirImH9Eo=
+github.com/kiali/k-charted v0.6.0 h1:0q3Cwkw40LN0N/3vvX1HQMVWvLTIcH+0QxogTipZVxs=
+github.com/kiali/k-charted v0.6.0/go.mod h1:EHpndpTT3uB6Q8lbyDf+Yiv/L7nIiV5XIVsirImH9Eo=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Bump k-charted 0.6.0-rc5 => 0.6.0 (no change, just use released final version)

DNM until @israel-hdez 's go module PR is emrged (based on it) ; and master-rebased then