### PR TITLE
Adding concurrency to istio components status

### DIFF
--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -125,7 +125,9 @@ func sampleIstioComponent() ([]apps_v1.Deployment, []v1.Pod, bool) {
 func healthyIstiods() []v1.Pod {
 	return []v1.Pod{
 		fakePod("istiod-x3v1kn0l-running", "istio-system", "istiod", "Running"),
+		fakePod("istiod-x3v1kn1l-running", "istio-system", "istiod", "Running"),
 		fakePod("istiod-x3v1kn0l-terminating", "istio-system", "istiod", "Terminating"),
+		fakePod("istiod-x3v1kn1l-terminating", "istio-system", "istiod", "Terminating"),
 	}
 }
 
@@ -373,12 +375,14 @@ func TestIstiodUnreachable(t *testing.T) {
 	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, false)
 	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)
 	assertComponent(assert, icsl, "istiod-x3v1kn0l-running", Unreachable, true)
-	assertComponent(assert, icsl, "istiod-x3v1kn0l-terminating", Unreachable, true)
+	assertComponent(assert, icsl, "istiod-x3v1kn1l-running", Unreachable, true)
 
 	// Don't return healthy deployments
 	assertNotPresent(assert, icsl, "grafana")
 	assertNotPresent(assert, icsl, "prometheus")
 	assertNotPresent(assert, icsl, "jaeger")
+	assertNotPresent(assert, icsl, "istiod-x3v1kn0l-terminating")
+	assertNotPresent(assert, icsl, "istiod-x3v1kn1l-terminating")
 
 	// Requests to AddOns have to be 1
 	assert.Equal(1, *grafanaCalls)

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -212,9 +212,9 @@ func (in *K8SClient) GetProxyStatus() ([]*ProxyStatus, error) {
 	}
 
 	healthyIstiods := make([]*core_v1.Pod, 0, len(istiods))
-	for _, istiod := range istiods {
+	for i, istiod := range istiods {
 		if istiod.Status.Phase == "Running" {
-			healthyIstiods = append(healthyIstiods, &istiod)
+			healthyIstiods = append(healthyIstiods, &istiods[i])
 		}
 	}
 


### PR DESCRIPTION
While computing the istio component status, in particular the istiod reachability, kiali might introduce a sequential 10s waiting.
This PR approach this adding recurrence in each call to istiod. 

The scenario to reproduce this should be having 2+ istiod pods not responding. Then, Kiali should be waiting 10s for each istiod. After this PR, Kiali should only wait for 10s max (due to the concurrence).

In addition, there it fixes a bug that might also impact the computation of the `proxy status`. A bad usage of pointers might kiali make fetch envoy status to non-healthy istiods.