### PR TITLE
Add hosts to SE node in graph

### DIFF
--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -84,7 +84,7 @@ type NodeData struct {
 	IsMisconfigured string              `json:"isMisconfigured,omitempty"` // set to misconfiguration list, current values: [ 'labels' ]
 	IsOutside       bool                `json:"isOutside,omitempty"`       // true | false
 	IsRoot          bool                `json:"isRoot,omitempty"`          // true | false
-	IsServiceEntry  string              `json:"isServiceEntry,omitempty"`  // set to the location, current values: [ 'MESH_EXTERNAL', 'MESH_INTERNAL' ]
+	IsServiceEntry  *graph.SEInfo       `json:"isServiceEntry,omitempty"`  // set static service entry information
 }
 
 type EdgeData struct {
@@ -276,9 +276,9 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 			}
 		}
 
-		// node may be a service entry
+		// node may have service entry static info
 		if val, ok := n.Metadata[graph.IsServiceEntry]; ok {
-			nd.IsServiceEntry = val.(string)
+			nd.IsServiceEntry = val.(*graph.SEInfo)
 		}
 
 		// node may be an aggregate

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -145,6 +145,7 @@ const (
 
 type serviceEntry struct {
 	exportTo  interface{}
+	hosts     []string
 	location  string
 	name      string // serviceEntry name
 	namespace string // namespace in which the service entry is defined
@@ -169,6 +170,7 @@ func (seh serviceEntryHosts) addHost(host string, se *serviceEntry) {
 	} else {
 		seh[host] = seArr
 	}
+	se.hosts = append(se.hosts, host)
 }
 
 func getServiceDefinitionList(ni *graph.AppenderNamespaceInfo) *models.ServiceDefinitionList {

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -193,7 +193,9 @@ func testTrafficMap() map[string]*graph.Node {
 
 	n9 := graph.NewNode(graph.Unknown, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n9.Metadata["httpIn"] = 0.8
-	n9.Metadata[graph.IsServiceEntry] = "MESH_EXTERNAL"
+	n9.Metadata[graph.IsServiceEntry] = &graph.SEInfo{
+		Location: "MESH_EXTERNAL",
+	}
 
 	n10 := graph.NewNode(graph.Unknown, "testNamespace", "egress.not.defined", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n10.Metadata["httpIn"] = 0.8

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -92,7 +92,10 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 	// Replace "se-service" nodes with an "se-aggregate" serviceEntry node
 	for se, seServiceNodes := range seMap {
 		serviceEntryNode := graph.NewNode(graph.Unknown, namespaceInfo.Namespace, se.name, "", "", "", "", a.GraphType)
-		serviceEntryNode.Metadata[graph.IsServiceEntry] = se.location
+		serviceEntryNode.Metadata[graph.IsServiceEntry] = &graph.SEInfo{
+			Location: se.location,
+			Hosts:    se.hosts,
+		}
 		serviceEntryNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata()
 		for _, doomedSeServiceNode := range seServiceNodes {
 			// aggregate node traffic

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -214,7 +214,10 @@ func TestServiceEntry(t *testing.T) {
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
-	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
+	externalHosts := externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Hosts
+	assert.Equal("host1.external.com", externalHosts[0])
+	assert.Equal("host2.external.com", externalHosts[1])
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
 	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
@@ -227,7 +230,10 @@ func TestServiceEntry(t *testing.T) {
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
-	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
+	internalHosts := externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Hosts
+	assert.Equal("host1.external.com", internalHosts[0])
+	assert.Equal("host2.external.com", internalHosts[1])
 	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 }
 
@@ -321,7 +327,7 @@ func TestServiceEntryExportAll(t *testing.T) {
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
-	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
 	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
@@ -334,7 +340,7 @@ func TestServiceEntryExportAll(t *testing.T) {
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
-	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 }
 
@@ -428,7 +434,7 @@ func TestServiceEntryExportNamespaceFound(t *testing.T) {
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
-	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
 	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
@@ -441,7 +447,7 @@ func TestServiceEntryExportNamespaceFound(t *testing.T) {
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
-	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 }
 
@@ -535,7 +541,7 @@ func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
-	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
 	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
@@ -548,7 +554,7 @@ func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
-	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 }
 
@@ -652,7 +658,7 @@ func TestServiceEntryExportNamespaceNotFound(t *testing.T) {
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
-	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_INTERNAL", internalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(internalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 }
 
@@ -727,7 +733,7 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 	for _, n := range trafficMap {
 		if n.Service == "externalSE" {
 			numMatches++
-			assert.Equal("MESH_INTERNAL", n.Metadata[graph.IsServiceEntry])
+			assert.Equal("MESH_INTERNAL", n.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 		}
 	}
 	assert.Equal(1, numMatches)
@@ -862,7 +868,7 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 	SE2Node, found2 := trafficMap[SE2ID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE2Node.Edges))
-	assert.Equal("MESH_EXTERNAL", SE2Node.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_EXTERNAL", SE2Node.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(SE2Node.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 }
 
@@ -990,7 +996,7 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 	SE1Node, found2 := trafficMap[SE1ID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE1Node.Edges))
-	assert.Equal("MESH_EXTERNAL", SE1Node.Metadata[graph.IsServiceEntry])
+	assert.Equal("MESH_EXTERNAL", SE1Node.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(1, len(SE1Node.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
 	notSEHost2ServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
@@ -998,5 +1004,4 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 	assert.Equal(true, found3)
 	assert.Equal(0, len(notSEHost2ServiceNode.Edges))
 	assert.Equal(nil, notSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
-
 }

--- a/graph/types.go
+++ b/graph/types.go
@@ -62,6 +62,12 @@ type ServiceName struct {
 	Name      string `json:"name"`
 }
 
+// SEInfo provides static information about the service entry
+type SEInfo struct {
+	Location string   `json:"location"` // e.g. MESH_EXTERNAL, MESH_INTERNAL
+	Hosts    []string `json:"hosts"`    // configured list of hosts
+}
+
 func (s *ServiceName) Key() string {
 	return fmt.Sprintf("%s %s %s", s.Cluster, s.Namespace, s.Name)
 }

--- a/swagger.json
+++ b/swagger.json
@@ -5717,8 +5717,7 @@
           "x-go-name": "IsRoot"
         },
         "isServiceEntry": {
-          "type": "string",
-          "x-go-name": "IsServiceEntry"
+          "$ref": "#/definitions/SEInfo"
         },
         "namespace": {
           "type": "string",
@@ -6243,6 +6242,24 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "SEInfo": {
+      "description": "SEInfo provides static information about the service entry",
+      "type": "object",
+      "properties": {
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Hosts"
+        },
+        "location": {
+          "type": "string",
+          "x-go-name": "Location"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/graph"
     },
     "Service": {
       "type": "object",


### PR DESCRIPTION
Replacing "isServiceEntry", which wasn't actually a bool but a string
MESH_INTERNAL or MESH_EXTERNAL, with a struct holding "location" and
"hosts"

Fixes https://github.com/kiali/kiali/issues/3728

Frotnend PR: https://github.com/kiali/kiali-ui/pull/2089