### PR TITLE
Better handle egress destination telemetry

### DIFF
--- a/graph/api/testdata/test_complex_graph.expected
+++ b/graph/api/testdata/test_complex_graph.expected
@@ -52,6 +52,24 @@
       },
       {
         "data": {
+          "id": "332209947916c37701f39500789b6792",
+          "nodeType": "app",
+          "namespace": "istio-system",
+          "workload": "istio-egressgateway",
+          "app": "istio-egressgateway",
+          "version": "unknown",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "400.00"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "data": {
           "id": "d75c918a12f72a1ea1797911cb9770f7",
           "nodeType": "app",
           "namespace": "tutorial",
@@ -74,7 +92,29 @@
             {
               "protocol": "http",
               "rates": {
-                "httpOut": "350.00"
+                "httpOut": "750.00"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "data": {
+          "id": "c4d8519b61e39974286357006b354f99",
+          "nodeType": "service",
+          "namespace": "unknown",
+          "service": "app.example-2.com",
+          "destServices": [
+            {
+              "namespace": "unknown",
+              "name": "app.example-2.com"
+            }
+          ],
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "400.00"
               }
             }
           ]
@@ -108,6 +148,30 @@
       }
     ],
     "edges": [
+      {
+        "data": {
+          "id": "b8652735083f361a13ab190a26f37e89",
+          "source": "332209947916c37701f39500789b6792",
+          "target": "c4d8519b61e39974286357006b354f99",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "400.00",
+              "httpPercentReq": "100.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "app.example-2.com": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
       {
         "data": {
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
@@ -158,6 +222,30 @@
       },
       {
         "data": {
+          "id": "864c8eae6f988891d9df2d9f378eece5",
+          "source": "d75c918a12f72a1ea1797911cb9770f7",
+          "target": "332209947916c37701f39500789b6792",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "400.00",
+              "httpPercentReq": "53.3"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "istio-egressgateway.istio-system.svc.cluster.local": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
           "id": "62adcb3e419f4bcee6f1528dd9d2eb56",
           "source": "d75c918a12f72a1ea1797911cb9770f7",
           "target": "7fb749d8703ff9fde566213cb1c98b41",
@@ -165,7 +253,7 @@
             "protocol": "http",
             "rates": {
               "http": "300.00",
-              "httpPercentReq": "85.7"
+              "httpPercentReq": "40.0"
             },
             "responses": {
               "200": {
@@ -189,7 +277,7 @@
             "protocol": "http",
             "rates": {
               "http": "50.00",
-              "httpPercentReq": "14.3"
+              "httpPercentReq": "6.7"
             },
             "responses": {
               "200": {

--- a/graph/telemetry/istio/appender/aggregate_node.go
+++ b/graph/telemetry/istio/appender/aggregate_node.go
@@ -175,11 +175,7 @@ func (a AggregateNodeAppender) injectAggregates(trafficMap graph.TrafficMap, vec
 		sourceWl := string(lSourceWl)
 		sourceApp := string(lSourceApp)
 		sourceVer := string(lSourceVer)
-		destWlNs := string(lDestWlNs)
 		destSvc := string(lDestSvc)
-		destWl := string(lDestWl)
-		destApp := string(lDestApp)
-		destVer := string(lDestVer)
 		code := string(lCode)
 		protocol := string(lProtocol)
 		flags := string(lFlags)
@@ -199,8 +195,8 @@ func (a AggregateNodeAppender) injectAggregates(trafficMap graph.TrafficMap, vec
 			// protocol = "tcp"
 		}
 
-		// handle multicluster requests
-		destSvcNs, destSvcName := util.HandleMultiClusterRequest(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvcName))
+		// handle unusual destinations
+		destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, _ := util.HandleDestination(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvc), string(lDestSvcName), string(lDestWlNs), string(lDestWl), string(lDestApp), string(lDestVer))
 
 		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -170,13 +170,7 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		sourceWl := string(lSourceWl)
 		sourceApp := string(lSourceApp)
 		sourceVer := string(lSourceVer)
-		destSvcNs := string(lDestSvcNs)
 		destSvc := string(lDestSvc)
-		destSvcName := string(lDestSvcName)
-		destWlNs := string(lDestWlNs)
-		destWl := string(lDestWl)
-		destApp := string(lDestApp)
-		destVer := string(lDestVer)
 		responseCode := string(lResponseCode)
 
 		if util.IsBadSourceTelemetry(sourceWlNs, sourceWl, sourceApp) {
@@ -196,7 +190,9 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		}
 
 		val := float64(s.Value)
-		destSvcNs, destSvcName = util.HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName)
+
+		// handle unusual destinations
+		destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, _ := util.HandleDestination(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvc), string(lDestSvcName), string(lDestWlNs), string(lDestWl), string(lDestApp), string(lDestVer))
 
 		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -189,10 +189,6 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o gra
 		sourceApp := string(lSourceApp)
 		sourceVer := string(lSourceVer)
 		destSvc := string(lDestSvc)
-		destWlNs := string(lDestWlNs)
-		destWl := string(lDestWl)
-		destApp := string(lDestApp)
-		destVer := string(lDestVer)
 		protocol := string(lProtocol)
 		code := string(lCode)
 		flags := string(lFlags)
@@ -204,8 +200,8 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o gra
 		// set response code in a backward compatible way
 		code = util.HandleResponseCode(protocol, code, grpcOk, string(lGrpc))
 
-		// handle multicluster requests
-		destSvcNs, destSvcName := util.HandleMultiClusterRequest(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvcName))
+		// handle unusual destinations
+		destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, _ := util.HandleDestination(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvc), string(lDestSvcName), string(lDestWlNs), string(lDestWl), string(lDestApp), string(lDestVer))
 
 		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue
@@ -290,18 +286,14 @@ func populateTrafficMapTCP(trafficMap graph.TrafficMap, vector *model.Vector, o 
 		sourceApp := string(lSourceApp)
 		sourceVer := string(lSourceVer)
 		destSvc := string(lDestSvc)
-		destWlNs := string(lDestWlNs)
-		destWl := string(lDestWl)
-		destApp := string(lDestApp)
-		destVer := string(lDestVer)
 		flags := string(lFlags)
 
 		if util.IsBadSourceTelemetry(sourceWlNs, sourceWl, sourceApp) {
 			continue
 		}
 
-		// handle multicluster requests
-		destSvcNs, destSvcName := util.HandleMultiClusterRequest(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvcName))
+		// handle unusual destinations
+		destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, _ := util.HandleDestination(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvc), string(lDestSvcName), string(lDestWlNs), string(lDestWl), string(lDestApp), string(lDestVer))
 
 		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -31,7 +31,7 @@ func HandleDestination(sourceWlNs, sourceWl, destSvcNs, destSvc, destSvcName, de
 		return istioNs, "istio-egressgateway", istioNs, "istio-egressgateway", "istio-egressgateway", "latest", true
 	}
 
-	return destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, true
+	return destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, false
 }
 
 // handleMultiClusterRequest ensures the proper destination service namespace and name

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -10,8 +11,30 @@ import (
 
 // badServiceMatcher looks for a physical IP address with optional port (e.g. 10.11.12.13:80)
 var badServiceMatcher = regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+(:\d+)?$`)
+var egressHost string
 
-// HandleMultiClusterRequest ensures the proper destination service workload and name
+// HandleDestination modifies the destination information, when necessary, for various corner
+// cases.  It should be called after source validation and before destination processing.
+// Returns destSvcNs, destSvcName, destWlNs, destWl, destApp, destVersion, isupdated
+func HandleDestination(sourceWlNs, sourceWl, destSvcNs, destSvc, destSvcName, destWlNs, destWl, destApp, destVer string) (string, string, string, string, string, string, bool) {
+	if destSvcNs, destSvcName, isUpdated := handleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName); isUpdated {
+		return destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, true
+	}
+
+	// Handle egressgateway (kiali#2999)
+	if egressHost == "" {
+		egressHost = fmt.Sprintf("istio-egressgateway.%s.svc.cluster.local", config.Get().IstioNamespace)
+	}
+
+	if destSvc == egressHost && destSvc == destSvcName {
+		istioNs := config.Get().IstioNamespace
+		return istioNs, "istio-egressgateway", istioNs, "istio-egressgateway", "istio-egressgateway", "latest", true
+	}
+
+	return destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, true
+}
+
+// handleMultiClusterRequest ensures the proper destination service namespace and name
 // for requests forwarded from another cluster (via a ServiceEntry).
 //
 // Given a request from clusterA to clusterB, clusterA will generate source telemetry
@@ -37,16 +60,18 @@ var badServiceMatcher = regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+(:\d+)?$`)
 // the MC format. When the source workload IS known the traffic it should be representing
 // the clusterA traffic to the ServiceEntry and being routed out of the cluster. That use
 // case is handled in the service_entry.go file.
-func HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName string) (string, string) {
+//
+// Returns destSvcNs, destSvcName, isUpdated
+func handleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName string) (string, string, bool) {
 	if sourceWlNs == graph.Unknown && sourceWl == graph.Unknown {
 		destSvcNameEntries := strings.Split(destSvcName, ".")
 
 		if len(destSvcNameEntries) == 3 && destSvcNameEntries[2] == config.IstioMultiClusterHostSuffix {
-			return destSvcNameEntries[1], destSvcNameEntries[0]
+			return destSvcNameEntries[1], destSvcNameEntries[0], true
 		}
 	}
 
-	return destSvcNs, destSvcName
+	return destSvcNs, destSvcName, false
 }
 
 // HandleResponseCode returns either the HTTP response code or the GRPC response status.  GRPC response


### PR DESCRIPTION
Egress destination telemetry is lacking and may not be easily fixed on the isti side.  This adds some special case code to help things out for the Kiali graph.

Note that the bad telem is still in Prometheus, so direct metric query won't match up completely unless we want to patch that as well.  That could be a follow up, if needed. 

Closes https://github.com/kiali/kiali/issues/2999
