### PR TITLE
Use remote cluster's api server

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -291,7 +291,7 @@ Kiali can display API Documentation of your services. See https://user-images.gi
 
 === Configure your services
 
-Your services must be annotated with the type of API ('rest', 'grpc', 'graphql') and a URL to the spec of the API. 
+Your services must be annotated with the type of API ('rest', 'grpc', 'graphql') and a URL to the spec of the API.
 If the API spec is served from the service itself, Kiali will infer the hostname and port :
 
 [source,yaml]
@@ -302,7 +302,7 @@ metadata:
   name: myservice
   annotations:
     kiali.io/api-type: rest
-    kiali.io/api-spec: /v1/api-spec  
+    kiali.io/api-spec: /v1/api-spec
 spec:
 ...
 ----
@@ -317,7 +317,7 @@ metadata:
   name: petstore
   annotations:
     kiali.io/api-type: rest
-    kiali.io/api-spec: https://petstore.swagger.io/v2/swagger.json  
+    kiali.io/api-spec: https://petstore.swagger.io/v2/swagger.json
 spec:
 ...
 ----
@@ -471,6 +471,51 @@ spec:
       mode: DISABLE
 ...
 ----
+
+== Experimental
+
+=== Observing a Remote Cluster
+
+There are certain use cases where Kiali needs to be deployed in one cluster (Control Plane) and observe a different cluster (Data Plane). link:https://user-images.githubusercontent.com/6889074/87819080-ad099980-c839-11ea-834b-56eec038ce4d.png:[Diagram].
+
+Follow these steps:
+
+1: You should have the link:https://github.com/istio/istio/wiki/Central-Istiod-single-cluster-steps[remote central istiod with a single cluster] setup running
+
+2: Create the link:https://github.com/istio/istio/blob/master/samples/addons/kiali.yaml[Kiali ClusterRole, ClusterRoleBinding, and ServiceAccount] in the Data Plane cluster
+
+3: Create a remote secret in the Control Plane, using the Data Plane ServiceAccount you just created. This allows the Control Plane to read from and modify the Data Plane
+[source,shell]
+----
+istioctl x create-remote-secret --service-account kiali-service-account --context=$DataPlane --name kiali | kubectl apply -n istio-system --context=$ControlPlane -f -
+----
+
+4: You will now run Kiali in the Control Plane. You need to add the remote secret to the Kiali Deployment by specifying a Volume and VolumeMount. When Kiali sees */kiali-remote-secret/kiali* it will use the remote cluster's API server instead of the local API server
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      containers:
+      - volumeMounts:
+        - mountPath: /kiali-remote-secret
+          name: kiali-remote-secret
+      volumes:
+      - name: kiali-remote-secret
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: istio-remote-secret-kiali
+----
+
+5: Kiali now needs the Istio metrics from the sidecars. You need to run Prometheus in the Control Plane and have it scrape the metrics from an link:https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig:[envoyMetricsService]. These metrics are *required*:
+
+  - istio_requests_total
+  - istio_request_duration_milliseconds
+  - istio_response_bytes
+  - istio_request_bytes
+
+6: Kiali in the Control Plane should now be fully functional with the Data Plane
 
 == Contributing
 

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,8 @@ k8s.io/api v0.0.0-20190313235455-40a48860b5ab h1:DG9A67baNpoeweOy2spF1OWHhnVY5KR
 k8s.io/api v0.0.0-20190313235455-40a48860b5ab/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20190816221834-a9f1d8a9c101 h1:QtHYUjIdgXTtJVdYQhWIQZZoXa32aF3O9BNX2up2plE=
 k8s.io/apimachinery v0.0.0-20190816221834-a9f1d8a9c101/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/client-go v1.5.1 h1:XaX/lo2/u3/pmFau8HN+sB5C/b4dc4Dmm2eXjBH4p1E=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/client-go v11.0.1-0.20190820062731-7e43eff7c80a+incompatible h1:fwpMaOlhJz7BDSwxomz6JvraPkXX1Q9FVGtwkEio7TY=
 k8s.io/client-go v11.0.1-0.20190820062731-7e43eff7c80a+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -1,9 +1,12 @@
 package kubernetes
 
 import (
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"
@@ -24,6 +27,8 @@ import (
 	kialiConfig "github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 )
+
+const RemoteSecretData = "/kiali-remote-secret/kiali"
 
 var (
 	emptyListOptions = meta_v1.ListOptions{}
@@ -177,13 +182,45 @@ func (client *K8SClient) GetToken() string {
 	return client.token
 }
 
+// Point the k8s client to a remote cluster's API server
+func UseRemoteCreds(remoteSecret *RemoteSecret) (*rest.Config, error) {
+	caData := remoteSecret.Clusters[0].Cluster.CertificateAuthorityData
+	rootCaDecoded, err := base64.StdEncoding.DecodeString(caData)
+	if err != nil {
+		return nil, err
+	}
+	// Basically implement rest.InClusterConfig() with the remote creds
+	tlsClientConfig := rest.TLSClientConfig{
+		CAData: []byte(rootCaDecoded),
+	}
+
+	serverParse := strings.Split(remoteSecret.Clusters[0].Cluster.Server, ":")
+	if len(serverParse) != 3 {
+		return nil, errors.New("Invalid remote API server URL")
+	}
+	host := strings.TrimPrefix(serverParse[1], "//")
+	port := serverParse[2]
+
+	// There's no need to add the BearerToken because it's ignored later on
+	return &rest.Config{
+		Host:            "https://" + net.JoinHostPort(host, port),
+		TLSClientConfig: tlsClientConfig,
+	}, nil
+}
+
 // ConfigClient return a client with the correct configuration
 // Returns configuration if Kiali is in Cluster when InCluster is true
 // Returns configuration if Kiali is not int Cluster when InCluster is false
 // It returns an error on any problem
 func ConfigClient() (*rest.Config, error) {
 	if kialiConfig.Get().InCluster {
-		incluster, err := rest.InClusterConfig()
+		var incluster *rest.Config
+		var err error
+		if remoteSecret, readErr := GetRemoteSecret(RemoteSecretData); readErr == nil {
+			incluster, err = UseRemoteCreds(remoteSecret)
+		} else {
+			incluster, err = rest.InClusterConfig()
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/secret.go
+++ b/kubernetes/secret.go
@@ -1,0 +1,48 @@
+package kubernetes
+
+import (
+	"io/ioutil"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type RemoteSecret struct {
+	APIVersion string `yaml:"apiVersion"`
+	Clusters   []struct {
+		Cluster struct {
+			CertificateAuthorityData string `yaml:"certificate-authority-data"`
+			Server                   string `yaml:"server"`
+		} `yaml:"cluster"`
+		Name string `yaml:"name"`
+	} `yaml:"clusters"`
+	Contexts []struct {
+		Context struct {
+			Cluster string `yaml:"cluster"`
+			User    string `yaml:"user"`
+		} `yaml:"context"`
+		Name string `yaml:"name"`
+	} `yaml:"contexts"`
+	CurrentContext string `yaml:"current-context"`
+	Kind           string `yaml:"kind"`
+	Preferences    struct {
+	} `yaml:"preferences"`
+	Users []struct {
+		Name string `yaml:"name"`
+		User struct {
+			Token string `yaml:"token"`
+		} `yaml:"user"`
+	} `yaml:"users"`
+}
+
+func GetRemoteSecret(path string) (*RemoteSecret, error) {
+	secret := &RemoteSecret{}
+	secretFile, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	err = yaml.Unmarshal(secretFile, &secret)
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -5,15 +5,21 @@ import "io/ioutil"
 // Be careful with how you use this token. This is the Kiali Service Account token, not the user token.
 // We need the Service Account token to access third-party in-cluster services (e.g. Grafana).
 
+const DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
 var KialiToken string
 
 func GetKialiToken() (string, error) {
 	if KialiToken == "" {
-		token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
-		if err != nil {
-			return "", err
+		if remoteSecret, err := GetRemoteSecret(RemoteSecretData); err == nil {
+			KialiToken = remoteSecret.Users[0].User.Token
+		} else {
+			token, err := ioutil.ReadFile(DefaultServiceAccountPath)
+			if err != nil {
+				return "", err
+			}
+			KialiToken = string(token)
 		}
-		KialiToken = string(token)
 	}
 	return KialiToken, nil
 }


### PR DESCRIPTION
## Describe the change

This is an experimental change that allows Kiali to fetch resources from a remote API server. Check the ticket for more details
![diagram](https://user-images.githubusercontent.com/6889074/87819080-ad099980-c839-11ea-834b-56eec038ce4d.png)

A few comments:
- I used `CAData` instead of `CAFile` with the TLSClientConfig. Sadly `certutil.NewPool()` only takes a file, so the CA file is not validated. Using `CAFile` would require me to write the CA file to the HOME directory
- There will have to be a Kiali Operator change later on to include only what the individual clusters need. So only include the ClusterRole, ClusterRoleBinding, and ServiceAccount for the Data Plane. Exclude them for the Control Plane and add the volume to the Deployment
- Istio uses `kubeclientset.CoreV1().Secrets(namespace)` to get the remote secrets from the local api server. That'll probably be required for the multi-cluster ticket, but I didn't want to use multiple kube configs for this initial PR. It would also get complicated with `GetKialiToken()`

@israel-hdez @linsun

## Issue reference

#3002 

## Backwards incompatible?

- No, this should not affect the normal use case

## Documentation

Check the README.adoc change
