### PR TITLE
[hack] install addons since istioctl doesn't do it anymore

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -239,6 +239,11 @@ else
     exit 1
   fi
 
+  echo Installing Addons except Kiali
+  ${CLIENT_EXE} apply -f ${ISTIO_DIR}/samples/addons/prometheus.yaml
+  ${CLIENT_EXE} apply -f ${ISTIO_DIR}/samples/addons/grafana.yaml
+  ${CLIENT_EXE} apply -f ${ISTIO_DIR}/samples/addons/jaeger.yaml
+
   # Do some OpenShift specific things
   if [[ "${CLIENT_EXE}" = *"oc" ]]; then
     ${CLIENT_EXE} -n ${NAMESPACE} expose svc/istio-ingressgateway --port=http2


### PR DESCRIPTION
We need the hack script to install the addons now that istio 1.7 does not include them anymore.