### PR TITLE
Validations: More than one Virtual Service for same host considers gateways

### DIFF
--- a/business/checkers/virtual_services/single_host_checker.go
+++ b/business/checkers/virtual_services/single_host_checker.go
@@ -92,6 +92,11 @@ func storeHost(hostCounter map[string]map[string]map[string]map[string][]*kubern
 		gwList = []string{"no-gateway"}
 	}
 
+	if !host.CompleteInput {
+		host.Cluster = config.Get().ExternalServices.Istio.IstioIdentityDomain
+		host.Namespace = vs.GetObjectMeta().Namespace
+	}
+
 	for _, gw := range gwList {
 		if hostCounter[gw] == nil {
 			hostCounter[gw] = map[string]map[string]map[string][]*kubernetes.IstioObject{

--- a/business/checkers/virtual_services/single_host_checker.go
+++ b/business/checkers/virtual_services/single_host_checker.go
@@ -15,7 +15,7 @@ type SingleHostChecker struct {
 }
 
 func (s SingleHostChecker) Check() models.IstioValidations {
-	hostCounter := make(map[string]map[string]map[string][]*kubernetes.IstioObject)
+	hostCounter := make(map[string]map[string]map[string]map[string][]*kubernetes.IstioObject)
 	validations := models.IstioValidations{}
 
 	for _, vs := range s.VirtualServices {
@@ -24,34 +24,32 @@ func (s SingleHostChecker) Check() models.IstioValidations {
 		}
 	}
 
-	for _, clusterCounter := range hostCounter {
-		for _, namespaceCounter := range clusterCounter {
-			for _, serviceCounter := range namespaceCounter {
-				isNamespaceWildcard := len(namespaceCounter["*"]) > 0
-				targetSameHost := len(serviceCounter) > 1
-				otherServiceHosts := len(namespaceCounter) > 1
-				for _, virtualService := range serviceCounter {
-					// Marking virtualService as invalid if:
-					// - there is more than one virtual service per a host
-					// - there is one virtual service with wildcard and there are other virtual services pointing
-					//   a host for that namespace
-					if hasGateways(virtualService) {
-						continue
-					}
-
-					if targetSameHost {
-						// Reference everything within serviceCounter
-						multipleVirtualServiceCheck(*virtualService, validations, serviceCounter)
-					}
-
-					if isNamespaceWildcard && otherServiceHosts {
-						// Reference the * or in case of * the other hosts inside namespace
-						// or other stars
-						refs := make([]*kubernetes.IstioObject, 0, len(namespaceCounter))
-						for _, serviceCounter := range namespaceCounter {
-							refs = append(refs, serviceCounter...)
+	for _, gateways := range hostCounter {
+		for _, clusterCounter := range gateways {
+			for _, namespaceCounter := range clusterCounter {
+				for _, serviceCounter := range namespaceCounter {
+					isNamespaceWildcard := len(namespaceCounter["*"]) > 0
+					targetSameHost := len(serviceCounter) > 1
+					otherServiceHosts := len(namespaceCounter) > 1
+					for _, virtualService := range serviceCounter {
+						// Marking virtualService as invalid if:
+						// - there is more than one virtual service per a host
+						// - there is one virtual service with wildcard and there are other virtual services pointing
+						//   a host for that namespace
+						if targetSameHost {
+							// Reference everything within serviceCounter
+							multipleVirtualServiceCheck(*virtualService, validations, serviceCounter)
 						}
-						multipleVirtualServiceCheck(*virtualService, validations, refs)
+
+						if isNamespaceWildcard && otherServiceHosts {
+							// Reference the * or in case of * the other hosts inside namespace
+							// or other stars
+							refs := make([]*kubernetes.IstioObject, 0, len(namespaceCounter))
+							for _, serviceCounter := range namespaceCounter {
+								refs = append(refs, serviceCounter...)
+							}
+							multipleVirtualServiceCheck(*virtualService, validations, refs)
+						}
 					}
 				}
 			}
@@ -86,24 +84,38 @@ func multipleVirtualServiceCheck(virtualService kubernetes.IstioObject, validati
 	validations.MergeValidations(models.IstioValidations{key: rrValidation})
 }
 
-func storeHost(hostCounter map[string]map[string]map[string][]*kubernetes.IstioObject, vs kubernetes.IstioObject, host kubernetes.Host) {
+func storeHost(hostCounter map[string]map[string]map[string]map[string][]*kubernetes.IstioObject, vs kubernetes.IstioObject, host kubernetes.Host) {
 	vsList := []*kubernetes.IstioObject{&vs}
 
-	if hostCounter[host.Cluster] == nil {
-		hostCounter[host.Cluster] = map[string]map[string][]*kubernetes.IstioObject{
-			host.Namespace: {
-				host.Service: vsList,
-			},
-		}
-	} else if hostCounter[host.Cluster][host.Namespace] == nil {
-		hostCounter[host.Cluster][host.Namespace] = map[string][]*kubernetes.IstioObject{
-			host.Service: vsList,
-		}
-	} else if _, ok := hostCounter[host.Cluster][host.Namespace][host.Service]; !ok {
-		hostCounter[host.Cluster][host.Namespace][host.Service] = vsList
-	} else {
-		hostCounter[host.Cluster][host.Namespace][host.Service] = append(hostCounter[host.Cluster][host.Namespace][host.Service], &vs)
+	gwList := getGateways(&vs)
+	if len(gwList) == 0 {
+		gwList = []string{"no-gateway"}
+	}
 
+	for _, gw := range gwList {
+		if hostCounter[gw] == nil {
+			hostCounter[gw] = map[string]map[string]map[string][]*kubernetes.IstioObject{
+				host.Cluster: {
+					host.Namespace: {
+						host.Service: vsList,
+					},
+				},
+			}
+		} else if hostCounter[gw][host.Cluster] == nil {
+			hostCounter[gw][host.Cluster] = map[string]map[string][]*kubernetes.IstioObject{
+				host.Namespace: {
+					host.Service: vsList,
+				},
+			}
+		} else if hostCounter[gw][host.Cluster][host.Namespace] == nil {
+			hostCounter[gw][host.Cluster][host.Namespace] = map[string][]*kubernetes.IstioObject{
+				host.Service: vsList,
+			}
+		} else if _, ok := hostCounter[gw][host.Cluster][host.Namespace][host.Service]; !ok {
+			hostCounter[gw][host.Cluster][host.Namespace][host.Service] = vsList
+		} else {
+			hostCounter[gw][host.Cluster][host.Namespace][host.Service] = append(hostCounter[gw][host.Cluster][host.Namespace][host.Service], &vs)
+		}
 	}
 }
 
@@ -137,10 +149,24 @@ func (s SingleHostChecker) getHosts(virtualService kubernetes.IstioObject) []kub
 	return targetHosts
 }
 
-func hasGateways(virtualService *kubernetes.IstioObject) bool {
-	if gateways, ok := (*virtualService).GetSpec()["gateways"]; ok {
-		vsGateways, ok := (gateways).([]interface{})
-		return ok && vsGateways != nil && len(vsGateways) > 0
+func getGateways(virtualService *kubernetes.IstioObject) []string {
+	gateways := make([]string, 0)
+
+	if gws, ok := (*virtualService).GetSpec()["gateways"]; ok {
+		vsGateways, ok := (gws).([]interface{})
+		if !ok || vsGateways == nil || len(vsGateways) == 0 {
+			return gateways
+		}
+
+		for _, gwRaw := range vsGateways {
+			gw, ok := gwRaw.(string)
+			if !ok {
+				continue
+			}
+
+			gateways = append(gateways, gw)
+		}
 	}
-	return false
+
+	return gateways
 }

--- a/business/checkers/virtual_services/single_host_checker_test.go
+++ b/business/checkers/virtual_services/single_host_checker_test.go
@@ -129,7 +129,7 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 	}.Check()
 
 	noObjectValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
+	noObjectValidationTest(t, validations, "virtual-2")
 
 	vss = []kubernetes.IstioObject{
 		buildVirtualService("virtual-1", "reviews"),
@@ -141,7 +141,7 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
+	noObjectValidationTest(t, validations, "virtual-1")
 	noObjectValidationTest(t, validations, "virtual-2")
 
 	vss = []kubernetes.IstioObject{
@@ -154,9 +154,13 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
-	noObjectValidationTest(t, validations, "virtual-1")
-	noObjectValidationTest(t, validations, "virtual-2")
-	emptyValidationTest(t, validations)
+	refKey := models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-2"}
+	presentValidationTest(t, validations, "virtual-1")
+	presentReference(t, *(validations[refKey]), "virtual-1")
+
+	refKey.Name = "virtual-2"
+	presentValidationTest(t, validations, "virtual-2")
+	presentReference(t, *(validations[refKey]), "virtual-1")
 }
 
 func TestRepeatingSVCNSHost(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/kiali/kiali/issues/1471

This is a validation on Virtual Services. It appears now when both Virtual Services shares the same gateway and same host. In case, the VS doesn't have Gateway, it is compared among other VS without Gateways.

Another scenario has been covered:
1. 2 Destination Rules pointing to the same host. Each DR defines one subset.
2. 1 Virtual Service pointing to one subset.
3. VS has a `no subset found` validation. (the checker only considered one DR pointing to same host).
(user-gateway/admin-gateway should not be presented with this validation)

Testing scenario: https://github.com/xeviknal/istio-lab/blob/master/1471/issue.yaml
Testing scenario with duplicates: https://github.com/xeviknal/istio-lab/blob/master/1471/issue-dups.yaml

Before:
![Screenshot of Kiali Console (34)](https://user-images.githubusercontent.com/613814/89642076-5e3ca600-d8b3-11ea-99e6-6285f54b9700.png)
![Screenshot of Kiali Console (35)](https://user-images.githubusercontent.com/613814/89642143-7d3b3800-d8b3-11ea-8ba8-c951ce470e49.png)
![Screenshot of Kiali Console (36)](https://user-images.githubusercontent.com/613814/89642151-7f9d9200-d8b3-11ea-847a-4339f144abe1.png)

After:
![Screenshot of Kiali Console (33)](https://user-images.githubusercontent.com/613814/89642081-60066980-d8b3-11ea-8a94-b7f9dd9b6f06.png)
