### PR TITLE
CVE-2020-14040

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/prometheus/common v0.4.1
 	github.com/prometheus/procfs v0.0.10 // indirect
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/ldap.v2 v2.5.1-0.20190417171812-9f0d712775a0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/jtblin/go-ldap-client v0.0.0-20161205001958-ad9f2ea47a83 h1:gJyptJO7dSNI9Fw/x4438AUhgHnCMqml/aQwqO2xb7M=
 github.com/jtblin/go-ldap-client v0.0.0-20161205001958-ad9f2ea47a83/go.mod h1:+0BcLY5d54TVv6irFzHoiFvwAHR6T0g9B+by/UaS9T0=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/kiali/k-charted v0.6.0-rc5 h1:6iqV0X2m3jcSPifpYg8p+ImKDkVnfJAOwdFkIOitnp4=
-github.com/kiali/k-charted v0.6.0-rc5/go.mod h1:EHpndpTT3uB6Q8lbyDf+Yiv/L7nIiV5XIVsirImH9Eo=
 github.com/kiali/k-charted v0.6.0 h1:0q3Cwkw40LN0N/3vvX1HQMVWvLTIcH+0QxogTipZVxs=
 github.com/kiali/k-charted v0.6.0/go.mod h1:EHpndpTT3uB6Q8lbyDf+Yiv/L7nIiV5XIVsirImH9Eo=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -161,6 +159,8 @@ golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fq
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20161028155119-f51c12702a4d h1:TnM+PKb3ylGmZvyPXmo9m/wktg7Jn/a/fNmr33HSj8g=
 golang.org/x/time v0.0.0-20161028155119-f51c12702a4d/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
https://issues.redhat.com/browse/MAISTRA-1636

Marking as backport to 1.12 but note that this can not be cherry-picked because master is using go modules and 1.12 is using glide for dep handling.  The 1.12 fix will need to be manual.