### PR TITLE
Add Service details into kialiCache

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -40,8 +40,12 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 
 	// Ensure the service exists
 	if service != "" {
-		if _, err := in.k8s.GetService(namespace, service); err != nil {
-			return nil, err
+		svc, err := in.businessLayer.Svc.getService(namespace, service)
+		if svc == nil || err != nil {
+			if err != nil {
+				log.Warningf("Error invoking GetService %s", err)
+			}
+			return nil, fmt.Errorf("Service [namespace: %s] [name: %s] doesn't exist for Validations.", namespace, service)
 		}
 	}
 

--- a/business/services.go
+++ b/business/services.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"fmt"
 	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -16,7 +17,6 @@ import (
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
-	"fmt"
 )
 
 // SvcService deals with fetching istio/kubernetes services related content and convert to kiali model

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -15,7 +15,7 @@ const (
 	CronJobType               = "CronJob"
 	DeploymentType            = "Deployment"
 	DeploymentConfigType      = "DeploymentConfig"
-	EndpointsType              = "Endpoints"
+	EndpointsType             = "Endpoints"
 	JobType                   = "Job"
 	PodType                   = "Pod"
 	ReplicationControllerType = "ReplicationController"

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -15,6 +15,7 @@ const (
 	CronJobType               = "CronJob"
 	DeploymentType            = "Deployment"
 	DeploymentConfigType      = "DeploymentConfig"
+	EndpointsType              = "Endpoints"
 	JobType                   = "Job"
 	PodType                   = "Pod"
 	ReplicationControllerType = "ReplicationController"


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3467

In some cases, fetching the kubernetes service bypassed the kiali cache.

This was unnoticed until we reviewed this WIP work https://github.com/kiali/kiali/pull/3362 that may need to fetch the service info more frequently so, it should use the caching mechanism.

Also adding an informer for Endpoints for consistency.

For QE: just validate that there are no regressions when deploying with operator.