### PR TITLE
Handle `ExportTo` when Service Entry matching

### DIFF
--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -139,8 +139,10 @@ const (
 )
 
 type serviceEntry struct {
-	location string
-	name     string // serviceEntry name
+	exportTo  interface{}
+	location  string
+	name      string // serviceEntry name
+	namespace string // namespace in which the service entry is defined
 }
 
 type serviceEntryHosts map[string]*serviceEntry

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -733,7 +733,7 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 	assert.Equal(1, numMatches)
 }
 
-func TestServiceEntrySameHost(t *testing.T) {
+func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 	k8s := kubetest.NewK8SClientMock()
 
 	SE1 := kubernetes.GenericIstioObject{
@@ -780,73 +780,57 @@ func TestServiceEntrySameHost(t *testing.T) {
 	// unknownNode
 	n0 := graph.NewNode(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	// NotSE host2 serviceNode
-	n1 := graph.NewNode("barNamespace", "host2.external.com", "barNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	// NotSE host3 serviceNode
+	n1 := graph.NewNode("testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
-	// SE1 host1 serviceNode
-	n2 := graph.NewNode("barNamespace", "host1.external.com", "barNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	// SE2 host1 serviceNode
+	n2 := graph.NewNode("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n2.Metadata = graph.NewMetadata()
 	destServices := graph.NewDestServicesMetadata()
 	destService := graph.ServiceName{Namespace: n2.Namespace, Name: n2.Service}
 	destServices[destService.Key()] = destService
 	n2.Metadata[graph.DestServices] = destServices
 
-	// SE2 host1 serviceNode
-	n3 := graph.NewNode("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	// SE2 host2 serviceNode
+	n3 := graph.NewNode("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n3.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n3.Namespace, Name: n3.Service}
 	destServices[destService.Key()] = destService
 	n3.Metadata[graph.DestServices] = destServices
 
-	// SE2 host2 serviceNode
-	n4 := graph.NewNode("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
-	n4.Metadata = graph.NewMetadata()
-	destServices = graph.NewDestServicesMetadata()
-	destService = graph.ServiceName{Namespace: n4.Namespace, Name: n4.Service}
-	destServices[destService.Key()] = destService
-	n4.Metadata[graph.DestServices] = destServices
-
 	trafficMap[n0.ID] = &n0
 	trafficMap[n1.ID] = &n1
 	trafficMap[n2.ID] = &n2
 	trafficMap[n3.ID] = &n3
-	trafficMap[n4.ID] = &n4
 
 	n0.AddEdge(&n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 	n0.AddEdge(&n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 	n0.AddEdge(&n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n0.AddEdge(&n4).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 
-	assert.Equal(5, len(trafficMap))
+	assert.Equal(4, len(trafficMap))
 
 	unknownID, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
-	assert.Equal(4, len(unknownNode.Edges))
+	assert.Equal(3, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id("barNamespace", "host2.external.com", "barNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ := graph.Id("testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(0, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE1Host1ServiceID, _ := graph.Id("barNamespace", "host1.external.com", "barNamespace", "", "", "", graph.GraphTypeVersionedApp)
-	SE1Host1ServiceNode, found2 := trafficMap[SE1Host1ServiceID]
-	assert.Equal(true, found2)
-	assert.Equal(0, len(SE1Host1ServiceNode.Edges))
-	assert.Equal(nil, SE1Host1ServiceNode.Metadata[graph.IsServiceEntry])
-
 	SE2Host1ServiceID, _ := graph.Id("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
-	SE2Host1ServiceNode, found3 := trafficMap[SE2Host1ServiceID]
-	assert.Equal(true, found3)
+	SE2Host1ServiceNode, found2 := trafficMap[SE2Host1ServiceID]
+	assert.Equal(true, found2)
 	assert.Equal(0, len(SE2Host1ServiceNode.Edges))
 	assert.Equal(nil, SE2Host1ServiceNode.Metadata[graph.IsServiceEntry])
 
 	SE2Host2ServiceID, _ := graph.Id("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
-	SE2Host2ServiceNode, found4 := trafficMap[SE2Host2ServiceID]
-	assert.Equal(true, found4)
+	SE2Host2ServiceNode, found3 := trafficMap[SE2Host2ServiceID]
+	assert.Equal(true, found3)
 	assert.Equal(0, len(SE2Host2ServiceNode.Edges))
 	assert.Equal(nil, SE2Host2ServiceNode.Metadata[graph.IsServiceEntry])
 
@@ -860,6 +844,134 @@ func TestServiceEntrySameHost(t *testing.T) {
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
 
+	assert.Equal(3, len(trafficMap))
+
+	unknownID, _ = graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 = trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(2, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEServiceID, _ = graph.Id("testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceNode, found1 = trafficMap[notSEServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(0, len(notSEServiceNode.Edges))
+	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+
+	SE2ID, _ := graph.Id("testNamespace", "SE2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE2Node, found2 := trafficMap[SE2ID]
+	assert.Equal(true, found2)
+	assert.Equal(0, len(SE2Node.Edges))
+	assert.Equal("MESH_EXTERNAL", SE2Node.Metadata[graph.IsServiceEntry])
+	assert.Equal(2, len(SE2Node.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
+}
+
+func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
+	k8s := kubetest.NewK8SClientMock()
+
+	SE1 := kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "SE1",
+			Namespace: "fooNamespace", // definition namespace is irrelevant in this case
+		},
+		Spec: map[string]interface{}{
+			"exportTo": []interface{}{"*"}, // can match a service in any namespace
+			"hosts": []interface{}{
+				"host1.external.com",
+			},
+			"location": "MESH_EXTERNAL",
+		},
+	}
+	SE2 := kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "SE2",
+			Namespace: "testNamespace",
+		},
+		Spec: map[string]interface{}{
+			"exportTo": []interface{}{"."}, // can match a service in only testNamespace
+			"hosts": []interface{}{
+				"host1.external.com",
+				"host2.external.com",
+			},
+			"location": "MESH_EXTERNAL",
+		},
+	}
+
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "serviceentries", "").Return([]kubernetes.IstioObject{
+		&SE1,
+		&SE2},
+		nil)
+	config.Set(config.NewConfig())
+
+	businessLayer := business.NewWithBackends(k8s, nil, nil)
+
+	assert := assert.New(t)
+
+	trafficMap := make(map[string]*graph.Node)
+
+	// unknownNode
+	n0 := graph.NewNode(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+
+	// NotSE host3 serviceNode
+	n1 := graph.NewNode("testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+
+	// SE1 host1 serviceNode
+	n2 := graph.NewNode("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n2.Metadata = graph.NewMetadata()
+	destServices := graph.NewDestServicesMetadata()
+	destService := graph.ServiceName{Namespace: n2.Namespace, Name: n2.Service}
+	destServices[destService.Key()] = destService
+	n2.Metadata[graph.DestServices] = destServices
+
+	// Not SE host2 serviceNode
+	n3 := graph.NewNode("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+
+	trafficMap[n0.ID] = &n0
+	trafficMap[n1.ID] = &n1
+	trafficMap[n2.ID] = &n2
+	trafficMap[n3.ID] = &n3
+
+	n0.AddEdge(&n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(&n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(&n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+
+	assert.Equal(4, len(trafficMap))
+
+	unknownID, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 := trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(3, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEHost3ServiceID, _ := graph.Id("testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost3ServiceNode, found1 := trafficMap[notSEHost3ServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(0, len(notSEHost3ServiceNode.Edges))
+	assert.Equal(nil, notSEHost3ServiceNode.Metadata[graph.IsServiceEntry])
+
+	SE1Host1ServiceID, _ := graph.Id("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE1Host1ServiceNode, found2 := trafficMap[SE1Host1ServiceID]
+	assert.Equal(true, found2)
+	assert.Equal(0, len(SE1Host1ServiceNode.Edges))
+	assert.Equal(nil, SE1Host1ServiceNode.Metadata[graph.IsServiceEntry])
+
+	notSEHost2ServiceID, _ := graph.Id("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost2ServiceNode, found3 := trafficMap[notSEHost2ServiceID]
+	assert.Equal(true, found3)
+	assert.Equal(0, len(notSEHost2ServiceNode.Edges))
+	assert.Equal(nil, notSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("otherNamespace")
+
+	// Run the appender...
+	a := ServiceEntryAppender{
+		AccessibleNamespaces: map[string]time.Time{"otherNamespace": time.Now()},
+	}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
 	assert.Equal(4, len(trafficMap))
 
 	unknownID, _ = graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
@@ -868,24 +980,23 @@ func TestServiceEntrySameHost(t *testing.T) {
 	assert.Equal(3, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id("barNamespace", "host2.external.com", "barNamespace", "", "", "", graph.GraphTypeVersionedApp)
-	notSEServiceNode, found1 = trafficMap[notSEServiceID]
+	notSEHost3ServiceID, _ = graph.Id("testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost3ServiceNode, found1 = trafficMap[notSEHost3ServiceID]
 	assert.Equal(true, found1)
-	assert.Equal(0, len(notSEServiceNode.Edges))
-	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+	assert.Equal(0, len(notSEHost3ServiceNode.Edges))
+	assert.Equal(nil, notSEHost3ServiceNode.Metadata[graph.IsServiceEntry])
 
-	// note that the SE namespace will always be set to the namespace being processed for the graph
-	SE1ID, _ := graph.Id("testNamespace", "SE1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE1ID, _ := graph.Id("otherNamespace", "SE1", "otherNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE1Node, found2 := trafficMap[SE1ID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE1Node.Edges))
 	assert.Equal("MESH_EXTERNAL", SE1Node.Metadata[graph.IsServiceEntry])
 	assert.Equal(1, len(SE1Node.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	SE2ID, _ := graph.Id("testNamespace", "SE2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
-	SE2Node, found3 := trafficMap[SE2ID]
+	notSEHost2ServiceID, _ = graph.Id("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost2ServiceNode, found3 = trafficMap[notSEHost2ServiceID]
 	assert.Equal(true, found3)
-	assert.Equal(0, len(SE2Node.Edges))
-	assert.Equal("MESH_EXTERNAL", SE2Node.Metadata[graph.IsServiceEntry])
-	assert.Equal(2, len(SE2Node.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
+	assert.Equal(0, len(notSEHost2ServiceNode.Edges))
+	assert.Equal(nil, notSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
 }

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -16,14 +16,16 @@ import (
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
-func setupServiceEntries() *business.Layer {
+func setupServiceEntries(exportTo interface{}) *business.Layer {
 	k8s := kubetest.NewK8SClientMock()
 
 	externalSE := kubernetes.GenericIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "externalSE",
+			Name:      "externalSE",
+			Namespace: "testNamespace",
 		},
 		Spec: map[string]interface{}{
+			"exportTo": exportTo,
 			"hosts": []interface{}{
 				"host1.external.com",
 				"host2.external.com"},
@@ -32,7 +34,8 @@ func setupServiceEntries() *business.Layer {
 	}
 	internalSE := kubernetes.GenericIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "internalSE",
+			Name:      "internalSE",
+			Namespace: "testNamespace",
 		},
 		Spec: map[string]interface{}{
 			"hosts": []interface{}{
@@ -124,7 +127,7 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 func TestServiceEntry(t *testing.T) {
 	assert := assert.New(t)
 
-	businessLayer := setupServiceEntries()
+	businessLayer := setupServiceEntries(nil)
 	trafficMap := serviceEntriesTrafficMap()
 
 	assert.Equal(8, len(trafficMap))
@@ -228,7 +231,432 @@ func TestServiceEntry(t *testing.T) {
 	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 }
 
-// TestDisjoingGlobalEntries checks that a service node representing traffic to a remote cluster
+func TestServiceEntryExportAll(t *testing.T) {
+	assert := assert.New(t)
+
+	businessLayer := setupServiceEntries([]interface{}{"*"})
+	trafficMap := serviceEntriesTrafficMap()
+
+	assert.Equal(8, len(trafficMap))
+
+	unknownID, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 := trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(1, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEServiceID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceNode, found1 := trafficMap[notSEServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(1, len(notSEServiceNode.Edges))
+	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+
+	notSEAppID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppNode, found2 := trafficMap[notSEAppID]
+	assert.Equal(true, found2)
+	assert.Equal(5, len(notSEAppNode.Edges))
+	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
+
+	externalSEHost1ServiceID, _ := graph.Id("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
+	assert.Equal(true, found3)
+	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
+	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
+
+	externalSEHost2ServiceID, _ := graph.Id("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
+	assert.Equal(true, found4)
+	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
+	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
+	externalHostXServiceID, _ := graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
+	assert.Equal(true, found5)
+	assert.Equal(0, len(externalHostXServiceNode.Edges))
+	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEHost1ServiceID, _ := graph.Id("testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
+	assert.Equal(true, found6)
+	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
+	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEHost2ServiceID, _ := graph.Id("testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
+	assert.Equal(true, found7)
+	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
+	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	// Run the appender...
+	a := ServiceEntryAppender{
+		AccessibleNamespaces: map[string]time.Time{"testNamespace": time.Now()},
+	}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(6, len(trafficMap))
+
+	unknownID, _ = graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 = trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(1, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEServiceID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceNode, found1 = trafficMap[notSEServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(1, len(notSEServiceNode.Edges))
+	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+
+	notSEAppID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppNode, found2 = trafficMap[notSEAppID]
+	assert.Equal(true, found2)
+	assert.Equal(4, len(notSEAppNode.Edges))
+	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
+
+	externalSEServiceEntryID, _ := graph.Id("testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
+	assert.Equal(true, found3)
+	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
+	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
+
+	externalHostXServiceID, _ = graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
+	assert.Equal(true, found4)
+	assert.Equal(0, len(externalHostXServiceNode.Edges))
+	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEServiceEntryID, _ := graph.Id("testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
+	assert.Equal(true, found5)
+	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
+	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
+}
+
+func TestServiceEntryExportNamespaceFound(t *testing.T) {
+	assert := assert.New(t)
+
+	businessLayer := setupServiceEntries([]interface{}{"fooNamespace", "testNamespace"})
+	trafficMap := serviceEntriesTrafficMap()
+
+	assert.Equal(8, len(trafficMap))
+
+	unknownID, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 := trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(1, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEServiceID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceNode, found1 := trafficMap[notSEServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(1, len(notSEServiceNode.Edges))
+	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+
+	notSEAppID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppNode, found2 := trafficMap[notSEAppID]
+	assert.Equal(true, found2)
+	assert.Equal(5, len(notSEAppNode.Edges))
+	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
+
+	externalSEHost1ServiceID, _ := graph.Id("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
+	assert.Equal(true, found3)
+	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
+	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
+
+	externalSEHost2ServiceID, _ := graph.Id("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
+	assert.Equal(true, found4)
+	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
+	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
+	externalHostXServiceID, _ := graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
+	assert.Equal(true, found5)
+	assert.Equal(0, len(externalHostXServiceNode.Edges))
+	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEHost1ServiceID, _ := graph.Id("testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
+	assert.Equal(true, found6)
+	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
+	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEHost2ServiceID, _ := graph.Id("testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
+	assert.Equal(true, found7)
+	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
+	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	// Run the appender...
+	a := ServiceEntryAppender{
+		AccessibleNamespaces: map[string]time.Time{"testNamespace": time.Now()},
+	}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(6, len(trafficMap))
+
+	unknownID, _ = graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 = trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(1, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEServiceID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceNode, found1 = trafficMap[notSEServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(1, len(notSEServiceNode.Edges))
+	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+
+	notSEAppID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppNode, found2 = trafficMap[notSEAppID]
+	assert.Equal(true, found2)
+	assert.Equal(4, len(notSEAppNode.Edges))
+	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
+
+	externalSEServiceEntryID, _ := graph.Id("testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
+	assert.Equal(true, found3)
+	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
+	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
+
+	externalHostXServiceID, _ = graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
+	assert.Equal(true, found4)
+	assert.Equal(0, len(externalHostXServiceNode.Edges))
+	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEServiceEntryID, _ := graph.Id("testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
+	assert.Equal(true, found5)
+	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
+	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
+}
+
+func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
+	assert := assert.New(t)
+
+	businessLayer := setupServiceEntries([]interface{}{"."})
+	trafficMap := serviceEntriesTrafficMap()
+
+	assert.Equal(8, len(trafficMap))
+
+	unknownID, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 := trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(1, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEServiceID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceNode, found1 := trafficMap[notSEServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(1, len(notSEServiceNode.Edges))
+	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+
+	notSEAppID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppNode, found2 := trafficMap[notSEAppID]
+	assert.Equal(true, found2)
+	assert.Equal(5, len(notSEAppNode.Edges))
+	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
+
+	externalSEHost1ServiceID, _ := graph.Id("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
+	assert.Equal(true, found3)
+	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
+	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
+
+	externalSEHost2ServiceID, _ := graph.Id("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
+	assert.Equal(true, found4)
+	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
+	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
+	externalHostXServiceID, _ := graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
+	assert.Equal(true, found5)
+	assert.Equal(0, len(externalHostXServiceNode.Edges))
+	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEHost1ServiceID, _ := graph.Id("testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
+	assert.Equal(true, found6)
+	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
+	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEHost2ServiceID, _ := graph.Id("testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
+	assert.Equal(true, found7)
+	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
+	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	// Run the appender...
+	a := ServiceEntryAppender{
+		AccessibleNamespaces: map[string]time.Time{"testNamespace": time.Now()},
+	}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(6, len(trafficMap))
+
+	unknownID, _ = graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 = trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(1, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEServiceID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceNode, found1 = trafficMap[notSEServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(1, len(notSEServiceNode.Edges))
+	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+
+	notSEAppID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppNode, found2 = trafficMap[notSEAppID]
+	assert.Equal(true, found2)
+	assert.Equal(4, len(notSEAppNode.Edges))
+	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
+
+	externalSEServiceEntryID, _ := graph.Id("testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
+	assert.Equal(true, found3)
+	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
+	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
+
+	externalHostXServiceID, _ = graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
+	assert.Equal(true, found4)
+	assert.Equal(0, len(externalHostXServiceNode.Edges))
+	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEServiceEntryID, _ := graph.Id("testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
+	assert.Equal(true, found5)
+	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
+	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
+}
+
+func TestServiceEntryExportNamespaceNotFound(t *testing.T) {
+	assert := assert.New(t)
+
+	businessLayer := setupServiceEntries([]interface{}{"fooNamespace", "barNamespace"})
+	trafficMap := serviceEntriesTrafficMap()
+
+	assert.Equal(8, len(trafficMap))
+
+	unknownID, _ := graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 := trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(1, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEServiceID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceNode, found1 := trafficMap[notSEServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(1, len(notSEServiceNode.Edges))
+	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+
+	notSEAppID, _ := graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppNode, found2 := trafficMap[notSEAppID]
+	assert.Equal(true, found2)
+	assert.Equal(5, len(notSEAppNode.Edges))
+	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
+
+	externalSEHost1ServiceID, _ := graph.Id("testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
+	assert.Equal(true, found3)
+	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
+	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
+
+	externalSEHost2ServiceID, _ := graph.Id("testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
+	assert.Equal(true, found4)
+	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
+	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
+	externalHostXServiceID, _ := graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
+	assert.Equal(true, found5)
+	assert.Equal(0, len(externalHostXServiceNode.Edges))
+	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEHost1ServiceID, _ := graph.Id("testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
+	assert.Equal(true, found6)
+	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
+	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEHost2ServiceID, _ := graph.Id("testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
+	assert.Equal(true, found7)
+	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
+	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	// Run the appender...
+	a := ServiceEntryAppender{
+		AccessibleNamespaces: map[string]time.Time{"testNamespace": time.Now()},
+	}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(7, len(trafficMap))
+
+	unknownID, _ = graph.Id(graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownNode, found0 = trafficMap[unknownID]
+	assert.Equal(true, found0)
+	assert.Equal(1, len(unknownNode.Edges))
+	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
+
+	notSEServiceID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceNode, found1 = trafficMap[notSEServiceID]
+	assert.Equal(true, found1)
+	assert.Equal(1, len(notSEServiceNode.Edges))
+	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
+
+	notSEAppID, _ = graph.Id("testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppNode, found2 = trafficMap[notSEAppID]
+	assert.Equal(true, found2)
+	assert.Equal(5, len(notSEAppNode.Edges))
+	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
+
+	externalSEServiceEntryID, _ := graph.Id("testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	_, found3 = trafficMap[externalSEServiceEntryID]
+	assert.Equal(false, found3)
+
+	externalHostXServiceID, _ = graph.Id("testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
+	assert.Equal(true, found4)
+	assert.Equal(0, len(externalHostXServiceNode.Edges))
+	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
+
+	internalSEServiceEntryID, _ := graph.Id("testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
+	assert.Equal(true, found5)
+	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
+	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
+}
+
+// TestDisjointGlobalEntries checks that a service node representing traffic to a remote cluster
 // is correctly identified as a ServiceEntry. Also checks that a service node representing traffic
 // to an internal service is not mixed with the node for the remote cluster.
 func TestDisjointMulticlusterEntries(t *testing.T) {


### PR DESCRIPTION
When matching Service Entries with hosts make sure the SE is exported to the current namespace.

Fixes https://github.com/kiali/kiali/issues/3552
