### PR TITLE
Workload Logs: Avoid business package name shadowing by using criterias

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -194,6 +194,13 @@ func (in *WorkloadService) GetPod(namespace, name string) (*models.Pod, error) {
 	return &pod, nil
 }
 
+func (in *WorkloadService) BuildLogOptionsCriteria() *LogOptions {
+	opts := &LogOptions{}
+	opts.PodLogOptions = core_v1.PodLogOptions{Timestamps: true}
+
+	return opts
+}
+
 func (in *WorkloadService) getParsedLogs(namespace, name string, opts *LogOptions) (*PodLog, error) {
 	k8sOpts := opts.PodLogOptions
 	tailLines := k8sOpts.TailLines

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1,7 +1,6 @@
 package business
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -16,7 +15,7 @@ import (
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -209,7 +208,7 @@ func (in *WorkloadService) BuildLogOptionsCriteria(container string, duration st
 		duration, err := time.ParseDuration(duration)
 
 		if err != nil {
-			return nil, errors.New(fmt.Sprintf("Invalid duration [%s]: %v", duration, err))
+			return nil, fmt.Errorf("Invalid duration [%s]: %v", duration, err)
 		}
 
 		opts.Duration = &duration
@@ -219,7 +218,7 @@ func (in *WorkloadService) BuildLogOptionsCriteria(container string, duration st
 		numTime, err := strconv.ParseInt(sinceTime, 10, 64)
 
 		if err != nil {
-			return nil, errors.New(fmt.Sprintf("Invalid sinceTime [%s]: %v", sinceTime, err))
+			return nil, fmt.Errorf("Invalid sinceTime [%s]: %v", sinceTime, err)
 		}
 
 		opts.SinceTime = &meta_v1.Time{Time: time.Unix(numTime, 0)}
@@ -231,7 +230,7 @@ func (in *WorkloadService) BuildLogOptionsCriteria(container string, duration st
 				opts.TailLines = &numLines
 			}
 		} else {
-			return nil, errors.New(fmt.Sprintf("Invalid tailLines [%s]: %v", tailLines, err))
+			return nil, fmt.Errorf("Invalid tailLines [%s]: %v", tailLines, err)
 		}
 	}
 
@@ -884,7 +883,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 			dep, err = layer.k8s.GetDeployment(namespace, workloadName)
 		}
 		if err != nil {
-			if k8s_errors.IsNotFound(err) {
+			if errors.IsNotFound(err) {
 				dep = nil
 			} else {
 				log.Errorf("Error fetching Deployment per namespace %s and name %s: %s", namespace, workloadName, err)
@@ -1348,7 +1347,7 @@ func updateWorkload(layer *Layer, namespace string, workloadName string, workloa
 				err = layer.k8s.UpdateWorkload(namespace, workloadName, wkType, jsonPatch)
 			}
 			if err != nil {
-				if !k8s_errors.IsNotFound(err) {
+				if !errors.IsNotFound(err) {
 					log.Errorf("Error fetching %s per namespace %s and name %s: %s", wkType, namespace, workloadName, err)
 					errChan <- err
 				}

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	businesspkg "github.com/kiali/kiali/business"
@@ -187,7 +186,7 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	pod := vars["pod"]
 
 	// Get log options
-	opts := businesspkg.LogOptions{PodLogOptions: core_v1.PodLogOptions{Timestamps: true}}
+	opts := business.Workload.BuildLogOptionsCriteria()
 	if container := queryParams.Get("container"); container != "" {
 		opts.Container = container
 	}
@@ -227,7 +226,7 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch pod logs
-	podLogs, err := business.Workload.GetPodLogs(namespace, pod, &opts)
+	podLogs, err := business.Workload.GetPodLogs(namespace, pod, opts)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	businesspkg "github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/prometheus"
 )
 
@@ -139,7 +139,7 @@ func WorkloadDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	svc := businesspkg.NewDashboardsService(prom)
+	svc := business.NewDashboardsService(prom)
 	dashboard, err := svc.GetIstioDashboard(params)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -1,14 +1,10 @@
 package handlers
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strconv"
-	"time"
 
 	"github.com/gorilla/mux"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/prometheus"
@@ -186,43 +182,15 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	pod := vars["pod"]
 
 	// Get log options
-	opts := business.Workload.BuildLogOptionsCriteria()
-	if container := queryParams.Get("container"); container != "" {
-		opts.Container = container
-	}
-	if duration := queryParams.Get("duration"); duration != "" {
-		duration, err := time.ParseDuration(duration)
+	opts, err := business.Workload.BuildLogOptionsCriteria(
+		queryParams.Get("container"),
+		queryParams.Get("duration"),
+		queryParams.Get("sinceTime"),
+		queryParams.Get("tailLines"))
 
-		if err != nil {
-			RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("Invalid duration [%s]: %v", duration, err))
-			return
-		}
-
-		opts.Duration = &duration
-	}
-	if sinceTime := queryParams.Get("sinceTime"); sinceTime != "" {
-		if numTime, err := strconv.ParseInt(sinceTime, 10, 64); err == nil {
-			opts.SinceTime = &meta_v1.Time{Time: time.Unix(numTime, 0)}
-		} else {
-			RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("Invalid sinceTime [%s]: %v", sinceTime, err))
-			return
-		}
-	}
-	if tailLines := queryParams.Get("tailLines"); tailLines != "" {
-		if numLines, err := strconv.ParseInt(tailLines, 10, 64); err == nil {
-			if numLines > 0 {
-				opts.TailLines = &numLines
-			}
-		} else {
-			RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("Invalid tailLines [%s]: %v", tailLines, err))
-			return
-		}
-	}
-
-	if duration := queryParams.Get("duration"); duration != "" {
-		if parsed, err := time.ParseDuration(duration); err != nil {
-			opts.Duration = &parsed
-		}
+	if err != nil {
+		handleErrorResponse(w, err)
+		return
 	}
 
 	// Fetch pod logs


### PR DESCRIPTION
This is a followup to #3331, using criterias to generate the options so we don't have to access the underlying types directly, and thus avoiding the `business` package to conflict with the `business` variable we use for the business layer.