### PR TITLE
Performance / custom dashboards: new configs

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -569,14 +569,19 @@ func (in *DashboardsService) GetCustomDashboardRefs(namespace, app, version stri
 
 	if len(runtimes) == 0 {
 		cfg := config.Get()
-		filters := make(map[string]string)
-		if app != "" {
-			filters[cfg.IstioLabels.AppLabelName] = app
+		discoveryEnabled := cfg.ExternalServices.CustomDashboards.DiscoveryEnabled
+		if discoveryEnabled == config.DashboardsDiscoveryEnabled ||
+			(discoveryEnabled == config.DashboardsDiscoveryAuto &&
+				len(pods) <= cfg.ExternalServices.CustomDashboards.DiscoveryAutoThreshold) {
+			filters := make(map[string]string)
+			if app != "" {
+				filters[cfg.IstioLabels.AppLabelName] = app
+			}
+			if version != "" {
+				filters[cfg.IstioLabels.VersionLabelName] = version
+			}
+			runtimes = in.discoverDashboards(namespace, filters)
 		}
-		if version != "" {
-			filters[cfg.IstioLabels.VersionLabelName] = version
-		}
-		runtimes = in.discoverDashboards(namespace, filters)
 	}
 	return runtimes
 }

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,12 @@ const (
 	OidcClientSecretFile        = "/kiali-secret/oidc-secret"
 )
 
+const (
+	DashboardsDiscoveryEnabled  = "true"
+	DashboardsDiscoveryDisabled = "false"
+	DashboardsDiscoveryAuto     = "auto"
+)
+
 // Global configuration for the application.
 var configuration Config
 var rwMutex sync.RWMutex
@@ -112,10 +118,12 @@ type PrometheusConfig struct {
 
 // CustomDashboardsConfig describes configuration specific to Custom Dashboards
 type CustomDashboardsConfig struct {
-	Enabled         bool             `yaml:"enabled,omitempty"`
-	IsCoreComponent bool             `yaml:"is_core_component,omitempty"`
-	NamespaceLabel  string           `yaml:"namespace_label,omitempty"`
-	Prometheus      PrometheusConfig `yaml:"prometheus,omitempty"`
+	DiscoveryEnabled       string           `yaml:"discovery_enabled,omitempty"`
+	DiscoveryAutoThreshold int              `yaml:"discovery_auto_threshold,omitempty"`
+	Enabled                bool             `yaml:"enabled,omitempty"`
+	IsCoreComponent        bool             `yaml:"is_core_component,omitempty"`
+	NamespaceLabel         string           `yaml:"namespace_label,omitempty"`
+	Prometheus             PrometheusConfig `yaml:"prometheus,omitempty"`
 }
 
 // GrafanaConfig describes configuration used for Grafana links
@@ -388,8 +396,10 @@ func NewConfig() (c *Config) {
 		},
 		ExternalServices: ExternalServices{
 			CustomDashboards: CustomDashboardsConfig{
-				Enabled:        true,
-				NamespaceLabel: "kubernetes_namespace",
+				DiscoveryEnabled:       DashboardsDiscoveryAuto,
+				DiscoveryAutoThreshold: 10,
+				Enabled:                true,
+				NamespaceLabel:         "kubernetes_namespace",
 			},
 			Grafana: GrafanaConfig{
 				Auth: Auth{


### PR DESCRIPTION
- discovery_enabled (true/false/auto) to switch discovery mode
- discovery_auto_threshold: pods threshold above which discovery is
  skipped in auto mode

Part of https://github.com/kiali/kiali/issues/3660

Operator PR: https://github.com/kiali/kiali-operator/pull/243