### PR TITLE
Add NotReady status for replicas downscaled to 0

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -51,7 +51,7 @@ func (ics *IstioComponentStatus) merge(cs IstioComponentStatus) IstioComponentSt
 const (
 	Healthy     string = "Healthy"
 	NotFound    string = "NotFound"
-	NotReady   	string = "NotReady"
+	NotReady    string = "NotReady"
 	Unhealthy   string = "Unhealthy"
 	Unreachable string = "Unreachable"
 )

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -50,8 +50,9 @@ func (ics *IstioComponentStatus) merge(cs IstioComponentStatus) IstioComponentSt
 
 const (
 	Healthy     string = "Healthy"
-	Unhealthy   string = "Unhealthy"
 	NotFound    string = "NotFound"
+	NotReady   	string = "NotReady"
+	Unhealthy   string = "Unhealthy"
 	Unreachable string = "Unreachable"
 )
 
@@ -227,7 +228,9 @@ func GetDeploymentStatus(d apps_v1.Deployment) string {
 	status := Unhealthy
 	wl := &models.Workload{}
 	wl.ParseDeployment(&d)
-	if wl.DesiredReplicas == wl.AvailableReplicas && wl.DesiredReplicas == wl.CurrentReplicas {
+	if wl.DesiredReplicas == 0 {
+		status = NotReady
+	} else if wl.DesiredReplicas == wl.AvailableReplicas && wl.DesiredReplicas == wl.CurrentReplicas {
 		status = Healthy
 	}
 	return status


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/3682
needs front end: https://github.com/kiali/kiali-ui/pull/2100

Steps to reproduce:
1. Downscale to 0 replicas for each istio component deployment you want to test

![Screenshot of Kiali (7)](https://user-images.githubusercontent.com/613814/110808041-ed63cf00-8283-11eb-941a-68ac091c47f9.png)

Note: Istiod and egress are the one downscaled. The ingress status is legit (nothing have to do with the modification)