### PR TITLE
Add a notification when kiali can't find any istio component

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -1,7 +1,6 @@
 package business
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -205,9 +204,9 @@ func (iss *IstioStatusService) getStatusOf(ds []apps_v1.Deployment) (IstioCompon
 	// When all the deployments are missing,
 	// Warn users that their kiali config might be wrong
 	if componentNotFound == len(statusComponents) {
-		return isc, errors.New(fmt.Sprintf(
-			"Are you sure Istio is installed in the %s namespace?",
-			config.Get().IstioNamespace))
+		return isc, fmt.Errorf(
+			"Kiali is unable to find any Istio deployment in namespace %s. Are you sure the Istio namespace is configured correctly in Kiali?",
+			config.Get().IstioNamespace)
 	}
 
 	return isc, nil

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -127,7 +127,6 @@ func TestGrafanaWorking(t *testing.T) {
 	k8s, httpServ, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(sampleIstioComponent())
 	defer httpServ.Close()
 
-
 	iss := IstioStatusService{k8s: k8s}
 	icsl, error := iss.GetStatus()
 	assert.NoError(error)


### PR DESCRIPTION
This change tries to approach [this comment](https://github.com/kiali/kiali/issues/3508#issuecomment-742617476).

The main point for them was:

1. They misplaced the `istio_namespace` config in the CR.
2. They correctly placed a different namespace for the `kiali` deployment (through: `spec.deployment.namespace`).
3. The operator set `istio_namespace` to `spec.deployment.namespace` (see [operator code](https://github.com/kiali/kiali-operator/blob/22e89317e94dc22667fe00ac98c5fdccda130b66/roles/v1.0/kiali-deploy/tasks/main.yml#L38-L47))
4. The istio components feature couldn't find any istio components (istiod, istio-ingress/egress).
5. The proxy status in health couldn't find any `istiod` pod to fetch the syncs.

In order to leverage attention in users minds, I've placed a notification like the following triggered by the Istio Status component. It is triggered when Kiali isn't able to find any Istio components (ingress/egress/istiod).

![Screenshot of Kiali Console (2)](https://user-images.githubusercontent.com/613814/102368664-64f2cc80-3fbb-11eb-8791-60673877bf22.png)
