### PR TITLE
Add proxy to OpenId metadata http requests

### DIFF
--- a/business/openid_auth.go
+++ b/business/openid_auth.go
@@ -299,7 +299,7 @@ func GetOpenIdMetadata() (*OpenIdMetadata, error) {
 
 		httpClient, err := createHttpClient(trimmedIssuerUri)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to create http client to fetch OpenId Metadata: %w", err)
 		}
 
 		// Fetch IdP metadata
@@ -383,7 +383,7 @@ func GetOpenIdJwks() (*jose.JSONWebKeySet, error) {
 		// Create HTTP client
 		httpClient, err := createHttpClient(oidcMetadata.JWKSURL)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to create http client to fetch OpenId JWKS document: %w", err)
 		}
 
 		// Fetch Keys document
@@ -458,7 +458,7 @@ func RequestOpenIdToken(openIdParams *OpenIdCallbackParams, redirect_uri string)
 
 	httpClient, err := createHttpClient(openIdMetadata.TokenURL)
 	if err != nil {
-		return err
+		return fmt.Errorf("failure when creating http client to request open id token: %w", err)
 	}
 
 	// Exchange authorization code for a token
@@ -734,7 +734,7 @@ func createHttpClient(toUrl string) (*http.Client, error) {
 	}
 
 	if cfg.HTTPProxy != "" || cfg.HTTPSProxy != "" {
-		proxyFunc := getProxyForUrl(parsedUrl, cfg.HTTPProxy, cfg.HTTPProxy)
+		proxyFunc := getProxyForUrl(parsedUrl, cfg.HTTPProxy, cfg.HTTPSProxy)
 		httpTransport.Proxy = proxyFunc
 	}
 

--- a/business/openid_auth.go
+++ b/business/openid_auth.go
@@ -456,14 +456,6 @@ func RequestOpenIdToken(openIdParams *OpenIdCallbackParams, redirect_uri string)
 
 	cfg := config.Get().Auth.OpenId
 
-	// Create HTTP client
-	httpTransport := &http.Transport{}
-	if cfg.InsecureSkipVerifyTLS {
-		httpTransport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-	}
-
 	httpClient, err := createHttpClient(openIdMetadata.TokenURL)
 	if err != nil {
 		return err
@@ -741,14 +733,14 @@ func createHttpClient(toUrl string) (*http.Client, error) {
 		}
 	}
 
-	httpClient := http.Client{
-		Timeout:   time.Second * 10,
-		Transport: httpTransport,
-	}
-
 	if cfg.HTTPProxy != "" || cfg.HTTPSProxy != "" {
 		proxyFunc := getProxyForUrl(parsedUrl, cfg.HTTPProxy, cfg.HTTPProxy)
 		httpTransport.Proxy = proxyFunc
+	}
+
+	httpClient := http.Client{
+		Timeout:   time.Second * 10,
+		Transport: httpTransport,
 	}
 
 	return &httpClient, nil

--- a/config/config.go
+++ b/config/config.go
@@ -274,6 +274,8 @@ type OpenIdConfig struct {
 	ClientId              string   `yaml:"client_id,omitempty"`
 	ClientSecret          string   `yaml:"client_secret,omitempty"`
 	DisableRBAC           bool     `yaml:"disable_rbac,omitempty"`
+	HTTPProxy             string   `yaml:"http_proxy,omitempty"`
+	HTTPSProxy            string   `yaml:"https_proxy,omitempty"`
 	InsecureSkipVerifyTLS bool     `yaml:"insecure_skip_verify_tls,omitempty"`
 	IssuerUri             string   `yaml:"issuer_uri,omitempty"`
 	Scopes                []string `yaml:"scopes,omitempty"`


### PR DESCRIPTION
Closes #3451 .

This PR adds proxy support to OpenId's requests for metadata for the
issuer. This fixes the problem where Kiali requires a proxy to connect
to the outside world. This is not normally a problem, as the resources we
connect using Kiali are usually inside the cluster.

OpenID is the exception, as we need to connect to the issuer to get
information to move the user forward. This PR adds proxy support to this
specific request.

## How to test this?

  1. Install Squid on your machine, or other HTTP proxy.
  2. Install kiali with the correct configuration options (`http_proxy`
  and `https_proxy` on the openid section of the CR, and OpenId configured).
  3. Connect/authenticate on Kiali using OpenID
  4. Check squid log for the request.