### PR TITLE
Istio ingress may be installed as a daemonset

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -118,7 +118,7 @@ func NewWithBackends(k8s kubernetes.ClientInterface, prom prometheus.ClientInter
 	temporaryLayer.App = AppService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.Health = HealthService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.IstioConfig = IstioConfigService{k8s: k8s, businessLayer: temporaryLayer}
-	temporaryLayer.IstioStatus = IstioStatusService{k8s: k8s}
+	temporaryLayer.IstioStatus = IstioStatusService{k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.Iter8 = Iter8Service{k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.Jaeger = JaegerService{loader: jaegerClient, businessLayer: temporaryLayer}
 	temporaryLayer.k8s = k8s


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/3725
needs operator PR: https://github.com/kiali/kiali-operator/pull/262
needs helm-chart PR: https://github.com/kiali/helm-charts/pull/51

To reproduce this one:

1. Delete the istio ingress deployment
2. Apply the following daemonset
`k apply -f https://raw.githubusercontent.com/xeviknal/istio-lab/master/istio-ingressgateway-daemonset.yaml -n istio-system`

DNM - needs https://github.com/kiali/kiali-operator/pull/261 to be merged first.
