### PR TITLE
Check if Istio has multi-cluster enabled

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/rest"
 
 	"github.com/kiali/kiali/config"
@@ -43,6 +44,12 @@ type Cluster struct {
 	SecretName string `json:"secretName"`
 }
 
+type meshIdConfig struct {
+	DefaultConfig struct {
+		MeshId string `yaml:"meshId,omitempty"`
+	} `yaml:"defaultConfig,omitempty"`
+}
+
 // NewMeshService initializes a new MeshService structure with the given k8s client and
 // newRemoteClientFunc arguments (see the MeshService struct for details). The newRemoteClientFunc
 // can be passed a nil value and a default function will be used.
@@ -78,6 +85,36 @@ func (in *MeshService) GetClusters() (clusters []Cluster, errVal error) {
 		clusters = remoteClusters
 	} else {
 		clusters = append(remoteClusters, *myCluster)
+	}
+
+	return
+}
+
+func (in *MeshService) IsMultiClusterEnabled() (isEnabled bool, returnErr error) {
+	isEnabled = false
+	cfg := config.Get()
+
+	istioConfig, err := in.k8s.GetConfigMap(cfg.IstioNamespace, config.IstioConfigMapName)
+	if err != nil {
+		returnErr = err
+		return
+	}
+
+	meshConfigYaml, ok := istioConfig.Data["mesh"]
+	if !ok {
+		log.Warning("Istio config not found when resolving if multi-cluster is enabled. Falling back to multi-cluster OFF.")
+		return
+	}
+
+	meshConfig := meshIdConfig{}
+	err = yaml.Unmarshal([]byte(meshConfigYaml), &meshConfig)
+	if err != nil {
+		returnErr = err
+		return
+	}
+
+	if len(meshConfig.DefaultConfig.MeshId) > 0 {
+		isEnabled = true
 	}
 
 	return

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -90,7 +90,7 @@ func (in *MeshService) GetClusters() (clusters []Cluster, errVal error) {
 	return
 }
 
-func (in *MeshService) IsMultiClusterEnabled() (isEnabled bool, returnErr error) {
+func (in *MeshService) IsMeshConfigured() (isEnabled bool, returnErr error) {
 	isEnabled = false
 	cfg := config.Get()
 
@@ -102,7 +102,7 @@ func (in *MeshService) IsMultiClusterEnabled() (isEnabled bool, returnErr error)
 
 	meshConfigYaml, ok := istioConfig.Data["mesh"]
 	if !ok {
-		log.Warning("Istio config not found when resolving if multi-cluster is enabled. Falling back to multi-cluster OFF.")
+		log.Warning("Istio config not found when resolving if mesh-id is set. Falling back to mesh-id not configured.")
 		return
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ const (
 )
 
 const (
+	IstioConfigMapName          = "istio"
 	IstioMultiClusterHostSuffix = "global"
 	OidcClientSecretFile        = "/kiali-secret/oidc-secret"
 )

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -101,16 +101,21 @@ func Config(w http.ResponseWriter, r *http.Request) {
 	if getTokenErr == nil {
 		layer, getLayerErr := business.Get(&api.AuthInfo{Token: token})
 		if getLayerErr == nil {
-			cluster, resolveClusterErr := layer.Mesh.ResolveKialiControlPlaneCluster()
-			if cluster != nil {
-				publicConfig.ClusterInfo = ClusterInfo{
-					Name:    cluster.Name,
-					Network: cluster.Network,
+			isMultiClusterEnabled, mcErr := layer.Mesh.IsMultiClusterEnabled()
+			if isMultiClusterEnabled {
+				cluster, resolveClusterErr := layer.Mesh.ResolveKialiControlPlaneCluster()
+				if cluster != nil {
+					publicConfig.ClusterInfo = ClusterInfo{
+						Name:    cluster.Name,
+						Network: cluster.Network,
+					}
+				} else if resolveClusterErr != nil {
+					log.Warningf("Failure while resolving cluster info: %s", resolveClusterErr.Error())
+				} else {
+					log.Info("Cluster ID couldn't be resolved. Most likely, no Cluster ID is set in the service mesh control plane configuration.")
 				}
-			} else if resolveClusterErr != nil {
-				log.Warningf("Failure while resolving cluster info: %s", resolveClusterErr.Error())
-			} else {
-				log.Info("Cluster ID couldn't be resolved. Most likely, no Cluster ID is set in the service mesh control plane configuration.")
+			} else if mcErr != nil {
+				log.Warningf("Failure when checking if multi-cluster is enabled: %s", mcErr.Error())
 			}
 		} else {
 			log.Warningf("Failed to create business layer when resolving cluster info: %s", getLayerErr.Error())

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -101,8 +101,8 @@ func Config(w http.ResponseWriter, r *http.Request) {
 	if getTokenErr == nil {
 		layer, getLayerErr := business.Get(&api.AuthInfo{Token: token})
 		if getLayerErr == nil {
-			isMultiClusterEnabled, mcErr := layer.Mesh.IsMultiClusterEnabled()
-			if isMultiClusterEnabled {
+			isMeshIdSet, mcErr := layer.Mesh.IsMeshConfigured()
+			if isMeshIdSet {
 				cluster, resolveClusterErr := layer.Mesh.ResolveKialiControlPlaneCluster()
 				if cluster != nil {
 					publicConfig.ClusterInfo = ClusterInfo{
@@ -115,7 +115,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 					log.Info("Cluster ID couldn't be resolved. Most likely, no Cluster ID is set in the service mesh control plane configuration.")
 				}
 			} else if mcErr != nil {
-				log.Warningf("Failure when checking if multi-cluster is enabled: %s", mcErr.Error())
+				log.Warningf("Failure when checking if mesh-id is configured: %s", mcErr.Error())
 			}
 		} else {
 			log.Warningf("Failed to create business layer when resolving cluster info: %s", getLayerErr.Error())


### PR DESCRIPTION
Adding a function to check if multi-cluster is enabled in Istio. The config endpoint uses this new funct to return cluster data only if multi-cluster is enabled. This is to allow the UI to conditionally hide or show multi-cluster features.

Related to #3592