### PR TITLE
Fix ServiceEntry model spec workloadSelector key

### DIFF
--- a/models/service_entry.go
+++ b/models/service_entry.go
@@ -36,7 +36,7 @@ func (se *ServiceEntry) Parse(serviceEntry kubernetes.IstioObject) {
 	se.Spec.Location = serviceEntry.GetSpec()["location"]
 	se.Spec.Resolution = serviceEntry.GetSpec()["resolution"]
 	se.Spec.Endpoints = serviceEntry.GetSpec()["endpoints"]
-	se.Spec.WorkloadSelector = serviceEntry.GetSpec()["serviceEntry"]
+	se.Spec.WorkloadSelector = serviceEntry.GetSpec()["workloadSelector"]
 	se.Spec.ExportTo = serviceEntry.GetSpec()["exportTo"]
 	se.Spec.SubjectAltNames = serviceEntry.GetSpec()["subjectAltNames"]
 }


### PR DESCRIPTION
** Describe the change **

Fixes the key in the ServiceEntry model spec for the workloadSelector, ensuring this displays correctly in the kiali UI.

** Issue reference **

https://github.com/kiali/kiali/issues/3587

** Backwards incompatible? **

Yes
