### PR TITLE
Add 'tls' Spec to virtual service matching.

### DIFF
--- a/models/virtual_service.go
+++ b/models/virtual_service.go
@@ -58,9 +58,10 @@ func (vService *VirtualService) IsValidHost(namespace string, serviceName string
 		return false
 	}
 
-	protocolNames := []string{"http", "tcp"}
+	protocolNames := []string{"http", "tls", "tcp"} // ordered by matching preference
 	protocols := map[string]interface{}{
 		"http": vService.Spec.Http,
+		"tls":  vService.Spec.Tls,
 		"tcp":  vService.Spec.Tcp,
 	}
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3271

Virtual Service matching for services was limited to 'http' and 'tcp' protocols, this PR adds 'tls'.  This is purely for visualization, the badging applied in the graph should now show VS badges for relevant service nodes.

To test, apply the following virtual service to bookinfo:

```
cat <<VSD | kubectl -n bookinfo create -f -
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  namespace: bookinfo
  name: badge-test
spec:
  hosts: 
  - badge-test.test.com
  tls:
  - match:
    - port: 8443
      sniHosts:
      - badge-test.test.com
    route:
      - destination:
          host: details
          port: 
            number: 8443
          subset: v1
        weight: 100
VSD
```

Note that this just a bogus VS, the PR is only related to detecting the VS for badging purposes.  Without the PR the details service node in the graph should not show a VS badge.  WIth the PR, it should.