### PR TITLE
Force kiali to use "app" label name for fetching istio components

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -164,7 +164,7 @@ func (iss *IstioStatusService) getStatusOf(ds []apps_v1.Deployment) (IstioCompon
 
 	// Map workloads there by app name
 	for _, d := range ds {
-		appLabel := labels.Set(d.Spec.Template.Labels).Get(config.Get().IstioLabels.AppLabelName)
+		appLabel := labels.Set(d.Spec.Template.Labels).Get("app")
 		if appLabel == "" {
 			continue
 		}

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -203,7 +203,7 @@ type SyncStatus struct {
 func (in *K8SClient) GetProxyStatus() ([]*ProxyStatus, error) {
 	c := config.Get()
 	istiods, err := in.GetPods(c.IstioNamespace, labels.Set(map[string]string{
-		c.IstioLabels.AppLabelName: "istiod",
+		"app": "istiod",
 	}).String())
 
 	if err != nil {


### PR DESCRIPTION
This is a workaround for the https://github.com/kiali/kiali/issues/3543

Right now, Istio forces the usage of the app label as "app" while there are user which use different app label in their other deployments. It sounds a bit inconsistent.

Need this PR to quickly fix the bug in our users but we expect Istio to fix this situation. When this is fixed in upstream Istio, we'll be back to previous usage.

To reproduce change the istio_labels settings in your CR similarly to the following snippet:
```yaml
istio_labels:
  app_label_name: different_app_label
  version_label_name: different_version_label
```

Previous behavior:
- Error message shown right after login:
![Screenshot of Kiali Console (4)](https://user-images.githubusercontent.com/613814/102797552-2476c280-43b0-11eb-8ed8-2f9230b69cfb.png)

- All health in warning (unsync'ed workloads):
![Screenshot of Kiali Console (5)](https://user-images.githubusercontent.com/613814/102797559-2771b300-43b0-11eb-9432-b0a90ad107db.png)
![Screenshot of Kiali Console (6)](https://user-images.githubusercontent.com/613814/102797568-293b7680-43b0-11eb-97d7-776fea99f832.png)


Right after, those errors shouldn't show up.