### PR TITLE
Fix some things to work with the new header auth strategy

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -3,14 +3,14 @@ package business
 import (
 	"sync"
 
+	"k8s.io/client-go/tools/clientcmd/api"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/jaeger"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus"
-
-	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 // Layer is a container for fast access to inner services

--- a/hack/run-molecule-tests.sh
+++ b/hack/run-molecule-tests.sh
@@ -118,7 +118,7 @@ ALL_TESTS=${ALL_TESTS:-$(cd "${KIALI_SRC_HOME}/operator/molecule"; ls -d *-test)
 
 # Put the names of any tests in here if you do not want to run them (space separated).
 if [ "${CLUSTER_TYPE}" == "openshift" ]; then
-  SKIP_TESTS="${SKIP_TESTS:-openid-test}"
+  SKIP_TESTS="${SKIP_TESTS:-header-auth-test openid-test}"
 elif [ "${CLUSTER_TYPE}" == "minikube" ]; then
   SKIP_TESTS="${SKIP_TESTS:-os-console-links-test}"
 fi
@@ -156,6 +156,7 @@ echo TEST_LOGS_DIR="$TEST_LOGS_DIR"
 echo TEST_CLIENT_EXE="$TEST_CLIENT_EXE"
 echo COLOR="$COLOR"
 echo MINIKUBE_PROFILE="$MINIKUBE_PROFILE"
+echo HELM_CHARTS_REPO="$HELM_CHARTS_REPO"
 echo "=============================="
 
 # Make sure the cluster is accessible
@@ -202,8 +203,8 @@ prepare_test() {
       fi
       ;;
 
-    # if running the non-OpenShift openid-test, create a rolebinding so the test can log in
-    openid-test)
+    # if running the non-OpenShift openid-test or header-auth-test, create a rolebinding so the test can log in
+    header-auth-test|openid-test)
       if [ "${CLUSTER_TYPE}" == "minikube" ]; then
         ${TEST_CLIENT_EXE:-kubectl} create rolebinding openid-rolebinding-istio-system --clusterrole=kiali --user=admin@example.com --namespace=istio-system >> ${TEST_LOGS_DIR}/${1}.log 2>&1
       fi
@@ -224,7 +225,7 @@ unprepare_test() {
       ;;
 
     # remove the rolebinding that was created
-    openid-test)
+    header-auth-test|openid-test)
       if [ "${CLUSTER_TYPE}" == "minikube" ]; then
         ${TEST_CLIENT_EXE:-kubectl} delete rolebinding openid-rolebinding-istio-system --namespace=istio-system >> ${TEST_LOGS_DIR}/${1}.log 2>&1
       fi

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -5,12 +5,11 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/models"
-
-	"github.com/gorilla/mux"
 )
 
 // CustomDashboard is the API handler to fetch runtime metrics to be displayed, related to a single app

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -4,11 +4,12 @@ import (
 	"errors"
 	"net/http"
 
+	"k8s.io/client-go/tools/clientcmd/api"
+
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
-	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 type promClientSupplier func() (*prometheus.Client, error)

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -2,9 +2,8 @@ package kubernetes
 
 import (
 	"bytes"
-	"fmt"
-
 	goerrors "errors"
+	"fmt"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"


### PR DESCRIPTION
Update the run-molecule-tests script so it prepares header-auth correctly.
Also change the k8s-minikube.sh hack script to only create that special role when requested.
Cleans up some import ordering, too.