### PR TITLE
Short term expiration cache for Health Prom queries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -96,7 +96,11 @@ func (a *Auth) Obfuscate() {
 
 // PrometheusConfig describes configuration of the Prometheus component
 type PrometheusConfig struct {
-	Auth            Auth            `yaml:"auth,omitempty"`
+	Auth Auth `yaml:"auth,omitempty"`
+	// Cache duration expressed in seconds
+	CacheDuration int `yaml:"cache_duration,omitempty"`
+	// Enable cache for Prometheus queries
+	CacheEnabled    bool            `yaml:"cache_enabled,omitempty"`
 	ComponentStatus ComponentStatus `yaml:"component_status,omitempty"`
 	URL             string          `yaml:"url,omitempty"`
 }
@@ -431,6 +435,8 @@ func NewConfig() (c *Config) {
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
+				CacheEnabled:  true,
+				CacheDuration: 10,
 				ComponentStatus: ComponentStatus{
 					AppLabel: "prometheus",
 					IsCore:   true,

--- a/config/config.go
+++ b/config/config.go
@@ -100,9 +100,9 @@ type PrometheusConfig struct {
 	// Cache duration per query expressed in seconds
 	CacheDuration int `yaml:"cache_duration,omitempty"`
 	// Enable cache for Prometheus queries
-	CacheEnabled    bool            `yaml:"cache_enabled,omitempty"`
+	CacheEnabled bool `yaml:"cache_enabled,omitempty"`
 	// Global cache expiration expressed in seconds
-	CacheExpiration int 			`yaml:"cache_expiration:omitempty"`
+	CacheExpiration int             `yaml:"cache_expiration:omitempty"`
 	ComponentStatus ComponentStatus `yaml:"component_status,omitempty"`
 	URL             string          `yaml:"url,omitempty"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -435,7 +435,7 @@ func NewConfig() (c *Config) {
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
-				CacheEnabled:  true,
+				CacheEnabled: true,
 				// 1/2 Prom Scrape Interval
 				CacheDuration: 7,
 				ComponentStatus: ComponentStatus{

--- a/config/config.go
+++ b/config/config.go
@@ -436,7 +436,8 @@ func NewConfig() (c *Config) {
 					Type: AuthTypeNone,
 				},
 				CacheEnabled:  true,
-				CacheDuration: 10,
+				// 1/2 Prom Scrape Interval
+				CacheDuration: 7,
 				ComponentStatus: ComponentStatus{
 					AppLabel: "prometheus",
 					IsCore:   true,

--- a/config/config.go
+++ b/config/config.go
@@ -97,10 +97,12 @@ func (a *Auth) Obfuscate() {
 // PrometheusConfig describes configuration of the Prometheus component
 type PrometheusConfig struct {
 	Auth Auth `yaml:"auth,omitempty"`
-	// Cache duration expressed in seconds
+	// Cache duration per query expressed in seconds
 	CacheDuration int `yaml:"cache_duration,omitempty"`
 	// Enable cache for Prometheus queries
 	CacheEnabled    bool            `yaml:"cache_enabled,omitempty"`
+	// Global cache expiration expressed in seconds
+	CacheExpiration int 			`yaml:"cache_expiration:omitempty"`
 	ComponentStatus ComponentStatus `yaml:"component_status,omitempty"`
 	URL             string          `yaml:"url,omitempty"`
 }
@@ -438,6 +440,8 @@ func NewConfig() (c *Config) {
 				CacheEnabled: true,
 				// 1/2 Prom Scrape Interval
 				CacheDuration: 7,
+				// Prom Cache expires and it forces to repopulate cache
+				CacheExpiration: 300,
 				ComponentStatus: ComponentStatus{
 					AppLabel: "prometheus",
 					IsCore:   true,

--- a/prometheus/cache.go
+++ b/prometheus/cache.go
@@ -71,7 +71,7 @@ func (c *promCacheImpl) GetAllRequestRates(namespace string, ratesInterval strin
 
 	if nsRates, okNs := c.cacheAllRequestRates[namespace]; okNs {
 		if rtInterval, okRt := nsRates[ratesInterval]; okRt {
-			if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+			if !queryTime.Before(rtInterval.queryTime) && queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
 				log.Tracef("[Prom Cache] GetAllRequestRates [namespace: %s] [ratesInterval: %s] [queryTime: %s]", namespace, ratesInterval, queryTime.String())
 				return true, rtInterval.inResult
 			}

--- a/prometheus/cache.go
+++ b/prometheus/cache.go
@@ -58,7 +58,7 @@ func NewPromCache() PromCache {
 	cacheExpiration := time.Duration(kConfig.ExternalServices.Prometheus.CacheExpiration) * time.Second
 	promCacheImpl := promCacheImpl{
 		cacheDuration:          cacheDuration,
-		cacheExpiration: 		cacheExpiration,
+		cacheExpiration:        cacheExpiration,
 		cacheAllRequestRates:   make(map[string]map[string]timeInResult),
 		cacheAppRequestRates:   make(map[string]map[string]map[string]timeInOutResult),
 		cacheNsSvcRequestRates: make(map[string]map[string]timeInResult),

--- a/prometheus/cache.go
+++ b/prometheus/cache.go
@@ -102,7 +102,7 @@ func (c *promCacheImpl) GetAppRequestRates(namespace string, app string, ratesIn
 	if nsRates, okNs := c.cacheAppRequestRates[namespace]; okNs {
 		if appInterval, okApp := nsRates[app]; okApp {
 			if rtInterval, okRt := appInterval[ratesInterval]; okRt {
-				if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+				if !queryTime.Before(rtInterval.queryTime) && queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
 					log.Tracef("[Prom Cache] GetAppRequestRates [namespace: %s] [app: %s] [ratesInterval: %s] [queryTime: %s]", namespace, app, ratesInterval, queryTime.String())
 					return true, rtInterval.inResult, rtInterval.outResult
 				}
@@ -138,7 +138,7 @@ func (c *promCacheImpl) GetNamespaceServicesRequestRates(namespace string, rates
 
 	if nsRates, okNs := c.cacheNsSvcRequestRates[namespace]; okNs {
 		if rtInterval, okRt := nsRates[ratesInterval]; okRt {
-			if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+			if !queryTime.Before(rtInterval.queryTime) && queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
 				log.Tracef("[Prom Cache] GetNamespaceServicesRequestRates [namespace: %s] [ratesInterval: %s] [queryTime: %s]", namespace, ratesInterval, queryTime.String())
 				return true, rtInterval.inResult
 			}
@@ -169,7 +169,7 @@ func (c *promCacheImpl) GetServiceRequestRates(namespace string, service string,
 	if nsRates, okNs := c.cacheSvcRequestRates[namespace]; okNs {
 		if svcInterval, okSvc := nsRates[service]; okSvc {
 			if rtInterval, okRt := svcInterval[ratesInterval]; okRt {
-				if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+				if !queryTime.Before(rtInterval.queryTime) && queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
 					log.Tracef("[Prom Cache] GetServiceRequestRates [namespace: %s] [service: %s] [ratesInterval: %s] [queryTime: %s]", namespace, service, ratesInterval, queryTime.String())
 					return true, rtInterval.inResult
 				}
@@ -205,7 +205,7 @@ func (c *promCacheImpl) GetWorkloadRequestRates(namespace string, workload strin
 	if nsRates, okNs := c.cacheWkRequestRates[namespace]; okNs {
 		if wkInterval, okWk := nsRates[workload]; okWk {
 			if rtInterval, okRt := wkInterval[ratesInterval]; okRt {
-				if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+				if !queryTime.Before(rtInterval.queryTime) && queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
 					log.Tracef("[Prom Cache] GetWorkloadRequestRates [namespace: %s] [workload: %s] [ratesInterval: %s] [queryTime: %s]", namespace, workload, ratesInterval, queryTime.String())
 					return true, rtInterval.inResult, rtInterval.outResult
 				}

--- a/prometheus/cache.go
+++ b/prometheus/cache.go
@@ -1,0 +1,236 @@
+package prometheus
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	kialiConfig "github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
+)
+
+type (
+	timeInResult struct {
+		queryTime time.Time
+		inResult  model.Vector
+	}
+
+	timeInOutResult struct {
+		queryTime time.Time
+		inResult  model.Vector
+		outResult model.Vector
+	}
+
+	PromCache interface {
+		GetAllRequestRates(namespace string, ratesInterval string, queryTime time.Time) (bool, model.Vector)
+		GetAppRequestRates(namespace, app, ratesInterval string, queryTime time.Time) (bool, model.Vector, model.Vector)
+		GetNamespaceServicesRequestRates(namespace string, ratesInterval string, queryTime time.Time) (bool, model.Vector)
+		GetServiceRequestRates(namespace, service, ratesInterval string, queryTime time.Time) (bool, model.Vector)
+		GetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time) (bool, model.Vector, model.Vector)
+		SetAllRequestRates(namespace string, ratesInterval string, queryTime time.Time, inResult model.Vector)
+		SetAppRequestRates(namespace, app, ratesInterval string, queryTime time.Time, inResult model.Vector, outResult model.Vector)
+		SetNamespaceServicesRequestRates(namespace string, ratesInterval string, queryTime time.Time, inResult model.Vector)
+		SetServiceRequestRates(namespace, service, ratesInterval string, queryTime time.Time, inResult model.Vector)
+		SetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time, inResult model.Vector, outResult model.Vector)
+	}
+
+	promCacheImpl struct {
+		cacheDuration          time.Duration
+		cacheAllRequestRates   map[string]map[string]timeInResult
+		cacheAppRequestRates   map[string]map[string]map[string]timeInOutResult
+		cacheNsSvcRequestRates map[string]map[string]timeInResult
+		cacheSvcRequestRates   map[string]map[string]map[string]timeInResult
+		cacheWkRequestRates    map[string]map[string]map[string]timeInOutResult
+		allRequestRatesLock    sync.RWMutex
+		appRequestRatesLock    sync.RWMutex
+		nsSvcRequestRatesLock  sync.RWMutex
+		svcRequestRatesLock    sync.RWMutex
+		wkRequestRatesLock     sync.RWMutex
+	}
+)
+
+func NewPromCache() PromCache {
+	kConfig := kialiConfig.Get()
+
+	cacheDuration := time.Duration(kConfig.ExternalServices.Prometheus.CacheDuration) * time.Second
+	promCacheImpl := promCacheImpl{
+		cacheDuration:          cacheDuration,
+		cacheAllRequestRates:   make(map[string]map[string]timeInResult),
+		cacheAppRequestRates:   make(map[string]map[string]map[string]timeInOutResult),
+		cacheNsSvcRequestRates: make(map[string]map[string]timeInResult),
+		cacheSvcRequestRates:   make(map[string]map[string]map[string]timeInResult),
+		cacheWkRequestRates:    make(map[string]map[string]map[string]timeInOutResult),
+	}
+	return &promCacheImpl
+}
+
+func (c *promCacheImpl) GetAllRequestRates(namespace string, ratesInterval string, queryTime time.Time) (bool, model.Vector) {
+	defer c.allRequestRatesLock.RUnlock()
+	c.allRequestRatesLock.RLock()
+
+	if nsRates, okNs := c.cacheAllRequestRates[namespace]; okNs {
+		if rtInterval, okRt := nsRates[ratesInterval]; okRt {
+			if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+				log.Tracef("[Prom Cache] GetAllRequestRates [namespace: %s] [ratesInterval: %s] [queryTime: %s]", namespace, ratesInterval, queryTime.String())
+				return true, rtInterval.inResult
+			}
+		}
+	}
+	return false, nil
+}
+
+func (c *promCacheImpl) SetAllRequestRates(namespace string, ratesInterval string, queryTime time.Time, inResult model.Vector) {
+	defer c.allRequestRatesLock.Unlock()
+	c.allRequestRatesLock.Lock()
+
+	if _, okNs := c.cacheAllRequestRates[namespace]; !okNs {
+		c.cacheAllRequestRates[namespace] = make(map[string]timeInResult)
+	}
+
+	c.cacheAllRequestRates[namespace][ratesInterval] = timeInResult{
+		queryTime: queryTime,
+		inResult:  inResult,
+	}
+	log.Tracef("[Prom Cache] SetAllRequestRates [namespace: %s] [ratesInterval: %s] [queryTime: %s]", namespace, ratesInterval, queryTime.String())
+}
+
+func (c *promCacheImpl) GetAppRequestRates(namespace string, app string, ratesInterval string, queryTime time.Time) (bool, model.Vector, model.Vector) {
+	defer c.appRequestRatesLock.RUnlock()
+	c.appRequestRatesLock.RLock()
+
+	if nsRates, okNs := c.cacheAppRequestRates[namespace]; okNs {
+		if appInterval, okApp := nsRates[app]; okApp {
+			if rtInterval, okRt := appInterval[ratesInterval]; okRt {
+				if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+					log.Tracef("[Prom Cache] GetAppRequestRates [namespace: %s] [app: %s] [ratesInterval: %s] [queryTime: %s]", namespace, app, ratesInterval, queryTime.String())
+					return true, rtInterval.inResult, rtInterval.outResult
+				}
+			}
+		}
+	}
+	return false, nil, nil
+}
+
+func (c *promCacheImpl) SetAppRequestRates(namespace string, app string, ratesInterval string, queryTime time.Time, inResult model.Vector, outResult model.Vector) {
+	defer c.appRequestRatesLock.Unlock()
+	c.appRequestRatesLock.Lock()
+
+	if _, okNs := c.cacheAppRequestRates[namespace]; !okNs {
+		c.cacheAppRequestRates[namespace] = make(map[string]map[string]timeInOutResult)
+	}
+
+	if _, okApp := c.cacheAppRequestRates[namespace][app]; !okApp {
+		c.cacheAppRequestRates[namespace][app] = make(map[string]timeInOutResult)
+	}
+
+	c.cacheAppRequestRates[namespace][app][ratesInterval] = timeInOutResult{
+		queryTime: queryTime,
+		inResult:  inResult,
+		outResult: outResult,
+	}
+	log.Tracef("[Prom Cache] SetAppRequestRates [namespace: %s] [app: %s] [ratesInterval: %s] [queryTime: %s]", namespace, app, ratesInterval, queryTime.String())
+}
+
+func (c *promCacheImpl) GetNamespaceServicesRequestRates(namespace string, ratesInterval string, queryTime time.Time) (bool, model.Vector) {
+	defer c.nsSvcRequestRatesLock.RUnlock()
+	c.nsSvcRequestRatesLock.RLock()
+
+	if nsRates, okNs := c.cacheNsSvcRequestRates[namespace]; okNs {
+		if rtInterval, okRt := nsRates[ratesInterval]; okRt {
+			if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+				log.Tracef("[Prom Cache] GetNamespaceServicesRequestRates [namespace: %s] [ratesInterval: %s] [queryTime: %s]", namespace, ratesInterval, queryTime.String())
+				return true, rtInterval.inResult
+			}
+		}
+	}
+	return false, nil
+}
+
+func (c *promCacheImpl) SetNamespaceServicesRequestRates(namespace string, ratesInterval string, queryTime time.Time, inResult model.Vector) {
+	defer c.nsSvcRequestRatesLock.Unlock()
+	c.nsSvcRequestRatesLock.Lock()
+
+	if _, okNs := c.cacheNsSvcRequestRates[namespace]; !okNs {
+		c.cacheNsSvcRequestRates[namespace] = make(map[string]timeInResult)
+	}
+
+	c.cacheNsSvcRequestRates[namespace][ratesInterval] = timeInResult{
+		queryTime: queryTime,
+		inResult:  inResult,
+	}
+	log.Tracef("[Prom Cache] SetNamespaceServicesRequestRates [namespace: %s] [ratesInterval: %s] [queryTime: %s]", namespace, ratesInterval, queryTime.String())
+}
+
+func (c *promCacheImpl) GetServiceRequestRates(namespace string, service string, ratesInterval string, queryTime time.Time) (bool, model.Vector) {
+	defer c.svcRequestRatesLock.RUnlock()
+	c.svcRequestRatesLock.RLock()
+
+	if nsRates, okNs := c.cacheSvcRequestRates[namespace]; okNs {
+		if svcInterval, okSvc := nsRates[service]; okSvc {
+			if rtInterval, okRt := svcInterval[ratesInterval]; okRt {
+				if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+					log.Tracef("[Prom Cache] GetServiceRequestRates [namespace: %s] [service: %s] [ratesInterval: %s] [queryTime: %s]", namespace, service, ratesInterval, queryTime.String())
+					return true, rtInterval.inResult
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+func (c *promCacheImpl) SetServiceRequestRates(namespace string, service string, ratesInterval string, queryTime time.Time, inResult model.Vector) {
+	defer c.svcRequestRatesLock.Unlock()
+	c.svcRequestRatesLock.Lock()
+
+	if _, okNs := c.cacheSvcRequestRates[namespace]; !okNs {
+		c.cacheSvcRequestRates[namespace] = make(map[string]map[string]timeInResult)
+	}
+
+	if _, okSvc := c.cacheSvcRequestRates[namespace][service]; !okSvc {
+		c.cacheSvcRequestRates[namespace][service] = make(map[string]timeInResult)
+	}
+
+	c.cacheSvcRequestRates[namespace][service][ratesInterval] = timeInResult{
+		queryTime: queryTime,
+		inResult:  inResult,
+	}
+	log.Tracef("[Prom Cache] SetServiceRequestRates [namespace: %s] [service: %s] [ratesInterval: %s] [queryTime: %s]", namespace, service, ratesInterval, queryTime.String())
+}
+
+func (c *promCacheImpl) GetWorkloadRequestRates(namespace string, workload string, ratesInterval string, queryTime time.Time) (bool, model.Vector, model.Vector) {
+	defer c.wkRequestRatesLock.RUnlock()
+	c.wkRequestRatesLock.RLock()
+
+	if nsRates, okNs := c.cacheWkRequestRates[namespace]; okNs {
+		if wkInterval, okWk := nsRates[workload]; okWk {
+			if rtInterval, okRt := wkInterval[ratesInterval]; okRt {
+				if queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
+					log.Tracef("[Prom Cache] GetWorkloadRequestRates [namespace: %s] [workload: %s] [ratesInterval: %s] [queryTime: %s]", namespace, workload, ratesInterval, queryTime.String())
+					return true, rtInterval.inResult, rtInterval.outResult
+				}
+			}
+		}
+	}
+	return false, nil, nil
+}
+
+func (c *promCacheImpl) SetWorkloadRequestRates(namespace string, workload string, ratesInterval string, queryTime time.Time, inResult model.Vector, outResult model.Vector) {
+	defer c.wkRequestRatesLock.Unlock()
+	c.wkRequestRatesLock.Lock()
+
+	if _, okNs := c.cacheWkRequestRates[namespace]; !okNs {
+		c.cacheWkRequestRates[namespace] = make(map[string]map[string]timeInOutResult)
+	}
+
+	if _, okApp := c.cacheWkRequestRates[namespace][workload]; !okApp {
+		c.cacheWkRequestRates[namespace][workload] = make(map[string]timeInOutResult)
+	}
+
+	c.cacheWkRequestRates[namespace][workload][ratesInterval] = timeInOutResult{
+		queryTime: queryTime,
+		inResult:  inResult,
+		outResult: outResult,
+	}
+	log.Tracef("[Prom Cache] SetAppRequestRates [namespace: %s] [workload: %s] [ratesInterval: %s] [queryTime: %s]", namespace, workload, ratesInterval, queryTime.String())
+}

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/util/httputil"
+	"sync"
 )
 
 // ClientInterface for mocks (only mocked function are necessary here)
@@ -39,11 +40,26 @@ type Client struct {
 	api prom_v1.API
 }
 
+var once sync.Once
+var promCache PromCache
+
+func initPromCache() {
+	if config.Get().ExternalServices.Prometheus.CacheEnabled {
+		log.Infof("[Prom Cache] Enabled")
+		promCache = NewPromCache()
+	} else {
+		log.Infof("[Prom Cache] Disabled")
+	}
+}
+
 // NewClient creates a new client to the Prometheus API.
 // It returns an error on any problem.
 func NewClient() (*Client, error) {
 	cfg := config.Get().ExternalServices.Prometheus
 	clientConfig := api.Config{Address: cfg.URL}
+
+	// Prom Cache will be initialized once at first use of Prometheus Client
+	once.Do(initPromCache)
 
 	// Be sure to copy config.Auth and not modify the existing
 	auth := cfg.Auth
@@ -89,7 +105,20 @@ func (in *Client) GetMetrics(query *IstioMetricsQuery) Metrics {
 // (e.g total rates / error rates).
 // Returns (rates, error)
 func (in *Client) GetAllRequestRates(namespace string, ratesInterval string, queryTime time.Time) (model.Vector, error) {
-	return getAllRequestRates(in.api, namespace, queryTime, ratesInterval)
+	log.Tracef("GetAllRequestRates [namespace: %s] [ratesInterval: %s] [queryTime: %s]", namespace, ratesInterval, queryTime.String())
+	if promCache != nil {
+		if isCached, result := promCache.GetAllRequestRates(namespace, ratesInterval, queryTime); isCached {
+			return result, nil
+		}
+	}
+	result, err := getAllRequestRates(in.api, namespace, queryTime, ratesInterval)
+	if err != nil {
+		return result, err
+	}
+	if promCache != nil {
+		promCache.SetAllRequestRates(namespace, ratesInterval, queryTime, result)
+	}
+	return result, nil
 }
 
 // GetNamespaceServicesRequestRates queries Prometheus to fetch request counter rates, over a time interval, limited to
@@ -98,7 +127,20 @@ func (in *Client) GetAllRequestRates(namespace string, ratesInterval string, que
 // (e.g total rates / error rates).
 // Returns (rates, error)
 func (in *Client) GetNamespaceServicesRequestRates(namespace string, ratesInterval string, queryTime time.Time) (model.Vector, error) {
-	return getNamespaceServicesRequestRates(in.api, namespace, queryTime, ratesInterval)
+	log.Tracef("GetNamespaceServicesRequestRates [namespace: %s] [ratesInterval: %s] [queryTime: %s]", namespace, ratesInterval, queryTime.String())
+	if promCache != nil {
+		if isCached, result := promCache.GetNamespaceServicesRequestRates(namespace, ratesInterval, queryTime); isCached {
+			return result, nil
+		}
+	}
+	result, err := getNamespaceServicesRequestRates(in.api, namespace, queryTime, ratesInterval)
+	if err != nil {
+		return result, err
+	}
+	if promCache != nil {
+		promCache.SetNamespaceServicesRequestRates(namespace, ratesInterval, queryTime, result)
+	}
+	return result, nil
 }
 
 // GetServiceRequestRates queries Prometheus to fetch request counters rates over a time interval
@@ -107,7 +149,20 @@ func (in *Client) GetNamespaceServicesRequestRates(namespace string, ratesInterv
 // (e.g total rates / error rates).
 // Returns (in, error)
 func (in *Client) GetServiceRequestRates(namespace, service, ratesInterval string, queryTime time.Time) (model.Vector, error) {
-	return getServiceRequestRates(in.api, namespace, service, queryTime, ratesInterval)
+	log.Tracef("GetServiceRequestRates [namespace: %s] [service: %s] [ratesInterval: %s] [queryTime: %s]", namespace, service, ratesInterval, queryTime.String())
+	if promCache != nil {
+		if isCached, result := promCache.GetServiceRequestRates(namespace, service, ratesInterval, queryTime); isCached {
+			return result, nil
+		}
+	}
+	result, err := getServiceRequestRates(in.api, namespace, service, queryTime, ratesInterval)
+	if err != nil {
+		return result, err
+	}
+	if promCache != nil {
+		promCache.SetServiceRequestRates(namespace, service, ratesInterval, queryTime, result)
+	}
+	return result, nil
 }
 
 // GetAppRequestRates queries Prometheus to fetch request counters rates over a time interval
@@ -116,7 +171,20 @@ func (in *Client) GetServiceRequestRates(namespace, service, ratesInterval strin
 // (e.g total rates / error rates).
 // Returns (in, out, error)
 func (in *Client) GetAppRequestRates(namespace, app, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error) {
-	return getItemRequestRates(in.api, namespace, app, "app", queryTime, ratesInterval)
+	log.Tracef("GetAppRequestRates [namespace: %s] [app: %s] [ratesInterval: %s] [queryTime: %s]", namespace, app, ratesInterval, queryTime.String())
+	if promCache != nil {
+		if isCached, inResult, outResult := promCache.GetAppRequestRates(namespace, app, ratesInterval, queryTime); isCached {
+			return inResult, outResult, nil
+		}
+	}
+	inResult, outResult, err := getItemRequestRates(in.api, namespace, app, "app", queryTime, ratesInterval)
+	if err != nil {
+		return inResult, outResult, err
+	}
+	if promCache != nil {
+		promCache.SetAppRequestRates(namespace, app, ratesInterval, queryTime, inResult, outResult)
+	}
+	return inResult, outResult, nil
 }
 
 // GetWorkloadRequestRates queries Prometheus to fetch request counters rates over a time interval
@@ -125,7 +193,20 @@ func (in *Client) GetAppRequestRates(namespace, app, ratesInterval string, query
 // (e.g total rates / error rates).
 // Returns (in, out, error)
 func (in *Client) GetWorkloadRequestRates(namespace, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error) {
-	return getItemRequestRates(in.api, namespace, workload, "workload", queryTime, ratesInterval)
+	log.Tracef("GetWorkloadRequestRates [namespace: %s] [workload: %s] [ratesInterval: %s] [queryTime: %s]", namespace, workload, ratesInterval, queryTime.String())
+	if promCache != nil {
+		if isCached, inResult, outResult := promCache.GetWorkloadRequestRates(namespace, workload, ratesInterval, queryTime); isCached {
+			return inResult, outResult, nil
+		}
+	}
+	inResult, outResult, err := getItemRequestRates(in.api, namespace, workload, "workload", queryTime, ratesInterval)
+	if err != nil {
+		return inResult, outResult, err
+	}
+	if promCache != nil {
+		promCache.SetWorkloadRequestRates(namespace, workload, ratesInterval, queryTime, inResult, outResult)
+	}
+	return inResult, outResult, nil
 }
 
 // FetchRange fetches a simple metric (gauge or counter) in given range

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
@@ -14,7 +15,6 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/util/httputil"
-	"sync"
 )
 
 // ClientInterface for mocks (only mocked function are necessary here)


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3315 

Analyzing the queries involved in a graph + healh generation we can see a pattern like this [1].
There are a level of repetitive queries when involved multiple namespaces and health.

This PR introduces caching on the prometheus/client.go API, similar as used for namespaces and proxy-status in the kubernetes/cache/cache.go.

As a first result, with a short term expiration of 10 seconds (used by default) it gets a hit ratio of ~76%.

It approaches only the `Get*` API used mainly for Health.

Also, it's configurable (enabled/disabled and duration).

In terms of design I think it's better to keep separated the three major domains: kubernetes, prometheus and jaeger, as each APIs may have their own particularities. I was tempted to propose a single abstraction for all of them but I think in this way design is simplified and clean.

Note, this requires operator and helm-chart additions for new config.
https://github.com/kiali/kiali-operator/pull/162.


[1] [get-all-requests-rates-no-cache.txt](https://github.com/kiali/kiali/files/5377070/get-all-requests-rates-no-cache.txt)
