### PR TITLE
Change degraded from 0.1 to 0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -495,7 +495,6 @@ func (conf *Config) AddHealthDefault() {
 						Code:      "^5\\d\\d$",
 						Protocol:  "http",
 						Direction: ".*",
-						Degraded:  0.1,
 						Failure:   10,
 					},
 					{
@@ -509,7 +508,6 @@ func (conf *Config) AddHealthDefault() {
 						Code:      "^[1-9]$|^1[0-6]$",
 						Protocol:  "grpc",
 						Direction: ".*",
-						Degraded:  0.1,
 						Failure:   10,
 					},
 				},


### PR DESCRIPTION
Change degraded values in configuration health
/api/config output
```json
{
        "namespace": ".*",
        "kind": ".*",
        "name": ".*",
        "tolerance": [
          {
            "code": "^5\\d\\d$",
            "degraded": 0,
            "failure": 10,
            "protocol": "http",
            "direction": ".*"
          },
          {
            "code": "^4\\d\\d$",
            "degraded": 10,
            "failure": 20,
            "protocol": "http",
            "direction": ".*"
          },
          {
            "code": "^[1-9]$|^1[0-6]$",
            "degraded": 0,
            "failure": 10,
            "protocol": "grpc",
            "direction": ".*"
          }
        ]
      }
```