### PR TITLE
Disable the proxy status into health when cache is disabled (all pods doesn't have sidecar)

### DIFF
--- a/business/health.go
+++ b/business/health.go
@@ -100,17 +100,6 @@ func (in *HealthService) GetWorkloadHealth(namespace, workload, workloadType, ra
 		}, nil
 	}
 
-	// Add Proxy Status info
-	if w.Pods != nil || len(w.Pods) > 0 {
-		syncedProxies := int32(0)
-		for _, p := range w.Pods {
-			if p.ProxyStatus != nil && p.ProxyStatus.IsSynced() {
-				syncedProxies++
-			}
-		}
-		status.SyncedProxies = syncedProxies
-	}
-
 	// Add Telemetry info
 	rate, err := in.getWorkloadRequestsHealth(namespace, workload, rateInterval, queryTime)
 	return models.WorkloadHealth{

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -820,11 +820,10 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		for _, pod := range w.Pods {
 			if pod.HasIstioSidecar() {
 				ps, err := layer.ProxyStatus.GetPodProxyStatus(namespace, pod.Name)
-				if err != nil || ps == nil {
-					pod.ProxyStatus = &models.ProxyStatus{}
-					continue
+				if err != nil {
+					log.Warningf("GetPodProxyStatus is failing for [namespace: %s] [pod: %s]: %s ", namespace, pod.Name, err.Error())
 				}
-				pod.ProxyStatus = castProxyStatus(*ps)
+				pod.ProxyStatus = castProxyStatus(ps)
 			}
 		}
 
@@ -1293,14 +1292,10 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		for _, pod := range w.Pods {
 			if pod.HasIstioSidecar() {
 				ps, err := layer.ProxyStatus.GetPodProxyStatus(namespace, pod.Name)
-				if err != nil || ps == nil {
-					if err != nil {
-						log.Warningf("GetPodProxyStatus is failing for [namespace: %s] [pod: %s]: %s ", namespace, pod.Name, err.Error())
-					}
-					pod.ProxyStatus = nil
-					continue
+				if err != nil {
+					log.Warningf("GetPodProxyStatus is failing for [namespace: %s] [pod: %s]: %s ", namespace, pod.Name, err.Error())
 				}
-				pod.ProxyStatus = castProxyStatus(*ps)
+				pod.ProxyStatus = castProxyStatus(ps)
 			}
 		}
 

--- a/models/pod.go
+++ b/models/pod.go
@@ -133,7 +133,7 @@ func (pods Pods) HasIstioSidecar() bool {
 	return true
 }
 
-// HasIstioSidecar returns true if the pod has an Isio proxy sidecar
+// HasIstioSidecar returns true if the pod has an Istio proxy sidecar
 func (pod Pod) HasIstioSidecar() bool {
 	return len(pod.IstioContainers) > 0
 }
@@ -142,16 +142,18 @@ func (pod Pod) HasIstioSidecar() bool {
 // If none of the pods have Istio Sidecar, then return -1
 func (pods Pods) SyncedPodProxiesCount() int32 {
 	syncedProxies := int32(0)
+	allNullProxies := true
 	hasSidecar := false
 
 	for _, pod := range pods {
 		hasSidecar = hasSidecar || pod.HasIstioSidecar()
+		allNullProxies = allNullProxies && pod.ProxyStatus == nil
 		if pod.ProxyStatus != nil && pod.ProxyStatus.IsSynced() {
 			syncedProxies++
 		}
 	}
 
-	if !hasSidecar {
+	if !hasSidecar || allNullProxies {
 		syncedProxies = -1
 	}
 


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/3539

The idea behind is to disable the unsync'ed pods when the cache is disabled.
This will avoid the situation mentioned in the issue linked right above and won't show warnings in all health.
The proxy-status is disabled when cache is disabled because the query performed can be massive and will dramatically damage the whole performance in medium deployments.

To reproduce:
Add the following config in your kiali CR to disable the cache:

```yaml
kubernetes_config:
  cache_enabled: false
```

Bug:
You should be able to see all the health in the mesh with unsynced proxies.