### PR TITLE
Bump golang version to 1.16.2

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - name: Set up Go 1.x
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16.2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.14.7
+GO_VERSION_KIALI = 1.16.2
 
 SWAGGER_VERSION ?= 0.22.0
 

--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ See the link:./LICENSE[LICENSE file].
 These build instructions assume you have the following installed on your system: (1) link:http://golang.org/doc/install[Go Programming Language], (2) link:http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[git], (3) link:https://docs.docker.com/installation/[Docker] or link:https://podman.io[Podman] , (4) link:https://nodejs.org[NPM], and (5) make. If you are using `podman` instead of `docker`, pass the environment variable `DORP=podman` when executing `make`. To run Kiali in a cluster after you build it, it is assumed you have a running OpenShift or Minikube environment available to you.
 
 [NOTE]
-Currently, Kiali releases are built using Go 1.14. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.14 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
+Currently, Kiali releases are built using Go 1.16. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.16.2 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
 
 To build Kiali:
 

--- a/deploy/jenkins-ci/Dockerfile
+++ b/deploy/jenkins-ci/Dockerfile
@@ -25,7 +25,7 @@ COPY bin/entrypoint.sh /usr/local/bin/
 
 RUN set -eux; \
     # Install golang \
-    curl -fsSL https://golang.org/dl/go1.14.7.linux-amd64.tar.gz -o go.tar.gz; \
+    curl -fsSL https://golang.org/dl/go1.16.2.linux-amd64.tar.gz -o go.tar.gz; \
     tar -C /usr/local -zxf go.tar.gz; \
     rm go.tar.gz; \
     # Add Yarn repository \


### PR DESCRIPTION
Because go 1.14 is now unmaintained.

Fixes #3722
