### PR TITLE
Support VirtualServices hosts in Authz Policies

### DIFF
--- a/business/checkers/authorization/mtls_enabled_checker.go
+++ b/business/checkers/authorization/mtls_enabled_checker.go
@@ -2,6 +2,7 @@ package authorization
 
 import (
 	"fmt"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/mtls"

--- a/business/checkers/authorization/no_host_checker.go
+++ b/business/checkers/authorization/no_host_checker.go
@@ -17,6 +17,7 @@ type NoHostChecker struct {
 	Namespaces          models.Namespaces
 	ServiceEntries      map[string][]string
 	Services            []core_v1.Service
+	VirtualServices     []kubernetes.IstioObject
 }
 
 func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
@@ -112,6 +113,11 @@ func (n NoHostChecker) hasMatchingService(host kubernetes.Host, itemNamespace st
 		}
 	}
 
-	// Otherwise Check ServiceEntries
-	return kubernetes.HasMatchingServiceEntries(host.Service, n.ServiceEntries)
+	// Check ServiceEntries
+	if kubernetes.HasMatchingServiceEntries(host.Service, n.ServiceEntries) {
+		return true
+	}
+
+	// Otherwise, check VirtualServices
+	return kubernetes.HasMatchingVirtualServices(host, n.VirtualServices)
 }

--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -19,6 +19,7 @@ type AuthorizationPolicyChecker struct {
 	Services              []core_v1.Service
 	WorkloadList          models.WorkloadList
 	MtlsDetails           kubernetes.MTLSDetails
+	VirtualServices       []kubernetes.IstioObject
 }
 
 func (a AuthorizationPolicyChecker) Check() models.IstioValidations {
@@ -49,7 +50,7 @@ func (a AuthorizationPolicyChecker) runChecks(authPolicy kubernetes.IstioObject)
 		common.SelectorNoWorkloadFoundChecker(AuthorizationPolicyCheckerType, authPolicy, a.WorkloadList),
 		authorization.NamespaceMethodChecker{AuthorizationPolicy: authPolicy, Namespaces: a.Namespaces.GetNames()},
 		authorization.NoHostChecker{AuthorizationPolicy: authPolicy, Namespace: a.Namespace, Namespaces: a.Namespaces,
-			ServiceEntries: serviceHosts, Services: a.Services},
+			ServiceEntries: serviceHosts, Services: a.Services, VirtualServices: a.VirtualServices},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -115,7 +115,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
 		checkers.ServiceRoleBindChecker{RBACDetails: rbacDetails},
-		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails},
+		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioDetails.VirtualServices},
 		checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces, WorkloadList: workloads, Services: services, ServiceEntries: istioDetails.ServiceEntries},
 	}
 }
@@ -205,7 +205,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
 			Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries,
-			WorkloadList: workloads, MtlsDetails: mtlsDetails}
+			WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioDetails.VirtualServices}
 		objectCheckers = []ObjectChecker{authPoliciesChecker}
 	case kubernetes.ServiceRoles:
 		objectCheckers = []ObjectChecker{noServiceChecker}

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"

--- a/kubernetes/cache/istio.go
+++ b/kubernetes/cache/istio.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 type (

--- a/kubernetes/host_test.go
+++ b/kubernetes/host_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
 )
@@ -20,4 +21,49 @@ func TestGatewayAsHost(t *testing.T) {
 	assert.Equal("mygateway.bookinfo.svc.cluster.local", ParseGatewayAsHost("mygateway.bookinfo", "bookinfo", "svc.cluster.local").String())
 	assert.Equal("mygateway.bookinfo.svc.cluster.local", ParseGatewayAsHost("mygateway.bookinfo", "bookinfo", "svc.cluster.local").String())
 	assert.Equal("mygateway.bookinfo.svc.cluster.local", ParseGatewayAsHost("mygateway.bookinfo.svc.cluster.local", "bookinfo", "svc.cluster.local").String())
+}
+
+func TestHasMatchingVirtualServices(t *testing.T) {
+	assert := assert.New(t)
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Short name service
+	assert.True(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bookinfo", []string{"reviews"})}))
+	assert.False(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bogus", []string{"reviews"})}))
+
+	// Half-FQDN
+	assert.True(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bookinfo", []string{"reviews.bookinfo"})}))
+	assert.False(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bogus", []string{"reviews.bogus"})}))
+
+	// FQDN
+	assert.True(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bookinfo", []string{"reviews.bookinfo.svc.cluster.local"})}))
+	assert.False(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bogus", []string{"reviews.bogus.svc.cluster.local"})}))
+
+	// Wildcard
+	assert.True(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bookinfo", []string{"*.bookinfo.svc.cluster.local"})}))
+	assert.True(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bookinfo", []string{"*"})}))
+	assert.False(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bogus", []string{"*.bogus.svc.cluster.local"})}))
+
+	// External host
+	assert.False(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bookinfo", []string{"foo.example.com"})}))
+	assert.False(HasMatchingVirtualServices(Host{Service: "reviews", Namespace: "bookinfo", Cluster: "svc.cluster.local"}, []IstioObject{createVirtualService("bookinfo", []string{"*.foo.example.com"})}))
+
+	assert.True(HasMatchingVirtualServices(Host{Service: "foo.example.com", Namespace: "", Cluster: ""}, []IstioObject{createVirtualService("bookinfo", []string{"foo.example.com"})}))
+	assert.True(HasMatchingVirtualServices(Host{Service: "new.foo.example.com", Namespace: "", Cluster: ""}, []IstioObject{createVirtualService("bookinfo", []string{"*.foo.example.com"})}))
+	assert.True(HasMatchingVirtualServices(Host{Service: "foo.example.com", Namespace: "", Cluster: ""}, []IstioObject{createVirtualService("bookinfo", []string{"*"})}))
+}
+
+func createVirtualService(namespace string, hosts []string) IstioObject {
+	return (&GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:        "virtual-service",
+			Namespace:   namespace,
+			ClusterName: "svc.cluster.local",
+		},
+		Spec: map[string]interface{}{
+			"hosts": hosts,
+		},
+	}).DeepCopyIstioObject()
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"bytes"
 	"fmt"
+
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	osroutes_v1 "github.com/openshift/api/route/v1"


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3001

AuthorizationPolicies might apply to specific request matching the target host. This host might not only be internal services or service entries in the mesh but all the possible hosts that the cluster allow to get in (through gateways and virtual services).

This PR removes the false positive of the following scenario where the AuthzPolicy is applied to a host declared in a Virtual Service.

Therefore, this PR includes VirtualService's hosts in the host checking process.

ServiceEntry
```
---
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: foo-dev
  namespace: istio-system
spec:
  endpoints:
  # ip is a vm/service outside the cluster
  - address: 10.15.1.121
  exportTo:
  - "."
  hosts:
  - foo-dev.istio-system.svc.cluster.local
  location: MESH_EXTERNAL
  ports:
  - name: http
    number: 49000
    protocol: HTTP
  resolution: STATIC
```
VirtualService:
```
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: foo-dev
  namespace: istio-system
spec:
  hosts:
  - foo-dev.example.com
  gateways:
  - foo-dev
  http:
  - name: foo-svc
    match:
    - uri:
        prefix: /foo
    rewrite:
      uri: "/foo"
    route:
    - destination:
        host: foo-dev.istio-system.svc.cluster.local
        port:
          number: 49000
```
Gateway:
```
---
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: foo-dev
  namespace: istio-system
spec:
  selector:
    istio: ingressgateway # use istio default controller
  servers:
  - hosts:
    - "foo-dev.example.com"
    port:
      number: 80
      name: http
      protocol: HTTP
    tls:
      httpsRedirect: true # sends 301 redirect for http requests
  - hosts:
    - "foo-dev.example.com"
    port:
      number: 443
      name: https
      protocol: HTTPS
    tls:
      mode: SIMPLE
      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
      privateKey: /etc/istio/ingressgateway-certs/tls.key
```
And finally AuthorizationPolicy
```
---
apiVersion: security.istio.io/v1beta1
kind: AuthorizationPolicy
metadata:
  name: allow-foo
  namespace: istio-system
spec:
  action: DENY
  selector:
    matchLabels:
      app: istio-ingressgateway
  rules:
  - to:
    - operation:
        hosts:
          - "foo-dev.example.com"
        paths:
          - "/foo"
    when:
    - key: request.headers[x-token]
      notValues:
      - "fooreader"
```

Huge thanks to @MarkDeckert for the energy and level of detail in his issue!