### PR TITLE
make client id prefix configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -239,9 +239,15 @@ type ApiNamespacesConfig struct {
 
 // AuthConfig provides details on how users are to authenticate
 type AuthConfig struct {
-	LDAP     LDAPConfig   `yaml:"ldap,omitempty"`
-	OpenId   OpenIdConfig `yaml:"openid,omitempty"`
-	Strategy string       `yaml:"strategy,omitempty"`
+	LDAP      LDAPConfig      `yaml:"ldap,omitempty"`
+	OpenId    OpenIdConfig    `yaml:"openid,omitempty"`
+	OpenShift OpenShiftConfig `yaml:"openshift,omitempty"`
+	Strategy  string          `yaml:"strategy,omitempty"`
+}
+
+// OpenShiftConfig contains specific configuration for authentication when on OpenShift
+type OpenShiftConfig struct {
+	ClientIdPrefix string `yaml:"client_id_prefix,omitempty"`
 }
 
 // OpenIdConfig contains specific configuration for authentication using an OpenID provider
@@ -327,6 +333,9 @@ func NewConfig() (c *Config) {
 				IssuerUri:             "",
 				Scopes:                []string{"openid", "profile", "email"},
 				UsernameClaim:         "sub",
+			},
+			OpenShift: OpenShiftConfig{
+				ClientIdPrefix: "kiali",
 			},
 		},
 		Deployment: DeploymentConfig{


### PR DESCRIPTION
Do not assume the Route name is `kiali` and the OAuthClient name is prefixed with `kiali`. Let it be configurable by the installer.

Default is "kiali" (which is the prefix today's installers use) - so even if an older installer installs kiali (and thus "client_id_prefix" is missing from the ConfigMap), the openshift auth strategy will still work.

Do not merge this PR unless [the kiali server helm chart PR](https://github.com/kiali/kiali-operator/pull/105) is merged.

part of fix for: https://github.com/kiali/kiali/issues/3069