### PR TITLE
[hack] multi-cluster setup scripts

### DIFF
--- a/hack/istio/multicluster/README.adoc
+++ b/hack/istio/multicluster/README.adoc
@@ -1,0 +1,23 @@
+= MultiCluster Install Hack Scripts
+
+These hack scripts can be used to install a 2-cluster multi-primary Istio installation.
+
+It utilizes the hack scripts located in link:..[the hack/istio directory].
+
+These should work on either OpenShift or Kubernetes environments. If you have both `kubectl` and `oc` in your PATH, you can specify which one to use (and hence which environment you want to use) via the `-c` option to the scripts.
+
+== Install
+
+Use the link:./install-everything.sh[install-everything.sh script]. See `--help` for options.
+
+== Uninstall
+
+You can uninstall everything from both clusters using the link:./uninstall-everything.sh[uninstall-everything.sh script]. Or you can individually uninstall things - see below.
+
+=== Istio
+
+To uninstall Istio, you can use link:../install-istio-via-istioctl.sh[install-istio-via-istioctl.sh]. Simply connect to your cluster and run that script with the `-di true` option to uninstall Istio from that cluster. Switch to the second cluster and do the same to uninstall Istio from there.
+
+=== Bookinfo
+
+If you used these scripts to install bookinfo, you can use link:../install-bookinfo-demo.sh[install-bookinfo-demo.sh] to uninstall it. Simply connect to your cluster and run that script with the `-db true` option to uninstall the bookinfo from that cluster. Switch to the second cluster and do the same to uninstall bookinfo from there.

--- a/hack/istio/multicluster/config-mesh-networks.sh
+++ b/hack/istio/multicluster/config-mesh-networks.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+##############################################################################
+# config-mesh-networks.sh
+#
+# Configures the mesh networks in the Istio ConfigMap to ensure the
+# two clusters' networks are linked.
+#
+# This is not needed to be performed on minikube since Istio can
+# discover the networks automatically. This is only needed on platforms
+# where Istio cannot figure out the external IPs of the gateways.
+#
+##############################################################################
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${SCRIPT_DIR}/env.sh $*
+
+if [ "${MANUAL_MESH_NETWORK_CONFIG}" != "true" ]; then
+  echo "Will not manually configure the mesh network"
+  return 0
+else
+  echo "Manually configuring the mesh network"
+fi
+
+get_gateway_load_balancer_ip() {
+  local ip="$(${CLIENT_EXE} get -n ${ISTIO_NAMESPACE} service istio-eastwestgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+  if [ "${ip}" == "" ]; then
+    return 1
+  fi
+  echo ${ip}
+}
+
+get_gateway_load_balancer_port() {
+  local port="$(${CLIENT_EXE} get -n ${ISTIO_NAMESPACE} service istio-eastwestgateway -o jsonpath='{.spec.ports[?(@.name=="tls")].port}')"
+  if [ "${port}" == "" ]; then
+    return 1
+  fi
+  echo ${port}
+}
+
+get_gateway_node_ip() {
+  local selector="$(${CLIENT_EXE} get -n ${ISTIO_NAMESPACE} service istio-eastwestgateway --output=json | jq -j '.spec.selector | to_entries | .[] | "\(.key)=\(.value),"' | sed -E 's/(.*),\\?/\1/')"
+  local hostip="$(${CLIENT_EXE} get -n ${ISTIO_NAMESPACE} pod -o jsonpath='{.items[0].status.hostIP}' -l "${selector}")"
+  if [ "${hostip}" == "" ]; then
+    return 1
+  fi
+  echo ${hostip}
+}
+
+get_gateway_node_port() {
+  local nodeport="$(${CLIENT_EXE} get -n ${ISTIO_NAMESPACE} service istio-eastwestgateway -o jsonpath='{.spec.ports[?(@.name=="tls")].nodePort}')"
+  if [ "${nodeport}" == "" ]; then
+    return 1
+  fi
+  echo ${nodeport}
+}
+
+echo "==== OBTAIN HOST IP AND NODE PORT FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+_GATEWAY_IP1="$(get_gateway_load_balancer_ip)"
+if [ "$?" == "0" ]; then
+  _GATEWAY_PORT1="$(get_gateway_load_balancer_port)"
+else
+  _GATEWAY_IP1="$(get_gateway_node_ip)"
+  _GATEWAY_PORT1="$(get_gateway_node_port)"
+fi
+
+echo "==== OBTAIN HOST IP AND NODE PORT FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+_GATEWAY_IP2="$(get_gateway_load_balancer_ip)"
+if [ "$?" == "0" ]; then
+  _GATEWAY_PORT2="$(get_gateway_load_balancer_port)"
+else
+  _GATEWAY_IP2="$(get_gateway_node_ip)"
+  _GATEWAY_PORT2="$(get_gateway_node_port)"
+fi
+
+_ISTIOD_CONFIG="{'networks':{'${NETWORK1_ID}':{'endpoints':[{'fromRegistry':'${CLUSTER1_NAME}'}],'gateways':[{'address':'${_GATEWAY_IP1}','port':${_GATEWAY_PORT1}}]},'${NETWORK2_ID}':{'endpoints':[{'fromRegistry':'${CLUSTER2_NAME}'}],'gateways':[{'address':'${_GATEWAY_IP2}','port':${_GATEWAY_PORT2}}]}}}"
+echo "MeshNetwork config: $_ISTIOD_CONFIG"
+
+echo "==== SETTING MESH NETWORK CONFIG FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+${CLIENT_EXE} get configmap istio -n ${ISTIO_NAMESPACE} -o json | jq ".data.meshNetworks=\"${_ISTIOD_CONFIG}\"" | ${CLIENT_EXE} apply -f -
+${CLIENT_EXE} delete pod -l app=istiod -n ${ISTIO_NAMESPACE}
+
+echo "==== SETTING MESH NETWORK CONFIG FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+${CLIENT_EXE} get configmap istio -n ${ISTIO_NAMESPACE} -o json | jq ".data.meshNetworks=\"${_ISTIOD_CONFIG}\"" | ${CLIENT_EXE} apply -f -
+${CLIENT_EXE} delete pod -l app=istiod -n ${ISTIO_NAMESPACE}

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+##############################################################################
+# deploy-kiali.sh
+#
+# Installs Kiali in both clusters.
+#
+##############################################################################
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${SCRIPT_DIR}/env.sh $*
+
+if [ "${KIALI_ENABLED}" != "true" ]; then
+  echo "Will not install kiali"
+  return 0
+else
+  echo "Installing Kiali in the two clusters"
+fi
+
+if ! which helm; then
+  echo "You do not have helm in your PATH - will not install Kiali"
+  return 1
+fi
+
+deploy_kiali() {
+  local helm_args=""
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    helm_args="--disable-openapi-validation"
+  fi
+  helm upgrade --install                 \
+    ${helm_args}                         \
+    --namespace ${ISTIO_NAMESPACE}       \
+    --set auth.strategy="anonymous"      \
+    --repo https://kiali.org/helm-charts \
+    kiali-server                         \
+    kiali-server
+}
+
+echo "==== DEPLOY KIALI TO CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+deploy_kiali
+
+echo "==== DEPLOY KIALI TO CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+deploy_kiali

--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -1,0 +1,455 @@
+#!/bin/bash
+
+##############################################################################
+# env.sh
+#
+# Configures the environment to prepare for multi-cluster installations.
+# The proper way to use this script is to source it (source env.sh) from
+# within other scripts.
+#
+# See: https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/
+#
+# See --help for more details on options to this script.
+#
+##############################################################################
+
+# If we have already been processed, skip everything
+if [ "${HACK_ENV_DONE:-}" == "true" ]; then
+  return 0
+fi
+
+set -u
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+
+switch_cluster() {
+  local context="${1}"
+  local username="${2:-}"
+  local password="${3:-}"
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    if ! ${CLIENT_EXE} login --username "${username}" --password "${password}" --server "${context}"; then
+      echo "Failed to log into OpenShift cluster. url=[${context}]"
+      exit 1
+    fi
+  else
+    if ! ${CLIENT_EXE} config use-context "${context}"; then
+      echo "Failed to switch to Kubernetes cluster. context=[${context}]"
+      exit 1
+    fi
+  fi
+}
+
+#
+# SET UP THE DEFAULTS FOR ALL SETTINGS
+#
+
+# CLIENT_EXE_NAME is going to either be "oc" or "kubectl"
+# ISTIO_DIR is where the Istio download is installed and thus where the Istio tools are found.
+CLIENT_EXE_NAME="kubectl"
+ISTIO_DIR=""
+
+# If the scripts need image registry client, this is it (docker or podman)
+DORP="docker"
+
+# The namespace where Istio will be found - this namespace must be the same on both clusters
+ISTIO_NAMESPACE="istio-system"
+
+# If you want to override the tag that istioctl will use for the container images it pulls, set this.
+# (note: needed this because openshift requires a dev build of istioctl but we still want the released images.
+# See: https://github.com/kiali/kiali/pull/3713#issuecomment-809920379)
+ISTIO_TAG=""
+
+# Certs directory where you want the generates cert files to be written
+CERTS_DIR="/tmp/istio-multicluster-certs"
+
+# The default Mesh and Network identifiers
+MESH_ID="mesh-hack"
+NETWORK1_ID="network-east"
+NETWORK2_ID="network-west"
+
+# If a gateway is required to cross the networks, set this to true and one will be created
+# See: https://istio.io/latest/docs/setup/install/multicluster/multi-primary_multi-network/
+CROSSNETWORK_GATEWAY_REQUIRED="true"
+
+# Under some conditions, manually configuring the mesh network will be required.
+MANUAL_MESH_NETWORK_CONFIG=""
+
+# The names of each cluster
+CLUSTER1_NAME="east"
+CLUSTER2_NAME="west"
+
+# If using Kubernetes, these are the kube context names used to connect to the clusters
+# If using OpenShift, these are the URLs to the API login server (e.g. "https://api.server-name.com:6443")
+CLUSTER1_CONTEXT=""
+CLUSTER2_CONTEXT=""
+
+# if using OpenShift, these are the credentials needed to log on to the clusters
+CLUSTER1_USER="kiali"
+CLUSTER1_PASS="kiali"
+CLUSTER2_USER="kiali"
+CLUSTER2_PASS="kiali"
+
+# Should Kiali be installed? This installs the last release of Kiali via the kiali-server helm chart.
+# If you want another verison or your own dev build, you must disable this and install what you want manually.
+KIALI_ENABLED="true"
+
+# Should Bookinfo demo be installed? If so, where?
+BOOKINFO_ENABLED="true"
+BOOKINFO_NAMESPACE="bookinfo"
+
+# If true and client exe is kubectl, then two minikube instances will be installed/uninstalled by these scripts
+MANAGE_MINIKUBE="true"
+
+# If true and client exe is kubectl, then two kind instances will be installed/uninstalled by these scripts
+MANAGE_KIND="false"
+
+# Minikube options - these are ignored if MANAGE_MINIKUBE is false
+MINIKUBE_DRIVER="virtualbox"
+MINIKUBE_CPU=""
+MINIKUBE_DISK=""
+MINIKUBE_MEMORY=""
+
+# process command line args
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -be|--bookinfo-enabled)
+      [ "${2:-}" != "true" -a "${2:-}" != "false" ] && echo "--bookinfo-enabled must be 'true' or 'false'" && exit 1
+      BOOKINFO_ENABLED="$2"
+      shift;shift
+      ;;
+    -bn|--bookinfo-namespace)
+      BOOKINFO_NAMESPACE="$2"
+      shift;shift
+      ;;
+    -c|--client-exe)
+      CLIENT_EXE_NAME="$2"
+      shift;shift
+      ;;
+    -c1c|--cluster1-context)
+      CLUSTER1_CONTEXT="$2"
+      shift;shift
+      ;;
+    -c1n|--cluster1-name)
+      CLUSTER1_NAME="$2"
+      shift;shift
+      ;;
+    -c1p|--cluster1-password)
+      CLUSTER1_PASS="$2"
+      shift;shift
+      ;;
+    -c1u|--cluster1-username)
+      CLUSTER1_USER="$2"
+      shift;shift
+      ;;
+    -c2c|--cluster2-context)
+      CLUSTER2_CONTEXT="$2"
+      shift;shift
+      ;;
+    -c2n|--cluster2-name)
+      CLUSTER2_NAME="$2"
+      shift;shift
+      ;;
+    -c2p|--cluster2-password)
+      CLUSTER2_PASS="$2"
+      shift;shift
+      ;;
+    -c2u|--cluster2-username)
+      CLUSTER2_USER="$2"
+      shift;shift
+      ;;
+    -dorp|--docker-or-podman)
+      [ "${2:-}" != "docker" -a "${2:-}" != "podman" ] && echo "-dorp must be 'docker' or 'podman'" && exit 1
+      DORP="$2"
+      shift;shift
+      ;;
+    -gr|--gateway-required)
+      [ "${2:-}" != "true" -a "${2:-}" != "false" ] && echo "--gateway-required must be 'true' or 'false'" && exit 1
+      CROSSNETWORK_GATEWAY_REQUIRED="$2"
+      shift;shift
+      ;;
+    -id|--istio-dir)
+      ISTIO_DIR="$2"
+      shift;shift
+      ;;
+    -in|--istio-namespace)
+      ISTIO_NAMESPACE="$2"
+      shift;shift
+      ;;
+    -it|--istio-tag)
+      ISTIO_TAG="$2"
+      shift;shift
+      ;;
+    -ke|--kiali-enabled)
+      [ "${2:-}" != "true" -a "${2:-}" != "false" ] && echo "--kiali-enabled must be 'true' or 'false'" && exit 1
+      KIALI_ENABLED="$2"
+      shift;shift
+      ;;
+    -mcpu|--minikube-cpu)
+      MINIKUBE_CPU="$2"
+      shift;shift
+      ;;
+    -md|--minikube-driver)
+      MINIKUBE_DRIVER="$2"
+      shift;shift
+      ;;
+    -mdisk|--minikube-disk)
+      MINIKUBE_DISK="$2"
+      shift;shift
+      ;;
+    -mi|--mesh-id)
+      MESH_ID="$2"
+      shift;shift
+      ;;
+    -mk|--manage-kind)
+      [ "${2:-}" != "true" -a "${2:-}" != "false" ] && echo "--manage-kind must be 'true' or 'false'" && exit 1
+      MANAGE_KIND="$2"
+      [ "${MANAGE_KIND}" == "true" ] && MANAGE_MINIKUBE="false" # cannot manage minikube if managing kind
+      shift;shift
+      ;;
+    -mm|--manage-minikube)
+      [ "${2:-}" != "true" -a "${2:-}" != "false" ] && echo "--manage-minikube must be 'true' or 'false'" && exit 1
+      MANAGE_MINIKUBE="$2"
+      [ "${MANAGE_MINIKUBE}" == "true" ] && MANAGE_KIND="false" # cannot manage kind if managing minikube
+      shift;shift
+      ;;
+    -mmem|--minikube-memory)
+      MINIKUBE_MEMORY="$2"
+      shift;shift
+      ;;
+    -mnc|--manual-network-config)
+      [ "${2:-}" != "true" -a "${2:-}" != "false" ] && echo "--manual-network-config must be 'true' or 'false'" && exit 1
+      MANUAL_MESH_NETWORK_CONFIG="$2"
+      shift;shift
+      ;;
+    -n1|--network1)
+      NETWORK1_ID="$2"
+      shift;shift
+      ;;
+    -n2|--network2)
+      NETWORK2_ID="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -be|--bookinfo-enabled <bool>: If true, install the bookinfo demo spread across the two clusters (Default: true)
+  -bn|--bookinfo-namespace: If the bookinfo demo will be installed, this is its namespace (Default: bookinfo)
+  -c|--client-exe <name>: Cluster client executable name - valid values are "kubectl" or "oc". If you use
+                          kubectl, it is assumed minikube will be used and the cluster names are profile names.
+  -c1c|--cluster1-context <name>: If cluster1 is Kubernetes, this is the context used to connect to the cluster
+  -c1n|--cluster1-name <name>: The name of cluster1 (Default: east)
+  -c1p|--cluster1-password <name>: If cluster1 is OpenShift, this is the password used to log in (Default: kiali)
+  -c1u|--cluster1-username <name>: If cluster1 is OpenShift, this is the username used to log in (Default: kiali)
+  -c2c|--cluster2-context <name>: If cluster2 is Kubernetes, this is the context used to connect to the cluster
+  -c2n|--cluster2-name <name>: The name of cluster2 (Default: west)
+  -c2p|--cluster2-password <name>: If cluster2 is OpenShift, this is the password used to log in (Default: kiali)
+  -c2u|--cluster2-username <name>: If cluster2 is OpenShift, this is the username used to log in (Default: kiali)
+  -dorp|--docker-or-podman <docker|podman>: What image registry client to use (Default: docker)
+  -gr|--gateway-required <bool>: If a gateway is required to cross between networks, set this to true
+  -id|--istio-dir <dir>: Where Istio has already been downloaded. If not found, this script aborts.
+  -in|--istio-namespace <name>: Where the Istio control plane is installed (default: istio-system).
+  -it|--istio-tag <tag>: If you want to override the image tag used by istioctl, set this to the tag name.
+  -ke|--kiali-enabled <bool>: If "true" the latest release of Kiali will be installed in both clusters. If you want
+                              a different version of Kiali installed, you must set this to "false" and install it yourself.
+                              (Default: true)
+  -mcpu|--minikube-cpu <cpu count>: Number of CPUs to give to each minikube cluster
+  -md|--minikube-driver <name>: The driver used by minikube (e.g. virtualbox, kvm2) (Default: virtualbox)
+  -mdisk|--minikube-disk <space>: Amount of disk space to give to each minikube cluster
+  -mi|--mesh-id <id>: When Istio is installed, it will be part of the mesh with this given name. (Default: mesh-default)
+  -mk|--manage-kind <bool>: If "true" and if --client-exe is kubectl, two kind instances will be managed
+  -mm|--manage-minikube <bool>: If "true" and if --client-exe is kubectl, two minikube instances will be managed
+  -mmem|--minikube-memory <mem>: Amount of memory to give to each minikube cluster
+  -mnc|--manual-network-config <bool>: If true, manually configure mesh network. False tells Istio to try to auto-discover things.
+                                       (Default: true if on OpenShift, false otherwise)
+  -n1|--network1 <id>: When Istio is installed in cluster 1, it will be part of the network with this given name. (Default: network-default)
+  -n2|--network2 <id>: When Istio is installed in cluster 2, it will be part of the network with this given name.
+                       If this is left as empty string, it will be the same as --network1. (Default: "")
+  -h|--help: this message
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+if [ "${ISTIO_DIR}" == "" ]; then
+  # Go to the main output directory and try to find an Istio there.
+  SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+  OUTPUT_DIR="${OUTPUT_DIR:-${SCRIPT_DIR}/../../../_output}"
+  ALL_ISTIOS=$(ls -dt1 ${OUTPUT_DIR}/istio-*)
+  if [ "$?" != "0" ]; then
+    ${OUTPUT_DIR}/../hack/istio/download-istio.sh
+    if [ "$?" != "0" ]; then
+      echo "ERROR: You do not have Istio installed and it cannot be downloaded"
+      exit 1
+    fi
+  fi
+  # use the Istio release that was last downloaded (that's the -t option to ls)
+  ISTIO_DIR=$(ls -dt1 ${OUTPUT_DIR}/istio-* | head -n1)
+fi
+
+if [ ! -d "${ISTIO_DIR}" ]; then
+   echo "ERROR: Istio cannot be found at: ${ISTIO_DIR}"
+   exit 1
+fi
+
+echo "Istio is found here: ${ISTIO_DIR}"
+
+ISTIOCTL="${ISTIO_DIR}/bin/istioctl"
+if [ -x "${ISTIOCTL}" ]; then
+  echo "istioctl is found here: ${ISTIOCTL}"
+  ${ISTIOCTL} version
+else
+  echo "ERROR: istioctl is NOT found at ${ISTIOCTL}"
+  exit 1
+fi
+
+CERT_MAKEFILE="${ISTIO_DIR}/tools/certs/Makefile.selfsigned.mk"
+if [ -f "${CERT_MAKEFILE}" ]; then
+  echo "Makefile is found here: ${CERT_MAKEFILE}"
+else
+  echo "ERROR: Makefile is NOT found at ${CERT_MAKEFILE}"
+  exit 1
+fi
+
+CLIENT_EXE=`which ${CLIENT_EXE_NAME}`
+if [ "$?" = "0" ]; then
+  echo "The cluster client executable is found here: ${CLIENT_EXE}"
+else
+  echo "You must install the cluster client ${CLIENT_EXE_NAME} in your PATH before you can continue"
+  exit 1
+fi
+
+# Are we on OpenShift or Kubernetes - just use the name of the exe for a very simply way to guess
+# If you want to explicitly use Kubernetes or OpenShift and you have both clients in PATH,
+# then tell the script which one you want to use via the -c option.
+if [[ "$CLIENT_EXE" = *"oc" ]]; then
+  IS_OPENSHIFT="true"
+  echo "Cluster type = OpenShift"
+else
+  IS_OPENSHIFT="false"
+  echo "Cluster type = Kubernetes"
+fi
+
+if [ "${IS_OPENSHIFT}" == "true" ]; then
+  if [ -z "${CLUSTER1_CONTEXT}" ]; then
+    echo "Cluster 1 context is not specified (--cluster1-context)"
+    echo "If OpenShift, it should be the api login server URL. If Kubernetes, it should be the kube context."
+    exit 1
+  fi
+  if [ -z "${CLUSTER2_CONTEXT}" ]; then
+    echo "Cluster 2 context is not specified (--cluster2-context)"
+    echo "If OpenShift, it should be the api login server URL. If Kubernetes, it should be the kube context."
+    exit 1
+  fi
+
+  # we do not manage minikube or kind when using OpenShift
+  MANAGE_MINIKUBE="false"
+  MANAGE_KIND="false"
+
+  # By default, we manually configure the mesh network when using OpenShift
+  if [ -z "${MANUAL_MESH_NETWORK_CONFIG}" ]; then
+    MANUAL_MESH_NETWORK_CONFIG="true"
+  fi
+else
+  if [ "${MANAGE_MINIKUBE}" == "true" -a "${MANAGE_KIND}" == "true" ]; then
+    echo "ERROR! Cannot manage both minikube and kind - pick one"
+    exit 1
+  fi
+
+  # when on Kubenetes (minikube or kind) assume the context name is the same as the cluster name
+  # If we know we are on kind, the context names are "kind-<name>"
+  if [ -z "${CLUSTER1_CONTEXT}" ]; then
+    if [ "${MANAGE_KIND}" == "true" ]; then
+      CLUSTER1_CONTEXT="kind-${CLUSTER1_NAME}"
+    else
+      CLUSTER1_CONTEXT="${CLUSTER1_NAME}"
+    fi
+  fi
+  if [ -z "${CLUSTER2_CONTEXT}" ]; then
+    if [ "${MANAGE_KIND}" == "true" ]; then
+      CLUSTER2_CONTEXT="kind-${CLUSTER2_NAME}"
+    else
+      CLUSTER2_CONTEXT="${CLUSTER2_NAME}"
+    fi
+  fi
+
+  # By default, we do not manually configure the mesh network when using Kubernetes (minikube or kind)
+  if [ -z "${MANUAL_MESH_NETWORK_CONFIG}" ]; then
+    MANUAL_MESH_NETWORK_CONFIG="false"
+  fi
+fi
+
+# If network2 is unspecified, assume it is the same as network1
+if [ -z "${NETWORK2_ID}" ]; then
+  NETWORK2_ID="${NETWORK1_ID}"
+fi
+
+# Export all variables so child scripts pick them up
+export BOOKINFO_ENABLED \
+       BOOKINFO_NAMESPACE \
+       CLIENT_EXE_NAME \
+       CLUSTER1_CONTEXT \
+       CLUSTER1_NAME \
+       CLUSTER1_PASS \
+       CLUSTER1_USER \
+       CLUSTER2_CONTEXT \
+       CLUSTER2_NAME \
+       CLUSTER2_PASS \
+       CLUSTER2_USER \
+       CROSSNETWORK_GATEWAY_REQUIRED \
+       DORP \
+       IS_OPENSHIFT \
+       ISTIO_DIR \
+       ISTIO_NAMESPACE \
+       ISTIO_TAG \
+       KIALI_ENABLED \
+       MANAGE_KIND \
+       MANAGE_MINIKUBE \
+       MANUAL_MESH_NETWORK_CONFIG \
+       MINIKUBE_CPU \
+       MINIKUBE_DISK \
+       MINIKUBE_DRIVER \
+       MINIKUBE_MEMORY \
+       MESH_ID \
+       NETWORK1_ID \
+       NETWORK2_ID
+
+cat <<EOM
+=== SETTINGS ===
+BOOKINFO_ENABLED=$BOOKINFO_ENABLED
+BOOKINFO_NAMESPACE=$BOOKINFO_NAMESPACE
+CLIENT_EXE_NAME=$CLIENT_EXE_NAME
+CLUSTER1_CONTEXT=$CLUSTER1_CONTEXT
+CLUSTER1_NAME=$CLUSTER1_NAME
+CLUSTER1_PASS=$CLUSTER1_PASS
+CLUSTER1_USER=$CLUSTER1_USER
+CLUSTER2_CONTEXT=$CLUSTER2_CONTEXT
+CLUSTER2_NAME=$CLUSTER2_NAME
+CLUSTER2_PASS=$CLUSTER2_PASS
+CLUSTER2_USER=$CLUSTER2_USER
+CROSSNETWORK_GATEWAY_REQUIRED=$CROSSNETWORK_GATEWAY_REQUIRED
+DORP=$DORP
+IS_OPENSHIFT=$IS_OPENSHIFT
+ISTIO_DIR=$ISTIO_DIR
+ISTIO_NAMESPACE=$ISTIO_NAMESPACE
+ISTIO_TAG=$ISTIO_TAG
+KIALI_ENABLED=$KIALI_ENABLED
+MANAGE_KIND=$MANAGE_KIND
+MANAGE_MINIKUBE=$MANAGE_MINIKUBE
+MANUAL_MESH_NETWORK_CONFIG=$MANUAL_MESH_NETWORK_CONFIG
+MINIKUBE_CPU=$MINIKUBE_CPU
+MINIKUBE_DISK=$MINIKUBE_DISK
+MINIKUBE_DRIVER=$MINIKUBE_DRIVER
+MINIKUBE_MEMORY=$MINIKUBE_MEMORY
+MESH_ID=$MESH_ID
+NETWORK1_ID=$NETWORK1_ID
+NETWORK2_ID=$NETWORK2_ID
+=== SETTINGS ===
+EOM
+
+export HACK_ENV_DONE="true"

--- a/hack/istio/multicluster/install-everything.sh
+++ b/hack/istio/multicluster/install-everything.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+##############################################################################
+# install-everything.sh
+#
+# Installs Istio across two clusters using the "multi-primary" model.
+#
+# See: https://istio.io/latest/docs/setup/install/multicluster/multi-primary/
+#
+# See --help for more details on options to this script.
+#
+##############################################################################
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${SCRIPT_DIR}/env.sh $*
+
+install_istio() {
+  local clustername="${1}"
+  local network="${2}"
+  if [ ! -z "${ISTIO_TAG}" ]; then
+    local image_tag_arg="--image-tag ${ISTIO_TAG}"
+  fi
+  "${ISTIO_INSTALL_SCRIPT}" ${image_tag_arg:-} --client-exe-path "${CLIENT_EXE}" --cluster-name "${clustername}" --istioctl "${ISTIOCTL}" --istio-dir "${ISTIO_DIR}" --mesh-id "${MESH_ID}" --namespace "${ISTIO_NAMESPACE}" --network "${network}"
+  if [ "$?" != "0" ]; then
+    echo "Failed to install Istio on cluster [${clustername}]"
+    exit 1
+  fi
+}
+
+create_crossnetwork_gateway() {
+  local clustername="${1}"
+  local network="${2}"
+
+  # create the gateway
+  local image_hub_arg="--set hub=gcr.io/istio-release"
+  if [ ! -z "${ISTIO_TAG}" ]; then
+    local image_tag_arg="--set tag=${ISTIO_TAG}"
+  fi
+  local gateway_yaml="$("${GEN_GATEWAY_SCRIPT}" --mesh "${MESH_ID}" --cluster "${clustername}" --network "${network}")"
+  printf "%s" "${gateway_yaml}" | "${ISTIOCTL}" install ${image_hub_arg} ${image_tag_arg:-} -y -f -
+  if [ "$?" != "0" ]; then
+    echo "Failed to install crossnetwork gateway on cluster [${clustername}]"
+    exit 1
+  fi
+
+  # expose services
+  ${CLIENT_EXE} apply -n ${ISTIO_NAMESPACE} -f "${EXPOSE_SERVICES_YAML}"
+  if [ "$?" != "0" ]; then
+    echo "Failed to expose services on cluster [${clustername}]"
+    exit 1
+  fi
+}
+
+create_remote_secret() {
+  local clustername="${1}"
+  local secretcount="$(${CLIENT_EXE} get sa -n ${ISTIO_NAMESPACE} istio-reader-service-account --no-headers | tr -s ' ' | cut -d ' ' -f 2)"
+  local secretname=""
+  if [ "${secretcount}" -gt 1 ]; then
+    # find the service account token secret (the word "token" will be in the secret name)
+    secretname="--secret-name $(${CLIENT_EXE} get sa -n ${ISTIO_NAMESPACE} istio-reader-service-account -o jsonpath='{.secrets[0].name}')"
+    if ! echo ${secretname} | grep "token"; then
+      secretname="--secret-name $(${CLIENT_EXE} get sa -n ${ISTIO_NAMESPACE} istio-reader-service-account -o jsonpath='{.secrets[1].name}')"
+      if ! echo ${secretname} | grep "token"; then
+        echo "Failed to find the sa token secret"
+        exit 1
+      fi
+    fi
+    echo "Choosing to use: [${secretname}]"
+  fi
+  REMOTE_SECRET="$("${ISTIOCTL}" x create-remote-secret --name "${clustername}" ${secretname})"
+  if [ "$?" != "0" ]; then
+    echo "Failed to generate remote secret for cluster [${clustername}]"
+    exit 1
+  fi
+
+  # if kind, then we have to make sure the remote secret has the external IP to the API server
+  if [ "${MANAGE_KIND}" == "true" ]; then
+    local kind_ip=$(${DORP} inspect ${clustername}-control-plane --format "{{ .NetworkSettings.Networks.kind.IPAddress }}")
+    REMOTE_SECRET="$(printf '%s' "${REMOTE_SECRET}" | sed -E 's!server:.*!server: https://'"${kind_ip}"':6443!')"
+    echo "Updating remote secret for kind cluster [${clustername}] to use API IP [${kind_ip}]"
+  fi
+}
+
+# Find the hack script to be used to install istio
+ISTIO_INSTALL_SCRIPT="${SCRIPT_DIR}/../install-istio-via-istioctl.sh"
+if [ -x "${ISTIO_INSTALL_SCRIPT}" ]; then
+  echo "Istio install script: ${ISTIO_INSTALL_SCRIPT}"
+else
+  echo "Cannot find the Istio install script at: ${ISTIO_INSTALL_SCRIPT}"
+  exit 1
+fi
+
+# Find the files necessary to create the crossnetwork gateway, if required
+if [ "${CROSSNETWORK_GATEWAY_REQUIRED}" == "true" ]; then
+  GEN_GATEWAY_SCRIPT="${ISTIO_DIR}/samples/multicluster/gen-eastwest-gateway.sh"
+  EXPOSE_SERVICES_YAML="${ISTIO_DIR}/samples/multicluster/expose-services.yaml"
+  if [ -x "${GEN_GATEWAY_SCRIPT}" ]; then
+    echo "Generate-gateway script: ${GEN_GATEWAY_SCRIPT}"
+  else
+    echo "Cannot find the generate-gateway script at: ${GEN_GATEWAY_SCRIPT}"
+    exit 1
+  fi
+  if [ -f "${EXPOSE_SERVICES_YAML}" ]; then
+    echo "Expose-services yaml: ${EXPOSE_SERVICES_YAML}"
+  else
+    echo "Cannot find the expose-services yaml at: ${EXPOSE_SERVICES_YAML}"
+    exit 1
+  fi
+fi
+
+# Start up two minikube instances if requested
+if [ "${MANAGE_MINIKUBE}" == "true" ]; then
+  echo "Starting minikube instances"
+  source ${SCRIPT_DIR}/start-minikube.sh
+fi
+
+# Start up two kind instances if requested
+if [ "${MANAGE_KIND}" == "true" ]; then
+  echo "Starting kind instances"
+  source ${SCRIPT_DIR}/start-kind.sh
+fi
+
+# Setup the certificates
+source ${SCRIPT_DIR}/setup-ca.sh
+
+echo "==== INSTALL ISTIO ON CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+install_istio "${CLUSTER1_NAME}" "${NETWORK1_ID}"
+
+echo "==== INSTALL ISTIO ON CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+install_istio "${CLUSTER2_NAME}" "${NETWORK2_ID}"
+
+if [ "${CROSSNETWORK_GATEWAY_REQUIRED}" == "true" ]; then
+  echo "==== CREATE CROSSNETWORK GATEWAY ON CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+  switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+  create_crossnetwork_gateway "${CLUSTER1_NAME}" "${NETWORK1_ID}"
+
+  echo "==== CREATE CROSSNETWORK GATEWAY ON CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+  switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+  create_crossnetwork_gateway "${CLUSTER2_NAME}" "${NETWORK2_ID}"
+
+  echo "==== SETTING UP THE MESH NETWORK CONFIGURATION MANUALLY"
+  source ${SCRIPT_DIR}/config-mesh-networks.sh
+else
+  echo "Crossnetwork gateway is not required - will not create one"
+fi
+
+echo "==== ENABLE ENDPOINT DISCOVERY ON CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+create_remote_secret "${CLUSTER1_NAME}"
+switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+printf "%s" "${REMOTE_SECRET}" | ${CLIENT_EXE} apply -f -
+
+echo "==== ENABLE ENDPOINT DISCOVERY ON CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+create_remote_secret "${CLUSTER2_NAME}"
+switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+printf "%s" "${REMOTE_SECRET}" | ${CLIENT_EXE} apply -f -
+
+# Install bookinfo across cluster if enabled
+source ${SCRIPT_DIR}/split-bookinfo.sh
+
+# Install Kiali in both clusters if enabled
+source ${SCRIPT_DIR}/deploy-kiali.sh

--- a/hack/istio/multicluster/setup-ca.sh
+++ b/hack/istio/multicluster/setup-ca.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+##############################################################################
+# setup-ca.sh
+#
+# Configures the Istio certificate authority (CA) with a root certificate,
+# signing certificate, and key.
+#
+# See: https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/
+#
+##############################################################################
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${SCRIPT_DIR}/env.sh $*
+
+create_secret() {
+  local clustername="${1}"
+
+  if ! ${CLIENT_EXE} get namespace ${ISTIO_NAMESPACE}; then
+    ${CLIENT_EXE} create namespace ${ISTIO_NAMESPACE}
+  fi
+
+  if ! ${CLIENT_EXE} get secret cacerts -n ${ISTIO_NAMESPACE}; then
+    ${CLIENT_EXE} create secret generic cacerts -n ${ISTIO_NAMESPACE} \
+        --from-file ${CERTS_DIR}/${clustername}/ca-cert.pem           \
+        --from-file ${CERTS_DIR}/${clustername}/ca-key.pem            \
+        --from-file ${CERTS_DIR}/${clustername}/root-cert.pem         \
+        --from-file ${CERTS_DIR}/${clustername}/cert-chain.pem
+
+    if [ "$?" != "0" ]; then
+      echo "Failed to create secret in cluster [${clustername}]"
+      exit 1
+    fi
+  else
+    echo "Secret already exists in cluster [${clustername}]. It will remain as-is"
+  fi
+}
+
+mkdir -p "${CERTS_DIR}"
+if [ ! -d "${CERTS_DIR}" ]; then
+  echo "Cannot create certs directory - ${CERTS_DIR}"
+  exit 1
+fi
+pushd "${CERTS_DIR}"
+make -f ${CERT_MAKEFILE} root-ca
+make -f ${CERT_MAKEFILE} ${CLUSTER1_NAME}-cacerts
+make -f ${CERT_MAKEFILE} ${CLUSTER2_NAME}-cacerts
+popd
+
+echo "==== CREATE CERTS FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+create_secret "${CLUSTER1_NAME}"
+
+echo "==== CREATE CERTS FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+create_secret "${CLUSTER2_NAME}"

--- a/hack/istio/multicluster/split-bookinfo.sh
+++ b/hack/istio/multicluster/split-bookinfo.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+##############################################################################
+# split-bookinfo.sh
+#
+# Installs Bookinfo, splitting up its components across the two clusters.
+#
+##############################################################################
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${SCRIPT_DIR}/env.sh $*
+
+if [ "${BOOKINFO_ENABLED}" != "true" ]; then
+  echo "Will not install bookinfo demo"
+  return 0
+else
+  echo "Installing bookinfo demo in namespace [${BOOKINFO_NAMESPACE}] across the two clusters"
+fi
+
+install_bookinfo() {
+  local profile="${1}"
+  local traffic_gen_enabled="${2}"
+  local traffic_gen_arg=""
+  if [ "${traffic_gen_enabled}" == "true" ]; then
+    traffic_gen_arg="-tg"
+  fi
+
+  "${INSTALL_BOOKINFO_SCRIPT}"             \
+    --client-exe "${CLIENT_EXE}"           \
+    --istio-dir "${ISTIO_DIR}"             \
+    --istio-namespace "${ISTIO_NAMESPACE}" \
+    --namespace "${BOOKINFO_NAMESPACE}"    \
+    --minikube-profile "${profile}"        \
+    ${traffic_gen_arg}
+
+  if [ "$?" != "0" ]; then
+    echo "Failed to install bookinfo"
+    exit 1
+  fi
+}
+
+# Find the hack script to be used to install bookinfo
+INSTALL_BOOKINFO_SCRIPT=${SCRIPT_DIR}/../install-bookinfo-demo.sh
+if [  -x "${INSTALL_BOOKINFO_SCRIPT}" ]; then
+  echo "Bookinfo install script: ${INSTALL_BOOKINFO_SCRIPT}"
+else
+  echo "Cannot find the Bookinfo install script at: ${INSTALL_BOOKINFO_SCRIPT}"
+  exit 1
+fi
+
+echo "==== INSTALL BOOKINFO ON CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+install_bookinfo "${CLUSTER1_CONTEXT}" "true"
+${CLIENT_EXE} scale deploy -n ${BOOKINFO_NAMESPACE} reviews-v2 --replicas=0
+${CLIENT_EXE} scale deploy -n ${BOOKINFO_NAMESPACE} reviews-v3 --replicas=0
+${CLIENT_EXE} scale deploy -n ${BOOKINFO_NAMESPACE} ratings-v1 --replicas=0
+
+if [ "${IS_OPENSHIFT}" == "true" ]; then
+  INGRESS_HOST=$(${CLIENT_EXE} -n ${ISTIO_NAMESPACE} get route istio-ingressgateway -o jsonpath='{.spec.host}')
+else
+  INGRESS_HOST=$(${CLIENT_EXE} -n ${ISTIO_NAMESPACE} get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+fi
+
+echo "==== INSTALL BOOKINFO ON CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+install_bookinfo "${CLUSTER2_CONTEXT}" "false"
+${CLIENT_EXE} scale deploy -n ${BOOKINFO_NAMESPACE} productpage-v1 --replicas=0
+${CLIENT_EXE} scale deploy -n ${BOOKINFO_NAMESPACE} details-v1 --replicas=0
+${CLIENT_EXE} scale deploy -n ${BOOKINFO_NAMESPACE} reviews-v1 --replicas=0
+
+echo "Bookinfo application will be available soon at http://${INGRESS_HOST}/productpage"
+

--- a/hack/istio/multicluster/start-kind.sh
+++ b/hack/istio/multicluster/start-kind.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+##############################################################################
+# start-kind.sh
+#
+# Starts up kind instances for each of the 2 clusters.
+#
+# For setting up the LB, see: https://kind.sigs.k8s.io/docs/user/loadbalancer
+#
+##############################################################################
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${SCRIPT_DIR}/env.sh $*
+
+start_kind() {
+  local clustername="${1}"
+  "${KIND_EXE}" create cluster --name ${clustername}
+  if [ "$?" != "0" ]; then
+    echo "Failed to start kind for cluster [${clustername}]"
+    exit 1
+  fi
+}
+
+config_metallb() {
+  local lb_addr_range="${1}"
+
+  ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/metallb/metallb/master/manifests/namespace.yaml
+  [ "$?" != "0" ] && echo "Failed to setup metallb namespace on kind" && exit 1
+
+  ${CLIENT_EXE} create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+  [ "$?" != "0" ] && echo "Failed to setup metallb secret on kind" && exit 1
+
+  ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/metallb/metallb/master/manifests/metallb.yaml
+  [ "$?" != "0" ] && echo "Failed to setup metallb resources on kind" && exit 1
+
+  local subnet=$(${DORP} network inspect kind --format '{{(index .IPAM.Config 0).Subnet}}')
+  [ "$?" != "0" ] && echo "Failed to inspect kind network" && exit 1
+
+  local subnet_trimmed=$(echo ${subnet} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+\..*/\1/')
+  local first_ip="${subnet_trimmed}.$(echo "${lb_addr_range}" | cut -d '-' -f 1)"
+  local last_ip="${subnet_trimmed}.$(echo "${lb_addr_range}" | cut -d '-' -f 2)"
+  cat <<LBCONFIGMAP | ${CLIENT_EXE} apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses: ['${first_ip}-${last_ip}']
+LBCONFIGMAP
+  [ "$?" != "0" ] && echo "Failed to configure metallb on kind" && exit 1
+}
+
+# Find the kind executable
+KIND_EXE=`which kind`
+if [  -x "${KIND_EXE}" ]; then
+  echo "Kind executable: ${KIND_EXE}"
+else
+  echo "Cannot find the kind executable. You must install it in your PATH. For details, see: https://kind.sigs.k8s.io/docs/user/quick-start"
+  exit 1
+fi
+
+echo "==== START KIND FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+start_kind "${CLUSTER1_NAME}"
+switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+config_metallb "255.70-255.84"
+
+echo "==== START KIND FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+start_kind "${CLUSTER2_NAME}"
+switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
+config_metallb "255.85-255.98"

--- a/hack/istio/multicluster/start-minikube.sh
+++ b/hack/istio/multicluster/start-minikube.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+##############################################################################
+# start-minikube.sh
+#
+# Starts up minikube instances for each of the 2 clusters.
+#
+##############################################################################
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${SCRIPT_DIR}/env.sh $*
+
+start_minikube() {
+  local profile="${1}"
+  local lb_addrs="${2}"
+
+  if [ "${MINIKUBE_CPU}" != "" ]; then local cpu="--kubernetes-cpu ${MINIKUBE_CPU}"; fi
+  if [ "${MINIKUBE_DISK}" != "" ]; then local disk="--kubernetes-disk ${MINIKUBE_DISK}"; fi
+  if [ "${MINIKUBE_MEMORY}" != "" ]; then local mem="--kubernetes-memory ${MINIKUBE_MEMORY}"; fi
+
+  "${K8S_MINIKUBE_SCRIPT}"                   \
+    --minikube-profile "${profile}"          \
+    --load-balancer-addrs "${lb_addrs}"      \
+    --kubernetes-driver "${MINIKUBE_DRIVER}" \
+    ${cpu:-} ${disk:-} ${mem:-}              \
+    start
+
+  if [ "$?" != "0" ]; then
+    echo "Failed to start minikube for cluster [${profile}]"
+    exit 1
+  fi
+}
+
+# Find the hack script to be used to start minikube
+K8S_MINIKUBE_SCRIPT=${SCRIPT_DIR}/../../k8s-minikube.sh
+if [  -x "${K8S_MINIKUBE_SCRIPT}" ]; then
+  echo "Minikube start script: ${K8S_MINIKUBE_SCRIPT}"
+else
+  echo "Cannot find the minikube start script at: ${K8S_MINIKUBE_SCRIPT}"
+  exit 1
+fi
+
+echo "==== START MINIKUBE FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+start_minikube "${CLUSTER1_NAME}" "70-84"
+
+echo "==== START MINIKUBE FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+start_minikube "${CLUSTER2_NAME}" "85-98"

--- a/hack/istio/multicluster/uninstall-everything.sh
+++ b/hack/istio/multicluster/uninstall-everything.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+##############################################################################
+# uninstall-everything.sh
+#
+# Attempts to purge Kiali, bookinfo, and Istio from both clusters.
+# If minikube is managed by us, the entire minikube instances are deleted.
+#
+##############################################################################
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${SCRIPT_DIR}/env.sh $*
+
+uninstall_everything() {
+  local clustername="${1}"
+  local context="${2}"
+  local user="${3}"
+  local pass="${4}"
+
+  switch_cluster "${context}" "${user}" "${pass}"
+  ${PURGE_KIALI_SCRIPT} -c ${CLIENT_EXE} && ${CLIENT_EXE} delete namespace kiali-operator
+  ${INSTALL_BOOKINFO_SCRIPT} -c ${CLIENT_EXE} --delete-bookinfo true
+  ${ISTIO_INSTALL_SCRIPT} -c ${CLIENT_EXE} --delete-istio true
+
+  if [ "${MANAGE_MINIKUBE}" == "true" ]; then
+    ${K8S_MINIKUBE_SCRIPT} --minikube-profile ${context} delete
+  fi
+
+  if [ "${MANAGE_KIND}" == "true" ]; then
+    ${KIND_EXE} delete cluster --name ${clustername}
+  fi
+}
+
+# Find the hack scripts to do the uninstalls
+ISTIO_INSTALL_SCRIPT="${SCRIPT_DIR}/../install-istio-via-istioctl.sh"
+INSTALL_BOOKINFO_SCRIPT="${SCRIPT_DIR}/../install-bookinfo-demo.sh"
+PURGE_KIALI_SCRIPT="${SCRIPT_DIR}/../../purge-kiali-from-cluster.sh"
+K8S_MINIKUBE_SCRIPT="${SCRIPT_DIR}/../../k8s-minikube.sh"
+KIND_EXE="$(which kind)"
+
+if [ -x "${ISTIO_INSTALL_SCRIPT}" ]; then
+  echo "Istio install script: ${ISTIO_INSTALL_SCRIPT}"
+else
+  echo "Cannot find the Istio install script at: ${ISTIO_INSTALL_SCRIPT}"
+  exit 1
+fi
+if [ -x "${INSTALL_BOOKINFO_SCRIPT}" ]; then
+  echo "Bookinfo install script: ${INSTALL_BOOKINFO_SCRIPT}"
+else
+  echo "Cannot find the Bookinfo install script at: ${INSTALL_BOOKINFO_SCRIPT}"
+  exit 1
+fi
+if [ -x "${PURGE_KIALI_SCRIPT}" ]; then
+  echo "Purge-kiali script: ${PURGE_KIALI_SCRIPT}"
+else
+  echo "Cannot find the purge-kiali script at: ${PURGE_KIALI_SCRIPT}"
+  exit 1
+fi
+if [ "${MANAGE_MINIKUBE}" == "true" ]; then
+  if [ -x "${K8S_MINIKUBE_SCRIPT}" ]; then
+    echo "k8s-minikube script: ${K8S_MINIKUBE_SCRIPT}"
+  else
+    echo "Cannot find the k8s-minikube script at: ${K8S_MINIKUBE_SCRIPT}"
+    exit 1
+  fi
+fi
+if [ "${MANAGE_KIND}" == "true" ]; then
+  if [ -x "${KIND_EXE}" ]; then
+    echo "kind executable: ${KIND_EXE}"
+  else
+    echo "Cannot find the kind executable."
+    exit 1
+  fi
+fi
+
+echo "==== PURGE CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+uninstall_everything "${CLUSTER1_NAME}" "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
+
+echo "==== PURGE CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+uninstall_everything "${CLUSTER2_NAME}" "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"


### PR DESCRIPTION
Based off work done by @israel-hdez - originally from his gist - see Discussion https://github.com/kiali/kiali/discussions/3699

This is now done. It supports `OpenShift` (you must start 2 clusters yourself), `Minikube` (the script can create 2 minikube clusters for you) and `Kind` (again, the script will create 2 kind clusters for you).

The main script is `install-everything.sh`. Use the option `--help` for usage. To uninstall, use `uninstall-everything.sh`.

### Example when using OpenShift:

```
./install-everything.sh \
  -c oc \
  -it 1.9.2 \
  -c1c https://api.your-openshift1.com:6443 \
  -c2c https://api.your-openshift2.com:6443
```

(note that today you need to build a custom istioctl to work with openshift due to an istioctl bug that is not fixed until Istio 1.10. For details on how to build it, see: https://github.com/kiali/kiali/pull/3713#issuecomment-809920379)

### Example when using Minikube:

```
./install-everything.sh -c kubectl -mm true
```

### Example when using Kind:

```
./install-everything.sh -c kubectl -mk true
```

When on Minikube or Kind, after all your pods are up and the traffic generator is pushing traffic, you can see the graph in Kiali show multicluster traffic. To launch the Kiali UI, use the [kiali-port-forward.sh](https://github.com/kiali/kiali/blob/master/hack/kiali-port-forward.sh) script. The Kiali UI that will be accessible is the one in the k8s cluster that is pointed to by your current kubectl context (`kubectl config current-context`). If you want to see a Kiali UI in another k8s cluster, pass in the kubectl context of that k8s cluster as the only argument to that `kiali-port-forward.sh` script (e.g. `hack/kiali-port-forward.sh kind-west`).