### PR TITLE
Add timeout and client close

### DIFF
--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -57,7 +57,7 @@ type OAuthRouteTLSSpec struct {
 
 const serverPrefix = "https://kubernetes.default.svc/"
 
-var defaultRequestTimeout, _ = time.ParseDuration("10s")
+const defaultRequestTimeout = 10 * time.Second
 
 var kialiNamespace string
 

--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -107,7 +108,7 @@ func getOAuthAuthorizationServer() (*OAuthAuthorizationServer, error) {
 
 	if err != nil {
 		log.Error(err)
-		message := fmt.Errorf("could not send request to the Openshift OAuth API: %v", err)
+		message := fmt.Errorf("could not get OAuthAuthorizationServer: %v", err)
 		return nil, message
 	}
 
@@ -115,7 +116,7 @@ func getOAuthAuthorizationServer() (*OAuthAuthorizationServer, error) {
 
 	if err != nil {
 		log.Error(err)
-		message := fmt.Errorf("could not parse data from the Openshift API: %v", err)
+		message := fmt.Errorf("could not parse OAuthAuthorizationServer: %v", err)
 		return nil, message
 	}
 
@@ -166,7 +167,7 @@ func getKialiRoutePath(routeName string) (*string, error) {
 	conf, err := kubernetes.ConfigClient()
 	if err != nil {
 		log.Error(err)
-		return nil, fmt.Errorf("could not connect to Openshift: %v", err)
+		return nil, fmt.Errorf("could not get openshift config client: %v", err)
 	}
 
 	response, err := request("GET", fmt.Sprintf("apis/route.openshift.io/v1/namespaces/%v/routes/%s", namespace, routeName), &conf.BearerToken)
@@ -211,6 +212,11 @@ func (in *OpenshiftOAuthService) Logout(token string) error {
 }
 
 func request(method string, url string, auth *string) ([]byte, error) {
+	timeout, _ := time.ParseDuration("5s")
+	return requestWithTimeout(method, url, auth, time.Duration(timeout))
+}
+
+func requestWithTimeout(method string, url string, auth *string, timeout time.Duration) ([]byte, error) {
 	certPool := x509.NewCertPool()
 	cert, err := ioutil.ReadFile("/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 
@@ -223,9 +229,12 @@ func request(method string, url string, auth *string) ([]byte, error) {
 	tlsConfig := &tls.Config{RootCAs: certPool}
 
 	client := &http.Client{
+		Timeout: timeout,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		}}
+
+	defer client.CloseIdleConnections()
 
 	request, err := http.NewRequest(method, strings.Join([]string{serverPrefix, url}, ""), nil)
 

--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -57,6 +57,8 @@ type OAuthRouteTLSSpec struct {
 
 const serverPrefix = "https://kubernetes.default.svc/"
 
+var defaultRequestTimeout, _ = time.ParseDuration("10s")
+
 var kialiNamespace string
 
 func (in *OpenshiftOAuthService) Metadata() (metadata *OAuthMetadata, err error) {
@@ -212,8 +214,7 @@ func (in *OpenshiftOAuthService) Logout(token string) error {
 }
 
 func request(method string, url string, auth *string) ([]byte, error) {
-	timeout, _ := time.ParseDuration("5s")
-	return requestWithTimeout(method, url, auth, time.Duration(timeout))
+	return requestWithTimeout(method, url, auth, time.Duration(defaultRequestTimeout))
 }
 
 func requestWithTimeout(method string, url string, auth *string, timeout time.Duration) ([]byte, error) {


### PR DESCRIPTION
As pointed out by @jotak , the go http client does not have a timeout by default, which can cause a hang in API calls.  Apply a timeout when interacting with the OpenAuth API.  Also, don't leave behind any keep-alive sessions.

In testing under load we did see the timeout trigger and the issue seems to be resolved with these changes.  This fix seemed to resurface a lingering issue, #3313, which we were hopefully able to finally squash.  So that UI PR is being required here.

UI PR: https://github.com/kiali/kiali-ui/pull/1994

Fixes #2905 