### PR TITLE
Format goimports

### DIFF
--- a/business/checkers/authorization/service_checker_test.go
+++ b/business/checkers/authorization/service_checker_test.go
@@ -3,13 +3,13 @@ package authorization
 import (
 	"testing"
 
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/tests/data"
-
 	"github.com/stretchr/testify/assert"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
 )
 
 func TestMatching(t *testing.T) {

--- a/business/checkers/common/multi_match_selector_checker.go
+++ b/business/checkers/common/multi_match_selector_checker.go
@@ -2,9 +2,11 @@ package common
 
 import (
 	"fmt"
+
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 type GenericMultiMatchChecker struct {

--- a/business/checkers/destinationrules/meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker_test.go
@@ -1,11 +1,13 @@
 package destinationrules
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // Context: DestinationRule enables mesh-wide mTLS

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -3,11 +3,12 @@ package destinationrules
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMultiHostMatchCorrect(t *testing.T) {

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -3,11 +3,12 @@ package gateways
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCorrectGateways(t *testing.T) {

--- a/business/checkers/gateways/port_checker_test.go
+++ b/business/checkers/gateways/port_checker_test.go
@@ -3,10 +3,11 @@ package gateways
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValidPortDefinition(t *testing.T) {

--- a/business/checkers/gateways/selector_checker.go
+++ b/business/checkers/gateways/selector_checker.go
@@ -1,9 +1,10 @@
 package gateways
 
 import (
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 type SelectorChecker struct {

--- a/business/checkers/gateways/selector_checker_test.go
+++ b/business/checkers/gateways/selector_checker_test.go
@@ -3,10 +3,11 @@ package gateways
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValidInternalSelector(t *testing.T) {

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -1,12 +1,13 @@
 package checkers
 
 import (
+	core_v1 "k8s.io/api/core/v1"
+
 	"github.com/kiali/kiali/business/checkers/authorization"
 	"github.com/kiali/kiali/business/checkers/destinationrules"
 	"github.com/kiali/kiali/business/checkers/virtual_services"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
-	core_v1 "k8s.io/api/core/v1"
 )
 
 const ServiceRoleCheckerType = "servicerole"

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
-
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 )

--- a/business/checkers/serviceentries/port_checker_test.go
+++ b/business/checkers/serviceentries/port_checker_test.go
@@ -3,10 +3,11 @@ package serviceentries
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValidPortDefinition(t *testing.T) {

--- a/business/checkers/services/port_mapping_checker_test.go
+++ b/business/checkers/services/port_mapping_checker_test.go
@@ -3,12 +3,11 @@ package services
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	apps_v1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"

--- a/business/checkers/sidecars/egress_listener_checker_test.go
+++ b/business/checkers/sidecars/egress_listener_checker_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEgressHostFormatCorrect(t *testing.T) {

--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -3,11 +3,12 @@ package virtual_services
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMissingGateway(t *testing.T) {

--- a/business/checkers/virtual_services/single_host_checker_test.go
+++ b/business/checkers/virtual_services/single_host_checker_test.go
@@ -3,10 +3,11 @@ package virtual_services
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestOneVirtualServicePerHost(t *testing.T) {

--- a/business/iter8.go
+++ b/business/iter8.go
@@ -3,12 +3,11 @@ package business
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
-
 	"sort"
 	"strconv"
 	"sync"
 
+	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	osproject_v1 "github.com/openshift/api/project/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCorrectMeshPeerAuthn(t *testing.T) {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -11,6 +11,7 @@ import (
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
@@ -19,7 +20,6 @@ import (
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 // Workload deals with fetching istio/kubernetes workloads related content and convert to kiali model

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -13,12 +13,12 @@ import (
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 	errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/prometheus/prometheustest"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func setupWorkloadService(k8s *kubetest.K8SClientMock) WorkloadService {

--- a/config/token.go
+++ b/config/token.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+
 	"github.com/kiali/kiali/util"
 )
 

--- a/doc.go
+++ b/doc.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	jaegerModels "github.com/jaegertracing/jaeger/model/json"
-
 	"github.com/kiali/k-charted/model"
+
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph/config/cytoscape"
 	"github.com/kiali/kiali/handlers"

--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -11,8 +11,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/kiali/kiali/graph"
-
 	"github.com/gorilla/mux"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/prometheus/common/model"
@@ -23,6 +21,7 @@ import (
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"

--- a/graph/telemetry/istio/appender/util.go
+++ b/graph/telemetry/istio/appender/util.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
-	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/prometheus/common/model"
 )
 
 // package-private util functions (used by multiple files)

--- a/graph/telemetry/istio/appender/util_test.go
+++ b/graph/telemetry/istio/appender/util_test.go
@@ -1,12 +1,12 @@
 package appender
 
 import (
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
-	"github.com/prometheus/common/model"
-
-	"github.com/stretchr/testify/mock"
 )
 
 // package-private test util functions (used by multiple test files)

--- a/hack/fix_imports.sh
+++ b/hack/fix_imports.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+FILES=`find . -path './vendor' -prune -o -type f -iname '*.go' -print`
+
+for gofile in $FILES; do
+  awk -i inplace '
+  {
+    if ($0 == "import (") {
+      in_imports = 1
+      print $0
+    }
+    else if (in_imports == 1) {
+      if ($0 == ")") {
+        in_imports = 0
+        print $0
+      }
+      else if ($0 != "") {
+        print $0
+      }
+    }
+    else {
+      print $0
+    }
+  }
+  ' $gofile
+  goimports -w -local "github.com/kiali/kiali" $gofile
+done

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -12,9 +12,10 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/util"
-	"github.com/stretchr/testify/assert"
 )
 
 type dummyHandler struct {

--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -2,12 +2,12 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/log"
-	"strings"
 )
 
 // Helper method to adjust error code in the handler's response

--- a/handlers/iter8.go
+++ b/handlers/iter8.go
@@ -1,12 +1,13 @@
 package handlers
 
 import (
-	"github.com/kiali/kiali/config"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"github.com/gorilla/mux"
+
+	"github.com/kiali/kiali/config"
 )
 
 func Iter8Status(w http.ResponseWriter, r *http.Request) {

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 )

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -12,11 +12,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/kiali/kiali/business"
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes/kubetest"
-	"github.com/kiali/kiali/prometheus"
-	"github.com/kiali/kiali/prometheus/prometheustest"
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -26,6 +21,12 @@ import (
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
+
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/prometheustest"
 )
 
 func setupWorkloadList() (*httptest.Server, *kubetest.K8SClientMock, *prometheustest.PromClientMock) {

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -2,11 +2,13 @@ package kubernetes
 
 import (
 	"fmt"
-	"github.com/kiali/kiali/config"
+	"strings"
+
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"strings"
+
+	"github.com/kiali/kiali/config"
 )
 
 // FilterPodsForService returns a subpart of pod list filtered according service selector

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -7,12 +7,11 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/client-go/rest"
-
 	"gopkg.in/yaml.v2"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"

--- a/kubernetes/iter8.go
+++ b/kubernetes/iter8.go
@@ -2,12 +2,12 @@ package kubernetes
 
 import (
 	"fmt"
+
 	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var iter8typeMeta = meta_v1.TypeMeta{

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"bytes"
+
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	osroutes_v1 "github.com/openshift/api/route/v1"

--- a/kubernetes/kubetest/mock_kubernetes.go
+++ b/kubernetes/kubetest/mock_kubernetes.go
@@ -1,12 +1,13 @@
 package kubetest
 
 import (
-	"github.com/kiali/kiali/kubernetes"
 	apps_v1 "k8s.io/api/apps/v1"
 	auth_v1 "k8s.io/api/authorization/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_apps_v1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
+
+	"github.com/kiali/kiali/kubernetes"
 )
 
 func (o *K8SClientMock) GetConfigMap(namespace, configName string) (*core_v1.ConfigMap, error) {

--- a/ldap/models.go
+++ b/ldap/models.go
@@ -2,8 +2,9 @@ package ldap
 
 import (
 	"fmt"
-	"github.com/kiali/kiali/config"
 	"time"
+
+	"github.com/kiali/kiali/config"
 )
 
 // UserInfo holds authenticatoin information

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -31,12 +31,13 @@ install:
 	${GO_BUILD_ENVVARS} ${GO} install \
 		-ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
-## format: Format all the files excluding vendor. Runs `gofmt` internally
+## format: Format all the files excluding vendor. Runs `gofmt` and `goimports` internally
 format:
 	@# Exclude more paths find . \( -path './vendor' -o -path <new_path_to_exclude> \) -prune -o -type f -iname '*.go' -print
 	@for gofile in $$(find . -path './vendor' -prune -o -type f -iname '*.go' -print); do \
 			${GOFMT} -w $$gofile; \
-	done
+	done; \
+	$(shell ./hack/fix_imports.sh)
 
 ## build-system-test: Building executable for system tests with code coverage enabled
 build-system-test:

--- a/models/authorization_policy.go
+++ b/models/authorization_policy.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	"github.com/kiali/kiali/kubernetes"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
 )
 
 // AuthorizationPolicies authorizationPolicies

--- a/models/iter8_test.go
+++ b/models/iter8_test.go
@@ -1,9 +1,9 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 
-	"encoding/json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/models/peer_authentication.go
+++ b/models/peer_authentication.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	"github.com/kiali/kiali/kubernetes"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
 )
 
 // PeerAuthentications peerAuthentications

--- a/models/request_authentication.go
+++ b/models/request_authentication.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	"github.com/kiali/kiali/kubernetes"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
 )
 
 // RequestAuthentications requestAuthentications

--- a/models/workload_test.go
+++ b/models/workload_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kiali/kiali/config"
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	"github.com/stretchr/testify/assert"
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/config"
 )
 
 func TestParseDeploymentToWorkload(t *testing.T) {

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/kiali/kiali/prometheus"
 	"github.com/prometheus/client_golang/api"
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/kiali/kiali/prometheus"
 )
 
 // PromAPIMock for mocking Prometheus API

--- a/tests/data/destination_rules_data.go
+++ b/tests/data/destination_rules_data.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"github.com/kiali/kiali/kubernetes"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
 )
 
 func CreateEmptyDestinationRule(namespace string, name string, host string) kubernetes.IstioObject {

--- a/tests/data/fiture_loader.go
+++ b/tests/data/fiture_loader.go
@@ -3,8 +3,9 @@ package data
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"

--- a/tests/data/gateway_data.go
+++ b/tests/data/gateway_data.go
@@ -1,9 +1,10 @@
 package data
 
 import (
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func CreateEmptyGateway(name, namespace string, selector map[string]string) kubernetes.IstioObject {

--- a/tests/data/service_role_data.go
+++ b/tests/data/service_role_data.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"github.com/kiali/kiali/kubernetes"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
 )
 
 func CreateEmptyServiceRole(name, namespace string) kubernetes.IstioObject {

--- a/tests/data/validations/test_asserter.go
+++ b/tests/data/validations/test_asserter.go
@@ -3,8 +3,9 @@ package validations
 import (
 	"testing"
 
-	"github.com/kiali/kiali/models"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/models"
 )
 
 type TestAsserter interface {

--- a/tests/data/virtual_service_data.go
+++ b/tests/data/virtual_service_data.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"github.com/kiali/kiali/kubernetes"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
 )
 
 func CreateEmptyVirtualService(name string, namespace string, hosts []string) kubernetes.IstioObject {

--- a/util/httputil/http_util_test.go
+++ b/util/httputil/http_util_test.go
@@ -1,10 +1,12 @@
 package httputil
 
 import (
-	"github.com/kiali/kiali/config"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
 )
 
 func setupAndCreateRequest() *http.Request {

--- a/util/maps_test.go
+++ b/util/maps_test.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRemoveNilValues(t *testing.T) {


### PR DESCRIPTION
This is for auto-formatting imports.

This "Works for me"© but would be nice to test by others. Especially I did already have goimports in my go bin path, not sure if it's the same for everyone.

To test it, mess around with some imports then run `make format`.

First commit includes the new scripts, second commit holds the generated changes.

Note 1: I'm not a Makefile guru; had some troubles with having multilines awk within the makefile, so I ended up putting everything in a separate shell script
Note 2: I'm not an awk wizard either. My awk file looks probably ugly to others. Feel free to suggest changes.