### PR TITLE
need to use the GO env var in makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ NAMESPACE ?= ${ISTIO_NAMESPACE}
 GOPATH ?= ${HOME}/go
 
 # Environment variables set when running the Go compiler.
-GOOS ?= $(shell go env GOOS)
-GOARCH ?= $(shell go env GOARCH)
+GOOS ?= $(shell ${GO} env GOOS)
+GOARCH ?= $(shell ${GO} env GOARCH)
 GO_BUILD_ENVVARS = \
 	GOOS=$(GOOS) \
 	GOARCH=$(GOARCH) \

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -96,7 +96,7 @@ run:
 swagger-install:
 	@echo "Installing swagger binary to ${GOPATH}/bin..."
 ifeq ($(GOARCH), ppc64le)
-	curl https://github.com/go-swagger/go-swagger/archive/v${SWAGGER_VERSION}.tar.gz --create-dirs -Lo /tmp/v${SWAGGER_VERSION}.tar.gz && tar -xzf /tmp/v${SWAGGER_VERSION}.tar.gz -C /tmp/ && src_dir='pwd' && cd /tmp/go-swagger-${SWAGGER_VERSION} && go install ./cmd/swagger && cd ${src_dir}
+	curl https://github.com/go-swagger/go-swagger/archive/v${SWAGGER_VERSION}.tar.gz --create-dirs -Lo /tmp/v${SWAGGER_VERSION}.tar.gz && tar -xzf /tmp/v${SWAGGER_VERSION}.tar.gz -C /tmp/ && src_dir='pwd' && cd /tmp/go-swagger-${SWAGGER_VERSION} && ${GO} install ./cmd/swagger && cd ${src_dir}
 else
 	curl https://github.com/go-swagger/go-swagger/releases/download/v${SWAGGER_VERSION}/swagger_linux_${GOARCH} --create-dirs -Lo ${GOPATH}/bin/swagger && chmod +x ${GOPATH}/bin/swagger
 endif


### PR DESCRIPTION
the Makefile is hardcoding "go" which assumes Go is in the PATH and that's the version of Go to use, which is not a good assumption. This is why we have the GO env var - so that should be used.