### PR TITLE
Update Cache with potential perf scenarios

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -195,7 +195,7 @@ func fetchNamespaceApps(layer *Layer, namespace string, appName string) (namespa
 		defer wg.Done()
 		var err error
 		// Check if namespace is cached
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			services, err = kialiCache.GetServices(namespace, nil)
 		} else {
 			services, err = layer.k8s.GetServices(namespace, nil)

--- a/business/health.go
+++ b/business/health.go
@@ -174,7 +174,7 @@ func (in *HealthService) GetNamespaceServiceHealth(namespace, rateInterval strin
 	}
 
 	// Check if namespace is cached
-	if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+	if IsNamespaceCached(namespace) {
 		services, err = kialiCache.GetServices(namespace, nil)
 	} else {
 		services, err = in.k8s.GetServices(namespace, nil)

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -126,7 +126,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 			var gg []kubernetes.IstioObject
 			var ggErr error
 			// Check if namespace is cached
-			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.Gateways) && kialiCache.CheckNamespace(criteria.Namespace) {
+			if IsResourceCached(criteria.Namespace, kubernetes.Gateways) {
 				gg, ggErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.Gateways, criteria.LabelSelector)
 			} else {
 				gg, ggErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.Gateways, criteria.LabelSelector)
@@ -145,7 +145,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 			var vs []kubernetes.IstioObject
 			var vsErr error
 			// Check if namespace is cached
-			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.VirtualServices) && kialiCache.CheckNamespace(criteria.Namespace) {
+			if IsResourceCached(criteria.Namespace, kubernetes.VirtualServices) {
 				vs, vsErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.VirtualServices, criteria.LabelSelector)
 			} else {
 				vs, vsErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.VirtualServices, criteria.LabelSelector)
@@ -164,7 +164,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 			var dr []kubernetes.IstioObject
 			var drErr error
 			// Check if namespace is cached
-			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.DestinationRules) && kialiCache.CheckNamespace(criteria.Namespace) {
+			if IsResourceCached(criteria.Namespace, kubernetes.DestinationRules) {
 				dr, drErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.DestinationRules, criteria.LabelSelector)
 			} else {
 				dr, drErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.DestinationRules, criteria.LabelSelector)
@@ -183,7 +183,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 			var se []kubernetes.IstioObject
 			var seErr error
 			// Check if namespace is cached
-			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.ServiceEntries) && kialiCache.CheckNamespace(criteria.Namespace) {
+			if IsResourceCached(criteria.Namespace, kubernetes.ServiceEntries) {
 				se, seErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.ServiceEntries, criteria.LabelSelector)
 			} else {
 				se, seErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.ServiceEntries, criteria.LabelSelector)
@@ -330,7 +330,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 		if criteria.IncludeAuthorizationPolicies {
 			var ap []kubernetes.IstioObject
 			var apErr error
-			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.AuthorizationPolicies) && kialiCache.CheckNamespace(criteria.Namespace) {
+			if IsResourceCached(criteria.Namespace, kubernetes.AuthorizationPolicies) {
 				ap, apErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.AuthorizationPolicies, criteria.LabelSelector)
 			} else {
 				ap, apErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.AuthorizationPolicies, criteria.LabelSelector)
@@ -348,7 +348,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 		if criteria.IncludePeerAuthentication {
 			var pa []kubernetes.IstioObject
 			var paErr error
-			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.PeerAuthentications) && kialiCache.CheckNamespace(criteria.Namespace) {
+			if IsResourceCached(criteria.Namespace, kubernetes.PeerAuthentications) {
 				pa, paErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.PeerAuthentications, criteria.LabelSelector)
 			} else {
 				pa, paErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.PeerAuthentications, criteria.LabelSelector)
@@ -366,7 +366,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 		if criteria.IncludeSidecars {
 			var sc []kubernetes.IstioObject
 			var scErr error
-			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.Sidecars) && kialiCache.CheckNamespace(criteria.Namespace) {
+			if IsResourceCached(criteria.Namespace, kubernetes.Sidecars) {
 				sc, scErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.Sidecars, criteria.LabelSelector)
 			} else {
 				sc, scErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.Sidecars, criteria.LabelSelector)
@@ -441,7 +441,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 		if criteria.IncludeRequestAuthentications {
 			var ra []kubernetes.IstioObject
 			var raErr error
-			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.RequestAuthentications) && kialiCache.CheckNamespace(criteria.Namespace) {
+			if IsResourceCached(criteria.Namespace, kubernetes.RequestAuthentications) {
 				ra, raErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.RequestAuthentications, criteria.LabelSelector)
 			} else {
 				ra, raErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.RequestAuthentications, criteria.LabelSelector)

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -328,7 +328,14 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeAuthorizationPolicies {
-			if ap, apErr := in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.AuthorizationPolicies, criteria.LabelSelector); apErr == nil {
+			var ap []kubernetes.IstioObject
+			var apErr error
+			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.AuthorizationPolicies) && kialiCache.CheckNamespace(criteria.Namespace) {
+				ap, apErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.AuthorizationPolicies, criteria.LabelSelector)
+			} else {
+				ap, apErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.AuthorizationPolicies, criteria.LabelSelector)
+			}
+			if apErr == nil {
 				(&istioConfigList.AuthorizationPolicies).Parse(ap)
 			} else {
 				errChan <- apErr
@@ -339,7 +346,14 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludePeerAuthentication {
-			if pa, paErr := in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.PeerAuthentications, criteria.LabelSelector); paErr == nil {
+			var pa []kubernetes.IstioObject
+			var paErr error
+			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.PeerAuthentications) && kialiCache.CheckNamespace(criteria.Namespace) {
+				pa, paErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.PeerAuthentications, criteria.LabelSelector)
+			} else {
+				pa, paErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.PeerAuthentications, criteria.LabelSelector)
+			}
+			if paErr == nil {
 				(&istioConfigList.PeerAuthentications).Parse(pa)
 			} else {
 				errChan <- paErr
@@ -350,7 +364,14 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeSidecars {
-			if sc, scErr := in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.Sidecars, criteria.LabelSelector); scErr == nil {
+			var sc []kubernetes.IstioObject
+			var scErr error
+			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.Sidecars) && kialiCache.CheckNamespace(criteria.Namespace) {
+				sc, scErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.Sidecars, criteria.LabelSelector)
+			} else {
+				sc, scErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.Sidecars, criteria.LabelSelector)
+			}
+			if scErr == nil {
 				(&istioConfigList.Sidecars).Parse(sc)
 			} else {
 				errChan <- scErr
@@ -418,7 +439,14 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.IncludeRequestAuthentications {
-			if ra, raErr := in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.RequestAuthentications, criteria.LabelSelector); raErr == nil {
+			var ra []kubernetes.IstioObject
+			var raErr error
+			if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.RequestAuthentications) && kialiCache.CheckNamespace(criteria.Namespace) {
+				ra, raErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.RequestAuthentications, criteria.LabelSelector)
+			} else {
+				ra, raErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.RequestAuthentications, criteria.LabelSelector)
+			}
+			if raErr == nil {
 				(&istioConfigList.RequestAuthentications).Parse(ra)
 			} else {
 				errChan <- raErr

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -80,7 +80,7 @@ func (iss *IstioStatusService) getComponentNamespacesWorkloads() ([]apps_v1.Depl
 				defer wg.Done()
 				var ds []apps_v1.Deployment
 				var err error
-				if kialiCache != nil && kialiCache.CheckNamespace(n) {
+				if IsNamespaceCached(n) {
 					ds, err = kialiCache.GetDeployments(n)
 				} else {
 					// Adding a warning to enable cache for fetching Istio Status.

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -563,6 +563,10 @@ func (in *IstioValidationsService) fetchNonLocalmTLSConfigs(mtlsDetails *kuberne
 		} else {
 			istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, kubernetes.IstioConfigMapName)
 		}
+		if err != nil {
+			errChan <- err
+			return
+		}
 		icm, err := kubernetes.GetIstioConfigMap(istioConfig)
 		if err != nil {
 			errChan <- err

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -65,7 +65,7 @@ func mockWorkLoadService(k8s *kubetest.K8SClientMock) WorkloadService {
 	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
 	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakePods().Items, nil)
-	k8s.On("GetIstioConfigMap").Return(&kubernetes.IstioMeshConfig{}, nil)
+	k8s.On("GetConfigMap", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.ConfigMap{}, nil)
 
 	svc := setupWorkloadService(k8s)
 	return svc
@@ -87,7 +87,10 @@ func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 	k8s.On("GetMeshPolicies", mock.AnythingOfType("string")).Return(fakeMeshPolicies(), nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "peerauthentications", "").Return(fakePolicies(), nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "requestauthentications", "").Return([]kubernetes.IstioObject{}, nil)
-	k8s.On("GetAuthorizationDetails", mock.AnythingOfType("string")).Return(&kubernetes.RBACDetails{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "clusterrbacconfigs", "").Return([]kubernetes.IstioObject{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "authorizationpolicies", "").Return([]kubernetes.IstioObject{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "servicerolebindings", "").Return([]kubernetes.IstioObject{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "serviceroles", "").Return([]kubernetes.IstioObject{}, nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "virtualservices", "").Return(fakeCombinedIstioDetails().VirtualServices, nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "serviceentries", "").Return(fakeCombinedIstioDetails().ServiceEntries, nil)
 
@@ -102,7 +105,10 @@ func mockCombinedValidationService(istioObjects *kubernetes.IstioDetails, servic
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDepSyncedWithRS(), nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "virtualservices", "").Return(fakeCombinedIstioDetails().VirtualServices, nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "destinationrules", "").Return(fakeCombinedIstioDetails().DestinationRules, nil)
-	k8s.On("GetAuthorizationDetails", mock.AnythingOfType("string")).Return(&kubernetes.RBACDetails{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "authorizationpolicies", "").Return([]kubernetes.IstioObject{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "clusterrbacconfigs", "").Return([]kubernetes.IstioObject{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "servicerolebindings", "").Return([]kubernetes.IstioObject{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "serviceroles", "").Return([]kubernetes.IstioObject{}, nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "serviceentries", "").Return(fakeCombinedIstioDetails().ServiceEntries, nil)
 	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "gateways", "").Return(fakeCombinedIstioDetails().Gateways, nil)
 	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(kubetest.FakeNamespace("test"), nil)

--- a/business/iter8.go
+++ b/business/iter8.go
@@ -35,7 +35,7 @@ func (in *Iter8Service) GetIter8Info() models.Iter8Info {
 
 	// It will be considered enabled if the extension is present in the Kiali configuration and the CRD is enabled on the cluster
 	if conf.Extensions.Iter8.Enabled && in.k8s.IsIter8Api() {
-		if kialiCache != nil && kialiCache.CheckNamespace(conf.Extensions.Iter8.Namespace) {
+		if IsNamespaceCached(conf.Extensions.Iter8.Namespace) {
 			ps, err = kialiCache.GetPods(conf.Extensions.Iter8.Namespace, "")
 		} else {
 			ps, err = in.k8s.GetPods(conf.Extensions.Iter8.Namespace, "")

--- a/business/layer.go
+++ b/business/layer.go
@@ -50,6 +50,19 @@ func initKialiCache() {
 	}
 }
 
+func IsNamespaceCached(namespace string) bool {
+	ok := kialiCache != nil && kialiCache.CheckNamespace(namespace)
+	return ok
+}
+
+func IsResourceCached(namespace string, resource string) bool {
+	ok := IsNamespaceCached(namespace)
+	if ok && resource != "" {
+		ok = kialiCache.CheckIstioResource(resource)
+	}
+	return ok
+}
+
 func GetUnauthenticated() (*Layer, error) {
 	return Get("")
 }

--- a/business/services.go
+++ b/business/services.go
@@ -50,7 +50,7 @@ func (in *SvcService) GetServiceList(namespace string) (*models.ServiceList, err
 		var err2 error
 		// Check if namespace is cached
 		// Namespace access is checked in the upper call
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			svcs, err2 = kialiCache.GetServices(namespace, nil)
 		} else {
 			svcs, err2 = in.k8s.GetServices(namespace, nil)
@@ -66,7 +66,7 @@ func (in *SvcService) GetServiceList(namespace string) (*models.ServiceList, err
 		var err2 error
 		// Check if namespace is cached
 		// Namespace access is checked in the upper call
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			pods, err2 = kialiCache.GetPods(namespace, "")
 		} else {
 			pods, err2 = in.k8s.GetPods(namespace, "")
@@ -82,7 +82,7 @@ func (in *SvcService) GetServiceList(namespace string) (*models.ServiceList, err
 		var err error
 		// Check if namespace is cached
 		// Namespace access is checked in the upper call
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			deployments, err = kialiCache.GetDeployments(namespace)
 		} else {
 			deployments, err = in.k8s.GetDeployments(namespace)
@@ -169,7 +169,7 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 			var err2 error
 			// Check if namespace is cached
 			// Namespace access is checked in the upper caller
-			if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+			if IsNamespaceCached(namespace) {
 				pods, err2 = kialiCache.GetPods(namespace, labelsSelector)
 			} else {
 				pods, err2 = in.k8s.GetPods(namespace, labelsSelector)
@@ -213,7 +213,7 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 		var err2 error
 		// Check if namespace is cached
 		// Namespace access is checked in the upper caller
-		if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.VirtualServices) && kialiCache.CheckNamespace(namespace) {
+		if IsResourceCached(namespace, kubernetes.VirtualServices) {
 			vs, err2 = kialiCache.GetIstioObjects(namespace, kubernetes.VirtualServices, "")
 		} else {
 			vs, err2 = in.k8s.GetIstioObjects(namespace, kubernetes.VirtualServices, "")
@@ -228,7 +228,7 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 	go func() {
 		defer wg.Done()
 		var err2 error
-		if kialiCache != nil && kialiCache.CheckIstioResource(kubernetes.DestinationRules) && kialiCache.CheckNamespace(namespace) {
+		if IsResourceCached(namespace, kubernetes.DestinationRules) {
 			dr, err2 = kialiCache.GetIstioObjects(namespace, kubernetes.DestinationRules, "")
 		} else {
 			dr, err2 = in.k8s.GetIstioObjects(namespace, kubernetes.DestinationRules, "")
@@ -339,7 +339,7 @@ func (in *SvcService) GetServiceDefinitionList(namespace string) (*models.Servic
 
 	var svcs []core_v1.Service
 	// Check if namespace is cached
-	if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+	if IsNamespaceCached(namespace) {
 		svcs, err = kialiCache.GetServices(namespace, nil)
 	} else {
 		svcs, err = in.k8s.GetServices(namespace, nil)

--- a/business/tls.go
+++ b/business/tls.go
@@ -57,6 +57,9 @@ func (in *TLSService) getMeshPeerAuthentications() ([]kubernetes.IstioObject, er
 		} else {
 			mps, err = in.k8s.GetIstioObjects(controlPlaneNs, kubernetes.PeerAuthentications, "")
 		}
+		if err != nil {
+			return mps, err
+		}
 	} else {
 		// ServiceMeshPolicies are namespace scoped.
 		// And Maistra will only consider resources under control-plane namespace

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -272,7 +272,11 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		defer wg.Done()
 		var err error
 		if isWorkloadIncluded(kubernetes.StatefulSetType) {
-			fulset, err = layer.k8s.GetStatefulSets(namespace)
+			if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+				fulset, err = kialiCache.GetStatefulSets(namespace)
+			} else {
+				fulset, err = layer.k8s.GetStatefulSets(namespace)
+			}
 			if err != nil {
 				log.Errorf("Error fetching StatefulSets per namespace %s: %s", namespace, err)
 				errChan <- err
@@ -780,7 +784,11 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		}
 		var err error
 		if isWorkloadIncluded(kubernetes.StatefulSetType) {
-			fulset, err = layer.k8s.GetStatefulSet(namespace, workloadName)
+			if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+				fulset, err = kialiCache.GetStatefulSet(namespace, workloadName)
+			} else {
+				fulset, err = layer.k8s.GetStatefulSet(namespace, workloadName)
+			}
 			if err != nil {
 				fulset = nil
 			}

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -92,7 +92,7 @@ func (in *WorkloadService) GetWorkload(namespace string, workloadName string, wo
 		var services []core_v1.Service
 		var err error
 		// Check if namespace is cached
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			// Cache uses Kiali ServiceAccount, check if user can access to the namespace
 			if _, err = in.businessLayer.Namespace.GetNamespace(namespace); err == nil {
 				services, err = kialiCache.GetServices(namespace, workload.Labels)
@@ -139,7 +139,7 @@ func (in *WorkloadService) GetPods(namespace string, labelSelector string) (mode
 
 	var ps []core_v1.Pod
 	// Check if namespace is cached
-	if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+	if IsNamespaceCached(namespace) {
 		// Cache uses Kiali ServiceAccount, check if user can access to the namespace
 		if _, err = in.businessLayer.Namespace.GetNamespace(namespace); err == nil {
 			ps, err = kialiCache.GetPods(namespace, labelSelector)
@@ -201,7 +201,7 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		var err error
 		// Check if namespace is cached
 		// Namespace access is checked in the upper caller
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			pods, err = kialiCache.GetPods(namespace, labelSelector)
 		} else {
 			pods, err = layer.k8s.GetPods(namespace, labelSelector)
@@ -217,7 +217,7 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		var err error
 		// Check if namespace is cached
 		// Namespace access is checked in the upper caller
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			dep, err = kialiCache.GetDeployments(namespace)
 		} else {
 			dep, err = layer.k8s.GetDeployments(namespace)
@@ -233,7 +233,7 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		var err error
 		// Check if namespace is cached
 		// Namespace access is checked in the upper caller
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			repset, err = kialiCache.GetReplicaSets(namespace)
 		} else {
 			repset, err = layer.k8s.GetReplicaSets(namespace)
@@ -272,7 +272,7 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		defer wg.Done()
 		var err error
 		if isWorkloadIncluded(kubernetes.StatefulSetType) {
-			if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+			if IsNamespaceCached(namespace) {
 				fulset, err = kialiCache.GetStatefulSets(namespace)
 			} else {
 				fulset, err = layer.k8s.GetStatefulSets(namespace)
@@ -690,7 +690,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		var err error
 		// Check if namespace is cached
 		// Namespace access is checked in the upper call
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			pods, err = kialiCache.GetPods(namespace, "")
 		} else {
 			pods, err = layer.k8s.GetPods(namespace, "")
@@ -710,7 +710,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		}
 		// Check if namespace is cached
 		// Namespace access is checked in the upper call
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			dep, err = kialiCache.GetDeployment(namespace, workloadName)
 		} else {
 			dep, err = layer.k8s.GetDeployment(namespace, workloadName)
@@ -734,7 +734,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		var err error
 		// Check if namespace is cached
 		// Namespace access is checked in the upper call
-		if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+		if IsNamespaceCached(namespace) {
 			repset, err = kialiCache.GetReplicaSets(namespace)
 		} else {
 			repset, err = layer.k8s.GetReplicaSets(namespace)
@@ -784,7 +784,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		}
 		var err error
 		if isWorkloadIncluded(kubernetes.StatefulSetType) {
-			if kialiCache != nil && kialiCache.CheckNamespace(namespace) {
+			if IsNamespaceCached(namespace) {
 				fulset, err = kialiCache.GetStatefulSet(namespace, workloadName)
 			} else {
 				fulset, err = layer.k8s.GetStatefulSet(namespace, workloadName)

--- a/config/config.go
+++ b/config/config.go
@@ -426,7 +426,7 @@ func NewConfig() (c *Config) {
 			Burst:                       200,
 			CacheDuration:               5 * 60,
 			CacheEnabled:                true,
-			CacheIstioTypes:             []string{"DestinationRule", "Gateway", "ServiceEntry", "VirtualService"},
+			CacheIstioTypes:             []string{"DestinationRule", "Gateway", "ServiceEntry", "VirtualService", "Sidecar", "PeerAuthentication", "RequestAuthentication", "AuthorizationPolicy"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -50,6 +50,7 @@ type (
 		istioClient            kubernetes.K8SClient
 		k8sApi                 kube.Interface
 		istioNetworkingGetter  cache.Getter
+		istioSecurityGetter    cache.Getter
 		refreshDuration        time.Duration
 		cacheNamespaces        []string
 		cacheIstioTypes        map[string]bool
@@ -122,6 +123,7 @@ func NewKialiCache() (KialiCache, error) {
 
 	kialiCacheImpl.k8sApi = istioClient.GetK8sApi()
 	kialiCacheImpl.istioNetworkingGetter = istioClient.GetIstioNetworkingApi()
+	kialiCacheImpl.istioSecurityGetter = istioClient.GetIstioSecurityApi()
 
 	log.Infof("Kiali Cache is active for namespaces %v", cacheNamespaces)
 	return &kialiCacheImpl, nil

--- a/kubernetes/cache/istio.go
+++ b/kubernetes/cache/istio.go
@@ -39,6 +39,18 @@ func (c *kialiCacheImpl) createIstioInformers(namespace string, informer *typeCa
 	if c.CheckIstioResource(kubernetes.ServiceEntries) {
 		(*informer)[kubernetes.ServiceEntries] = createIstioIndexInformer(c.istioNetworkingGetter, kubernetes.ServiceEntries, c.refreshDuration, namespace)
 	}
+	if c.CheckIstioResource(kubernetes.Sidecars) {
+		(*informer)[kubernetes.Sidecars] = createIstioIndexInformer(c.istioNetworkingGetter, kubernetes.Sidecars, c.refreshDuration, namespace)
+	}
+	if c.CheckIstioResource(kubernetes.PeerAuthentications) {
+		(*informer)[kubernetes.PeerAuthentications] = createIstioIndexInformer(c.istioSecurityGetter, kubernetes.PeerAuthentications, c.refreshDuration, namespace)
+	}
+	if c.CheckIstioResource(kubernetes.RequestAuthentications) {
+		(*informer)[kubernetes.RequestAuthentications] = createIstioIndexInformer(c.istioSecurityGetter, kubernetes.RequestAuthentications, c.refreshDuration, namespace)
+	}
+	if c.CheckIstioResource(kubernetes.AuthorizationPolicies) {
+		(*informer)[kubernetes.AuthorizationPolicies] = createIstioIndexInformer(c.istioSecurityGetter, kubernetes.AuthorizationPolicies, c.refreshDuration, namespace)
+	}
 }
 
 func (c *kialiCacheImpl) isIstioSynced(namespace string) bool {
@@ -47,7 +59,11 @@ func (c *kialiCacheImpl) isIstioSynced(namespace string) bool {
 		isSynced = nsCache[kubernetes.VirtualServices].HasSynced() &&
 			nsCache[kubernetes.DestinationRules].HasSynced() &&
 			nsCache[kubernetes.Gateways].HasSynced() &&
-			nsCache[kubernetes.ServiceEntries].HasSynced()
+			nsCache[kubernetes.ServiceEntries].HasSynced() &&
+			nsCache[kubernetes.Sidecars].HasSynced() &&
+			nsCache[kubernetes.PeerAuthentications].HasSynced() &&
+			nsCache[kubernetes.RequestAuthentications].HasSynced() &&
+			nsCache[kubernetes.AuthorizationPolicies].HasSynced()
 	} else {
 		isSynced = false
 	}

--- a/kubernetes/cache/istio.go
+++ b/kubernetes/cache/istio.go
@@ -56,14 +56,31 @@ func (c *kialiCacheImpl) createIstioInformers(namespace string, informer *typeCa
 func (c *kialiCacheImpl) isIstioSynced(namespace string) bool {
 	var isSynced bool
 	if nsCache, exist := c.nsCache[namespace]; exist {
-		isSynced = nsCache[kubernetes.VirtualServices].HasSynced() &&
-			nsCache[kubernetes.DestinationRules].HasSynced() &&
-			nsCache[kubernetes.Gateways].HasSynced() &&
-			nsCache[kubernetes.ServiceEntries].HasSynced() &&
-			nsCache[kubernetes.Sidecars].HasSynced() &&
-			nsCache[kubernetes.PeerAuthentications].HasSynced() &&
-			nsCache[kubernetes.RequestAuthentications].HasSynced() &&
-			nsCache[kubernetes.AuthorizationPolicies].HasSynced()
+		isSynced = true
+		if c.CheckIstioResource(kubernetes.VirtualServices) {
+			isSynced = isSynced && nsCache[kubernetes.VirtualServices].HasSynced()
+		}
+		if c.CheckIstioResource(kubernetes.DestinationRules) {
+			isSynced = isSynced && nsCache[kubernetes.DestinationRules].HasSynced()
+		}
+		if c.CheckIstioResource(kubernetes.Gateways) {
+			isSynced = isSynced && nsCache[kubernetes.Gateways].HasSynced()
+		}
+		if c.CheckIstioResource(kubernetes.ServiceEntries) {
+			isSynced = isSynced && nsCache[kubernetes.ServiceEntries].HasSynced()
+		}
+		if c.CheckIstioResource(kubernetes.Sidecars) {
+			isSynced = isSynced && nsCache[kubernetes.Sidecars].HasSynced()
+		}
+		if c.CheckIstioResource(kubernetes.PeerAuthentications) {
+			isSynced = isSynced && nsCache[kubernetes.PeerAuthentications].HasSynced()
+		}
+		if c.CheckIstioResource(kubernetes.RequestAuthentications) {
+			isSynced = isSynced && nsCache[kubernetes.RequestAuthentications].HasSynced()
+		}
+		if c.CheckIstioResource(kubernetes.AuthorizationPolicies) {
+			isSynced = isSynced && nsCache[kubernetes.AuthorizationPolicies].HasSynced()
+		}
 	} else {
 		isSynced = false
 	}

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -40,7 +40,6 @@ type PodLogs struct {
 }
 
 type IstioClientInterface interface {
-	GetAuthorizationDetails(namespace string) (*RBACDetails, error)
 	CreateIstioObject(api, namespace, resourceType, json string) (IstioObject, error)
 	DeleteIstioObject(api, namespace, resourceType, name string) error
 	GetIstioObject(namespace, resourceType, name string) (IstioObject, error)
@@ -85,7 +84,6 @@ type OSClientInterface interface {
 type ClientInterface interface {
 	GetServerVersion() (*version.Info, error)
 	GetToken() string
-	GetIstioConfigMap() (*IstioMeshConfig, error)
 	IsMaistraApi() bool
 	IsOpenShift() bool
 	IsMixerDisabled() bool

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
 	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"sync"
-
 	"gopkg.in/yaml.v2"
+	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,7 +19,7 @@ import (
 var (
 	portNameMatcher    = regexp.MustCompile(`^[\-].*`)
 	portProtocols      = [...]string{"grpc", "http", "http2", "https", "mongo", "redis", "tcp", "tls", "udp", "mysql"}
-	istioConfigmapName = "istio"
+	IstioConfigMapName = "istio"
 )
 
 // Aux method to fetch proper (RESTClient, APIVersion) per API group
@@ -351,86 +350,21 @@ func (in *K8SClient) getAuthenticationResources() map[string]bool {
 	return *in.authenticationResources
 }
 
-// GetAuthorizationDetails returns ServiceRoles, ServiceRoleBindings and ClusterRbacDetails
-func (in *K8SClient) GetAuthorizationDetails(namespace string) (*RBACDetails, error) {
-	rb := &RBACDetails{}
-
-	errChan := make(chan error, 1)
-	var wg sync.WaitGroup
-	wg.Add(4)
-
-	go func(errChan chan error) {
-		defer wg.Done()
-		if aps, err := in.GetIstioObjects(namespace, AuthorizationPolicies, ""); err == nil {
-			rb.AuthorizationPolicies = aps
-		} else {
-			errChan <- err
-		}
-	}(errChan)
-
-	go func(errChan chan error) {
-		defer wg.Done()
-		if srb, err := in.GetIstioObjects(namespace, ServiceRoleBindings, ""); err == nil {
-			rb.ServiceRoleBindings = srb
-		} else {
-			errChan <- err
-		}
-	}(errChan)
-
-	go func(errChan chan error) {
-		defer wg.Done()
-		if sr, err := in.GetIstioObjects(namespace, ServiceRoles, ""); err == nil {
-			rb.ServiceRoles = sr
-		} else {
-			errChan <- err
-		}
-	}(errChan)
-
-	go func(errChan chan error) {
-		defer wg.Done()
-		// Maistra has migrated ClusterRbacConfigs to ServiceMeshRbacConfigs resources
-		if !in.IsMaistraApi() {
-			if crc, err := in.GetIstioObjects("", ClusterRbacConfigs, ""); err == nil {
-				rb.ClusterRbacConfigs = crc
-			} else {
-				errChan <- err
-			}
-		} else {
-			if smrc, err := in.GetIstioObjects(namespace, ServiceMeshRbacConfigs, ""); err == nil {
-				rb.ServiceMeshRbacConfigs = smrc
-			} else {
-				errChan <- err
-			}
-		}
-	}(errChan)
-
-	wg.Wait()
-	close(errChan)
-
-	for e := range errChan {
-		if e != nil { // Check that default value wasn't returned
-			return rb, e
-		}
-	}
-
-	return rb, nil
-}
-
-func (in *K8SClient) GetIstioConfigMap() (*IstioMeshConfig, error) {
+func GetIstioConfigMap(istioConfig *core_v1.ConfigMap) (*IstioMeshConfig, error) {
 	meshConfig := &IstioMeshConfig{}
 
-	cfg := config.Get()
-	istioConfig, err := in.GetConfigMap(cfg.IstioNamespace, istioConfigmapName)
-	if err != nil {
-		log.Warningf("GetIstioConfigMap: Cannot retrieve Istio ConfigMap.")
-		return nil, err
+	// Used for test cases
+	if istioConfig == nil || istioConfig.Data == nil {
+		return meshConfig, nil
 	}
 
+	var err error
 	meshConfigYaml, ok := istioConfig.Data["mesh"]
 	log.Tracef("meshConfig: %v", meshConfigYaml)
 	if !ok {
-		log.Warningf("GetIstioConfigMap: Cannot find Istio mesh configuration.")
-		return nil, err
+		errMsg := "GetIstioConfigMap: Cannot find Istio mesh configuration [%v]."
+		log.Warningf(errMsg, istioConfig)
+		return nil, fmt.Errorf(errMsg, istioConfig)
 	}
 
 	err = yaml.Unmarshal([]byte(meshConfigYaml), &meshConfig)
@@ -447,7 +381,13 @@ func (in *K8SClient) IsMixerDisabled() bool {
 		return *in.isMixerDisabled
 	}
 
-	meshConfig, err := in.GetIstioConfigMap()
+	cfg := config.Get()
+	istioConfig, err := in.GetConfigMap(cfg.IstioNamespace, IstioConfigMapName)
+	if err != nil {
+		log.Warningf("GetIstioConfigMap: Cannot retrieve Istio ConfigMap.")
+		return false
+	}
+	meshConfig, err := GetIstioConfigMap(istioConfig)
 	if err != nil {
 		log.Warningf("IsMixerDisabled: Cannot read Istio mesh configuration.")
 		return true

--- a/kubernetes/kubetest/mock_istio.go
+++ b/kubernetes/kubetest/mock_istio.go
@@ -1,6 +1,8 @@
 package kubetest
 
-import "github.com/kiali/kiali/kubernetes"
+import (
+	"github.com/kiali/kiali/kubernetes"
+)
 
 func (o *K8SClientMock) CreateIstioObject(api, namespace, resourceType, json string) (kubernetes.IstioObject, error) {
 	args := o.Called(api, namespace, resourceType, json)
@@ -10,16 +12,6 @@ func (o *K8SClientMock) CreateIstioObject(api, namespace, resourceType, json str
 func (o *K8SClientMock) DeleteIstioObject(api, namespace, objectType, objectName string) error {
 	args := o.Called(api, namespace, objectType, objectName)
 	return args.Error(0)
-}
-
-func (o *K8SClientMock) GetAuthorizationDetails(namespace string) (*kubernetes.RBACDetails, error) {
-	args := o.Called(namespace)
-	return args.Get(0).(*kubernetes.RBACDetails), args.Error(1)
-}
-
-func (o *K8SClientMock) GetIstioConfigMap() (*kubernetes.IstioMeshConfig, error) {
-	args := o.Called()
-	return args.Get(0).(*kubernetes.IstioMeshConfig), args.Error(1)
 }
 
 func (o *K8SClientMock) GetIstioObject(namespace string, resourceType string, object string) (kubernetes.IstioObject, error) {

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	// Kubernetes Controllers
+	ConfigMapType             = "ConfigMap"
 	CronJobType               = "CronJob"
 	DeploymentType            = "Deployment"
 	DeploymentConfigType      = "DeploymentConfig"


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3147

Added to the cache:
- StatefulSets
- ConfigMaps
- Istio: Sidecar, PeerAuthentication, RequestAuthentication, AuthorizationPolicy

All of them used for common operations of tls, istio status and validations.

Refactor some logic placed on kubernetes package that makes sense to use it in the business package.

It requires a followup to update operator defaults.

@hhovsepy main testing of this PR is to validate there is no regression or any obvious perf penalty.
Otherwise it should be transparent from feature perspective.