### PR TITLE
(trivial) Initialize stats array for non-null json

### DIFF
--- a/business/metrics.go
+++ b/business/metrics.go
@@ -180,7 +180,9 @@ func (in *MetricsService) getSingleQueryStats(q *models.MetricsStatsQuery) (*mod
 	if err != nil {
 		return nil, err
 	}
-	metricsStats := models.MetricsStats{}
+	metricsStats := models.MetricsStats{
+		ResponseTimes: []models.Stat{},
+	}
 	for stat, vec := range stats {
 		for _, sample := range vec {
 			value := float64(sample.Value)


### PR DESCRIPTION
This may happen when there's no metrics at all for the target workload (eg. when workload is in CrashLoopBackoff state)