### PR TITLE
[v1.24] Fix no trace displayed for istio ingress service

### DIFF
--- a/business/jaeger_test.go
+++ b/business/jaeger_test.go
@@ -124,7 +124,7 @@ func TestTracesToSpanWithServiceFilter(t *testing.T) {
 		Data:              []jaegerModels.Trace{trace1, trace2},
 		JaegerServiceName: "reviews.default",
 	}
-	spans := tracesToSpans("reviews", &r, svcSpanFilter("default", "reviews"))
+	spans := tracesToSpans("reviews", &r, operationSpanFilter("default", "reviews"))
 	assert.Len(spans, 2)
 	assert.Equal("t1_process_1", string(spans[0].ProcessID))
 	assert.Equal("t2_process_1", string(spans[1].ProcessID))
@@ -133,7 +133,7 @@ func TestTracesToSpanWithServiceFilter(t *testing.T) {
 		Data:              []jaegerModels.Trace{trace1, trace2},
 		JaegerServiceName: "rating.default",
 	}
-	spans = tracesToSpans("rating", &r, svcSpanFilter("default", "rating"))
+	spans = tracesToSpans("rating", &r, operationSpanFilter("default", "rating"))
 	assert.Len(spans, 1)
 	assert.Equal("t2_process_2", string(spans[0].ProcessID))
 }

--- a/jaeger/util.go
+++ b/jaeger/util.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 )
 
@@ -36,6 +37,7 @@ func prepareQuery(u *url.URL, jaegerServiceName string, query models.TracingQuer
 		q.Set("limit", strconv.Itoa(query.Limit))
 	}
 	u.RawQuery = q.Encode()
+	log.Debugf("Prepared Jaeger query: %v", u)
 }
 
 func makeRequest(client http.Client, endpoint string, body io.Reader) (response []byte, status int, err error) {


### PR DESCRIPTION
Fix no trace displayed for istio ingress service

For Service traces, a post-filtering based on operation names was performed.
It's generally ok, except some special situations like when trace comes from ingress (or when trace isn't generated from envoy)
Now we're by-passing this post-filtering in the case where the service name matches the app name.
