### PR TITLE
Add ConfigMapName setting to kiali CR

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -556,9 +556,9 @@ func (in *IstioValidationsService) fetchNonLocalmTLSConfigs(mtlsDetails *kuberne
 		var istioConfig *core_v1.ConfigMap
 		var err error
 		if IsNamespaceCached(cfg.IstioNamespace) {
-			istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, kubernetes.GetIstioConfigMapName())
+			istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 		} else {
-			istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, kubernetes.GetIstioConfigMapName())
+			istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 		}
 		if err != nil {
 			errChan <- err

--- a/business/tls.go
+++ b/business/tls.go
@@ -188,9 +188,9 @@ func (in *TLSService) hasAutoMTLSEnabled() bool {
 	var istioConfig *core_v1.ConfigMap
 	var err error
 	if IsNamespaceCached(cfg.IstioNamespace) {
-		istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, kubernetes.GetIstioConfigMapName())
+		istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	} else {
-		istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, kubernetes.GetIstioConfigMapName())
+		istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	}
 	if err != nil {
 		return true

--- a/config/config.go
+++ b/config/config.go
@@ -147,7 +147,7 @@ type IstioConfig struct {
 	IstioSidecarAnnotation   string            `yaml:"istio_sidecar_annotation,omitempty"`
 	ComponentStatuses        ComponentStatuses `yaml:"component_status,omitempty"`
 	UrlServiceVersion        string            `yaml:"url_service_version"`
-	Revision                 string            `yaml:"revision,omitempty"`
+	ConfigMapName            string            `yaml:"config_map_name,omitempty"`
 }
 
 type ComponentStatuses struct {
@@ -416,7 +416,7 @@ func NewConfig() (c *Config) {
 					},
 				},
 				UrlServiceVersion: "http://istiod:15014/version",
-				Revision:          "",
+				ConfigMapName:     "istio",
 			},
 			Prometheus: PrometheusConfig{
 				Auth: Auth{

--- a/config/config.go
+++ b/config/config.go
@@ -142,12 +142,12 @@ type TracingConfig struct {
 
 // IstioConfig describes configuration used for istio links
 type IstioConfig struct {
+	ComponentStatuses        ComponentStatuses `yaml:"component_status,omitempty"`
+	ConfigMapName            string            `yaml:"config_map_name,omitempty"`
 	IstioIdentityDomain      string            `yaml:"istio_identity_domain,omitempty"`
 	IstioInjectionAnnotation string            `yaml:"istio_injection_annotation,omitempty"`
 	IstioSidecarAnnotation   string            `yaml:"istio_sidecar_annotation,omitempty"`
-	ComponentStatuses        ComponentStatuses `yaml:"component_status,omitempty"`
 	UrlServiceVersion        string            `yaml:"url_service_version"`
-	ConfigMapName            string            `yaml:"config_map_name,omitempty"`
 }
 
 type ComponentStatuses struct {
@@ -415,8 +415,8 @@ func NewConfig() (c *Config) {
 						},
 					},
 				},
-				UrlServiceVersion: "http://istiod:15014/version",
 				ConfigMapName:     "istio",
+				UrlServiceVersion: "http://istiod:15014/version",
 			},
 			Prometheus: PrometheusConfig{
 				Auth: Auth{

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -57,7 +57,7 @@ type PublicConfig struct {
 	IstioComponentNamespaces config.IstioComponentNamespaces `json:"istioComponentNamespaces,omitempty"`
 	IstioLabels              config.IstioLabels              `json:"istioLabels,omitempty"`
 	IstioTelemetryV2         bool                            `json:"istioTelemetryV2"`
-	IstioRevision            string                          `json:"istioRevision"`
+	IstioConfigMap           string                          `json:"istioConfigMap"`
 	KialiFeatureFlags        config.KialiFeatureFlags        `json:"kialiFeatureFlags,omitempty"`
 	Prometheus               PrometheusConfig                `json:"prometheus,omitempty"`
 }
@@ -94,7 +94,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 		IstioNamespace:           config.IstioNamespace,
 		IstioComponentNamespaces: config.IstioComponentNamespaces,
 		IstioLabels:              config.IstioLabels,
-		IstioRevision:            config.ExternalServices.Istio.Revision,
+		IstioConfigMap:           config.ExternalServices.Istio.ConfigMapName,
 		KialiFeatureFlags:        config.KialiFeatureFlags,
 		Prometheus: PrometheusConfig{
 			GlobalScrapeInterval: promConfig.GlobalScrapeInterval,

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -351,15 +351,6 @@ func (in *K8SClient) getAuthenticationResources() map[string]bool {
 	return *in.authenticationResources
 }
 
-func GetIstioConfigMapName() string {
-	revision := config.Get().ExternalServices.Istio.Revision
-	name := IstioConfigMapName
-	if revision != "" {
-		name = fmt.Sprintf("%s-%s", IstioConfigMapName, revision)
-	}
-	return name
-}
-
 func GetIstioConfigMap(istioConfig *core_v1.ConfigMap) (*IstioMeshConfig, error) {
 	meshConfig := &IstioMeshConfig{}
 
@@ -392,7 +383,7 @@ func (in *K8SClient) IsMixerDisabled() bool {
 	}
 
 	cfg := config.Get()
-	istioConfig, err := in.GetConfigMap(cfg.IstioNamespace, GetIstioConfigMapName())
+	istioConfig, err := in.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	if err != nil {
 		log.Warningf("GetIstioConfigMap: Cannot retrieve Istio ConfigMap.")
 		return false

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -18,9 +18,8 @@ import (
 )
 
 var (
-	portNameMatcher    = regexp.MustCompile(`^[\-].*`)
-	portProtocols      = [...]string{"grpc", "http", "http2", "https", "mongo", "redis", "tcp", "tls", "udp", "mysql"}
-	IstioConfigMapName = "istio"
+	portNameMatcher = regexp.MustCompile(`^[\-].*`)
+	portProtocols   = [...]string{"grpc", "http", "http2", "https", "mongo", "redis", "tcp", "tls", "udp", "mysql"}
 )
 
 // Aux method to fetch proper (RESTClient, APIVersion) per API group

--- a/kubernetes/istio_test.go
+++ b/kubernetes/istio_test.go
@@ -9,22 +9,6 @@ import (
 	"github.com/kiali/kiali/config"
 )
 
-func TestGetIstioConfigMap(t *testing.T) {
-	conf := config.NewConfig()
-
-	// When Revision is empty ("")
-	conf.ExternalServices.Istio.Revision = ""
-	config.Set(conf)
-
-	assert.Equal(t, "istio", GetIstioConfigMapName())
-
-	// When Revision is not empty
-	conf.ExternalServices.Istio.Revision = "canary"
-	config.Set(conf)
-
-	assert.Equal(t, "istio-canary", GetIstioConfigMapName())
-}
-
 func TestFilterByHost(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)


### PR DESCRIPTION
Rename revision by config map name setting.
Reduce kiali code and remove the hardcoded istio config-map also.

related to https://github.com/kiali/kiali-operator/pull/127