### PR TITLE
Istio Components Status: addons in different ns, modify name and severity each component

### DIFF
--- a/business/checkers/authorization/mtls_enabled_checker.go
+++ b/business/checkers/authorization/mtls_enabled_checker.go
@@ -2,6 +2,7 @@ package authorization
 
 import (
 	"fmt"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/mtls"

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -61,9 +61,14 @@ func (iss *IstioStatusService) GetStatus() (IstioComponentStatus, error) {
 func (iss *IstioStatusService) getComponentNamespacesWorkloads() ([]apps_v1.Deployment, error) {
 	var wg sync.WaitGroup
 
-	comNs := config.Get().IstioComponentNamespaces
 	nss := map[string]bool{}
 	deps := make([]apps_v1.Deployment, 0)
+
+	comNs := config.Get().IstioComponentNamespaces
+	// In case there isn't any namespace set up, check the control plane namespace
+	if comNs == nil || len(comNs) == 0 {
+		comNs = map[string]string{"istiod": config.Get().IstioNamespace}
+	}
 
 	depsChan := make(chan []apps_v1.Deployment, len(comNs))
 	errChan := make(chan error, len(comNs))

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -77,7 +77,7 @@ func TestComponentRunning(t *testing.T) {
 func TestGrafanaDisabled(t *testing.T) {
 	assert := assert.New(t)
 
-	conf := config.NewConfig()
+	conf := confWithIstioComponents()
 	conf.ExternalServices.Grafana.Enabled = false
 	config.Set(conf)
 
@@ -127,8 +127,7 @@ func TestTracingDisabled(t *testing.T) {
 func TestMonolithComp(t *testing.T) {
 	assert := assert.New(t)
 
-	conf := config.NewConfig()
-	config.Set(conf)
+	config.Set(confWithIstioComponents())
 
 	pods := []apps_v1.Deployment{
 		fakeDeploymentWithStatus("istio-egressgateway", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, healthyStatus),
@@ -165,8 +164,7 @@ func TestMonolithComp(t *testing.T) {
 func TestMixerComp(t *testing.T) {
 	assert := assert.New(t)
 
-	conf := config.NewConfig()
-	config.Set(conf)
+	config.Set(confWithIstioComponents())
 
 	pods := []apps_v1.Deployment{
 		fakeDeploymentWithStatus("istio-citadel", map[string]string{"app": "citadel", "istio": "citadel"}, healthyStatus),
@@ -252,4 +250,13 @@ func shutdown() {
 	delete(components["mixer"], TRACING_COMPONENT)
 	delete(components["mixerless"], TRACING_COMPONENT)
 	delete(components["mixerless"], GRAFANA_COMPONENT)
+}
+
+func confWithIstioComponents() *config.Config {
+	conf := config.NewConfig()
+	conf.IstioComponentNamespaces = config.IstioComponentNamespaces{
+		"grafana": "istio-system",
+		"istiod":  "istio-config",
+	}
+	return conf
 }

--- a/config/config.go
+++ b/config/config.go
@@ -159,8 +159,8 @@ type ComponentStatuses struct {
 }
 
 type ComponentStatus struct {
-	Name   string `yaml:"name,omitempty"`
-	IsCore bool   `yaml:"is_core,omitempty"`
+	AppLabel string `yaml:"app_label,omitempty"`
+	IsCore   bool   `yaml:"is_core,omitempty"`
 }
 
 // ThreeScaleConfig describes configuration used for 3Scale adapter
@@ -365,8 +365,8 @@ func NewConfig() (c *Config) {
 				},
 				Enabled: true,
 				ComponentStatus: ComponentStatus{
-					Name:   "grafana",
-					IsCore: false,
+					AppLabel: "grafana",
+					IsCore:   false,
 				},
 			},
 			Istio: IstioConfig{
@@ -376,16 +376,16 @@ func NewConfig() (c *Config) {
 					Enabled: true,
 					Components: []ComponentStatus{
 						{
-							Name:   "istio-egressgateway",
-							IsCore: false,
+							AppLabel: "istio-egressgateway",
+							IsCore:   false,
 						},
 						{
-							Name:   "istio-ingressgateway",
-							IsCore: true,
+							AppLabel: "istio-ingressgateway",
+							IsCore:   true,
 						},
 						{
-							Name:   "istiod",
-							IsCore: true,
+							AppLabel: "istiod",
+							IsCore:   true,
 						},
 					},
 				},
@@ -396,8 +396,8 @@ func NewConfig() (c *Config) {
 					Type: AuthTypeNone,
 				},
 				ComponentStatus: ComponentStatus{
-					Name:   "prometheus",
-					IsCore: true,
+					AppLabel: "prometheus",
+					IsCore:   true,
 				},
 				CustomMetricsURL: "http://prometheus.istio-system:9090",
 				URL:              "http://prometheus.istio-system:9090",
@@ -407,8 +407,8 @@ func NewConfig() (c *Config) {
 					Type: AuthTypeNone,
 				},
 				ComponentStatus: ComponentStatus{
-					Name:   "jaeger",
-					IsCore: false,
+					AppLabel: "jaeger",
+					IsCore:   false,
 				},
 				Enabled:              true,
 				NamespaceSelector:    true,

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -76,7 +76,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 		InstallationTag:          config.InstallationTag,
-		IstioStatusEnabled:       config.ExternalServices.Istio.IstioStatusEnabled,
+		IstioStatusEnabled:       config.ExternalServices.Istio.ComponentStatuses.Enabled,
 		IstioIdentityDomain:      config.ExternalServices.Istio.IstioIdentityDomain,
 		IstioNamespace:           config.IstioNamespace,
 		IstioComponentNamespaces: config.IstioComponentNamespaces,

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"

--- a/kubernetes/cache/istio.go
+++ b/kubernetes/cache/istio.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 type (

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"bytes"
 	"fmt"
+
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	osroutes_v1 "github.com/openshift/api/route/v1"


### PR DESCRIPTION
This comes after the following issues found:
- https://github.com/kiali/kiali/issues/2916 : Support add-ons installed in different namespaces
- https://github.com/kiali/kiali/issues/3027 : Istio 1.7 changed tracing deployment name

The result is a more flexible solution for the istio components namespace. it removes hardcoded components, istio architectures (mixer or monolith) and allows users to change the severity of each component (error or warning). 

The defaults for this PR supports both 1.7 and 1.6 versions.

Needs operator changes: https://github.com/kiali/kiali-operator/pull/98

Testing comments:
This PR needs to be tested in both 1.7 and 1.6 upstream istio version. Defaults values should work with both versions.

fixes https://github.com/kiali/kiali/issues/2916
fixes https://github.com/kiali/kiali/issues/3027