### PR TITLE
Allow users to specify namespace for each Istio health component

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -66,10 +66,12 @@ func (iss *IstioStatusService) getComponentNamespacesWorkloads() ([]apps_v1.Depl
 	deps := make([]apps_v1.Deployment, 0)
 
 	comNs := config.Get().IstioComponentNamespaces
-	// In case there isn't any namespace set up, check the control plane namespace
-	if comNs == nil || len(comNs) == 0 {
-		comNs = map[string]string{"istiod": config.Get().IstioNamespace}
+	if comNs == nil {
+		comNs = map[string]string{}
 	}
+
+	// Always add the Istio Namespace to fetch istio-related components
+	comNs["default"] = config.Get().IstioNamespace
 
 	depsChan := make(chan []apps_v1.Deployment, len(comNs))
 	errChan := make(chan error, len(comNs))

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -75,7 +75,7 @@ func TestComponentNamespaces(t *testing.T) {
 
 	nss := getComponentNamespaces()
 
-	a.Contains(nss,"istio-system")
+	a.Contains(nss, "istio-system")
 	a.Contains(nss, "istio-admin")
 	a.Contains(nss, "prometheus-system")
 	a.Contains(nss, "grafana-system")
@@ -262,20 +262,20 @@ func confWithComponentNamespaces() *config.Config {
 	}
 
 	conf.ExternalServices.Grafana.ComponentStatus = config.ComponentStatus{
-		AppLabel: "grafana",
-		IsCore: false,
+		AppLabel:  "grafana",
+		IsCore:    false,
 		Namespace: "grafana-system",
 	}
 
 	conf.ExternalServices.Tracing.ComponentStatus = config.ComponentStatus{
-		AppLabel: "tracing",
-		IsCore: false,
+		AppLabel:  "tracing",
+		IsCore:    false,
 		Namespace: "tracing-system",
 	}
 
 	conf.ExternalServices.Prometheus.ComponentStatus = config.ComponentStatus{
-		AppLabel: "prometheus",
-		IsCore: true,
+		AppLabel:  "prometheus",
+		IsCore:    true,
 		Namespace: "prometheus-system",
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -156,8 +156,8 @@ type ComponentStatuses struct {
 }
 
 type ComponentStatus struct {
-	AppLabel string `yaml:"app_label,omitempty"`
-	IsCore   bool   `yaml:"is_core,omitempty"`
+	AppLabel  string `yaml:"app_label,omitempty"`
+	IsCore    bool   `yaml:"is_core,omitempty"`
 	Namespace string `yaml:"namespace,omitempty"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -158,6 +158,7 @@ type ComponentStatuses struct {
 type ComponentStatus struct {
 	AppLabel string `yaml:"app_label,omitempty"`
 	IsCore   bool   `yaml:"is_core,omitempty"`
+	Namespace string `yaml:"namespace,omitempty"`
 }
 
 // ThreeScaleConfig describes configuration used for 3Scale adapter


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3201
Requires https://github.com/kiali/kiali-operator/pull/128

Due to the removal of `istio_component_namespaces` from the settings, the istio component health feature needs other ways to let users specify where are their components located in.

This PR adds a new namespace field in each `component_status` object. In case, the namespace is empty, it defaults to the `istioNamespace` setting (typically `istio-system`). This way, users might specify the components of tracing, grafana, prometheus and the istio components (ingress, egress and istiod).
