### PR TITLE
Prevent Proxy Status endpoint to hang + Add unreachable istiod into Istio Component Statuses

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -271,6 +271,10 @@ func (iss *IstioStatusService) getIstiodReachingCheck() (IstioComponentStatus, e
 	}
 
 	for _, istiod := range istiods {
+		// Using the proxy method to make sure that K8s API has access to the Istio Control Plane namespace.
+		// By proxying one Istiod, we ensure that the following connection is allowed:
+		// Kiali -> K8s API (proxy) -> istiod
+		// This scenario is no obvious for private clusters (like GKE private cluster)
 		_, err := iss.k8s.GetPodProxy(istiod.Namespace, istiod.Name, "/ready")
 		if err != nil {
 			ics.merge([]ComponentStatus{

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -65,6 +65,7 @@ type K8SClientInterface interface {
 	GetNamespaces(labelSelector string) ([]core_v1.Namespace, error)
 	GetPod(namespace, name string) (*core_v1.Pod, error)
 	GetPodLogs(namespace, name string, opts *core_v1.PodLogOptions) (*PodLogs, error)
+	GetPodProxy(namespace, name, path string) ([]byte, error)
 	GetPods(namespace, labelSelector string) ([]core_v1.Pod, error)
 	GetReplicationControllers(namespace string) ([]core_v1.ReplicationController, error)
 	GetReplicaSets(namespace string) ([]apps_v1.ReplicaSet, error)

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -211,35 +211,36 @@ func (in *K8SClient) GetProxyStatus() ([]*ProxyStatus, error) {
 		return nil, err
 	}
 
-	if len(istiods) == 0 {
-		return nil, errors.New("unable to find any Pilot instances")
+	healthyIstiods := make([]*core_v1.Pod, 0, len(istiods))
+	for _, istiod := range istiods {
+		if istiod.Status.Phase == "Running" {
+			healthyIstiods = append(healthyIstiods, &istiod)
+		}
+	}
+
+	if len(healthyIstiods) == 0 {
+		return nil, errors.New("unable to find any healthy Pilot instance")
+	}
+
+	// Check if the kube-api has proxy access to pods in the istio-system
+	// https://github.com/kiali/kiali/issues/3494#issuecomment-772486224
+	_, err = in.GetPodProxyUrl(istiods[0].Name, c.IstioNamespace, "/ready", 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("unable to proxy Istiod pods. " +
+			"Make sure your Kubernetes API server has access to the Istio control plane through 8080 port")
 	}
 
 	wg := sync.WaitGroup{}
-	wg.Add(len(istiods))
-	errChan := make(chan error, len(istiods))
-	syncChan := make(chan map[string][]byte, len(istiods))
+	wg.Add(len(healthyIstiods))
+	errChan := make(chan error, len(healthyIstiods))
+	syncChan := make(chan map[string][]byte, len(healthyIstiods))
 
-	healthyIstiods := 0
 	result := map[string][]byte{}
-	for _, istiod := range istiods {
-		if istiod.Status.Phase != "Running" {
-			wg.Add(-1)
-			continue
-		}
-		healthyIstiods = healthyIstiods + 1
-
+	for _, istiod := range healthyIstiods {
 		go func(name, namespace string) {
 			defer wg.Done()
-			res, err := in.k8s.CoreV1().Pods(namespace).
-				ProxyGet(
-					"http",
-					name,
-					"8080",
-					"/debug/syncz",
-					map[string]string{}).
-				DoRaw(in.ctx)
 
+			res, err := in.GetPodProxyUrl(name, namespace, "/debug/syncz", 10*time.Second)
 			if err != nil {
 				errChan <- fmt.Errorf("%s: %s", name, err.Error())
 			} else {
@@ -273,6 +274,17 @@ func (in *K8SClient) GetProxyStatus() ([]*ProxyStatus, error) {
 	}
 
 	return nil, errors.New(errs)
+}
+
+func (in *K8SClient) GetPodProxyUrl(name, namespace, path string, timeout time.Duration) ([]byte, error) {
+	return in.k8s.CoreV1().RESTClient().Get().
+		Timeout(timeout).
+		Namespace(namespace).
+		Resource("pods").
+		SubResource("proxy").
+		Name(name).
+		Suffix(path).
+		DoRaw(in.ctx)
 }
 
 func getStatus(statuses map[string][]byte) ([]*ProxyStatus, error) {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	goerrors "errors"
 	"fmt"
+	"time"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"
@@ -287,6 +288,17 @@ func (in *K8SClient) GetPodLogs(namespace, name string, opts *core_v1.PodLogOpti
 	}
 
 	return &PodLogs{Logs: buf.String()}, nil
+}
+
+func (in *K8SClient) GetPodProxy(namespace, name, path string) ([]byte, error) {
+	return in.k8s.CoreV1().RESTClient().Get().
+		Timeout(10 * time.Second).
+		Namespace(namespace).
+		Resource("pods").
+		SubResource("proxy").
+		Name(name).
+		Suffix(path).
+		DoRaw(in.ctx)
 }
 
 func (in *K8SClient) GetCronJobs(namespace string) ([]batch_v1beta1.CronJob, error) {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	goerrors "errors"
 	"fmt"
-	"time"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	osproject_v1 "github.com/openshift/api/project/v1"
@@ -23,6 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kiali/kiali/util/httputil"
 )
 
 // GetConfigMap fetches and returns the specified ConfigMap definition
@@ -292,7 +293,7 @@ func (in *K8SClient) GetPodLogs(namespace, name string, opts *core_v1.PodLogOpti
 
 func (in *K8SClient) GetPodProxy(namespace, name, path string) ([]byte, error) {
 	return in.k8s.CoreV1().RESTClient().Get().
-		Timeout(10 * time.Second).
+		Timeout(httputil.DefaultTimeout).
 		Namespace(namespace).
 		Resource("pods").
 		SubResource("proxy").

--- a/kubernetes/kubetest/mock_kubernetes.go
+++ b/kubernetes/kubetest/mock_kubernetes.go
@@ -70,6 +70,11 @@ func (o *K8SClientMock) GetPodLogs(namespace, name string, opts *core_v1.PodLogO
 	return args.Get(0).(*kubernetes.PodLogs), args.Error(1)
 }
 
+func (o *K8SClientMock) GetPodProxy(namespace, name, path string) ([]byte, error) {
+	args := o.Called(namespace, name, path)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 func (o *K8SClientMock) GetReplicationControllers(namespace string) ([]core_v1.ReplicationController, error) {
 	args := o.Called(namespace)
 	return args.Get(0).([]core_v1.ReplicationController), args.Error(1)


### PR DESCRIPTION
This PR attempts to add prevention fixes to the forever taking request when the kube-api doesn't have access to istiod pods.
Fixes https://github.com/kiali/kiali/issues/3494

Three additions:
1. Adding timeouts to Pod Proxy calls.
2. Early return when Kiali can't check one healthy Istiod liveliness probe endpoint.
3. The Istio Component Status (masthead light) incorporates the liveliness probe result for each istiod pod (only shows the non reachable istiods)

To reproduce the scenario:
```
watch -n 3 kubectl delete pod -n istio-system --selector=app=istiod
```

![Screenshot of Kiali (4)](https://user-images.githubusercontent.com/613814/107028313-acbcf580-67ad-11eb-9ba8-3de28fbb0af1.png)

