### PR TITLE
Implement duration filtering for logs

### DIFF
--- a/business/test_util.go
+++ b/business/test_util.go
@@ -617,8 +617,8 @@ func FakePodLogsSyncedWithDeployments() *kubernetes.PodLogs {
 	return &kubernetes.PodLogs{
 		Logs: `2018-01-02T03:34:28+00:00 INFO Fake Log Entry
 2018-01-02T04:34:28+00:00 WARN Fake Warning Entry
-2018-01-02T04:34:28+00:00 Log Entry Without Severity
-2018-01-02T04:34:28+00:00 error Log Entry With LowerCase Severity`,
+2018-01-02T05:34:28+00:00 Log Entry Without Severity
+2018-01-02T06:34:28+00:00 error Log Entry With LowerCase Severity`,
 	}
 }
 

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -615,10 +615,10 @@ func FakePodSyncedWithDeployments() *core_v1.Pod {
 
 func FakePodLogsSyncedWithDeployments() *kubernetes.PodLogs {
 	return &kubernetes.PodLogs{
-		Logs: `2018-01-02T03:34:28+00:00 INFO Fake Log Entry
-2018-01-02T04:34:28+00:00 WARN Fake Warning Entry
-2018-01-02T05:34:28+00:00 Log Entry Without Severity
-2018-01-02T06:34:28+00:00 error Log Entry With LowerCase Severity`,
+		Logs: `2018-01-02T03:34:28+00:00 INFO #1 Log Message
+2018-01-02T04:34:28+00:00 WARN #2 Log Message
+2018-01-02T05:34:28+00:00 #3 Log Message
+2018-01-02T06:34:28+00:00 #4 Log error Message`,
 	}
 }
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -209,6 +209,7 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *LogOption
 	entries := make([]LogEntry, 0)
 
 	var startTime *time.Time
+	var endTime *time.Time
 	if k8sOpts.SinceTime != nil {
 		startTime = &k8sOpts.SinceTime.Time
 	}
@@ -243,8 +244,15 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *LogOption
 				startTime = &parsed
 			}
 
-			if opts.Duration != nil && parsed.After(startTime.Add(*opts.Duration)) {
-				break
+			if opts.Duration != nil {
+				if endTime == nil {
+					end := parsed.Add(*opts.Duration)
+					endTime = &end
+				}
+
+				if parsed.After(*endTime) {
+					break
+				}
 			}
 
 			entry.TimestampUnix = parsed.Unix()

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -449,22 +449,22 @@ func TestGetPodLogs(t *testing.T) {
 
 	assert.Equal("2018-01-02T03:34:28+00:00", podLogs.Entries[0].Timestamp)
 	assert.Equal(int64(1514864068), podLogs.Entries[0].TimestampUnix)
-	assert.Equal("INFO Fake Log Entry", podLogs.Entries[0].Message)
+	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
 	assert.Equal("INFO", podLogs.Entries[0].Severity)
 
 	assert.Equal("2018-01-02T04:34:28+00:00", podLogs.Entries[1].Timestamp)
 	assert.Equal(int64(1514867668), podLogs.Entries[1].TimestampUnix)
-	assert.Equal("WARN Fake Warning Entry", podLogs.Entries[1].Message)
+	assert.Equal("WARN #2 Log Message", podLogs.Entries[1].Message)
 	assert.Equal("WARN", podLogs.Entries[1].Severity)
 
 	assert.Equal("2018-01-02T05:34:28+00:00", podLogs.Entries[2].Timestamp)
 	assert.Equal(int64(1514871268), podLogs.Entries[2].TimestampUnix)
-	assert.Equal("Log Entry Without Severity", podLogs.Entries[2].Message)
+	assert.Equal("#3 Log Message", podLogs.Entries[2].Message)
 	assert.Equal("INFO", podLogs.Entries[2].Severity)
 
 	assert.Equal("2018-01-02T06:34:28+00:00", podLogs.Entries[3].Timestamp)
 	assert.Equal(int64(1514874868), podLogs.Entries[3].TimestampUnix)
-	assert.Equal("error Log Entry With LowerCase Severity", podLogs.Entries[3].Message)
+	assert.Equal("#4 Log error Message", podLogs.Entries[3].Message)
 	assert.Equal("ERROR", podLogs.Entries[3].Severity)
 }
 
@@ -484,16 +484,8 @@ func TestGetPodLogsTailLines(t *testing.T) {
 	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}})
 
 	assert.Equal(2, len(podLogs.Entries))
-
-	assert.Equal("2018-01-02T03:34:28+00:00", podLogs.Entries[0].Timestamp)
-	assert.Equal(int64(1514864068), podLogs.Entries[0].TimestampUnix)
-	assert.Equal("INFO Fake Log Entry", podLogs.Entries[0].Message)
-	assert.Equal("INFO", podLogs.Entries[0].Severity)
-
-	assert.Equal("2018-01-02T04:34:28+00:00", podLogs.Entries[1].Timestamp)
-	assert.Equal(int64(1514867668), podLogs.Entries[1].TimestampUnix)
-	assert.Equal("WARN Fake Warning Entry", podLogs.Entries[1].Message)
-	assert.Equal("WARN", podLogs.Entries[1].Severity)
+	assert.Equal("#3 Log Message", podLogs.Entries[0].Message)
+	assert.Equal("#4 Log error Message", podLogs.Entries[1].Message)
 }
 
 func TestGetPodLogsDuration(t *testing.T) {
@@ -509,21 +501,25 @@ func TestGetPodLogsDuration(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	duration, _ := time.ParseDuration("59m")
-
 	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details"}, Duration: &duration})
 	assert.Equal(1, len(podLogs.Entries))
+	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
 
 	duration, _ = time.ParseDuration("1h")
 	podLogs, _ = svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details"}, Duration: &duration})
 	assert.Equal(2, len(podLogs.Entries))
+	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
+	assert.Equal("WARN #2 Log Message", podLogs.Entries[1].Message)
 
 	duration, _ = time.ParseDuration("2h")
 	podLogs, _ = svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details"}, Duration: &duration})
 	assert.Equal(3, len(podLogs.Entries))
+	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
+	assert.Equal("WARN #2 Log Message", podLogs.Entries[1].Message)
+	assert.Equal("#3 Log Message", podLogs.Entries[2].Message)
 }
 
-// Test that tail lines actually have the priority over durations
-func TestGetPodLogsDurationAndTailLines(t *testing.T) {
+func TestGetPodLogsTailLinesAndDurations(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -535,19 +531,24 @@ func TestGetPodLogsDurationAndTailLines(t *testing.T) {
 
 	svc := setupWorkloadService(k8s)
 
+	tailLines := int64(2)
 	duration, _ := time.ParseDuration("2h")
-
-	tailLines := int64(99)
-	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}, Duration: &duration})
-	assert.Equal(3, len(podLogs.Entries))
+	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}})
+	assert.Equal(2, len(podLogs.Entries))
+	assert.Equal("WARN #2 Log Message", podLogs.Entries[0].Message)
+	assert.Equal("#3 Log Message", podLogs.Entries[1].Message)
 
 	tailLines = int64(1)
-	podLogs, _ = svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}, Duration: &duration})
+	duration, _ = time.ParseDuration("2h")
+	podLogs, _ = svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}})
 	assert.Equal(1, len(podLogs.Entries))
+	assert.Equal("#3 Log Message", podLogs.Entries[0].Message)
 
-	tailLines = int64(2)
-	podLogs, _ = svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}, Duration: &duration})
-	assert.Equal(2, len(podLogs.Entries))
+	tailLines = int64(1)
+	duration, _ = time.ParseDuration("3h")
+	podLogs, _ = svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}})
+	assert.Equal(1, len(podLogs.Entries))
+	assert.Equal("#4 Log error Message", podLogs.Entries[0].Message)
 }
 
 func TestDuplicatedControllers(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -127,6 +127,16 @@ type SinceTimeParam struct {
 	Name string `json:"sinceTime"`
 }
 
+// swagger:parameters podLogs
+type DurationLogParam struct {
+	// Query time-range duration (Golang string duration). Duration starts on
+	// `sinceTime` if set, or the time for the first log message if not set.
+	//
+	// in: query
+	// required: false
+	Name string `json:"duration"`
+}
+
 // swagger:parameters traceDetails
 type TraceIDParam struct {
 	// The trace ID.

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -11,7 +11,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kiali/kiali/business"
+	businesspkg "github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/prometheus"
 )
 
@@ -140,7 +140,7 @@ func WorkloadDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	svc := business.NewDashboardsService(prom)
+	svc := businesspkg.NewDashboardsService(prom)
 	dashboard, err := svc.GetIstioDashboard(params)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
@@ -178,7 +178,7 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 
 	// Get business layer
-	businessLayer, err := getBusiness(r)
+	business, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Pod Logs initialization error: "+err.Error())
 		return
@@ -187,7 +187,7 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	pod := vars["pod"]
 
 	// Get log options
-	opts := business.LogOptions{PodLogOptions: core_v1.PodLogOptions{Timestamps: true}}
+	opts := businesspkg.LogOptions{PodLogOptions: core_v1.PodLogOptions{Timestamps: true}}
 	if container := queryParams.Get("container"); container != "" {
 		opts.Container = container
 	}
@@ -227,7 +227,7 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch pod logs
-	podLogs, err := businessLayer.Workload.GetPodLogs(namespace, pod, &opts)
+	podLogs, err := business.Workload.GetPodLogs(namespace, pod, &opts)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return

--- a/swagger.json
+++ b/swagger.json
@@ -2263,6 +2263,13 @@
             "description": "The start time for fetching logs. UNIX time in seconds. Default is all logs.",
             "name": "sinceTime",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Query time-range duration (Golang string duration). Duration starts on\n`sinceTime` if set, or the time for the first log message if not set.",
+            "name": "duration",
+            "in": "query"
           }
         ],
         "responses": {


### PR DESCRIPTION
Closes #3303.

This adds support to a new `duration` param to the logs endpoint. It supports the usual duration format we use everywhere else (`1m`, `1h` and so on).

It has less priority than tail lines filtering, so their behaviours should not clash.