### PR TITLE
Remove mixer/telemetry-v1 use of request_duration_seconds

### DIFF
--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -74,9 +74,9 @@ func fakeMetrics() prometheus.Metrics {
 			"tcp_sent":            fakeCounter(13),
 		},
 		Histograms: map[string]prometheus.Histogram{
-			"request_duration": fakeHistogram(20),
-			"request_size":     fakeHistogram(21),
-			"response_size":    fakeHistogram(22),
+			"request_duration_millis": fakeHistogram(20000),
+			"request_size":            fakeHistogram(21),
+			"response_size":           fakeHistogram(22),
 		},
 	}
 }

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -70,8 +70,6 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	responseTimeMap := make(map[string]float64)
 
 	// query prometheus for the responseTime info in three queries:
-	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
-	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
 	// 1) query for responseTime originating from "unknown" (i.e. the internet)
 	groupBy := fmt.Sprintf("le,source_workload_namespace,source_workload,source_%s,source_%s,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_%s,destination_%s,response_code,grpc_response_status", appLabel, verLabel, appLabel, verLabel)
 	query := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v"}[%vs])) by (%s)) > 0`,

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -74,26 +74,19 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
 	// 1) query for responseTime originating from "unknown" (i.e. the internet)
 	groupBy := fmt.Sprintf("le,source_workload_namespace,source_workload,source_%s,source_%s,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_%s,destination_%s,response_code,grpc_response_status", appLabel, verLabel, appLabel, verLabel)
-	millisQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v"}[%vs])) by (%s))`,
+	query := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v"}[%vs])) by (%s)) > 0`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
 		namespace,
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	secondsQuery := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",source_workload="unknown",destination_workload_namespace="%v"}[%vs])) by (%s))`,
-		quantile,
-		"istio_request_duration_seconds_bucket",
-		namespace,
-		int(duration.Seconds()), // range duration for the query
-		groupBy)
-	query := fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
 	unkVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 	a.populateResponseTimeMap(responseTimeMap, &unkVector)
 
 	// 2) query for external traffic, originating from a workload outside of the namespace.  Exclude any "unknown" source telemetry (an unusual corner case)
 	reporter := "source"
 	sourceWorkloadQuery := fmt.Sprintf(`source_workload_namespace!="%s"`, namespace)
-	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v"}[%vs])) by (%s))`,
+	query = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v"}[%vs])) by (%s)) > 0`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
 		reporter,
@@ -101,32 +94,16 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 		namespace,
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="%s",%s,source_workload!="unknown",destination_service_namespace="%v"}[%vs])) by (%s))`,
-		quantile,
-		"istio_request_duration_seconds_bucket",
-		reporter,
-		sourceWorkloadQuery,
-		namespace,
-		int(duration.Seconds()), // range duration for the query
-		groupBy)
-	query = fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
 	outVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 	a.populateResponseTimeMap(responseTimeMap, &outVector)
 
 	// 3) query for responseTime originating from a workload inside of the namespace
-	millisQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v"}[%vs])) by (%s))`,
+	query = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v"}[%vs])) by (%s)) > 0`,
 		quantile,
 		"istio_request_duration_milliseconds_bucket",
 		namespace,
 		int(duration.Seconds()), // range duration for the query
 		groupBy)
-	secondsQuery = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%v"}[%vs])) by (%s))`,
-		quantile,
-		"istio_request_duration_seconds_bucket",
-		namespace,
-		int(duration.Seconds()), // range duration for the query
-		groupBy)
-	query = fmt.Sprintf(`((%s > 0) OR ((%s > 0) * 1000.0))`, millisQuery, secondsQuery)
 	inVector := promQuery(query, time.Unix(a.QueryTime, 0), client.API(), a)
 	a.populateResponseTimeMap(responseTimeMap, &inVector)
 

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -1,7 +1,6 @@
 package appender
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -14,14 +13,10 @@ import (
 func TestResponseTime(t *testing.T) {
 	assert := assert.New(t)
 
-	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
-	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
-	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
-	q0 := fmt.Sprintf(`round(%s > 0,0.001)`, q0Temp)
+	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status)) > 0,0.001)`
 	v0 := model.Vector{}
 
-	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
-	q1 := fmt.Sprintf(`round(%s > 0,0.001)`, q1Temp)
+	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status)) > 0,0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -40,8 +35,7 @@ func TestResponseTime(t *testing.T) {
 			Metric: q1m0,
 			Value:  0.010}}
 
-	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
-	q2 := fmt.Sprintf(`round(%s > 0,0.001)`, q2Temp)
+	q2 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status)) > 0,0.001)`
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -16,12 +16,12 @@ func TestResponseTime(t *testing.T) {
 
 	// note - Istio is migrating their latency metric from seconds to milliseconds. We need to support both until
 	//        the 'seconds' variant is removed. That is why we have these complex queries with OR logic.
-	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
-	q0 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q0Temp, "milliseconds"), fmt.Sprintf(q0Temp, "seconds"))
+	q0Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
+	q0 := fmt.Sprintf(`round(%s > 0,0.001)`, q0Temp)
 	v0 := model.Vector{}
 
-	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
-	q1 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q1Temp, "milliseconds"), fmt.Sprintf(q1Temp, "seconds"))
+	q1Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
+	q1 := fmt.Sprintf(`round(%s > 0,0.001)`, q1Temp)
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -40,8 +40,8 @@ func TestResponseTime(t *testing.T) {
 			Metric: q1m0,
 			Value:  0.010}}
 
-	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_%s_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
-	q2 := fmt.Sprintf(`round(((%s > 0) OR ((%s > 0) * 1000.0)),0.001)`, fmt.Sprintf(q2Temp, "milliseconds"), fmt.Sprintf(q2Temp, "seconds"))
+	q2Temp := `histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_app,source_version,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_app,destination_version,response_code,grpc_response_status))`
+	q2 := fmt.Sprintf(`round(%s > 0,0.001)`, q2Temp)
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",

--- a/prometheus/metrics_definitions.go
+++ b/prometheus/metrics_definitions.go
@@ -20,11 +20,6 @@ var istioMetrics = []istioMetric{
 		useErrorLabels: true,
 	},
 	{
-		kialiName: "request_duration",
-		istioName: "istio_request_duration_seconds",
-		isHisto:   true,
-	},
-	{
 		kialiName: "request_duration_millis",
 		istioName: "istio_request_duration_milliseconds",
 		isHisto:   true,

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -69,7 +69,7 @@ func TestGetServiceMetrics(t *testing.T) {
 	metrics := client.GetMetrics(&q)
 
 	assert.Equal(t, 6, len(metrics.Metrics), "Should have 6 simple metrics")
-	assert.Equal(t, 3, len(metrics.Histograms), "Should have 4 histograms")
+	assert.Equal(t, 3, len(metrics.Histograms), "Should have 3 histograms")
 	rqCountIn := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountIn)
 	rqErrorCountIn := metrics.Metrics["request_error_count"]
@@ -127,7 +127,7 @@ func TestGetAppMetrics(t *testing.T) {
 	metrics := client.GetMetrics(&q)
 
 	assert.Equal(t, 6, len(metrics.Metrics), "Should have 6 simple metrics")
-	assert.Equal(t, 3, len(metrics.Histograms), "Should have 4 histograms")
+	assert.Equal(t, 3, len(metrics.Histograms), "Should have 3 histograms")
 	rqCountIn := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountIn)
 	rqErrorCountIn := metrics.Metrics["request_error_count"]
@@ -268,7 +268,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	metrics := client.GetMetrics(&q)
 
 	assert.Equal(t, 6, len(metrics.Metrics), "Should have 6 simple metrics")
-	assert.Equal(t, 3, len(metrics.Histograms), "Should have 4 histograms")
+	assert.Equal(t, 3, len(metrics.Histograms), "Should have 3 histograms")
 	rqCountOut := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountOut)
 	rqErrorCountOut := metrics.Metrics["request_error_count"]

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -62,7 +62,6 @@ func TestGetServiceMetrics(t *testing.T) {
 	mockWithRange(api, expectedRange, round("sum(rate(istio_tcp_received_bytes_total{"+labels+"}[5m]))"), 11)
 	mockWithRange(api, expectedRange, round("sum(rate(istio_tcp_sent_bytes_total{"+labels+"}[5m]))"), 13)
 	mockHistogram(api, "istio_request_bytes", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.7)
-	mockHistogram(api, "istio_request_duration_seconds", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.8)
 	mockHistogram(api, "istio_request_duration_milliseconds", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.8)
 	mockHistogram(api, "istio_response_bytes", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.9)
 
@@ -70,7 +69,7 @@ func TestGetServiceMetrics(t *testing.T) {
 	metrics := client.GetMetrics(&q)
 
 	assert.Equal(t, 6, len(metrics.Metrics), "Should have 6 simple metrics")
-	assert.Equal(t, 4, len(metrics.Histograms), "Should have 4 histograms")
+	assert.Equal(t, 3, len(metrics.Histograms), "Should have 4 histograms")
 	rqCountIn := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountIn)
 	rqErrorCountIn := metrics.Metrics["request_error_count"]
@@ -81,8 +80,6 @@ func TestGetServiceMetrics(t *testing.T) {
 	assert.NotNil(t, rsThroughput)
 	rqSizeIn := metrics.Histograms["request_size"]
 	assert.NotNil(t, rqSizeIn)
-	rqDurationIn := metrics.Histograms["request_duration"]
-	assert.NotNil(t, rqDurationIn)
 	rqDurationMillisIn := metrics.Histograms["request_duration_millis"]
 	assert.NotNil(t, rqDurationMillisIn)
 	rsSizeIn := metrics.Histograms["response_size"]
@@ -97,7 +94,7 @@ func TestGetServiceMetrics(t *testing.T) {
 	assert.Equal(t, 1000.0, float64(rqThroughput.Matrix[0].Values[0].Value))
 	assert.Equal(t, 1001.0, float64(rsThroughput.Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.7, float64(rqSizeIn["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.8, float64(rqDurationIn["0.99"].Matrix[0].Values[0].Value))
+	assert.Equal(t, 0.8, float64(rqDurationMillisIn["0.99"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.9, float64(rsSizeIn["0.99"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 11.0, float64(tcpRecIn.Matrix[0].Values[0].Value))
 	assert.Equal(t, 13.0, float64(tcpSentIn.Matrix[0].Values[0].Value))
@@ -117,7 +114,6 @@ func TestGetAppMetrics(t *testing.T) {
 	mockRange(api, round("sum(rate(istio_tcp_received_bytes_total{"+labels+"}[5m]))"), 10)
 	mockRange(api, round("sum(rate(istio_tcp_sent_bytes_total{"+labels+"}[5m]))"), 12)
 	mockHistogram(api, "istio_request_bytes", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_duration_seconds", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.5)
 	mockHistogram(api, "istio_request_duration_milliseconds", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.5)
 	mockHistogram(api, "istio_response_bytes", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.6)
 
@@ -131,7 +127,7 @@ func TestGetAppMetrics(t *testing.T) {
 	metrics := client.GetMetrics(&q)
 
 	assert.Equal(t, 6, len(metrics.Metrics), "Should have 6 simple metrics")
-	assert.Equal(t, 4, len(metrics.Histograms), "Should have 4 histograms")
+	assert.Equal(t, 3, len(metrics.Histograms), "Should have 4 histograms")
 	rqCountIn := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountIn)
 	rqErrorCountIn := metrics.Metrics["request_error_count"]
@@ -142,8 +138,6 @@ func TestGetAppMetrics(t *testing.T) {
 	assert.NotNil(t, rsThroughput)
 	rqSizeIn := metrics.Histograms["request_size"]
 	assert.NotNil(t, rqSizeIn)
-	rqDurationIn := metrics.Histograms["request_duration"]
-	assert.NotNil(t, rqDurationIn)
 	rqDurationMillisIn := metrics.Histograms["request_duration_millis"]
 	assert.NotNil(t, rqDurationMillisIn)
 	rsSizeIn := metrics.Histograms["response_size"]
@@ -161,7 +155,7 @@ func TestGetAppMetrics(t *testing.T) {
 	assert.Equal(t, 0.2, float64(rqSizeIn["0.5"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.3, float64(rqSizeIn["0.95"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.4, float64(rqSizeIn["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.5, float64(rqDurationIn["0.99"].Matrix[0].Values[0].Value))
+	assert.Equal(t, 0.5, float64(rqDurationMillisIn["0.99"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.6, float64(rsSizeIn["0.99"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 10.0, float64(tcpRecIn.Matrix[0].Values[0].Value))
 	assert.Equal(t, 12.0, float64(tcpSentIn.Matrix[0].Values[0].Value))
@@ -262,7 +256,6 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	mockRange(api, round("sum(rate(istio_tcp_received_bytes_total{"+labels+"}[5m]))"), 10)
 	mockRange(api, round("sum(rate(istio_tcp_sent_bytes_total{"+labels+"}[5m]))"), 12)
 	mockHistogram(api, "istio_request_bytes", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.4)
-	mockHistogram(api, "istio_request_duration_seconds", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.5)
 	mockHistogram(api, "istio_request_duration_milliseconds", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.5)
 	mockHistogram(api, "istio_response_bytes", "{"+labels+"}[5m]", 0.35, 0.2, 0.3, 0.6)
 
@@ -275,7 +268,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	metrics := client.GetMetrics(&q)
 
 	assert.Equal(t, 6, len(metrics.Metrics), "Should have 6 simple metrics")
-	assert.Equal(t, 4, len(metrics.Histograms), "Should have 4 histograms")
+	assert.Equal(t, 3, len(metrics.Histograms), "Should have 4 histograms")
 	rqCountOut := metrics.Metrics["request_count"]
 	assert.NotNil(t, rqCountOut)
 	rqErrorCountOut := metrics.Metrics["request_error_count"]
@@ -286,8 +279,6 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	assert.NotNil(t, rsThroughput)
 	rqSizeOut := metrics.Histograms["request_size"]
 	assert.NotNil(t, rqSizeOut)
-	rqDurationOut := metrics.Histograms["request_duration"]
-	assert.NotNil(t, rqDurationOut)
 	rqDurationMillisOut := metrics.Histograms["request_duration_millis"]
 	assert.NotNil(t, rqDurationMillisOut)
 	rsSizeOut := metrics.Histograms["response_size"]
@@ -305,7 +296,7 @@ func TestGetNamespaceMetrics(t *testing.T) {
 	assert.Equal(t, 0.2, float64(rqSizeOut["0.5"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.3, float64(rqSizeOut["0.95"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.4, float64(rqSizeOut["0.99"].Matrix[0].Values[0].Value))
-	assert.Equal(t, 0.5, float64(rqDurationOut["0.99"].Matrix[0].Values[0].Value))
+	assert.Equal(t, 0.5, float64(rqDurationMillisOut["0.99"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 0.6, float64(rsSizeOut["0.99"].Matrix[0].Values[0].Value))
 	assert.Equal(t, 10.0, float64(tcpRecOut.Matrix[0].Values[0].Value))
 	assert.Equal(t, 12.0, float64(tcpSentOut.Matrix[0].Values[0].Value))

--- a/tests/e2e/tests/test_kiali_application_endpoint.py
+++ b/tests/e2e/tests/test_kiali_application_endpoint.py
@@ -58,6 +58,6 @@ def test_application_metrics_endpoint(kiali_client):
     assert 'tcp_sent' in metrics
 
     histograms = app_metrics.get('histograms')
-    assert 'request_duration' in histograms
+    assert 'request_duration_millis' in histograms
     assert 'request_size' in histograms
     assert 'response_size' in histograms

--- a/tests/e2e/tests/test_kiali_service_endpoint.py
+++ b/tests/e2e/tests/test_kiali_service_endpoint.py
@@ -196,7 +196,7 @@ def test_service_metrics_endpoint(kiali_client):
     assert 'tcp_sent' in metrics
 
     histograms = service.get('histograms')
-    assert 'request_duration' in histograms
+    assert 'request_duration_millis' in histograms
     assert 'request_size' in histograms
     assert 'response_size' in histograms
 

--- a/tests/e2e/tests/test_kiali_workload_endpoint.py
+++ b/tests/e2e/tests/test_kiali_workload_endpoint.py
@@ -91,7 +91,7 @@ def test_workload_metrics(kiali_client):
     assert 'tcp_sent' in metrics
 
     histograms = workload.get('histograms')
-    assert 'request_duration' in histograms
+    assert 'request_duration_millis' in histograms
     assert 'request_size' in histograms
     assert 'response_size' in histograms
 


### PR DESCRIPTION
- remove telem-v1 request_duration_seconds metric, v2 supports only request_duration_milliseconds

closes https://github.com/kiali/kiali/issues/3338
