### PR TITLE
workload logs: remove support for logs blob

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -278,10 +278,10 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *LogOption
 		}
 
 		entries = append(entries, entry)
+	}
 
-		if isBounded && tailLines != nil && len(entries) >= int(*tailLines) {
-			break
-		}
+	if isBounded && tailLines != nil && len(entries) > int(*tailLines) {
+		entries = entries[len(entries)-int(*tailLines):]
 	}
 
 	message := PodLog{

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -25,19 +25,19 @@ import (
 	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
-// Workload deals with fetching istio/kubernetes workloads related content and convert to kiali model
+// WorkloadService deals with fetching istio/kubernetes workloads related content and convert to kiali model
 type WorkloadService struct {
 	prom          prometheus.ClientInterface
 	k8s           kubernetes.ClientInterface
 	businessLayer *Layer
 }
 
-// Structures for workload log messages
+// PodLog reports log entries
 type PodLog struct {
-	Logs    string     `json:"logs,omitempty"`
 	Entries []LogEntry `json:"entries,omitempty"`
 }
 
+// LogEntry holds a single log entry
 type LogEntry struct {
 	Message       string `json:"message,omitempty"`
 	Severity      string `json:"severity,omitempty"`
@@ -45,6 +45,7 @@ type LogEntry struct {
 	TimestampUnix int64  `json:"timestampUnix,omitempty"`
 }
 
+// LogOptions holds query parameter values
 type LogOptions struct {
 	Duration *time.Duration
 	core_v1.PodLogOptions
@@ -237,6 +238,10 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *LogOption
 		}
 
 		entry.Message = strings.TrimSpace(splitted[1])
+		if entry.Message == "" {
+			log.Debugf("Skipping empty log line [%s]", line)
+			continue
+		}
 
 		parsed, err := time.Parse(time.RFC3339, entry.Timestamp)
 		if err == nil {
@@ -274,13 +279,13 @@ func (in *WorkloadService) getParsedLogs(namespace, name string, opts *LogOption
 	}
 
 	message := PodLog{
-		Logs:    podLog.Logs,
 		Entries: entries,
 	}
 
 	return &message, err
 }
 
+// GetPodLogs returns pod logs given the provided options
 func (in *WorkloadService) GetPodLogs(namespace, name string, opts *LogOptions) (*PodLog, error) {
 	return in.getParsedLogs(namespace, name, opts)
 }

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -479,7 +479,7 @@ func TestGetPodLogsTailLines(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	tailLines := int64(2)
-	duration, _ := time.ParseDuration("6h")
+	duration, _ := time.ParseDuration("6h") // still need a duration to force manual tailLines handling
 	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}, Duration: &duration})
 
 	assert.Equal(2, len(podLogs.Entries))

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -479,7 +479,8 @@ func TestGetPodLogsTailLines(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	tailLines := int64(2)
-	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}})
+	duration, _ := time.ParseDuration("6h")
+	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}, Duration: &duration})
 
 	assert.Equal(2, len(podLogs.Entries))
 	assert.Equal("#3 Log Message", podLogs.Entries[0].Message)

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -443,8 +443,6 @@ func TestGetPodLogs(t *testing.T) {
 
 	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details"}})
 
-	assert.Equal(FakePodLogsSyncedWithDeployments().Logs, podLogs.Logs)
-
 	assert.Equal(len(podLogs.Entries), 4)
 
 	assert.Equal("2018-01-02T03:34:28+00:00", podLogs.Entries[0].Timestamp)


### PR DESCRIPTION
- leave support only for log entries
- be more careful about sending empty log messages

part of https://github.com/kiali/kiali/issues/3067
