### PR TITLE
Add Support for requests with no response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -515,7 +515,7 @@ func (conf *Config) AddHealthDefault() {
 						Code:      "^-$", // no response is indicated with a "-" code
 						Protocol:  "http|grpc",
 						Direction: ".*",
-						Degraded:  0.1,
+						Degraded:  0,
 						Failure:   10,
 					},
 				},

--- a/config/config.go
+++ b/config/config.go
@@ -515,7 +515,6 @@ func (conf *Config) AddHealthDefault() {
 						Code:      "^-$", // no response is indicated with a "-" code
 						Protocol:  "http|grpc",
 						Direction: ".*",
-						Degraded:  0,
 						Failure:   10,
 					},
 				},

--- a/config/config.go
+++ b/config/config.go
@@ -482,7 +482,7 @@ func NewConfig() (c *Config) {
 	return
 }
 
-// Add Health Default Configuration
+// AddHealthDefault Configuration
 func (conf *Config) AddHealthDefault() {
 	// Health default configuration
 	healthConfig := HealthConfig{
@@ -509,6 +509,13 @@ func (conf *Config) AddHealthDefault() {
 						Code:      "^[1-9]$|^1[0-6]$",
 						Protocol:  "grpc",
 						Direction: ".*",
+						Failure:   10,
+					},
+					{
+						Code:      "^-$", // no response is indicated with a "-" code
+						Protocol:  "http|grpc",
+						Direction: ".*",
+						Degraded:  0.1,
 						Failure:   10,
 					},
 				},

--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -1703,6 +1703,7 @@ func TestServiceNodeGraph(t *testing.T) {
 // - bad dest telemetry filtering
 // - bad source telemetry filtering
 // - workload -> egress -> service-entry traffic
+// - 0 response code (no response)
 // note: appenders still tested in separate unit tests given that they create their own new business/kube clients
 func TestComplexGraph(t *testing.T) {
 	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
@@ -1863,6 +1864,36 @@ func TestComplexGraph(t *testing.T) {
 		"request_protocol":               "http",
 		"response_code":                  "200",
 		"response_flags":                 "-"}
+	q8m5 := model.Metric{ // no response http
+		"source_workload_namespace":      "tutorial",
+		"source_workload":                "customer-v1",
+		"source_app":                     "customer",
+		"source_version":                 "v1",
+		"destination_service_namespace":  "unknown",
+		"destination_service":            "istio-egressgateway.istio-system.svc.cluster.local",
+		"destination_service_name":       "istio-egressgateway.istio-system.svc.cluster.local",
+		"destination_workload_namespace": "unknown",
+		"destination_workload":           "unknown",
+		"destination_app":                "unknown",
+		"destination_version":            "unknown",
+		"request_protocol":               "http",
+		"response_code":                  "0",
+		"response_flags":                 "DC"}
+	q8m6 := model.Metric{ // no response grpc
+		"source_workload_namespace":      "tutorial",
+		"source_workload":                "customer-v1",
+		"source_app":                     "customer",
+		"source_version":                 "v1",
+		"destination_service_namespace":  "unknown",
+		"destination_service":            "istio-egressgateway.istio-system.svc.cluster.local",
+		"destination_service_name":       "istio-egressgateway.istio-system.svc.cluster.local",
+		"destination_workload_namespace": "unknown",
+		"destination_workload":           "unknown",
+		"destination_app":                "unknown",
+		"destination_version":            "unknown",
+		"request_protocol":               "grpc",
+		"response_code":                  "0", // note, grpc_response_status is not reported for grpc with no response
+		"response_flags":                 "DC"}
 	v8 := model.Vector{
 		&model.Sample{
 			Metric: q8m0,
@@ -1878,7 +1909,13 @@ func TestComplexGraph(t *testing.T) {
 			Value:  300},
 		&model.Sample{
 			Metric: q8m4,
-			Value:  400}}
+			Value:  400},
+		&model.Sample{
+			Metric: q8m5,
+			Value:  500},
+		&model.Sample{
+			Metric: q8m6,
+			Value:  600}}
 
 	q9 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_flags),0.001)`
 	v9 := model.Vector{}

--- a/graph/api/testdata/test_complex_graph.expected
+++ b/graph/api/testdata/test_complex_graph.expected
@@ -86,13 +86,14 @@
             {
               "protocol": "grpc",
               "rates": {
-                "grpcIn": "50.00"
+                "grpcIn": "50.00",
+                "grpcOut": "600.00"
               }
             },
             {
               "protocol": "http",
               "rates": {
-                "httpOut": "750.00"
+                "httpOut": "1250.00"
               }
             }
           ]
@@ -228,13 +229,49 @@
           "traffic": {
             "protocol": "http",
             "rates": {
-              "http": "400.00",
-              "httpPercentReq": "53.3"
+              "http": "900.00",
+              "httpNoResponse": "500.00",
+              "httpPercentErr": "55.6",
+              "httpPercentReq": "72.0"
             },
             "responses": {
+              "-": {
+                "flags": {
+                  "DC": "55.6"
+                },
+                "hosts": {
+                  "istio-egressgateway.istio-system.svc.cluster.local": "55.6"
+                }
+              },
               "200": {
                 "flags": {
-                  "-": "100.0"
+                  "-": "44.4"
+                },
+                "hosts": {
+                  "istio-egressgateway.istio-system.svc.cluster.local": "44.4"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "485623cf19d454363bc392d13e19902f",
+          "source": "d75c918a12f72a1ea1797911cb9770f7",
+          "target": "332209947916c37701f39500789b6792",
+          "traffic": {
+            "protocol": "grpc",
+            "rates": {
+              "grpc": "600.00",
+              "grpcNoResponse": "600.00",
+              "grpcPercentErr": "100.0",
+              "grpcPercentReq": "100.0"
+            },
+            "responses": {
+              "-": {
+                "flags": {
+                  "DC": "100.0"
                 },
                 "hosts": {
                   "istio-egressgateway.istio-system.svc.cluster.local": "100.0"
@@ -253,7 +290,7 @@
             "protocol": "http",
             "rates": {
               "http": "300.00",
-              "httpPercentReq": "40.0"
+              "httpPercentReq": "24.0"
             },
             "responses": {
               "200": {
@@ -277,7 +314,7 @@
             "protocol": "http",
             "rates": {
               "http": "50.00",
-              "httpPercentReq": "6.7"
+              "httpPercentReq": "4.0"
             },
             "responses": {
               "200": {

--- a/graph/api/testdata/test_complex_graph.expected
+++ b/graph/api/testdata/test_complex_graph.expected
@@ -118,7 +118,8 @@
                 "httpIn": "400.00"
               }
             }
-          ]
+          ],
+          "isInaccessible": true
         }
       },
       {

--- a/graph/telemetry/common.go
+++ b/graph/telemetry/common.go
@@ -55,7 +55,7 @@ func MarkOutsideOrInaccessible(trafficMap graph.TrafficMap, o graph.TelemetryOpt
 		case graph.NodeTypeUnknown:
 			n.Metadata[graph.IsInaccessible] = true
 		case graph.NodeTypeService:
-			if n.Namespace == graph.Unknown && n.Service == graph.Unknown {
+			if n.Namespace == graph.Unknown {
 				n.Metadata[graph.IsInaccessible] = true
 			} else if n.Metadata[graph.IsEgressCluster] == true {
 				n.Metadata[graph.IsInaccessible] = true

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	regexpHTTPFailure, _ = regexp.Compile(`^[4|5]\d\d$`)
+	regexpHTTPFailure, _ = regexp.Compile(`^0$|^[4|5]\d\d$`) // include 0, Istio's flag for no response received
 )
 
 // ResponseTimeAppender is responsible for adding responseTime information to the graph. ResponseTime

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -84,35 +84,45 @@ func (in *Client) GetMetrics(query *IstioMetricsQuery) Metrics {
 }
 
 // GetAllRequestRates queries Prometheus to fetch request counter rates, over a time interval, for requests
-// into, internal to, or out of the namespace.
+// into, internal to, or out of the namespace. Note that it does not discriminate on "reporter", so rates can
+// be inflated due to duplication, and therefore should be used mainly for calculating ratios
+// (e.g total rates / error rates).
 // Returns (rates, error)
 func (in *Client) GetAllRequestRates(namespace string, ratesInterval string, queryTime time.Time) (model.Vector, error) {
 	return getAllRequestRates(in.api, namespace, queryTime, ratesInterval)
 }
 
 // GetNamespaceServicesRequestRates queries Prometheus to fetch request counter rates, over a time interval, limited to
-// requests for services in the namespace.
+// requests for services in the namespace. Note that it does not discriminate on "reporter", so rates can
+// be inflated due to duplication, and therefore should be used mainly for calculating ratios
+// (e.g total rates / error rates).
 // Returns (rates, error)
 func (in *Client) GetNamespaceServicesRequestRates(namespace string, ratesInterval string, queryTime time.Time) (model.Vector, error) {
 	return getNamespaceServicesRequestRates(in.api, namespace, queryTime, ratesInterval)
 }
 
 // GetServiceRequestRates queries Prometheus to fetch request counters rates over a time interval
-// for a given service (hence only inbound).
+// for a given service (hence only inbound). Note that it does not discriminate on "reporter", so rates can
+// be inflated due to duplication, and therefore should be used mainly for calculating ratios
+// (e.g total rates / error rates).
 // Returns (in, error)
 func (in *Client) GetServiceRequestRates(namespace, service, ratesInterval string, queryTime time.Time) (model.Vector, error) {
 	return getServiceRequestRates(in.api, namespace, service, queryTime, ratesInterval)
 }
 
 // GetAppRequestRates queries Prometheus to fetch request counters rates over a time interval
-// for a given app, both in and out.
+// for a given app, both in and out. Note that it does not discriminate on "reporter", so rates can
+// be inflated due to duplication, and therefore should be used mainly for calculating ratios
+// (e.g total rates / error rates).
 // Returns (in, out, error)
 func (in *Client) GetAppRequestRates(namespace, app, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error) {
 	return getItemRequestRates(in.api, namespace, app, "app", queryTime, ratesInterval)
 }
 
 // GetWorkloadRequestRates queries Prometheus to fetch request counters rates over a time interval
-// for a given workload, both in and out.
+// for a given workload, both in and out. Note that it does not discriminate on "reporter", so rates can
+// be inflated due to duplication, and therefore should be used mainly for calculating ratios
+// (e.g total rates / error rates).
 // Returns (in, out, error)
 func (in *Client) GetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error) {
 	return getItemRequestRates(in.api, namespace, workload, "workload", queryTime, ratesInterval)

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	regexGrpcResponseStatusErr = "^[1-9]$|^1[0-6]$"
-	regexResponseCodeErr       = "^0$|^[4-5]\\d\\d$"
+	regexResponseCodeErr       = "^0$|^[4-5]\\\\d\\\\d$"
 )
 
 func getMetrics(api prom_v1.API, q *IstioMetricsQuery) Metrics {

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -58,16 +58,20 @@ func buildLabelStrings(q *IstioMetricsQuery) (string, []string) {
 
 	errors := []string{}
 	protocol := strings.ToLower(q.RequestProtocol)
-	if protocol == "" || protocol == "grpc" {
-		// this is intentionally not `grpc_response_status!="0"`. We need to be backward compatible and
-		// handle the case where grpc_response_status does not exist.  In Prometheus, negative tests on a
-		// non-existent label match everything, but positive tests match nothing. So, we stay positive.
-		grpcLabels := append(labels, `grpc_response_status=~"^[1-9]$|^1[0-6]$"`)
+
+	// both http and grpc requests can suffer from no response (response_code=0) or an http error
+	// (response_code=4xx,5xx), and so we always perform a query against response_code:
+	httpLabels := append(labels, `response_code=~"^0$|^[4-5]\\d\\d$"`)
+	errors = append(errors, "{"+strings.Join(httpLabels, ",")+"}")
+
+	// if necessary also look for grpc errors. note that the grpc test intentionally avoids
+	// `grpc_response_status!="0"`. We need to be backward compatible and handle the case where
+	// grpc_response_status does not exist, or if it is simply unset. In Prometheus, negative tests on a
+	// non-existent label match everything, but positive tests match nothing. So, we stay positive.
+	// furthermore, make sure we only count grpc errors with successful http status.
+	if protocol != "http" {
+		grpcLabels := append(labels, `grpc_response_status=~"^[1-9]$|^1[0-6]$",response_code!~"^0$|^[4-5]\\d\\d$"`)
 		errors = append(errors, ("{" + strings.Join(grpcLabels, ",") + "}"))
-	}
-	if protocol == "" || protocol == "http" {
-		httpLabels := append(labels, `response_code=~"^0$|[4-5]\\d\\d$"`)
-		errors = append(errors, "{"+strings.Join(httpLabels, ",")+"}")
 	}
 
 	return full, errors
@@ -207,7 +211,8 @@ func fetchRange(api prom_v1.API, query string, bounds prom_v1.Range) *Metric {
 }
 
 // getAllRequestRates retrieves traffic rates for requests entering, internal to, or exiting the namespace.
-// Uses source telemetry unless working on the Istio namespace.
+// Note that it does not discriminate on "reporter", so rates can be inflated due to duplication, and therefore
+// should be used mainly for calculating ratios (e.g total rates / error rates)
 func getAllRequestRates(api prom_v1.API, namespace string, queryTime time.Time, ratesInterval string) (model.Vector, error) {
 	// traffic originating outside the namespace to destinations inside the namespace
 	lbl := fmt.Sprintf(`destination_service_namespace="%s",source_workload_namespace!="%s"`, namespace, namespace)
@@ -227,7 +232,8 @@ func getAllRequestRates(api prom_v1.API, namespace string, queryTime time.Time, 
 }
 
 // getNamespaceServicesRequestRates retrieves traffic rates for requests entering or internal to the namespace.
-// Uses source telemetry unless working on the Istio namespace.
+// Note that it does not discriminate on "reporter", so rates can be inflated due to duplication, and therefore
+// should be used mainly for calculating ratios (e.g total rates / error rates)
 func getNamespaceServicesRequestRates(api prom_v1.API, namespace string, queryTime time.Time, ratesInterval string) (model.Vector, error) {
 	// traffic for the namespace services
 	lblNs := fmt.Sprintf(`destination_service_namespace="%s"`, namespace)
@@ -238,6 +244,9 @@ func getNamespaceServicesRequestRates(api prom_v1.API, namespace string, queryTi
 	return ns, nil
 }
 
+// getServiceRequestRates retrieves traffic rates for requests entering, or internal to the namespace, for a specific service name
+// Note that it does not discriminate on "reporter", so rates can be inflated due to duplication, and therefore
+// should be used mainly for calculating ratios (e.g total rates / error rates)
 func getServiceRequestRates(api prom_v1.API, namespace, service string, queryTime time.Time, ratesInterval string) (model.Vector, error) {
 	lbl := fmt.Sprintf(`destination_service_name="%s",destination_service_namespace="%s"`, service, namespace)
 	in, err := getRequestRatesForLabel(api, queryTime, lbl, ratesInterval)
@@ -247,6 +256,9 @@ func getServiceRequestRates(api prom_v1.API, namespace, service string, queryTim
 	return in, nil
 }
 
+// getItemRequestRates retrieves traffic rates for requests entering, internal to, or exiting the namespace, for a specific destinatation_<itemLabelSuffix> value
+// Note that it does not discriminate on "reporter", so rates can be inflated due to duplication, and therefore
+// should be used mainly for calculating ratios (e.g total rates / error rates)
 func getItemRequestRates(api prom_v1.API, namespace, item, itemLabelSuffix string, queryTime time.Time, ratesInterval string) (model.Vector, model.Vector, error) {
 	lblIn := fmt.Sprintf(`destination_workload_namespace="%s",destination_%s="%s"`, namespace, itemLabelSuffix, item)
 	lblOut := fmt.Sprintf(`source_workload_namespace="%s",source_%s="%s"`, namespace, itemLabelSuffix, item)
@@ -262,7 +274,7 @@ func getItemRequestRates(api prom_v1.API, namespace, item, itemLabelSuffix strin
 }
 
 func getRequestRatesForLabel(api prom_v1.API, time time.Time, labels, ratesInterval string) (model.Vector, error) {
-	query := fmt.Sprintf("rate(istio_requests_total{%s}[%s])", labels, ratesInterval)
+	query := fmt.Sprintf("rate(istio_requests_total{%s}[%s]) > 0", labels, ratesInterval)
 	promtimer := internalmetrics.GetPrometheusProcessingTimePrometheusTimer("Metrics-GetRequestRates")
 	result, err := api.Query(context.Background(), query, time)
 	if err != nil {

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -66,7 +66,7 @@ func buildLabelStrings(q *IstioMetricsQuery) (string, []string) {
 		errors = append(errors, ("{" + strings.Join(grpcLabels, ",") + "}"))
 	}
 	if protocol == "" || protocol == "http" {
-		httpLabels := append(labels, `response_code=~"^[4-5]\\d\\d$"`)
+		httpLabels := append(labels, `response_code=~"^0$|[4-5]\\d\\d$"`)
 		errors = append(errors, "{"+strings.Join(httpLabels, ",")+"}")
 	}
 

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -327,7 +327,7 @@ func TestGetAllRequestRates(t *testing.T) {
 			Metric:    model.Metric{"foo": "bar"},
 		},
 	}
-	mockQueryWithTime(api, `rate(istio_requests_total{destination_service_namespace="ns",source_workload_namespace!="ns"}[5m])`, queryTime, &vectorQ1)
+	mockQueryWithTime(api, `rate(istio_requests_total{destination_service_namespace="ns",source_workload_namespace!="ns"}[5m]) > 0`, queryTime, &vectorQ1)
 
 	vectorQ2 := model.Vector{
 		&model.Sample{
@@ -335,7 +335,7 @@ func TestGetAllRequestRates(t *testing.T) {
 			Value:     model.SampleValue(2),
 			Metric:    model.Metric{"foo": "bar"}},
 	}
-	mockQueryWithTime(api, `rate(istio_requests_total{source_workload_namespace="ns"}[5m])`, queryTime, &vectorQ2)
+	mockQueryWithTime(api, `rate(istio_requests_total{source_workload_namespace="ns"}[5m]) > 0`, queryTime, &vectorQ2)
 
 	rates, _ := client.GetAllRequestRates("ns", "5m", queryTime)
 	assert.Equal(t, 2, rates.Len())
@@ -359,7 +359,7 @@ func TestGetAllRequestRatesIstioSystem(t *testing.T) {
 			Metric:    model.Metric{"foo": "bar"},
 		},
 	}
-	mockQueryWithTime(api, `rate(istio_requests_total{destination_service_namespace="istio-system",source_workload_namespace!="istio-system"}[5m])`, queryTime, &vectorQ1)
+	mockQueryWithTime(api, `rate(istio_requests_total{destination_service_namespace="istio-system",source_workload_namespace!="istio-system"}[5m]) > 0`, queryTime, &vectorQ1)
 
 	vectorQ2 := model.Vector{
 		&model.Sample{
@@ -367,7 +367,7 @@ func TestGetAllRequestRatesIstioSystem(t *testing.T) {
 			Value:     model.SampleValue(2),
 			Metric:    model.Metric{"foo": "bar"}},
 	}
-	mockQueryWithTime(api, `rate(istio_requests_total{source_workload_namespace="istio-system"}[5m])`, queryTime, &vectorQ2)
+	mockQueryWithTime(api, `rate(istio_requests_total{source_workload_namespace="istio-system"}[5m]) > 0`, queryTime, &vectorQ2)
 
 	rates, _ := client.GetAllRequestRates("istio-system", "5m", queryTime)
 	assert.Equal(t, 2, rates.Len())
@@ -391,7 +391,7 @@ func TestGetNamespaceServicesRequestRates(t *testing.T) {
 			Metric:    model.Metric{"foo": "bar"},
 		},
 	}
-	mockQueryWithTime(api, `rate(istio_requests_total{destination_service_namespace="ns"}[5m])`, queryTime, &vectorQ1)
+	mockQueryWithTime(api, `rate(istio_requests_total{destination_service_namespace="ns"}[5m]) > 0`, queryTime, &vectorQ1)
 
 	rates, _ := client.GetNamespaceServicesRequestRates("ns", "5m", queryTime)
 	assert.Equal(t, 1, rates.Len())

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -56,7 +56,7 @@ func TestGetServiceMetrics(t *testing.T) {
 
 	labels := `reporter="source",destination_service_name="productpage",destination_service_namespace="bookinfo"`
 	mockWithRange(api, expectedRange, round("sum(rate(istio_requests_total{"+labels+"}[5m]))"), 2.5)
-	mockWithRange(api, expectedRange, roundErrs("sum(rate(istio_requests_total{"+labels+`,grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{`+labels+`,response_code=~"^[4-5]\\d\\d$"}[5m]))`), 4.5)
+	mockWithRange(api, expectedRange, roundErrs("sum(rate(istio_requests_total{"+labels+`,response_code=~"^0$|^[4-5]\\d\\d$"}[5m])) OR sum(rate(istio_requests_total{`+labels+`,grpc_response_status=~"^[1-9]$|^1[0-6]$",response_code!~"^0$|^[4-5]\\d\\d$"}[5m]))`), 4.5)
 	mockWithRange(api, expectedRange, round("sum(rate(istio_request_bytes_sum{"+labels+"}[5m]))"), 1000)
 	mockWithRange(api, expectedRange, round("sum(rate(istio_response_bytes_sum{"+labels+"}[5m]))"), 1001)
 	mockWithRange(api, expectedRange, round("sum(rate(istio_tcp_received_bytes_total{"+labels+"}[5m]))"), 11)
@@ -111,7 +111,7 @@ func TestGetAppMetrics(t *testing.T) {
 	}
 	labels := `reporter="source",source_workload_namespace="bookinfo",source_app="productpage"`
 	mockRange(api, round("sum(rate(istio_requests_total{"+labels+"}[5m]))"), 1.5)
-	mockRange(api, roundErrs("sum(rate(istio_requests_total{"+labels+`,grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{`+labels+`,response_code=~"^[4-5]\\d\\d$"}[5m]))`), 3.5)
+	mockRange(api, roundErrs("sum(rate(istio_requests_total{"+labels+`,response_code=~"^0$|^[4-5]\\d\\d$"}[5m])) OR sum(rate(istio_requests_total{`+labels+`,grpc_response_status=~"^[1-9]$|^1[0-6]$",response_code!~"^0$|^[4-5]\\d\\d$"}[5m]))`), 3.5)
 	mockRange(api, round("sum(rate(istio_request_bytes_sum{"+labels+"}[5m]))"), 1000)
 	mockRange(api, round("sum(rate(istio_response_bytes_sum{"+labels+"}[5m]))"), 1001)
 	mockRange(api, round("sum(rate(istio_tcp_received_bytes_total{"+labels+"}[5m]))"), 10)
@@ -256,7 +256,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	}
 	labels := `reporter="source",source_workload_namespace="bookinfo"`
 	mockRange(api, round("sum(rate(istio_requests_total{"+labels+"}[5m]))"), 1.5)
-	mockRange(api, roundErrs("sum(rate(istio_requests_total{"+labels+`,grpc_response_status=~"^[1-9]$|^1[0-6]$"}[5m])) OR sum(rate(istio_requests_total{`+labels+`,response_code=~"^[4-5]\\d\\d$"}[5m]))`), 3.5)
+	mockRange(api, roundErrs("sum(rate(istio_requests_total{"+labels+`,response_code=~"^0$|^[4-5]\\d\\d$"}[5m])) OR sum(rate(istio_requests_total{`+labels+`,grpc_response_status=~"^[1-9]$|^1[0-6]$",response_code!~"^0$|^[4-5]\\d\\d$"}[5m]))`), 3.5)
 	mockRange(api, round("sum(rate(istio_request_bytes_sum{"+labels+"}[5m]))"), 1000)
 	mockRange(api, round("sum(rate(istio_response_bytes_sum{"+labels+"}[5m]))"), 1001)
 	mockRange(api, round("sum(rate(istio_tcp_received_bytes_total{"+labels+"}[5m]))"), 10)


### PR DESCRIPTION
Fixes #3194 

Requests that have no response must also be treated as errors because the request never completes, and a response is never sent.  Error handling up to this point assumed a valid response code for the request protocol. But when there is no response Istio sets the response_code=0 to indicate the inability to set a proper code.  Kiali needs to treat the "no response" case as an error.
- For the graph generation and appenders add support for the new case.
- For health enhance the defaults with a new error rate config and update rate eggregation
- For metrics capture the no response case in the errors queries

Also:
- fix issue by making service nodes with unknown namespace inaccessible.

**Requires UI PR: https://github.com/kiali/kiali-ui/pull/1925**

For Testing:
One way to force the 0 response_code scenario is to deploy bookinfo and then apply our hack:

`> oc apply -n bookinfo -f hack/istio/bookinfo-ratings-delay.yaml`

It should result in some various failure scenarios giving you red edges and red nodes.  The edges should likely show code="-", flags="DC" in the "flags" tab of the side panel.  The nodes should reflect traffic rate issues in the side panel health tooltip.

@jmazzitelli please review the graph code changes
@jotak  please review the metrics code changes
@aljesusg please review the health code changes
