### PR TITLE
KIA0203 - If host not found, kiali will never find workloads matching labels

### DIFF
--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -38,8 +38,7 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 					valid = false
 					validations = append(validations, &validation)
 				}
-			}
-			if subsets, ok := n.DestinationRule.GetSpec()["subsets"]; ok {
+			} else if subsets, ok := n.DestinationRule.GetSpec()["subsets"]; ok {
 				if dSubsets, ok := subsets.([]interface{}); ok {
 					// Check that each subset has a matching workload somewhere..
 					for i, subset := range dSubsets {


### PR DESCRIPTION
Since cross-ns validations are not in-place, when the host is not found for a DR, there is no need to check if there are workloads serving traffic for that host and matching the subset. It will always result in a not found place: the host is not found, therefore no workloads under the service listening to that host.

fixes https://github.com/kiali/kiali/issues/800#issuecomment-804741626