### PR TITLE
Bump go to version 1.14.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" != "push" ]; then snyk test --org=kiali --prune-repeated-subdependencies; fi
 
 go:
-- 1.14.5
+- 1.14.7
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.14.2
+GO_VERSION_KIALI = 1.14.7
 
 SWAGGER_VERSION ?= 0.22.0
 

--- a/deploy/jenkins-ci/Dockerfile
+++ b/deploy/jenkins-ci/Dockerfile
@@ -25,7 +25,7 @@ COPY bin/entrypoint.sh /usr/local/bin/
 
 RUN set -eux; \
     # Install golang \
-    curl -fsSL https://dl.google.com/go/go1.14.linux-amd64.tar.gz -o go.tar.gz; \
+    curl -fsSL https://golang.org/dl/go1.14.7.linux-amd64.tar.gz -o go.tar.gz; \
     tar -C /usr/local -zxf go.tar.gz; \
     rm go.tar.gz; \
     # Add Yarn repository \


### PR DESCRIPTION
Because of a CVE in golang: https://groups.google.com/g/golang-announce/c/NyPIaucMgXo/m/GdsyQP6QAAAJ?pli=1
