### PR TITLE
Add multi-arch image builds supports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SHELL=/bin/bash
 ROOTDIR=$(CURDIR)
 OUTDIR=${ROOTDIR}/_output
 
+# list for multi-arch image publishing
+TARGET_ARCHS ?= amd64 arm64 s390x ppc64le
+
 # Identifies the current build.
 # These will be embedded in the app and displayed when it starts.
 VERSION ?= v1.27.0-SNAPSHOT
@@ -40,7 +43,7 @@ CONTAINER_VERSION ?= dev
 
 # These two vars allow Jenkins to override values.
 QUAY_NAME ?= quay.io/${CONTAINER_NAME}
-QUAY_TAG = ${QUAY_NAME}:${CONTAINER_VERSION}
+QUAY_TAG ?= ${QUAY_NAME}:${CONTAINER_VERSION}
 
 # Identifies the Kiali operator container images that will be built
 OPERATOR_CONTAINER_NAME ?= ${IMAGE_ORG}/kiali-operator

--- a/deploy/docker/Dockerfile-multi-arch
+++ b/deploy/docker/Dockerfile-multi-arch
@@ -1,0 +1,30 @@
+FROM registry.access.redhat.com/ubi7-minimal AS base-amd64
+FROM registry.access.redhat.com/ubi8-minimal AS base-arm64
+FROM registry.access.redhat.com/ubi8-minimal AS base-s390x
+FROM registry.access.redhat.com/ubi8-minimal AS base-ppc64le
+
+FROM base-${TARGETARCH:-amd64}
+
+LABEL maintainer="kiali-dev@googlegroups.com"
+
+ENV KIALI_HOME=/opt/kiali \
+    PATH=$KIALI_HOME:$PATH
+
+WORKDIR $KIALI_HOME
+
+RUN microdnf install -y shadow-utils && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum && \
+    adduser --uid 1000 kiali
+
+ARG TARGETARCH
+COPY kiali-${TARGETARCH} $KIALI_HOME/kiali
+
+ADD console $KIALI_HOME/console/
+
+RUN chown -R kiali:kiali $KIALI_HOME/console && \
+    chmod -R g=u $KIALI_HOME/console
+
+USER 1000
+
+ENTRYPOINT ["/opt/kiali/kiali"]

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -25,6 +25,14 @@ build: go-check
 	${GO_BUILD_ENVVARS} ${GO} build \
 		-o ${GOPATH}/bin/kiali -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
+## build-linux-multi-arch: Build Kiali binary with arch suffix for multi-arch
+build-linux-multi-arch:
+	@for arch in ${TARGET_ARCHS}; do \
+		echo "Building for architecture [$${arch}]"; \
+		${GO_BUILD_ENVVARS} GOOS=linux GOARCH=$${arch} ${GO} build \
+			-o ${GOPATH}/bin/kiali-$${arch} -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"; \
+	done
+
 ## install: Install missing dependencies. Runs `go install` internally
 install:
 	@echo Installing...

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -8,7 +8,7 @@
 	@echo Preparing container image files
 	@mkdir -p ${OUTDIR}/docker
 	@cp -r deploy/docker/* ${OUTDIR}/docker
-	@cp ${GOPATH}/bin/kiali ${OUTDIR}/docker
+	@cp ${GOPATH}/bin/kiali* ${OUTDIR}/docker
 
 .download-operator-sdk-if-needed:
 	@if [ "$(shell which operator-sdk 2>/dev/null || echo -n "")" == "" ]; then \
@@ -62,3 +62,34 @@ endif
 
 ## container-push: Pushes all container images to quay
 container-push: container-push-kiali-quay
+
+# Ensure "docker buildx" is available and enabled. For more details, see: https://github.com/docker/buildx/blob/master/README.md
+.ensure-docker-buildx:
+	@if docker buildx version > /dev/null 2>&1 || DOCKER_CLI_EXPERIMENTAL="${DOCKER_CLI_EXPERIMENTAL}" docker buildx version > /dev/null 2>&1 ; then \
+	  echo "'docker buildx' is available and enabled."; \
+	else \
+	  echo "installing docker buildx"; \
+	  mkdir -p ~/.docker/cli-plugins; \
+	  curl -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.$$(go env GOOS)-$$(go env GOARCH); \
+	  chmod a+x ~/.docker/cli-plugins/docker-buildx; \
+	  docker buildx version; \
+	  echo "'docker buildx' is available and enabled. Set DOCKER_CLI_EXPERIMENTAL=enabled if you want to use it."; \
+	fi
+
+# Ensure a local builder for multi-arch build. For more details, see: https://github.com/docker/buildx/blob/master/README.md#building-multi-platform-images
+.ensure-buildx-builder:
+	@if [[  ! -f ~/.docker/buildx/instances/kiali-builder ]]; then \
+  		echo "builder 'kiali-builder' not exists. creating 'kiali-builder'"; \
+  		DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx create --name=kiali-builder; \
+  	fi; \
+	if [[ $$(uname -s) == "Linux" ]]; then \
+	  	echo "setup qemu for Linux"; \
+		docker run --privileged --rm tonistiigi/binfmt --install all; \
+	fi; \
+	echo "buildx use 'kiali-builder'"; \
+	DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx use kiali-builder
+
+## container-multi-arch-push-kiali-quay: Pushes the Kiali multi-arch image to quay.
+container-multi-arch-push-kiali-quay: .ensure-docker-buildx .ensure-buildx-builder .prepare-kiali-image-files
+	@echo Pushing Kiali multi-arch image to ${QUAY_TAG} using docker buildx
+	DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx build --push $(foreach arch,${TARGET_ARCHS},--platform=linux/${arch}) $(foreach tag,${QUAY_TAG},--tag=${tag}) -f ${OUTDIR}/docker/Dockerfile-multi-arch ${OUTDIR}/docker

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -90,7 +90,7 @@ container-push: container-push-kiali-quay
 .ensure-buildx-builder: .ensure-docker-buildx
 	@if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx inspect kiali-builder > /dev/null 2>&1; then \
 	  echo "The buildx builder instance named 'kiali-builder' does not exist. Creating one now."; \
-	  if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx create --name=kiali-builder; then \
+	  if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx create --name=kiali-builder --driver-opt=image=moby/buildkit:v0.8.0-rc2; then \
 	    echo "Failed to create the buildx builder 'kiali-builder'"; \
 	    exit 1; \
 	  fi \

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -65,25 +65,18 @@ container-push: container-push-kiali-quay
 
 # Ensure "docker buildx" is available and enabled. For more details, see: https://github.com/docker/buildx/blob/master/README.md
 .ensure-docker-buildx:
-	@if docker buildx version > /dev/null 2>&1 || DOCKER_CLI_EXPERIMENTAL="${DOCKER_CLI_EXPERIMENTAL}" docker buildx version > /dev/null 2>&1 ; then \
+	@required_buildx_version="v0.4.2"; \
+	current_buildx_version=$$(DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version); \
+	if [[ "$${current_buildx_version}" == *"$${required_buildx_version}"* ]]; then \
 	  echo "'docker buildx' is available and enabled."; \
 	else \
-	  if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version > /dev/null 2>&1 ; then \
-	    echo "You do not have 'docker buildx' installed. Will now download and install it to [${HOME}/.docker/cli-plugins]."; \
-	    mkdir -p ${HOME}/.docker/cli-plugins; \
-	    curl -L --output ${HOME}/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.${GOOS}-${GOARCH}; \
-	    chmod a+x ${HOME}/.docker/cli-plugins/docker-buildx; \
-	    DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version; \
-	    if docker buildx version > /dev/null 2>&1 || DOCKER_CLI_EXPERIMENTAL="${DOCKER_CLI_EXPERIMENTAL}" docker buildx version > /dev/null 2>&1 ; then \
-	      echo "'docker buildx' has been installed and is enabled."; \
-	    else \
-	      echo "'docker buildx' has been installed but is not enabled by default. Set DOCKER_CLI_EXPERIMENTAL=enabled if you want to use it."; \
-	      exit 1; \
-	    fi \
-	  else \
-	    echo "'docker buildx' is available but not enabled. Set DOCKER_CLI_EXPERIMENTAL=enabled if you want to use it."; \
-	    exit 1; \
-	  fi \
+		buildx_download_url=https://github.com/docker/buildx/releases/download/$${required_buildx_version}/buildx-$${required_buildx_version}.${GOOS}-${GOARCH}; \
+		echo "You do not have 'docker buildx' installed. Will now download from $${buildx_download_url} and install it to [${HOME}/.docker/cli-plugins]."; \
+		mkdir -p ${HOME}/.docker/cli-plugins; \
+		curl -L --output ${HOME}/.docker/cli-plugins/docker-buildx "$${buildx_download_url}"; \
+		chmod a+x ${HOME}/.docker/cli-plugins/docker-buildx; \
+		DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version; \
+		echo "'docker buildx' is available and enabled."; \
 	fi
 
 # Ensure a local builder for multi-arch build. For more details, see: https://github.com/docker/buildx/blob/master/README.md#building-multi-platform-images

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -64,26 +64,50 @@ endif
 container-push: container-push-kiali-quay
 
 # Ensure "docker buildx" is available and enabled. For more details, see: https://github.com/docker/buildx/blob/master/README.md
+# This does a few things:
+#  1. Makes sure docker is in PATH
+#  2. Downloads and installs buildx if no version of buildx is installed yet
+#  3. Makes sure any installed buildx is a required version or newer
+#  4. Makes sure the user has enabled buildx (either by default or by setting DOCKER_CLI_EXPERIMENTAL env var to 'enabled')
+#  Thus, this target will only ever succeed if a required (or newer) version of 'docker buildx' is available and enabled.
 .ensure-docker-buildx:
-	@required_buildx_version="v0.4.2"; \
-	current_buildx_version=$$(DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version); \
-	if [[ "$${current_buildx_version}" == *"$${required_buildx_version}"* ]]; then \
-	  echo "'docker buildx' is available and enabled."; \
+	@if ! which docker > /dev/null 2>&1; then echo "'docker' is not in your PATH."; exit 1; fi
+	@required_buildx_version="0.4.2"; \
+	if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version > /dev/null 2>&1 ; then \
+	  buildx_download_url="https://github.com/docker/buildx/releases/download/$${required_buildx_version}/buildx-$${required_buildx_version}.${GOOS}-${GOARCH}"; \
+	  echo "You do not have 'docker buildx' installed. Will now download from [$${buildx_download_url}] and install it to [${HOME}/.docker/cli-plugins]."; \
+	  mkdir -p ${HOME}/.docker/cli-plugins; \
+	  curl -L --output ${HOME}/.docker/cli-plugins/docker-buildx "$${buildx_download_url}"; \
+	  chmod a+x ${HOME}/.docker/cli-plugins/docker-buildx; \
+	  installed_version="$$(DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version || echo "unknown")"; \
+	  if docker buildx version > /dev/null 2>&1; then \
+	    echo "'docker buildx' has been installed and is enabled [version=$${installed_version}]"; \
+	  else \
+	    echo "An attempt to install 'docker buildx' has been made but it either failed or is not enabled by default. [version=$${installed_version}]"; \
+	    echo "Set DOCKER_CLI_EXPERIMENTAL=enabled to enable it."; \
+	    exit 1; \
+	  fi \
+	fi; \
+	current_buildx_version="$$(DOCKER_CLI_EXPERIMENTAL=enabled docker buildx version 2>/dev/null | sed -E 's/.*v([0-9]+\.[0-9]+\.[0-9]+).*/\1/g')"; \
+	is_valid_buildx_version="$$(if [ "$$(printf $${required_buildx_version}\\n$${current_buildx_version} | sort -V | head -n1)" == "$${required_buildx_version}" ]; then echo "true"; else echo "false"; fi)"; \
+	if [ "$${is_valid_buildx_version}" == "true" ]; then \
+	  echo "A valid version of 'docker buildx' is available: $${current_buildx_version}"; \
 	else \
-		buildx_download_url=https://github.com/docker/buildx/releases/download/$${required_buildx_version}/buildx-$${required_buildx_version}.${GOOS}-${GOARCH}; \
-		echo "You do not have 'docker buildx' installed. Will now download from $${buildx_download_url} and install it to [${HOME}/.docker/cli-plugins]."; \
-		mkdir -p ${HOME}/.docker/cli-plugins; \
-		curl -L --output ${HOME}/.docker/cli-plugins/docker-buildx "$${buildx_download_url}"; \
-		chmod a+x ${HOME}/.docker/cli-plugins/docker-buildx; \
-		DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version; \
-		echo "'docker buildx' is available and enabled."; \
+	  echo "You have an older version of 'docker buildx' that is not compatible. Please upgrade to at least v$${required_buildx_version}"; \
+	  exit 1; \
+	fi; \
+	if docker buildx version > /dev/null 2>&1; then \
+	  echo "'docker buildx' is enabled"; \
+	else \
+	  echo "'docker buildx' is not enabled. Set DOCKER_CLI_EXPERIMENTAL=enabled if you want to use it."; \
+	  exit 1; \
 	fi
 
 # Ensure a local builder for multi-arch build. For more details, see: https://github.com/docker/buildx/blob/master/README.md#building-multi-platform-images
 .ensure-buildx-builder: .ensure-docker-buildx
-	@if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx inspect kiali-builder > /dev/null 2>&1; then \
+	@if ! docker buildx inspect kiali-builder > /dev/null 2>&1; then \
 	  echo "The buildx builder instance named 'kiali-builder' does not exist. Creating one now."; \
-	  if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx create --name=kiali-builder --driver-opt=image=moby/buildkit:v0.8.0-rc2; then \
+	  if ! docker buildx create --name=kiali-builder --driver-opt=image=moby/buildkit:v0.8.0-rc2; then \
 	    echo "Failed to create the buildx builder 'kiali-builder'"; \
 	    exit 1; \
 	  fi \
@@ -93,9 +117,9 @@ container-push: container-push-kiali-quay
 	  if ! docker run --privileged --rm tonistiigi/binfmt --install all; then \
 	    echo "Failed to ensure QEMU is set up. This build will be allowed to continue, but it may fail at a later step."; \
 	  fi \
-	fi; \
+	fi
 
 ## container-multi-arch-push-kiali-quay: Pushes the Kiali multi-arch image to quay.
 container-multi-arch-push-kiali-quay: .ensure-buildx-builder .prepare-kiali-image-files
 	@echo Pushing Kiali multi-arch image to ${QUAY_TAG} using docker buildx
-	DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx build --push --builder=kiali-builder $(foreach arch,${TARGET_ARCHS},--platform=linux/${arch}) $(foreach tag,${QUAY_TAG},--tag=${tag}) -f ${OUTDIR}/docker/Dockerfile-multi-arch ${OUTDIR}/docker
+	docker buildx build --push --builder=kiali-builder $(foreach arch,${TARGET_ARCHS},--platform=linux/${arch}) $(foreach tag,${QUAY_TAG},--tag=${tag}) -f ${OUTDIR}/docker/Dockerfile-multi-arch ${OUTDIR}/docker


### PR DESCRIPTION
** Describe the change **

_Please describe what the code change is about_

* Merge `Dockerfile-ubi{7|8}-minimal` to single `Dockerfile` (and make it support `docker build` & `docker buildx build` both)
* added `DORP=dockerx` to build mulit-arch image by [buildx](https://docs.docker.com/buildx/working-with-buildx/)

```bash
TARGET_ARCH="amd64 arm64 ppc64le" DORP=dockerx make build-linux container-build-kiali container-push-kiali-quay
```

example: https://hub.docker.com/r/morlay/kiali/tags

** Issue reference **

#1091
