### PR TITLE
Add jaeger measurements, fix handler metrics

### DIFF
--- a/business/jaeger.go
+++ b/business/jaeger.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kiali/kiali/jaeger"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 type JaegerLoader = func() (jaeger.ClientInterface, error)
@@ -57,10 +58,18 @@ func mergeResponses(dest *jaeger.JaegerResponse, src *jaeger.JaegerResponse) {
 }
 
 func (in *JaegerService) GetAppSpans(ns, app string, query models.TracingQuery) ([]jaeger.JaegerSpan, error) {
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "Jaeger", "GetAppSpans")
+	defer promtimer.ObserveNow(&err)
+
 	return in.getFilteredSpans(ns, app, query, nil /*no post-filtering for apps*/)
 }
 
 func (in *JaegerService) GetServiceSpans(ns, service string, query models.TracingQuery) ([]jaeger.JaegerSpan, error) {
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "Jaeger", "GetServiceSpans")
+	defer promtimer.ObserveNow(&err)
+
 	app, err := in.businessLayer.Svc.GetServiceAppName(ns, service)
 	if err != nil {
 		return nil, err
@@ -83,6 +92,10 @@ func operationSpanFilter(ns, service string) SpanFilter {
 }
 
 func (in *JaegerService) GetWorkloadSpans(ns, workload string, query models.TracingQuery) ([]jaeger.JaegerSpan, error) {
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "Jaeger", "GetWorkloadSpans")
+	defer promtimer.ObserveNow(&err)
+
 	app, err := in.businessLayer.Workload.GetWorkloadAppName(ns, workload)
 	if err != nil {
 		return nil, err
@@ -98,6 +111,10 @@ func wkdSpanFilter(ns, workload string) SpanFilter {
 }
 
 func (in *JaegerService) GetAppTraces(ns, app string, query models.TracingQuery) (*jaeger.JaegerResponse, error) {
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "Jaeger", "GetAppTraces")
+	defer promtimer.ObserveNow(&err)
+
 	client, err := in.client()
 	if err != nil {
 		return nil, err
@@ -122,6 +139,10 @@ func (in *JaegerService) GetAppTraces(ns, app string, query models.TracingQuery)
 }
 
 func (in *JaegerService) GetServiceTraces(ns, service string, query models.TracingQuery) (*jaeger.JaegerResponse, error) {
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "Jaeger", "GetServiceTraces")
+	defer promtimer.ObserveNow(&err)
+
 	app, err := in.businessLayer.Svc.GetServiceAppName(ns, service)
 	if err != nil {
 		return nil, err
@@ -153,6 +174,10 @@ func (in *JaegerService) GetServiceTraces(ns, service string, query models.Traci
 }
 
 func (in *JaegerService) GetWorkloadTraces(ns, workload string, query models.TracingQuery) (*jaeger.JaegerResponse, error) {
+	var err error
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "Jaeger", "GetWorkloadTraces")
+	defer promtimer.ObserveNow(&err)
+
 	app, err := in.businessLayer.Workload.GetWorkloadAppName(ns, workload)
 	if err != nil {
 		return nil, err
@@ -228,6 +253,9 @@ func (in *JaegerService) getAppTracesSlicedInterval(ns, app string, query models
 }
 
 func (in *JaegerService) GetJaegerTraceDetail(traceID string) (trace *jaeger.JaegerSingleTrace, err error) {
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "Jaeger", "GetJaegerTraceDetail")
+	defer promtimer.ObserveNow(&err)
+
 	client, err := in.client()
 	if err != nil {
 		return nil, err
@@ -236,6 +264,9 @@ func (in *JaegerService) GetJaegerTraceDetail(traceID string) (trace *jaeger.Jae
 }
 
 func (in *JaegerService) GetErrorTraces(ns, app string, duration time.Duration) (errorTraces int, err error) {
+	promtimer := internalmetrics.GetGoFunctionMetric("business", "Jaeger", "GetErrorTraces")
+	defer promtimer.ObserveNow(&err)
+
 	client, err := in.client()
 	if err != nil {
 		return 0, err

--- a/routing/router.go
+++ b/routing/router.go
@@ -49,10 +49,11 @@ func NewRouter() *mux.Router {
 	apiRoutes := NewRoutes()
 	authenticationHandler, _ := handlers.NewAuthenticationHandler()
 	for _, route := range apiRoutes.Routes {
-		var handlerFunction http.Handler = authenticationHandler.HandleUnauthenticated(route.HandlerFunc)
-		handlerFunction = metricHandler(handlerFunction, route)
+		handlerFunction := metricHandler(route.HandlerFunc, route)
 		if route.Authenticated {
-			handlerFunction = authenticationHandler.Handle(route.HandlerFunc)
+			handlerFunction = authenticationHandler.Handle(handlerFunction)
+		} else {
+			handlerFunction = authenticationHandler.HandleUnauthenticated(handlerFunction)
 		}
 		appRouter.
 			Methods(route.Method).


### PR DESCRIPTION
- There was no internal metrics for jaeger, adding some
- There was a bug in handler metrics, only the ones from unauthenticated
  routes were created. Fix that.

This is a prequel of https://github.com/kiali/kiali/issues/3514 , to measure performance changes before/after that task