### PR TITLE
Remove Jenkins generation of the all-in-one yaml

### DIFF
--- a/deploy/jenkins-ci/Makefile.operator.jenkins
+++ b/deploy/jenkins-ci/Makefile.operator.jenkins
@@ -91,9 +91,7 @@ operator-build-release:
 	OPERATOR_QUAY_NAME="$(QUAY_OPERATOR_NAME)" \
 	  $(MAKE) clean build
 ifneq ($(IS_SNAPSHOT),y)
-	OPERATOR_IMAGE_VERSION="$(OPERATOR_VERSION_TO_RELEASE)" \
-	  $(MAKE) generate-all-in-one update-helm-repo
-	cp _output/kiali-operator-all-in-one.yaml deploy/
+	OPERATOR_IMAGE_VERSION="$(OPERATOR_VERSION_TO_RELEASE)" $(MAKE) update-helm-repo
 endif
 
 operator-push-quay:
@@ -119,7 +117,6 @@ endif
 operator-push-version-tag:
 ifeq ($(PUSH_GITHUB_TAG),y)
 	git add Makefile
-	git add deploy/kiali-operator-all-in-one.yaml
 	git add docs/charts
 	git commit -m "Release $(OPERATOR_VERSION)"
 	git push $(OPERATOR_GITHUB_URI) $$(git rev-parse HEAD):refs/tags/$(VERSION_TAG)
@@ -163,12 +160,8 @@ endif
 operator-prepare-master-next-version:
 	# Only minor releases require to prepare the master branch for the next release
 ifeq ($(RELEASE_TYPE),minor)
-	OPERATOR_IMAGE_VERSION="latest" \
-	  $(MAKE) generate-all-in-one
-	cp _output/kiali-operator-all-in-one.yaml deploy/
 	sed -i -r "s/^VERSION \?= (.*)/VERSION \?= v$(OPERATOR_BUMPED_VERSION)-SNAPSHOT/" Makefile
 	git add Makefile
-	git add deploy/kiali-operator-all-in-one.yaml
 	git commit -m "Prepare for next version"
 	# First, try to push directly to master
 	git push $(OPERATOR_GITHUB_URI) $$(git rev-parse HEAD):refs/heads/$(OPERATOR_MAIN_BRANCH) || touch pr_needed.txt


### PR DESCRIPTION
Users can generate it via helm now.

operator PR that goes with this: https://github.com/kiali/kiali-operator/pull/108

fixes: https://github.com/kiali/kiali/issues/3075
