### PR TITLE
Make hack scripts easier for deploying local demo versions

### DIFF
--- a/hack/istio/install-error-rates-demo.sh
+++ b/hack/istio/install-error-rates-demo.sh
@@ -3,10 +3,11 @@
 # This deploys the travel agency demo
 
 : ${CLIENT_EXE:=oc}
+: ${DELETE_DEMO:=false}
+: ${ENABLE_INJECTION:=true}
 : ${NAMESPACE_ALPHA:=alpha}
 : ${NAMESPACE_BETA:=beta}
-: ${ENABLE_INJECTION:=true}
-: ${DELETE_DEMO:=false}
+: ${SOURCE:="https://raw.githubusercontent.com/kiali/demos/master"}
 
 while [ $# -gt 0 ]; do
   key="$1"
@@ -30,8 +31,13 @@ Valid command line arguments:
   -d|--delete: either 'true' or 'false'. If 'true' the travel agency demo will be deleted, not installed.
   -ei|--enable-injection: either 'true' or 'false' (default is true). If 'true' auto-inject proxies for the workloads.
   -h|--help: this text
+  -s|--source: demo file source. For example: file:///home/me/demos Default: https://raw.githubusercontent.com/kiali/demos/master
 HELPMSG
       exit 1
+      ;;
+    -s|--source)
+      SOURCE="$2"
+      shift;shift
       ;;
     *)
       echo "Unknown argument [$key]. Aborting."
@@ -42,9 +48,11 @@ done
 
 echo Will deploy Error Rates Demo using these settings:
 echo CLIENT_EXE=${CLIENT_EXE}
+echo DELETE_DEMO=${DELETE_DEMO}
+echo ENABLE_INJECTION=${ENABLE_INJECTION}
 echo NAMESPACE_ALPHA=${NAMESPACE_ALPHA}
 echo NAMESPACE_BETA=${NAMESPACE_BETA}
-echo ENABLE_INJECTION=${ENABLE_INJECTION}
+echo SOURCE=${SOURCE}
 
 # If we are to delete, remove everything and exit immediately after
 if [ "${DELETE_DEMO}" == "true" ]; then
@@ -92,7 +100,7 @@ fi
 
 # Deploy the demo
 
-${CLIENT_EXE} apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/error-rates/alpha.yaml) -n ${NAMESPACE_ALPHA}
-${CLIENT_EXE} apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/error-rates/beta.yaml) -n ${NAMESPACE_BETA}
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/error-rates/alpha.yaml") -n ${NAMESPACE_ALPHA}
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/error-rates/beta.yaml") -n ${NAMESPACE_BETA}
 
 

--- a/hack/istio/install-travel-agency-demo.sh
+++ b/hack/istio/install-travel-agency-demo.sh
@@ -3,13 +3,14 @@
 # This deploys the travel agency demo
 
 : ${CLIENT_EXE:=oc}
-: ${NAMESPACE_AGENCY:=travel-agency}
-: ${NAMESPACE_PORTAL:=travel-portal}
-: ${NAMESPACE_CONTROL:=travel-control}
+: ${DELETE_DEMO:=false}
 : ${ENABLE_INJECTION:=true}
 : ${ENABLE_OPERATION_METRICS:=false}
-: ${DELETE_DEMO:=false}
+: ${NAMESPACE_AGENCY:=travel-agency}
+: ${NAMESPACE_CONTROL:=travel-control}
+: ${NAMESPACE_PORTAL:=travel-portal}
 : ${SHOW_GUI:=false}
+: ${SOURCE:="https://raw.githubusercontent.com/kiali/demos/master"}
 
 while [ $# -gt 0 ]; do
   key="$1"
@@ -30,6 +31,10 @@ while [ $# -gt 0 ]; do
       ENABLE_OPERATION_METRICS="$2"
       shift;shift
       ;;
+    -s|--source)
+      SOURCE="$2"
+      shift;shift
+      ;;
     -sg|--show-gui)
       SHOW_GUI="$2"
       shift;shift
@@ -41,6 +46,7 @@ Valid command line arguments:
   -d|--delete: either 'true' or 'false'. If 'true' the travel agency demo will be deleted, not installed.
   -ei|--enable-injection: either 'true' or 'false' (default is true). If 'true' auto-inject proxies for the workloads.
   -eo|--enable-operation-metrics: either 'true' or 'false' (default is false). Only works on Istio 1.9 installed in istio-system.
+  -s|--source: demo file source. For example: file:///home/me/demos Default: https://raw.githubusercontent.com/kiali/demos/master
   -sg|--show-gui: do not install anything, but bring up the travel agency GUI in a browser window
   -h|--help: this text
 HELPMSG
@@ -63,11 +69,13 @@ fi
 
 echo Will deploy Travel Agency using these settings:
 echo CLIENT_EXE=${CLIENT_EXE}
-echo NAMESPACE_AGENCY=${NAMESPACE_AGENCY}
-echo NAMESPACE_PORTAL=${NAMESPACE_PORTAL}
-echo NAMESPACE_CONTROL=${NAMESPACE_CONTROL}
+echo DELETE_DEMO=${DELETE_DEMO}
 echo ENABLE_INJECTION=${ENABLE_INJECTION}
 echo ENABLE_OPERATION_METRICS=${ENABLE_OPERATION_METRICS}
+echo NAMESPACE_AGENCY=${NAMESPACE_AGENCY}
+echo NAMESPACE_CONTROL=${NAMESPACE_CONTROL}
+echo NAMESPACE_PORTAL=${NAMESPACE_PORTAL}
+echo SOURCE=${SOURCE}
 
 
 # If we are to delete, remove everything and exit immediately after
@@ -133,9 +141,9 @@ fi
 
 # Deploy the demo
 
-${CLIENT_EXE} apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/travels/travel_agency.yaml) -n ${NAMESPACE_AGENCY}
-${CLIENT_EXE} apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/travels/travel_portal.yaml) -n ${NAMESPACE_PORTAL}
-${CLIENT_EXE} apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/travels/travel_control.yaml) -n ${NAMESPACE_CONTROL}
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/travels/travel_agency.yaml") -n ${NAMESPACE_AGENCY}
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/travels/travel_portal.yaml") -n ${NAMESPACE_PORTAL}
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/travels/travel_control.yaml") -n ${NAMESPACE_CONTROL}
 
 # Set up metric classification
 


### PR DESCRIPTION
Make hack scripts easier for deploying local demo versions of travel or error-rates demo

adds -s|--source option