### PR TITLE
Bug: Disabled mtls at ns-level + Strict mtls at mesh-level

### DIFF
--- a/business/checkers/peerauthentications/disabled_namespacewide_checker_test.go
+++ b/business/checkers/peerauthentications/disabled_namespacewide_checker_test.go
@@ -47,6 +47,14 @@ func TestPeerAuthnDisabledNoDestRule(t *testing.T) {
 	testNoDisabledNsValidations("disabled_namespacewide_checker_5.yaml", t)
 }
 
+// Context: PeerAuthn disabled at namespace
+// Context: DR disabled at namespace
+// Context: mTLS strict at mesh-level (PeerAuthn + DestRule)
+// It doesn't return any validation
+func TestPeerAuthnDisabledNamespaceMtlsMeshWideEnabled(t *testing.T) {
+	testNoDisabledNsValidations("disabled_namespacewide_checker_6.yaml", t)
+}
+
 func disabledNamespacetestPrep(scenario string, t *testing.T) ([]*models.IstioCheck, bool) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/tests/data/validations/peerauthentications/disabled_namespacewide_checker_6.yaml
+++ b/tests/data/validations/peerauthentications/disabled_namespacewide_checker_6.yaml
@@ -1,0 +1,39 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mtls-bookinfo"
+  namespace: "bookinfo"
+spec:
+  mtls:
+    mode: DISABLE
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "disable-mtls-bookinfo"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "enable-mesh-mtls"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "details-disable-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "details"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/tests/data/validations/peerauthentications/disabled_namespacewide_checker_6.yaml
+++ b/tests/data/validations/peerauthentications/disabled_namespacewide_checker_6.yaml
@@ -10,7 +10,7 @@ spec:
 apiVersion: "security.istio.io/v1beta1"
 kind: "PeerAuthentication"
 metadata:
-  name: "disable-mtls-bookinfo"
+  name: "mtls-mesh"
   namespace: "istio-system"
 spec:
   mtls:
@@ -30,10 +30,10 @@ spec:
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:
-  name: "details-disable-mtls"
+  name: "bookinfo-disable-mtls"
   namespace: "bookinfo"
 spec:
-  host: "details"
+  host: "*.bookinfo.svc.cluster.local"
   trafficPolicy:
     tls:
       mode: DISABLE


### PR DESCRIPTION
Found when preparing the demo last friday.

To reproduce:
- Enable mtls at mesh-level (PeerAuthn + DR)
- Disable mtls at ns-level (PA + DR)

See this yaml: [disabled_namespacewide_checker_6.yaml](https://github.com/kiali/kiali/blob/dbaa2698d80ea0321a8e157dde18f38d6e5ec1fb/tests/data/validations/peerauthentications/disabled_namespacewide_checker_6.yaml)

Before the PR: validations should apply into DR/PA at NS-level.
After PR: no validations for DR/PA at NS-level.