### PR TITLE
Add missing token validation for implicit flow

### DIFF
--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -219,7 +219,16 @@ func performOpenIdAuthentication(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 
-	if !conf.Auth.OpenId.DisableRBAC {
+	if conf.Auth.OpenId.DisableRBAC {
+		// When RBAC is on, we delegate some validations to the Kubernetes cluster. However, if RBAC is off
+		// the token must be fully validated, as we no longer pass the OpenId token to the cluster API server.
+		// Since the configuration indicates RBAC is off, we do the validations:
+		err = business.ValidateOpenTokenInHouse(openIdParams)
+		if err != nil {
+			RespondWithDetailedError(w, http.StatusForbidden, "the OpenID token was rejected", err.Error())
+			return true
+		}
+	} else {
 		// Check if user trying to login has enough privileges to login. This check is only done if
 		// config indicates that RBAC is on. For cases where RBAC is off, we simply assume that the
 		// Kiali ServiceAccount token should have enough privileges and skip this privilege check.


### PR DESCRIPTION
The code handling OIDC authentication for the "implicit flow" is not
fully validating the received id_token *when* RBAC is turned off. Under
these cofiguration, only the CSRF mitigation check and the replay attack
mitigation is happening.

This is adding the missing lines of code to fully verify the id_token on
an "implicit flow + RBAC off" configuration.

