### PR TITLE
3224 - define USER as numeric uid in dockerfile

### DIFF
--- a/deploy/docker/Dockerfile-ubi7-minimal
+++ b/deploy/docker/Dockerfile-ubi7-minimal
@@ -10,7 +10,7 @@ WORKDIR $KIALI_HOME
 RUN microdnf install -y shadow-utils && \
     microdnf clean all && \
     rm -rf /var/cache/yum && \
-    adduser kiali
+    adduser --uid 1000 kiali
 
 COPY kiali $KIALI_HOME/
 
@@ -19,6 +19,6 @@ ADD console $KIALI_HOME/console/
 RUN chown -R kiali:kiali $KIALI_HOME/console && \
     chmod -R g=u $KIALI_HOME/console
 
-USER kiali
+USER 1000
 
 ENTRYPOINT ["/opt/kiali/kiali"]

--- a/deploy/docker/Dockerfile-ubi8-minimal
+++ b/deploy/docker/Dockerfile-ubi8-minimal
@@ -10,7 +10,7 @@ WORKDIR $KIALI_HOME
 RUN microdnf install -y shadow-utils && \
     microdnf clean all && \
     rm -rf /var/cache/yum && \
-    adduser kiali
+    adduser --uid 1000 kiali
 
 COPY kiali $KIALI_HOME/
 
@@ -19,6 +19,6 @@ ADD console $KIALI_HOME/console/
 RUN chown -R kiali:kiali $KIALI_HOME/console && \
     chmod -R g=u $KIALI_HOME/console
 
-USER kiali
+USER 1000
 
 ENTRYPOINT ["/opt/kiali/kiali"]


### PR DESCRIPTION
** Describe the change **

If someone wants to use a PodSecurityPolicies with runAsNonRootUser (even though Kiali already does this), Kiali Dockerfile needs to be set with a numeric USER. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups where it says, `MustRunAsNonRoot - Requires that the pod be submitted with a non-zero runAsUser or have the USER directive defined (using a numeric UID) in the image`.

** Issue reference **

https://github.com/kiali/kiali/issues/3224

** Backwards incompatible? **

Yes. This PR simply uses the same UID as what was used before (1000) except now the Dockerfile is explicit about it (rather than use the uesr name "kiali").
