### PR TITLE
Remove : from URL link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -477,7 +477,7 @@ spec:
 
 === Observing a Remote Cluster
 
-There are certain use cases where Kiali needs to be deployed in one cluster (Control Plane) and observe a different cluster (Data Plane). link:https://user-images.githubusercontent.com/6889074/87819080-ad099980-c839-11ea-834b-56eec038ce4d.png:[Diagram].
+There are certain use cases where Kiali needs to be deployed in one cluster (Control Plane) and observe a different cluster (Data Plane). link:https://user-images.githubusercontent.com/6889074/87819080-ad099980-c839-11ea-834b-56eec038ce4d.png[Diagram].
 
 Follow these steps:
 


### PR DESCRIPTION
The URL of the diagram contains an extra : that effectively breaks the URL. Removing the : fixed it.
