### PR TITLE
Update mis-spelled ratio_statitics to ratio_statistics

### DIFF
--- a/kubernetes/iter8.go
+++ b/kubernetes/iter8.go
@@ -113,7 +113,7 @@ type Iter8CriterionAssessment struct {
 				Lower *float32 `json:"lower"`
 				Upper *float32 `json:"upper"`
 			} `json:"credible_interval"`
-		} `json:"ratio_statitics,omitempty"`
+		} `json:"ratio_statistics,omitempty"`
 	} `json:"statistics,omitempty"`
 	ThresholdAssessment *struct {
 		ThresholdBreached                bool     `json:"threshold_breached"`


### PR DESCRIPTION
** Describe the change **

Support Ratio_Statistics ( in Kiali-ui, the data is used in the experiment assessment page for min/max credible interval)


