### PR TITLE
Fix issue with aggregate node detail graphs

### DIFF
--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -683,7 +683,7 @@ func buildAggregateNodeTrafficMap(namespace string, n graph.Node, o graph.Teleme
 	if n.Service != "" {
 		serviceFragment = fmt.Sprintf(`,destination_service_name="%s"`, n.Service)
 	}
-	groupBy := "source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags"
+	groupBy := "source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags"
 	httpQuery := fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_service_namespace="%s",%s="%s"%s}[%vs])) by (%s) > 0`,
 		"istio_requests_total",
 		namespace,


### PR DESCRIPTION
This fixes a regression in Kiali v1.29

Fixes https://github.com/kiali/kiali/issues/3644

To test:
1) using istio 1.8, deploy travel demo via hack script, using the enable-operation-metrics option
    - note, you may need to have istio configured for multi-cluster, I'm not sure.

`> hack/istio/install-travel-agency-demo.sh -eo true`

2) in the UI select the travel namespaces and also enable the Show Operation Nodes Display option

3) double-click on an operation node to drill into the node detail graph

pre-fix: the operation node will be missing from the detail graph
post-fix: the operation node will appear as expected

