### PR TITLE
Fix Snyk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,21 @@ jobs:
     - arch: amd64
     - arch: arm64
     - arch: ppc64le
+    - name: Snyk
+      if: branch == master AND fork == false
+      node_js:
+        - 12
+      env:
+        - NODE_OPTIONS=--max-old-space-size=8192
+        - secure: fA6zOOsbgJXlHe9nkuW4XOAtfQ9QTxorDJGLA97ic1+tCWpJzJlcTJ+cW1vMQXvpmoyLzZWl8PhS9PLeHY5wgwPc+EtTAc1l9JhNPr72V0yPCuZdIwc9HHG6gDFaoy28Ms4NFwIWFST11ZaZ0BLoi11uIDScngtcvbW94/HUw9giSpAbPGAjCa1+uLw4Oci678W072b0gtaTs8HujpePB1aofBhx1p6ZVMCY/O7VjJ6UdOcyBtNL8/DfupKHAQIpbNFvqO+GpscVNY7ZNyubj7K3Fw2CGSrvZ3V0iBcliA3jhQ8+bTTE0IvuXPcy79Cid5YQgxCcmAPlwkZeo8dLMspdTFiGkFINfAZkrfODWO1wgQ9tpJtCCr/PnycBYliT1XW1lCr2Uw2K5u0cn0JHeJLUwZPBKG9vTzq8zjIQBae7ZCb7x1PcuznbQpvo0zIkDOyNTJI5w5waroZ8VBJ8VkYNe0sNw0GgeM2doHVKPkayx/I1LgqBYv2oktLf25uhIvzKR3jByCsVOiWdw9/lvluQ77F4qzyDa58M9KM3FMsP84izxEQXjrgLUwIsgqvW9B9EROW9Thllllvc1/3gVKADYbiSD03RML7W1T+q8tX7KUiru1kGGSGjX7VDy46YooiUAA/Ou8aw9mP4jjN6eTEL2moZMN1frOgI9EJ49aY=
+      install:
+        - npm install -g snyk
+      script:
+        - if [ "$TRAVIS_EVENT_TYPE" == "push" ]; then snyk monitor --org=kiali --prune-repeated-subdependencies; fi
+        - if [ "$TRAVIS_EVENT_TYPE" != "push" ]; then snyk test --org=kiali --prune-repeated-subdependencies; fi
 
 go:
-- 1.14.2
+- 1.14.5
 
 cache:
   directories:


### PR DESCRIPTION
Running Snyk within CI, because Snyk's GitHub integration does not support go modules.

Once this is merged, and after the first Snyk CLI run completes, we should see a new entry in the Snyk dashboard for Kiali. Thereafter, we can disable Snyk's GitHub integration for this repo (and leave enabled the integration for the front-end). On the web dashboard, we should be able to see the dependency tree alike in the front-end case.

This is not that ideal because this will run a Snyk check and create a snapshot on each merged PR (while the GitHub integration does a full check only if dependencies change). But it's OK from the point of view that Snyk is working again.

See an example of a run in https://travis-ci.org/github/kiali/kiali/builds/708086245 - there is a new "Snyk" job doing the checks. It says `✓ Tested 293 dependencies for known issues, no vulnerable paths found.` :-)

Since it's a new job, we *may* get a notification on IRC if Snyk check fails with a vulnerability (but I'm not sure, it depends on the exit code of the snyk CLI). Not sure if we later will receive a notification by e-mail.

Fixes #2965 .