### PR TITLE
Support parsed log messages for the workload logs

### DIFF
--- a/business/test_util.go
+++ b/business/test_util.go
@@ -615,7 +615,7 @@ func FakePodSyncedWithDeployments() *core_v1.Pod {
 
 func FakePodLogsSyncedWithDeployments() *kubernetes.PodLogs {
 	return &kubernetes.PodLogs{
-		Logs: "Fake Log Entry 1\nFake Log Entry 2",
+		Logs: "2018-01-02T03:34:28+0000 INFO Fake Log Entry 1\n2018-01-02T04:34:28+0000 WARN Fake Log Entry 2",
 	}
 }
 

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -615,7 +615,10 @@ func FakePodSyncedWithDeployments() *core_v1.Pod {
 
 func FakePodLogsSyncedWithDeployments() *kubernetes.PodLogs {
 	return &kubernetes.PodLogs{
-		Logs: "2018-01-02T03:34:28+00:00 INFO Fake Log Entry 1\n2018-01-02T04:34:28+00:00 WARN Fake Log Entry 2\n2018-01-02T04:34:28+00:00 Fake Log Entry 3",
+		Logs: `2018-01-02T03:34:28+00:00 INFO Fake Log Entry
+2018-01-02T04:34:28+00:00 WARN Fake Warning Entry
+2018-01-02T04:34:28+00:00 Log Entry Without Severity
+2018-01-02T04:34:28+00:00 error Log Entry With LowerCase Severity`,
 	}
 }
 

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -615,7 +615,7 @@ func FakePodSyncedWithDeployments() *core_v1.Pod {
 
 func FakePodLogsSyncedWithDeployments() *kubernetes.PodLogs {
 	return &kubernetes.PodLogs{
-		Logs: "2018-01-02T03:34:28+0000 INFO Fake Log Entry 1\n2018-01-02T04:34:28+0000 WARN Fake Log Entry 2",
+		Logs: "2018-01-02T03:34:28+0000 INFO Fake Log Entry 1\n2018-01-02T04:34:28+0000 WARN Fake Log Entry 2\n2018-01-02T04:34:28+0000 Fake Log Entry 3",
 	}
 }
 

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -615,7 +615,7 @@ func FakePodSyncedWithDeployments() *core_v1.Pod {
 
 func FakePodLogsSyncedWithDeployments() *kubernetes.PodLogs {
 	return &kubernetes.PodLogs{
-		Logs: "2018-01-02T03:34:28+0000 INFO Fake Log Entry 1\n2018-01-02T04:34:28+0000 WARN Fake Log Entry 2\n2018-01-02T04:34:28+0000 Fake Log Entry 3",
+		Logs: "2018-01-02T03:34:28+00:00 INFO Fake Log Entry 1\n2018-01-02T04:34:28+00:00 WARN Fake Log Entry 2\n2018-01-02T04:34:28+00:00 Fake Log Entry 3",
 	}
 }
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -209,7 +209,7 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *core_v1.P
 
 		timestamp := timestampRegexp.FindString(line)
 		if timestamp != "" {
-			parsed, _ := time.Parse("2006-01-02T15:04:05+0000", string(timestamp))
+			parsed, err := time.Parse("2006-01-02T15:04:05+0000", string(timestamp))
 
 			if err == nil {
 				message.Timestamp = timestamp

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -39,12 +39,16 @@ type PodLog struct {
 
 type LogEntry struct {
 	Message   string `json:"message,omitempty"`
-	Timestamp int64  `json:"timestamp,omitempty"`
 	Severity  string `json:"severity,omitempty"`
+	Timestamp int64  `json:"timestamp,omitempty"`
 }
 
 var (
 	excludedWorkloads map[string]bool
+
+	// Matches an ISO8601 full date
+	timestampRegexp = regexp.MustCompile(`^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(([+-]\d\d:\d\d)|Z)?(\+\d{4})?`)
+	severityRegexp  = regexp.MustCompile(`(\s+|^)(INFO|WARN|DEBUG|TRACE)\s+`)
 )
 
 func isWorkloadIncluded(workload string) bool {
@@ -190,10 +194,6 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *core_v1.P
 	if err != nil {
 		return nil, err
 	}
-
-	// Matches an ISO8601 full date
-	timestampRegexp := regexp.MustCompile("^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?(\\+\\d{4})?")
-	severityRegexp := regexp.MustCompile("(\\s+|^)(INFO|WARN|DEBUG|TRACE)\\s+")
 
 	lines := strings.Split(podLog.Logs, "\n")
 	messages := make([]LogEntry, 0)

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -48,8 +48,7 @@ var (
 	excludedWorkloads map[string]bool
 
 	// Matches an ISO8601 full date
-	timestampRegexp = regexp.MustCompile(`^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(([+-]\d\d:\d\d)|Z)?(\+\d{4})?`)
-	severityRegexp  = regexp.MustCompile(`(\s+|^)(INFO|WARN|DEBUG|TRACE)\s+`)
+	severityRegexp = regexp.MustCompile(`(\s+|^)(INFO|WARN|DEBUG|TRACE)\s+`)
 )
 
 func isWorkloadIncluded(workload string) bool {
@@ -207,18 +206,16 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *core_v1.P
 			Severity:      "",
 		}
 
-		timestamp := timestampRegexp.FindString(line)
-		if timestamp != "" {
-			parsed, err := time.Parse("2006-01-02T15:04:05+0000", string(timestamp))
+		splitted := strings.Split(line, " ")
+		timestamp := splitted[0]
+		parsed, err := time.Parse("2006-01-02T15:04:05+0000", string(timestamp))
 
-			if err == nil {
-				message.Timestamp = timestamp
-				message.TimestampUnix = parsed.Unix()
-			}
+		if err == nil {
+			message.Timestamp = timestamp
+			message.TimestampUnix = parsed.Unix()
 		}
 
-		line = string(timestampRegexp.ReplaceAll([]byte(line), []byte("")))
-		message.Message = line
+		line = strings.Join(splitted[1:], " ")
 
 		severity := severityRegexp.FindString(line)
 		if severity != "" {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -49,7 +49,7 @@ var (
 	excludedWorkloads map[string]bool
 
 	// Matches an ISO8601 full date
-	severityRegexp = regexp.MustCompile(`ERROR|WARN|DEBUG|TRACE`)
+	severityRegexp = regexp.MustCompile(`(?i)ERROR|WARN|DEBUG|TRACE`)
 )
 
 func isWorkloadIncluded(workload string) bool {
@@ -233,7 +233,7 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *core_v1.P
 
 		severity := severityRegexp.FindString(line)
 		if severity != "" {
-			entry.Severity = severity
+			entry.Severity = strings.ToUpper(severity)
 		}
 
 		messages = append(messages, entry)

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -33,11 +33,11 @@ type WorkloadService struct {
 
 // Structures for workload log messages
 type PodLog struct {
-	Logs     string       `json:"logs,omitempty"`
-	Messages []LogMessage `json:"messages,omitempty"`
+	Logs    string     `json:"logs,omitempty"`
+	Entries []LogEntry `json:"entries,omitempty"`
 }
 
-type LogMessage struct {
+type LogEntry struct {
 	Message   string `json:"message,omitempty"`
 	Timestamp int64  `json:"timestamp,omitempty"`
 	Severity  string `json:"severity,omitempty"`
@@ -196,10 +196,10 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *core_v1.P
 	severityRegexp := regexp.MustCompile("(\\s+|^)(INFO|WARN|DEBUG|TRACE)\\s+")
 
 	lines := strings.Split(podLog.Logs, "\n")
-	messages := make([]LogMessage, 0)
+	messages := make([]LogEntry, 0)
 
 	for _, line := range lines {
-		message := LogMessage{
+		message := LogEntry{
 			Message:   line,
 			Timestamp: 0,
 			Severity:  "",
@@ -232,8 +232,8 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *core_v1.P
 	}
 
 	message := PodLog{
-		Logs:     podLog.Logs,
-		Messages: messages,
+		Logs:    podLog.Logs,
+		Entries: messages,
 	}
 
 	return &message, err

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -38,9 +38,10 @@ type PodLog struct {
 }
 
 type LogEntry struct {
-	Message   string `json:"message,omitempty"`
-	Severity  string `json:"severity,omitempty"`
-	Timestamp int64  `json:"timestamp,omitempty"`
+	Message       string `json:"message,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	Timestamp     string `json:"timestamp,omitempty"`
+	TimestampUnix int64  `json:"timestampUnix,omitempty"`
 }
 
 var (
@@ -200,9 +201,10 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *core_v1.P
 
 	for _, line := range lines {
 		message := LogEntry{
-			Message:   line,
-			Timestamp: 0,
-			Severity:  "",
+			Message:       line,
+			Timestamp:     "",
+			TimestampUnix: 0,
+			Severity:      "",
 		}
 
 		timestamp := timestampRegexp.FindString(line)
@@ -210,7 +212,8 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *core_v1.P
 			parsed, _ := time.Parse("2006-01-02T15:04:05+0000", string(timestamp))
 
 			if err == nil {
-				message.Timestamp = parsed.Unix()
+				message.Timestamp = timestamp
+				message.TimestampUnix = parsed.Unix()
 			}
 		}
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -218,7 +218,9 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *core_v1.P
 		line = strings.Join(splitted[1:], " ")
 
 		severity := severityRegexp.FindString(line)
-		if severity != "" {
+		if severity == "" {
+			message.Severity = "INFO"
+		} else {
 			message.Severity = strings.TrimSpace(severity)
 
 			line = string(severityRegexp.ReplaceAll([]byte(line), []byte("")))

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -442,22 +442,22 @@ func TestGetPodLogs(t *testing.T) {
 
 	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &core_v1.PodLogOptions{Container: "details"})
 
-	assert.Equal("2018-01-02T03:34:28+0000 INFO Fake Log Entry 1\n2018-01-02T04:34:28+0000 WARN Fake Log Entry 2\n2018-01-02T04:34:28+0000 Fake Log Entry 3", podLogs.Logs)
+	assert.Equal("2018-01-02T03:34:28+00:00 INFO Fake Log Entry 1\n2018-01-02T04:34:28+00:00 WARN Fake Log Entry 2\n2018-01-02T04:34:28+00:00 Fake Log Entry 3", podLogs.Logs)
 
 	assert.Equal(len(podLogs.Entries), 3)
 
-	assert.Equal("2018-01-02T03:34:28+0000", podLogs.Entries[0].Timestamp)
+	assert.Equal("2018-01-02T03:34:28+00:00", podLogs.Entries[0].Timestamp)
 	assert.Equal(int64(1514864068), podLogs.Entries[0].TimestampUnix)
-	assert.Equal("Fake Log Entry 1", podLogs.Entries[0].Message)
+	assert.Equal("INFO Fake Log Entry 1", podLogs.Entries[0].Message)
 	assert.Equal("INFO", podLogs.Entries[0].Severity)
 
-	assert.Equal("2018-01-02T04:34:28+0000", podLogs.Entries[1].Timestamp)
+	assert.Equal("2018-01-02T04:34:28+00:00", podLogs.Entries[1].Timestamp)
 	assert.Equal(int64(1514867668), podLogs.Entries[1].TimestampUnix)
-	assert.Equal("Fake Log Entry 2", podLogs.Entries[1].Message)
+	assert.Equal("WARN Fake Log Entry 2", podLogs.Entries[1].Message)
 	assert.Equal("WARN", podLogs.Entries[1].Severity)
 
 	// Set default severity to INFO if none is present
-	assert.Equal("2018-01-02T04:34:28+0000", podLogs.Entries[2].Timestamp)
+	assert.Equal("2018-01-02T04:34:28+00:00", podLogs.Entries[2].Timestamp)
 	assert.Equal(int64(1514867668), podLogs.Entries[2].TimestampUnix)
 	assert.Equal("Fake Log Entry 3", podLogs.Entries[2].Message)
 	assert.Equal("INFO", podLogs.Entries[2].Severity)

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -442,25 +442,29 @@ func TestGetPodLogs(t *testing.T) {
 
 	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &core_v1.PodLogOptions{Container: "details"})
 
-	assert.Equal("2018-01-02T03:34:28+00:00 INFO Fake Log Entry 1\n2018-01-02T04:34:28+00:00 WARN Fake Log Entry 2\n2018-01-02T04:34:28+00:00 Fake Log Entry 3", podLogs.Logs)
+	assert.Equal(FakePodLogsSyncedWithDeployments().Logs, podLogs.Logs)
 
-	assert.Equal(len(podLogs.Entries), 3)
+	assert.Equal(len(podLogs.Entries), 4)
 
 	assert.Equal("2018-01-02T03:34:28+00:00", podLogs.Entries[0].Timestamp)
 	assert.Equal(int64(1514864068), podLogs.Entries[0].TimestampUnix)
-	assert.Equal("INFO Fake Log Entry 1", podLogs.Entries[0].Message)
+	assert.Equal("INFO Fake Log Entry", podLogs.Entries[0].Message)
 	assert.Equal("INFO", podLogs.Entries[0].Severity)
 
 	assert.Equal("2018-01-02T04:34:28+00:00", podLogs.Entries[1].Timestamp)
 	assert.Equal(int64(1514867668), podLogs.Entries[1].TimestampUnix)
-	assert.Equal("WARN Fake Log Entry 2", podLogs.Entries[1].Message)
+	assert.Equal("WARN Fake Warning Entry", podLogs.Entries[1].Message)
 	assert.Equal("WARN", podLogs.Entries[1].Severity)
 
-	// Set default severity to INFO if none is present
 	assert.Equal("2018-01-02T04:34:28+00:00", podLogs.Entries[2].Timestamp)
 	assert.Equal(int64(1514867668), podLogs.Entries[2].TimestampUnix)
-	assert.Equal("Fake Log Entry 3", podLogs.Entries[2].Message)
+	assert.Equal("Log Entry Without Severity", podLogs.Entries[2].Message)
 	assert.Equal("INFO", podLogs.Entries[2].Severity)
+
+	assert.Equal("2018-01-02T04:34:28+00:00", podLogs.Entries[3].Timestamp)
+	assert.Equal(int64(1514867668), podLogs.Entries[3].TimestampUnix)
+	assert.Equal("error Log Entry With LowerCase Severity", podLogs.Entries[3].Message)
+	assert.Equal("ERROR", podLogs.Entries[3].Severity)
 }
 
 func TestDuplicatedControllers(t *testing.T) {

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -442,7 +442,15 @@ func TestGetPodLogs(t *testing.T) {
 
 	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &core_v1.PodLogOptions{Container: "details"})
 
-	assert.Equal("Fake Log Entry 1\nFake Log Entry 2", podLogs.Logs)
+	assert.Equal("2018-01-02T03:34:28+0000 INFO Fake Log Entry 1\n2018-01-02T04:34:28+0000 WARN Fake Log Entry 2", podLogs.Logs)
+
+	assert.Equal(int64(1514864068), podLogs.Messages[0].Timestamp)
+	assert.Equal("Fake Log Entry 1", podLogs.Messages[0].Message)
+	assert.Equal("INFO", podLogs.Messages[0].Severity)
+
+	assert.Equal(int64(1514867668), podLogs.Messages[1].Timestamp)
+	assert.Equal("Fake Log Entry 2", podLogs.Messages[1].Message)
+	assert.Equal("WARN", podLogs.Messages[1].Severity)
 }
 
 func TestDuplicatedControllers(t *testing.T) {

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -442,9 +442,9 @@ func TestGetPodLogs(t *testing.T) {
 
 	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &core_v1.PodLogOptions{Container: "details"})
 
-	assert.Equal("2018-01-02T03:34:28+0000 INFO Fake Log Entry 1\n2018-01-02T04:34:28+0000 WARN Fake Log Entry 2", podLogs.Logs)
+	assert.Equal("2018-01-02T03:34:28+0000 INFO Fake Log Entry 1\n2018-01-02T04:34:28+0000 WARN Fake Log Entry 2\n2018-01-02T04:34:28+0000 Fake Log Entry 3", podLogs.Logs)
 
-	assert.Equal(len(podLogs.Entries), 2)
+	assert.Equal(len(podLogs.Entries), 3)
 
 	assert.Equal("2018-01-02T03:34:28+0000", podLogs.Entries[0].Timestamp)
 	assert.Equal(int64(1514864068), podLogs.Entries[0].TimestampUnix)
@@ -455,6 +455,12 @@ func TestGetPodLogs(t *testing.T) {
 	assert.Equal(int64(1514867668), podLogs.Entries[1].TimestampUnix)
 	assert.Equal("Fake Log Entry 2", podLogs.Entries[1].Message)
 	assert.Equal("WARN", podLogs.Entries[1].Severity)
+
+	// Set default severity to INFO if none is present
+	assert.Equal("2018-01-02T04:34:28+0000", podLogs.Entries[2].Timestamp)
+	assert.Equal(int64(1514867668), podLogs.Entries[2].TimestampUnix)
+	assert.Equal("Fake Log Entry 3", podLogs.Entries[2].Message)
+	assert.Equal("INFO", podLogs.Entries[2].Severity)
 }
 
 func TestDuplicatedControllers(t *testing.T) {

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -446,11 +446,13 @@ func TestGetPodLogs(t *testing.T) {
 
 	assert.Equal(len(podLogs.Entries), 2)
 
-	assert.Equal(int64(1514864068), podLogs.Entries[0].Timestamp)
+	assert.Equal("2018-01-02T03:34:28+0000", podLogs.Entries[0].Timestamp)
+	assert.Equal(int64(1514864068), podLogs.Entries[0].TimestampUnix)
 	assert.Equal("Fake Log Entry 1", podLogs.Entries[0].Message)
 	assert.Equal("INFO", podLogs.Entries[0].Severity)
 
-	assert.Equal(int64(1514867668), podLogs.Entries[1].Timestamp)
+	assert.Equal("2018-01-02T04:34:28+0000", podLogs.Entries[1].Timestamp)
+	assert.Equal(int64(1514867668), podLogs.Entries[1].TimestampUnix)
 	assert.Equal("Fake Log Entry 2", podLogs.Entries[1].Message)
 	assert.Equal("WARN", podLogs.Entries[1].Severity)
 }

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -444,13 +444,15 @@ func TestGetPodLogs(t *testing.T) {
 
 	assert.Equal("2018-01-02T03:34:28+0000 INFO Fake Log Entry 1\n2018-01-02T04:34:28+0000 WARN Fake Log Entry 2", podLogs.Logs)
 
-	assert.Equal(int64(1514864068), podLogs.Messages[0].Timestamp)
-	assert.Equal("Fake Log Entry 1", podLogs.Messages[0].Message)
-	assert.Equal("INFO", podLogs.Messages[0].Severity)
+	assert.Equal(len(podLogs.Entries), 2)
 
-	assert.Equal(int64(1514867668), podLogs.Messages[1].Timestamp)
-	assert.Equal("Fake Log Entry 2", podLogs.Messages[1].Message)
-	assert.Equal("WARN", podLogs.Messages[1].Severity)
+	assert.Equal(int64(1514864068), podLogs.Entries[0].Timestamp)
+	assert.Equal("Fake Log Entry 1", podLogs.Entries[0].Message)
+	assert.Equal("INFO", podLogs.Entries[0].Severity)
+
+	assert.Equal(int64(1514867668), podLogs.Entries[1].Timestamp)
+	assert.Equal("Fake Log Entry 2", podLogs.Entries[1].Message)
+	assert.Equal("WARN", podLogs.Entries[1].Severity)
 }
 
 func TestDuplicatedControllers(t *testing.T) {


### PR DESCRIPTION
Closes #3264.

This PR adds some support to parsing log messages from the workload, so we can apply some better filtering (as an example, kubernetes pod logs api supports a start time, but not an end time).

Some implementation details:

- Timestamp support uses ISO8601 instead of RFC3339 (which is go default), because no other stack seems to be using it from what I've seen.
- I could not find a good ISO8601 (or RFC3339 for that matter) regexp that could cover all our cases, because go does not support Perl-like lookarounds, like many mature regexp engines around.

For log severity, I'm currently supporting only named ones (INFO, WARN, ERROR). Log formats are really, really unreliable.