### PR TITLE
Supporting Iter8-v0.2

### DIFF
--- a/business/iter8.go
+++ b/business/iter8.go
@@ -2,9 +2,10 @@ package business
 
 import (
 	"encoding/json"
-	"fmt"
-	"sort"
+	"github.com/hashicorp/go-version"
+	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 
 	"gopkg.in/yaml.v2"
@@ -24,6 +25,9 @@ type Iter8Service struct {
 
 func (in *Iter8Service) GetIter8Info() models.Iter8Info {
 	var err error
+	var ps []core_v1.Pod
+	var controllerImgVersion string
+	var analyticsImgVersion string
 	promtimer := internalmetrics.GetGoFunctionMetric("business", "Iter8Service", "GetIter8Info")
 	defer promtimer.ObserveNow(&err)
 
@@ -31,12 +35,50 @@ func (in *Iter8Service) GetIter8Info() models.Iter8Info {
 
 	// It will be considered enabled if the extension is present in the Kiali configuration and the CRD is enabled on the cluster
 	if conf.Extensions.Iter8.Enabled && in.k8s.IsIter8Api() {
+		if kialiCache != nil && kialiCache.CheckNamespace("iter8") {
+			ps, err = kialiCache.GetPods("iter8", "")
+		} else {
+			ps, err = in.k8s.GetPods("iter8", "")
+		}
+		if err == nil {
+			pods := models.Pods{}
+			pods.Parse(ps)
+			reg, _ := regexp.Compile("[a-zA-Z]+")
+			for _, pod := range pods {
+				for _, ct := range pod.Containers {
+					imgInfo := strings.Split(ct.Image, ":")
+					if strings.Contains(imgInfo[0], "iter8-controller") {
+						controllerImgVersion = reg.ReplaceAllString(imgInfo[1], "")
+					} else if strings.Contains(imgInfo[0], "iter8-analytics") {
+						analyticsImgVersion = reg.ReplaceAllString(imgInfo[1], "")
+					}
+				}
+			}
+		}
+
+		supportedVersion := true
+		if controllerImgVersion != "" && analyticsImgVersion != "" {
+
+			if !validateVersion(config.Iter8VersionSupported, controllerImgVersion) {
+				supportedVersion = false
+			}
+			if !validateVersion(config.Iter8VersionSupported, analyticsImgVersion) {
+				supportedVersion = false
+			}
+		}
+
 		return models.Iter8Info{
-			Enabled: true,
+			Enabled:                true,
+			SupportedVersion:       supportedVersion,
+			ControllerImageVersion: controllerImgVersion,
+			AnalyticsImageVersion:  analyticsImgVersion,
 		}
 	}
 	return models.Iter8Info{
-		Enabled: false,
+		Enabled:                false,
+		SupportedVersion:       false,
+		ControllerImageVersion: controllerImgVersion,
+		AnalyticsImageVersion:  analyticsImgVersion,
 	}
 }
 
@@ -133,15 +175,8 @@ func (in *Iter8Service) CreateIter8Experiment(namespace string, body []byte) (mo
 	defer promtimer.ObserveNow(&err)
 
 	iter8ExperimentDetail := models.Iter8ExperimentDetail{}
-	// get RoutingReference
-	newExperimentSpec := models.Iter8ExperimentSpec{}
-	err = json.Unmarshal(body, &newExperimentSpec)
-	if err != nil {
-		return iter8ExperimentDetail, err
-	}
-	rr, _ := in.GetIter8RoutingReferences(namespace, newExperimentSpec.Service)
 
-	jsonByte, err := in.ParseJsonForCreate(body, rr)
+	jsonByte, err := in.ParseJsonForCreate(body)
 
 	iter8ExperimentObject, err := in.k8s.CreateIter8Experiment(namespace, jsonByte)
 	if err != nil {
@@ -167,12 +202,10 @@ func (in *Iter8Service) UpdateIter8Experiment(namespace string, name string, bod
 	newExperimentSpec := models.Iter8ExperimentSpec{}
 	newExperimentSpec.Parse(experiment)
 	newExperimentSpec.Action = action.Action
-	// get RoutingReference
-	rr, _ := in.GetIter8RoutingReferences(newExperimentSpec.Namespace, newExperimentSpec.Service)
 
 	var newObject []byte
 	newObject, err = json.Marshal(newExperimentSpec)
-	jsonByte, err := in.ParseJsonForCreate(newObject, rr)
+	jsonByte, err := in.ParseJsonForCreate(newObject)
 	if err != nil {
 		return iter8ExperimentDetail, err
 	}
@@ -186,7 +219,7 @@ func (in *Iter8Service) UpdateIter8Experiment(namespace string, name string, bod
 	return iter8ExperimentDetail, nil
 }
 
-func (in *Iter8Service) ParseJsonForCreate(body []byte, rr core_v1.ObjectReference) (string, error) {
+func (in *Iter8Service) ParseJsonForCreate(body []byte) (string, error) {
 
 	newExperimentSpec := models.Iter8ExperimentSpec{}
 	err := json.Unmarshal(body, &newExperimentSpec)
@@ -209,16 +242,29 @@ func (in *Iter8Service) ParseJsonForCreate(body []byte, rr core_v1.ObjectReferen
 	object.Spec.TargetService.Name = newExperimentSpec.Service
 	object.Spec.TargetService.Baseline = newExperimentSpec.Baseline
 	object.Spec.TargetService.Candidate = newExperimentSpec.Candidate
+	if newExperimentSpec.ExperimentKind == "" {
+		object.Spec.TargetService.Kind = "Deployment"
+	} else {
+		object.Spec.TargetService.Kind = newExperimentSpec.ExperimentKind
+	}
+
 	object.Spec.TrafficControl.Strategy = newExperimentSpec.TrafficControl.Algorithm
 	object.Spec.TrafficControl.MaxTrafficPercentage = newExperimentSpec.TrafficControl.MaxTrafficPercentage
 	object.Spec.TrafficControl.MaxIterations = newExperimentSpec.TrafficControl.MaxIterations
 	object.Spec.TrafficControl.TrafficStepSize = newExperimentSpec.TrafficControl.TrafficStepSize
 	object.Spec.TrafficControl.Interval = newExperimentSpec.TrafficControl.Interval
 	object.Spec.Analysis.AnalyticsService = "http://iter8-analytics.iter8:" + strconv.Itoa(in.GetAnalyticPort())
-	if rr.Name != "" {
-		object.Spec.RoutingReference = &rr
-	}
 
+	for _, host := range newExperimentSpec.Hosts {
+		object.Spec.TargetService.Hosts = append(object.Spec.TargetService.Hosts,
+			struct {
+				Name    string `json:"name"`
+				Gateway string `json:"gateway"`
+			}{
+				Name:    host.Name,
+				Gateway: host.Gateway,
+			})
+	}
 	for _, criteria := range newExperimentSpec.Criterias {
 		min_max := struct {
 			Min float64 `json:"min,omitempty"`
@@ -244,6 +290,34 @@ func (in *Iter8Service) ParseJsonForCreate(body []byte, rr core_v1.ObjectReferen
 				Tolerance:     criteria.Tolerance,
 				SampleSize:    criteria.SampleSize,
 				StopOnFailure: criteria.StopOnFailure,
+				MinMax:        min_max,
+			})
+	}
+	if len(object.Spec.Analysis.SuccessCriteria) == 0 {
+		min_max := struct {
+			Min float64 `json:"min,omitempty"`
+			Max float64 `json:"max,omitempty"`
+		}{
+			Min: 0.1,
+			Max: 1.0,
+		}
+		object.Spec.Analysis.SuccessCriteria = append(object.Spec.Analysis.SuccessCriteria,
+			struct {
+				MetricName    string  `json:"metricName,omitempty"`
+				ToleranceType string  `json:"toleranceType,omitempty"`
+				Tolerance     float64 `json:"tolerance,omitempty"`
+				SampleSize    int     `json:"sampleSize,omitempty"`
+				MinMax        struct {
+					Min float64 `json:"min,omitempty"`
+					Max float64 `json:"max,omitempty"`
+				} `json:"min_max,omitempty"`
+				StopOnFailure bool `json:"stopOnFailure,omitempty"`
+			}{
+				MetricName:    "iter8_latency",
+				ToleranceType: "threshold",
+				Tolerance:     200,
+				SampleSize:    5,
+				StopOnFailure: false,
 				MinMax:        min_max,
 			})
 	}
@@ -291,83 +365,24 @@ func (in *Iter8Service) GetAnalyticPort() int {
 	return analyticConfig.Port
 }
 
-func (in *Iter8Service) GetIter8RoutingReferences(namespace string, servicename string) (routingReference core_v1.ObjectReference, err error) {
-	promtimer := internalmetrics.GetGoFunctionMetric("business", "Iter8Service", "GetIter8Metrics")
-	defer promtimer.ObserveNow(&err)
-	istioCfg, err := in.businessLayer.IstioConfig.GetIstioConfigList(IstioConfigCriteria{
-		IncludeGateways:        true,
-		IncludeVirtualServices: true,
-		Namespace:              namespace,
-	})
-	rf := core_v1.ObjectReference{}
-	if err != nil {
-		return rf, err
+func validateVersion(requiredVersion string, installedVersion string) bool {
+	reqWords := strings.Split(requiredVersion, " ")
+	requirementV, errReqV := version.NewVersion(reqWords[1])
+	installedV, errInsV := version.NewVersion(installedVersion)
+	if errReqV != nil || errInsV != nil {
+		return false
 	}
-	gwNames := make([]string, 0)
-
-	for _, gw := range istioCfg.Gateways {
-		gwNames = append(gwNames, gw.Metadata.Name)
+	switch operator := reqWords[0]; operator {
+	case "==":
+		return installedV.Equal(requirementV)
+	case ">=":
+		return installedV.GreaterThan(requirementV) || installedV.Equal(requirementV)
+	case ">":
+		return installedV.GreaterThan(requirementV)
+	case "<=":
+		return installedV.LessThan(requirementV) || installedV.Equal(requirementV)
+	case "<":
+		return installedV.LessThan(requirementV)
 	}
-
-	for _, item := range istioCfg.VirtualServices.Items {
-		if item.IsValidHost(namespace, servicename) {
-			gws := item.Spec.Gateways
-			if gateways, ok := gws.([]interface{}); ok {
-				for _, g := range gateways {
-					if gate, ok := g.(string); ok {
-						if contains(gwNames, gate) {
-
-							rf.APIVersion = item.APIVersion
-							rf.Name = item.Metadata.Name
-							rf.Kind = item.Kind
-
-						}
-					}
-				}
-			}
-			if rf.Name != "" {
-				proto := item.Spec.Http
-				if aHttp, ok := proto.([]interface{}); ok {
-					for _, httpRoute := range aHttp {
-						if mHttpRoute, ok := httpRoute.(map[string]interface{}); ok {
-							if route, ok := mHttpRoute["route"]; ok {
-								if aDestinationWeight, ok := route.([]interface{}); ok {
-									for _, destination := range aDestinationWeight {
-										host := parseHost(destination)
-										if host == "" {
-											continue
-										} else if host == servicename {
-											return rf, nil
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	return rf, fmt.Errorf("unable to locate routing references")
-}
-
-func contains(s []string, searchterm string) bool {
-	i := sort.SearchStrings(s, searchterm)
-	return i < len(s) && s[i] == searchterm
-}
-
-func parseHost(destination interface{}) string {
-	if mDestination, ok := destination.(map[string]interface{}); ok {
-		if destinationW, ok := mDestination["destination"]; ok {
-			if mDestinationW, ok := destinationW.(map[string]interface{}); ok {
-				if host, ok := mDestinationW["host"]; ok {
-					if sHost, ok := host.(string); ok {
-						return sHost
-					}
-				}
-			}
-		}
-	}
-	return ""
+	return false
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ const (
 	IstioVersionSupported   = ">= 1.0"
 	MaistraVersionSupported = ">= 0.7.0"
 	OSSMVersionSupported    = ">= 1.0"
+	Iter8VersionSupported   = ">= 0.2"
 )
 
 // The valid auth strategies and values for cookie handling

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sync"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/kiali/kiali/config/security"
 	"github.com/kiali/kiali/log"
@@ -162,6 +162,8 @@ type ThreeScaleConfig struct {
 
 type Iter8Config struct {
 	Enabled bool `yaml:"enabled"`
+	// Defein which namespace Iter8 is installed on, default to iter8
+	Namespace string `yaml:"namespace"`
 }
 
 // Extensions struct describes configuration for Kiali add-ons (extensions)
@@ -343,7 +345,8 @@ func NewConfig() (c *Config) {
 				TemplateName:   "threescale-authorization",
 			},
 			Iter8: Iter8Config{
-				Enabled: false,
+				Enabled:   false,
+				Namespace: "iter8",
 			},
 		},
 		ExternalServices: ExternalServices{

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
@@ -26,7 +26,8 @@ type ThreeScaleConfig struct {
 	TemplateName   string `json:"templateName"`
 }
 type Iter8Config struct {
-	Enabled bool `json:"enabled"`
+	Enabled   bool   `json:"enabled"`
+	Namespace string `json:"namespace"`
 }
 type Extensions struct {
 	ThreeScale ThreeScaleConfig `json:"threescale,omitempty"`
@@ -72,7 +73,8 @@ func Config(w http.ResponseWriter, r *http.Request) {
 				TemplateName:   config.Extensions.ThreeScale.TemplateName,
 			},
 			Iter8: Iter8Config{
-				Enabled: config.Extensions.Iter8.Enabled,
+				Enabled:   config.Extensions.Iter8.Enabled,
+				Namespace: config.Extensions.Iter8.Namespace,
 			},
 		},
 		InstallationTag:          config.InstallationTag,

--- a/kubernetes/iter8.go
+++ b/kubernetes/iter8.go
@@ -21,8 +21,13 @@ type Iter8ExperimentSpec struct {
 		ApiVersion string `json:"apiVersion"`
 		Name       string `json:"name"`
 		Namespace  string `json:"namespace"`
+		Kind       string `json:"kind"`
 		Baseline   string `json:"baseline"`
 		Candidate  string `json:"candidate"`
+		Hosts      []struct {
+			Name    string `json:"name"`
+			Gateway string `json:"gateway"`
+		} `json:"hosts,omitempty"`
 	} `json:"targetService"`
 	TrafficControl struct {
 		Strategy             string  `json:"strategy,omitempty"`
@@ -58,6 +63,12 @@ type Iter8ExperimentSpec struct {
 }
 
 type Iter8ExperimentAction string
+type Iter8Host struct {
+	// Name of the Host
+	Name string `json:"name"`
+	// The gateway
+	Gateway string `json:"gateway"`
+}
 
 type Iter8ExperimentStatus struct {
 	Conditions []struct {

--- a/kubernetes/iter8.go
+++ b/kubernetes/iter8.go
@@ -3,6 +3,8 @@ package kubernetes
 import (
 	"fmt"
 
+	"github.com/kiali/kiali/config"
+
 	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -311,9 +313,10 @@ func (in *K8SClient) IsIter8Api() bool {
 }
 
 func (in *K8SClient) Iter8ConfigMap() ([]string, error) {
+	conf := config.Get()
 	mnames := make([]string, 0)
 	var result = &core_v1.ConfigMap{}
-	err := in.k8s.CoreV1().RESTClient().Get().Namespace("iter8").Resource("configmaps").
+	err := in.k8s.CoreV1().RESTClient().Get().Namespace(conf.Extensions.Iter8.Namespace).Resource("configmaps").
 		Name(Iter8ConfigMap).Do().Into(result)
 	if err == nil {
 		metrics := []Iter8AnalyticMetric{}

--- a/status/versions.go
+++ b/status/versions.go
@@ -386,3 +386,8 @@ func AreCanonicalMetricsAvailable() bool { // AreCanonicalMetricsAvailable() boo
 	// AND if mixer is disabled.
 	return *istioSupportsCanonical && IsMixerDisabled()
 }
+
+// Check Iter8 Supported Version
+func IsIter8Supported(analyticsImgVersion string) bool {
+	return validateVersion(config.Iter8VersionSupported, analyticsImgVersion)
+}

--- a/swagger.json
+++ b/swagger.json
@@ -4396,6 +4396,7 @@
       "x-go-package": "github.com/kiali/kiali/models"
     },
     "Iter8ExperimentDetail": {
+      "description": "For Displaying Iter8 Experiment Tabs",
       "type": "object",
       "properties": {
         "action": {
@@ -4412,6 +4413,13 @@
         "experimentItem": {
           "$ref": "#/definitions/Iter8ExperimentItem"
         },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Iter8Host"
+          },
+          "x-go-name": "Hosts"
+        },
         "permissions": {
           "$ref": "#/definitions/ResourcePermissions"
         },
@@ -4422,6 +4430,7 @@
       "x-go-package": "github.com/kiali/kiali/models"
     },
     "Iter8ExperimentItem": {
+      "description": "For Displaying Iter8 Experiment Details",
       "type": "object",
       "properties": {
         "assessmentConclusion": {
@@ -4467,6 +4476,10 @@
           "format": "int64",
           "x-go-name": "EndedAt"
         },
+        "kind": {
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"
@@ -4499,12 +4512,38 @@
       },
       "x-go-package": "github.com/kiali/kiali/models"
     },
+    "Iter8Host": {
+      "type": "object",
+      "properties": {
+        "gateway": {
+          "type": "string",
+          "x-go-name": "Gateway"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
     "Iter8Info": {
       "type": "object",
       "properties": {
+        "analyticsImgVersion": {
+          "type": "string",
+          "x-go-name": "AnalyticsImageVersion"
+        },
+        "controllerImgVersion": {
+          "type": "string",
+          "x-go-name": "ControllerImageVersion"
+        },
         "enabled": {
           "type": "boolean",
           "x-go-name": "Enabled"
+        },
+        "supportedVersion": {
+          "type": "boolean",
+          "x-go-name": "SupportedVersion"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"


### PR DESCRIPTION
** Describe the change **

1. Add Host section in CR
2. Remove RoutingPreference in the CR ( Iter8 v0.1)
3. Enforce Supporting level. (Iter8 v0.2)

*** Refer to Issue
#2007 

** Backwards incompatible? **
With this changes, we only support Iter8 v0.2 and above.
Old version of Kiali-UI will work with these changes, but will not be able to take advantage of new feature introduced in V0.2

*** Note ***
