### PR TITLE
Include ControlPlane workloads to KIA0302 no matching workload

### DIFF
--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -9,10 +9,9 @@ import (
 const GatewayCheckerType = "gateway"
 
 type GatewayChecker struct {
-	GatewaysPerNamespace     [][]kubernetes.IstioObject
-	Namespace                string
-	WorkloadList             models.WorkloadList
-	ControlPlaneWorkloadList models.WorkloadList
+	GatewaysPerNamespace  [][]kubernetes.IstioObject
+	Namespace             string
+	WorkloadsPerNamespace map[string]models.WorkloadList
 }
 
 // Check runs checks for the all namespaces actions as well as for the single namespace validations
@@ -39,9 +38,8 @@ func (g GatewayChecker) runSingleChecks(gw kubernetes.IstioObject) models.IstioV
 
 	enabledCheckers := []Checker{
 		gateways.SelectorChecker{
-			ControlPlaneWorkloadList: g.ControlPlaneWorkloadList,
-			WorkloadList:             g.WorkloadList,
-			Gateway:                  gw,
+			Gateway:               gw,
+			WorkloadsPerNamespace: g.WorkloadsPerNamespace,
 		},
 	}
 

--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -9,9 +9,10 @@ import (
 const GatewayCheckerType = "gateway"
 
 type GatewayChecker struct {
-	GatewaysPerNamespace [][]kubernetes.IstioObject
-	Namespace            string
-	WorkloadList         models.WorkloadList
+	GatewaysPerNamespace     [][]kubernetes.IstioObject
+	Namespace                string
+	WorkloadList             models.WorkloadList
+	ControlPlaneWorkloadList models.WorkloadList
 }
 
 // Check runs checks for the all namespaces actions as well as for the single namespace validations
@@ -38,8 +39,9 @@ func (g GatewayChecker) runSingleChecks(gw kubernetes.IstioObject) models.IstioV
 
 	enabledCheckers := []Checker{
 		gateways.SelectorChecker{
-			WorkloadList: g.WorkloadList,
-			Gateway:      gw,
+			ControlPlaneWorkloadList: g.ControlPlaneWorkloadList,
+			WorkloadList:             g.WorkloadList,
+			Gateway:                  gw,
 		},
 	}
 

--- a/business/checkers/gateways/selector_checker_test.go
+++ b/business/checkers/gateways/selector_checker_test.go
@@ -64,6 +64,37 @@ func TestValidNamespaceSelector(t *testing.T) {
 	assert.Empty(validations)
 }
 
+func TestValidIstioNamespaceSelector(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gw := data.CreateEmptyGateway("gwone", "test", map[string]string{"app": "proxy"})
+
+	validations, valid := SelectorChecker{
+		Gateway: gw,
+		ControlPlaneWorkloadList: data.CreateWorkloadList(conf.IstioNamespace,
+			data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+
+	validations, valid = SelectorChecker{
+		Gateway: gw,
+		ControlPlaneWorkloadList: models.WorkloadList{
+			Namespace: models.Namespace{
+				Name: "test",
+			},
+			Workloads: []models.WorkloadListItem{},
+		},
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+}
+
 func TestMissingSelectorTarget(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/gateways/selector_checker_test.go
+++ b/business/checkers/gateways/selector_checker_test.go
@@ -21,11 +21,9 @@ func TestValidInternalSelector(t *testing.T) {
 
 	validations, valid := SelectorChecker{
 		Gateway: ingress,
-		WorkloadList: models.WorkloadList{
-			Namespace: models.Namespace{
-				Name: "test",
-			},
-			Workloads: []models.WorkloadListItem{},
+		WorkloadsPerNamespace: map[string]models.WorkloadList{
+			"test": data.CreateWorkloadList("istio-system",
+				data.CreateWorkloadListItem("istio-ingressgateway", map[string]string{"istio": "ingressgateway"})),
 		},
 	}.Check()
 
@@ -34,11 +32,9 @@ func TestValidInternalSelector(t *testing.T) {
 
 	validations, valid = SelectorChecker{
 		Gateway: egress,
-		WorkloadList: models.WorkloadList{
-			Namespace: models.Namespace{
-				Name: "test",
-			},
-			Workloads: []models.WorkloadListItem{},
+		WorkloadsPerNamespace: map[string]models.WorkloadList{
+			"test": data.CreateWorkloadList("istio-system",
+				data.CreateWorkloadListItem("istio-egressgateway", map[string]string{"istio": "egressgateway"})),
 		},
 	}.Check()
 
@@ -56,8 +52,10 @@ func TestValidNamespaceSelector(t *testing.T) {
 
 	validations, valid := SelectorChecker{
 		Gateway: gw,
-		WorkloadList: data.CreateWorkloadList("test",
-			data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
+		WorkloadsPerNamespace: map[string]models.WorkloadList{
+			"test": data.CreateWorkloadList("test",
+				data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
+		},
 	}.Check()
 
 	assert.True(valid)
@@ -74,8 +72,10 @@ func TestValidIstioNamespaceSelector(t *testing.T) {
 
 	validations, valid := SelectorChecker{
 		Gateway: gw,
-		ControlPlaneWorkloadList: data.CreateWorkloadList(conf.IstioNamespace,
-			data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
+		WorkloadsPerNamespace: map[string]models.WorkloadList{
+			"testproxy": data.CreateWorkloadList(conf.IstioNamespace,
+				data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
+		},
 	}.Check()
 
 	assert.True(valid)
@@ -83,11 +83,13 @@ func TestValidIstioNamespaceSelector(t *testing.T) {
 
 	validations, valid = SelectorChecker{
 		Gateway: gw,
-		ControlPlaneWorkloadList: models.WorkloadList{
-			Namespace: models.Namespace{
-				Name: "test",
+		WorkloadsPerNamespace: map[string]models.WorkloadList{
+			"test": {
+				Namespace: models.Namespace{
+					Name: "test",
+				},
+				Workloads: []models.WorkloadListItem{},
 			},
-			Workloads: []models.WorkloadListItem{},
 		},
 	}.Check()
 
@@ -104,9 +106,10 @@ func TestMissingSelectorTarget(t *testing.T) {
 	gw := data.CreateEmptyGateway("gwone", "test", map[string]string{"app": "proxy"})
 
 	validations, valid := SelectorChecker{
-		Gateway:      gw,
-		WorkloadList: data.CreateWorkloadList("test"),
-		// data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
+		Gateway: gw,
+		WorkloadsPerNamespace: map[string]models.WorkloadList{
+			"test": data.CreateWorkloadList("test"),
+		},
 	}.Check()
 
 	assert.False(valid)

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -52,13 +52,13 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 	var services []core_v1.Service
 	var namespaces models.Namespaces
 	var pods []core_v1.Pod
-	var workloads models.WorkloadList
+	var workloads, controlPlaneWorkloads models.WorkloadList
 	var gatewaysPerNamespace [][]kubernetes.IstioObject
 	var mtlsDetails kubernetes.MTLSDetails
 	var rbacDetails kubernetes.RBACDetails
 	var deployments []apps_v1.Deployment
 
-	wg.Add(7) // We need to add these here to make sure we don't execute wg.Wait() before scheduler has started goroutines
+	wg.Add(8) // We need to add these here to make sure we don't execute wg.Wait() before scheduler has started goroutines
 
 	if service != "" {
 		// These resources are not used if no service is targeted
@@ -71,6 +71,7 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 	go in.fetchDetails(&istioDetails, namespace, errChan, &wg)
 	go in.fetchNamespaces(&namespaces, errChan, &wg)
 	go in.fetchWorkloads(&workloads, namespace, errChan, &wg)
+	go in.fetchWorkloads(&controlPlaneWorkloads, config.Get().IstioNamespace, errChan, &wg)
 	go in.fetchGatewaysPerNamespace(&gatewaysPerNamespace, errChan, &wg)
 	go in.fetchNonLocalmTLSConfigs(&mtlsDetails, namespace, errChan, &wg)
 	go in.fetchAuthorizationDetails(&rbacDetails, namespace, errChan, &wg)
@@ -84,7 +85,7 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 		}
 	}
 
-	objectCheckers := in.getAllObjectCheckers(namespace, istioDetails, services, workloads, gatewaysPerNamespace, mtlsDetails, rbacDetails, namespaces)
+	objectCheckers := in.getAllObjectCheckers(namespace, istioDetails, services, controlPlaneWorkloads, workloads, gatewaysPerNamespace, mtlsDetails, rbacDetails, namespaces)
 
 	if service != "" {
 		objectCheckers = append(objectCheckers, in.getServiceCheckers(namespace, services, deployments, pods)...)
@@ -105,12 +106,12 @@ func (in *IstioValidationsService) getServiceCheckers(namespace string, services
 	}
 }
 
-func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioDetails kubernetes.IstioDetails, services []core_v1.Service, workloads models.WorkloadList, gatewaysPerNamespace [][]kubernetes.IstioObject, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace) []ObjectChecker {
+func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioDetails kubernetes.IstioDetails, services []core_v1.Service, controlPlaneWorkloads, workloads models.WorkloadList, gatewaysPerNamespace [][]kubernetes.IstioObject, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace) []ObjectChecker {
 	return []ObjectChecker{
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails},
 		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices},
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
-		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads},
+		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads, ControlPlaneWorkloadList: controlPlaneWorkloads},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioDetails.VirtualServices},
@@ -127,7 +128,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	var istioDetails kubernetes.IstioDetails
 	var namespaces models.Namespaces
 	var services []core_v1.Service
-	var workloads models.WorkloadList
+	var workloads, controlPlaneWorkloads models.WorkloadList
 	var gatewaysPerNamespace [][]kubernetes.IstioObject
 	var mtlsDetails kubernetes.MTLSDetails
 	var rbacDetails kubernetes.RBACDetails
@@ -144,11 +145,12 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	errChan := make(chan error, 1)
 
 	// Get all the Istio objects from a Namespace and all gateways from every namespace
-	wg.Add(7)
+	wg.Add(8)
 	go in.fetchNamespaces(&namespaces, errChan, &wg)
 	go in.fetchDetails(&istioDetails, namespace, errChan, &wg)
 	go in.fetchServices(&services, namespace, errChan, &wg)
 	go in.fetchWorkloads(&workloads, namespace, errChan, &wg)
+	go in.fetchWorkloads(&controlPlaneWorkloads, config.Get().IstioNamespace, errChan, &wg)
 	go in.fetchGatewaysPerNamespace(&gatewaysPerNamespace, errChan, &wg)
 	go in.fetchNonLocalmTLSConfigs(&mtlsDetails, namespace, errChan, &wg)
 	go in.fetchAuthorizationDetails(&rbacDetails, namespace, errChan, &wg)
@@ -159,7 +161,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	switch objectType {
 	case kubernetes.Gateways:
 		objectCheckers = []ObjectChecker{
-			checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads},
+			checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads, ControlPlaneWorkloadList: controlPlaneWorkloads},
 		}
 	case kubernetes.VirtualServices:
 		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -52,7 +52,8 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 	var services []core_v1.Service
 	var namespaces models.Namespaces
 	var pods []core_v1.Pod
-	var workloads, controlPlaneWorkloads models.WorkloadList
+	var workloads models.WorkloadList
+	var workloadsPerNamespace map[string]models.WorkloadList
 	var gatewaysPerNamespace [][]kubernetes.IstioObject
 	var mtlsDetails kubernetes.MTLSDetails
 	var rbacDetails kubernetes.RBACDetails
@@ -71,7 +72,7 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 	go in.fetchDetails(&istioDetails, namespace, errChan, &wg)
 	go in.fetchNamespaces(&namespaces, errChan, &wg)
 	go in.fetchWorkloads(&workloads, namespace, errChan, &wg)
-	go in.fetchWorkloads(&controlPlaneWorkloads, config.Get().IstioNamespace, errChan, &wg)
+	go in.fetchAllWorkloads(&workloadsPerNamespace, errChan, &wg)
 	go in.fetchGatewaysPerNamespace(&gatewaysPerNamespace, errChan, &wg)
 	go in.fetchNonLocalmTLSConfigs(&mtlsDetails, namespace, errChan, &wg)
 	go in.fetchAuthorizationDetails(&rbacDetails, namespace, errChan, &wg)
@@ -85,7 +86,7 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 		}
 	}
 
-	objectCheckers := in.getAllObjectCheckers(namespace, istioDetails, services, controlPlaneWorkloads, workloads, gatewaysPerNamespace, mtlsDetails, rbacDetails, namespaces)
+	objectCheckers := in.getAllObjectCheckers(namespace, istioDetails, services, workloadsPerNamespace, workloads, gatewaysPerNamespace, mtlsDetails, rbacDetails, namespaces)
 
 	if service != "" {
 		objectCheckers = append(objectCheckers, in.getServiceCheckers(namespace, services, deployments, pods)...)
@@ -106,12 +107,12 @@ func (in *IstioValidationsService) getServiceCheckers(namespace string, services
 	}
 }
 
-func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioDetails kubernetes.IstioDetails, services []core_v1.Service, controlPlaneWorkloads, workloads models.WorkloadList, gatewaysPerNamespace [][]kubernetes.IstioObject, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace) []ObjectChecker {
+func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioDetails kubernetes.IstioDetails, services []core_v1.Service, workloadsPerNamespace map[string]models.WorkloadList, workloads models.WorkloadList, gatewaysPerNamespace [][]kubernetes.IstioObject, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace) []ObjectChecker {
 	return []ObjectChecker{
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails},
 		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices},
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
-		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads, ControlPlaneWorkloadList: controlPlaneWorkloads},
+		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioDetails.VirtualServices},
@@ -128,7 +129,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	var istioDetails kubernetes.IstioDetails
 	var namespaces models.Namespaces
 	var services []core_v1.Service
-	var workloads, controlPlaneWorkloads models.WorkloadList
+	var workloads models.WorkloadList
+	var workloadsPerNamespace map[string]models.WorkloadList
 	var gatewaysPerNamespace [][]kubernetes.IstioObject
 	var mtlsDetails kubernetes.MTLSDetails
 	var rbacDetails kubernetes.RBACDetails
@@ -150,7 +152,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	go in.fetchDetails(&istioDetails, namespace, errChan, &wg)
 	go in.fetchServices(&services, namespace, errChan, &wg)
 	go in.fetchWorkloads(&workloads, namespace, errChan, &wg)
-	go in.fetchWorkloads(&controlPlaneWorkloads, config.Get().IstioNamespace, errChan, &wg)
+	go in.fetchAllWorkloads(&workloadsPerNamespace, errChan, &wg)
 	go in.fetchGatewaysPerNamespace(&gatewaysPerNamespace, errChan, &wg)
 	go in.fetchNonLocalmTLSConfigs(&mtlsDetails, namespace, errChan, &wg)
 	go in.fetchAuthorizationDetails(&rbacDetails, namespace, errChan, &wg)
@@ -161,7 +163,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	switch objectType {
 	case kubernetes.Gateways:
 		objectCheckers = []ObjectChecker{
-			checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadList: workloads, ControlPlaneWorkloadList: controlPlaneWorkloads},
+			checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		}
 	case kubernetes.VirtualServices:
 		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules}
@@ -369,6 +371,31 @@ func (in *IstioValidationsService) fetchWorkloads(rValue *models.WorkloadList, n
 		} else {
 			*rValue = workloadList
 		}
+	}
+}
+
+func (in *IstioValidationsService) fetchAllWorkloads(rValue *map[string]models.WorkloadList, errChan chan error, wg *sync.WaitGroup) {
+	defer wg.Done()
+	if len(errChan) == 0 {
+		nss, err := in.businessLayer.Namespace.GetNamespaces()
+		if err != nil {
+			errChan <- err
+			return
+
+		}
+		allWorkloads := map[string]models.WorkloadList{}
+		for _, ns := range nss {
+			workloadList, err := in.businessLayer.Workload.GetWorkloadList(ns.Name)
+			if err != nil {
+				select {
+				case errChan <- err:
+				default:
+				}
+			} else {
+				allWorkloads[ns.Name] = workloadList
+			}
+		}
+		*rValue = allWorkloads
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3265#

Goal: include istio-system workloads to the look up for workloads in the gateways selector checker.

I have several thoughts regarding this change:
1. It breaks the cross-namespace validation rule. Security-wise, bad-intended users without access to istio-system could gain information about workloads in the istio-system that match that specific selector. Is it that bad?
2. I think it might be different kinds of deployments where the ingress/egress are going to be in different namespaces than the control plane. Therefore, the validation will keep failing.
3. Because of the previous thoughts, I am wondering if we should remove the warning at all. 

Thoughts?