### PR TITLE
[hack] be able to install in a non-default namespace

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -272,7 +272,7 @@ if [ "${DELETE_ISTIO}" == "true" ]; then
   done
 
   echo Deleting Core Istio
-  ${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | sed "s/istio-system/${NAMESPACE}/g" | ${CLIENT_EXE} delete -n ${NAMESPACE} -f -
+  ${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | sed "s/istio-system/${NAMESPACE}/g" | ${CLIENT_EXE} delete -f -
   # THIS IS HOW IT SHOULD BE IMPLEMENTED BUT WE CANNOT USE THIS UNTIL THIS IS FIXED: https://github.com/istio/istio/issues/30897
   #${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | ${CLIENT_EXE} delete -n ${NAMESPACE} -f -
   if [[ "${CLIENT_EXE}" = *"oc" ]]; then
@@ -288,7 +288,7 @@ if [ "${DELETE_ISTIO}" == "true" ]; then
   ${CLIENT_EXE} delete namespace ${NAMESPACE}
 else
   echo Installing Istio...
-  ${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | sed "s/istio-system/${NAMESPACE}/g" | ${CLIENT_EXE} apply -n ${NAMESPACE} -f -
+  ${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | sed "s/istio-system/${NAMESPACE}/g" | ${CLIENT_EXE} apply -f -
   # THIS IS HOW IT SHOULD BE IMPLEMENTED BUT WE CANNOT USE THIS UNTIL THIS IS FIXED: https://github.com/istio/istio/issues/30897
   # ${ISTIOCTL} manifest install --skip-confirmation=true --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY}
   if [ "$?" != "0" ]; then

--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -288,7 +288,11 @@ if [ "${DELETE_ISTIO}" == "true" ]; then
   ${CLIENT_EXE} delete namespace ${NAMESPACE}
 else
   echo Installing Istio...
-  ${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | sed "s/istio-system/${NAMESPACE}/g" | ${CLIENT_EXE} apply -f -
+  while ! (${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | sed "s/istio-system/${NAMESPACE}/g" | ${CLIENT_EXE} apply -f -)
+  do
+    echo Sleeping for 10 seconds before retrying...
+    sleep 10
+  done
   # THIS IS HOW IT SHOULD BE IMPLEMENTED BUT WE CANNOT USE THIS UNTIL THIS IS FIXED: https://github.com/istio/istio/issues/30897
   # ${ISTIOCTL} manifest install --skip-confirmation=true --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY}
   if [ "$?" != "0" ]; then

--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -272,7 +272,9 @@ if [ "${DELETE_ISTIO}" == "true" ]; then
   done
 
   echo Deleting Core Istio
-  ${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | ${CLIENT_EXE} delete -n ${NAMESPACE} -f -
+  ${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | sed "s/istio-system/${NAMESPACE}/g" | ${CLIENT_EXE} delete -n ${NAMESPACE} -f -
+  # THIS IS HOW IT SHOULD BE IMPLEMENTED BUT WE CANNOT USE THIS UNTIL THIS IS FIXED: https://github.com/istio/istio/issues/30897
+  #${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | ${CLIENT_EXE} delete -n ${NAMESPACE} -f -
   if [[ "${CLIENT_EXE}" = *"oc" ]]; then
     echo "===== IMPORTANT ====="
     echo "For each namespace in the mesh, run these commands to remove previously created policies:"
@@ -286,7 +288,9 @@ if [ "${DELETE_ISTIO}" == "true" ]; then
   ${CLIENT_EXE} delete namespace ${NAMESPACE}
 else
   echo Installing Istio...
-  ${ISTIOCTL} manifest install --skip-confirmation=true --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY}
+  ${ISTIOCTL} manifest generate --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY} | sed "s/istio-system/${NAMESPACE}/g" | ${CLIENT_EXE} apply -n ${NAMESPACE} -f -
+  # THIS IS HOW IT SHOULD BE IMPLEMENTED BUT WE CANNOT USE THIS UNTIL THIS IS FIXED: https://github.com/istio/istio/issues/30897
+  # ${ISTIOCTL} manifest install --skip-confirmation=true --set profile=${CONFIG_PROFILE} --set namespace=${NAMESPACE} ${MANIFEST_CONFIG_SETTINGS_TO_APPLY}
   if [ "$?" != "0" ]; then
     echo "Failed to install Istio with profile [${CONFIG_PROFILE}]"
     exit 1


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3714

The problem here is we need to also workaround a bug in istioctl that also doesn't allow us to install in a non-istio-system namespace. We need that bug to be fixed. For now, there is workaround code in here that avoids that istioctl bug.