### PR TITLE
Adding Status field into Istio Objects

### DIFF
--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -488,6 +488,8 @@ type IstioObject interface {
 	runtime.Object
 	GetSpec() map[string]interface{}
 	SetSpec(map[string]interface{})
+	GetStatus() map[string]interface{}
+	SetStatus(map[string]interface{})
 	GetTypeMeta() meta_v1.TypeMeta
 	SetTypeMeta(meta_v1.TypeMeta)
 	GetObjectMeta() meta_v1.ObjectMeta
@@ -560,6 +562,7 @@ type GenericIstioObject struct {
 	meta_v1.TypeMeta   `json:",inline" yaml:",inline"`
 	meta_v1.ObjectMeta `json:"metadata" yaml:"metadata"`
 	Spec               map[string]interface{} `json:"spec"`
+	Status             map[string]interface{} `json:"status"`
 }
 
 // GenericIstioObjectList is the generic Kubernetes API list wrapper
@@ -597,6 +600,16 @@ func (in *GenericIstioObject) GetObjectMeta() meta_v1.ObjectMeta {
 // SetObjectMeta for a wrapper
 func (in *GenericIstioObject) SetObjectMeta(metadata meta_v1.ObjectMeta) {
 	in.ObjectMeta = metadata
+}
+
+// GetStatus from a wrapper
+func (in *GenericIstioObject) GetStatus() map[string]interface{} {
+	return in.Status
+}
+
+// SetStatus for a wrapper
+func (in *GenericIstioObject) SetStatus(status map[string]interface{}) {
+	in.Status = status
 }
 
 func (in *GenericIstioObject) HasWorkloadSelectorLabels() bool {

--- a/models/attribute_manifest.go
+++ b/models/attribute_manifest.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -21,9 +19,8 @@ type AttributeManifests []AttributeManifest
 //
 // swagger:model attributeManifest
 type AttributeManifest struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Revision   interface{} `json:"revision"`
 		Name       interface{} `json:"name"`
 		Attributes interface{} `json:"attributes"`
@@ -39,8 +36,7 @@ func (ams *AttributeManifests) Parse(attributeManifests []kubernetes.IstioObject
 }
 
 func (am *AttributeManifest) Parse(attributeManifest kubernetes.IstioObject) {
-	am.TypeMeta = attributeManifest.GetTypeMeta()
-	am.Metadata = attributeManifest.GetObjectMeta()
+	am.IstioBase.Parse(attributeManifest)
 	am.Spec.Revision = attributeManifest.GetSpec()["revision"]
 	am.Spec.Name = attributeManifest.GetSpec()["name"]
 	am.Spec.Attributes = attributeManifest.GetSpec()["attributes"]

--- a/models/authorization_policy.go
+++ b/models/authorization_policy.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -21,9 +19,8 @@ type AuthorizationPolicies []AuthorizationPolicy
 //
 // swagger:model authorizationPolicy
 type AuthorizationPolicy struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Selector interface{} `json:"selector"`
 		Rules    interface{} `json:"rules"`
 		Action   interface{} `json:"action"`
@@ -39,8 +36,7 @@ func (aps *AuthorizationPolicies) Parse(authorizationPolicies []kubernetes.Istio
 }
 
 func (ap *AuthorizationPolicy) Parse(authorizationPolicy kubernetes.IstioObject) {
-	ap.TypeMeta = authorizationPolicy.GetTypeMeta()
-	ap.Metadata = authorizationPolicy.GetObjectMeta()
+	ap.IstioBase.Parse(authorizationPolicy)
 	ap.Spec.Selector = authorizationPolicy.GetSpec()["selector"]
 	ap.Spec.Rules = authorizationPolicy.GetSpec()["rules"]
 	ap.Spec.Action = authorizationPolicy.GetSpec()["action"]

--- a/models/cluster_rbac_config.go
+++ b/models/cluster_rbac_config.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -14,9 +12,8 @@ type ClusterRbacConfigSpec struct {
 
 type ClusterRbacConfigs []ClusterRbacConfig
 type ClusterRbacConfig struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta    `json:"metadata"`
-	Spec     ClusterRbacConfigSpec `json:"spec"`
+	IstioBase
+	Spec ClusterRbacConfigSpec `json:"spec"`
 }
 
 func (rcs *ClusterRbacConfigs) Parse(clusterRbacConfigs []kubernetes.IstioObject) {
@@ -28,8 +25,7 @@ func (rcs *ClusterRbacConfigs) Parse(clusterRbacConfigs []kubernetes.IstioObject
 }
 
 func (rc *ClusterRbacConfig) Parse(clusterRbacConfig kubernetes.IstioObject) {
-	rc.TypeMeta = clusterRbacConfig.GetTypeMeta()
-	rc.Metadata = clusterRbacConfig.GetObjectMeta()
+	rc.IstioBase.Parse(clusterRbacConfig)
 	rc.Spec.Mode = clusterRbacConfig.GetSpec()["mode"]
 	rc.Spec.Inclusion = clusterRbacConfig.GetSpec()["inclusion"]
 	rc.Spec.Exclusion = clusterRbacConfig.GetSpec()["exclusion"]
@@ -40,9 +36,8 @@ func (rc *ClusterRbacConfig) Parse(clusterRbacConfig kubernetes.IstioObject) {
 
 type ServiceMeshRbacConfigs []ServiceMeshRbacConfig
 type ServiceMeshRbacConfig struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta    `json:"metadata"`
-	Spec     ClusterRbacConfigSpec `json:"spec"`
+	IstioBase
+	Spec ClusterRbacConfigSpec `json:"spec"`
 }
 
 func (rcs *ServiceMeshRbacConfigs) Parse(smRbacConfigs []kubernetes.IstioObject) {
@@ -54,8 +49,7 @@ func (rcs *ServiceMeshRbacConfigs) Parse(smRbacConfigs []kubernetes.IstioObject)
 }
 
 func (rc *ServiceMeshRbacConfig) Parse(smRbacConfig kubernetes.IstioObject) {
-	rc.TypeMeta = smRbacConfig.GetTypeMeta()
-	rc.Metadata = smRbacConfig.GetObjectMeta()
+	rc.IstioBase.Parse(smRbacConfig)
 	rc.Spec.Mode = smRbacConfig.GetSpec()["mode"]
 	rc.Spec.Inclusion = smRbacConfig.GetSpec()["inclusion"]
 	rc.Spec.Exclusion = smRbacConfig.GetSpec()["exclusion"]

--- a/models/destination_rule.go
+++ b/models/destination_rule.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 )
@@ -25,9 +23,8 @@ type DestinationRules struct {
 //
 // swagger:model destinationRule
 type DestinationRule struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Host          interface{} `json:"host,omitempty"`
 		TrafficPolicy interface{} `json:"trafficPolicy,omitempty"`
 		Subsets       interface{} `json:"subsets,omitempty"`
@@ -45,8 +42,7 @@ func (dRules *DestinationRules) Parse(destinationRules []kubernetes.IstioObject)
 }
 
 func (dRule *DestinationRule) Parse(destinationRule kubernetes.IstioObject) {
-	dRule.TypeMeta = destinationRule.GetTypeMeta()
-	dRule.Metadata = destinationRule.GetObjectMeta()
+	dRule.IstioBase.Parse(destinationRule)
 	dRule.Spec.Host = destinationRule.GetSpec()["host"]
 	dRule.Spec.TrafficPolicy = destinationRule.GetSpec()["trafficPolicy"]
 	dRule.Spec.Subsets = destinationRule.GetSpec()["subsets"]

--- a/models/envoy_filter.go
+++ b/models/envoy_filter.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -21,9 +19,8 @@ type EnvoyFilters []EnvoyFilter
 //
 // swagger:model envoyFilter
 type EnvoyFilter struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		WorkloadSelector interface{} `json:"workloadSelector"`
 		ConfigPatches    interface{} `json:"configPatches"`
 	} `json:"spec"`
@@ -38,8 +35,7 @@ func (efs *EnvoyFilters) Parse(envoyFilters []kubernetes.IstioObject) {
 }
 
 func (ef *EnvoyFilter) Parse(envoyFilter kubernetes.IstioObject) {
-	ef.TypeMeta = envoyFilter.GetTypeMeta()
-	ef.Metadata = envoyFilter.GetObjectMeta()
+	ef.IstioBase.Parse(envoyFilter)
 	ef.Spec.WorkloadSelector = envoyFilter.GetSpec()["workloadSelector"]
 	ef.Spec.ConfigPatches = envoyFilter.GetSpec()["configPatches"]
 }

--- a/models/gateway.go
+++ b/models/gateway.go
@@ -1,16 +1,11 @@
 package models
 
-import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kiali/kiali/kubernetes"
-)
+import "github.com/kiali/kiali/kubernetes"
 
 type Gateways []Gateway
 type Gateway struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Servers  interface{} `json:"servers"`
 		Selector interface{} `json:"selector"`
 	} `json:"spec"`
@@ -25,8 +20,7 @@ func (gws *Gateways) Parse(gateways []kubernetes.IstioObject) {
 }
 
 func (gw *Gateway) Parse(gateway kubernetes.IstioObject) {
-	gw.TypeMeta = gateway.GetTypeMeta()
-	gw.Metadata = gateway.GetObjectMeta()
+	gw.IstioBase.Parse(gateway)
 	gw.Spec.Servers = gateway.GetSpec()["servers"]
 	gw.Spec.Selector = gateway.GetSpec()["selector"]
 }

--- a/models/http_api_spec.go
+++ b/models/http_api_spec.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -21,9 +19,8 @@ type HttpApiSpecs []HttpApiSpec
 //
 // swagger:model httpApiSpec
 type HttpApiSpec struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Attributes interface{} `json:"attributes"`
 		Patterns   interface{} `json:"patterns"`
 		ApiKeys    interface{} `json:"apiKeys"`
@@ -39,8 +36,7 @@ func (has *HttpApiSpecs) Parse(httpApiSpecs []kubernetes.IstioObject) {
 }
 
 func (ef *HttpApiSpec) Parse(httpApiSpec kubernetes.IstioObject) {
-	ef.TypeMeta = httpApiSpec.GetTypeMeta()
-	ef.Metadata = httpApiSpec.GetObjectMeta()
+	ef.IstioBase.Parse(httpApiSpec)
 	ef.Spec.Attributes = httpApiSpec.GetSpec()["attributes"]
 	ef.Spec.Patterns = httpApiSpec.GetSpec()["patterns"]
 	ef.Spec.ApiKeys = httpApiSpec.GetSpec()["apiKeys"]

--- a/models/http_api_spec_binding.go
+++ b/models/http_api_spec_binding.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -21,9 +19,8 @@ type HttpApiSpecBindings []HttpApiSpecBinding
 //
 // swagger:model httpApiSpecBinding
 type HttpApiSpecBinding struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Services interface{} `json:"services"`
 		ApiSpecs interface{} `json:"apiSpecs"`
 	} `json:"spec"`
@@ -38,8 +35,7 @@ func (has *HttpApiSpecBindings) Parse(httpApiSpecBindings []kubernetes.IstioObje
 }
 
 func (ha *HttpApiSpecBinding) Parse(httpApiSpecBinding kubernetes.IstioObject) {
-	ha.TypeMeta = httpApiSpecBinding.GetTypeMeta()
-	ha.Metadata = httpApiSpecBinding.GetObjectMeta()
+	ha.IstioBase.Parse(httpApiSpecBinding)
 	ha.Spec.Services = httpApiSpecBinding.GetSpec()["services"]
 	ha.Spec.ApiSpecs = httpApiSpecBinding.GetSpec()["apiSpecs"]
 }

--- a/models/istio_base.go
+++ b/models/istio_base.go
@@ -1,0 +1,19 @@
+package models
+
+import (
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+type IstioBase struct {
+	meta_v1.TypeMeta
+	Metadata meta_v1.ObjectMeta     `json:"metadata"`
+	Status   map[string]interface{} `json:"status,omitempty"`
+}
+
+func (ib *IstioBase) Parse(io kubernetes.IstioObject) {
+	ib.TypeMeta = io.GetTypeMeta()
+	ib.Metadata = io.GetObjectMeta()
+	ib.Status = io.GetStatus()
+}

--- a/models/istio_rule.go
+++ b/models/istio_rule.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -26,9 +24,8 @@ type IstioRules []IstioRule
 //
 // swagger:model istioRule
 type IstioRule struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Match   interface{} `json:"match"`
 		Actions interface{} `json:"actions"`
 	} `json:"spec"`
@@ -49,9 +46,8 @@ type IstioAdapters []IstioAdapter
 //
 // swagger:model istioAdapter
 type IstioAdapter struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     interface{}        `json:"spec"`
+	IstioBase
+	Spec interface{} `json:"spec"`
 }
 
 // IstioTemplates istioTemplates
@@ -69,9 +65,8 @@ type IstioTemplates []IstioTemplate
 //
 // swagger:model istioTemplate
 type IstioTemplate struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     interface{}        `json:"spec"`
+	IstioBase
+	Spec interface{} `json:"spec"`
 }
 
 // IstioHandlers istioHandlers
@@ -89,9 +84,8 @@ type IstioHandlers []IstioHandler
 //
 // swagger:model istioHandler
 type IstioHandler struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     interface{}        `json:"spec"`
+	IstioBase
+	Spec interface{} `json:"spec"`
 }
 
 // IstioInstances istioInstances
@@ -109,9 +103,8 @@ type IstioInstances []IstioInstance
 //
 // swagger:model istioInstance
 type IstioInstance struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     interface{}        `json:"spec"`
+	IstioBase
+	Spec interface{} `json:"spec"`
 }
 
 func CastIstioRulesCollection(rules []kubernetes.IstioObject) IstioRules {
@@ -124,8 +117,7 @@ func CastIstioRulesCollection(rules []kubernetes.IstioObject) IstioRules {
 
 func CastIstioRule(rule kubernetes.IstioObject) IstioRule {
 	istioRule := IstioRule{}
-	istioRule.TypeMeta = rule.GetTypeMeta()
-	istioRule.Metadata = rule.GetObjectMeta()
+	istioRule.IstioBase.Parse(rule)
 	istioRule.Spec.Match = rule.GetSpec()["match"]
 	istioRule.Spec.Actions = rule.GetSpec()["actions"]
 	return istioRule
@@ -141,8 +133,7 @@ func CastIstioAdaptersCollection(adapters []kubernetes.IstioObject) IstioAdapter
 
 func CastIstioAdapter(adapter kubernetes.IstioObject) IstioAdapter {
 	istioAdapter := IstioAdapter{}
-	istioAdapter.TypeMeta = adapter.GetTypeMeta()
-	istioAdapter.Metadata = adapter.GetObjectMeta()
+	istioAdapter.IstioBase.Parse(adapter)
 	istioAdapter.Spec = adapter.GetSpec()
 	return istioAdapter
 }
@@ -157,8 +148,7 @@ func CastIstioTemplatesCollection(templates []kubernetes.IstioObject) IstioTempl
 
 func CastIstioTemplate(template kubernetes.IstioObject) IstioTemplate {
 	istioTemplate := IstioTemplate{}
-	istioTemplate.TypeMeta = template.GetTypeMeta()
-	istioTemplate.Metadata = template.GetObjectMeta()
+	istioTemplate.IstioBase.Parse(template)
 	istioTemplate.Spec = template.GetSpec()
 	return istioTemplate
 }
@@ -173,8 +163,7 @@ func CastIstioHandlersCollection(handlers []kubernetes.IstioObject) IstioHandler
 
 func CastIstioHandler(handler kubernetes.IstioObject) IstioHandler {
 	istioHandler := IstioHandler{}
-	istioHandler.TypeMeta = handler.GetTypeMeta()
-	istioHandler.Metadata = handler.GetObjectMeta()
+	istioHandler.IstioBase.Parse(handler)
 	istioHandler.Spec = handler.GetSpec()
 	return istioHandler
 }
@@ -189,8 +178,7 @@ func CastIstioInstancesCollection(instances []kubernetes.IstioObject) IstioInsta
 
 func CastIstioInstance(instance kubernetes.IstioObject) IstioInstance {
 	istioInstance := IstioInstance{}
-	istioInstance.TypeMeta = instance.GetTypeMeta()
-	istioInstance.Metadata = instance.GetObjectMeta()
+	istioInstance.IstioBase.Parse(instance)
 	istioInstance.Spec = instance.GetSpec()
 	return istioInstance
 }

--- a/models/mesh_policy.go
+++ b/models/mesh_policy.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -17,9 +15,8 @@ type MeshPolicySpec struct {
 
 type MeshPolicies []MeshPolicy
 type MeshPolicy struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     MeshPolicySpec     `json:"spec"`
+	IstioBase
+	Spec MeshPolicySpec `json:"spec"`
 }
 
 func (mps *MeshPolicies) Parse(meshPolicies []kubernetes.IstioObject) {
@@ -31,8 +28,7 @@ func (mps *MeshPolicies) Parse(meshPolicies []kubernetes.IstioObject) {
 }
 
 func (mp *MeshPolicy) Parse(meshPolicy kubernetes.IstioObject) {
-	mp.TypeMeta = meshPolicy.GetTypeMeta()
-	mp.Metadata = meshPolicy.GetObjectMeta()
+	mp.IstioBase.Parse(meshPolicy)
 	mp.Spec.Targets = meshPolicy.GetSpec()["targets"]
 	mp.Spec.Peers = meshPolicy.GetSpec()["peers"]
 	mp.Spec.PeerIsOptional = meshPolicy.GetSpec()["peersIsOptional"]
@@ -46,9 +42,8 @@ func (mp *MeshPolicy) Parse(meshPolicy kubernetes.IstioObject) {
 
 type ServiceMeshPolicies []ServiceMeshPolicy
 type ServiceMeshPolicy struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     MeshPolicySpec     `json:"spec"`
+	IstioBase
+	Spec MeshPolicySpec `json:"spec"`
 }
 
 func (mps *ServiceMeshPolicies) Parse(smPolicies []kubernetes.IstioObject) {
@@ -60,8 +55,7 @@ func (mps *ServiceMeshPolicies) Parse(smPolicies []kubernetes.IstioObject) {
 }
 
 func (mp *ServiceMeshPolicy) Parse(smPolicy kubernetes.IstioObject) {
-	mp.TypeMeta = smPolicy.GetTypeMeta()
-	mp.Metadata = smPolicy.GetObjectMeta()
+	mp.IstioBase.Parse(smPolicy)
 	mp.Spec.Targets = smPolicy.GetSpec()["targets"]
 	mp.Spec.Peers = smPolicy.GetSpec()["peers"]
 	mp.Spec.PeerIsOptional = smPolicy.GetSpec()["peersIsOptional"]

--- a/models/peer_authentication.go
+++ b/models/peer_authentication.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -21,9 +19,8 @@ type PeerAuthentications []PeerAuthentication
 //
 // swagger:model peerAuthentication
 type PeerAuthentication struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Selector      interface{} `json:"selector"`
 		Mtls          interface{} `json:"mtls"`
 		PortLevelMtls interface{} `json:"portLevelMtls"`
@@ -39,8 +36,7 @@ func (pas *PeerAuthentications) Parse(peerAuthentications []kubernetes.IstioObje
 }
 
 func (pa *PeerAuthentication) Parse(peerAuthentication kubernetes.IstioObject) {
-	pa.TypeMeta = peerAuthentication.GetTypeMeta()
-	pa.Metadata = peerAuthentication.GetObjectMeta()
+	pa.IstioBase.Parse(peerAuthentication)
 	pa.Spec.Selector = peerAuthentication.GetSpec()["selector"]
 	pa.Spec.Mtls = peerAuthentication.GetSpec()["mtls"]
 	pa.Spec.PortLevelMtls = peerAuthentication.GetSpec()["portLevelMtls"]

--- a/models/policy.go
+++ b/models/policy.go
@@ -1,16 +1,13 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type Policies []Policy
 type Policy struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Targets          interface{} `json:"targets"`
 		Peers            interface{} `json:"peers"`
 		PeerIsOptional   interface{} `json:"peerIsOptional"`
@@ -29,8 +26,7 @@ func (ps *Policies) Parse(policies []kubernetes.IstioObject) {
 }
 
 func (p *Policy) Parse(policy kubernetes.IstioObject) {
-	p.TypeMeta = policy.GetTypeMeta()
-	p.Metadata = policy.GetObjectMeta()
+	p.IstioBase.Parse(policy)
 	p.Spec.Targets = policy.GetSpec()["targets"]
 	p.Spec.Peers = policy.GetSpec()["peers"]
 	p.Spec.PeerIsOptional = policy.GetSpec()["peersIsOptional"]

--- a/models/quota_spec.go
+++ b/models/quota_spec.go
@@ -1,16 +1,13 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type QuotaSpecs []QuotaSpec
 type QuotaSpec struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Rules interface{} `json:"rules"`
 	} `json:"spec"`
 }
@@ -24,7 +21,6 @@ func (qss *QuotaSpecs) Parse(quotaSpecs []kubernetes.IstioObject) {
 }
 
 func (qs *QuotaSpec) Parse(quotaSpec kubernetes.IstioObject) {
-	qs.TypeMeta = quotaSpec.GetTypeMeta()
-	qs.Metadata = quotaSpec.GetObjectMeta()
+	qs.IstioBase.Parse(quotaSpec)
 	qs.Spec.Rules = quotaSpec.GetSpec()["rules"]
 }

--- a/models/quota_spec_binding.go
+++ b/models/quota_spec_binding.go
@@ -1,16 +1,13 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type QuotaSpecBindings []QuotaSpecBinding
 type QuotaSpecBinding struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		QuotaSpecs interface{} `json:"quotaSpecs"`
 		Services   interface{} `json:"services"`
 	} `json:"spec"`
@@ -25,8 +22,7 @@ func (qsbs *QuotaSpecBindings) Parse(quotaSpecBindings []kubernetes.IstioObject)
 }
 
 func (qsb *QuotaSpecBinding) Parse(quotaSpecBinding kubernetes.IstioObject) {
-	qsb.TypeMeta = quotaSpecBinding.GetTypeMeta()
-	qsb.Metadata = quotaSpecBinding.GetObjectMeta()
+	qsb.IstioBase.Parse(quotaSpecBinding)
 	qsb.Spec.QuotaSpecs = quotaSpecBinding.GetSpec()["quotaSpecs"]
 	qsb.Spec.Services = quotaSpecBinding.GetSpec()["services"]
 }

--- a/models/rbac_config.go
+++ b/models/rbac_config.go
@@ -1,16 +1,13 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type RbacConfigs []RbacConfig
 type RbacConfig struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Mode      interface{} `json:"mode"`
 		Inclusion interface{} `json:"inclusion"`
 		Exclusion interface{} `json:"exclusion"`
@@ -26,8 +23,7 @@ func (rcs *RbacConfigs) Parse(rbacConfigs []kubernetes.IstioObject) {
 }
 
 func (rc *RbacConfig) Parse(rbacConfig kubernetes.IstioObject) {
-	rc.TypeMeta = rbacConfig.GetTypeMeta()
-	rc.Metadata = rbacConfig.GetObjectMeta()
+	rc.IstioBase.Parse(rbacConfig)
 	rc.Spec.Mode = rbacConfig.GetSpec()["mode"]
 	rc.Spec.Inclusion = rbacConfig.GetSpec()["inclusion"]
 	rc.Spec.Exclusion = rbacConfig.GetSpec()["exclusion"]

--- a/models/request_authentication.go
+++ b/models/request_authentication.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -21,9 +19,8 @@ type RequestAuthentications []RequestAuthentication
 //
 // swagger:model requestAuthentication
 type RequestAuthentication struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Selector interface{} `json:"selector"`
 		JwtRules interface{} `json:"jwtRules"`
 	} `json:"spec"`
@@ -38,8 +35,7 @@ func (ras *RequestAuthentications) Parse(requestAuthentications []kubernetes.Ist
 }
 
 func (ra *RequestAuthentication) Parse(requestAuthentication kubernetes.IstioObject) {
-	ra.TypeMeta = requestAuthentication.GetTypeMeta()
-	ra.Metadata = requestAuthentication.GetObjectMeta()
+	ra.IstioBase.Parse(requestAuthentication)
 	ra.Spec.Selector = requestAuthentication.GetSpec()["selector"]
 	ra.Spec.JwtRules = requestAuthentication.GetSpec()["jwtRules"]
 }

--- a/models/service_entry.go
+++ b/models/service_entry.go
@@ -1,16 +1,13 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type ServiceEntries []ServiceEntry
 type ServiceEntry struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Hosts            interface{} `json:"hosts"`
 		Addresses        interface{} `json:"addresses"`
 		Ports            interface{} `json:"ports"`
@@ -32,8 +29,7 @@ func (ses *ServiceEntries) Parse(serviceEntries []kubernetes.IstioObject) {
 }
 
 func (se *ServiceEntry) Parse(serviceEntry kubernetes.IstioObject) {
-	se.TypeMeta = serviceEntry.GetTypeMeta()
-	se.Metadata = serviceEntry.GetObjectMeta()
+	se.IstioBase.Parse(serviceEntry)
 	se.Spec.Hosts = serviceEntry.GetSpec()["hosts"]
 	se.Spec.Addresses = serviceEntry.GetSpec()["addresses"]
 	se.Spec.Ports = serviceEntry.GetSpec()["ports"]

--- a/models/service_role.go
+++ b/models/service_role.go
@@ -1,16 +1,13 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type ServiceRoles []ServiceRole
 type ServiceRole struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Rules interface{} `json:"rules"`
 	} `json:"spec"`
 }
@@ -24,7 +21,6 @@ func (srs *ServiceRoles) Parse(serviceRoles []kubernetes.IstioObject) {
 }
 
 func (sr *ServiceRole) Parse(serviceRole kubernetes.IstioObject) {
-	sr.TypeMeta = serviceRole.GetTypeMeta()
-	sr.Metadata = serviceRole.GetObjectMeta()
+	sr.IstioBase.Parse(serviceRole)
 	sr.Spec.Rules = serviceRole.GetSpec()["rules"]
 }

--- a/models/service_role_binding.go
+++ b/models/service_role_binding.go
@@ -1,16 +1,13 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type ServiceRoleBindings []ServiceRoleBinding
 type ServiceRoleBinding struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Subjects interface{} `json:"subjects"`
 		RoleRef  interface{} `json:"roleRef"`
 	} `json:"spec"`
@@ -25,8 +22,7 @@ func (srbs *ServiceRoleBindings) Parse(serviceRoleBindings []kubernetes.IstioObj
 }
 
 func (srb *ServiceRoleBinding) Parse(serviceRoleBinding kubernetes.IstioObject) {
-	srb.TypeMeta = serviceRoleBinding.GetTypeMeta()
-	srb.Metadata = serviceRoleBinding.GetObjectMeta()
+	srb.IstioBase.Parse(serviceRoleBinding)
 	srb.Spec.Subjects = serviceRoleBinding.GetSpec()["subjects"]
 	srb.Spec.RoleRef = serviceRoleBinding.GetSpec()["roleRef"]
 }

--- a/models/sidecars.go
+++ b/models/sidecars.go
@@ -1,16 +1,13 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
 type Sidecars []Sidecar
 type Sidecar struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		WorkloadSelector      interface{} `json:"workloadSelector"`
 		Ingress               interface{} `json:"ingress"`
 		Egress                interface{} `json:"egress"`
@@ -28,8 +25,7 @@ func (scs *Sidecars) Parse(sidecars []kubernetes.IstioObject) {
 }
 
 func (sc *Sidecar) Parse(sidecar kubernetes.IstioObject) {
-	sc.TypeMeta = sidecar.GetTypeMeta()
-	sc.Metadata = sidecar.GetObjectMeta()
+	sc.IstioBase.Parse(sidecar)
 	sc.Spec.WorkloadSelector = sidecar.GetSpec()["workloadSelector"]
 	sc.Spec.Ingress = sidecar.GetSpec()["ingress"]
 	sc.Spec.Egress = sidecar.GetSpec()["egress"]

--- a/models/virtual_service.go
+++ b/models/virtual_service.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -24,10 +22,8 @@ type VirtualServices struct {
 //
 // swagger:model virtualService
 type VirtualService struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Status map[string]interface{} `json:"status,omitempty"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Hosts    interface{} `json:"hosts,omitempty"`
 		Gateways interface{} `json:"gateways,omitempty"`
 		Http     interface{} `json:"http,omitempty"`
@@ -47,9 +43,7 @@ func (vServices *VirtualServices) Parse(virtualServices []kubernetes.IstioObject
 }
 
 func (vService *VirtualService) Parse(virtualService kubernetes.IstioObject) {
-	vService.TypeMeta = virtualService.GetTypeMeta()
-	vService.Metadata = virtualService.GetObjectMeta()
-	vService.Status = virtualService.GetStatus()
+	vService.IstioBase.Parse(virtualService)
 	vService.Spec.Hosts = virtualService.GetSpec()["hosts"]
 	vService.Spec.Gateways = virtualService.GetSpec()["gateways"]
 	vService.Spec.Http = virtualService.GetSpec()["http"]

--- a/models/virtual_service.go
+++ b/models/virtual_service.go
@@ -26,6 +26,7 @@ type VirtualServices struct {
 type VirtualService struct {
 	meta_v1.TypeMeta
 	Metadata meta_v1.ObjectMeta `json:"metadata"`
+	Status map[string]interface{} `json:"status,omitempty"`
 	Spec     struct {
 		Hosts    interface{} `json:"hosts,omitempty"`
 		Gateways interface{} `json:"gateways,omitempty"`
@@ -48,6 +49,7 @@ func (vServices *VirtualServices) Parse(virtualServices []kubernetes.IstioObject
 func (vService *VirtualService) Parse(virtualService kubernetes.IstioObject) {
 	vService.TypeMeta = virtualService.GetTypeMeta()
 	vService.Metadata = virtualService.GetObjectMeta()
+	vService.Status = virtualService.GetStatus()
 	vService.Spec.Hosts = virtualService.GetSpec()["hosts"]
 	vService.Spec.Gateways = virtualService.GetSpec()["gateways"]
 	vService.Spec.Http = virtualService.GetSpec()["http"]

--- a/models/workload_entry.go
+++ b/models/workload_entry.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -21,9 +19,8 @@ type WorkloadEntries []WorkloadEntry
 //
 // swagger:model workloadEntry
 type WorkloadEntry struct {
-	meta_v1.TypeMeta
-	Metadata meta_v1.ObjectMeta `json:"metadata"`
-	Spec     struct {
+	IstioBase
+	Spec struct {
 		Address        interface{} `json:"address"`
 		Ports          interface{} `json:"ports"`
 		Labels         interface{} `json:"labels"`
@@ -43,8 +40,7 @@ func (wes *WorkloadEntries) Parse(workloadEntries []kubernetes.IstioObject) {
 }
 
 func (we *WorkloadEntry) Parse(workloadEntry kubernetes.IstioObject) {
-	we.TypeMeta = workloadEntry.GetTypeMeta()
-	we.Metadata = workloadEntry.GetObjectMeta()
+	we.IstioBase.Parse(workloadEntry)
 	we.Spec.Address = workloadEntry.GetSpec()["address"]
 	we.Spec.Ports = workloadEntry.GetSpec()["ports"]
 	we.Spec.Labels = workloadEntry.GetSpec()["labels"]

--- a/swagger.json
+++ b/swagger.json
@@ -3746,6 +3746,13 @@
         },
         "spec": {
           "$ref": "#/definitions/ClusterRbacConfigSpec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -3997,6 +4004,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -4817,6 +4831,13 @@
         },
         "spec": {
           "$ref": "#/definitions/MeshPolicySpec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -5327,6 +5348,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -5426,6 +5454,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -5459,6 +5494,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -5510,6 +5552,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -5837,6 +5886,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -5895,6 +5951,13 @@
         },
         "spec": {
           "$ref": "#/definitions/MeshPolicySpec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -5917,6 +5980,13 @@
         },
         "spec": {
           "$ref": "#/definitions/ClusterRbacConfigSpec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -6007,6 +6077,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -6040,6 +6117,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -6110,6 +6194,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -6771,6 +6862,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "AttributeManifest",
@@ -6831,6 +6929,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "AuthorizationPolicy",
@@ -6875,6 +6980,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "DestinationRule",
@@ -6930,6 +7042,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "EnvoyFilter",
@@ -7010,6 +7129,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "HttpApiSpec",
@@ -7046,6 +7172,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "HttpApiSpecBinding",
@@ -7092,6 +7225,13 @@
         "spec": {
           "type": "object",
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "IstioAdapter",
@@ -7128,6 +7268,13 @@
         "spec": {
           "type": "object",
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "IstioHandler",
@@ -7164,6 +7311,13 @@
         "spec": {
           "type": "object",
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "IstioInstance",
@@ -7210,6 +7364,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "IstioRule",
@@ -7246,6 +7407,13 @@
         "spec": {
           "type": "object",
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "IstioTemplate",
@@ -7321,6 +7489,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "PeerAuthentication",
@@ -7367,6 +7542,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "RequestAuthentication",
@@ -7429,6 +7611,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "VirtualService",
@@ -7514,6 +7703,13 @@
             }
           },
           "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
         }
       },
       "x-go-name": "WorkloadEntry",


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2236
Requires: https://github.com/kiali/kiali-ui/pull/1915

This feature needs to be tested in two different installations: with and without status enabled.
In order to enable the status field, please run the following:
```
istioctl install --set values.pilot.env.PILOT_ENABLE_STATUS=true --set values.global.istiod.enableAnalysis=true
```

This is an example of a Istio Analyzer message:
```
kubectl apply -f - <<EOF 
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: httpbin-bogus
spec:
  hosts:
  - "*"
  gateways:
  - httpbin-gateway-bogus # Expected validation
  http:
  - route:
    - destination:
        host: reviews.default.svc.cluster.local
        subset: v1
EOF
```
