### PR TITLE
Traces workload matching, use "hostname" as well

### DIFF
--- a/jaeger/traces.go
+++ b/jaeger/traces.go
@@ -76,6 +76,18 @@ func matchesWorkload(trace jaegerModels.Trace, namespace, workload string) bool 
 				}
 			}
 		}
+		if process, ok := trace.Processes[span.ProcessID]; ok {
+			// Tag not found => try with 'hostname' in process' tags
+			for _, tag := range process.Tags {
+				if tag.Key == "hostname" {
+					if v, ok := tag.Value.(string); ok {
+						if strings.HasPrefix(v, workload) {
+							return true
+						}
+					}
+				}
+			}
+		}
 	}
 	return false
 }

--- a/jaeger/traces_test.go
+++ b/jaeger/traces_test.go
@@ -1,0 +1,52 @@
+package jaeger
+
+import (
+	"testing"
+
+	jaegerModels "github.com/jaegertracing/jaeger/model/json"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchingWorkload(t *testing.T) {
+	assert := assert.New(t)
+
+	trace := jaegerModels.Trace{
+		Spans: []jaegerModels.Span{{
+			ProcessID: "process_1",
+			Tags: []jaegerModels.KeyValue{{
+				Key:   "dummy",
+				Value: "dummy",
+			}, {
+				Key:   "node_id",
+				Value: "sidecar~172.17.0.20~reviews-6d8996bff-ztg6z.default~default.svc.cluster.local",
+			}},
+		}, {
+			ProcessID: "process_2",
+			Tags: []jaegerModels.KeyValue{{
+				Key:   "dummy",
+				Value: "dummy",
+			}},
+		}},
+		Processes: map[jaegerModels.ProcessID]jaegerModels.Process{
+			"process_1": {
+				Tags: []jaegerModels.KeyValue{{
+					Key:   "dummy",
+					Value: "dummy",
+				}},
+			},
+			"process_2": {
+				Tags: []jaegerModels.KeyValue{{
+					Key:   "dummy",
+					Value: "dummy",
+				}, {
+					Key:   "hostname",
+					Value: "my-pod-123456-789abc",
+				}},
+			},
+		},
+	}
+
+	assert.False(matchesWorkload(trace, "default", "some-workload"))
+	assert.True(matchesWorkload(trace, "default", "reviews"))
+	assert.True(matchesWorkload(trace, "default", "my-pod"))
+}


### PR DESCRIPTION
This works in general for non-envoy spans.

Related frontend PR: https://github.com/kiali/kiali-ui/pull/1914