### PR TITLE
Fix the path of the cookie for OpenShift authentication strategy

### DIFF
--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -138,6 +138,7 @@ func performOpenshiftAuthentication(w http.ResponseWriter, r *http.Request) bool
 		Value:    tokenString,
 		Expires:  expiresOn,
 		HttpOnly: true,
+		Path:     config.Get().Server.WebRoot,
 		SameSite: http.SameSiteStrictMode,
 	}
 	http.SetCookie(w, &tokenCookie)
@@ -559,6 +560,7 @@ func Logout(w http.ResponseWriter, r *http.Request) {
 				Value:    "",
 				Expires:  time.Unix(0, 0),
 				HttpOnly: true,
+				MaxAge:   -1,
 				Path:     conf.Server.WebRoot,
 				SameSite: http.SameSiteStrictMode,
 			}


### PR DESCRIPTION
The missing path directive for OpenShift authentication is creating a cookie targeting https://{fqdn}/{webroot}/api (notice the "api" sub-path).

When logging out, cookies are cleared using the Kiali root path (i.e. https://{fqdn}/{webroot}). This causes a mismatch in the browser and the session cookie is not cleared for OpenShift strategy. As a consequence, Kiali ends in a bad state where it's not possible to login again (workaround is to manually clear browser cookies).

This fixes the creation of the session cookie for OpenShift by specifying the root path. Also, when deleting the session cookie, in addition to setting an expiry time in the past, the MaxAge attribute is also passed with negative value.

Fixes kiali/kiali#3313
