### PR TITLE
Bump k-charted 0.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/jaegertracing/jaeger v1.15.1
-	github.com/kiali/k-charted v0.6.1
+	github.com/kiali/k-charted v0.6.2
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/openshift/api v0.0.0-20200221181648-8ce0047d664f
 	github.com/prometheus/client_golang v0.9.4

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/kiali/k-charted v0.6.1-rc4 h1:Phi6LkupsgFCiXlqPVdIt9NlUTdcNNMRzWSx1y8
 github.com/kiali/k-charted v0.6.1-rc4/go.mod h1:I4r4ETMi0fyi6ljX2VCYy16g/a3Vpx5oET9xXkyXmbY=
 github.com/kiali/k-charted v0.6.1 h1:IDGwtnPDvUN6rHoxfhbA8XiHZdidFo+c5KZ8eLbl51s=
 github.com/kiali/k-charted v0.6.1/go.mod h1:I4r4ETMi0fyi6ljX2VCYy16g/a3Vpx5oET9xXkyXmbY=
+github.com/kiali/k-charted v0.6.2 h1:Suqtcml0qPXRxpzBZRNs7CFhilbgJrTiUU2yK+734aI=
+github.com/kiali/k-charted v0.6.2/go.mod h1:I4r4ETMi0fyi6ljX2VCYy16g/a3Vpx5oET9xXkyXmbY=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Note, there's actually no code change here, it's only on the frontend, but this PR is to keep version consistent with kiali-ui