### PR TITLE
Better support for custom controllers

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -926,7 +926,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		defer wg.Done()
 		// Check if workloadType is passed
 		// Unknown workload type will fetch ReplicaSet list
-		if workloadType != "" && workloadType != kubernetes.ReplicaSetType  && knownWorkloadType {
+		if workloadType != "" && workloadType != kubernetes.ReplicaSetType && knownWorkloadType {
 			return
 		}
 		var err error

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -56,7 +56,7 @@ func FilterPodsForController(controllerName string, controllerType string, allPo
 	var pods []core_v1.Pod
 	for _, pod := range allPods {
 		for _, ref := range pod.OwnerReferences {
-			if ref.Controller != nil && *ref.Controller && strings.HasPrefix(ref.Name, controllerName)&& ref.Kind == controllerType {
+			if ref.Controller != nil && *ref.Controller && strings.HasPrefix(ref.Name, controllerName) && ref.Kind == controllerType {
 				pods = append(pods, pod)
 				break
 			}

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -56,7 +56,7 @@ func FilterPodsForController(controllerName string, controllerType string, allPo
 	var pods []core_v1.Pod
 	for _, pod := range allPods {
 		for _, ref := range pod.OwnerReferences {
-			if ref.Controller != nil && *ref.Controller && ref.Name == controllerName && ref.Kind == controllerType {
+			if ref.Controller != nil && *ref.Controller && strings.HasPrefix(ref.Name, controllerName)&& ref.Kind == controllerType {
 				pods = append(pods, pod)
 				break
 			}

--- a/models/workload.go
+++ b/models/workload.go
@@ -179,6 +179,20 @@ func (workload *Workload) ParseReplicaSet(r *apps_v1.ReplicaSet) {
 	workload.AvailableReplicas = r.Status.AvailableReplicas
 }
 
+func (workload *Workload) ParseReplicaSetParent(r *apps_v1.ReplicaSet, workloadName string, workloadType string) {
+	// Some properties are taken from the ReplicaSet
+	workload.parseObjectMeta(&r.ObjectMeta, &r.Spec.Template.ObjectMeta)
+	// But name and type are coming from the parent
+	// Custom properties from parent controller are not processed by Kiali
+	workload.Type = workloadType
+	workload.Name = workloadName
+	if r.Spec.Replicas != nil {
+		workload.DesiredReplicas = *r.Spec.Replicas
+	}
+	workload.CurrentReplicas = r.Status.Replicas
+	workload.AvailableReplicas = r.Status.AvailableReplicas
+}
+
 func (workload *Workload) ParseReplicationController(r *core_v1.ReplicationController) {
 	workload.Type = "ReplicationController"
 	workload.parseObjectMeta(&r.ObjectMeta, &r.Spec.Template.ObjectMeta)
@@ -289,8 +303,8 @@ func (workload *Workload) ParsePods(controllerName string, controllerType string
 	workload.AvailableReplicas = podAvailableReplicas
 	// We fetch one pod as template for labels
 	// There could be corner cases not correct, then we should support more controllers
+	workload.Labels = map[string]string{}
 	if len(pods) > 0 {
-		workload.Labels = map[string]string{}
 		if pods[0].Labels != nil {
 			workload.Labels = pods[0].Labels
 		}


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3532

Some frameworks create custom workload controllers replacing standard "Deployment" or kubernetes controller with a custom one.

This fix improves the support for those cornercases.

It assumes that, as it happens with a Deployment, a custom controller define a child controller as a ReplicaSet and try to use it for basic workload information: pod and service status.

Most information is ok but custom properties of the controller are not supported as we would need to extend the native controllers that Kiali can handle beyond the standard ones.

For QE, how to test:
- Verify no regressions on existing workloads logic.
- Install a third party framework with custom controllers, i.e. https://argoproj.github.io/argo-rollouts/#quick-start
- Deploy an example with custom controllers i.e. https://github.com/argoproj/argo-rollouts/blob/master/examples/rollout-analysis-step.yaml

Verify that Kiali has basic support for custom controllers as workloads without errors:

Workload List
![image](https://user-images.githubusercontent.com/1662329/104745443-65af8780-574e-11eb-9b81-78edcd376039.png)

Workload Detail
![image](https://user-images.githubusercontent.com/1662329/104745497-76f89400-574e-11eb-975c-f18e1dd81d0a.png)
