### PR TITLE
Initial implementation of OpenId's auth code flow

### DIFF
--- a/business/openid_auth.go
+++ b/business/openid_auth.go
@@ -460,7 +460,7 @@ func VerifyOpenIdUserAccess(token string) (int, string, error) {
 
 	// If namespace list is empty, return unauthorized error
 	if len(nsList) == 0 {
-		return http.StatusUnauthorized, "Not enough privileges to login", nil
+		return http.StatusUnauthorized, "Cannot view any namespaces. Please read Kiali's RBAC documentation for more details.", nil
 	}
 
 	return http.StatusOK, "", nil

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -800,26 +800,26 @@ func OpenIdCodeFlowHandler(w http.ResponseWriter, r *http.Request) bool {
 	sessionData := business.BuildOpenIdJwtClaims(openIdParams)
 	sessionDataJson, err := json.Marshal(sessionData)
 	if err != nil {
-		RespondWithDetailedError(w, http.StatusInternalServerError, "Error when creating credentials", err.Error())
+		RespondWithDetailedError(w, http.StatusInternalServerError, "Error when creating credentials - failed to marshal json", err.Error())
 		return true
 	}
 
 	// Cihper the session data
 	block, err := aes.NewCipher([]byte(config.GetSigningKey()))
 	if err != nil {
-		RespondWithDetailedError(w, http.StatusInternalServerError, "Error when creating credentials", err.Error())
+		RespondWithDetailedError(w, http.StatusInternalServerError, "Error when creating credentials - failed to create cipher", err.Error())
 		return true
 	}
 
 	aesGcm, err := cipher.NewGCM(block)
 	if err != nil {
-		RespondWithDetailedError(w, http.StatusInternalServerError, "Error when creating credentials", err.Error())
+		RespondWithDetailedError(w, http.StatusInternalServerError, "Error when creating credentials - failed to create gcm", err.Error())
 		return true
 	}
 
 	aesGcmNonce, err := util.CryptoRandomBytes(aesGcm.NonceSize())
 	if err != nil {
-		RespondWithDetailedError(w, http.StatusInternalServerError, "Error when creating credentials", err.Error())
+		RespondWithDetailedError(w, http.StatusInternalServerError, "Error when creating credentials - failed to generate random bytes", err.Error())
 		return true
 	}
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -67,6 +67,16 @@ func NewRouter() *mux.Router {
 		http.ServeFile(w, r, conf.Server.StaticContentRootDirectory+"/index.html")
 	})
 
+	if conf.Auth.Strategy == config.AuthStrategyOpenId {
+		appRouter.Methods("GET").Path("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !handlers.OpenIdCodeFlowHandler(w, r) {
+				// If the OpenID handler does not handle the request, pass the
+				// request to the file server.
+				staticFileServer.ServeHTTP(w, r)
+			}
+		})
+	}
+
 	appRouter.PathPrefix("/").Handler(staticFileServer)
 
 	return rootRouter


### PR DESCRIPTION
This initial implementation of the "authorization code" flow for OpenID authentication let's Kiali negotiate authentication with an extenal IdP provider as described in [section 3.1 of the OpenID spec](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth). Kiali is acting as an "unauthenticated client" (i.e. no client secret is used).

This is using AES-GCM encryption to encode the cookie which prevents revealing the OpenId id_token to the network and to the browser.

Related to #3088