### PR TITLE
[hack] clean up the istio-cni pods from kube-system, too

### DIFF
--- a/hack/istio/install-sm2.sh
+++ b/hack/istio/install-sm2.sh
@@ -548,6 +548,7 @@ elif [ "$_CMD" = "sm-uninstall" ]; then
   ${OC} delete mutatingwebhookconfigurations/istio-sidecar-injector
   debug "Clean up deamonsets"
   ${OC} delete -n openshift-operators daemonset/istio-node
+  ${OC} delete -n kube-system daemonset/istio-cni-node
   debug "Clean up some more clusterroles/bindings"
   ${OC} delete clusterrole/istio-admin clusterrole/istio-cni clusterrolebinding/istio-cni
   debug "Clean up some security related things from the operator"


### PR DESCRIPTION
This is still left behind doing the documented uninstall procedures:

```
$ oc get -n kube-system daemonset
NAME             DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
istio-cni-node   3         3         3       3            3           kubernetes.io/os=linux   7d20h
```

This PR deletes that.