### PR TITLE
[v1.18 backport] Better handle egress destination telemetry (#3004)

### DIFF
--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -1703,6 +1703,7 @@ func TestServiceNodeGraph(t *testing.T) {
 // - request.host
 // - bad dest telemetry filtering
 // - bad source telemetry filtering
+// - workload -> egress -> service-entry traffic
 // note: appenders still tested in separate unit tests given that they create their own new business/kube clients
 func TestComplexGraph(t *testing.T) {
 	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
@@ -1848,6 +1849,21 @@ func TestComplexGraph(t *testing.T) {
 		"request_protocol":               "http",
 		"response_code":                  "200",
 		"response_flags":                 "-"}
+	q8m4 := model.Metric{ // good telem (service entry via egressgateway, see the second hop below)
+		"source_workload_namespace":      "tutorial",
+		"source_workload":                "customer-v1",
+		"source_app":                     "customer",
+		"source_version":                 "v1",
+		"destination_service_namespace":  "unknown",
+		"destination_service":            "istio-egressgateway.istio-system.svc.cluster.local",
+		"destination_service_name":       "istio-egressgateway.istio-system.svc.cluster.local",
+		"destination_workload_namespace": "unknown",
+		"destination_workload":           "unknown",
+		"destination_app":                "unknown",
+		"destination_version":            "unknown",
+		"request_protocol":               "http",
+		"response_code":                  "200",
+		"response_flags":                 "-"}
 	v8 := model.Vector{
 		&model.Sample{
 			Metric: q8m0,
@@ -1860,7 +1876,10 @@ func TestComplexGraph(t *testing.T) {
 			Value:  200},
 		&model.Sample{
 			Metric: q8m3,
-			Value:  300}}
+			Value:  300},
+		&model.Sample{
+			Metric: q8m4,
+			Value:  400}}
 
 	q9 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_flags),0.001)`
 	v9 := model.Vector{}
@@ -1878,7 +1897,27 @@ func TestComplexGraph(t *testing.T) {
 	v13 := model.Vector{}
 
 	q14 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
-	v14 := model.Vector{}
+	q14m0 := model.Metric{ // good telem (service entry via egressgateway, see the second hop below)
+		"source_workload_namespace":      "istio-system",
+		"source_workload":                "istio-egressgateway",
+		"source_app":                     "istio-egressgateway",
+		"source_version":                 "unknown",
+		"source_canonical_revision":      "latest",
+		"source_canonical_service":       "istio-egressgateway",
+		"destination_service_namespace":  "unknown",
+		"destination_service":            "app.example-2.com",
+		"destination_service_name":       "app.example-2.com",
+		"destination_workload_namespace": "unknown",
+		"destination_workload":           "unknown",
+		"destination_app":                "unknown",
+		"destination_version":            "unknown",
+		"request_protocol":               "http",
+		"response_code":                  "200",
+		"response_flags":                 "-"}
+	v14 := model.Vector{
+		&model.Sample{
+			Metric: q14m0,
+			Value:  400}}
 
 	q15 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="istio-system",destination_service_namespace=~"istio-system"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v15 := model.Vector{}

--- a/graph/api/testdata/test_complex_graph.expected
+++ b/graph/api/testdata/test_complex_graph.expected
@@ -52,6 +52,24 @@
       },
       {
         "data": {
+          "id": "332209947916c37701f39500789b6792",
+          "nodeType": "app",
+          "namespace": "istio-system",
+          "workload": "istio-egressgateway",
+          "app": "istio-egressgateway",
+          "version": "unknown",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "400.00"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "data": {
           "id": "d75c918a12f72a1ea1797911cb9770f7",
           "nodeType": "app",
           "namespace": "tutorial",
@@ -74,7 +92,29 @@
             {
               "protocol": "http",
               "rates": {
-                "httpOut": "350.00"
+                "httpOut": "750.00"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "data": {
+          "id": "c4d8519b61e39974286357006b354f99",
+          "nodeType": "service",
+          "namespace": "unknown",
+          "service": "app.example-2.com",
+          "destServices": [
+            {
+              "namespace": "unknown",
+              "name": "app.example-2.com"
+            }
+          ],
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "400.00"
               }
             }
           ]
@@ -108,6 +148,30 @@
       }
     ],
     "edges": [
+      {
+        "data": {
+          "id": "b8652735083f361a13ab190a26f37e89",
+          "source": "332209947916c37701f39500789b6792",
+          "target": "c4d8519b61e39974286357006b354f99",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "400.00",
+              "httpPercentReq": "100.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "app.example-2.com": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
       {
         "data": {
           "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
@@ -158,6 +222,30 @@
       },
       {
         "data": {
+          "id": "864c8eae6f988891d9df2d9f378eece5",
+          "source": "d75c918a12f72a1ea1797911cb9770f7",
+          "target": "332209947916c37701f39500789b6792",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "400.00",
+              "httpPercentReq": "53.3"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "istio-egressgateway.istio-system.svc.cluster.local": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
           "id": "62adcb3e419f4bcee6f1528dd9d2eb56",
           "source": "d75c918a12f72a1ea1797911cb9770f7",
           "target": "7fb749d8703ff9fde566213cb1c98b41",
@@ -165,7 +253,7 @@
             "protocol": "http",
             "rates": {
               "http": "300.00",
-              "httpPercentReq": "85.7"
+              "httpPercentReq": "40.0"
             },
             "responses": {
               "200": {
@@ -189,7 +277,7 @@
             "protocol": "http",
             "rates": {
               "http": "50.00",
-              "httpPercentReq": "14.3"
+              "httpPercentReq": "6.7"
             },
             "responses": {
               "200": {

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -211,13 +211,7 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		sourceWl := string(lSourceWl)
 		sourceApp := string(lSourceApp)
 		sourceVer := string(lSourceVer)
-		destSvcNs := string(lDestSvcNs)
 		destSvc := string(lDestSvc)
-		destSvcName := string(lDestSvcName)
-		destWlNs := string(lDestWlNs)
-		destWl := string(lDestWl)
-		destApp := string(lDestApp)
-		destVer := string(lDestVer)
 		responseCode := string(lResponseCode)
 
 		if util.IsBadSourceTelemetry(sourceWlNs, sourceWl, sourceApp) {
@@ -237,7 +231,9 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		}
 
 		val := float64(s.Value)
-		destSvcNs, destSvcName = util.HandleMultiClusterRequest(sourceWlNs, sourceWl, destSvcNs, destSvcName)
+
+		// handle unusual destinations
+		destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, _ := util.HandleDestination(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvc), string(lDestSvcName), string(lDestWlNs), string(lDestWl), string(lDestApp), string(lDestVer))
 
 		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -223,10 +223,6 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o gra
 		sourceApp := string(lSourceApp)
 		sourceVer := string(lSourceVer)
 		destSvc := string(lDestSvc)
-		destWlNs := string(lDestWlNs)
-		destWl := string(lDestWl)
-		destApp := string(lDestApp)
-		destVer := string(lDestVer)
 		protocol := string(lProtocol)
 		code := string(lCode)
 		flags := string(lFlags)
@@ -238,8 +234,8 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, o gra
 		// set response code in a backward compatible way
 		code = util.HandleResponseCode(protocol, code, grpcOk, string(lGrpc))
 
-		// handle multicluster requests
-		destSvcNs, destSvcName := util.HandleMultiClusterRequest(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvcName))
+		// handle unusual destinations
+		destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, _ := util.HandleDestination(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvc), string(lDestSvcName), string(lDestWlNs), string(lDestWl), string(lDestApp), string(lDestVer))
 
 		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue
@@ -323,18 +319,14 @@ func populateTrafficMapTCP(trafficMap graph.TrafficMap, vector *model.Vector, o 
 		sourceApp := string(lSourceApp)
 		sourceVer := string(lSourceVer)
 		destSvc := string(lDestSvc)
-		destWlNs := string(lDestWlNs)
-		destWl := string(lDestWl)
-		destApp := string(lDestApp)
-		destVer := string(lDestVer)
 		flags := string(lFlags)
 
 		if util.IsBadSourceTelemetry(sourceWlNs, sourceWl, sourceApp) {
 			continue
 		}
 
-		// handle multicluster requests
-		destSvcNs, destSvcName := util.HandleMultiClusterRequest(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvcName))
+		// handle unusual destinations
+		destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, _ := util.HandleDestination(sourceWlNs, sourceWl, string(lDestSvcNs), string(lDestSvc), string(lDestSvcName), string(lDestWlNs), string(lDestWl), string(lDestApp), string(lDestVer))
 
 		if util.IsBadDestTelemetry(destSvc, destSvcName, destWl) {
 			continue


### PR DESCRIPTION
UI PR: https://github.com/kiali/kiali-ui/pull/1858

Istio Egress destination telemetry is lacking and may not be easily fixed on their side. So, add some special case code to help things out for the Kiali graph.  Note that the bad telem is still in Prometheus, so direct metric query won't match up completely unless we want to patch that as well.

https://github.com/kiali/kiali/issues/2999