### PR TITLE
Add workload validation support to RequestAuthentication

### DIFF
--- a/business/checkers/common/multi_match_selector_checker.go
+++ b/business/checkers/common/multi_match_selector_checker.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/kubernetes"
@@ -100,7 +98,7 @@ func (m GenericMultiMatchChecker) buildSelectorLessSubjectValidations(subjects [
 
 	for _, subjectWithIndex := range subjects {
 		references := extractReferences(subjectWithIndex.Index, subjects)
-		checks := models.Build(fmt.Sprintf("%s.multimatch.selectorless", m.SubjectType), m.Path)
+		checks := models.Build("generic.multimatch.selectorless", m.Path)
 		validations.MergeValidations(
 			models.IstioValidations{
 				*subjectWithIndex.Key: &models.IstioValidation{
@@ -184,7 +182,7 @@ func (m GenericMultiMatchChecker) buildMultipleSubjectValidation(scs []models.Is
 			refs = append(refs, scs[i+1:]...)
 		}
 
-		checks := models.Build(fmt.Sprintf("%s.multimatch.selector", m.SubjectType), m.Path)
+		checks := models.Build("generic.multimatch.selector", m.Path)
 		validation := models.IstioValidations{
 			sck: &models.IstioValidation{
 				Name:       sck.Name,

--- a/business/checkers/common/multi_match_selector_checker_test.go
+++ b/business/checkers/common/multi_match_selector_checker_test.go
@@ -43,8 +43,8 @@ func TestTwoSidecarsWithoutSelector(t *testing.T) {
 		workloadList(),
 	).Check()
 
-	assertMultimatchFailure(t, "sidecar.multimatch.selectorless", validations, "sidecar1", []string{"sidecar2"})
-	assertMultimatchFailure(t, "sidecar.multimatch.selectorless", validations, "sidecar2", []string{"sidecar1"})
+	assertMultimatchFailure(t, "generic.multimatch.selectorless", validations, "sidecar1", []string{"sidecar2"})
+	assertMultimatchFailure(t, "generic.multimatch.selectorless", validations, "sidecar2", []string{"sidecar1"})
 }
 
 func TestTwoSidecarsTargetingOneDeployment(t *testing.T) {
@@ -62,9 +62,9 @@ func TestTwoSidecarsTargetingOneDeployment(t *testing.T) {
 		Path:              "spec/workloadSelector",
 	}.Check()
 
-	assertMultimatchFailure(t, "sidecar.multimatch.selector", validations, "sidecar1", []string{"sidecar3", "sidecar4"})
-	assertMultimatchFailure(t, "sidecar.multimatch.selector", validations, "sidecar3", []string{"sidecar1", "sidecar4"})
-	assertMultimatchFailure(t, "sidecar.multimatch.selector", validations, "sidecar4", []string{"sidecar1", "sidecar3"})
+	assertMultimatchFailure(t, "generic.multimatch.selector", validations, "sidecar1", []string{"sidecar3", "sidecar4"})
+	assertMultimatchFailure(t, "generic.multimatch.selector", validations, "sidecar3", []string{"sidecar1", "sidecar4"})
+	assertMultimatchFailure(t, "generic.multimatch.selector", validations, "sidecar4", []string{"sidecar1", "sidecar3"})
 }
 
 func assertMultimatchFailure(t *testing.T, code string, validations models.IstioValidations, item string, references []string) {

--- a/business/checkers/common/workload_selector_checker.go
+++ b/business/checkers/common/workload_selector_checker.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/kubernetes"
@@ -38,16 +36,16 @@ func WorkloadSelectorNoWorkloadFoundChecker(subjectType string, subject kubernet
 }
 
 func (wsc GenericNoWorkloadFoundChecker) Check() ([]*models.IstioCheck, bool) {
-	checks, valid := make([]*models.IstioCheck, 0), true
+	checks := make([]*models.IstioCheck, 0)
 
 	labels := wsc.GetSelectorLabels(wsc.Subject)
 	if len(labels) > 0 {
 		if !wsc.hasMatchingWorkload(labels) {
-			check := models.Build(fmt.Sprintf("%s.selector.workloadnotfound", wsc.SubjectType), wsc.Path)
+			check := models.Build("generic.selector.workloadnotfound", wsc.Path)
 			checks = append(checks, &check)
 		}
 	}
-	return checks, valid
+	return checks, true
 }
 
 func (wsc GenericNoWorkloadFoundChecker) hasMatchingWorkload(labelSelector map[string]string) bool {

--- a/business/checkers/common/workload_selector_checker_test.go
+++ b/business/checkers/common/workload_selector_checker_test.go
@@ -49,11 +49,11 @@ func TestWorkloadNotFound(t *testing.T) {
 }
 
 func testFailureWithWorkloadList(assert *assert.Assertions, selector map[string]interface{}) {
-	testFailure(assert, selector, workloadList(), "sidecar.selector.workloadnotfound")
+	testFailure(assert, selector, workloadList(), "generic.selector.workloadnotfound")
 }
 
 func testFailureWithEmptyWorkloadList(assert *assert.Assertions, selector map[string]interface{}) {
-	testFailure(assert, selector, data.CreateWorkloadList("test", models.WorkloadListItem{}), "sidecar.selector.workloadnotfound")
+	testFailure(assert, selector, data.CreateWorkloadList("test", models.WorkloadListItem{}), "generic.selector.workloadnotfound")
 }
 
 func testFailure(assert *assert.Assertions, selector map[string]interface{}, wl models.WorkloadList, code string) {

--- a/business/checkers/request_authentication_checker.go
+++ b/business/checkers/request_authentication_checker.go
@@ -1,0 +1,44 @@
+package checkers
+
+import (
+	"github.com/kiali/kiali/business/checkers/common"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+const RequestAuthenticationCheckerType = "requestauthentication"
+
+type RequestAuthenticationChecker struct {
+	RequestAuthentications []kubernetes.IstioObject
+	WorkloadList           models.WorkloadList
+}
+
+func (m RequestAuthenticationChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	validations.MergeValidations(common.SelectorMultiMatchChecker(RequestAuthenticationCheckerType, m.RequestAuthentications, m.WorkloadList).Check())
+
+	for _, peerAuthn := range m.RequestAuthentications {
+		validations.MergeValidations(m.runChecks(peerAuthn))
+	}
+
+	return validations
+}
+
+// runChecks runs all the individual checks for a single mesh policy and appends the result into validations.
+func (m RequestAuthenticationChecker) runChecks(requestAuthn kubernetes.IstioObject) models.IstioValidations {
+	requestAuthnName := requestAuthn.GetObjectMeta().Name
+	key, rrValidation := EmptyValidValidation(requestAuthnName, requestAuthn.GetObjectMeta().Namespace, RequestAuthenticationCheckerType)
+
+	enabledCheckers := []Checker{
+		common.SelectorNoWorkloadFoundChecker(RequestAuthenticationCheckerType, requestAuthn, m.WorkloadList),
+	}
+
+	for _, checker := range enabledCheckers {
+		checks, validChecker := checker.Check()
+		rrValidation.Checks = append(rrValidation.Checks, checks...)
+		rrValidation.Valid = rrValidation.Valid && validChecker
+	}
+
+	return models.IstioValidations{key: rrValidation}
+}

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -86,6 +86,7 @@ func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDepSyncedWithRS(), nil)
 	k8s.On("GetMeshPolicies", mock.AnythingOfType("string")).Return(fakeMeshPolicies(), nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "peerauthentications", "").Return(fakePolicies(), nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "requestauthentications", "").Return([]kubernetes.IstioObject{}, nil)
 	k8s.On("GetAuthorizationDetails", mock.AnythingOfType("string")).Return(&kubernetes.RBACDetails{}, nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "virtualservices", "").Return(fakeCombinedIstioDetails().VirtualServices, nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "serviceentries", "").Return(fakeCombinedIstioDetails().ServiceEntries, nil)
@@ -96,6 +97,7 @@ func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 func mockCombinedValidationService(istioObjects *kubernetes.IstioDetails, services []string, podList *core_v1.PodList) IstioValidationsService {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "sidecars", "").Return(istioObjects.Sidecars, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "requestauthentications", "").Return(istioObjects.RequestAuthentications, nil)
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return(fakeCombinedServices(services), nil)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDepSyncedWithRS(), nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "virtualservices", "").Return(fakeCombinedIstioDetails().VirtualServices, nil)

--- a/kubernetes/iter8.go
+++ b/kubernetes/iter8.go
@@ -3,13 +3,13 @@ package kubernetes
 import (
 	"fmt"
 
-	"github.com/kiali/kiali/config"
-
 	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kiali/kiali/config"
 )
 
 var iter8typeMeta = meta_v1.TypeMeta{

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -528,11 +528,12 @@ type ServiceDetails struct {
 // IstioDetails is a wrapper to group all Istio objects related to a Service.
 // Used to fetch all Istio information in a single operation instead to invoke individual APIs per each group.
 type IstioDetails struct {
-	VirtualServices  []IstioObject `json:"virtualservices"`
-	DestinationRules []IstioObject `json:"destinationrules"`
-	ServiceEntries   []IstioObject `json:"serviceentries"`
-	Gateways         []IstioObject `json:"gateways"`
-	Sidecars         []IstioObject `json:"sidecars"`
+	VirtualServices        []IstioObject `json:"virtualservices"`
+	DestinationRules       []IstioObject `json:"destinationrules"`
+	ServiceEntries         []IstioObject `json:"serviceentries"`
+	Gateways               []IstioObject `json:"gateways"`
+	Sidecars               []IstioObject `json:"sidecars"`
+	RequestAuthentications []IstioObject `json:"requestauthentications"`
 }
 
 // MTLSDetails is a wrapper to group all Istio objects related to non-local mTLS configurations

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -85,21 +85,22 @@ const (
 )
 
 var ObjectTypeSingular = map[string]string{
-	"gateways":              "gateway",
-	"virtualservices":       "virtualservice",
-	"destinationrules":      "destinationrule",
-	"serviceentries":        "serviceentry",
-	"rules":                 "rule",
-	"quotaspecs":            "quotaspec",
-	"quotaspecbindings":     "quotaspecbinding",
-	"servicemeshpolicies":   "servicemeshpolicy",
-	"policies":              "policy",
-	"serviceroles":          "servicerole",
-	"servicerolebindings":   "servicerolebinding",
-	"clusterrbacconfigs":    "clusterrbacconfig",
-	"authorizationpolicies": "authorizationpolicy",
-	"sidecars":              "sidecar",
-	"peerauthentications":   "peerauthentication",
+	"gateways":               "gateway",
+	"virtualservices":        "virtualservice",
+	"destinationrules":       "destinationrule",
+	"serviceentries":         "serviceentry",
+	"rules":                  "rule",
+	"quotaspecs":             "quotaspec",
+	"quotaspecbindings":      "quotaspecbinding",
+	"servicemeshpolicies":    "servicemeshpolicy",
+	"policies":               "policy",
+	"serviceroles":           "servicerole",
+	"servicerolebindings":    "servicerolebinding",
+	"clusterrbacconfigs":     "clusterrbacconfig",
+	"authorizationpolicies":  "authorizationpolicy",
+	"sidecars":               "sidecar",
+	"peerauthentications":    "peerauthentication",
+	"requestauthentications": "requestauthentication",
 }
 
 var checkDescriptors = map[string]IstioCheck{
@@ -202,6 +203,18 @@ var checkDescriptors = map[string]IstioCheck{
 	"port.name.mismatch": {
 		Message:  "KIA0601 Port name must follow <protocol>[-suffix] form",
 		Severity: ErrorSeverity,
+	},
+	"requestauthentication.multimatch.selectorless": {
+		Message:  "KIA1201 More than one selector-less RequestAuthentication in the same namespace",
+		Severity: WarningSeverity,
+	},
+	"requestauthentication.multimatch.selector": {
+		Message:  "KIA1005 More than one RequestAuthentication applied to the same workload",
+		Severity: ErrorSeverity,
+	},
+	"requestauthentication.selector.workloadnotfound": {
+		Message:  "KIA1001 No matching workload found for the selector in this namespace",
+		Severity: WarningSeverity,
 	},
 	"service.deployment.port.mismatch": {
 		Message:  "KIA0701 Deployment exposing same port as Service not found",

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -209,11 +209,11 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"requestauthentication.multimatch.selector": {
-		Message:  "KIA1005 More than one RequestAuthentication applied to the same workload",
+		Message:  "KIA1202 More than one RequestAuthentication applied to the same workload",
 		Severity: ErrorSeverity,
 	},
 	"requestauthentication.selector.workloadnotfound": {
-		Message:  "KIA1001 No matching workload found for the selector in this namespace",
+		Message:  "KIA1203 No matching workload found for the selector in this namespace",
 		Severity: WarningSeverity,
 	},
 	"service.deployment.port.mismatch": {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -177,7 +177,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: ErrorSeverity,
 	},
 	"generic.selector.workloadnotfound": {
-		Message:  "KIA0003 No matching workload found for the selector in this namespace",
+		Message:  "KIA0004 No matching workload found for the selector in this namespace",
 		Severity: WarningSeverity,
 	},
 	"peerauthentication.mtls.destinationrulemissing": {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -112,10 +112,6 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA0102 Only HTTP methods and fully-qualified gRPC names are allowed",
 		Severity: WarningSeverity,
 	},
-	"authorizationpolicy.selector.workloadnotfound": {
-		Message:  "KIA0103 No matching workload found for authorization policy selector in this namespace",
-		Severity: WarningSeverity,
-	},
 	"authorizationpolicy.nodest.matchingregistry": {
 		Message:  "KIA0104 This host has no matching entry in the service registry",
 		Severity: ErrorSeverity,
@@ -172,6 +168,18 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA0302 No matching workload found for gateway selector in this namespace",
 		Severity: WarningSeverity,
 	},
+	"generic.multimatch.selectorless": {
+		Message:  "KIA0002 More than one selector-less object in the same namespace",
+		Severity: ErrorSeverity,
+	},
+	"generic.multimatch.selector": {
+		Message:  "KIA0003 More than one object applied to the same workload",
+		Severity: ErrorSeverity,
+	},
+	"generic.selector.workloadnotfound": {
+		Message:  "KIA0003 No matching workload found for the selector in this namespace",
+		Severity: WarningSeverity,
+	},
 	"peerauthentication.mtls.destinationrulemissing": {
 		Message:  "KIA0401 Mesh-wide Destination Rule enabling mTLS is missing",
 		Severity: ErrorSeverity,
@@ -179,18 +187,6 @@ var checkDescriptors = map[string]IstioCheck{
 	"peerauthentications.mtls.destinationrulemissing": {
 		Message:  "KIA0501 Destination Rule enabling namespace-wide mTLS is missing",
 		Severity: ErrorSeverity,
-	},
-	"peerauthentication.multimatch.selectorless": {
-		Message:  "KIA0502 More than one selector-less PeerAuthentication in the same namespace",
-		Severity: WarningSeverity,
-	},
-	"peerauthentication.multimatch.selector": {
-		Message:  "KIA0503 More than one PeerAuthentication applied to the same workload",
-		Severity: WarningSeverity,
-	},
-	"peerauthentication.selector.workloadnotfound": {
-		Message:  "KIA0504 No matching workload found for PeerAuthentication selector in this namespace",
-		Severity: WarningSeverity,
 	},
 	"peerauthentications.mtls.disabledestinationrulemissing": {
 		Message:  "KIA0505 Destination Rule disabling namespace-wide mTLS is missing",
@@ -203,18 +199,6 @@ var checkDescriptors = map[string]IstioCheck{
 	"port.name.mismatch": {
 		Message:  "KIA0601 Port name must follow <protocol>[-suffix] form",
 		Severity: ErrorSeverity,
-	},
-	"requestauthentication.multimatch.selectorless": {
-		Message:  "KIA1201 More than one selector-less RequestAuthentication in the same namespace",
-		Severity: WarningSeverity,
-	},
-	"requestauthentication.multimatch.selector": {
-		Message:  "KIA1202 More than one RequestAuthentication applied to the same workload",
-		Severity: ErrorSeverity,
-	},
-	"requestauthentication.selector.workloadnotfound": {
-		Message:  "KIA1203 No matching workload found for the selector in this namespace",
-		Severity: WarningSeverity,
 	},
 	"service.deployment.port.mismatch": {
 		Message:  "KIA0701 Deployment exposing same port as Service not found",
@@ -236,14 +220,6 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA0903 ServiceRole does not exists in this namespace",
 		Severity: ErrorSeverity,
 	},
-	"sidecar.selector.workloadnotfound": {
-		Message:  "KIA1001 No matching workload found for authorization policy selector in this namespace",
-		Severity: WarningSeverity,
-	},
-	"sidecar.multimatch.selectorless": {
-		Message:  "KIA1002 More than one selector-less Sidecar in the same namespace",
-		Severity: ErrorSeverity,
-	},
 	"sidecar.egress.invalidhostformat": {
 		Message:  "KIA1003 Invalid host format. 'namespace/dnsName' format expected",
 		Severity: ErrorSeverity,
@@ -251,10 +227,6 @@ var checkDescriptors = map[string]IstioCheck{
 	"sidecar.egress.servicenotfound": {
 		Message:  "KIA1004 This host has no matching entry in the service registry",
 		Severity: WarningSeverity,
-	},
-	"sidecar.multimatch.selector": {
-		Message:  "KIA1005 More than one Sidecar applied to the same workload",
-		Severity: ErrorSeverity,
 	},
 	"sidecar.global.selector": {
 		Message:  "KIA1006 Global default sidecar should not have workloadSelector",


### PR DESCRIPTION
Add basic support to RequestAuthentication objects:

- Multiple ns-wide objects found
- Two objects pointing to the same workload
- Workload not found

![Screenshot of Kiali Console (30)](https://user-images.githubusercontent.com/613814/89408051-19ccd100-d720-11ea-9282-6abe68b5433e.png)

Testing scenarios: https://github.com/xeviknal/istio-lab/blob/master/2543.yaml

Fixes https://github.com/kiali/kiali/issues/2543