### PR TITLE
Prom, Jaeger, Grafana component status computed using their service url

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -243,8 +243,7 @@ func (iss *IstioStatusService) getAddonComponentStatus() IstioComponentStatus {
 func getAddonStatus(name string, enabled bool, url string, auth *config.Auth, isCore bool, staChan chan<- IstioComponentStatus, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	addonAuth := auth
-	if addonAuth.UseKialiToken {
+	if auth.UseKialiToken {
 		token, err := kubernetes.GetKialiToken()
 		if err != nil {
 			log.Errorf("Could not read the Kiali Service Account token: %v", err)

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -218,6 +218,7 @@ func (iss *IstioStatusService) getAddonComponentStatus() IstioComponentStatus {
 	ics.merge(getAddonStatus("prometheus", true, extServices.Prometheus.URL, &extServices.Prometheus.Auth, true))
 	ics.merge(getAddonStatus("grafana", extServices.Grafana.Enabled, extServices.Grafana.InClusterURL, &extServices.Grafana.Auth, extServices.Grafana.CoreComponent))
 	ics.merge(getAddonStatus("jaeger", extServices.Tracing.Enabled, extServices.Tracing.InClusterURL, &extServices.Tracing.Auth, extServices.Tracing.CoreComponent))
+	ics.merge(getAddonStatus("custom dashboards", extServices.CustomDashboards.Enabled, extServices.CustomDashboards.Prometheus.URL, &extServices.CustomDashboards.Prometheus.Auth, extServices.CustomDashboards.IsCoreComponent))
 
 	return ics
 }

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -215,8 +215,8 @@ func (iss *IstioStatusService) getAddonComponentStatus() IstioComponentStatus {
 	ics := IstioComponentStatus{}
 
 	ics.merge(getAddonStatus("prometheus", true, extServices.Prometheus.URL, true))
-	ics.merge(getAddonStatus("grafana", extServices.Grafana.Enabled, extServices.Grafana.InClusterURL, false))
-	ics.merge(getAddonStatus("jaeger", extServices.Tracing.Enabled, extServices.Tracing.InClusterURL, false))
+	ics.merge(getAddonStatus("grafana", extServices.Grafana.Enabled, extServices.Grafana.InClusterURL, extServices.Grafana.CoreComponent))
+	ics.merge(getAddonStatus("jaeger", extServices.Tracing.Enabled, extServices.Tracing.InClusterURL, extServices.Tracing.CoreComponent))
 
 	return ics
 }

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -216,8 +216,8 @@ func (iss *IstioStatusService) getAddonComponentStatus() IstioComponentStatus {
 	ics := IstioComponentStatus{}
 
 	ics.merge(getAddonStatus("prometheus", true, extServices.Prometheus.URL, &extServices.Prometheus.Auth, true))
-	ics.merge(getAddonStatus("grafana", extServices.Grafana.Enabled, extServices.Grafana.InClusterURL, &extServices.Grafana.Auth, extServices.Grafana.CoreComponent))
-	ics.merge(getAddonStatus("jaeger", extServices.Tracing.Enabled, extServices.Tracing.InClusterURL, &extServices.Tracing.Auth, extServices.Tracing.CoreComponent))
+	ics.merge(getAddonStatus("grafana", extServices.Grafana.Enabled, extServices.Grafana.InClusterURL, &extServices.Grafana.Auth, extServices.Grafana.IsCoreComponent))
+	ics.merge(getAddonStatus("jaeger", extServices.Tracing.Enabled, extServices.Tracing.InClusterURL, &extServices.Tracing.Auth, extServices.Tracing.IsCoreComponent))
 	ics.merge(getAddonStatus("custom dashboards", extServices.CustomDashboards.Enabled, extServices.CustomDashboards.Prometheus.URL, &extServices.CustomDashboards.Prometheus.Auth, extServices.CustomDashboards.IsCoreComponent))
 
 	return ics

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -368,9 +368,11 @@ func defaultAddOnCalls(jaeger, grafana, prom *int) map[string]addOnsSetup {
 
 func addonAddMockUrls(baseUrl string, conf *config.Config) *config.Config {
 	conf.ExternalServices.Grafana.Enabled = true
+	conf.ExternalServices.Grafana.CoreComponent = false
 	conf.ExternalServices.Grafana.InClusterURL = baseUrl + "/grafana/mock"
 
 	conf.ExternalServices.Tracing.Enabled = true
+	conf.ExternalServices.Tracing.CoreComponent = false
 	conf.ExternalServices.Tracing.InClusterURL = baseUrl + "/jaeger/mock"
 
 	conf.ExternalServices.Prometheus.URL = baseUrl + "/prometheus/mock"

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -1,8 +1,11 @@
 package business
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -11,7 +14,14 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/log"
 )
+
+type addOnsSetup struct {
+	Url        string
+	StatusCode int
+	CallCount  *int
+}
 
 var healthyStatus = apps_v1.DeploymentStatus{
 	Replicas:            2,
@@ -77,119 +87,174 @@ func TestComponentNamespaces(t *testing.T) {
 
 	a.Contains(nss, "istio-system")
 	a.Contains(nss, "istio-admin")
-	a.Contains(nss, "prometheus-system")
-	a.Contains(nss, "grafana-system")
 	a.Contains(nss, "ingress-egress")
-	a.Contains(nss, "tracing-system")
-	a.Len(nss, 7)
+	a.Len(nss, 4)
+}
+
+func mockAddOnsCalls(ds []apps_v1.Deployment) (*kubetest.K8SClientMock, *httptest.Server, *int, *int, *int) {
+	// Prepare the Call counts for each Addon
+	jaegerCalls, grafanaCalls, prometheusCalls := 0, 0, 0
+
+	// Mock k8s api calls
+	k8s := mockDeploymentCall(ds)
+	routes := mockAddOnCalls(defaultAddOnCalls(&jaegerCalls, &grafanaCalls, &prometheusCalls))
+	httpServer := mockServer(routes)
+
+	// Adapt the AddOns URLs to the mock Server
+	conf := addonAddMockUrls(httpServer.URL, config.NewConfig())
+	config.Set(conf)
+
+	return k8s, httpServer, &jaegerCalls, &grafanaCalls, &prometheusCalls
+}
+
+func TestGrafanaWorking(t *testing.T) {
+	assert := assert.New(t)
+
+	k8s, httpServ, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls([]apps_v1.Deployment{})
+	defer httpServ.Close()
+
+	iss := IstioStatusService{k8s: k8s}
+	icsl, error := iss.GetStatus()
+	assert.NoError(error)
+
+	// Requests to AddOns have to be 1
+	assert.Equal(1, *grafanaCalls)
+	assert.Equal(1, *jaegerCalls)
+	assert.Equal(1, *promCalls)
+
+	assertNotPresent(assert, icsl, "grafana")
+	assertNotPresent(assert, icsl, "prometheus")
+	assertNotPresent(assert, icsl, "jaeger")
 }
 
 func TestGrafanaDisabled(t *testing.T) {
 	assert := assert.New(t)
 
-	conf := confWithIstioComponents()
+	k8s, httpServ, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls([]apps_v1.Deployment{})
+	defer httpServ.Close()
+
+	// Disable Grafana
+	conf := config.Get()
 	conf.ExternalServices.Grafana.Enabled = false
 	config.Set(conf)
 
-	pods := []apps_v1.Deployment{
-		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
-	}
-
-	k8s := mockDeploymentCall(pods, true)
 	iss := IstioStatusService{k8s: k8s}
-
 	icsl, error := iss.GetStatus()
 	assert.NoError(error)
-	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, true)
 
-	// Don't return status of mixer deployment
+	// No request performed to Grafana endpoint
+	assert.Zero(*grafanaCalls)
+
+	// Requests to Jaeger and Prometheus performed once
+	assert.Equal(1, *jaegerCalls)
+	assert.Equal(1, *promCalls)
+
 	assertNotPresent(assert, icsl, "grafana")
+	assertNotPresent(assert, icsl, "prometheus")
+	assertNotPresent(assert, icsl, "jaeger")
 }
 
-func TestTracingDisabled(t *testing.T) {
+func TestGrafanaNotWorking(t *testing.T) {
 	assert := assert.New(t)
+	jaegerCalls, grafanaCalls, prometheusCalls := 0, 0, 0
+	k8s := mockDeploymentCall([]apps_v1.Deployment{})
+	addOnsStetup := defaultAddOnCalls(&jaegerCalls, &grafanaCalls, &prometheusCalls)
+	addOnsStetup["grafana"] = addOnsSetup{
+		Url:        "/grafana/mock",
+		StatusCode: 501,
+		CallCount:  &grafanaCalls,
+	}
+	routes := mockAddOnCalls(addOnsStetup)
+	httpServer := mockServer(routes)
+	defer httpServer.Close()
 
-	conf := config.NewConfig()
-	conf.ExternalServices.Tracing.Enabled = false
+	// Adapt the AddOns URLs to the mock Server
+	conf := addonAddMockUrls(httpServer.URL, config.NewConfig())
 	config.Set(conf)
 
-	pods := []apps_v1.Deployment{
-		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
-	}
-
-	k8s := mockDeploymentCall(pods, true)
 	iss := IstioStatusService{k8s: k8s}
-
 	icsl, error := iss.GetStatus()
 	assert.NoError(error)
-	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, true)
 
-	// Don't return status of mixer deployment
+	// Requests to AddOns have to be 1
+	assert.Equal(1, grafanaCalls)
+	assert.Equal(1, jaegerCalls)
+	assert.Equal(1, prometheusCalls)
+
+	assertComponent(assert, icsl, "grafana", Unreachable, false)
+	assertNotPresent(assert, icsl, "prometheus")
 	assertNotPresent(assert, icsl, "jaeger")
 }
 
 func TestDefaults(t *testing.T) {
 	assert := assert.New(t)
 
-	config.Set(confWithIstioComponents())
-
 	pods := []apps_v1.Deployment{
-		fakeDeploymentWithStatus("istio-egressgateway", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, healthyStatus),
+		fakeDeploymentWithStatus("istio-egressgateway", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, unhealthyStatus),
 		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
-		fakeDeploymentWithStatus("grafana", map[string]string{"app": "grafana"}, unhealthyStatus),
-		fakeDeploymentWithStatus("jaeger", map[string]string{"app": "jaeger"}, unhealthyStatus),
 	}
 
-	k8s := mockDeploymentCall(pods, true)
+	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(pods)
+	defer httpServer.Close()
+
 	iss := IstioStatusService{k8s: k8s}
 
 	icsl, error := iss.GetStatus()
 	assert.NoError(error)
 	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, true)
-	assertComponent(assert, icsl, "grafana", Unhealthy, false)
-	assertComponent(assert, icsl, "jaeger", Unhealthy, false)
-	assertComponent(assert, icsl, "prometheus", NotFound, true)
+	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)
 
 	// Don't return healthy deployments
-	assertNotPresent(assert, icsl, "istio-egressgateway")
 	assertNotPresent(assert, icsl, "istiod")
+	assertNotPresent(assert, icsl, "grafana")
+	assertNotPresent(assert, icsl, "prometheus")
+	assertNotPresent(assert, icsl, "jaeger")
+
+	// Requests to AddOns have to be 1
+	assert.Equal(1, *grafanaCalls)
+	assert.Equal(1, *jaegerCalls)
+	assert.Equal(1, *promCalls)
 }
 
 func TestNonDefaults(t *testing.T) {
 	assert := assert.New(t)
 
-	c := confWithIstioComponents()
-	c.ExternalServices.Tracing.ComponentStatus = config.ComponentStatus{AppLabel: "jaeger", IsCore: true}
+	pods := []apps_v1.Deployment{
+		fakeDeploymentWithStatus("istio-egressgateway", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, unhealthyStatus),
+		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
+	}
+
+	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(pods)
+	defer httpServer.Close()
+
+	c := config.Get()
 	c.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
 		Enabled: true,
 		Components: []config.ComponentStatus{
-			{AppLabel: "istiod", IsCore: true},
+			{AppLabel: "istiod", IsCore: false},
 			{AppLabel: "istio-egressgateway", IsCore: false},
 			{AppLabel: "istio-ingressgateway", IsCore: false},
 		},
 	}
 	config.Set(c)
 
-	pods := []apps_v1.Deployment{
-		fakeDeploymentWithStatus("istio-egressgateway", map[string]string{"app": "istio-egressgateway", "istio": "egressgateway"}, healthyStatus),
-		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
-		fakeDeploymentWithStatus("grafana", map[string]string{"app": "grafana"}, unhealthyStatus),
-		fakeDeploymentWithStatus("jaeger", map[string]string{"app": "jaeger"}, unhealthyStatus),
-	}
-
-	k8s := mockDeploymentCall(pods, true)
 	iss := IstioStatusService{k8s: k8s}
 
 	icsl, error := iss.GetStatus()
 	assert.NoError(error)
 	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, false)
-	assertComponent(assert, icsl, "grafana", Unhealthy, false)
-	assertComponent(assert, icsl, "jaeger", Unhealthy, true)
-	assertComponent(assert, icsl, "prometheus", NotFound, true)
+	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)
 
 	// Don't return healthy deployments
-	assertNotPresent(assert, icsl, "istio-egressgateway")
 	assertNotPresent(assert, icsl, "istiod")
+	assertNotPresent(assert, icsl, "grafana")
+	assertNotPresent(assert, icsl, "prometheus")
+	assertNotPresent(assert, icsl, "jaeger")
+
+	// Requests to AddOns have to be 1
+	assert.Equal(1, *grafanaCalls)
+	assert.Equal(1, *jaegerCalls)
+	assert.Equal(1, *promCalls)
 }
 
 func assertComponent(assert *assert.Assertions, icsl IstioComponentStatus, name string, status string, isCore bool) {
@@ -216,10 +281,9 @@ func assertNotPresent(assert *assert.Assertions, icsl IstioComponentStatus, name
 }
 
 // Setup K8S api call to fetch Pods
-func mockDeploymentCall(deployments []apps_v1.Deployment, mixerDisabled bool) *kubetest.K8SClientMock {
+func mockDeploymentCall(deployments []apps_v1.Deployment) *kubetest.K8SClientMock {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(deployments, nil)
-	k8s.On("IsMixerDisabled").Return(mixerDisabled)
 
 	return k8s
 }
@@ -242,13 +306,6 @@ func fakeDeploymentWithStatus(name string, labels map[string]string, status apps
 		}}
 }
 
-func confWithIstioComponents() *config.Config {
-	conf := config.NewConfig()
-	conf.ExternalServices.Grafana.ComponentStatus.Namespace = "istio-config"
-
-	return conf
-}
-
 func confWithComponentNamespaces() *config.Config {
 	conf := config.NewConfig()
 	conf.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
@@ -261,23 +318,61 @@ func confWithComponentNamespaces() *config.Config {
 		},
 	}
 
-	conf.ExternalServices.Grafana.ComponentStatus = config.ComponentStatus{
-		AppLabel:  "grafana",
-		IsCore:    false,
-		Namespace: "grafana-system",
-	}
+	return conf
+}
 
-	conf.ExternalServices.Tracing.ComponentStatus = config.ComponentStatus{
-		AppLabel:  "tracing",
-		IsCore:    false,
-		Namespace: "tracing-system",
-	}
+func mockServer(mr *mux.Router) *httptest.Server {
+	return httptest.NewServer(mr)
+}
 
-	conf.ExternalServices.Prometheus.ComponentStatus = config.ComponentStatus{
-		AppLabel:  "prometheus",
-		IsCore:    true,
-		Namespace: "prometheus-system",
-	}
+func addAddOnRoute(mr *mux.Router, url string, statusCode int, callNum *int) {
+	mr.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		*callNum = *callNum + 1
+		if statusCode > 299 {
+			http.Error(w, "Not a success", statusCode)
+		} else {
+			if c, err := w.Write([]byte("OK")); err != nil {
+				log.Errorf("Error when mocking the addon call: %s (%d)", url, c)
+			}
+		}
+	})
+}
 
+func mockAddOnCalls(addons map[string]addOnsSetup) *mux.Router {
+	mr := mux.NewRouter()
+	for _, addon := range addons {
+		addAddOnRoute(mr, addon.Url, addon.StatusCode, addon.CallCount)
+	}
+	return mr
+}
+
+func defaultAddOnCalls(jaeger, grafana, prom *int) map[string]addOnsSetup {
+	return map[string]addOnsSetup{
+		"prometheus": {
+			Url:        "/prometheus/mock",
+			StatusCode: 200,
+			CallCount:  prom,
+		},
+		"jaeger": {
+			Url:        "/jaeger/mock",
+			StatusCode: 200,
+			CallCount:  jaeger,
+		},
+		"grafana": {
+			Url:        "/grafana/mock",
+			StatusCode: 200,
+			CallCount:  grafana,
+		},
+	}
+}
+
+func addonAddMockUrls(baseUrl string, conf *config.Config) *config.Config {
+	conf.ExternalServices.Grafana.Enabled = true
+	conf.ExternalServices.Grafana.InClusterURL = baseUrl + "/grafana/mock"
+
+	conf.ExternalServices.Tracing.Enabled = true
+	conf.ExternalServices.Tracing.InClusterURL = baseUrl + "/jaeger/mock"
+
+	conf.ExternalServices.Prometheus.URL = baseUrl + "/prometheus/mock"
 	return conf
 }

--- a/config/config.go
+++ b/config/config.go
@@ -109,9 +109,10 @@ type PrometheusConfig struct {
 
 // CustomDashboardsConfig describes configuration specific to Custom Dashboards
 type CustomDashboardsConfig struct {
-	Enabled        bool             `yaml:"enabled,omitempty"`
-	NamespaceLabel string           `yaml:"namespace_label,omitempty"`
-	Prometheus     PrometheusConfig `yaml:"prometheus,omitempty"`
+	Enabled         bool             `yaml:"enabled,omitempty"`
+	IsCoreComponent bool             `yaml:"is_core_component,omitempty"`
+	NamespaceLabel  string           `yaml:"namespace_label,omitempty"`
+	Prometheus      PrometheusConfig `yaml:"prometheus,omitempty"`
 }
 
 // GrafanaConfig describes configuration used for Grafana links

--- a/config/config.go
+++ b/config/config.go
@@ -117,12 +117,12 @@ type CustomDashboardsConfig struct {
 
 // GrafanaConfig describes configuration used for Grafana links
 type GrafanaConfig struct {
-	Auth          Auth                     `yaml:"auth"`
-	CoreComponent bool                     `yaml:"core_component"`
-	Dashboards    []GrafanaDashboardConfig `yaml:"dashboards"`
-	Enabled       bool                     `yaml:"enabled"` // Enable or disable Grafana support in Kiali
-	InClusterURL  string                   `yaml:"in_cluster_url"`
-	URL           string                   `yaml:"url"`
+	Auth            Auth                     `yaml:"auth"`
+	Dashboards      []GrafanaDashboardConfig `yaml:"dashboards"`
+	Enabled         bool                     `yaml:"enabled"` // Enable or disable Grafana support in Kiali
+	InClusterURL    string                   `yaml:"in_cluster_url"`
+	IsCoreComponent bool                     `yaml:"is_core_component"`
+	URL             string                   `yaml:"url"`
 }
 
 type GrafanaDashboardConfig struct {
@@ -141,9 +141,9 @@ type GrafanaVariablesConfig struct {
 // TracingConfig describes configuration used for tracing links
 type TracingConfig struct {
 	Auth                 Auth     `yaml:"auth"`
-	CoreComponent        bool     `yaml:"core_component"`
 	Enabled              bool     `yaml:"enabled"` // Enable Jaeger in Kiali
 	InClusterURL         string   `yaml:"in_cluster_url"`
+	IsCoreComponent      bool     `yaml:"is_core_component"`
 	NamespaceSelector    bool     `yaml:"namespace_selector"`
 	URL                  string   `yaml:"url"`
 	WhiteListIstioSystem []string `yaml:"whitelist_istio_system"`
@@ -389,8 +389,8 @@ func NewConfig() (c *Config) {
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
-				CoreComponent: false,
-				Enabled:       true,
+				Enabled:         true,
+				IsCoreComponent: false,
 			},
 			Istio: IstioConfig{
 				IstioIdentityDomain:      "svc.cluster.local",
@@ -431,7 +431,7 @@ func NewConfig() (c *Config) {
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
-				CoreComponent:        false,
+				IsCoreComponent:      false,
 				Enabled:              true,
 				NamespaceSelector:    true,
 				InClusterURL:         "http://tracing.istio-system/jaeger",

--- a/config/config.go
+++ b/config/config.go
@@ -103,9 +103,8 @@ type PrometheusConfig struct {
 	// Enable cache for Prometheus queries
 	CacheEnabled bool `yaml:"cache_enabled,omitempty"`
 	// Global cache expiration expressed in seconds
-	CacheExpiration int             `yaml:"cache_expiration:omitempty"`
-	ComponentStatus ComponentStatus `yaml:"component_status,omitempty"`
-	URL             string          `yaml:"url,omitempty"`
+	CacheExpiration int    `yaml:"cache_expiration:omitempty"`
+	URL             string `yaml:"url,omitempty"`
 }
 
 // CustomDashboardsConfig describes configuration specific to Custom Dashboards
@@ -117,12 +116,12 @@ type CustomDashboardsConfig struct {
 
 // GrafanaConfig describes configuration used for Grafana links
 type GrafanaConfig struct {
-	Auth            Auth                     `yaml:"auth"`
-	ComponentStatus ComponentStatus          `yaml:"component_status,omitempty"`
-	Dashboards      []GrafanaDashboardConfig `yaml:"dashboards"`
-	Enabled         bool                     `yaml:"enabled"` // Enable or disable Grafana support in Kiali
-	InClusterURL    string                   `yaml:"in_cluster_url"`
-	URL             string                   `yaml:"url"`
+	Auth          Auth                     `yaml:"auth"`
+	CoreComponent bool                     `yaml:"core_component"`
+	Dashboards    []GrafanaDashboardConfig `yaml:"dashboards"`
+	Enabled       bool                     `yaml:"enabled"` // Enable or disable Grafana support in Kiali
+	InClusterURL  string                   `yaml:"in_cluster_url"`
+	URL           string                   `yaml:"url"`
 }
 
 type GrafanaDashboardConfig struct {
@@ -140,13 +139,13 @@ type GrafanaVariablesConfig struct {
 
 // TracingConfig describes configuration used for tracing links
 type TracingConfig struct {
-	Auth                 Auth            `yaml:"auth"`
-	ComponentStatus      ComponentStatus `yaml:"component_status,omitempty"`
-	Enabled              bool            `yaml:"enabled"` // Enable Jaeger in Kiali
-	InClusterURL         string          `yaml:"in_cluster_url"`
-	NamespaceSelector    bool            `yaml:"namespace_selector"`
-	URL                  string          `yaml:"url"`
-	WhiteListIstioSystem []string        `yaml:"whitelist_istio_system"`
+	Auth                 Auth     `yaml:"auth"`
+	CoreComponent        bool     `yaml:"core_component"`
+	Enabled              bool     `yaml:"enabled"` // Enable Jaeger in Kiali
+	InClusterURL         string   `yaml:"in_cluster_url"`
+	NamespaceSelector    bool     `yaml:"namespace_selector"`
+	URL                  string   `yaml:"url"`
+	WhiteListIstioSystem []string `yaml:"whitelist_istio_system"`
 }
 
 // IstioConfig describes configuration used for istio links
@@ -389,11 +388,8 @@ func NewConfig() (c *Config) {
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
-				Enabled: true,
-				ComponentStatus: ComponentStatus{
-					AppLabel: "grafana",
-					IsCore:   false,
-				},
+				CoreComponent: false,
+				Enabled:       true,
 			},
 			Istio: IstioConfig{
 				IstioIdentityDomain:      "svc.cluster.local",
@@ -428,20 +424,13 @@ func NewConfig() (c *Config) {
 				CacheDuration: 7,
 				// Prom Cache expires and it forces to repopulate cache
 				CacheExpiration: 300,
-				ComponentStatus: ComponentStatus{
-					AppLabel: "prometheus",
-					IsCore:   true,
-				},
-				URL: "http://prometheus.istio-system:9090",
+				URL:             "http://prometheus.istio-system:9090",
 			},
 			Tracing: TracingConfig{
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
-				ComponentStatus: ComponentStatus{
-					AppLabel: "jaeger",
-					IsCore:   false,
-				},
+				CoreComponent:        false,
 				Enabled:              true,
 				NamespaceSelector:    true,
 				InClusterURL:         "http://tracing.istio-system/jaeger",

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -111,11 +111,6 @@ func (o *K8SClientMock) MockServices(namespace string, names []string) {
 	o.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
 }
 
-func (o *K8SClientMock) IsMixerDisabled() bool {
-	args := o.Called()
-	return args.Get(0).(bool)
-}
-
 func fakeService(namespace, name string) core_v1.Service {
 	return core_v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3353
requires https://github.com/kiali/kiali-ui/pull/1999
requires https://github.com/kiali/kiali-operator/pull/195

Instead of computing the health of these addons (jaeger, prom, grafana) using their deployment components, this PRs aims to use their service urls (defined in the config) to see if they are reachable or not.

- Grafana/tracing: using the internal_url
- prometheus: the url.

In case there is a problem fetching these endpoints, the status will be `unreachable`.

There is still one flag in the config for grafana/tracing for users to tune in the behavior:
- `external_services.tracing.core_component = [true | false]`
- `external_services.grafana.core_component = [true | false]`

When the mentioned flags above are set to true:

![Screenshot of Kiali Console (74)](https://user-images.githubusercontent.com/613814/98822330-00c77080-2431-11eb-8938-ccf45e9515b3.png)

With default settings:
![Screenshot of Kiali Console (75)](https://user-images.githubusercontent.com/613814/98822620-58fe7280-2431-11eb-8187-d8cfce695eff.png)

