### PR TITLE
Add mutex to prevent test-race in Istio Status test scenario

### DIFF
--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -361,7 +361,7 @@ func mockServer(mr *mux.Router) *httptest.Server {
 	return httptest.NewServer(mr)
 }
 
-func addAddOnRoute(mr *mux.Router, mu sync.Mutex, url string, statusCode int, callNum *int) {
+func addAddOnRoute(mr *mux.Router, mu *sync.Mutex, url string, statusCode int, callNum *int) {
 	mr.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		if callNum != nil {
@@ -382,7 +382,7 @@ func mockAddOnCalls(addons map[string]addOnsSetup) *mux.Router {
 	var mu sync.Mutex
 	mr := mux.NewRouter()
 	for _, addon := range addons {
-		addAddOnRoute(mr, mu, addon.Url, addon.StatusCode, addon.CallCount)
+		addAddOnRoute(mr, &mu, addon.Url, addon.StatusCode, addon.CallCount)
 	}
 	return mr
 }

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -3,6 +3,7 @@ package business
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -360,11 +361,13 @@ func mockServer(mr *mux.Router) *httptest.Server {
 	return httptest.NewServer(mr)
 }
 
-func addAddOnRoute(mr *mux.Router, url string, statusCode int, callNum *int) {
+func addAddOnRoute(mr *mux.Router, mu sync.Mutex, url string, statusCode int, callNum *int) {
 	mr.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		if callNum != nil {
 			*callNum = *callNum + 1
 		}
+		mu.Unlock()
 		if statusCode > 299 {
 			http.Error(w, "Not a success", statusCode)
 		} else {
@@ -376,9 +379,10 @@ func addAddOnRoute(mr *mux.Router, url string, statusCode int, callNum *int) {
 }
 
 func mockAddOnCalls(addons map[string]addOnsSetup) *mux.Router {
+	var mu sync.Mutex
 	mr := mux.NewRouter()
 	for _, addon := range addons {
-		addAddOnRoute(mr, addon.Url, addon.StatusCode, addon.CallCount)
+		addAddOnRoute(mr, mu, addon.Url, addon.StatusCode, addon.CallCount)
 	}
 	return mr
 }


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/3453

Adding a mutex to prevent a race condition when accessing to same counter at the same time.