### PR TITLE
modify default blacklist

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -345,7 +345,7 @@ func NewConfig() (c *Config) {
 			Namespaces: ApiNamespacesConfig{
 				Exclude: []string{
 					"istio-operator",
-					"kube.*",
+					"kube-system",
 					"openshift.*",
 					"ibm.*",
 					"kial-operator",


### PR DESCRIPTION
Signed-off-by: zackzhangkai <zackzhang@yunify.com>

** Describe the change **

_Please describe what the code change is about_

Modify the default namespace of the blacklist, maybe filter out all the namespaces started with kube* is not elegant
