### PR TITLE
Add the IstiodDeploymentName to config and use it in the mesh business

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -158,7 +158,7 @@ func (in *MeshService) ResolveKialiControlPlaneCluster(r *http.Request) (*Cluste
 
 	// The "cluster_id" is set in an environment variable of
 	// the "istiod" deployment. Let's try to fetch it.
-	istioDeployment, err := in.k8s.GetDeployment(conf.IstioNamespace, "istiod")
+	istioDeployment, err := in.k8s.GetDeployment(conf.IstioNamespace, conf.ExternalServices.Istio.IstiodDeploymentName)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -169,6 +169,7 @@ type IstioConfig struct {
 	IstioIdentityDomain      string            `yaml:"istio_identity_domain,omitempty"`
 	IstioInjectionAnnotation string            `yaml:"istio_injection_annotation,omitempty"`
 	IstioSidecarAnnotation   string            `yaml:"istio_sidecar_annotation,omitempty"`
+	IstiodDeploymentName     string            `yaml:"istiod_deployment_name,omitempty"`
 	UrlServiceVersion        string            `yaml:"url_service_version"`
 }
 
@@ -441,6 +442,7 @@ func NewConfig() (c *Config) {
 				IstioIdentityDomain:      "svc.cluster.local",
 				IstioInjectionAnnotation: "sidecar.istio.io/inject",
 				IstioSidecarAnnotation:   "sidecar.istio.io/status",
+				IstiodDeploymentName:     "istiod",
 				UrlServiceVersion:        "http://istiod:15014/version",
 			},
 			Prometheus: PrometheusConfig{


### PR DESCRIPTION
Istiod deployment might have different names depending of the instalation. for example, istio upgrade via canary deployments changes the name in the following convention `istiod-${istio-version}` (e.g. istiod-1-9-1). However, the other bits of the deployment aren't changed at all (image, labels, template labels, so on).

This PR approaches the problem as it was approached for the config map: adding a new config into the kiali CR to specify the specific name.

```
external_services:
  istio:
    istiod_deployment_name: "istiod-1-9-1"
    config_map_name: "istio-1-9-1"
```

This partially fixes https://github.com/kiali/kiali/issues/2884 (at least the original description).
This PR needs an operator PR: https://github.com/kiali/kiali-operator/pull/270

**Steps to test:**
One way to try this fix is by following the task of upgrading istio: https://istio.io/latest/docs/setup/upgrade/canary/#control-plane
Note: you'll need to change both config listed above: deployment name and config map name.