### PR TITLE
Proxy status: fetching status only from running istiod pods + always returning status if present

### DIFF
--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -214,26 +215,63 @@ func (in *K8SClient) GetProxyStatus() ([]*ProxyStatus, error) {
 		return nil, errors.New("unable to find any Pilot instances")
 	}
 
+	wg := sync.WaitGroup{}
+	wg.Add(len(istiods))
+	errChan := make(chan error, len(istiods))
+	syncChan := make(chan map[string][]byte, len(istiods))
+
+	healthyIstiods := 0
 	result := map[string][]byte{}
 	for _, istiod := range istiods {
-		res, err := in.k8s.CoreV1().RESTClient().Get().
-			Namespace(istiod.Namespace).
-			Resource("pods").
-			SubResource("proxy").
-			Name(istiod.Name).
-			Suffix("/debug/syncz").
-			DoRaw(in.ctx)
-
-		if err != nil {
-			return nil, err
+		if istiod.Status.Phase != "Running" {
+			wg.Add(-1)
+			continue
 		}
+		healthyIstiods = healthyIstiods + 1
 
-		if len(res) > 0 {
-			result[istiod.Name] = res
+		go func() {
+			defer wg.Done()
+			res, err := in.k8s.CoreV1().RESTClient().Get().
+				Namespace(istiod.Namespace).
+				Resource("pods").
+				SubResource("proxy").
+				Name(istiod.Name).
+				Suffix("/debug/syncz").
+				DoRaw(in.ctx)
+
+			if err != nil {
+				errChan <- errors.New(fmt.Sprintf("Error fetching the proxy-status from %s pod: %s", istiod.Name, err.Error()))
+			} else {
+				syncChan <- map[string][]byte{ istiod.Name: res }
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errChan)
+	close(syncChan)
+
+	errs := ""
+	for err := range errChan {
+		if errs != "" {
+			errs = errs + "; "
+		}
+		errs = errs + err.Error()
+	}
+	errs = "Error fetching the proxy-status in the following pods: " + errs
+
+	for status := range syncChan {
+		for pilot, sync := range status {
+			result[pilot] = sync
 		}
 	}
 
-	return getStatus(result)
+	// If there is one sync, we consider it as valid
+	if len(result) > 0 {
+		return getStatus(result)
+	}
+
+	return nil, errors.New(errs)
 }
 
 func getStatus(statuses map[string][]byte) ([]*ProxyStatus, error) {


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/3605

1. The proxy-status is only fetch from pods in the `Running` state.
2. Kiali returns the proxy-status even if there is one non-responding `istiod` (following the `istioctl` approach). The proxy-status then might be partial because each `istiod` pod controls different set of envoys (e.g. `istiod1` controls `details` and `productpage`, `istiod2` controls `ratings` and `reviews`). If this scenario happens, then the Istio Component Status modal in the mast-head will be in red. Hence, it'd mean that the mesh is unstable and the admin/op needs to act.
3. New logs has been added to better troubleshoot this scenarios.