### PR TITLE
[v1.29] Use the configured name for the Istio ConfigMap - do not use the constant

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -94,7 +94,7 @@ func (in *MeshService) IsMeshConfigured() (isEnabled bool, returnErr error) {
 	isEnabled = false
 	cfg := config.Get()
 
-	istioConfig, err := in.k8s.GetConfigMap(cfg.IstioNamespace, config.IstioConfigMapName)
+	istioConfig, err := in.k8s.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	if err != nil {
 		returnErr = err
 		return

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,6 @@ const (
 )
 
 const (
-	IstioConfigMapName          = "istio"
 	IstioMultiClusterHostSuffix = "global"
 	OidcClientSecretFile        = "/kiali-secret/oidc-secret"
 )


### PR DESCRIPTION
This is a backport of https://github.com/kiali/kiali/pull/3636