### PR TITLE
Fix redirection from root-path without slash to root-path with slash

### DIFF
--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -99,7 +99,7 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 	check.Len(a[0].KialiInstances, 1, "GetClusters didn't resolve the local Kiali instance")
 	check.Equal("foo", a[0].KialiInstances[0].Namespace, "GetClusters didn't set the right namespace of the Kiali instance")
 	check.Equal("kiali-operator/myKialiCR", a[0].KialiInstances[0].OperatorResource, "GetClusters didn't set the right operator resource of the Kiali instance")
-	check.Equal("http://kiali.url.local/", a[0].KialiInstances[0].Url, "GetClusters didn't set the right URL of the Kiali instance")
+	check.Equal("http://kiali.url.local", a[0].KialiInstances[0].Url, "GetClusters didn't set the right URL of the Kiali instance")
 	check.Equal("v1.25", a[0].KialiInstances[0].Version, "GetClusters didn't set the right version of the Kiali instance")
 	check.Equal("kiali-service", a[0].KialiInstances[0].ServiceName, "GetClusters didn't set the right service name of the Kiali instance")
 }

--- a/routing/router.go
+++ b/routing/router.go
@@ -41,6 +41,8 @@ func NewRouter() *mux.Router {
 			r.URL.Path = webRootWithSlash
 			rootRouter.ServeHTTP(w, r)
 		})
+	} else {
+		webRootWithSlash = "/"
 	}
 
 	appRouter = appRouter.StrictSlash(true)

--- a/routing/router.go
+++ b/routing/router.go
@@ -69,7 +69,7 @@ func NewRouter() *mux.Router {
 	})
 
 	if conf.Auth.Strategy == config.AuthStrategyOpenId {
-		appRouter.Methods("GET").Path("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rootRouter.Methods("GET").Path(webRootWithSlash).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !handlers.OpenIdCodeFlowHandler(w, r) {
 				// If the OpenID handler does not handle the request, pass the
 				// request to the file server.
@@ -78,7 +78,7 @@ func NewRouter() *mux.Router {
 		})
 	}
 
-	appRouter.PathPrefix("/").Handler(staticFileServer)
+	rootRouter.PathPrefix(webRootWithSlash).Handler(staticFileServer)
 
 	return rootRouter
 }

--- a/util/httputil/http_util.go
+++ b/util/httputil/http_util.go
@@ -185,5 +185,5 @@ func GuessKialiURL(r *http.Request) string {
 		guessedKialiURL = fmt.Sprintf("%s://%s:%s%s", schema, host, port, cfg.Server.WebRoot)
 	}
 
-	return guessedKialiURL
+	return strings.TrimRight(guessedKialiURL, "/")
 }


### PR DESCRIPTION
I'm not sure why this is happening, because #3144 was supposed to fix the unneeded redirection. Anyway, this is yet another change to fix it "again".

Fixes #3762
