### PR TITLE
Checkpoint WIP for https://github.com/kiali/kiali/issues/3439

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -52,6 +52,15 @@ type AppVersionParam struct {
 	Name string `json:"version"`
 }
 
+// swagger:parameters graphAggregate graphAggregateByService graphApp graphAppVersion graphService graphWorkload
+type ClusterParam struct {
+	// The cluster name. If not supplied queries/results will not be constrained by cluster.
+	//
+	// in: query
+	// required: false
+	Name string `json:"container"`
+}
+
 // swagger:parameters podLogs
 type ContainerParam struct {
 	// The pod container name. Optional for single-container pod. Otherwise required.
@@ -207,13 +216,13 @@ type GraphTypeParam struct {
 }
 
 // swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
-type GroupByParam struct {
-	// App box grouping characteristic. Available groupings: [app, none, version].
+type BoxByParam struct {
+	// Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].
 	//
 	// in: query
 	// required: false
 	// default: none
-	Name string `json:"groupBy"`
+	Name string `json:"boxBy"`
 }
 
 // swagger:parameters graphApp graphAppVersion graphNamespaces graphWorkload

--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -172,7 +172,7 @@ func mockQuery(api *prometheustest.PromAPIMock, query string, ret *model.Vector)
 
 // mockNamespaceGraph provides the same single-namespace mocks to be used for different graph types
 func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -213,7 +213,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 			Metric: q0m1,
 			Value:  50}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -235,7 +235,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 			Metric: q1m0,
 			Value:  100}}
 
-	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -537,7 +537,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 			Metric: q2m15,
 			Value:  4}}
 
-	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	q3m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -556,7 +556,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 			Metric: q3m0,
 			Value:  400}}
 
-	q4 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q4 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	q4m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -575,7 +575,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, error) {
 			Metric: q4m0,
 			Value:  150}}
 
-	q5 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q5 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	q5m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -779,7 +779,7 @@ func TestWorkloadGraph(t *testing.T) {
 }
 
 func TestAppNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_canonical_service="productpage"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_canonical_service="productpage"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -820,7 +820,7 @@ func TestAppNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -991,10 +991,10 @@ func TestAppNodeGraph(t *testing.T) {
 			Metric: q1m8,
 			Value:  4}}
 
-	q2 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_service_namespace="bookinfo",destination_canonical_service="productpage"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_service_namespace="bookinfo",destination_canonical_service="productpage"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v2 := model.Vector{}
 
-	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	q3m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1056,7 +1056,7 @@ func TestAppNodeGraph(t *testing.T) {
 }
 
 func TestVersionedAppNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_canonical_service="productpage",destination_canonical_revision="v1"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",destination_canonical_service="productpage",destination_canonical_revision="v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1097,7 +1097,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage",source_canonical_revision="v1"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage",source_canonical_revision="v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1268,10 +1268,10 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 			Metric: q1m8,
 			Value:  4}}
 
-	q2 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_service_namespace="bookinfo",destination_canonical_service="productpage",destination_canonical_revision="v1"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_service_namespace="bookinfo",destination_canonical_service="productpage",destination_canonical_revision="v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v2 := model.Vector{}
 
-	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage",source_canonical_revision="v1"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage",source_canonical_revision="v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	q3m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1333,7 +1333,7 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 }
 
 func TestWorkloadNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
@@ -1374,7 +1374,7 @@ func TestWorkloadNodeGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  100}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1545,10 +1545,10 @@ func TestWorkloadNodeGraph(t *testing.T) {
 			Metric: q1m8,
 			Value:  4}}
 
-	q2 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v2 := model.Vector{}
 
-	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	q3m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1610,10 +1610,10 @@ func TestWorkloadNodeGraph(t *testing.T) {
 }
 
 func TestServiceNodeGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name=~"productpage|productpage\\..+\\.global"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -1635,7 +1635,7 @@ func TestServiceNodeGraph(t *testing.T) {
 			Metric: q1m0,
 			Value:  100}}
 
-	q2 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name="productpage"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",destination_service_namespace="bookinfo",destination_service_name="productpage"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -1696,6 +1696,7 @@ func TestServiceNodeGraph(t *testing.T) {
 }
 
 // TestComplexGraph aims to provide test coverage for a more robust graph and specific corner cases. Listed below are coverage cases
+// - multi-cluster graph
 // - multi-namespace graph
 // - istio namespace
 // - a "shared" node (internal in ns-1, outsider in ns-2)
@@ -1706,12 +1707,14 @@ func TestServiceNodeGraph(t *testing.T) {
 // - 0 response code (no response)
 // note: appenders still tested in separate unit tests given that they create their own new business/kube clients
 func TestComplexGraph(t *testing.T) {
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 "unknown",
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
 		"source_canonical_service":       "unknown",
 		"source_canonical_revision":      "unknown",
+		"destination_cluster":            "cluster-bookinfo",
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage:9080",
 		"destination_service_name":       "productpage",
@@ -1728,27 +1731,29 @@ func TestComplexGraph(t *testing.T) {
 			Metric: q0m0,
 			Value:  50}}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v1 := model.Vector{}
 
-	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q2 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v2 := model.Vector{}
 
-	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v3 := model.Vector{}
 
-	q4 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q4 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v4 := model.Vector{}
 
-	q5 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q5 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v5 := model.Vector{}
 
-	q6 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q6 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q6m0 := model.Metric{
+		"source_cluster":                 "unknown",
 		"source_workload_namespace":      "unknown",
 		"source_workload":                "unknown",
 		"source_canonical_service":       "unknown",
 		"source_canonical_revision":      "unknown",
+		"destination_cluster":            "cluster-tutorial",
 		"destination_service_namespace":  "tutorial",
 		"destination_service":            "customer:9080",
 		"destination_service_name":       "customer",
@@ -1761,10 +1766,12 @@ func TestComplexGraph(t *testing.T) {
 		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q6m1 := model.Metric{
+		"source_cluster":                 "unknown",
 		"source_workload_namespace":      "bad-source-temetry",
 		"source_workload":                "unknown",
 		"source_canonical_service":       "unknown",
 		"source_canonical_revision":      "unknown",
+		"destination_cluster":            "cluster-tutorial",
 		"destination_service_namespace":  "tutorial",
 		"destination_service":            "customer:9080",
 		"destination_service_name":       "customer",
@@ -1784,15 +1791,17 @@ func TestComplexGraph(t *testing.T) {
 			Metric: q6m1,
 			Value:  50}}
 
-	q7 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q7 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v7 := model.Vector{}
 
-	q8 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q8 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q8m0 := model.Metric{
+		"source_cluster":                 "cluster-tutorial",
 		"source_workload_namespace":      "tutorial",
 		"source_workload":                "customer-v1",
 		"source_canonical_service":       "customer",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            "cluster-bookinfo",
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage:9080",
 		"destination_service_name":       "productpage",
@@ -1805,10 +1814,12 @@ func TestComplexGraph(t *testing.T) {
 		"grpc_response_status":           "0",
 		"response_flags":                 "-"}
 	q8m1 := model.Metric{ // bad telem (variant 1)
+		"source_cluster":                 "cluster-tutorial",
 		"source_workload_namespace":      "tutorial",
 		"source_workload":                "customer-v1",
 		"source_canonical_service":       "customer",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            "cluster-bookinfo",
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "10.20.30.40:9080",
 		"destination_service_name":       "10.20.30.40:9080",
@@ -1820,10 +1831,12 @@ func TestComplexGraph(t *testing.T) {
 		"response_code":                  "200",
 		"response_flags":                 "-"}
 	q8m2 := model.Metric{ // bad telem (variant 2)
+		"source_cluster":                 "cluster-tutorial",
 		"source_workload_namespace":      "tutorial",
 		"source_workload":                "customer-v1",
 		"source_canonical_service":       "customer",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            "cluster-bookinfo",
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "10.20.30.40",
 		"destination_service_name":       "10.20.30.40",
@@ -1835,10 +1848,12 @@ func TestComplexGraph(t *testing.T) {
 		"response_code":                  "200",
 		"response_flags":                 "-"}
 	q8m3 := model.Metric{ // good telem (mock service entry)
+		"source_cluster":                 "cluster-tutorial",
 		"source_workload_namespace":      "tutorial",
 		"source_workload":                "customer-v1",
 		"source_canonical_service":       "customer",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            "cluster-bookinfo",
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "app.example.com",
 		"destination_service_name":       "app.example.com",
@@ -1850,10 +1865,12 @@ func TestComplexGraph(t *testing.T) {
 		"response_code":                  "200",
 		"response_flags":                 "-"}
 	q8m4 := model.Metric{ // good telem (service entry via egressgateway, see the second hop below)
+		"source_cluster":                 "cluster-tutorial",
 		"source_workload_namespace":      "tutorial",
 		"source_workload":                "customer-v1",
 		"source_canonical_service":       "customer",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            "unknown",
 		"destination_service_namespace":  "unknown",
 		"destination_service":            "istio-egressgateway.istio-system.svc.cluster.local",
 		"destination_service_name":       "istio-egressgateway.istio-system.svc.cluster.local",
@@ -1865,10 +1882,12 @@ func TestComplexGraph(t *testing.T) {
 		"response_code":                  "200",
 		"response_flags":                 "-"}
 	q8m5 := model.Metric{ // no response http
+		"source_cluster":                 "cluster-tutorial",
 		"source_workload_namespace":      "tutorial",
 		"source_workload":                "customer-v1",
 		"source_canonical_service":       "customer",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            "unknown",
 		"destination_service_namespace":  "unknown",
 		"destination_service":            "istio-egressgateway.istio-system.svc.cluster.local",
 		"destination_service_name":       "istio-egressgateway.istio-system.svc.cluster.local",
@@ -1880,10 +1899,12 @@ func TestComplexGraph(t *testing.T) {
 		"response_code":                  "0",
 		"response_flags":                 "DC"}
 	q8m6 := model.Metric{ // no response grpc
+		"source_cluster":                 "cluster-tutorial",
 		"source_workload_namespace":      "tutorial",
 		"source_workload":                "customer-v1",
 		"source_canonical_service":       "customer",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            "unknown",
 		"destination_service_namespace":  "unknown",
 		"destination_service":            "istio-egressgateway.istio-system.svc.cluster.local",
 		"destination_service_name":       "istio-egressgateway.istio-system.svc.cluster.local",
@@ -1917,27 +1938,29 @@ func TestComplexGraph(t *testing.T) {
 			Metric: q8m6,
 			Value:  600}}
 
-	q9 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q9 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="tutorial"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v9 := model.Vector{}
 
-	q10 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q10 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="tutorial",source_workload!="unknown",destination_service_namespace="tutorial"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v10 := model.Vector{}
 
-	q11 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q11 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v11 := model.Vector{}
 
-	q12 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q12 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload="unknown",destination_workload_namespace="istio-system"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v12 := model.Vector{}
 
-	q13 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="istio-system",source_workload!="unknown",destination_service_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q13 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace!="istio-system",source_workload!="unknown",destination_service_namespace="istio-system"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	v13 := model.Vector{}
 
-	q14 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
+	q14 := `round(sum(rate(istio_requests_total{reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags),0.001)`
 	q14m0 := model.Metric{ // good telem (service entry via egressgateway, see the second hop below)
+		"source_cluster":                 "cluster-cp",
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "istio-egressgateway",
 		"source_canonical_service":       "istio-egressgateway",
 		"source_canonical_revision":      "latest",
+		"destination_cluster":            "unknown",
 		"destination_service_namespace":  "unknown",
 		"destination_service":            "app.example-2.com",
 		"destination_service_name":       "app.example-2.com",
@@ -1953,13 +1976,13 @@ func TestComplexGraph(t *testing.T) {
 			Metric: q14m0,
 			Value:  400}}
 
-	q15 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q15 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload="unknown",destination_workload_namespace="istio-system"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v15 := model.Vector{}
 
-	q16 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="istio-system",source_workload!="unknown",destination_service_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q16 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="istio-system",source_workload!="unknown",destination_service_namespace="istio-system"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v16 := model.Vector{}
 
-	q17 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
+	q17 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags),0.001)`
 	v17 := model.Vector{}
 
 	client, api, _, err := setupMockedWithIstioComponentNamespaces()

--- a/graph/api/testdata/test_app_graph.expected
+++ b/graph/api/testdata/test_app_graph.expected
@@ -6,12 +6,14 @@
     "nodes": [
       {
         "data": {
-          "id": "66bce9783dc2dbb5fecb178b0108484e",
+          "id": "4e958835e3486518a0acc09297780511",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bankapp",
           "app": "pricing",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bankapp",
               "name": "pricing"
             }
@@ -30,8 +32,9 @@
       },
       {
         "data": {
-          "id": "7b1032e9c5683c53fb50ed8831fbd61b",
+          "id": "b94359ba714ee15770e25d49d16b48bd",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "kiali-2412",
           "traffic": [
@@ -46,12 +49,14 @@
       },
       {
         "data": {
-          "id": "6cdb3cf3ee9a17772f13b295368e112a",
+          "id": "7cfbf9099e17c55901bf2f60a799c9d6",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "app": "details",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "details"
             }
@@ -71,12 +76,14 @@
       },
       {
         "data": {
-          "id": "2c22af42b0c750749399ed2838c56054",
+          "id": "3be4b9f5a87d64357e9b54f0b94a5cde",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "app": "productpage",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "productpage"
             }
@@ -100,12 +107,14 @@
       },
       {
         "data": {
-          "id": "c219903556c3afdb05eda7e610aba628",
+          "id": "ade778da2388a16e1417504fcb442c63",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "app": "ratings",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "ratings"
             }
@@ -123,12 +132,14 @@
       },
       {
         "data": {
-          "id": "37ddc91db761d432f3fff1943802cad7",
+          "id": "972d1587fe96aaaa64d0207c1401ae27",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "app": "reviews",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -146,12 +157,14 @@
       },
       {
         "data": {
-          "id": "4ee8019fc0454770a401b89d427277bf",
+          "id": "dd3bd1e097c5e644137e4b816e3037a6",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "app": "tcp",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "tcp"
             }
@@ -168,8 +181,9 @@
       },
       {
         "data": {
-          "id": "19950ddefadd370bf5434953c1944c80",
+          "id": "f00f54a2f51e81b86ac6d6ebb483470b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "istio-system",
           "app": "ingressgateway",
           "traffic": [
@@ -193,8 +207,9 @@
       },
       {
         "data": {
-          "id": "4a639f9922515051205421a93f94e0b8",
+          "id": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "unknown",
           "service": "unknown",
           "traffic": [
@@ -211,8 +226,9 @@
       },
       {
         "data": {
-          "id": "b30b0078325bf2e1adb4d57c4c0c2665",
+          "id": "375ab940b56ae7bcf0f89cb1a7af5d44",
           "nodeType": "unknown",
+          "cluster": "unknown",
           "namespace": "unknown",
           "workload": "unknown",
           "app": "unknown",
@@ -239,14 +255,14 @@
     "edges": [
       {
         "data": {
-          "id": "2c8bf7e7efb0982b18c76d507200a8b7",
-          "source": "19950ddefadd370bf5434953c1944c80",
-          "target": "2c22af42b0c750749399ed2838c56054",
+          "id": "4a3baa4bf69e481dd447a1fc4e3dc197",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "3be4b9f5a87d64357e9b54f0b94a5cde",
           "traffic": {
             "protocol": "http",
             "rates": {
-              "http": "100.00",
-              "httpPercentReq": "100.0"
+              "http": "50.00",
+              "httpPercentReq": "50.0"
             },
             "responses": {
               "200": {
@@ -263,13 +279,34 @@
       },
       {
         "data": {
-          "id": "18fa6836a929941e8deabad5fa1cae62",
-          "source": "19950ddefadd370bf5434953c1944c80",
-          "target": "4ee8019fc0454770a401b89d427277bf",
+          "id": "806203ba5574f9612c8a187798a2d39c",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "b94359ba714ee15770e25d49d16b48bd",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "50.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "85546ede28da39778e5444d77e5d69c5",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "dd3bd1e097c5e644137e4b816e3037a6",
           "traffic": {
             "protocol": "tcp",
             "rates": {
-              "tcp": "150.00"
+              "tcp": "400.00"
             },
             "responses": {
               "-": {
@@ -286,9 +323,9 @@
       },
       {
         "data": {
-          "id": "e9ffbf24e385c93dfa124d81e2ac33a7",
-          "source": "2c22af42b0c750749399ed2838c56054",
-          "target": "2c22af42b0c750749399ed2838c56054",
+          "id": "d9ae8b79c27cd801d592e3a65c481f34",
+          "source": "3be4b9f5a87d64357e9b54f0b94a5cde",
+          "target": "3be4b9f5a87d64357e9b54f0b94a5cde",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -310,56 +347,9 @@
       },
       {
         "data": {
-          "id": "ff5217a9064e30e4fb875256dab56037",
-          "source": "2c22af42b0c750749399ed2838c56054",
-          "target": "37ddc91db761d432f3fff1943802cad7",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "60.00",
-              "httpPercentReq": "37.5"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "16a0c4225bbdbd471e6e7b8fd438733d",
-          "source": "2c22af42b0c750749399ed2838c56054",
-          "target": "4ee8019fc0454770a401b89d427277bf",
-          "traffic": {
-            "protocol": "tcp",
-            "rates": {
-              "tcp": "31.00"
-            },
-            "responses": {
-              "-": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "tcp:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "89fa162a49acca6ff974afd30aab2ff0",
-          "source": "2c22af42b0c750749399ed2838c56054",
-          "target": "6cdb3cf3ee9a17772f13b295368e112a",
+          "id": "ffe01d37d4ecb9e9abba3e30058debe1",
+          "source": "3be4b9f5a87d64357e9b54f0b94a5cde",
+          "target": "7cfbf9099e17c55901bf2f60a799c9d6",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -409,14 +399,14 @@
       },
       {
         "data": {
-          "id": "4aaf7cb151db415f3ba4918be2296c38",
-          "source": "37ddc91db761d432f3fff1943802cad7",
-          "target": "37ddc91db761d432f3fff1943802cad7",
+          "id": "8f745f650660645a12579c15d592571e",
+          "source": "3be4b9f5a87d64357e9b54f0b94a5cde",
+          "target": "972d1587fe96aaaa64d0207c1401ae27",
           "traffic": {
             "protocol": "http",
             "rates": {
-              "http": "40.00",
-              "httpPercentReq": "32.3"
+              "http": "60.00",
+              "httpPercentReq": "37.5"
             },
             "responses": {
               "200": {
@@ -433,24 +423,21 @@
       },
       {
         "data": {
-          "id": "5fb225e800c037b99f8767d961d187fc",
-          "source": "37ddc91db761d432f3fff1943802cad7",
-          "target": "4a639f9922515051205421a93f94e0b8",
+          "id": "7553c207ed4b5f557e59a0e63a66c974",
+          "source": "3be4b9f5a87d64357e9b54f0b94a5cde",
+          "target": "dd3bd1e097c5e644137e4b816e3037a6",
           "traffic": {
-            "protocol": "http",
+            "protocol": "tcp",
             "rates": {
-              "http": "4.00",
-              "http4xx": "4.00",
-              "httpPercentErr": "100.0",
-              "httpPercentReq": "3.2"
+              "tcp": "31.00"
             },
             "responses": {
-              "404": {
+              "-": {
                 "flags": {
-                  "NR": "100.0"
+                  "-": "100.0"
                 },
                 "hosts": {
-                  "unknown": "100.0"
+                  "tcp:9080": "100.0"
                 }
               }
             }
@@ -459,9 +446,9 @@
       },
       {
         "data": {
-          "id": "edb2cdfc2a757d260aa847d55e9eadde",
-          "source": "37ddc91db761d432f3fff1943802cad7",
-          "target": "66bce9783dc2dbb5fecb178b0108484e",
+          "id": "76677863610f5dad62508ce1457974be",
+          "source": "972d1587fe96aaaa64d0207c1401ae27",
+          "target": "4e958835e3486518a0acc09297780511",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -483,9 +470,33 @@
       },
       {
         "data": {
-          "id": "a553e38605904d17c50ab1d0db84f113",
-          "source": "37ddc91db761d432f3fff1943802cad7",
-          "target": "c219903556c3afdb05eda7e610aba628",
+          "id": "cfaad3aab9836640adbbb5afbf2a4cc1",
+          "source": "972d1587fe96aaaa64d0207c1401ae27",
+          "target": "972d1587fe96aaaa64d0207c1401ae27",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "40.00",
+              "httpPercentReq": "32.3"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "1bf3eb7dcf83cbbbbd8d7a5e86703a44",
+          "source": "972d1587fe96aaaa64d0207c1401ae27",
+          "target": "ade778da2388a16e1417504fcb442c63",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -517,14 +528,40 @@
       },
       {
         "data": {
-          "id": "efe83e483ada36899c34ef66a7974d31",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "2c22af42b0c750749399ed2838c56054",
+          "id": "5abb0a4cd0f9ded6f31372b6c5afd39a",
+          "source": "972d1587fe96aaaa64d0207c1401ae27",
+          "target": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "traffic": {
             "protocol": "http",
             "rates": {
-              "http": "50.00",
-              "httpPercentReq": "50.0"
+              "http": "4.00",
+              "http4xx": "4.00",
+              "httpPercentErr": "100.0",
+              "httpPercentReq": "3.2"
+            },
+            "responses": {
+              "404": {
+                "flags": {
+                  "NR": "100.0"
+                },
+                "hosts": {
+                  "unknown": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "33ccba733bbc80e8e00bf3667c211386",
+          "source": "f00f54a2f51e81b86ac6d6ebb483470b",
+          "target": "3be4b9f5a87d64357e9b54f0b94a5cde",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
             },
             "responses": {
               "200": {
@@ -541,13 +578,13 @@
       },
       {
         "data": {
-          "id": "d4fc7bd6594937fa94402fcfcc9f3a95",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "4ee8019fc0454770a401b89d427277bf",
+          "id": "641e06b119ab3e45521f0ed11e9a7704",
+          "source": "f00f54a2f51e81b86ac6d6ebb483470b",
+          "target": "dd3bd1e097c5e644137e4b816e3037a6",
           "traffic": {
             "protocol": "tcp",
             "rates": {
-              "tcp": "400.00"
+              "tcp": "150.00"
             },
             "responses": {
               "-": {
@@ -556,27 +593,6 @@
                 },
                 "hosts": {
                   "tcp:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "53c67fb349dcfbd2327e3162a0e338aa",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "7b1032e9c5683c53fb50ed8831fbd61b",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "50.00",
-              "httpPercentReq": "50.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
                 }
               }
             }

--- a/graph/api/testdata/test_app_node_graph.expected
+++ b/graph/api/testdata/test_app_node_graph.expected
@@ -8,6 +8,7 @@
         "data": {
           "id": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "app": "reviews",
           "isGroup": "app"
@@ -15,14 +16,16 @@
       },
       {
         "data": {
-          "id": "50113397f439f05f3280ad0772b9b307",
+          "id": "f569f02ca0fd194ed28a6e5e0d95a98d",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "details-v1",
           "app": "details",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "details"
             }
@@ -42,14 +45,16 @@
       },
       {
         "data": {
-          "id": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "354af352ce8b5c4103bc86828039622d",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "productpage-v1",
           "app": "productpage",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "productpage"
             }
@@ -73,15 +78,17 @@
       },
       {
         "data": {
-          "id": "acd188a125352509e86ce104323c5d4f",
+          "id": "ab3aaaac969f359da3dd1f50364f1952",
           "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v1",
           "app": "reviews",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -98,15 +105,17 @@
       },
       {
         "data": {
-          "id": "5cb6f79f37cb95cf40ea6fb23779b0e6",
+          "id": "dfeed878f470746a60e51dfbea7db762",
           "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v2",
           "app": "reviews",
           "version": "v2",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -123,15 +132,17 @@
       },
       {
         "data": {
-          "id": "dd4c5162b7f38a52e7f984766f88d807",
+          "id": "984add433545d4b5012c54cc76a17596",
           "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v3",
           "app": "reviews",
           "version": "v3",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -148,14 +159,16 @@
       },
       {
         "data": {
-          "id": "2a4ce65a837db250466f2cbf1cdd7357",
+          "id": "6029f784361ec8773f59e1855b882961",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "tcp-v1",
           "app": "tcp",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "tcp"
             }
@@ -172,8 +185,9 @@
       },
       {
         "data": {
-          "id": "933d90e5172f69af1baa035e8a8ad27c",
+          "id": "0803054a9187a09d121dd2dedf79cece",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "istio-system",
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
@@ -193,8 +207,9 @@
       },
       {
         "data": {
-          "id": "4a639f9922515051205421a93f94e0b8",
+          "id": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "unknown",
           "service": "unknown",
           "traffic": [
@@ -211,8 +226,9 @@
       },
       {
         "data": {
-          "id": "b30b0078325bf2e1adb4d57c4c0c2665",
+          "id": "375ab940b56ae7bcf0f89cb1a7af5d44",
           "nodeType": "unknown",
+          "cluster": "unknown",
           "namespace": "unknown",
           "workload": "unknown",
           "app": "unknown",
@@ -233,9 +249,9 @@
     "edges": [
       {
         "data": {
-          "id": "8088ca79aa13e423747334c532144c4f",
-          "source": "933d90e5172f69af1baa035e8a8ad27c",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "ea191cd201cd7633178d64426791bdab",
+          "source": "0803054a9187a09d121dd2dedf79cece",
+          "target": "354af352ce8b5c4103bc86828039622d",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -257,9 +273,33 @@
       },
       {
         "data": {
-          "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "2a4ce65a837db250466f2cbf1cdd7357",
+          "id": "229560b36e0b51f3e949b72d856986d1",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "354af352ce8b5c4103bc86828039622d",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "productpage:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "f4361c196dcc8c598700ed93b0a2c4b7",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "6029f784361ec8773f59e1855b882961",
           "traffic": {
             "protocol": "tcp",
             "rates": {
@@ -280,9 +320,57 @@
       },
       {
         "data": {
-          "id": "53647ccde5dac94c94c1162a735d9d3c",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "4a639f9922515051205421a93f94e0b8",
+          "id": "ef3072f36ed0ab9f4b316069f0e5043b",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "984add433545d4b5012c54cc76a17596",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "1ea11ebe21ce86ff79e16e857e95fef8",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "ab3aaaac969f359da3dd1f50364f1952",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "5de3289cb647f6fd6785ebb95300f1a3",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -306,9 +394,33 @@
       },
       {
         "data": {
-          "id": "9f6a2ed75734d99002d37ac867190b9e",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "50113397f439f05f3280ad0772b9b307",
+          "id": "91ea66fa4cb431f019cb9092010b69f6",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "dfeed878f470746a60e51dfbea7db762",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "2c57e04336ed3ccb6f5ca898932cc1a0",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "f569f02ca0fd194ed28a6e5e0d95a98d",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -358,105 +470,9 @@
       },
       {
         "data": {
-          "id": "0d38eb7edb4da38dac33b79a24c3c208",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "4ab6875deb3c0cbec4c8f260841f3d24",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "productpage:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "acd188a125352509e86ce104323c5d4f",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "d99fa824b2d85a2053f51fe3bd94ef60",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "fa70dcf5a35f2316ebcf120980a07b82",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "354af352ce8b5c4103bc86828039622d",
           "traffic": {
             "protocol": "http",
             "rates": {

--- a/graph/api/testdata/test_complex_graph.expected
+++ b/graph/api/testdata/test_complex_graph.expected
@@ -6,12 +6,14 @@
     "nodes": [
       {
         "data": {
-          "id": "7fb749d8703ff9fde566213cb1c98b41",
+          "id": "c2fbd34235fb33d25809469e43f19344",
           "nodeType": "service",
+          "cluster": "cluster-bookinfo",
           "namespace": "bookinfo",
           "service": "app.example.com",
           "destServices": [
             {
+              "cluster": "cluster-bookinfo",
               "namespace": "bookinfo",
               "name": "app.example.com"
             }
@@ -28,14 +30,16 @@
       },
       {
         "data": {
-          "id": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "d4f8c4953121af1b02155b494ebb6063",
           "nodeType": "app",
+          "cluster": "cluster-bookinfo",
           "namespace": "bookinfo",
           "workload": "productpage-v1",
           "app": "productpage",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "cluster-bookinfo",
               "namespace": "bookinfo",
               "name": "productpage"
             }
@@ -52,8 +56,10 @@
       },
       {
         "data": {
-          "id": "332209947916c37701f39500789b6792",
+          "id": "ddedb716cef6d38da883fcb5ca8797e9",
+          "parent": "fa75195fe2333d2362fce7f62eaeac7e",
           "nodeType": "app",
+          "cluster": "cluster-cp",
           "namespace": "istio-system",
           "workload": "istio-egressgateway",
           "app": "istio-egressgateway",
@@ -65,19 +71,22 @@
                 "httpOut": "400.00"
               }
             }
-          ]
+          ],
+          "isRoot": true
         }
       },
       {
         "data": {
-          "id": "d75c918a12f72a1ea1797911cb9770f7",
+          "id": "11de61605e36ab80a0b85d03f8d48a48",
           "nodeType": "app",
+          "cluster": "cluster-tutorial",
           "namespace": "tutorial",
           "workload": "customer-v1",
           "app": "customer",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "cluster-tutorial",
               "namespace": "tutorial",
               "name": "customer"
             }
@@ -101,12 +110,59 @@
       },
       {
         "data": {
-          "id": "c4d8519b61e39974286357006b354f99",
+          "id": "fa75195fe2333d2362fce7f62eaeac7e",
+          "nodeType": "app",
+          "cluster": "unknown",
+          "namespace": "istio-system",
+          "app": "istio-egressgateway",
+          "isGroup": "app"
+        }
+      },
+      {
+        "data": {
+          "id": "2b8c0b20b3d123cfd18420b39505349e",
+          "parent": "fa75195fe2333d2362fce7f62eaeac7e",
+          "nodeType": "app",
+          "cluster": "unknown",
+          "namespace": "istio-system",
+          "workload": "istio-egressgateway",
+          "app": "istio-egressgateway",
+          "version": "latest",
+          "destServices": [
+            {
+              "cluster": "unknown",
+              "namespace": "istio-system",
+              "name": "istio-egressgateway"
+            }
+          ],
+          "traffic": [
+            {
+              "protocol": "grpc",
+              "rates": {
+                "grpcIn": "600.00",
+                "grpcInNoResponse": "600.00"
+              }
+            },
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "900.00",
+                "httpInNoResponse": "500.00"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "data": {
+          "id": "7f92c6688ae60c2f8095fff466a1a7fa",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "unknown",
           "service": "app.example-2.com",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "unknown",
               "name": "app.example-2.com"
             }
@@ -124,8 +180,9 @@
       },
       {
         "data": {
-          "id": "b30b0078325bf2e1adb4d57c4c0c2665",
+          "id": "375ab940b56ae7bcf0f89cb1a7af5d44",
           "nodeType": "unknown",
+          "cluster": "unknown",
           "namespace": "unknown",
           "workload": "unknown",
           "app": "unknown",
@@ -152,81 +209,9 @@
     "edges": [
       {
         "data": {
-          "id": "b8652735083f361a13ab190a26f37e89",
-          "source": "332209947916c37701f39500789b6792",
-          "target": "c4d8519b61e39974286357006b354f99",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "400.00",
-              "httpPercentReq": "100.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "app.example-2.com": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "50.00",
-              "httpPercentReq": "100.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "productpage:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "1f024523da856e5b5a549d4a64b26cd3",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "d75c918a12f72a1ea1797911cb9770f7",
-          "traffic": {
-            "protocol": "grpc",
-            "rates": {
-              "grpc": "50.00",
-              "grpcPercentReq": "100.0"
-            },
-            "responses": {
-              "0": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "customer:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "864c8eae6f988891d9df2d9f378eece5",
-          "source": "d75c918a12f72a1ea1797911cb9770f7",
-          "target": "332209947916c37701f39500789b6792",
+          "id": "77899caeb6bf5939c31a1966cdf977f7",
+          "source": "11de61605e36ab80a0b85d03f8d48a48",
+          "target": "2b8c0b20b3d123cfd18420b39505349e",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -258,9 +243,9 @@
       },
       {
         "data": {
-          "id": "485623cf19d454363bc392d13e19902f",
-          "source": "d75c918a12f72a1ea1797911cb9770f7",
-          "target": "332209947916c37701f39500789b6792",
+          "id": "21376d8a16db38773a4f5c4f08b50f06",
+          "source": "11de61605e36ab80a0b85d03f8d48a48",
+          "target": "2b8c0b20b3d123cfd18420b39505349e",
           "traffic": {
             "protocol": "grpc",
             "rates": {
@@ -284,9 +269,9 @@
       },
       {
         "data": {
-          "id": "62adcb3e419f4bcee6f1528dd9d2eb56",
-          "source": "d75c918a12f72a1ea1797911cb9770f7",
-          "target": "7fb749d8703ff9fde566213cb1c98b41",
+          "id": "94e90d3a3a2fa9f92042e6c4bac9a584",
+          "source": "11de61605e36ab80a0b85d03f8d48a48",
+          "target": "c2fbd34235fb33d25809469e43f19344",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -308,9 +293,9 @@
       },
       {
         "data": {
-          "id": "de3e83491767bce819c83b9f9a75b497",
-          "source": "d75c918a12f72a1ea1797911cb9770f7",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "0d2c42e0ce8e8657642ea70e2d9f2e4d",
+          "source": "11de61605e36ab80a0b85d03f8d48a48",
+          "target": "d4f8c4953121af1b02155b494ebb6063",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -324,6 +309,78 @@
                 },
                 "hosts": {
                   "productpage:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "7538d228a4a583d292019bfc8c4ce6d6",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "11de61605e36ab80a0b85d03f8d48a48",
+          "traffic": {
+            "protocol": "grpc",
+            "rates": {
+              "grpc": "50.00",
+              "grpcPercentReq": "100.0"
+            },
+            "responses": {
+              "0": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "customer:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "a7a647415970806452ba65adfe29f7e0",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "d4f8c4953121af1b02155b494ebb6063",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "100.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "productpage:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "4fc5a84e4417d16fe352d3b5d749dcc4",
+          "source": "ddedb716cef6d38da883fcb5ca8797e9",
+          "target": "7f92c6688ae60c2f8095fff466a1a7fa",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "400.00",
+              "httpPercentReq": "100.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "app.example-2.com": "100.0"
                 }
               }
             }

--- a/graph/api/testdata/test_service_graph.expected
+++ b/graph/api/testdata/test_service_graph.expected
@@ -6,12 +6,14 @@
     "nodes": [
       {
         "data": {
-          "id": "715046fe06feb0ca6986fde2c2d18e22",
+          "id": "a7eca0fd957917dbc4261dcde45c5f0e",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "bankapp",
           "service": "pricing",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bankapp",
               "name": "pricing"
             }
@@ -30,12 +32,14 @@
       },
       {
         "data": {
-          "id": "35533a08d948509abf8ae4d5d5647594",
+          "id": "54a94ae2c0eb2b812652f935bf4e8e02",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "service": "details",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "details"
             }
@@ -55,12 +59,14 @@
       },
       {
         "data": {
-          "id": "42c017b34656a709d614f53967b05cc8",
+          "id": "2ed6d7c6166eb65a92dab83bf82f047b",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "service": "productpage",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "productpage"
             }
@@ -84,12 +90,14 @@
       },
       {
         "data": {
-          "id": "e96a4db610f877425f52a4b563e24c4c",
+          "id": "b4358ad1724438c11aac643fe42abc18",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "service": "ratings",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "ratings"
             }
@@ -107,12 +115,14 @@
       },
       {
         "data": {
-          "id": "e8a4c5a8a5a937ec63d1da940d4b68a1",
+          "id": "0ba1b71c02126ecb217c23ea5452b133",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "service": "reviews",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -130,12 +140,14 @@
       },
       {
         "data": {
-          "id": "8a4a4ea447daf00b8a30169659086b5f",
+          "id": "ddf880e71a8f43f7821c72220a811a68",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "service": "tcp",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "tcp"
             }
@@ -152,8 +164,9 @@
       },
       {
         "data": {
-          "id": "c72e12859eac1424516065e6a64c92e0",
+          "id": "d5644516f2f70a6e887a3d366876c647",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "istio-system",
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
@@ -180,8 +193,9 @@
       },
       {
         "data": {
-          "id": "4a639f9922515051205421a93f94e0b8",
+          "id": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "unknown",
           "service": "unknown",
           "traffic": [
@@ -198,8 +212,9 @@
       },
       {
         "data": {
-          "id": "b30b0078325bf2e1adb4d57c4c0c2665",
+          "id": "375ab940b56ae7bcf0f89cb1a7af5d44",
           "nodeType": "unknown",
+          "cluster": "unknown",
           "namespace": "unknown",
           "workload": "unknown",
           "app": "unknown",
@@ -226,9 +241,165 @@
     "edges": [
       {
         "data": {
-          "id": "619130e72e856618da923e25348f370f",
-          "source": "42c017b34656a709d614f53967b05cc8",
-          "target": "35533a08d948509abf8ae4d5d5647594",
+          "id": "49470f39583bd24d155af11bb0ce1055",
+          "source": "0ba1b71c02126ecb217c23ea5452b133",
+          "target": "0ba1b71c02126ecb217c23ea5452b133",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "40.00",
+              "httpPercentReq": "32.3"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "f1a06587835a68345d2b2031e22b1f3b",
+          "source": "0ba1b71c02126ecb217c23ea5452b133",
+          "target": "a7eca0fd957917dbc4261dcde45c5f0e",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "16.1"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "pricing:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "30fafda3cbef6f849f73dbf7d735875f",
+          "source": "0ba1b71c02126ecb217c23ea5452b133",
+          "target": "b4358ad1724438c11aac643fe42abc18",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "60.00",
+              "http5xx": "20.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "48.4"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "66.7"
+                },
+                "hosts": {
+                  "ratings:9080": "66.7"
+                }
+              },
+              "500": {
+                "flags": {
+                  "-": "33.3"
+                },
+                "hosts": {
+                  "ratings:9080": "33.3"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "01d13c580c685412c97f8b3556be56e9",
+          "source": "0ba1b71c02126ecb217c23ea5452b133",
+          "target": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "4.00",
+              "http4xx": "4.00",
+              "httpPercentErr": "100.0",
+              "httpPercentReq": "3.2"
+            },
+            "responses": {
+              "404": {
+                "flags": {
+                  "NR": "100.0"
+                },
+                "hosts": {
+                  "unknown": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "11a7fb37cc531ca27421eadf9d4dc165",
+          "source": "2ed6d7c6166eb65a92dab83bf82f047b",
+          "target": "0ba1b71c02126ecb217c23ea5452b133",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "60.00",
+              "httpPercentReq": "37.5"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "d9c30070c6d2022534716231674c8a73",
+          "source": "2ed6d7c6166eb65a92dab83bf82f047b",
+          "target": "2ed6d7c6166eb65a92dab83bf82f047b",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "productpage:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "42b02af568fa73ca8fcaa41bac0f2f8f",
+          "source": "2ed6d7c6166eb65a92dab83bf82f047b",
+          "target": "54a94ae2c0eb2b812652f935bf4e8e02",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -278,33 +449,9 @@
       },
       {
         "data": {
-          "id": "fafebffe3d83500a33fcdc0e268fabe4",
-          "source": "42c017b34656a709d614f53967b05cc8",
-          "target": "42c017b34656a709d614f53967b05cc8",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.5"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "productpage:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "e4b85b504c8777f3882217b3791d4c60",
-          "source": "42c017b34656a709d614f53967b05cc8",
-          "target": "8a4a4ea447daf00b8a30169659086b5f",
+          "id": "1f9ee8b12a9d79a5eeb72fc7985ed953",
+          "source": "2ed6d7c6166eb65a92dab83bf82f047b",
+          "target": "ddf880e71a8f43f7821c72220a811a68",
           "traffic": {
             "protocol": "tcp",
             "rates": {
@@ -325,33 +472,9 @@
       },
       {
         "data": {
-          "id": "1cf252f0a8d0ab09f9f5408ae22792f2",
-          "source": "42c017b34656a709d614f53967b05cc8",
-          "target": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "60.00",
-              "httpPercentReq": "37.5"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "1f3288555e23c16338013c2413d5987b",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "42c017b34656a709d614f53967b05cc8",
+          "id": "3bececea463fc1bce152cfe229e93bce",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "2ed6d7c6166eb65a92dab83bf82f047b",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -373,9 +496,9 @@
       },
       {
         "data": {
-          "id": "8c1b4e5d28259bbb16fac3edeb229115",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "8a4a4ea447daf00b8a30169659086b5f",
+          "id": "970728875182fe02d5c9d580aaab8ae8",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "ddf880e71a8f43f7821c72220a811a68",
           "traffic": {
             "protocol": "tcp",
             "rates": {
@@ -396,9 +519,9 @@
       },
       {
         "data": {
-          "id": "eed4f01258af80c8c8e2f07c548550f8",
-          "source": "c72e12859eac1424516065e6a64c92e0",
-          "target": "42c017b34656a709d614f53967b05cc8",
+          "id": "1253a38431743ab716e188b4a50b2095",
+          "source": "d5644516f2f70a6e887a3d366876c647",
+          "target": "2ed6d7c6166eb65a92dab83bf82f047b",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -420,9 +543,9 @@
       },
       {
         "data": {
-          "id": "dee0c874bb93f64c52f13ee82c5eee11",
-          "source": "c72e12859eac1424516065e6a64c92e0",
-          "target": "8a4a4ea447daf00b8a30169659086b5f",
+          "id": "2f5ce577b4c7977268a1b3732a844448",
+          "source": "d5644516f2f70a6e887a3d366876c647",
+          "target": "ddf880e71a8f43f7821c72220a811a68",
           "traffic": {
             "protocol": "tcp",
             "rates": {
@@ -435,114 +558,6 @@
                 },
                 "hosts": {
                   "tcp:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "79f41d0b23f15260f278310b2f3c44df",
-          "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "target": "4a639f9922515051205421a93f94e0b8",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "4.00",
-              "http4xx": "4.00",
-              "httpPercentErr": "100.0",
-              "httpPercentReq": "3.2"
-            },
-            "responses": {
-              "404": {
-                "flags": {
-                  "NR": "100.0"
-                },
-                "hosts": {
-                  "unknown": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "c8ee3a318ac7b96bd1800e9d500e3db5",
-          "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "target": "715046fe06feb0ca6986fde2c2d18e22",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "16.1"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "pricing:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "1bec06d1f0bf0a55ec9501008f3d14d4",
-          "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "target": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "40.00",
-              "httpPercentReq": "32.3"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "c8c0d78efa927aaff53a1a275cdc5e5e",
-          "source": "e8a4c5a8a5a937ec63d1da940d4b68a1",
-          "target": "e96a4db610f877425f52a4b563e24c4c",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "60.00",
-              "http5xx": "20.00",
-              "httpPercentErr": "33.3",
-              "httpPercentReq": "48.4"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "66.7"
-                },
-                "hosts": {
-                  "ratings:9080": "66.7"
-                }
-              },
-              "500": {
-                "flags": {
-                  "-": "33.3"
-                },
-                "hosts": {
-                  "ratings:9080": "33.3"
                 }
               }
             }

--- a/graph/api/testdata/test_service_node_graph.expected
+++ b/graph/api/testdata/test_service_node_graph.expected
@@ -6,14 +6,16 @@
     "nodes": [
       {
         "data": {
-          "id": "240c2314cefc993c5d9479a5c349fbd2",
+          "id": "aa79c6b34228bebc55a417555ccc779e",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "productpage-v1",
           "app": "productpage",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "productpage"
             }
@@ -36,8 +38,9 @@
       },
       {
         "data": {
-          "id": "c72e12859eac1424516065e6a64c92e0",
+          "id": "d5644516f2f70a6e887a3d366876c647",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "istio-system",
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
@@ -66,9 +69,9 @@
     "edges": [
       {
         "data": {
-          "id": "347e210a97f5235b5a60b810ef1bfaa6",
-          "source": "c72e12859eac1424516065e6a64c92e0",
-          "target": "240c2314cefc993c5d9479a5c349fbd2",
+          "id": "57a9fcf6d2882fbe11c32989224d50b0",
+          "source": "d5644516f2f70a6e887a3d366876c647",
+          "target": "aa79c6b34228bebc55a417555ccc779e",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -90,9 +93,9 @@
       },
       {
         "data": {
-          "id": "c3fa6dedc4a1b3d61a3bb48dcb46dafa",
-          "source": "c72e12859eac1424516065e6a64c92e0",
-          "target": "240c2314cefc993c5d9479a5c349fbd2",
+          "id": "c3092cfc23ee87b44610e8244e0f2063",
+          "source": "d5644516f2f70a6e887a3d366876c647",
+          "target": "aa79c6b34228bebc55a417555ccc779e",
           "traffic": {
             "protocol": "tcp",
             "rates": {

--- a/graph/api/testdata/test_versioned_app_graph.expected
+++ b/graph/api/testdata/test_versioned_app_graph.expected
@@ -6,14 +6,16 @@
     "nodes": [
       {
         "data": {
-          "id": "87100ff76f5122d56e8aa75d018b5d67",
+          "id": "d9cacc9216b4842f38a302f91d36315c",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bankapp",
           "workload": "pricing-v1",
           "app": "pricing",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bankapp",
               "name": "pricing"
             }
@@ -34,6 +36,7 @@
         "data": {
           "id": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "app": "reviews",
           "isGroup": "app"
@@ -41,8 +44,9 @@
       },
       {
         "data": {
-          "id": "7b1032e9c5683c53fb50ed8831fbd61b",
+          "id": "b94359ba714ee15770e25d49d16b48bd",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "kiali-2412",
           "traffic": [
@@ -57,14 +61,16 @@
       },
       {
         "data": {
-          "id": "50113397f439f05f3280ad0772b9b307",
+          "id": "f569f02ca0fd194ed28a6e5e0d95a98d",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "details-v1",
           "app": "details",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "details"
             }
@@ -84,14 +90,16 @@
       },
       {
         "data": {
-          "id": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "354af352ce8b5c4103bc86828039622d",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "productpage-v1",
           "app": "productpage",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "productpage"
             }
@@ -115,14 +123,16 @@
       },
       {
         "data": {
-          "id": "08d6a5dd6e290fbc42e259053b86a762",
+          "id": "38c5480ad0943e8516dd6fc42af6039d",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "ratings-v1",
           "app": "ratings",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "ratings"
             }
@@ -140,15 +150,17 @@
       },
       {
         "data": {
-          "id": "acd188a125352509e86ce104323c5d4f",
+          "id": "ab3aaaac969f359da3dd1f50364f1952",
           "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v1",
           "app": "reviews",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -165,15 +177,17 @@
       },
       {
         "data": {
-          "id": "5cb6f79f37cb95cf40ea6fb23779b0e6",
+          "id": "dfeed878f470746a60e51dfbea7db762",
           "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v2",
           "app": "reviews",
           "version": "v2",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -191,15 +205,17 @@
       },
       {
         "data": {
-          "id": "dd4c5162b7f38a52e7f984766f88d807",
+          "id": "984add433545d4b5012c54cc76a17596",
           "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v3",
           "app": "reviews",
           "version": "v3",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -217,14 +233,16 @@
       },
       {
         "data": {
-          "id": "2a4ce65a837db250466f2cbf1cdd7357",
+          "id": "6029f784361ec8773f59e1855b882961",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "tcp-v1",
           "app": "tcp",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "tcp"
             }
@@ -241,8 +259,9 @@
       },
       {
         "data": {
-          "id": "933d90e5172f69af1baa035e8a8ad27c",
+          "id": "0803054a9187a09d121dd2dedf79cece",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "istio-system",
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
@@ -268,8 +287,9 @@
       },
       {
         "data": {
-          "id": "4a639f9922515051205421a93f94e0b8",
+          "id": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "unknown",
           "service": "unknown",
           "traffic": [
@@ -286,8 +306,9 @@
       },
       {
         "data": {
-          "id": "b30b0078325bf2e1adb4d57c4c0c2665",
+          "id": "375ab940b56ae7bcf0f89cb1a7af5d44",
           "nodeType": "unknown",
+          "cluster": "unknown",
           "namespace": "unknown",
           "workload": "unknown",
           "app": "unknown",
@@ -314,90 +335,9 @@
     "edges": [
       {
         "data": {
-          "id": "ddf45549de5e603dee9a0cd9c83f9cfb",
-          "source": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "target": "08d6a5dd6e290fbc42e259053b86a762",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "30.00",
-              "http5xx": "10.00",
-              "httpPercentErr": "33.3",
-              "httpPercentReq": "60.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "66.7"
-                },
-                "hosts": {
-                  "ratings:9080": "66.7"
-                }
-              },
-              "500": {
-                "flags": {
-                  "-": "33.3"
-                },
-                "hosts": {
-                  "ratings:9080": "33.3"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "e23d51a059f4d5e45ed6ae625f9b9a5f",
-          "source": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "40.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "9f5ad0240b6a9e430d3dc2bcb2b3daaa",
-          "source": "933d90e5172f69af1baa035e8a8ad27c",
-          "target": "2a4ce65a837db250466f2cbf1cdd7357",
-          "traffic": {
-            "protocol": "tcp",
-            "rates": {
-              "tcp": "150.00"
-            },
-            "responses": {
-              "-": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "tcp:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "8088ca79aa13e423747334c532144c4f",
-          "source": "933d90e5172f69af1baa035e8a8ad27c",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "ea191cd201cd7633178d64426791bdab",
+          "source": "0803054a9187a09d121dd2dedf79cece",
+          "target": "354af352ce8b5c4103bc86828039622d",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -419,9 +359,56 @@
       },
       {
         "data": {
-          "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "2a4ce65a837db250466f2cbf1cdd7357",
+          "id": "6c161662a8505866596093537b4b9cd7",
+          "source": "0803054a9187a09d121dd2dedf79cece",
+          "target": "6029f784361ec8773f59e1855b882961",
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "150.00"
+            },
+            "responses": {
+              "-": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "tcp:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "229560b36e0b51f3e949b72d856986d1",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "354af352ce8b5c4103bc86828039622d",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "productpage:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "f4361c196dcc8c598700ed93b0a2c4b7",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "6029f784361ec8773f59e1855b882961",
           "traffic": {
             "protocol": "tcp",
             "rates": {
@@ -442,9 +429,81 @@
       },
       {
         "data": {
-          "id": "9f6a2ed75734d99002d37ac867190b9e",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "50113397f439f05f3280ad0772b9b307",
+          "id": "ef3072f36ed0ab9f4b316069f0e5043b",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "984add433545d4b5012c54cc76a17596",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "1ea11ebe21ce86ff79e16e857e95fef8",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "ab3aaaac969f359da3dd1f50364f1952",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "91ea66fa4cb431f019cb9092010b69f6",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "dfeed878f470746a60e51dfbea7db762",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "2c57e04336ed3ccb6f5ca898932cc1a0",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "f569f02ca0fd194ed28a6e5e0d95a98d",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -494,38 +553,14 @@
       },
       {
         "data": {
-          "id": "0d38eb7edb4da38dac33b79a24c3c208",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
+          "id": "fa70dcf5a35f2316ebcf120980a07b82",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "354af352ce8b5c4103bc86828039622d",
           "traffic": {
             "protocol": "http",
             "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.5"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "4ab6875deb3c0cbec4c8f260841f3d24",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.5"
+              "http": "50.00",
+              "httpPercentReq": "50.0"
             },
             "responses": {
               "200": {
@@ -542,57 +577,9 @@
       },
       {
         "data": {
-          "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "acd188a125352509e86ce104323c5d4f",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.5"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "d99fa824b2d85a2053f51fe3bd94ef60",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.5"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "d5054f4fd0140de3542ad2764d0f20bf",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "2a4ce65a837db250466f2cbf1cdd7357",
+          "id": "7c99699290e4b7a226b6ea22ef9ac369",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "6029f784361ec8773f59e1855b882961",
           "traffic": {
             "protocol": "tcp",
             "rates": {
@@ -613,9 +600,9 @@
       },
       {
         "data": {
-          "id": "53c67fb349dcfbd2327e3162a0e338aa",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "7b1032e9c5683c53fb50ed8831fbd61b",
+          "id": "806203ba5574f9612c8a187798a2d39c",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "b94359ba714ee15770e25d49d16b48bd",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -634,33 +621,9 @@
       },
       {
         "data": {
-          "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "50.00",
-              "httpPercentReq": "50.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "productpage:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "4fe76972070982cc0fe01b5d42836ca1",
-          "source": "dd4c5162b7f38a52e7f984766f88d807",
-          "target": "08d6a5dd6e290fbc42e259053b86a762",
+          "id": "e2ef6af2be31048bd4167e66c2c13bb6",
+          "source": "984add433545d4b5012c54cc76a17596",
+          "target": "38c5480ad0943e8516dd6fc42af6039d",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -692,9 +655,33 @@
       },
       {
         "data": {
-          "id": "fb2d0efdb81a37d8a1fdbbea3b82ea73",
-          "source": "dd4c5162b7f38a52e7f984766f88d807",
-          "target": "4a639f9922515051205421a93f94e0b8",
+          "id": "e606b2011ab08387d833e3756f5ef13e",
+          "source": "984add433545d4b5012c54cc76a17596",
+          "target": "984add433545d4b5012c54cc76a17596",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "27.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "182b1787ce4587c12a84b1ea1796949c",
+          "source": "984add433545d4b5012c54cc76a17596",
+          "target": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -718,9 +705,9 @@
       },
       {
         "data": {
-          "id": "5d3f0ce188557ed9741bda52cb245ff4",
-          "source": "dd4c5162b7f38a52e7f984766f88d807",
-          "target": "87100ff76f5122d56e8aa75d018b5d67",
+          "id": "60ec1b41480d53dfa817a937903a3428",
+          "source": "984add433545d4b5012c54cc76a17596",
+          "target": "d9cacc9216b4842f38a302f91d36315c",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -742,14 +729,48 @@
       },
       {
         "data": {
-          "id": "1959f1719d95c1a853a435a5807df1c3",
-          "source": "dd4c5162b7f38a52e7f984766f88d807",
-          "target": "dd4c5162b7f38a52e7f984766f88d807",
+          "id": "8a581ab46ac66316116cea28a273d280",
+          "source": "dfeed878f470746a60e51dfbea7db762",
+          "target": "38c5480ad0943e8516dd6fc42af6039d",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "30.00",
+              "http5xx": "10.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "60.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "66.7"
+                },
+                "hosts": {
+                  "ratings:9080": "66.7"
+                }
+              },
+              "500": {
+                "flags": {
+                  "-": "33.3"
+                },
+                "hosts": {
+                  "ratings:9080": "33.3"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "0740a3c74622cd9bcddc412a23da567e",
+          "source": "dfeed878f470746a60e51dfbea7db762",
+          "target": "dfeed878f470746a60e51dfbea7db762",
           "traffic": {
             "protocol": "http",
             "rates": {
               "http": "20.00",
-              "httpPercentReq": "27.0"
+              "httpPercentReq": "40.0"
             },
             "responses": {
               "200": {

--- a/graph/api/testdata/test_versioned_app_node_graph.expected
+++ b/graph/api/testdata/test_versioned_app_node_graph.expected
@@ -8,6 +8,7 @@
         "data": {
           "id": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "app": "reviews",
           "isGroup": "app"
@@ -15,14 +16,16 @@
       },
       {
         "data": {
-          "id": "50113397f439f05f3280ad0772b9b307",
+          "id": "f569f02ca0fd194ed28a6e5e0d95a98d",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "details-v1",
           "app": "details",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "details"
             }
@@ -42,14 +45,16 @@
       },
       {
         "data": {
-          "id": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "354af352ce8b5c4103bc86828039622d",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "productpage-v1",
           "app": "productpage",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "productpage"
             }
@@ -73,15 +78,17 @@
       },
       {
         "data": {
-          "id": "acd188a125352509e86ce104323c5d4f",
+          "id": "ab3aaaac969f359da3dd1f50364f1952",
           "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v1",
           "app": "reviews",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -98,15 +105,17 @@
       },
       {
         "data": {
-          "id": "5cb6f79f37cb95cf40ea6fb23779b0e6",
+          "id": "dfeed878f470746a60e51dfbea7db762",
           "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v2",
           "app": "reviews",
           "version": "v2",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -123,15 +132,17 @@
       },
       {
         "data": {
-          "id": "dd4c5162b7f38a52e7f984766f88d807",
+          "id": "984add433545d4b5012c54cc76a17596",
           "parent": "4dbce17737348d2e200a0b22fea3145b",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v3",
           "app": "reviews",
           "version": "v3",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -148,14 +159,16 @@
       },
       {
         "data": {
-          "id": "2a4ce65a837db250466f2cbf1cdd7357",
+          "id": "6029f784361ec8773f59e1855b882961",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "tcp-v1",
           "app": "tcp",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "tcp"
             }
@@ -172,8 +185,9 @@
       },
       {
         "data": {
-          "id": "933d90e5172f69af1baa035e8a8ad27c",
+          "id": "0803054a9187a09d121dd2dedf79cece",
           "nodeType": "app",
+          "cluster": "unknown",
           "namespace": "istio-system",
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
@@ -193,8 +207,9 @@
       },
       {
         "data": {
-          "id": "4a639f9922515051205421a93f94e0b8",
+          "id": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "unknown",
           "service": "unknown",
           "traffic": [
@@ -211,8 +226,9 @@
       },
       {
         "data": {
-          "id": "b30b0078325bf2e1adb4d57c4c0c2665",
+          "id": "375ab940b56ae7bcf0f89cb1a7af5d44",
           "nodeType": "unknown",
+          "cluster": "unknown",
           "namespace": "unknown",
           "workload": "unknown",
           "app": "unknown",
@@ -233,9 +249,9 @@
     "edges": [
       {
         "data": {
-          "id": "8088ca79aa13e423747334c532144c4f",
-          "source": "933d90e5172f69af1baa035e8a8ad27c",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "ea191cd201cd7633178d64426791bdab",
+          "source": "0803054a9187a09d121dd2dedf79cece",
+          "target": "354af352ce8b5c4103bc86828039622d",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -257,9 +273,33 @@
       },
       {
         "data": {
-          "id": "fa6b92c07cf9c0ba681192a89cde4ec6",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "2a4ce65a837db250466f2cbf1cdd7357",
+          "id": "229560b36e0b51f3e949b72d856986d1",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "354af352ce8b5c4103bc86828039622d",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "productpage:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "f4361c196dcc8c598700ed93b0a2c4b7",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "6029f784361ec8773f59e1855b882961",
           "traffic": {
             "protocol": "tcp",
             "rates": {
@@ -280,9 +320,57 @@
       },
       {
         "data": {
-          "id": "53647ccde5dac94c94c1162a735d9d3c",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "4a639f9922515051205421a93f94e0b8",
+          "id": "ef3072f36ed0ab9f4b316069f0e5043b",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "984add433545d4b5012c54cc76a17596",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "1ea11ebe21ce86ff79e16e857e95fef8",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "ab3aaaac969f359da3dd1f50364f1952",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "5de3289cb647f6fd6785ebb95300f1a3",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -306,9 +394,33 @@
       },
       {
         "data": {
-          "id": "9f6a2ed75734d99002d37ac867190b9e",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "50113397f439f05f3280ad0772b9b307",
+          "id": "91ea66fa4cb431f019cb9092010b69f6",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "dfeed878f470746a60e51dfbea7db762",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "2c57e04336ed3ccb6f5ca898932cc1a0",
+          "source": "354af352ce8b5c4103bc86828039622d",
+          "target": "f569f02ca0fd194ed28a6e5e0d95a98d",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -358,105 +470,9 @@
       },
       {
         "data": {
-          "id": "0d38eb7edb4da38dac33b79a24c3c208",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "5cb6f79f37cb95cf40ea6fb23779b0e6",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "4ab6875deb3c0cbec4c8f260841f3d24",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "productpage:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "1e0acd7daba1b394b6d5be3cb5caf68b",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "acd188a125352509e86ce104323c5d4f",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "d99fa824b2d85a2053f51fe3bd94ef60",
-          "source": "a1ffc0d6abdf480e17b214b85257e633",
-          "target": "dd4c5162b7f38a52e7f984766f88d807",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "e0040271cbc5fd1bcf9e605d7a2c367d",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "a1ffc0d6abdf480e17b214b85257e633",
+          "id": "fa70dcf5a35f2316ebcf120980a07b82",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "354af352ce8b5c4103bc86828039622d",
           "traffic": {
             "protocol": "http",
             "rates": {

--- a/graph/api/testdata/test_workload_graph.expected
+++ b/graph/api/testdata/test_workload_graph.expected
@@ -6,14 +6,16 @@
     "nodes": [
       {
         "data": {
-          "id": "2075586d4defa2622017ea76b7c582c0",
+          "id": "cd934145e81488df6b719eebcb068a28",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bankapp",
           "workload": "pricing-v1",
           "app": "pricing",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bankapp",
               "name": "pricing"
             }
@@ -32,8 +34,9 @@
       },
       {
         "data": {
-          "id": "7b1032e9c5683c53fb50ed8831fbd61b",
+          "id": "b94359ba714ee15770e25d49d16b48bd",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "kiali-2412",
           "traffic": [
@@ -48,14 +51,16 @@
       },
       {
         "data": {
-          "id": "5cd385c1ee3309ae40828b5702ae57fb",
+          "id": "72e0aae7c2a0b5d06dd7cf0802c47316",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "details-v1",
           "app": "details",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "details"
             }
@@ -75,14 +80,16 @@
       },
       {
         "data": {
-          "id": "240c2314cefc993c5d9479a5c349fbd2",
+          "id": "aa79c6b34228bebc55a417555ccc779e",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "productpage-v1",
           "app": "productpage",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "productpage"
             }
@@ -106,14 +113,16 @@
       },
       {
         "data": {
-          "id": "5fd49fef66081810598406b0686500ae",
+          "id": "de23ee22deb54cd006e50786eb5cca28",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "ratings-v1",
           "app": "ratings",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "ratings"
             }
@@ -131,14 +140,16 @@
       },
       {
         "data": {
-          "id": "fc3e7c5bb695ef8ed8ab2c5f6ac4725b",
+          "id": "21ba5dfa2ef5225b8e0c9a0c691590ba",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v1",
           "app": "reviews",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -155,14 +166,16 @@
       },
       {
         "data": {
-          "id": "9e97011b2086f59a90626cfd5cf23fbf",
+          "id": "1a8c87d9d76558361eede9b4a830149d",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v2",
           "app": "reviews",
           "version": "v2",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -180,14 +193,16 @@
       },
       {
         "data": {
-          "id": "731126638001dfa2b6cbeb3b326b6678",
+          "id": "a31610f853c036d085df2b80c2f24615",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v3",
           "app": "reviews",
           "version": "v3",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -205,14 +220,16 @@
       },
       {
         "data": {
-          "id": "9c4a705d62316000f11544ec6d27cdc6",
+          "id": "03533eaac2b4b0973ed07a0c2c7ef8d7",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "tcp-v1",
           "app": "tcp",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "tcp"
             }
@@ -229,8 +246,9 @@
       },
       {
         "data": {
-          "id": "c72e12859eac1424516065e6a64c92e0",
+          "id": "d5644516f2f70a6e887a3d366876c647",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "istio-system",
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
@@ -257,8 +275,9 @@
       },
       {
         "data": {
-          "id": "4a639f9922515051205421a93f94e0b8",
+          "id": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "unknown",
           "service": "unknown",
           "traffic": [
@@ -275,8 +294,9 @@
       },
       {
         "data": {
-          "id": "b30b0078325bf2e1adb4d57c4c0c2665",
+          "id": "375ab940b56ae7bcf0f89cb1a7af5d44",
           "nodeType": "unknown",
+          "cluster": "unknown",
           "namespace": "unknown",
           "workload": "unknown",
           "app": "unknown",
@@ -303,14 +323,95 @@
     "edges": [
       {
         "data": {
-          "id": "710c2bf1d8a5b3fc854451e7346e05f5",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "240c2314cefc993c5d9479a5c349fbd2",
+          "id": "e18a95b6876b3a57dece9df6c5960e00",
+          "source": "1a8c87d9d76558361eede9b4a830149d",
+          "target": "1a8c87d9d76558361eede9b4a830149d",
           "traffic": {
             "protocol": "http",
             "rates": {
               "http": "20.00",
-              "httpPercentReq": "12.5"
+              "httpPercentReq": "40.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "4581ea6a7cfb76c4ead028975fe122ee",
+          "source": "1a8c87d9d76558361eede9b4a830149d",
+          "target": "de23ee22deb54cd006e50786eb5cca28",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "30.00",
+              "http5xx": "10.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "60.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "66.7"
+                },
+                "hosts": {
+                  "ratings:9080": "66.7"
+                }
+              },
+              "500": {
+                "flags": {
+                  "-": "33.3"
+                },
+                "hosts": {
+                  "ratings:9080": "33.3"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "55798fbf115d0652891f91961c34dbad",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "03533eaac2b4b0973ed07a0c2c7ef8d7",
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "400.00"
+            },
+            "responses": {
+              "-": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "tcp:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "fa247d902a148cae81ef8af8007614e8",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "aa79c6b34228bebc55a417555ccc779e",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "50.0"
             },
             "responses": {
               "200": {
@@ -327,9 +428,209 @@
       },
       {
         "data": {
-          "id": "df66cffc756bf9983dd453837e4e14a7",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "5cd385c1ee3309ae40828b5702ae57fb",
+          "id": "806203ba5574f9612c8a187798a2d39c",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "b94359ba714ee15770e25d49d16b48bd",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "50.00",
+              "httpPercentReq": "50.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "3f8a2942530dec331ae8c5f2b30ab0a9",
+          "source": "a31610f853c036d085df2b80c2f24615",
+          "target": "a31610f853c036d085df2b80c2f24615",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "27.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "fb49aeae0887f280fb73d939a4a2587f",
+          "source": "a31610f853c036d085df2b80c2f24615",
+          "target": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "4.00",
+              "http4xx": "4.00",
+              "httpPercentErr": "100.0",
+              "httpPercentReq": "5.4"
+            },
+            "responses": {
+              "404": {
+                "flags": {
+                  "NR": "100.0"
+                },
+                "hosts": {
+                  "unknown": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "64939a1e46f90349149e6767cb055fe6",
+          "source": "a31610f853c036d085df2b80c2f24615",
+          "target": "cd934145e81488df6b719eebcb068a28",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "27.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "pricing:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "eedb14b8dcb593d3e25bdcc96c1e0597",
+          "source": "a31610f853c036d085df2b80c2f24615",
+          "target": "de23ee22deb54cd006e50786eb5cca28",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "30.00",
+              "http5xx": "10.00",
+              "httpPercentErr": "33.3",
+              "httpPercentReq": "40.5"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "66.7"
+                },
+                "hosts": {
+                  "ratings:9080": "66.7"
+                }
+              },
+              "500": {
+                "flags": {
+                  "-": "33.3"
+                },
+                "hosts": {
+                  "ratings:9080": "33.3"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "5686985336f05006df3ae891e7ff84d0",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "03533eaac2b4b0973ed07a0c2c7ef8d7",
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "31.00"
+            },
+            "responses": {
+              "-": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "tcp:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "a2b341a531426e091380724ada4f9696",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "1a8c87d9d76558361eede9b4a830149d",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "b5a1efeea68049babb8c671e1ddab333",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "21ba5dfa2ef5225b8e0c9a0c691590ba",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.5"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "57ff66c55d3375a26dfb046f2f4b7be9",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "72e0aae7c2a0b5d06dd7cf0802c47316",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -379,9 +680,9 @@
       },
       {
         "data": {
-          "id": "1da31b81ccaf408abccbc57071458462",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "731126638001dfa2b6cbeb3b326b6678",
+          "id": "e5370a71133c550e0a00af6ff72f8173",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "a31610f853c036d085df2b80c2f24615",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -403,251 +704,14 @@
       },
       {
         "data": {
-          "id": "cc4b63704dba836d37dd97aacf75afee",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "traffic": {
-            "protocol": "tcp",
-            "rates": {
-              "tcp": "31.00"
-            },
-            "responses": {
-              "-": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "tcp:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "c2ab8814859ec0974c5efd597b5bb4fd",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "9e97011b2086f59a90626cfd5cf23fbf",
+          "id": "cf999093be60dc6b63d5eca641f37c49",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "aa79c6b34228bebc55a417555ccc779e",
           "traffic": {
             "protocol": "http",
             "rates": {
               "http": "20.00",
               "httpPercentReq": "12.5"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "943e5cc1b00d97a8a344fe1efd941130",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "fc3e7c5bb695ef8ed8ab2c5f6ac4725b",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.5"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "dfb27d138c8b9b95b699e910fdda93bf",
-          "source": "731126638001dfa2b6cbeb3b326b6678",
-          "target": "2075586d4defa2622017ea76b7c582c0",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "27.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "pricing:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "3fef98ac0ce94000c6dbfcab4533361a",
-          "source": "731126638001dfa2b6cbeb3b326b6678",
-          "target": "4a639f9922515051205421a93f94e0b8",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "4.00",
-              "http4xx": "4.00",
-              "httpPercentErr": "100.0",
-              "httpPercentReq": "5.4"
-            },
-            "responses": {
-              "404": {
-                "flags": {
-                  "NR": "100.0"
-                },
-                "hosts": {
-                  "unknown": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "fa1db53921ef4a16b273c5260df63c2d",
-          "source": "731126638001dfa2b6cbeb3b326b6678",
-          "target": "5fd49fef66081810598406b0686500ae",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "30.00",
-              "http5xx": "10.00",
-              "httpPercentErr": "33.3",
-              "httpPercentReq": "40.5"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "66.7"
-                },
-                "hosts": {
-                  "ratings:9080": "66.7"
-                }
-              },
-              "500": {
-                "flags": {
-                  "-": "33.3"
-                },
-                "hosts": {
-                  "ratings:9080": "33.3"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "6822e986b101e54af3305af8d2d08051",
-          "source": "731126638001dfa2b6cbeb3b326b6678",
-          "target": "731126638001dfa2b6cbeb3b326b6678",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "27.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "0b356bd23faa1d1f26b3edeb4bbf0502",
-          "source": "9e97011b2086f59a90626cfd5cf23fbf",
-          "target": "5fd49fef66081810598406b0686500ae",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "30.00",
-              "http5xx": "10.00",
-              "httpPercentErr": "33.3",
-              "httpPercentReq": "60.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "66.7"
-                },
-                "hosts": {
-                  "ratings:9080": "66.7"
-                }
-              },
-              "500": {
-                "flags": {
-                  "-": "33.3"
-                },
-                "hosts": {
-                  "ratings:9080": "33.3"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "0d137e50b408f6108b52a8db15f90472",
-          "source": "9e97011b2086f59a90626cfd5cf23fbf",
-          "target": "9e97011b2086f59a90626cfd5cf23fbf",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "40.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "b38eaa93622c6c652c3daf15b31a476d",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "50.00",
-              "httpPercentReq": "50.0"
             },
             "responses": {
               "200": {
@@ -664,34 +728,13 @@
       },
       {
         "data": {
-          "id": "53c67fb349dcfbd2327e3162a0e338aa",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "7b1032e9c5683c53fb50ed8831fbd61b",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "50.00",
-              "httpPercentReq": "50.0"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "add44fff17f11c9c090f09d178d6090c",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "9c4a705d62316000f11544ec6d27cdc6",
+          "id": "ddc66fe0aacf6094ae85a13ab442f973",
+          "source": "d5644516f2f70a6e887a3d366876c647",
+          "target": "03533eaac2b4b0973ed07a0c2c7ef8d7",
           "traffic": {
             "protocol": "tcp",
             "rates": {
-              "tcp": "400.00"
+              "tcp": "150.00"
             },
             "responses": {
               "-": {
@@ -708,9 +751,9 @@
       },
       {
         "data": {
-          "id": "347e210a97f5235b5a60b810ef1bfaa6",
-          "source": "c72e12859eac1424516065e6a64c92e0",
-          "target": "240c2314cefc993c5d9479a5c349fbd2",
+          "id": "57a9fcf6d2882fbe11c32989224d50b0",
+          "source": "d5644516f2f70a6e887a3d366876c647",
+          "target": "aa79c6b34228bebc55a417555ccc779e",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -724,29 +767,6 @@
                 },
                 "hosts": {
                   "productpage:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "5644333566484a57ab42a2567bd5d805",
-          "source": "c72e12859eac1424516065e6a64c92e0",
-          "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "traffic": {
-            "protocol": "tcp",
-            "rates": {
-              "tcp": "150.00"
-            },
-            "responses": {
-              "-": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "tcp:9080": "100.0"
                 }
               }
             }

--- a/graph/api/testdata/test_workload_node_graph.expected
+++ b/graph/api/testdata/test_workload_node_graph.expected
@@ -6,14 +6,16 @@
     "nodes": [
       {
         "data": {
-          "id": "5cd385c1ee3309ae40828b5702ae57fb",
+          "id": "72e0aae7c2a0b5d06dd7cf0802c47316",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "details-v1",
           "app": "details",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "details"
             }
@@ -33,14 +35,16 @@
       },
       {
         "data": {
-          "id": "240c2314cefc993c5d9479a5c349fbd2",
+          "id": "aa79c6b34228bebc55a417555ccc779e",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "productpage-v1",
           "app": "productpage",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "productpage"
             }
@@ -64,14 +68,16 @@
       },
       {
         "data": {
-          "id": "fc3e7c5bb695ef8ed8ab2c5f6ac4725b",
+          "id": "21ba5dfa2ef5225b8e0c9a0c691590ba",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v1",
           "app": "reviews",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -88,14 +94,16 @@
       },
       {
         "data": {
-          "id": "9e97011b2086f59a90626cfd5cf23fbf",
+          "id": "1a8c87d9d76558361eede9b4a830149d",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v2",
           "app": "reviews",
           "version": "v2",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -112,14 +120,16 @@
       },
       {
         "data": {
-          "id": "731126638001dfa2b6cbeb3b326b6678",
+          "id": "a31610f853c036d085df2b80c2f24615",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "reviews-v3",
           "app": "reviews",
           "version": "v3",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "reviews"
             }
@@ -136,14 +146,16 @@
       },
       {
         "data": {
-          "id": "9c4a705d62316000f11544ec6d27cdc6",
+          "id": "03533eaac2b4b0973ed07a0c2c7ef8d7",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "bookinfo",
           "workload": "tcp-v1",
           "app": "tcp",
           "version": "v1",
           "destServices": [
             {
+              "cluster": "unknown",
               "namespace": "bookinfo",
               "name": "tcp"
             }
@@ -160,8 +172,9 @@
       },
       {
         "data": {
-          "id": "c72e12859eac1424516065e6a64c92e0",
+          "id": "d5644516f2f70a6e887a3d366876c647",
           "nodeType": "workload",
+          "cluster": "unknown",
           "namespace": "istio-system",
           "workload": "ingressgateway-unknown",
           "app": "ingressgateway",
@@ -180,8 +193,9 @@
       },
       {
         "data": {
-          "id": "4a639f9922515051205421a93f94e0b8",
+          "id": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
           "nodeType": "service",
+          "cluster": "unknown",
           "namespace": "unknown",
           "service": "unknown",
           "traffic": [
@@ -198,8 +212,9 @@
       },
       {
         "data": {
-          "id": "b30b0078325bf2e1adb4d57c4c0c2665",
+          "id": "375ab940b56ae7bcf0f89cb1a7af5d44",
           "nodeType": "unknown",
+          "cluster": "unknown",
           "namespace": "unknown",
           "workload": "unknown",
           "app": "unknown",
@@ -220,14 +235,14 @@
     "edges": [
       {
         "data": {
-          "id": "710c2bf1d8a5b3fc854451e7346e05f5",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "240c2314cefc993c5d9479a5c349fbd2",
+          "id": "fa247d902a148cae81ef8af8007614e8",
+          "source": "375ab940b56ae7bcf0f89cb1a7af5d44",
+          "target": "aa79c6b34228bebc55a417555ccc779e",
           "traffic": {
             "protocol": "http",
             "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
+              "http": "50.00",
+              "httpPercentReq": "100.0"
             },
             "responses": {
               "200": {
@@ -244,24 +259,21 @@
       },
       {
         "data": {
-          "id": "1fdebf7bec889df76208b55ef5cb0e03",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "4a639f9922515051205421a93f94e0b8",
+          "id": "5686985336f05006df3ae891e7ff84d0",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "03533eaac2b4b0973ed07a0c2c7ef8d7",
           "traffic": {
-            "protocol": "http",
+            "protocol": "tcp",
             "rates": {
-              "http": "4.00",
-              "http4xx": "4.00",
-              "httpPercentErr": "100.0",
-              "httpPercentReq": "2.4"
+              "tcp": "31.00"
             },
             "responses": {
-              "404": {
+              "-": {
                 "flags": {
-                  "NR": "100.0"
+                  "-": "100.0"
                 },
                 "hosts": {
-                  "unknown": "100.0"
+                  "tcp:9080": "100.0"
                 }
               }
             }
@@ -270,9 +282,57 @@
       },
       {
         "data": {
-          "id": "df66cffc756bf9983dd453837e4e14a7",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "5cd385c1ee3309ae40828b5702ae57fb",
+          "id": "a2b341a531426e091380724ada4f9696",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "1a8c87d9d76558361eede9b4a830149d",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "b5a1efeea68049babb8c671e1ddab333",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "21ba5dfa2ef5225b8e0c9a0c691590ba",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "20.00",
+              "httpPercentReq": "12.2"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "57ff66c55d3375a26dfb046f2f4b7be9",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "72e0aae7c2a0b5d06dd7cf0802c47316",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -322,9 +382,9 @@
       },
       {
         "data": {
-          "id": "1da31b81ccaf408abccbc57071458462",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "731126638001dfa2b6cbeb3b326b6678",
+          "id": "e5370a71133c550e0a00af6ff72f8173",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "a31610f853c036d085df2b80c2f24615",
           "traffic": {
             "protocol": "http",
             "rates": {
@@ -346,85 +406,14 @@
       },
       {
         "data": {
-          "id": "cc4b63704dba836d37dd97aacf75afee",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "9c4a705d62316000f11544ec6d27cdc6",
-          "traffic": {
-            "protocol": "tcp",
-            "rates": {
-              "tcp": "31.00"
-            },
-            "responses": {
-              "-": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "tcp:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "c2ab8814859ec0974c5efd597b5bb4fd",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "9e97011b2086f59a90626cfd5cf23fbf",
+          "id": "cf999093be60dc6b63d5eca641f37c49",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "aa79c6b34228bebc55a417555ccc779e",
           "traffic": {
             "protocol": "http",
             "rates": {
               "http": "20.00",
               "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "943e5cc1b00d97a8a344fe1efd941130",
-          "source": "240c2314cefc993c5d9479a5c349fbd2",
-          "target": "fc3e7c5bb695ef8ed8ab2c5f6ac4725b",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "20.00",
-              "httpPercentReq": "12.2"
-            },
-            "responses": {
-              "200": {
-                "flags": {
-                  "-": "100.0"
-                },
-                "hosts": {
-                  "reviews:9080": "100.0"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "data": {
-          "id": "b38eaa93622c6c652c3daf15b31a476d",
-          "source": "b30b0078325bf2e1adb4d57c4c0c2665",
-          "target": "240c2314cefc993c5d9479a5c349fbd2",
-          "traffic": {
-            "protocol": "http",
-            "rates": {
-              "http": "50.00",
-              "httpPercentReq": "100.0"
             },
             "responses": {
               "200": {
@@ -441,9 +430,35 @@
       },
       {
         "data": {
-          "id": "347e210a97f5235b5a60b810ef1bfaa6",
-          "source": "c72e12859eac1424516065e6a64c92e0",
-          "target": "240c2314cefc993c5d9479a5c349fbd2",
+          "id": "b7b0f60aac03a71984c855c8215026f0",
+          "source": "aa79c6b34228bebc55a417555ccc779e",
+          "target": "c806ddbb86ea4bb8a9c7c8b6be3ce196",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "4.00",
+              "http4xx": "4.00",
+              "httpPercentErr": "100.0",
+              "httpPercentReq": "2.4"
+            },
+            "responses": {
+              "404": {
+                "flags": {
+                  "NR": "100.0"
+                },
+                "hosts": {
+                  "unknown": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "57a9fcf6d2882fbe11c32989224d50b0",
+          "source": "d5644516f2f70a6e887a3d366876c647",
+          "target": "aa79c6b34228bebc55a417555ccc779e",
           "traffic": {
             "protocol": "http",
             "rates": {

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -9,7 +9,7 @@
 //
 // Algorithm: Process the graph structure adding nodes and edges, decorating each
 //            with information provided.  An optional second pass generates compound
-//            nodes for version grouping.
+//            nodes for requested boxing.
 //
 // The package provides the Cytoscape implementation of graph/ConfigVendor.
 package cytoscape
@@ -18,6 +18,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/kiali/kiali/graph"
 )
@@ -55,11 +56,12 @@ type ProtocolTraffic struct {
 
 type NodeData struct {
 	// Cytoscape Fields
-	Id     string `json:"id"`               // unique internal node ID (n0, n1...)
+	ID     string `json:"id"`               // unique internal node ID (n0, n1...)
 	Parent string `json:"parent,omitempty"` // Compound Node parent ID
 
 	// App Fields (not required by Cytoscape)
 	NodeType        string              `json:"nodeType"`
+	Cluster         string              `json:"cluster"`
 	Namespace       string              `json:"namespace"`
 	Workload        string              `json:"workload,omitempty"`
 	App             string              `json:"app,omitempty"`
@@ -71,8 +73,8 @@ type NodeData struct {
 	HasCB           bool                `json:"hasCB,omitempty"`           // true (has circuit breaker) | false
 	HasMissingSC    bool                `json:"hasMissingSC,omitempty"`    // true (has missing sidecar) | false
 	HasVS           bool                `json:"hasVS,omitempty"`           // true (has route rule) | false
+	IsBox           string              `json:"isBox,omitempty"`           // set for NodeTypeBox, current values: [ 'app', 'cluster', 'namespace' ]
 	IsDead          bool                `json:"isDead,omitempty"`          // true (has no pods) | false
-	IsGroup         string              `json:"isGroup,omitempty"`         // set to the grouping type, current values: [ 'app', 'version' ]
 	IsInaccessible  bool                `json:"isInaccessible,omitempty"`  // true if the node exists in an inaccessible namespace
 	IsMisconfigured string              `json:"isMisconfigured,omitempty"` // set to misconfiguration list, current values: [ 'labels' ]
 	IsOutside       bool                `json:"isOutside,omitempty"`       // true | false
@@ -83,7 +85,7 @@ type NodeData struct {
 
 type EdgeData struct {
 	// Cytoscape Fields
-	Id     string `json:"id"`     // unique internal edge ID (e0, e1...)
+	ID     string `json:"id"`     // unique internal edge ID (e0, e1...)
 	Source string `json:"source"` // parent node ID
 	Target string `json:"target"` // child node ID
 
@@ -130,28 +132,39 @@ func NewConfig(trafficMap graph.TrafficMap, o graph.ConfigOptions) (result Confi
 
 	buildConfig(trafficMap, &nodes, &edges, o)
 
-	// Add compound nodes as needed
-	switch o.GroupBy {
-	case graph.GroupByApp:
-		if o.GraphType != graph.GraphTypeService {
-			groupByApp(&nodes)
-		}
-	case graph.GroupByVersion:
-		if o.GraphType == graph.GraphTypeVersionedApp {
-			groupByVersion(&nodes)
-		}
-	default:
-		// no grouping
+	// Add compound nodes as needed, inner boxes first
+	if strings.Contains(o.BoxBy, graph.BoxByApp) && o.GraphType != graph.GraphTypeService {
+		boxByApp(&nodes)
+	}
+	if strings.Contains(o.BoxBy, graph.BoxByNamespace) {
+		boxByNamespace(&nodes)
+	}
+	if strings.Contains(o.BoxBy, graph.BoxByCluster) {
+		boxByCluster(&nodes)
 	}
 
 	// sort nodes and edges for better json presentation (and predictable testing)
-	// kiali-1258 compound/isGroup/parent nodes must come before the child references
+	// kiali-1258 parent nodes must come before the child references
 	sort.Slice(nodes, func(i, j int) bool {
 		switch {
+		case nodes[i].Data.IsBox != nodes[j].Data.IsBox:
+			rank := func(boxBy string) int {
+				switch boxBy {
+				case graph.BoxByCluster:
+					return 0
+				case graph.BoxByNamespace:
+					return 1
+				case graph.BoxByApp:
+					return 2
+				default:
+					return 3
+				}
+			}
+			return rank(nodes[i].Data.IsBox) < rank(nodes[j].Data.IsBox)
+		case nodes[i].Data.Cluster != nodes[j].Data.Cluster:
+			return nodes[i].Data.Cluster < nodes[j].Data.Cluster
 		case nodes[i].Data.Namespace != nodes[j].Data.Namespace:
 			return nodes[i].Data.Namespace < nodes[j].Data.Namespace
-		case nodes[i].Data.IsGroup != nodes[j].Data.IsGroup:
-			return nodes[i].Data.IsGroup > nodes[j].Data.IsGroup
 		case nodes[i].Data.App != nodes[j].Data.App:
 			return nodes[i].Data.App < nodes[j].Data.App
 		case nodes[i].Data.Version != nodes[j].Data.Version:
@@ -185,11 +198,12 @@ func NewConfig(trafficMap graph.TrafficMap, o graph.ConfigOptions) (result Confi
 
 func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*EdgeWrapper, o graph.ConfigOptions) {
 	for id, n := range trafficMap {
-		nodeId := nodeHash(id)
+		nodeID := nodeHash(id)
 
 		nd := &NodeData{
-			Id:        nodeId,
+			ID:        nodeID,
 			NodeType:  n.NodeType,
+			Cluster:   n.Cluster,
 			Namespace: n.Namespace,
 			Workload:  n.Workload,
 			App:       n.App,
@@ -269,17 +283,17 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		*nodes = append(*nodes, &nw)
 
 		for _, e := range n.Edges {
-			sourceIdHash := nodeHash(n.ID)
-			destIdHash := nodeHash(e.Dest.ID)
+			sourceIDHash := nodeHash(n.ID)
+			destIDHash := nodeHash(e.Dest.ID)
 			protocol := ""
 			if e.Metadata[graph.ProtocolKey] != nil {
 				protocol = e.Metadata[graph.ProtocolKey].(string)
 			}
-			edgeId := edgeHash(sourceIdHash, destIdHash, protocol)
+			edgeID := edgeHash(sourceIDHash, destIDHash, protocol)
 			ed := EdgeData{
-				Id:     edgeId,
-				Source: sourceIdHash,
-				Target: destIdHash,
+				ID:     edgeID,
+				Source: sourceIDHash,
+				Target: destIDHash,
 				Traffic: ProtocolTraffic{
 					Protocol: protocol,
 				},
@@ -411,46 +425,70 @@ func getRate(md graph.Metadata, k graph.MetadataKey) float64 {
 	return 0.0
 }
 
-// groupByVersion adds compound nodes to group multiple versions of the same app
-func groupByVersion(nodes *[]*NodeWrapper) {
-	appBox := make(map[string][]*NodeData)
-
-	for _, nw := range *nodes {
-		if nw.Data.NodeType == graph.NodeTypeApp {
-			k := fmt.Sprintf("box_%s_%s", nw.Data.Namespace, nw.Data.App)
-			appBox[k] = append(appBox[k], nw.Data)
-		}
-	}
-
-	generateGroupCompoundNodes(appBox, nodes, graph.GroupByVersion)
-}
-
-// groupByApp adds compound nodes to group all nodes for the same app
-func groupByApp(nodes *[]*NodeWrapper) {
-	appBox := make(map[string][]*NodeData)
+// boxByApp adds compound nodes to box nodes for the same app
+func boxByApp(nodes *[]*NodeWrapper) {
+	box := make(map[string][]*NodeData)
 
 	for _, nw := range *nodes {
 		if nw.Data.App != "unknown" && nw.Data.App != "" {
-			k := fmt.Sprintf("box_%s_%s", nw.Data.Namespace, nw.Data.App)
-			appBox[k] = append(appBox[k], nw.Data)
+			k := fmt.Sprintf("box_%s_%s_%s", nw.Data.Cluster, nw.Data.Namespace, nw.Data.App)
+			box[k] = append(box[k], nw.Data)
 		}
 	}
 
-	generateGroupCompoundNodes(appBox, nodes, graph.GroupByApp)
+	generateBoxCompoundNodes(box, nodes, graph.BoxByApp)
 }
 
-func generateGroupCompoundNodes(appBox map[string][]*NodeData, nodes *[]*NodeWrapper, groupBy string) {
-	for k, members := range appBox {
-		if len(members) > 1 {
+// boxByNamespace adds compound nodes to box nodes in the same namespace
+func boxByNamespace(nodes *[]*NodeWrapper) {
+	box := make(map[string][]*NodeData)
+
+	for _, nw := range *nodes {
+		if nw.Data.Parent == "" {
+			k := fmt.Sprintf("box_%s_%s", nw.Data.Cluster, nw.Data.Namespace)
+			box[k] = append(box[k], nw.Data)
+		}
+	}
+
+	generateBoxCompoundNodes(box, nodes, graph.BoxByNamespace)
+}
+
+// boxByCluster adds compound nodes to box nodes in the same cluster
+func boxByCluster(nodes *[]*NodeWrapper) {
+	box := make(map[string][]*NodeData)
+
+	for _, nw := range *nodes {
+		if nw.Data.Parent == "" {
+			k := fmt.Sprintf("box_%s", nw.Data.Cluster)
+			box[k] = append(box[k], nw.Data)
+		}
+	}
+
+	generateBoxCompoundNodes(box, nodes, graph.BoxByCluster)
+}
+
+func generateBoxCompoundNodes(box map[string][]*NodeData, nodes *[]*NodeWrapper, boxBy string) {
+	for k, members := range box {
+		if boxBy != graph.BoxByApp || len(members) > 1 {
 			// create the compound (parent) node for the member nodes
-			nodeId := nodeHash(k)
+			nodeID := nodeHash(k)
+			namespace := ""
+			app := ""
+			switch boxBy {
+			case graph.BoxByNamespace:
+				namespace = members[0].Namespace
+			case graph.BoxByApp:
+				namespace = members[0].Namespace
+				app = members[0].App
+			}
 			nd := NodeData{
-				Id:        nodeId,
-				NodeType:  graph.NodeTypeApp,
-				Namespace: members[0].Namespace,
-				App:       members[0].App,
+				ID:        nodeID,
+				NodeType:  graph.NodeTypeBox,
+				Cluster:   members[0].Cluster,
+				Namespace: namespace,
+				App:       app,
 				Version:   "",
-				IsGroup:   groupBy,
+				IsBox:     boxBy,
 			}
 
 			nw := NodeWrapper{
@@ -463,12 +501,14 @@ func generateGroupCompoundNodes(appBox map[string][]*NodeData, nodes *[]*NodeWra
 			nd.IsOutside = false
 
 			for _, n := range members {
-				n.Parent = nodeId
+				n.Parent = nodeID
 
-				// copy some member attributes to to the compound node (aka app box)
-				nd.HasMissingSC = nd.HasMissingSC || n.HasMissingSC
-				nd.IsInaccessible = nd.IsInaccessible || n.IsInaccessible
-				nd.IsOutside = nd.IsOutside || n.IsOutside
+				// For logical boxing (app), copy some member attributes to to the box node
+				if boxBy == graph.BoxByApp {
+					nd.HasMissingSC = nd.HasMissingSC || n.HasMissingSC
+					nd.IsInaccessible = nd.IsInaccessible || n.IsInaccessible
+					nd.IsOutside = nd.IsOutside || n.IsOutside
+				}
 			}
 
 			// add the compound node to the list of nodes

--- a/graph/telemetry/istio/appender/aggregate_node_test.go
+++ b/graph/telemetry/istio/appender/aggregate_node_test.go
@@ -13,10 +13,10 @@ import (
 func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -66,7 +66,7 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id("bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -131,10 +131,10 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
+	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -184,7 +184,7 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(false)
-	ppID, _ := graph.Id("bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -243,7 +243,7 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 func TestNodeGraphWithServiceInjection(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top",destination_service_name="reviews"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top",destination_service_name="reviews"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -273,7 +273,7 @@ func TestNodeGraphWithServiceInjection(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id("bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -323,7 +323,7 @@ func TestNodeGraphWithServiceInjection(t *testing.T) {
 func TestNodeGraphNoServiceInjection(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
+	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -353,7 +353,7 @@ func TestNodeGraphNoServiceInjection(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(false)
-	ppID, _ := graph.Id("bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -395,9 +395,9 @@ func TestNodeGraphNoServiceInjection(t *testing.T) {
 }
 
 func aggregateNodeTestTraffic(injectServices bool) graph.TrafficMap {
-	productpage := graph.NewNode("bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviews := graph.NewNode("bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode("bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviews := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsService := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
 
 	trafficMap := graph.NewTrafficMap()
 	trafficMap[productpage.ID] = &productpage

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -113,13 +113,13 @@ func TestDeadNode(t *testing.T) {
 	trafficMap := testTrafficMap()
 
 	assert.Equal(12, len(trafficMap))
-	unknownID, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found := trafficMap[unknownID]
 	assert.Equal(true, found)
 	assert.Equal(graph.Unknown, unknownNode.Workload)
 	assert.Equal(10, len(unknownNode.Edges))
 
-	ingressID, _ := graph.Id(graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(graph.Unknown, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingressNode, found := trafficMap[ingressID]
 	assert.Equal(true, found)
 	assert.Equal("istio-ingressgateway", ingressNode.Workload)
@@ -149,7 +149,7 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal("testNodeWithTcpSentTraffic-v1", ingressNode.Edges[5].Dest.Workload)
 	assert.Equal("testNodeWithTcpSentOutTraffic-v1", ingressNode.Edges[6].Dest.Workload)
 
-	id, _ := graph.Id("testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	id, _ := graph.Id(graph.Unknown, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 	noPodsNoTraffic, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	isDead, ok := noPodsNoTraffic.Metadata[graph.IsDead]
@@ -157,7 +157,7 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal(true, isDead)
 
 	// Check that external services are not removed
-	id, _ = graph.Id("testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	_, okExternal := trafficMap[id]
 	assert.Equal(true, okExternal)
 }
@@ -165,37 +165,37 @@ func TestDeadNode(t *testing.T) {
 func testTrafficMap() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n00 := graph.NewNode(graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	n00 := graph.NewNode(graph.Unknown, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	n00.Metadata["httpOut"] = 4.8
 
-	n1 := graph.NewNode("testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(graph.Unknown, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n1.Metadata["httpIn"] = 0.8
 
-	n2 := graph.NewNode("testNamespace", "testPodsNoTraffic", "testNamespace", "testPodsNoTraffic-v1", "testPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(graph.Unknown, "testNamespace", "testPodsNoTraffic", "testNamespace", "testPodsNoTraffic-v1", "testPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n3 := graph.NewNode("testNamespace", "testNoPodsWithTraffic", "testNamespace", "testNoPodsWithTraffic-v1", "testNoPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n3 := graph.NewNode(graph.Unknown, "testNamespace", "testNoPodsWithTraffic", "testNamespace", "testNoPodsWithTraffic-v1", "testNoPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n3.Metadata["httpIn"] = 0.8
 
-	n4 := graph.NewNode("testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n4 := graph.NewNode(graph.Unknown, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n5 := graph.NewNode("testNamespace", "testNoDeploymentWithTraffic", "testNamespace", "testNoDeploymentWithTraffic-v1", "testNoDeploymentWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n5 := graph.NewNode(graph.Unknown, "testNamespace", "testNoDeploymentWithTraffic", "testNamespace", "testNoDeploymentWithTraffic-v1", "testNoDeploymentWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n5.Metadata["httpIn"] = 0.8
 
-	n6 := graph.NewNode("testNamespace", "testNoDeploymentNoTraffic", "testNamespace", "testNoDeploymentNoTraffic-v1", "testNoDeploymentNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n6 := graph.NewNode(graph.Unknown, "testNamespace", "testNoDeploymentNoTraffic", "testNamespace", "testNoDeploymentNoTraffic-v1", "testNoDeploymentNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n7 := graph.NewNode("testNamespace", "testNodeWithTcpSentTraffic", "testNamespace", "testNodeWithTcpSentTraffic-v1", "testNodeWithTcpSentTraffic", "v1", graph.GraphTypeVersionedApp)
+	n7 := graph.NewNode(graph.Unknown, "testNamespace", "testNodeWithTcpSentTraffic", "testNamespace", "testNodeWithTcpSentTraffic-v1", "testNodeWithTcpSentTraffic", "v1", graph.GraphTypeVersionedApp)
 	n7.Metadata["tcpIn"] = 74.1
 
-	n8 := graph.NewNode("testNamespace", "testNodeWithTcpSentOutTraffic", "testNamespace", "testNodeWithTcpSentOutTraffic-v1", "testNodeWithTcpSentOutTraffic", "v1", graph.GraphTypeVersionedApp)
+	n8 := graph.NewNode(graph.Unknown, "testNamespace", "testNodeWithTcpSentOutTraffic", "testNamespace", "testNodeWithTcpSentOutTraffic-v1", "testNodeWithTcpSentOutTraffic", "v1", graph.GraphTypeVersionedApp)
 	n8.Metadata["tcpOut"] = 74.1
 
-	n9 := graph.NewNode("testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n9 := graph.NewNode(graph.Unknown, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n9.Metadata["httpIn"] = 0.8
 	n9.Metadata[graph.IsServiceEntry] = "MESH_EXTERNAL"
 
-	n10 := graph.NewNode("testNamespace", "egress.not.defined", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n10 := graph.NewNode(graph.Unknown, "testNamespace", "egress.not.defined", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n10.Metadata["httpIn"] = 0.8
 
 	trafficMap[n0.ID] = &n0
@@ -261,17 +261,17 @@ func TestDeadNodeIssue2783(t *testing.T) {
 	trafficMap := testTrafficMapIssue2783()
 
 	assert.Equal(3, len(trafficMap))
-	aID, _ := graph.Id("testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	aID, _ := graph.Id(graph.Unknown, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
 	aNode, found := trafficMap[aID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(aNode.Edges))
 
-	bSvcID, _ := graph.Id("testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	bSvcID, _ := graph.Id(graph.Unknown, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	bSvcNode, found := trafficMap[bSvcID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(bSvcNode.Edges))
 
-	bID, _ := graph.Id("testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	bID, _ := graph.Id(graph.Unknown, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 	bNode, found := trafficMap[bID]
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
@@ -290,11 +290,11 @@ func TestDeadNodeIssue2783(t *testing.T) {
 func testTrafficMapIssue2783() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode("testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(graph.Unknown, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
 
-	n1 := graph.NewNode("testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(graph.Unknown, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n2 := graph.NewNode("testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(graph.Unknown, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 
 	trafficMap[n0.ID] = &n0
 	trafficMap[n1.ID] = &n1
@@ -313,17 +313,17 @@ func TestDeadNodeIssue2982(t *testing.T) {
 	trafficMap := testTrafficMapIssue2982()
 
 	assert.Equal(3, len(trafficMap))
-	aID, _ := graph.Id("testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	aID, _ := graph.Id(graph.Unknown, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "a", "v1", graph.GraphTypeVersionedApp)
 	aNode, found := trafficMap[aID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(aNode.Edges))
 
-	bSvcID, _ := graph.Id("testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	bSvcID, _ := graph.Id(graph.Unknown, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	bSvcNode, found := trafficMap[bSvcID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(bSvcNode.Edges))
 
-	bID, _ := graph.Id("testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	bID, _ := graph.Id(graph.Unknown, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 	bNode, found := trafficMap[bID]
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
@@ -344,12 +344,12 @@ func TestDeadNodeIssue2982(t *testing.T) {
 func testTrafficMapIssue2982() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode("testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(graph.Unknown, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n0.Metadata["httpIn"] = 0.8
 
-	n1 := graph.NewNode("testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(graph.Unknown, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n2 := graph.NewNode("testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(graph.Unknown, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 
 	trafficMap[n0.ID] = &n0
 	trafficMap[n1.ID] = &n1

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -19,26 +19,26 @@ import (
 func setupTrafficMap() (map[string]*graph.Node, string, string, string, string, string, string) {
 	trafficMap := graph.NewTrafficMap()
 
-	appNode := graph.NewNode("testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
+	appNode := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
 	appNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNode.ID] = &appNode
 
-	appNodeV1 := graph.NewNode("testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	appNodeV1 := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	appNodeV1.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV1.ID] = &appNodeV1
 
-	appNodeV2 := graph.NewNode("testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
+	appNodeV2 := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
 	appNodeV2.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV2.ID] = &appNodeV2
 
-	serviceNode := graph.NewNode("testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	serviceNode := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[serviceNode.ID] = &serviceNode
 
-	workloadNode := graph.NewNode("testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+	workloadNode := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
 	workloadNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[workloadNode.ID] = &workloadNode
 
-	fooServiceNode := graph.NewNode("testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	fooServiceNode := graph.NewNode(graph.Unknown, "testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[fooServiceNode.ID] = &fooServiceNode
 
 	return trafficMap, appNode.ID, appNodeV1.ID, appNodeV2.ID, serviceNode.ID, workloadNode.ID, fooServiceNode.ID

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -13,10 +13,10 @@ import (
 func TestResponseTime(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_code,grpc_response_status)) > 0,0.001)`
+	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="destination",source_workload="unknown",destination_workload_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_code,grpc_response_status)) > 0,0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_code,grpc_response_status)) > 0,0.001)`
+	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace!="bookinfo",source_workload!="unknown",destination_service_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_code,grpc_response_status)) > 0,0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -35,7 +35,7 @@ func TestResponseTime(t *testing.T) {
 			Metric: q1m0,
 			Value:  0.010}}
 
-	q2 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_code,grpc_response_status)) > 0,0.001)`
+	q2 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_code,grpc_response_status)) > 0,0.001)`
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -147,7 +147,7 @@ func TestResponseTime(t *testing.T) {
 	mockQuery(api, q2, &v2)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _ := graph.Id("istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -233,14 +233,14 @@ func TestResponseTime(t *testing.T) {
 }
 
 func responseTimeTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode("istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService := graph.NewNode("bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode("bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode("bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
-	reviewsV1 := graph.NewNode("bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsV2 := graph.NewNode("bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
-	ratingsService := graph.NewNode("bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
-	ratings := graph.NewNode("bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	reviewsV1 := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsV2 := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
+	ratingsService := graph.NewNode(graph.Unknown, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
+	ratings := graph.NewNode(graph.Unknown, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
 	trafficMap[ingress.ID] = &ingress

--- a/graph/telemetry/istio/appender/security_policy.go
+++ b/graph/telemetry/istio/appender/security_policy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/graph/telemetry/istio/util"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus"
 )
@@ -54,7 +55,7 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 
 	// query prometheus for mutual_tls info in two queries (use dest telemetry because it reports the security policy):
 	// 1) query for requests originating from a workload outside the namespace.
-	groupBy := "source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy"
+	groupBy := "source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy"
 	httpQuery := fmt.Sprintf(`sum(rate(%s{reporter="destination",source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
 		"istio_requests_total",
 		namespace,
@@ -96,11 +97,13 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 func (a SecurityPolicyAppender) populateSecurityPolicyMap(securityPolicyMap map[string]PolicyRates, principalMap map[string]map[graph.MetadataKey]string, vector *model.Vector) {
 	for _, s := range *vector {
 		m := s.Metric
+		lSourceCluster, sourceClusterOk := m["source_cluster"]
 		lSourceWlNs, sourceWlNsOk := m["source_workload_namespace"]
 		lSourceWl, sourceWlOk := m["source_workload"]
 		lSourceApp, sourceAppOk := m["source_canonical_service"]
 		lSourceVer, sourceVerOk := m["source_canonical_revision"]
 		lSourcePrincipal, sourcePrincipalOk := m["source_principal"]
+		lDestCluster, destClusterOk := m["destination_cluster"]
 		lDestSvcNs, destSvcNsOk := m["destination_service_namespace"]
 		lDestSvcName, destSvcNameOk := m["destination_service_name"]
 		lDestWlNs, destWlNsOk := m["destination_workload_namespace"]
@@ -131,27 +134,30 @@ func (a SecurityPolicyAppender) populateSecurityPolicyMap(securityPolicyMap map[
 
 		val := float64(s.Value)
 
+		// handle clusters
+		sourceCluster, destCluster := util.HandleClusters(lSourceCluster, sourceClusterOk, lDestCluster, destClusterOk)
+
 		// don't inject a service node if destSvcName is not set or the dest node is already a service node.
 		inject := false
 		if a.InjectServiceNodes && graph.IsOK(destSvcName) {
-			_, destNodeType := graph.Id(destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType)
+			_, destNodeType := graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType)
 			inject = (graph.NodeTypeService != destNodeType)
 		}
 		if inject {
-			a.addSecurityPolicy(securityPolicyMap, csp, val, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, "", "", "", "")
-			a.addSecurityPolicy(securityPolicyMap, csp, val, destSvcNs, destSvcName, "", "", "", destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
-			a.addPrincipal(principalMap, sourceWlNs, "", sourceWl, sourceApp, sourceVer, sourcePrincipal, destSvcNs, destSvcName, "", "", "", "", destPrincipal)
-			a.addPrincipal(principalMap, destSvcNs, destSvcName, "", "", "", sourcePrincipal, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, destPrincipal)
+			a.addSecurityPolicy(securityPolicyMap, csp, val, sourceCluster, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destCluster, destSvcNs, destSvcName, "", "", "", "")
+			a.addSecurityPolicy(securityPolicyMap, csp, val, destCluster, destSvcNs, destSvcName, "", "", "", destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
+			a.addPrincipal(principalMap, sourceCluster, sourceWlNs, "", sourceWl, sourceApp, sourceVer, sourcePrincipal, destCluster, destSvcNs, destSvcName, "", "", "", "", destPrincipal)
+			a.addPrincipal(principalMap, destCluster, destSvcNs, destSvcName, "", "", "", sourcePrincipal, destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, destPrincipal)
 		} else {
-			a.addSecurityPolicy(securityPolicyMap, csp, val, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
-			a.addPrincipal(principalMap, sourceWlNs, "", sourceWl, sourceApp, sourceVer, sourcePrincipal, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, destPrincipal)
+			a.addSecurityPolicy(securityPolicyMap, csp, val, sourceCluster, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
+			a.addPrincipal(principalMap, sourceCluster, sourceWlNs, "", sourceWl, sourceApp, sourceVer, sourcePrincipal, destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, destPrincipal)
 		}
 	}
 }
 
-func (a SecurityPolicyAppender) addSecurityPolicy(securityPolicyMap map[string]PolicyRates, csp string, val float64, sourceNs, sourceSvc, sourceWl, sourceApp, sourceVer, destSvcNs, destSvc, destWlNs, destWl, destApp, destVer string) {
-	sourceId, _ := graph.Id(sourceNs, sourceSvc, sourceNs, sourceWl, sourceApp, sourceVer, a.GraphType)
-	destId, _ := graph.Id(destSvcNs, destSvc, destWlNs, destWl, destApp, destVer, a.GraphType)
+func (a SecurityPolicyAppender) addSecurityPolicy(securityPolicyMap map[string]PolicyRates, csp string, val float64, sourceCluster, sourceNs, sourceSvc, sourceWl, sourceApp, sourceVer, destCluster, destSvcNs, destSvc, destWlNs, destWl, destApp, destVer string) {
+	sourceId, _ := graph.Id(sourceCluster, sourceNs, sourceSvc, sourceNs, sourceWl, sourceApp, sourceVer, a.GraphType)
+	destId, _ := graph.Id(destCluster, destSvcNs, destSvc, destWlNs, destWl, destApp, destVer, a.GraphType)
 	key := fmt.Sprintf("%s %s", sourceId, destId)
 	var policyRates PolicyRates
 	var ok bool
@@ -188,10 +194,10 @@ func applySecurityPolicy(trafficMap graph.TrafficMap, securityPolicyMap map[stri
 	}
 }
 
-func (a SecurityPolicyAppender) addPrincipal(principalMap map[string]map[graph.MetadataKey]string, sourceNs, sourceSvc, sourceWl, sourceApp, sourceVer, sourcePrincipal, destSvcNs, destSvc, destWlNs, destWl, destApp, destVer, destPrincipal string) {
-	sourceId, _ := graph.Id(sourceNs, sourceSvc, sourceNs, sourceWl, sourceApp, sourceVer, a.GraphType)
-	destId, _ := graph.Id(destSvcNs, destSvc, destWlNs, destWl, destApp, destVer, a.GraphType)
-	key := fmt.Sprintf("%s %s", sourceId, destId)
+func (a SecurityPolicyAppender) addPrincipal(principalMap map[string]map[graph.MetadataKey]string, sourceCluster, sourceNs, sourceSvc, sourceWl, sourceApp, sourceVer, sourcePrincipal, destCluster, destSvcNs, destSvc, destWlNs, destWl, destApp, destVer, destPrincipal string) {
+	sourceID, _ := graph.Id(sourceCluster, sourceNs, sourceSvc, sourceNs, sourceWl, sourceApp, sourceVer, a.GraphType)
+	destID, _ := graph.Id(destCluster, destSvcNs, destSvc, destWlNs, destWl, destApp, destVer, a.GraphType)
+	key := fmt.Sprintf("%s %s", sourceID, destID)
 	var ok bool
 	if _, ok = principalMap[key]; !ok {
 		kPrincipalMap := make(map[graph.MetadataKey]string)

--- a/graph/telemetry/istio/appender/security_policy_test.go
+++ b/graph/telemetry/istio/appender/security_policy_test.go
@@ -13,10 +13,10 @@ import (
 func TestSecurityPolicy(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
+	q0 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
+	q1 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -62,7 +62,7 @@ func TestSecurityPolicy(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTraffic()
-	ingressID, _ := graph.Id("istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -99,10 +99,10 @@ func TestSecurityPolicy(t *testing.T) {
 func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
+	q0 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
 	v0 := model.Vector{}
 
-	q1 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
+	q1 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -131,7 +131,7 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTrafficWithServiceNodes()
-	ingressId, _ := graph.Id("istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressId, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressId]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -170,8 +170,8 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 }
 
 func securityPolicyTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode("istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode("bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 	trafficMap[ingress.ID] = &ingress
 	trafficMap[productpage.ID] = &productpage
@@ -182,9 +182,9 @@ func securityPolicyTestTraffic() graph.TrafficMap {
 }
 
 func securityPolicyTestTrafficWithServiceNodes() graph.TrafficMap {
-	ingress := graph.NewNode("istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpagesvc := graph.NewNode("bookinfo", "productpage", "bookinfo", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode("bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpagesvc := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "", "", "", graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 	trafficMap[ingress.ID] = &ingress
 	trafficMap[productpagesvc.ID] = &productpagesvc

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -116,7 +116,7 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 
 	// Replace "se-service" nodes with an "se-aggregate" serviceEntry node
 	for se, seServiceNodes := range seMap {
-		serviceEntryNode := graph.NewNode(namespaceInfo.Namespace, se.name, "", "", "", "", a.GraphType)
+		serviceEntryNode := graph.NewNode(graph.Unknown, namespaceInfo.Namespace, se.name, "", "", "", "", a.GraphType)
 		serviceEntryNode.Metadata[graph.IsServiceEntry] = se.location
 		serviceEntryNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata()
 		for _, doomedSeServiceNode := range seServiceNodes {

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -58,16 +58,16 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
 	// unknownNode
-	n0 := graph.NewNode(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
 	// NotSE serviceNode
-	n1 := graph.NewNode("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// NotSE appNode
-	n2 := graph.NewNode("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 
 	// externalSE host1 serviceNode
-	n3 := graph.NewNode("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n3 := graph.NewNode(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n3.Metadata = graph.NewMetadata()
 	destServices := graph.NewDestServicesMetadata()
 	destService := graph.ServiceName{Namespace: n3.Namespace, Name: n3.Service}
@@ -75,7 +75,7 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	n3.Metadata[graph.DestServices] = destServices
 
 	// externalSE host2 serviceNode
-	n4 := graph.NewNode("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n4 := graph.NewNode(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n4.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n4.Namespace, Name: n4.Service}
@@ -83,10 +83,10 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	n4.Metadata[graph.DestServices] = destServices
 
 	// non-service-entry (ALLOW_ANY) serviceNode
-	n5 := graph.NewNode("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n5 := graph.NewNode(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// internalSE host1 serviceNode
-	n6 := graph.NewNode("testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n6 := graph.NewNode(graph.Unknown, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n6.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n6.Namespace, Name: n6.Service}
@@ -94,7 +94,7 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	n6.Metadata[graph.DestServices] = destServices
 
 	// internalSE host2 serviceNode (test prefix)
-	n7 := graph.NewNode("testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n7 := graph.NewNode(graph.Unknown, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n7.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n7.Namespace, Name: n7.Service}
@@ -129,49 +129,49 @@ func TestServiceEntry(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id("testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id("testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -189,38 +189,38 @@ func TestServiceEntry(t *testing.T) {
 
 	assert.Equal(6, len(trafficMap))
 
-	unknownID, _ = graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ = graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id("testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
 	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	externalHostXServiceID, _ = graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id("testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -259,9 +259,9 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 	// Create a VersionedApp traffic map where a workload is calling a remote service entry and also an internal one
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode("namespace", "source", "namespace", "wk0", "source", "v0", graph.GraphTypeVersionedApp)
-	n1 := graph.NewNode("namespace", "svc1.namespace.global", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
-	n2 := graph.NewNode("namespace", "svc1", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(graph.Unknown, "namespace", "source", "namespace", "wk0", "source", "v0", graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(graph.Unknown, "namespace", "svc1.namespace.global", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(graph.Unknown, "namespace", "svc1", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
 
 	trafficMap[n0.ID] = &n0
 	trafficMap[n1.ID] = &n1

--- a/graph/telemetry/istio/appender/sidecars_check_test.go
+++ b/graph/telemetry/istio/appender/sidecars_check_test.go
@@ -132,7 +132,7 @@ func TestServicesAreAlwaysValid(t *testing.T) {
 func buildWorkloadTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode("testNamespace", "", "testNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+	node := graph.NewNode(graph.Unknown, "testNamespace", "", "testNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
 	trafficMap[node.ID] = &node
 
 	return trafficMap
@@ -141,7 +141,7 @@ func buildWorkloadTrafficMap() graph.TrafficMap {
 func buildAppTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode("testNamespace", "", "testNamespace", graph.Unknown, "myTest", graph.Unknown, graph.GraphTypeVersionedApp)
+	node := graph.NewNode(graph.Unknown, "testNamespace", "", "testNamespace", graph.Unknown, "myTest", graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[node.ID] = &node
 
 	return trafficMap
@@ -150,7 +150,7 @@ func buildAppTrafficMap() graph.TrafficMap {
 func buildServiceTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode("testNamespace", "svc", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	node := graph.NewNode(graph.Unknown, "testNamespace", "svc", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[node.ID] = &node
 
 	return trafficMap

--- a/graph/telemetry/istio/appender/unused_node.go
+++ b/graph/telemetry/istio/appender/unused_node.go
@@ -66,11 +66,11 @@ func (a UnusedNodeAppender) buildUnusedTrafficMap(trafficMap graph.TrafficMap, n
 	unusedTrafficMap := graph.NewTrafficMap()
 
 	for _, s := range services {
-		id, nodeType := graph.Id(namespace, s.Service.Name, "", "", "", "", a.GraphType)
+		id, nodeType := graph.Id(graph.Unknown, namespace, s.Service.Name, "", "", "", "", a.GraphType)
 		if _, found := trafficMap[id]; !found {
 			if _, found = unusedTrafficMap[id]; !found {
 				log.Tracef("Adding unused node for service [%s]", s.Service.Name)
-				node := graph.NewNodeExplicit(id, namespace, "", "", "", s.Service.Name, nodeType, a.GraphType)
+				node := graph.NewNodeExplicit(id, graph.Unknown, namespace, "", "", "", s.Service.Name, nodeType, a.GraphType)
 				// note: we don't know what the protocol really should be, http is most common, it's a dead edge anyway
 				node.Metadata = graph.Metadata{"httpIn": 0.0, "httpOut": 0.0, "isUnused": true}
 				unusedTrafficMap[id] = &node
@@ -91,11 +91,11 @@ func (a UnusedNodeAppender) buildUnusedTrafficMap(trafficMap graph.TrafficMap, n
 		if v, ok := labels[versionLabel]; ok {
 			version = v
 		}
-		id, nodeType := graph.Id("", "", namespace, w.Name, app, version, a.GraphType)
+		id, nodeType := graph.Id(graph.Unknown, "", "", namespace, w.Name, app, version, a.GraphType)
 		if _, found := trafficMap[id]; !found {
 			if _, found = unusedTrafficMap[id]; !found {
 				log.Tracef("Adding unused node for workload [%s] with labels [%v]", w.Name, labels)
-				node := graph.NewNodeExplicit(id, namespace, w.Name, app, version, "", nodeType, a.GraphType)
+				node := graph.NewNodeExplicit(id, graph.Unknown, namespace, w.Name, app, version, "", nodeType, a.GraphType)
 				// note: we don't know what the protocol really should be, http is most common, it's a dead edge anyway
 				node.Metadata = graph.Metadata{"httpIn": 0.0, "httpOut": 0.0, "isUnused": true}
 				unusedTrafficMap[id] = &node

--- a/graph/telemetry/istio/appender/unused_node_test.go
+++ b/graph/telemetry/istio/appender/unused_node_test.go
@@ -29,7 +29,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	a.addUnusedNodes(trafficMap, "testNamespace", services, workloads)
 	assert.Equal(7, len(trafficMap))
 
-	id, _ := graph.Id("testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	id, _ := graph.Id(graph.Unknown, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
 	n, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("customer-v1", n.Workload)
@@ -37,7 +37,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsUnused])
 
-	id, _ = graph.Id("testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("preference-v1", n.Workload)
@@ -45,7 +45,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsUnused])
 
-	id, _ = graph.Id("testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v1", n.Workload)
@@ -53,7 +53,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsUnused])
 
-	id, _ = graph.Id("testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v2", n.Workload)
@@ -61,21 +61,21 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v2", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsUnused])
 
-	id, _ = graph.Id("testNamespace", "customer", "", "", "", "", a.GraphType)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "customer", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
 	assert.Equal("customer", n.Service)
 	assert.Equal(true, n.Metadata[graph.IsUnused])
 
-	id, _ = graph.Id("testNamespace", "preference", "", "", "", "", a.GraphType)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "preference", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
 	assert.Equal("preference", n.Service)
 	assert.Equal(true, n.Metadata[graph.IsUnused])
 
-	id, _ = graph.Id("testNamespace", "recommendation", "", "", "", "", a.GraphType)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
@@ -101,7 +101,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	a.addUnusedNodes(trafficMap, "testNamespace", services, workloads)
 
 	assert.Equal(5, len(trafficMap))
-	id, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	id, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
 	unknown, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.Unknown, unknown.Workload)
@@ -115,7 +115,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(nil, n.Metadata[graph.IsUnused])
 
-	id, _ = graph.Id("testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("preference-v1", n.Workload)
@@ -123,7 +123,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsUnused])
 
-	id, _ = graph.Id("testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v1", n.Workload)
@@ -131,7 +131,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsUnused])
 
-	id, _ = graph.Id("testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
+	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v2", n.Workload)
@@ -158,7 +158,7 @@ func TestVersionWithNoTrafficScenario(t *testing.T) {
 	a.addUnusedNodes(trafficMap, "testNamespace", services, workloads)
 
 	assert.Equal(5, len(trafficMap))
-	id, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	id, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
 	unknown, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.Unknown, unknown.Workload)
@@ -247,8 +247,8 @@ func mockWorkloads(a UnusedNodeAppender) []models.WorkloadListItem {
 func (a *UnusedNodeAppender) oneNodeTraffic() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	unknown := graph.NewNode(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
-	customer := graph.NewNode("testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	unknown := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	customer := graph.NewNode(graph.Unknown, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
 	trafficMap[unknown.ID] = &unknown
 	trafficMap[customer.ID] = &customer
 	edge := unknown.AddEdge(&customer)
@@ -262,10 +262,10 @@ func (a *UnusedNodeAppender) oneNodeTraffic() map[string]*graph.Node {
 func (a *UnusedNodeAppender) v1Traffic() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	unknown := graph.NewNode(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
-	customer := graph.NewNode("testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
-	preference := graph.NewNode("testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
-	recommendation := graph.NewNode("testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	unknown := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	customer := graph.NewNode(graph.Unknown, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	preference := graph.NewNode(graph.Unknown, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	recommendation := graph.NewNode(graph.Unknown, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
 	trafficMap[unknown.ID] = &unknown
 	trafficMap[customer.ID] = &customer
 	trafficMap[preference.ID] = &preference

--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -14,15 +14,18 @@
 
 # ISTIO_DIR is where the Istio download is installed and thus where the istioctl binary is found.
 # CLIENT_EXE_NAME must be either "oc" or "kubectl"
+ADDONS="prometheus grafana jaeger"
+CLIENT_EXE_NAME="oc"
+CLUSTER_NAME="cluster-default"
+CONFIG_PROFILE="demo" # see "istioctl profile list" for valid values. See: https://istio.io/docs/setup/additional-setup/config-profiles/
+DELETE_ISTIO="false"
 ISTIOCTL=
 ISTIO_DIR=
-CLIENT_EXE_NAME="oc"
-NAMESPACE="istio-system"
-MTLS="true"
-DELETE_ISTIO="false"
 ISTIO_EGRESSGATEWAY_ENABLED="true"
-CONFIG_PROFILE="demo" # see "istioctl profile list" for valid values. See: https://istio.io/docs/setup/additional-setup/config-profiles/
-ADDONS="prometheus grafana jaeger"
+MESH_ID="mesh-default"
+MTLS="true"
+NAMESPACE="istio-system"
+NETWORK="network-default"
 
 # process command line args
 while [[ $# -gt 0 ]]; do
@@ -38,6 +41,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -cep|--client-exe-path)
       CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -cn|--cluster-name)
+      CLUSTER_NAME="$2"
       shift;shift
       ;;
     -cp|--config-profile)
@@ -70,6 +77,10 @@ while [[ $# -gt 0 ]]; do
       fi
       shift;shift
       ;;
+    -mid|--mesh-id)
+      MESH_ID="$2"
+      shift;shift
+      ;;
     -m|--mtls)
       if [ "${2}" == "true" ] || [ "${2}" == "false" ]; then
         MTLS="$2"
@@ -81,6 +92,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -n|--namespace)
       NAMESPACE="$2"
+      shift;shift
+      ;;
+    -net|--network)
+      NETWORK="$2"
       shift;shift
       ;;
     -s|--set)
@@ -101,6 +116,9 @@ Valid command line arguments:
   -cep|--client-exe-path <full path to client exec>:
        Cluster client executable path - e.g. "/bin/kubectl" or "minikube kubectl --"
        This value overrides any other value set with --client-exe
+  -cn|--cluster-name <cluster name>:
+       Installs istio as part of cluster with the given name.
+       Default: cluster-default
   -cp|--config-profile <profile name>:
        Installs Istio with the given profile.
        Run "istioctl profile list" to see the valid list of configuration profiles available.
@@ -120,9 +138,15 @@ Valid command line arguments:
   -m|--mtls (true|false):
        Indicate if you want global MTLS auto enabled.
        Default: false
+  -mid|--mesh-id <mesh ID>:
+       Installs istio as part of mesh with the given name.
+       Default: mesh-default
   -n|--namespace <name>:
        Install Istio in this namespace.
        Default: istio-system
+  -net|--network <network>:
+       Installs istio as part of network with the given name.
+       Default: network-default
   -s|--set <name=value>:
        Sets a name/value pair for a custom install setting. Some examples you may want to use:
        --set installPackagePath=/git/clone/istio.io/installer
@@ -210,6 +234,9 @@ fi
 for s in \
    "${MTLS_OPTIONS}" \
    "--set values.gateways.istio-egressgateway.enabled=${ISTIO_EGRESSGATEWAY_ENABLED}" \
+   "--set values.global.meshID=${MESH_ID}" \
+   "--set values.global.multiCluster.clusterName=${CLUSTER_NAME}" \
+   "--set values.global.network=${NETWORK}" \
    "${CNI_OPTIONS}" \
    "${TELEMETRY_OPTIONS}" \
    "${CUSTOM_INSTALL_SETTINGS}"

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -21,7 +21,7 @@ package handlers
 //   configVendor:    default: cytoscape
 //   duration:        time.Duration indicating desired query range duration, (default: 10m)
 //   graphType:       Determines how to present the telemetry data. app | service | versionedApp | workload (default: workload)
-//   groupBy:         If supported by vendor, visually group by a specified node attribute (default: version)
+//   boxBy:           If supported by vendor, visually box by a specified node attribute (default: none)
 //   namespaces:      Comma-separated list of namespace names to use in the graph. Will override namespace path param
 //   queryTime:       Unix time (seconds) for query such that range is queryTime-duration..queryTime (default now)
 //   TelemetryVendor: default: istio

--- a/swagger.json
+++ b/swagger.json
@@ -599,8 +599,8 @@
             "type": "string",
             "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
-            "name": "groupBy",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -714,6 +714,13 @@
             "name": "aggregateValue",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The cluster name. If not supplied queries/results will not be constrained by cluster.",
+            "name": "container",
+            "in": "query"
           },
           {
             "type": "string",
@@ -930,6 +937,13 @@
           {
             "type": "string",
             "x-go-name": "Name",
+            "description": "The cluster name. If not supplied queries/results will not be constrained by cluster.",
+            "name": "container",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
             "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
@@ -983,6 +997,13 @@
           {
             "type": "string",
             "x-go-name": "Name",
+            "description": "The cluster name. If not supplied queries/results will not be constrained by cluster.",
+            "name": "container",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
             "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
@@ -1016,8 +1037,8 @@
             "type": "string",
             "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
-            "name": "groupBy",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -1084,6 +1105,13 @@
           {
             "type": "string",
             "x-go-name": "Name",
+            "description": "The cluster name. If not supplied queries/results will not be constrained by cluster.",
+            "name": "container",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
             "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
@@ -1117,8 +1145,8 @@
             "type": "string",
             "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
-            "name": "groupBy",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -2613,6 +2641,13 @@
           {
             "type": "string",
             "x-go-name": "Name",
+            "description": "The cluster name. If not supplied queries/results will not be constrained by cluster.",
+            "name": "container",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
             "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
@@ -2654,8 +2689,8 @@
             "type": "string",
             "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
-            "name": "groupBy",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -3331,6 +3366,13 @@
           {
             "type": "string",
             "x-go-name": "Name",
+            "description": "The cluster name. If not supplied queries/results will not be constrained by cluster.",
+            "name": "container",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
             "description": "The namespace name.",
             "name": "namespace",
             "in": "path",
@@ -3372,8 +3414,8 @@
             "type": "string",
             "default": "none",
             "x-go-name": "Name",
-            "description": "App box grouping characteristic. Available groupings: [app, none, version].",
-            "name": "groupBy",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -4272,7 +4314,7 @@
         "id": {
           "description": "Cytoscape Fields",
           "type": "string",
-          "x-go-name": "Id"
+          "x-go-name": "ID"
         },
         "isMTLS": {
           "type": "string",
@@ -5572,6 +5614,10 @@
           "type": "string",
           "x-go-name": "App"
         },
+        "cluster": {
+          "type": "string",
+          "x-go-name": "Cluster"
+        },
         "destServices": {
           "type": "array",
           "items": {
@@ -5594,15 +5640,15 @@
         "id": {
           "description": "Cytoscape Fields",
           "type": "string",
-          "x-go-name": "Id"
+          "x-go-name": "ID"
+        },
+        "isBox": {
+          "type": "string",
+          "x-go-name": "IsBox"
         },
         "isDead": {
           "type": "boolean",
           "x-go-name": "IsDead"
-        },
-        "isGroup": {
-          "type": "string",
-          "x-go-name": "IsGroup"
         },
         "isInaccessible": {
           "type": "boolean",
@@ -6347,6 +6393,10 @@
     "ServiceName": {
       "type": "object",
       "properties": {
+        "cluster": {
+          "type": "string",
+          "x-go-name": "Cluster"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"


### PR DESCRIPTION
- work cluster attrs throughout trafficMap gen
- add support for "cluster" queryParam for node graph requests
  - this mantains the REST API while also allowing flexibility to graph
    a node cross-cluster or in a cluster-specific way.
- add Cluster to NodeData and DestServices
- add Cluster to the JSON sorting
- Change "Group" to "Box" to consolidate terminology and avoid the overused 'group' terminology.
- Add some handling for bad istio telemetry (see https://github.com/istio/istio/issues/29373)
- Comment out old MC telem massaging as it should be outdated
- update swagger
- initial boxing support clusters, namespaces, and apps together

