### PR TITLE
use LOG_LEVEL in make run target since -v is invalid now

### DIFF
--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -78,7 +78,7 @@ test-e2e:
 ## run: Run kiali binary
 run:
 	@echo Running...
-	@${GOPATH}/bin/kiali -v 4 -config config.yaml
+	@LOG_LEVEL="debug" ${GOPATH}/bin/kiali -config config.yaml
 
 #
 # Swagger Documentation


### PR DESCRIPTION
this should have been part of https://github.com/kiali/kiali/issues/2893
-v no longer valid - set LOG_LEVEL env var.
