### PR TITLE
Fix Idle Node detection for multi-cluster

### DIFF
--- a/graph/telemetry/istio/appender/idle_node_test.go
+++ b/graph/telemetry/istio/appender/idle_node_test.go
@@ -26,7 +26,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	services := mockServices(a)
 	workloads := mockWorkloads(a)
 
-	a.addIdleNodes(trafficMap, "testNamespace", services, workloads)
+	a.addIdleNodes(trafficMap, graph.Unknown, "testNamespace", services, workloads)
 	assert.Equal(7, len(trafficMap))
 
 	id, _ := graph.Id(graph.Unknown, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
@@ -98,7 +98,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	services := mockServices(a)
 	workloads := mockWorkloads(a)
 
-	a.addIdleNodes(trafficMap, "testNamespace", services, workloads)
+	a.addIdleNodes(trafficMap, graph.Unknown, "testNamespace", services, workloads)
 
 	assert.Equal(5, len(trafficMap))
 	id, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
@@ -155,7 +155,7 @@ func TestVersionWithNoTrafficScenario(t *testing.T) {
 	services := mockServices(a)
 	workloads := mockWorkloads(a)
 
-	a.addIdleNodes(trafficMap, "testNamespace", services, workloads)
+	a.addIdleNodes(trafficMap, graph.Unknown, "testNamespace", services, workloads)
 
 	assert.Equal(5, len(trafficMap))
 	id, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)


### PR DESCRIPTION
When checking for Idle Nodes we need to incorporate the proper clusterName into the ID of the candidate node.

Fixes https://github.com/kiali/kiali/issues/3611

For QE Test:
With master:
1) Install using hack/istio/install-istio-via-istioctl.sh or otherwise ensure you configure with a meshId and clusterName
2) Generate bookinfo graph with traffic
3) Enable Display Idle Nodes

See unexpected Idle Nodes appear

Repeat with PR, no Idle Nodes should appear

