### PR TITLE
Add support for cluster API proxies on OpenId strategy

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -50,10 +50,6 @@ func initKialiCache() {
 	}
 }
 
-func GetUnauthenticated() (*Layer, error) {
-	return Get("")
-}
-
 // Get the business.Layer
 func Get(token string) (*Layer, error) {
 	// Kiali Cache will be initialized once at first use of Business layer

--- a/config/config.go
+++ b/config/config.go
@@ -264,6 +264,8 @@ type OpenShiftConfig struct {
 
 // OpenIdConfig contains specific configuration for authentication using an OpenID provider
 type OpenIdConfig struct {
+	ApiProxy              string   `yaml:"api_proxy,omitempty"`
+	ApiProxyCAData        string   `yaml:"api_proxy_ca_data,omitempty"`
 	AuthenticationTimeout int      `yaml:"authentication_timeout,omitempty"`
 	AuthorizationEndpoint string   `yaml:"authorization_endpoint,omitempty"`
 	ClientId              string   `yaml:"client_id,omitempty"`
@@ -326,6 +328,8 @@ func NewConfig() (c *Config) {
 		Auth: AuthConfig{
 			Strategy: "token",
 			OpenId: OpenIdConfig{
+				ApiProxy:              "",
+				ApiProxyCAData:        "",
 				AuthenticationTimeout: 300,
 				AuthorizationEndpoint: "",
 				ClientId:              "",

--- a/kubernetes/secret.go
+++ b/kubernetes/secret.go
@@ -6,16 +6,20 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+type RemoteSecretCluster struct {
+	CertificateAuthorityData string `yaml:"certificate-authority-data"`
+	Server                   string `yaml:"server"`
+}
+
+type RemoteSecretClusterListItem struct {
+	Cluster RemoteSecretCluster `yaml:"cluster"`
+	Name    string              `yaml:"name"`
+}
+
 type RemoteSecret struct {
-	APIVersion string `yaml:"apiVersion"`
-	Clusters   []struct {
-		Cluster struct {
-			CertificateAuthorityData string `yaml:"certificate-authority-data"`
-			Server                   string `yaml:"server"`
-		} `yaml:"cluster"`
-		Name string `yaml:"name"`
-	} `yaml:"clusters"`
-	Contexts []struct {
+	APIVersion string                        `yaml:"apiVersion"`
+	Clusters   []RemoteSecretClusterListItem `yaml:"clusters"`
+	Contexts   []struct {
 		Context struct {
 			Cluster string `yaml:"cluster"`
 			User    string `yaml:"user"`

--- a/models/workload.go
+++ b/models/workload.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"strconv"
+
 	kmodel "github.com/kiali/k-charted/model"
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -11,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
-	"strconv"
 )
 
 type WorkloadList struct {


### PR DESCRIPTION
Since some cloud providers won't support configuring OpenID integration in the managed Kubernetes, users may want to use workarounds. One of them is to place a proxy in front of the Kubernetes API handing the OpenID auth (an example is kube-oidc-proxy).

This is adding support for such API proxies.

Fixes kiali/kiali#3042