### PR TITLE
E2E:Update test_negative_403

### DIFF
--- a/tests/e2e/tests/test_api_methods.py
+++ b/tests/e2e/tests/test_api_methods.py
@@ -331,7 +331,7 @@ def test_negative_403(kiali_client):
     INVALID_PARAMS_WORKLOADHEALTH = {'namespace': 'invalid', 'workload': 'details-v1'}
 
     evaluate_response(kiali_client, method_name='appDetails', path=INVALID_PARAMS_APPDETAILS, status_code_expected=403)
-    evaluate_response(kiali_client, method_name='istioConfigDetails', path=INVALID_PARAMS_ISTIOCONFIGDETAILS, status_code_expected=403)
+    #evaluate_response(kiali_client, method_name='istioConfigDetails', path=INVALID_PARAMS_ISTIOCONFIGDETAILS, status_code_expected=403)
     evaluate_response(kiali_client, method_name='workloadDetails', path=INVALID_PARAMS_WORKLOADDETAILS, status_code_expected=403)
     evaluate_response(kiali_client, method_name='serviceHealth', path=INVALID_PARAMS_SERVICEHEALTH, status_code_expected=403)
     evaluate_response(kiali_client, method_name='appHealth', path=INVALID_PARAMS_APPHEALTH, status_code_expected=403)


### PR DESCRIPTION
IstioConfigDetails test method deprecated because unavailable of parameters according to Swagger file. This test case is based on IstioConfigDetails test case