### PR TITLE
Increase limit while fetching traces for workloads and services

### DIFF
--- a/business/jaeger.go
+++ b/business/jaeger.go
@@ -55,7 +55,7 @@ func (in *JaegerService) GetServiceTraces(ns, service string, query models.Traci
 	reqLimit := query.Limit
 	query.Limit *= 2
 	r, err := client.GetServiceTraces(ns, app, service, query)
-	if reqLimit > 0 && r != nil {
+	if reqLimit > 0 && r != nil && len(r.Data) > reqLimit {
 		r.Data = r.Data[:reqLimit]
 	}
 	return r, err
@@ -77,7 +77,7 @@ func (in *JaegerService) GetWorkloadTraces(ns, workload string, query models.Tra
 	reqLimit := query.Limit
 	query.Limit *= 5
 	r, err := client.GetWorkloadTraces(ns, app, workload, query)
-	if reqLimit > 0 && r != nil {
+	if reqLimit > 0 && r != nil && len(r.Data) > reqLimit {
 		r.Data = r.Data[:reqLimit]
 	}
 	return r, err

--- a/business/jaeger.go
+++ b/business/jaeger.go
@@ -51,7 +51,14 @@ func (in *JaegerService) GetServiceTraces(ns, service string, query models.Traci
 	if err != nil {
 		return nil, err
 	}
-	return client.GetServiceTraces(ns, app, service, query)
+	// Artificial increase of limit (see explanation in GetWorkloadTraces)
+	reqLimit := query.Limit
+	query.Limit *= 2
+	r, err := client.GetServiceTraces(ns, app, service, query)
+	if reqLimit > 0 && r != nil {
+		r.Data = r.Data[:reqLimit]
+	}
+	return r, err
 }
 
 func (in *JaegerService) GetWorkloadTraces(ns, workload string, query models.TracingQuery) (*jaeger.JaegerResponse, error) {
@@ -63,7 +70,17 @@ func (in *JaegerService) GetWorkloadTraces(ns, workload string, query models.Tra
 	if err != nil {
 		return nil, err
 	}
-	return client.GetWorkloadTraces(ns, app, workload, query)
+	// Because Traces are fetched per App and not Workloads, the 'limit' query param will apply to app's traces, not workloads,
+	// so it will not be consistent with the final result. In other words, we ask for 15 traces but could very well end up with
+	// only 3 traces for the workload even if there's more.
+	// To try to attenuate this effect, we will artificially increase the limit, then cut it down after workload filtering.
+	reqLimit := query.Limit
+	query.Limit *= 5
+	r, err := client.GetWorkloadTraces(ns, app, workload, query)
+	if reqLimit > 0 && r != nil {
+		r.Data = r.Data[:reqLimit]
+	}
+	return r, err
 }
 
 func (in *JaegerService) GetJaegerTraceDetail(traceID string) (trace *jaeger.JaegerSingleTrace, err error) {

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -139,6 +139,11 @@ func TraceDetails(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
+	if trace == nil {
+		// Trace not found
+		RespondWithError(w, http.StatusNotFound, fmt.Sprintf("Trace %s not found", traceID))
+		return
+	}
 	RespondWithJSON(w, http.StatusOK, trace)
 }
 

--- a/jaeger/util.go
+++ b/jaeger/util.go
@@ -46,6 +46,8 @@ func makeRequest(client http.Client, endpoint string, body io.Reader) (response 
 	if err != nil {
 		return
 	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	if err != nil {
 		return


### PR DESCRIPTION
... because they are fetched for apps, and narrowed-down later. Re-apply initial limit after post-filtering.

This should attenuate the effect of having an inconsistent number of traces displayed for workloads and services (though not entirely eliminating that possibility)

Plus properly recognize "trace not found" error as a 404 instead of 503 / unmarshalling issue

Part of https://github.com/kiali/kiali/issues/3048
