### PR TITLE
Rollback a few changes to NewClientFromConfig

### DIFF
--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -9,7 +9,6 @@ import (
 	kube "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd/api"
 
 	kialiConfig "github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -101,7 +100,7 @@ func NewKialiCache() (KialiCache, error) {
 		BearerToken:     cacheToken,
 		Burst:           config.Burst,
 	}
-	istioClient, err := kubernetes.NewClientFromConfig(&istioConfig, &api.AuthInfo{Token: cacheToken})
+	istioClient, err := kubernetes.NewClientFromConfig(&istioConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -101,7 +101,7 @@ type ClientInterface interface {
 // It hides the way it queries each API
 type K8SClient struct {
 	ClientInterface
-	authInfo           *api.AuthInfo
+	token              string
 	k8s                *kube.Clientset
 	istioNetworkingApi *rest.RESTClient
 	istioSecurityApi   *rest.RESTClient
@@ -146,12 +146,7 @@ func (client *K8SClient) GetIstioSecurityApi() *rest.RESTClient {
 
 // GetToken returns the BearerToken used from the config
 func (client *K8SClient) GetToken() string {
-	return client.authInfo.Token
-}
-
-// GetAuthInfo returns the AuthInfo struct for the client
-func (client *K8SClient) GetAuthInfo() *api.AuthInfo {
-	return client.authInfo
+	return client.token
 }
 
 // Point the k8s client to a remote cluster's API server
@@ -226,15 +221,9 @@ func ConfigClient() (*rest.Config, error) {
 // It hides the access to Kubernetes/Openshift credentials.
 // It hides the low level use of the API of Kubernetes and Istio, it should be considered as an implementation detail.
 // It returns an error on any problem.
-func NewClientFromConfig(config *rest.Config, authInfo *api.AuthInfo) (*K8SClient, error) {
+func NewClientFromConfig(config *rest.Config) (*K8SClient, error) {
 	client := K8SClient{
-		authInfo: authInfo,
-	}
-
-	if authInfo.Impersonate != "" {
-		config.Impersonate.UserName = authInfo.Impersonate
-		config.Impersonate.Groups = authInfo.ImpersonateGroups
-		config.Impersonate.Extra = authInfo.ImpersonateUserExtra
+		token: config.BearerToken,
 	}
 
 	log.Debugf("Rest perf config QPS: %f Burst: %d", config.QPS, config.Burst)

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -127,7 +127,14 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo) (ClientInterface, err
 		}
 	}
 
-	return NewClientFromConfig(&config, authInfo)
+	// Impersonation is valid only for header authentication strategy
+	if cfg.Auth.Strategy == kialiConfig.AuthStrategyHeader && authInfo.Impersonate != "" {
+		config.Impersonate.UserName = authInfo.Impersonate
+		config.Impersonate.Groups = authInfo.ImpersonateGroups
+		config.Impersonate.Extra = authInfo.ImpersonateUserExtra
+	}
+
+	return NewClientFromConfig(&config)
 }
 
 // GetClient returns a client for the specified token. Creating one if necessary.


### PR DESCRIPTION
These changes are, apparently, unneeded. Also, it's a error prone, because there were two tokens involved when creating the client. There was one in the `config` parameter, and another one in `authInfo` parameter. Only the token in `config` was being used. The `authInfo` is used only to pass impersonation data, but this data shouldn't always be honored because it's only valid when using the `header` strategy.

So, I think it's better to rollback these changes and pass the impersonation data already embedded in the `config` parameter when it's strictly needed. The `config` parameter already has impersonation fields, so the extra `authInfo` is, apaprently, redundant.

Related kiali/kiali#3207
