### PR TITLE
operator should watch all namespaces by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,15 @@ MINIKUBE_PROFILE ?= minikube
 # Details about the Kiali operator image used when deploying to remote cluster
 OPERATOR_IMAGE_PULL_POLICY ?= Always
 OPERATOR_NAMESPACE ?= kiali-operator
-OPERATOR_WATCH_NAMESPACE ?= kiali-operator
+OPERATOR_WATCH_NAMESPACE ?= \"\"
 
-# When deploying the Kiali operator via make, this indicates if it should install Kiali also.
+# When deploying the Kiali operator via make, this indicates if it should install Kiali also and where to put the CR
 OPERATOR_INSTALL_KIALI ?= false
+ifeq ($(OPERATOR_WATCH_NAMESPACE),\"\")
+OPERATOR_INSTALL_KIALI_CR_NAMESPACE ?= ${OPERATOR_NAMESPACE}
+else
+OPERATOR_INSTALL_KIALI_CR_NAMESPACE ?= ${OPERATOR_WATCH_NAMESPACE}
+endif
 
 # When installing Kiali to a remote cluster via make, here are some configuration settings for it.
 ACCESSIBLE_NAMESPACES ?= **

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -82,17 +82,17 @@ ROUTER_HOSTNAME="$(shell ${OC} get $(shell (${OC} get routes -n ${NAMESPACE} -o 
 SERVICE_TYPE="${SERVICE_TYPE}" \
 VERBOSE_MODE="${VERBOSE_MODE}" \
 KIALI_CR_SPEC_VERSION="${KIALI_CR_SPEC_VERSION}" \
-envsubst | ${OC} apply -n "${OPERATOR_WATCH_NAMESPACE}" -f -
+envsubst | ${OC} apply -n "${OPERATOR_INSTALL_KIALI_CR_NAMESPACE}" -f -
 
 ## kiali-delete: Remove a Kiali CR from the cluster, informing the Kiali operator to uninstall Kiali.
 kiali-delete: .ensure-oc-exists secret-delete
 	@echo Remove Kiali
-	${OC} delete --ignore-not-found=true kiali kiali -n "${OPERATOR_WATCH_NAMESPACE}" ; true
+	${OC} delete --ignore-not-found=true kiali kiali -n "${OPERATOR_INSTALL_KIALI_CR_NAMESPACE}" ; true
 
 ## kiali-purge: Purges all Kiali resources directly without going through the operator or ansible.
 kiali-purge: .ensure-oc-exists
 	@echo Purge Kiali resources
-	${OC} patch kiali kiali -n "${OPERATOR_WATCH_NAMESPACE}" -p '{"metadata":{"finalizers": []}}' --type=merge ; true
+	${OC} patch kiali kiali -n "${OPERATOR_INSTALL_KIALI_CR_NAMESPACE}" -p '{"metadata":{"finalizers": []}}' --type=merge ; true
 	${OC} delete --ignore-not-found=true all,secrets,sa,configmaps,deployments,roles,rolebindings,clusterroles,clusterrolebindings,ingresses,customresourcedefinitions --selector="app=kiali" -n "${NAMESPACE}"
 ifeq ($(CLUSTER_TYPE),openshift)
 	${OC} delete --ignore-not-found=true oauthclients.oauth.openshift.io,consolelinks.console.openshift.io --selector="app=kiali" -n "${NAMESPACE}" ; true


### PR DESCRIPTION
part of https://github.com/kiali/kiali/issues/2889

Dependent resource watching only works for those resources in watched namespaces - so deploy the operator with a default watch namespace of empty string ("") -- i.e. all namespaces.

