### PR TITLE
Simplify pipeline parameters and update README

### DIFF
--- a/deploy/jenkins-ci/Dockerfile
+++ b/deploy/jenkins-ci/Dockerfile
@@ -21,9 +21,6 @@ USER root
 COPY bin/entrypoint.sh /usr/local/bin/
 
 RUN set -eux; \
-    # Install a requirement to un-tar nodejs.
-    apt-get -qq update; \
-    apt-get install --no-install-recommends -qq xz-utils; \
     # Install golang \
     curl -fsSL https://golang.org/dl/go1.14.7.linux-amd64.tar.gz -o go.tar.gz; \
     tar -C /usr/local -zxf go.tar.gz; \
@@ -32,10 +29,10 @@ RUN set -eux; \
     # curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
     # echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
     # Install NodeJs \
-    curl -fsSL https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-x64.tar.xz -o node.tar.xz; \
+    curl -fsSL https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-x64.tar.gz -o node.tar.gz; \
     mkdir -p /usr/local/lib/nodejs; \
-    tar -xJf node.tar.xz -C /usr/local/lib/nodejs; \
-    rm node.tar.xz; \
+    tar -xzf node.tar.gz -C /usr/local/lib/nodejs; \
+    rm node.tar.gz; \
     # Install Yarn \
     curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import; \
     curl -fsSL https://yarnpkg.com/downloads/1.22.4/yarn-v1.22.4.tar.gz.asc -o yarn.tar.gz.asc; \
@@ -58,6 +55,8 @@ RUN set -eux; \
     apt-get install --no-install-recommends -qq build-essential gosu docker-ce-cli; \
     # Install some things to support generating operator all-in-one yaml (gettext-base has 'envsubst') \
     apt-get -qq install gettext-base; \
+    # Install python2, required to build the UI \
+    apt-get -qq --no-install-recommends install python; \
     # Create Docker group \
     groupadd -r docker; \
     usermod -aG docker jenkins; \
@@ -73,7 +72,7 @@ COPY jenkins_ref /usr/share/jenkins/ref/
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Adjust PATH to include tools: golang, nodejs, yarn
-ENV PATH "/usr/local/lib/nodejs/node-v10.19.0-linux-x64/bin:/usr/local/yarn-v1.22.4/bin:/usr/local/go/bin:$PATH"
+ENV PATH "/usr/local/lib/nodejs/node-v14.16.0-linux-x64/bin:/usr/local/yarn-v1.22.4/bin:/usr/local/go/bin:$PATH"
 
 # Skip Jenkins setup wizard
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false

--- a/deploy/jenkins-ci/Dockerfile
+++ b/deploy/jenkins-ci/Dockerfile
@@ -13,9 +13,6 @@ FROM jenkins/jenkins:lts
 RUN /usr/local/bin/install-plugins.sh credentials-binding email-ext git ssh-agent mailer \
         pipeline-stage-view rebuild timestamper workflow-aggregator ws-cleanup
 
-# Install setup script and preconfigured jobs
-COPY jenkins_ref /usr/share/jenkins/ref/
-
 ## Install tools
 #
 USER root
@@ -24,6 +21,9 @@ USER root
 COPY bin/entrypoint.sh /usr/local/bin/
 
 RUN set -eux; \
+    # Install a requirement to un-tar nodejs.
+    apt-get -qq update; \
+    apt-get install --no-install-recommends -qq xz-utils; \
     # Install golang \
     curl -fsSL https://golang.org/dl/go1.14.7.linux-amd64.tar.gz -o go.tar.gz; \
     tar -C /usr/local -zxf go.tar.gz; \
@@ -65,6 +65,9 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*; \
     # Set exec permissions to entrypoint; \
     chmod +x /usr/local/bin/entrypoint.sh;
+
+# Install setup script and preconfigured jobs
+COPY jenkins_ref /usr/share/jenkins/ref/
 
 # Overide entrypoint of the base image with our own
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -7,24 +7,16 @@
  *      defaultValue: auto
  *      description: Valid values are: auto, minor, snapshot.0, snapshot.1, edge. When "auto" is
  *                   specified, the type of the release will be determined based on the current date.
- *   - BACKEND_RELEASING_BRANCH
+ *   - RELEASING_BRANCHES
  *      defaultValue: refs/heads/master
- *      description: Branch of the backend to release
- *   - UI_RELEASING_BRANCH
- *      defaultValue: refs/heads/master
- *      description: Branch of the UI to release
- *   - SITE_RELEASING_BRANCH
- *      defaultValue: refs/heads/master
- *      description: Branch of the website to release
- *   - OPERATOR_RELEASING_BRANCH
- *      defaultValue: refs/heads/master
- *      description: Branch of the operator to release
- *   - BACKEND_GITHUB_URI
- *      defaultValue: git@github.com:kiali/kiali.git
- *      description: SSH Url of the kiali-backend GitHub repository
- *   - UI_GITHUB_URI
- *      defaultValue: git@github.com:kiali/kiali-ui.git
- *      description: SSH Url of the kiali-ui GitHub repository
+ *      description: Name of branch of all repositories to checkout and run the release. The only
+ *                   exception is the website which is always run on the `master` branch.
+ *   - BACKEND_REPO
+ *      defaultValue: kiali/kiali
+ *      description: The GitHub repo of the back-end sources, in owner/repo format.
+ *   - UI_REPO
+ *      defaultValue: kiali/kiali-ui
+ *      description: The GitHub repo of the front-end sources, in owner/repo format.
  *   - OPERATOR_REPO
  *      defaultValue: kiali/kiali-operator
  *      description: The GitHub repo of the kiali-operator sources, in owner/repo format.
@@ -40,12 +32,6 @@
  *   - QUAY_OPERATOR_NAME
  *      defaultValue: quay.io/kiali/kiali-operator
  *      description: The name of the Quay repository to push the operator release
- *   - BACKEND_PULL_URI
- *      defaultValue: https://api.github.com/repos/kiali/kiali/pulls
- *      description: The URL of the GitHub API to use to create pull requests for the back-end (changes to prepare for next version)
- *   - UI_PULL_URI
- *      defaultValue: https://api.github.com/repos/kiali/kiali-ui/pulls
- *      description: The URL of the GitHub API to use to create pull requests for the UI (changes to prepare for next version)
  *   - NPM_DRY_RUN
  *      defaultValue: n
  *      description: Set to "y" if you want to make a "dry run" of the front-end release process
@@ -70,14 +56,17 @@
  *                    unset to use the version present in the main Makefile (e.g. leave unset for patch releases)
  *   - NPM_CONFIG_REGISTRY
  *       defaultValue: ''
- *       description: Registry to use for fetching packages. This is not used for publishing releases.
+ *       description: NPM registry to use for fetching packages. This is not used for publishing releases.
  *                    Do not include the trailing slash.
  */
 
 node('kiali-build && fedora') {
-  def (backendForkUri, uiForkUri) = ['git@github.com:kiali-bot/kiali.git', 'git@github.com:kiali-bot/kiali-ui.git']
-  def (backendDir, uiDir) = ['src/github.com/kiali/kiali', 'src/github.com/kiali/kiali-ui']
-  def (backendMakefile, uiMakefile) = ['deploy/jenkins-ci/Makefile', 'Makefile.jenkins']
+  def backendDir = 'src/github.com/kiali/kiali'
+  def backendMakefile = 'deploy/jenkins-ci/Makefile'
+
+  def uiDir = 'src/github.com/kiali/kiali-ui'
+  def uiMakefile = 'Makefile.jenkins'
+
   def buildUi = params.SKIP_UI_RELEASE != "y"
   def buildBackend = params.SKIP_BACKEND_RELEASE != "y"
   def buildOperator = params.SKIP_OPERATOR_RELEASE != "y"
@@ -97,7 +86,7 @@ node('kiali-build && fedora') {
       if ( buildBackend || buildOperator || buildHelm || buildSite ) {
         checkout([
           $class: 'GitSCM',
-          branches: [[name: params.BACKEND_RELEASING_BRANCH]],
+          branches: [[name: params.RELEASING_BRANCHES]],
           doGenerateSubmoduleConfigurations: false,
           extensions: [
             [$class: 'RelativeTargetDirectory', relativeTargetDir: backendDir]
@@ -114,7 +103,7 @@ node('kiali-build && fedora') {
       if ( buildUi ) {
         checkout([
           $class: 'GitSCM',
-          branches: [[name: params.UI_RELEASING_BRANCH]],
+          branches: [[name: params.RELEASING_BRANCHES]],
           doGenerateSubmoduleConfigurations: false,
           extensions: [
             [$class: 'RelativeTargetDirectory', relativeTargetDir: uiDir]
@@ -141,14 +130,20 @@ node('kiali-build && fedora') {
     buildSite = params.SKIP_SITE_RELEASE != "y" && releaseType == "minor"
     buildHelm = params.SKIP_HELM_RELEASE != "y" && (releaseType == "minor" || releaseType == "patch")
     echo "Resolved release type: ${releaseType}"
-    echo "Will build Helm charts? ${buildHelm}"
+    echo "Will build back-end? ${buildBackend}"
+    echo "Will build front-end? ${buildUi}"
     echo "Will build operator? ${buildOperator}"
+    echo "Will build Helm charts? ${buildHelm}"
     echo "Will build site? ${buildSite}"
 
     withEnv(["PATH+TOOLS=${env.WORKSPACE}/${backendDir}/deploy/jenkins-ci/bin",
             "GOPATH=${env.WORKSPACE}",
-            "BACKEND_FORK_URI=${backendForkUri}",
-            "UI_FORK_URI=${uiForkUri}",
+            "BACKEND_GITHUB_URI=git@github.com:${params.BACKEND_REPO}.git",
+            "BACKEND_FORK_URI=git@github.com:kiali-bot/kiali.git",
+            "BACKEND_PULL_URI=https://api.github.com/repos/${params.BACKEND_REPO}/pulls",
+            "UI_GITHUB_URI=git@github.com:${params.UI_REPO}.git",
+            "UI_FORK_URI=git@github.com:kiali-bot/kiali-ui.git",
+            "UI_PULL_URI=https://api.github.com/repos/${params.UI_REPO}/pulls",
             "RELEASE_TYPE=${releaseType}"
     ]) {
       parallel backend: {
@@ -222,16 +217,22 @@ node('kiali-build && fedora') {
               parameters: [
               [$class: 'StringParameterValue', value: releaseType, name: 'RELEASE_TYPE'],
               [$class: 'StringParameterValue', value: params.OPERATOR_REPO, name: 'OPERATOR_REPO'],
-              [$class: 'StringParameterValue', value: params.OPERATOR_RELEASING_BRANCH, name: 'OPERATOR_RELEASING_BRANCH'],
+              [$class: 'StringParameterValue', value: params.RELEASING_BRANCHES, name: 'OPERATOR_RELEASING_BRANCH'],
               [$class: 'StringParameterValue', value: params.QUAY_OPERATOR_NAME, name: 'QUAY_OPERATOR_NAME']
               ], wait: false
               )
         }
         if ( buildSite ) {
+          // Although the `kiali-website-release` can receive the "releasing branch",
+          // don't pass it and let it use the default `refs/heads/master`. It's unused at the moment.
+          // The website is "released" only on minor and major releases and it's only tagged. No "version branch"
+          // is created. This is because versioned docs are simple folders within the repository
+          // that are in the `master` branch. So, if a previous version of the doc needs to be
+          // updated, that's done manually. Docs tend to not change for patch releases and also
+          // tend to be fixed regardless if there is (or not) a patch release.
           build(job: 'kiali-website-release',
               parameters: [
-              [$class: 'StringParameterValue', value: params.SITE_REPO, name: 'SITE_REPO'],
-              [$class: 'StringParameterValue', value: params.SITE_RELEASING_BRANCH, name: 'SITE_RELEASING_BRANCH']
+              [$class: 'StringParameterValue', value: params.SITE_REPO, name: 'SITE_REPO']
               ], wait: false
               )
         }
@@ -240,6 +241,7 @@ node('kiali-build && fedora') {
               parameters: [
               [$class: 'StringParameterValue', value: releaseType, name: 'RELEASE_TYPE'],
               [$class: 'StringParameterValue', value: params.HELM_REPO, name: 'HELM_REPO']
+              [$class: 'StringParameterValue', value: params.RELEASING_BRANCHES, name: 'HELM_RELEASING_BRANCH']
               ], wait: false
               )
         }

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -259,6 +259,14 @@ node('kiali-build && fedora') {
         }
       }
     }
+  } catch (e) {
+    emailext(
+        to: 'kiali-internal@redhat.com',
+        subject: 'Kiali build failure',
+        body: '${JELLY_SCRIPT,template="html"}',
+        attachLog: true,
+        mimeType: 'text/html'
+    )
   } finally {
     cleanWs()
   }

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -35,12 +35,12 @@
  *   - NPM_DRY_RUN
  *      defaultValue: n
  *      description: Set to "y" if you want to make a "dry run" of the front-end release process
- *   - SKIP_UI_RELEASE
- *      defaultValue: n
- *      description: Set to 'y' if you don't want to release the UI
  *   - SKIP_BACKEND_RELEASE
  *      defaultValue: n
  *      description: Set to 'y' if you don't want to release the backend
+  *   - SKIP_UI_RELEASE
+  *      defaultValue: n
+  *      description: Set to 'y' if you don't want to release the UI
  *   - SKIP_OPERATOR_RELEASE
  *      defaultValue: n
  *      description: Set to 'y' if you don't want to release the operator
@@ -58,6 +58,9 @@
  *       defaultValue: ''
  *       description: NPM registry to use for fetching packages. This is not used for publishing releases.
  *                    Do not include the trailing slash.
+ *   - NOTIFICATIONS_EMAIL
+ *       defaultValue: ''
+ *       description: E-mail for sending build failure notifications.
  */
 
 node('kiali-build && fedora') {
@@ -240,7 +243,7 @@ node('kiali-build && fedora') {
           build(job: 'kiali-helm-release',
               parameters: [
               [$class: 'StringParameterValue', value: releaseType, name: 'RELEASE_TYPE'],
-              [$class: 'StringParameterValue', value: params.HELM_REPO, name: 'HELM_REPO']
+              [$class: 'StringParameterValue', value: params.HELM_REPO, name: 'HELM_REPO'],
               [$class: 'StringParameterValue', value: params.RELEASING_BRANCHES, name: 'HELM_RELEASING_BRANCH']
               ], wait: false
               )
@@ -260,13 +263,17 @@ node('kiali-build && fedora') {
       }
     }
   } catch (e) {
-    emailext(
-        to: 'kiali-internal@redhat.com',
-        subject: 'Kiali build failure',
-        body: '${JELLY_SCRIPT,template="html"}',
-        attachLog: true,
-        mimeType: 'text/html'
-    )
+    echo e.toString()
+    if (params.NOTIFICATIONS_EMAIL.length() != 0) {
+        emailext(
+            to: params.NOTIFICATIONS_EMAIL,
+            subject: 'Kiali build failure',
+            body: '${JELLY_SCRIPT,template="html"}',
+            attachLog: true,
+            mimeType: 'text/html'
+        )
+    }
+    throw e
   } finally {
     cleanWs()
   }

--- a/deploy/jenkins-ci/Jenkinsfile
+++ b/deploy/jenkins-ci/Jenkinsfile
@@ -97,7 +97,7 @@ node('kiali-build && fedora') {
           submoduleCfg: [],
           userRemoteConfigs: [[
             credentialsId: 'kiali-bot-gh-ssh',
-            url: params.BACKEND_GITHUB_URI]]
+            url: "git@github.com:${params.BACKEND_REPO}.git"]]
         ])
 
         sh "cd ${backendDir}; git config user.email 'kiali-dev@googlegroups.com'"
@@ -114,7 +114,7 @@ node('kiali-build && fedora') {
           submoduleCfg: [],
           userRemoteConfigs: [[
             credentialsId: 'kiali-bot-gh-ssh',
-            url: params.UI_GITHUB_URI]]
+            url: "git@github.com:${params.UI_REPO}.git"]]
         ])
 
         sh "cd ${uiDir}; git config user.email 'kiali-dev@googlegroups.com'"

--- a/deploy/jenkins-ci/jenkins_ref/init.groovy.d/setup-jenkins.groovy
+++ b/deploy/jenkins-ci/jenkins_ref/init.groovy.d/setup-jenkins.groovy
@@ -1,10 +1,18 @@
 // References when creating this script:
 // * https://github.com/samrocketman/jenkins-bootstrap-shared/tree/master/scripts
 // * https://github.com/rgoodwin/jenkins-master-preconfigured
+// * https://nickcharlton.net/posts/setting-jenkins-credentials-with-groovy.html
 
+import com.cloudbees.plugins.credentials.CredentialsScope
+import com.cloudbees.plugins.credentials.domains.Domain
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey
 import hudson.security.csrf.DefaultCrumbIssuer
-import jenkins.model.*
 import hudson.security.*
+import hudson.util.Secret
+import jenkins.model.*
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
+
 
 def hudsonRealm = new HudsonPrivateSecurityRealm(false)
 hudsonRealm.createAccount('admin', 'admin')
@@ -12,13 +20,62 @@ hudsonRealm.createAccount('admin', 'admin')
 def authorizationStrategy = new FullControlOnceLoggedInAuthorizationStrategy()
 authorizationStrategy.setAllowAnonymousRead(false)
 
-JenkinsLocationConfiguration location = Jenkins.instance.getExtensionList('jenkins.model.JenkinsLocationConfiguration')[0]
+def instance = Jenkins.get()
+JenkinsLocationConfiguration location = instance.getExtensionList('jenkins.model.JenkinsLocationConfiguration')[0]
 
 location.url = 'http://localhost:8080'
-Jenkins.instance.getExtensionList(jenkins.security.s2m.MasterKillSwitchWarning.class)[0].disable(true)
-Jenkins.instance.setAuthorizationStrategy(authorizationStrategy)
-Jenkins.instance.setCrumbIssuer(new DefaultCrumbIssuer(true))
-Jenkins.instance.setLabelString('kiali-build')
-Jenkins.instance.setSecurityRealm(hudsonRealm)
+instance.getExtensionList(jenkins.security.s2m.MasterKillSwitchWarning.class)[0].disable(true)
+instance.setAuthorizationStrategy(authorizationStrategy)
+instance.setCrumbIssuer(new DefaultCrumbIssuer(true))
+instance.setLabelString('kiali-build fedora')
+instance.setSecurityRealm(hudsonRealm)
 
-Jenkins.instance.save()
+instance.save()
+
+// Create secrets, if environment variables are set
+def domain = Domain.global()
+def store = instance.getExtensionList("com.cloudbees.plugins.credentials.SystemCredentialsProvider")[0].getStore()
+
+def npmSecret = new StringCredentialsImpl(
+    CredentialsScope.GLOBAL,
+    "kiali-npm",
+    "NPM token: Used to push the front-end release to NPM. For development, use any arbitrary string.",
+    Secret.fromString(org.apache.commons.lang.RandomStringUtils.random(10, true, true))
+)
+store.addCredentials(domain, npmSecret)
+
+if (System.getenv('BOT_TOKEN') != null) {
+    def botSecret = new StringCredentialsImpl(
+        CredentialsScope.GLOBAL,
+        "kiali-bot-gh-token",
+        "GitHub token of the BOT account. Used to make calls to the GitHub REST API. For development, you can use a GitHub Personal access token. This token and the SSH keys of the previous bullet should be associated to the same GitHub account.",
+        Secret.fromString(System.getenv('BOT_TOKEN'))
+    )
+    store.addCredentials(domain, botSecret)
+}
+
+if (System.getenv('QUAY_USERNAME') != null && System.getenv('QUAY_PASSWORD') != null) {
+    def quaySecret = new UsernamePasswordCredentialsImpl(
+        CredentialsScope.GLOBAL,
+        "kiali-quay",
+        "Quay credentials: Used to push the Kiali image and the Kiali operator image to Quay.io. For development, use your Quay.io account (it will be safer if you use an account without push rights to the Quay Kiali repositories.)",
+        System.getenv('QUAY_USERNAME'),
+        System.getenv('QUAY_PASSWORD')
+    )
+
+    store.addCredentials(domain, quaySecret)
+}
+
+if (System.getenv('BOT_SSH_KEY') != null) {
+    def botSshKey = new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(System.getenv('BOT_SSH_KEY'))
+    def botSshSecret = new BasicSSHUserPrivateKey(
+        CredentialsScope.GLOBAL,
+        "kiali-bot-gh-ssh",
+        "foo",
+        botSshKey,
+        "",
+        "GitHub SSH keys of the BOT account: Used to checkout the code to be built, and also to push tags and branches to the repositories. For development, you can use an SSH key associated with your GitHub account (it will be safer if you have an account without privileges to push to the Kiali repositories.)"
+    )
+
+    store.addCredentials(domain, botSshSecret)
+}

--- a/deploy/jenkins-ci/jenkins_ref/jobs/kiali-helm-release/config.xml
+++ b/deploy/jenkins-ci/jenkins_ref/jobs/kiali-helm-release/config.xml
@@ -1,0 +1,68 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.40">
+  <actions/>
+  <description>Releases the Helm charts.&#xd;
+&#xd;
+This pipeline supports only `minor` releases. Don&apos;t run it on&#xd;
+`major`, `patch`, `snapshot`, nor `edge` releases.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>20</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.32">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>RELEASE_TYPE</name>
+          <description>Valid values are: minor.</description>
+          <defaultValue>minor</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>HELM_REPO</name>
+          <description>The GitHub repo of the helm-charts sources, in owner/repo format.</description>
+          <defaultValue>kiali/helm-charts</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>HELM_RELEASING_BRANCH</name>
+          <description>Branch of the helm-charts repo to checkout and run the release</description>
+          <defaultValue>refs/heads/master</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.90">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@4.6.0">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>https://github.com/kiali/helm-charts.git</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>refs/heads/master</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <submoduleCfg class="list"/>
+      <extensions/>
+    </scm>
+    <scriptPath>Jenkinsfile</scriptPath>
+    <lightweight>true</lightweight>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>

--- a/deploy/jenkins-ci/jenkins_ref/jobs/kiali-operator-release/config.xml
+++ b/deploy/jenkins-ci/jenkins_ref/jobs/kiali-operator-release/config.xml
@@ -1,0 +1,65 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.40">
+  <description>This pipeline executes the needed steps to generate a release of the Kiali Operator.&#xd;
+&#xd;
+The `minor`, `patch`, `snapshot` and `edge` releases are supported.&#xd;
+It also SHOULD support `major` releases, but it&apos;s untested.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.32">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>RELEASE_TYPE</name>
+          <description>Valid values are: minor, patch, snapshot, and edge. &quot;major&quot; possibly will work fine as well.</description>
+          <defaultValue>minor</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>OPERATOR_REPO</name>
+          <description>The GitHub repo of the kiali-operator sources, in owner/repo format.</description>
+          <defaultValue>kiali/kiali-operator</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>OPERATOR_RELEASING_BRANCH</name>
+          <description>Branch of the kiali-operator repo to checkout and run the release</description>
+          <defaultValue>refs/heads/master</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>QUAY_OPERATOR_NAME</name>
+          <description>The name of the Quay repository to push the operator release</description>
+          <defaultValue>quay.io/kiali/kiali-operator</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.90">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@4.6.0">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>https://github.com/kiali/kiali-operator.git</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>refs/heads/master</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <submoduleCfg class="list"/>
+      <extensions/>
+    </scm>
+    <scriptPath>Jenkinsfile</scriptPath>
+    <lightweight>true</lightweight>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>

--- a/deploy/jenkins-ci/jenkins_ref/jobs/kiali-release/config.xml
+++ b/deploy/jenkins-ci/jenkins_ref/jobs/kiali-release/config.xml
@@ -1,18 +1,18 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.33">
+<flow-definition plugin="workflow-job@2.40">
   <actions>
-    <org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction plugin="workflow-multibranch@2.21">
+    <org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction plugin="workflow-multibranch@2.22">
       <jobPropertyDescriptors>
         <string>org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty</string>
         <string>hudson.model.ParametersDefinitionProperty</string>
       </jobPropertyDescriptors>
     </org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction>
   </actions>
-  <description/>
+  <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.31">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.32">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -26,57 +26,39 @@ specified, the type of the release will be determined based on the current date.
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>BACKEND_RELEASING_BRANCH</name>
-          <description>Branch of the backend to release</description>
+          <name>RELEASING_BRANCHES</name>
+          <description>Name of branch of all repositories to checkout and run the release. The only exception is the website which is always run on the `master` branch.</description>
           <defaultValue>refs/heads/master</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>UI_RELEASING_BRANCH</name>
-          <description>Branch of the UI to release</description>
-          <defaultValue>refs/heads/master</defaultValue>
+          <name>BACKEND_REPO</name>
+          <description>The GitHub repo of the back-end sources, in owner/repo format.</description>
+          <defaultValue>kiali/kiali</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>SITE_RELEASING_BRANCH</name>
-          <description>Branch of the website to release</description>
-          <defaultValue>refs/heads/master</defaultValue>
+          <name>UI_REPO</name>
+          <description>The GitHub repo of the front-end sources, in owner/repo format.</description>
+          <defaultValue>kiali/kiali-ui</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>OPERATOR_RELEASING_BRANCH</name>
-          <description>Branch of the operator to release</description>
-          <defaultValue>refs/heads/master</defaultValue>
+          <name>OPERATOR_REPO</name>
+          <description>The GitHub repo of the kiali-operator sources, in owner/repo format.</description>
+          <defaultValue>kiali/kiali-operator</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>BACKEND_GITHUB_URI</name>
-          <description>SSH Url of the kiali-backend GitHub repository</description>
-          <defaultValue>git@github.com:kiali/kiali.git</defaultValue>
+          <name>SITE_REPO</name>
+          <description>The GitHub repo of the website sources, in owner/repo format.</description>
+          <defaultValue>kiali/kiali.io</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>UI_GITHUB_URI</name>
-          <description>SSH Url of the kiali-ui GitHub repository</description>
-          <defaultValue>git@github.com:kiali/kiali-ui.git</defaultValue>
-          <trim>true</trim>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>SITE_GITHUB_URI</name>
-          <description>SSH Url of the kiali.io GitHub repository</description>
-          <defaultValue>git@github.com:kiali/kiali.io.git</defaultValue>
-          <trim>true</trim>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>OPERATOR_GITHUB_URI</name>
-          <description>SSH Url of the kiali-operator GitHub repository</description>
-          <defaultValue>git@github.com:kiali/kiali-operator.git</defaultValue>
-          <trim>true</trim>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>HELM_GITHUB_URI</name>
-          <description>SSH Url of the helm-charts GitHub repository</description>
-          <defaultValue>git@github.com:kiali/helm-charts.git</defaultValue>
+          <name>HELM_REPO</name>
+          <description>The GitHub repo of the Helm charts sources, in owner/repo format.</description>
+          <defaultValue>kiali/helm-charts</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
@@ -92,55 +74,20 @@ specified, the type of the release will be determined based on the current date.
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>BACKEND_PULL_URI</name>
-          <description>The URL of the GitHub API to use to create pull requests for the
-back-end (changes to prepare for next version)</description>
-          <defaultValue>https://api.github.com/repos/kiali/kiali/pulls</defaultValue>
-          <trim>true</trim>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>UI_PULL_URI</name>
-          <description>The URL of the GitHub API to use to create pull requests for the
-UI (changes to prepare for next version)</description>
-          <defaultValue>https://api.github.com/repos/kiali/kiali-ui/pulls</defaultValue>
-          <trim>true</trim>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>SITE_PULL_URI</name>
-          <description>The URL of the GitHub API to use to create pull requests for the
-UI (changes to prepare for next version)</description>
-          <defaultValue>https://api.github.com/repos/kiali/kiali.io/pulls</defaultValue>
-          <trim>true</trim>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>OPERATOR_PULL_URI</name>
-          <description>The URL of the GitHub API to use to create pull requests for the
-operator (changes to prepare for next version)</description>
-          <defaultValue>https://api.github.com/repos/kiali/kiali-operator/pulls</defaultValue>
-          <trim>true</trim>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>HELM_PULL_URI</name>
-          <description>The URL of the GitHub API to use to create pull requests for the
-helm-charts (changes to prepare for next version)</description>
-          <defaultValue>https://api.github.com/repos/kiali/helm-charts/pulls</defaultValue>
-          <trim>true</trim>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
           <name>NPM_DRY_RUN</name>
           <description>Set to &quot;y&quot; if you want to make a &quot;dry run&quot; of the front-end release process</description>
           <defaultValue>y</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>SKIP_UI_RELEASE</name>
-          <description>Set to &apos;y&apos; if you don&apos;t want to release the UI</description>
+          <name>SKIP_BACKEND_RELEASE</name>
+          <description>Set to &apos;y&apos; if you don&apos;t want to release the backend</description>
           <defaultValue>n</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>SKIP_BACKEND_RELEASE</name>
-          <description>Set to &apos;y&apos; if you don&apos;t want to release the backend</description>
+          <name>SKIP_UI_RELEASE</name>
+          <description>Set to &apos;y&apos; if you don&apos;t want to release the UI</description>
           <defaultValue>n</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
@@ -157,29 +104,29 @@ helm-charts (changes to prepare for next version)</description>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>SHOULD_RELEASE_SITE</name>
-          <description>Set to &apos;y&apos; to force release of the website</description>
-          <defaultValue>auto</defaultValue>
+          <name>SKIP_SITE_RELEASE</name>
+          <description>Set to &apos;y&apos; if you don&apos;t want to release the website</description>
+          <defaultValue>n</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>UI_VERSION</name>
           <description>If you are skipping UI release. Specify the UI version to package, or leave
 unset to use the version present in the main Makefile (e.g. leave unset for patch releases)</description>
-          <defaultValue/>
+          <defaultValue></defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>NPM_CONFIG_REGISTRY</name>
           <description>Registry to use for fetching packages. This is not used for publishing releases. Do not include the trailing slash.</description>
-          <defaultValue/>
+          <defaultValue></defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.70">
-    <scm class="hudson.plugins.git.GitSCM" plugin="git@3.10.0">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.90">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@4.6.0">
       <configVersion>2</configVersion>
       <userRemoteConfigs>
         <hudson.plugins.git.UserRemoteConfig>
@@ -193,7 +140,7 @@ unset to use the version present in the main Makefile (e.g. leave unset for patc
         </hudson.plugins.git.BranchSpec>
       </branches>
       <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
-      <submoduleCfg class="list"/>
+      <submoduleCfg class="empty-list"/>
       <extensions/>
     </scm>
     <scriptPath>deploy/jenkins-ci/Jenkinsfile</scriptPath>

--- a/deploy/jenkins-ci/jenkins_ref/jobs/kiali-website-release/config.xml
+++ b/deploy/jenkins-ci/jenkins_ref/jobs/kiali-website-release/config.xml
@@ -1,0 +1,60 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.40">
+  <actions/>
+  <description>Releases the website (copies staging documentation to a versioned doc)</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>20</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.32">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>SITE_REPO</name>
+          <description>The GitHub repo of the website sources, in owner/repo format.</description>
+          <defaultValue>kiali/kiali.io</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>SITE_RELEASING_BRANCH</name>
+          <description>Branch of the website to checkout and run the release
+</description>
+          <defaultValue>refs/heads/master</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.90">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@4.6.0">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>https://github.com/kiali/kiali.io.git</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>refs/heads/master</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <submoduleCfg class="list"/>
+      <extensions/>
+    </scm>
+    <scriptPath>Jenkinsfile</scriptPath>
+    <lightweight>true</lightweight>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>


### PR DESCRIPTION
This is also adding mail notifications for failed builds... only if back-end or front-end fails. Operator, Helm charts and website won't have failure notifications, because that needs to be added in the corresponding repos.

Related to #2895
