### PR TITLE
Provide better flexibility when building helm charts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,10 @@ else
 KIALI_CR_FILE ?= ${ROOTDIR}/operator/deploy/kiali/kiali_cr_dev.yaml
 endif
 
+# When ensuring the helm chart repo exists, by default the make infrastructure will pull the latest code from git.
+# If you do not want this to happen (i.e. if you want to retain the local copies of your helm charts), set this to false.
+HELM_CHARTS_REPO_PULL ?= true
+
 include make/Makefile.build.mk
 include make/Makefile.container.mk
 include make/Makefile.cluster.mk

--- a/make/Makefile.helm.mk
+++ b/make/Makefile.helm.mk
@@ -29,7 +29,11 @@
 	  echo; echo "ERROR! You specified an invalid helm-charts repo: ${HELM_CHARTS_REPO}"; echo; \
 	  exit 1; \
 	fi
-	@cd ${HELM_CHARTS_REPO}; git pull > /dev/null
+ifeq ($(HELM_CHARTS_REPO_PULL),true)
+	@echo "Pulling down latest helm-charts from remote repo to here: ${HELM_CHARTS_REPO}"; cd ${HELM_CHARTS_REPO}; git pull > /dev/null || (printf "==========\nFailed to update your local helm chart repo.\nYou can either attempt to correct the error mentioned above,\nor set 'HELM_CHARTS_REPO_PULL=false' and try again.\n==========\n"; exit 1)
+else
+	@echo "Using local helm-charts repo found here: ${HELM_CHARTS_REPO}"
+endif
 
 .ensure-operator-helm-chart-exists: .ensure-helm-charts-repo-exists
 	@echo "Git repo for the helm charts is found here: ${HELM_CHARTS_REPO}"


### PR DESCRIPTION
Be able to turn off the git pull of the helm-chart repo (via `HELM_CHARTS_REPO_PULL=false`)
If the git pull is turned on (which is the default) but it fails, a better error message is output to the user.

fixes https://github.com/kiali/kiali/issues/3500

There are three scenarios:

1) You want to pull the helm charts by default, and your helm repo has a branch checked out that has a remote upstream branch set up. In this case, the build just succeeds:

```
$ make .ensure-helm-charts-repo-exists
Pulling down latest helm-charts from remote repo to here: /home/jmazzite/source/kiali/helm-charts
```

2) You want to pull the helm charts by default, but your helm chart repo does not have a branch with a valid remote upstream branch. In this case, the build will fail, but you now get a better error message:

```
$ make .ensure-helm-charts-repo-exists
Pulling down latest helm-charts from remote repo to here: /home/jmazzite/source/kiali/helm-charts
X11 forwarding request failed on channel 0
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>

If you wish to set tracking information for this branch you can do so with:

    git branch --set-upstream-to=<remote>/<branch> 2983-operator-sdk-1.0

==========
Failed to update your local helm chart repo.
You can either attempt to correct the error mentioned above,
or set 'HELM_CHARTS_REPO_PULL=false' and try again.
==========
make: *** [.ensure-helm-charts-repo-exists] Error 1
```

3) You DO NOT want to pull the helm charts - either because you want to use the local changes or your helm chart repo does not have a branch with a valid remote upstream branch. In this case, the build will now succeed:

```
$ HELM_CHARTS_REPO_PULL=false make .ensure-helm-charts-repo-exists
Using local helm-charts repo found here: /home/jmazzite/source/kiali/helm-charts
```