### PR TITLE
Add revision field into config + use it to fetch istio configmap

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -556,9 +556,9 @@ func (in *IstioValidationsService) fetchNonLocalmTLSConfigs(mtlsDetails *kuberne
 		var istioConfig *core_v1.ConfigMap
 		var err error
 		if IsNamespaceCached(cfg.IstioNamespace) {
-			istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, kubernetes.IstioConfigMapName)
+			istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, kubernetes.GetIstioConfigMapName())
 		} else {
-			istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, kubernetes.IstioConfigMapName)
+			istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, kubernetes.GetIstioConfigMapName())
 		}
 		if err != nil {
 			errChan <- err

--- a/business/tls.go
+++ b/business/tls.go
@@ -188,9 +188,9 @@ func (in *TLSService) hasAutoMTLSEnabled() bool {
 	var istioConfig *core_v1.ConfigMap
 	var err error
 	if IsNamespaceCached(cfg.IstioNamespace) {
-		istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, kubernetes.IstioConfigMapName)
+		istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, kubernetes.GetIstioConfigMapName())
 	} else {
-		istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, kubernetes.IstioConfigMapName)
+		istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, kubernetes.GetIstioConfigMapName())
 	}
 	if err != nil {
 		return true

--- a/config/config.go
+++ b/config/config.go
@@ -147,6 +147,7 @@ type IstioConfig struct {
 	IstioSidecarAnnotation   string            `yaml:"istio_sidecar_annotation,omitempty"`
 	ComponentStatuses        ComponentStatuses `yaml:"component_status,omitempty"`
 	UrlServiceVersion        string            `yaml:"url_service_version"`
+	Revision                 string            `yaml:"revision,omitempty"`
 }
 
 type ComponentStatuses struct {
@@ -415,6 +416,7 @@ func NewConfig() (c *Config) {
 					},
 				},
 				UrlServiceVersion: "http://istiod:15014/version",
+				Revision:          "",
 			},
 			Prometheus: PrometheusConfig{
 				Auth: Auth{

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -57,6 +57,7 @@ type PublicConfig struct {
 	IstioComponentNamespaces config.IstioComponentNamespaces `json:"istioComponentNamespaces,omitempty"`
 	IstioLabels              config.IstioLabels              `json:"istioLabels,omitempty"`
 	IstioTelemetryV2         bool                            `json:"istioTelemetryV2"`
+	IstioRevision            string                          `json:"istioRevision"`
 	KialiFeatureFlags        config.KialiFeatureFlags        `json:"kialiFeatureFlags,omitempty"`
 	Prometheus               PrometheusConfig                `json:"prometheus,omitempty"`
 }
@@ -93,6 +94,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 		IstioNamespace:           config.IstioNamespace,
 		IstioComponentNamespaces: config.IstioComponentNamespaces,
 		IstioLabels:              config.IstioLabels,
+		IstioRevision:            config.ExternalServices.Istio.Revision,
 		KialiFeatureFlags:        config.KialiFeatureFlags,
 		Prometheus: PrometheusConfig{
 			GlobalScrapeInterval: promConfig.GlobalScrapeInterval,

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -351,6 +351,15 @@ func (in *K8SClient) getAuthenticationResources() map[string]bool {
 	return *in.authenticationResources
 }
 
+func GetIstioConfigMapName() string {
+	revision := config.Get().ExternalServices.Istio.Revision
+	name := IstioConfigMapName
+	if revision != "" {
+		name = fmt.Sprintf("%s-%s", IstioConfigMapName, revision)
+	}
+	return name
+}
+
 func GetIstioConfigMap(istioConfig *core_v1.ConfigMap) (*IstioMeshConfig, error) {
 	meshConfig := &IstioMeshConfig{}
 
@@ -383,7 +392,7 @@ func (in *K8SClient) IsMixerDisabled() bool {
 	}
 
 	cfg := config.Get()
-	istioConfig, err := in.GetConfigMap(cfg.IstioNamespace, IstioConfigMapName)
+	istioConfig, err := in.GetConfigMap(cfg.IstioNamespace, GetIstioConfigMapName())
 	if err != nil {
 		log.Warningf("GetIstioConfigMap: Cannot retrieve Istio ConfigMap.")
 		return false

--- a/kubernetes/istio_test.go
+++ b/kubernetes/istio_test.go
@@ -9,6 +9,22 @@ import (
 	"github.com/kiali/kiali/config"
 )
 
+func TestGetIstioConfigMap(t *testing.T) {
+	conf := config.NewConfig()
+
+	// When Revision is empty ("")
+	conf.ExternalServices.Istio.Revision = ""
+	config.Set(conf)
+
+	assert.Equal(t, "istio", GetIstioConfigMapName())
+
+	// When Revision is not empty
+	conf.ExternalServices.Istio.Revision = "canary"
+	config.Set(conf)
+
+	assert.Equal(t, "istio-canary", GetIstioConfigMapName())
+}
+
 func TestFilterByHost(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3187
Requires: https://github.com/kiali/kiali-operator/pull/126

When istio is installed using the canary upgrade feature [1], Kiali have errors in service details page. This is the following error:

![lclKJB6](https://user-images.githubusercontent.com/613814/92607458-70e03b80-f2b4-11ea-87b1-05a5050ef5eb.png)

In order to indicate the installation revision, there is now available the following setting:

```yaml
external_services:
  istio:
    revision: canary
```
In case istio is installed without revision, then this revision setting should be `""` (or left it empty).

[1] https://istio.io/latest/docs/setup/upgrade/