### PR TITLE
[OpenId] Support for clusters without OIDC integration (no RBAC will be possible)

### DIFF
--- a/business/openid_auth.go
+++ b/business/openid_auth.go
@@ -1,7 +1,6 @@
 package business
 
 import (
-	"crypto"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/sha256"
@@ -408,16 +407,6 @@ func GetOpenIdJwks() (*jose.JSONWebKeySet, error) {
 			return nil, fmt.Errorf("cannot parse OpenId JWKS document: %s", err.Error())
 		}
 
-	// TODO: Remove this loop. It's only for debugging
-	log.Debugf("OIDC has %i keys", len(oidcKeys.Keys))
-	for _, key := range oidcKeys.Keys {
-		thumbprint, e := key.Thumbprint(crypto.SHA256)
-		if e != nil {
-			thumbprint = []byte{0}
-		}
-		log.Debugf("OIDC Key: ID = %s, ALG = %s, Use = %s, Key thumbprint = %x", key.KeyID, key.Algorithm, key.Use, thumbprint)
-	}
-
 		cachedOpenIdKeySet = &oidcKeys // Store the keyset in a "cache"
 		return cachedOpenIdKeySet, nil
 	})
@@ -635,7 +624,7 @@ func ValidateOpenTokenInHouse(openIdParams *OpenIdCallbackParams) error {
 		// Let's do the minimal check to ensure that the token wasn't issued in the future
 		// we add a little offset to "now" to add one minute tolerance
 		iatTime := time.Unix(parsedIat, 0)
-		nowTime := util.Clock.Now().Add(60*time.Second)
+		nowTime := util.Clock.Now().Add(60 * time.Second)
 		if iatTime.After(nowTime) {
 			return fmt.Errorf("we don't like people living in the future - enjoy the present!; iat = '%d'", parsedIat)
 		}
@@ -655,7 +644,6 @@ func ValidateOpenTokenInHouse(openIdParams *OpenIdCallbackParams) error {
 	//       need to provide it nor we need to verify it.
 	//   - auth_time: we are not asking for this claim at authorization, so the IdP doesn't
 	//	     need to provide it nor we need to verify it.
-
 
 	// If execution flow reached this point, all claims look valid, but that won't guarantee that
 	// the id_token hasn't been tampered. So, we check the signature to find if

--- a/business/openid_auth.go
+++ b/business/openid_auth.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/util"
 )
 
 const (
@@ -143,28 +144,15 @@ func ParseOpenIdToken(openIdParams *OpenIdCallbackParams) error {
 	idTokenClaims := parsedIdToken.Claims.(jwt.MapClaims)
 
 	// Set a default value for expiration date
-	openIdParams.ExpiresOn = time.Now().Add(time.Second * time.Duration(config.Get().LoginToken.ExpirationSeconds))
-
-	// If the expiration date is present on the claim, we use that
-	expiresInNumber := int64(0)
-
-	// As it turns out, the response from the exp claim can be either a f64 and
-	// a json.Number. With this, we take care of it, converting to the int64
-	// that we need to use timestamps in go.
-	switch exp := idTokenClaims["exp"].(type) {
-	case float64:
-		// This can not fail
-		expiresInNumber = int64(exp)
-	case json.Number:
-		// This can fail, so we short-circuit if we get an invalid value.
-		expiresInNumber, err = exp.Int64()
-
+	if expClaim, ok := idTokenClaims["exp"]; !ok {
+		return errors.New("the received id_token from the OpenId provider has missing the required 'exp' claim")
+	} else {
+		// If the expiration date is present on the claim, we use that
+		expiresInNumber, err := parseTimeClaim(expClaim)
 		if err != nil {
 			return fmt.Errorf("token exp claim is present, but invalid: %w", err)
 		}
-	}
 
-	if expiresInNumber != 0 {
 		openIdParams.ExpiresOn = time.Unix(expiresInNumber, 0)
 	}
 
@@ -521,6 +509,145 @@ func ValidateOpenIdState(openIdParams *OpenIdCallbackParams) (validationFailure 
 	return
 }
 
+func ValidateOpenTokenInHouse(openIdParams *OpenIdCallbackParams) error {
+	oidCfg := config.Get().Auth.OpenId
+	oidMetadata, err := GetOpenIdMetadata()
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("Raw token to validate: %s", openIdParams.IdToken)
+
+	idTokenClaims := openIdParams.ParsedIdToken.Claims.(jwt.MapClaims)
+
+	// Check iss claim matches fetched metadata at discovery
+	if issuerClaim, ok := idTokenClaims["iss"].(string); !ok || issuerClaim != oidMetadata.Issuer {
+		return fmt.Errorf("the OpenId token has unexpected issuer claim; got iss = '%s'", issuerClaim)
+	}
+
+	// Check the aud claim contains our client-id
+	checkAzpClaim := false
+	if audienceClaim, ok := idTokenClaims["aud"]; !ok {
+		return errors.New("the OpenId token has no aud claim")
+	} else {
+		switch ac := audienceClaim.(type) {
+		case string:
+			if oidCfg.ClientId != ac {
+				return fmt.Errorf("the OpenId token is not targeted for Kiali; got aud = '%s'", audienceClaim)
+			}
+		case []string:
+			audFound := false
+			for _, audItem := range ac {
+				if oidCfg.ClientId == audItem {
+					audFound = true
+				}
+			}
+			if !audFound {
+				return fmt.Errorf("the OpenId token is not targeted for Kiali; got aud = %v", audienceClaim)
+			}
+
+			// The OIDC Spec says that if the aud claim contains multiple audiences, we "SHOULD" check
+			// the azp claim is present. In Kiali, there is currently no known reason to omit this
+			// check, so we do it.
+			checkAzpClaim = true
+		default:
+			return fmt.Errorf("the OpenId token has an unexpected audience claim; got '%v'", audienceClaim)
+		}
+	}
+
+	if checkAzpClaim {
+		// Check that the azp claim is present and contains our client_id
+		if authorizedPartyClaim, ok := idTokenClaims["azp"].(string); !ok {
+			return fmt.Errorf("the OpenId token has an invalid 'azp' claim")
+		} else if oidCfg.ClientId != authorizedPartyClaim {
+			return fmt.Errorf("the OpenId token is not targeted for Kiali; got azp = %v", authorizedPartyClaim)
+		}
+	}
+
+	// Currently, we only support tokens with an RSA signature with SHA-256, which is the default in the OIDC spec
+	if algHeader, ok := openIdParams.ParsedIdToken.Header["alg"].(string); !ok || algHeader != "RS256" {
+		return fmt.Errorf("the OpenId token has unexpected alg header claim; got alg = '%s'", algHeader)
+	}
+
+	// Check iat (issued at) claim
+	if iatClaim, ok := idTokenClaims["iat"]; !ok {
+		return errors.New("the OpenId token has no iat claim or is invalid")
+	} else {
+		parsedIat, parseErr := parseTimeClaim(iatClaim)
+		if parseErr != nil {
+			return fmt.Errorf("the OpenId token has an invalid iat claim: %w", err)
+		}
+		if parsedIat == 0 {
+			// This is weird. This would mean an invalid type
+			return fmt.Errorf("the OpenId token has an invalid value in the iat claim; got '%v'", iatClaim)
+		}
+
+		// Let's do the minimal check to ensure that the token wasn't issued in the future
+		// we add a little offset to "now" to add one minute tolerance
+		iatTime := time.Unix(parsedIat, 0)
+		nowTime := util.Clock.Now().Add(60*time.Second)
+		if iatTime.After(nowTime) {
+			return fmt.Errorf("we don't like people living in the future - enjoy the present!; iat = '%d'", parsedIat)
+		}
+	}
+
+	// Check exp (expiration time) claim
+	// The OIDC spec says: "The current time MUST be before the time represented by the exp Claim"
+	// No tolerance for this check.
+	if !util.Clock.Now().Before(openIdParams.ExpiresOn) {
+		return fmt.Errorf("the OpenId token has expired; exp = '%s'", openIdParams.ExpiresOn.String())
+	}
+
+	// There are other claims that could be checked, but are not verified here:
+	//   - nonce: This should be verified regardless if RBAC is on/off. So, it's verified in
+	//       another part of the authentication flow.
+	//   - acr: we are not asking for this claim at authorization, so the IdP doesn't
+	//       need to provide it nor we need to verify it.
+	//   - auth_time: we are not asking for this claim at authorization, so the IdP doesn't
+	//	     need to provide it nor we need to verify it.
+
+
+	// If execution flow reached this point, all claims look valid, but that won't guarantee that
+	// the id_token hasn't been tampered. So, we check the signature to find if
+	// the token is genuine
+	oidcKeySet, err := GetOpenIdJwks()
+	if err != nil {
+		return err
+	}
+
+	if kidHeader, ok := openIdParams.ParsedIdToken.Header["kid"]; !ok {
+		return errors.New("the OpenId token is missing the kid header claim")
+	} else {
+		// Find the key in the fetched keyset
+		var matchingKey *jose.JSONWebKey;
+		for _, key := range oidcKeySet.Keys {
+			if key.KeyID == kidHeader.(string) {
+				matchingKey = &key
+				break
+			}
+		}
+
+		if matchingKey == nil {
+			return errors.New("the OpenId token is signed with an unknown key")
+		}
+
+		if jws, parseErr := jose.ParseSigned(openIdParams.IdToken); parseErr != nil {
+			return fmt.Errorf("error when parsing the OpenId token: %w", parseErr)
+		} else {
+			if len(jws.Signatures) == 0 {
+				return errors.New("an unsigned OpenId token is not acceptable")
+			}
+
+			_, signVerifyErr := jws.Verify(matchingKey)
+			if signVerifyErr != nil {
+				return fmt.Errorf("cannot verify signature of OpenId token: %w", signVerifyErr)
+			}
+		}
+	}
+
+	return nil
+}
+
 func VerifyOpenIdUserAccess(token string) (int, string, error) {
 	// Create business layer using the id_token
 	business, err := Get(token)
@@ -541,4 +668,29 @@ func VerifyOpenIdUserAccess(token string) (int, string, error) {
 	}
 
 	return http.StatusOK, "", nil
+}
+
+// As it turns out, the response from time claims can be either a f64 and
+// a json.Number. With this, we take care of it, converting to the int64
+// that we need to use timestamps in go.
+func parseTimeClaim(claimValue interface{}) (int64, error) {
+	var err error
+	parsedTime := int64(0)
+
+	switch exp := claimValue.(type) {
+	case float64:
+		// This can not fail
+		parsedTime = int64(exp)
+	case json.Number:
+		// This can fail, so we short-circuit if we get an invalid value.
+		parsedTime, err = exp.Int64()
+
+		if err != nil {
+			return 0, err
+		}
+	default:
+		return 0, errors.New("the 'exp' claim of the OpenId token has invalid type")
+	}
+
+	return parsedTime, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -274,6 +274,7 @@ type OpenIdConfig struct {
 	AuthorizationEndpoint string   `yaml:"authorization_endpoint,omitempty"`
 	ClientId              string   `yaml:"client_id,omitempty"`
 	ClientSecret          string   `yaml:"client_secret,omitempty"`
+	DisableRBAC           bool     `yaml:"disable_rbac,omitempty"`
 	InsecureSkipVerifyTLS bool     `yaml:"insecure_skip_verify_tls,omitempty"`
 	IssuerUri             string   `yaml:"issuer_uri,omitempty"`
 	Scopes                []string `yaml:"scopes,omitempty"`
@@ -362,6 +363,7 @@ func NewConfig() (c *Config) {
 				AuthorizationEndpoint: "",
 				ClientId:              "",
 				ClientSecret:          "",
+				DisableRBAC:           false,
 				InsecureSkipVerifyTLS: false,
 				IssuerUri:             "",
 				Scopes:                []string{"openid", "profile", "email"},

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
+	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0-20190313235455-40a48860b5ab
 	k8s.io/apimachinery v0.0.0-20190816221834-a9f1d8a9c101

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/prometheus/common v0.4.1
 	github.com/prometheus/procfs v0.0.10 // indirect
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
+gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -722,9 +722,7 @@ func OpenIdCodeFlowHandler(w http.ResponseWriter, r *http.Request) bool {
 			RespondWithDetailedError(w, http.StatusForbidden, "the OpenID token was rejected", err.Error())
 			return true
 		}
-	}
-
-	if !conf.Auth.OpenId.DisableRBAC {
+	} else {
 		// Check if user trying to login has enough privileges to login. This check is only done if
 		// config indicates that RBAC is on. For cases where RBAC is off, we simply assume that the
 		// Kiali ServiceAccount token should have enough privileges and skip this privilege check.

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -688,9 +688,6 @@ func OpenIdCodeFlowHandler(w http.ResponseWriter, r *http.Request) bool {
 		return true
 	}
 
-	// TODO: remove/re-locate
-	business.GetOpenIdJwks()
-
 	if err := business.ParseOpenIdToken(openIdParams); err != nil {
 		RespondWithError(w, http.StatusUnauthorized, err.Error())
 		return true
@@ -701,6 +698,12 @@ func OpenIdCodeFlowHandler(w http.ResponseWriter, r *http.Request) bool {
 		RespondWithError(w, http.StatusForbidden, fmt.Sprintf("OpenId token rejected: %s", nonceError))
 		return true
 	}
+
+	// TODO: this should conditionally run if RBAC is off
+    err = business.ValidateOpenTokenInHouse(openIdParams)
+    if err != nil {
+	    RespondWithDetailedError(w, http.StatusForbidden, "the OpenID token is invalid", err.Error())
+    }
 
 	// Check if user trying to login has enough privileges to login
 	httpStatus, errMsg, detailedError := business.VerifyOpenIdUserAccess(openIdParams.IdToken)

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -688,6 +688,9 @@ func OpenIdCodeFlowHandler(w http.ResponseWriter, r *http.Request) bool {
 		return true
 	}
 
+	// TODO: remove/re-locate
+	business.GetOpenIdJwks()
+
 	if err := business.ParseOpenIdToken(openIdParams); err != nil {
 		RespondWithError(w, http.StatusUnauthorized, err.Error())
 		return true


### PR DESCRIPTION
Add support for using OpenId providers to login into Kiali even if the Kubernetes cluster has no OIDC integration. This is done by turning off RBAC and using the Kiali ServiceAccount token regardless of the logged in user.

Most of the code is related to adding several checks on the OpenId token. On the "integrated" scenario, these checks were delegated to the Kubernetes cluster. But on the "non-integrated" scenario (which this PR is adding support for) we are no longer passing the openid token to Kubernetes (because we are using the Kiali ServiceAccount token). Thus, without these checks, the token would not be fully validated.

This is adding two new dependencies:
* golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e -- used for multi-thread synchronization when fetching "common" data from the OpenId Server
* gopkg.in/square/go-jose.v2 v2.5.1 -- used for validating openid token signatures

Operator side PR: https://github.com/kiali/kiali-operator/pull/165

Related kiali/kiali#3084