### PR TITLE
Include ServiceEntries in GetPermissions

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -72,6 +72,7 @@ var newIstioConfigTypes = []string{
 	kubernetes.Gateways,
 	kubernetes.PeerAuthentications,
 	kubernetes.RequestAuthentications,
+	kubernetes.ServiceEntries,
 }
 
 // GetIstioConfigList returns a list of Istio routing objects, Mixer Rules, (etc.)


### PR DESCRIPTION
Required for https://github.com/kiali/kiali/issues/3763

One line fix, it doesn't need to wait for a UI pr.

How to test:

```
GET http://admin:admin@localhost:8000/api/istio/permissions?namespaces=default
```

should include "serviceentries" in the "permissions" result.