### PR TITLE
make error messages unique

### DIFF
--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -240,7 +240,7 @@ func requestWithTimeout(method string, url string, auth *string, timeout time.Du
 	request, err := http.NewRequest(method, strings.Join([]string{serverPrefix, url}, ""), nil)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to get api endpoint %s for oauth consumption, error: %s", url, err)
+		return nil, fmt.Errorf("Failed to create request for api endpoint [%s] for oauth consumption, error: %s", url, err)
 	}
 
 	if auth != nil {
@@ -250,7 +250,7 @@ func requestWithTimeout(method string, url string, auth *string, timeout time.Du
 	response, err := client.Do(request)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to get api endpoint %s for oauth consumption, error: %s", url, err)
+		return nil, fmt.Errorf("Failed to get response for api endpoint [%s] for oauth consumption, error: %s", url, err)
 	}
 
 	defer response.Body.Close()
@@ -258,11 +258,11 @@ func requestWithTimeout(method string, url string, auth *string, timeout time.Du
 	body, err := ioutil.ReadAll(response.Body)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to get api endpoint %s for oauth consumption, error: %s", url, err)
+		return nil, fmt.Errorf("Failed to read response body for api endpoint [%s] for oauth consumption, error: %s", url, err)
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get api endpoint %s for oauth consumption, error: %s", url, string(body))
+		return nil, fmt.Errorf("Failed to get OK status from api endpoint [%s] for oauth consumption, error: %s", url, string(body))
 	}
 
 	return body, nil


### PR DESCRIPTION
This one function has *four* identical error messages that could get logged. Because all four messages are identical, when you see the log message in the pod logs, it isn't immediately easy to figure out where the error was happening.

This PR makes the messages unique so you know what failed immediately when you read the message.