### PR TITLE
Allow users to override add-on urls to check health for istio component status

### DIFF
--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -616,17 +616,17 @@ func defaultAddOnCalls(jaeger, grafana, prom *int) map[string]addOnsSetup {
 
 func addonAddMockUrls(baseUrl string, conf *config.Config) *config.Config {
 	conf.ExternalServices.Grafana.Enabled = true
-	conf.ExternalServices.Grafana.IsCoreComponent = false
 	conf.ExternalServices.Grafana.InClusterURL = baseUrl + "/grafana/mock"
+	conf.ExternalServices.Grafana.ComponentStatus = config.AddonComponentStatus{IsCore: false}
 
 	conf.ExternalServices.Tracing.Enabled = true
-	conf.ExternalServices.Tracing.IsCoreComponent = false
 	conf.ExternalServices.Tracing.InClusterURL = baseUrl + "/jaeger/mock"
+	conf.ExternalServices.Tracing.ComponentStatus = config.AddonComponentStatus{IsCore: false}
 
 	conf.ExternalServices.Prometheus.URL = baseUrl + "/prometheus/mock"
 
 	conf.ExternalServices.CustomDashboards.Enabled = true
-	conf.ExternalServices.CustomDashboards.IsCoreComponent = false
 	conf.ExternalServices.CustomDashboards.Prometheus.URL = baseUrl + "/prometheus-dashboards/mock"
+	conf.ExternalServices.CustomDashboards.ComponentStatus = config.AddonComponentStatus{IsCore: false}
 	return conf
 }

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -99,7 +99,7 @@ func TestComponentNamespaces(t *testing.T) {
 	a.Len(nss, 4)
 }
 
-func mockAddOnsCalls(ds []apps_v1.Deployment, pods []v1.Pod, isIstioReachable bool) (*kubetest.K8SClientMock, *httptest.Server, *int, *int, *int) {
+func mockAddOnsCalls(ds []apps_v1.Deployment, pods []v1.Pod, isIstioReachable bool, overrideAddonURLs bool) (*kubetest.K8SClientMock, *httptest.Server, *int, *int, *int) {
 	// Prepare the Call counts for each Addon
 	jaegerCalls, grafanaCalls, prometheusCalls := 0, 0, 0
 
@@ -109,13 +109,13 @@ func mockAddOnsCalls(ds []apps_v1.Deployment, pods []v1.Pod, isIstioReachable bo
 	httpServer := mockServer(routes)
 
 	// Adapt the AddOns URLs to the mock Server
-	conf := addonAddMockUrls(httpServer.URL, config.NewConfig())
+	conf := addonAddMockUrls(httpServer.URL, config.NewConfig(), overrideAddonURLs)
 	config.Set(conf)
 
 	return k8s, httpServer, &jaegerCalls, &grafanaCalls, &prometheusCalls
 }
 
-func sampleIstioComponent() ([]apps_v1.Deployment, []v1.Pod, bool) {
+func sampleIstioComponent() ([]apps_v1.Deployment, []v1.Pod, bool, bool) {
 	return []apps_v1.Deployment{
 		fakeDeploymentWithStatus(
 			"istio-egressgateway",
@@ -125,7 +125,7 @@ func sampleIstioComponent() ([]apps_v1.Deployment, []v1.Pod, bool) {
 				AvailableReplicas:   2,
 				UnavailableReplicas: 0,
 			}),
-	}, healthyIstiods(), true
+	}, healthyIstiods(), true, false
 }
 
 func healthyIstiods() []v1.Pod {
@@ -208,7 +208,8 @@ func TestGrafanaDisabled(t *testing.T) {
 func TestGrafanaNotWorking(t *testing.T) {
 	assert := assert.New(t)
 	jaegerCalls, grafanaCalls, prometheusCalls := 0, 0, 0
-	k8s := mockDeploymentCall(sampleIstioComponent())
+	dps, pods, istiodReachable, _ := sampleIstioComponent()
+	k8s := mockDeploymentCall(dps, pods, istiodReachable)
 	addOnsStetup := defaultAddOnCalls(&jaegerCalls, &grafanaCalls, &prometheusCalls)
 	addOnsStetup["grafana"] = addOnsSetup{
 		Url:        "/grafana/mock",
@@ -220,7 +221,7 @@ func TestGrafanaNotWorking(t *testing.T) {
 	defer httpServer.Close()
 
 	// Adapt the AddOns URLs to the mock Server
-	conf := addonAddMockUrls(httpServer.URL, config.NewConfig())
+	conf := addonAddMockUrls(httpServer.URL, config.NewConfig(), false)
 	config.Set(conf)
 
 	iss := IstioStatusService{k8s: k8s}
@@ -236,6 +237,28 @@ func TestGrafanaNotWorking(t *testing.T) {
 	assert.Equal(1, prometheusCalls)
 
 	assertComponent(assert, icsl, "grafana", Unreachable, false)
+	assertNotPresent(assert, icsl, "prometheus")
+	assertNotPresent(assert, icsl, "jaeger")
+	assertNotPresent(assert, icsl, "custom dashboards")
+}
+
+func TestOverriddenUrls(t *testing.T) {
+	assert := assert.New(t)
+
+	dps, pods, idReachable, _ := sampleIstioComponent()
+	k8s, httpServ, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(dps, pods, idReachable, true)
+	defer httpServ.Close()
+
+	iss := IstioStatusService{k8s: k8s}
+	icsl, error := iss.GetStatus()
+	assert.NoError(error)
+
+	// Requests to AddOns have to be 1
+	assert.Equal(1, *grafanaCalls)
+	assert.Equal(1, *jaegerCalls)
+	assert.Equal(1, *promCalls)
+
+	assertNotPresent(assert, icsl, "grafana")
 	assertNotPresent(assert, icsl, "prometheus")
 	assertNotPresent(assert, icsl, "jaeger")
 	assertNotPresent(assert, icsl, "custom dashboards")
@@ -270,7 +293,7 @@ func TestCustomDashboardsMainPrometheus(t *testing.T) {
 func TestNoIstioComponentFoundError(t *testing.T) {
 	assert := assert.New(t)
 
-	k8s, httpServ, _, _, _ := mockAddOnsCalls([]apps_v1.Deployment{}, []v1.Pod{}, true)
+	k8s, httpServ, _, _, _ := mockAddOnsCalls([]apps_v1.Deployment{}, []v1.Pod{}, true, false)
 	defer httpServ.Close()
 
 	iss := IstioStatusService{k8s: k8s}
@@ -286,7 +309,7 @@ func TestDefaults(t *testing.T) {
 		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
 	}
 
-	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(depl, healthyIstiods(), true)
+	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(depl, healthyIstiods(), true, false)
 	defer httpServer.Close()
 
 	iss := IstioStatusService{k8s: k8s}
@@ -316,7 +339,7 @@ func TestNonDefaults(t *testing.T) {
 		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
 	}
 
-	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(pods, healthyIstiods(), true)
+	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(pods, healthyIstiods(), true, false)
 	defer httpServer.Close()
 
 	c := config.Get()
@@ -359,7 +382,7 @@ func TestIstiodNotReady(t *testing.T) {
 		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, notReadyStatus),
 	}
 
-	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(pods, healthyIstiods(), false)
+	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(pods, healthyIstiods(), false, false)
 	defer httpServer.Close()
 
 	c := config.Get()
@@ -406,7 +429,7 @@ func TestIstiodUnreachable(t *testing.T) {
 		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
 	}
 
-	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(pods, healthyIstiods(), false)
+	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(pods, healthyIstiods(), false, false)
 	defer httpServer.Close()
 
 	c := config.Get()
@@ -454,7 +477,7 @@ func TestCustomizedAppLabel(t *testing.T) {
 		fakeDeploymentWithStatus("istiod", map[string]string{"app": "istiod", "istio": "pilot"}, healthyStatus),
 	}
 
-	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(depls, healthyIstiods(), true)
+	k8s, httpServer, jaegerCalls, grafanaCalls, promCalls := mockAddOnsCalls(depls, healthyIstiods(), true, false)
 	defer httpServer.Close()
 
 	c := config.Get()
@@ -614,7 +637,7 @@ func defaultAddOnCalls(jaeger, grafana, prom *int) map[string]addOnsSetup {
 	}
 }
 
-func addonAddMockUrls(baseUrl string, conf *config.Config) *config.Config {
+func addonAddMockUrls(baseUrl string, conf *config.Config, overrideUrl bool) *config.Config {
 	conf.ExternalServices.Grafana.Enabled = true
 	conf.ExternalServices.Grafana.InClusterURL = baseUrl + "/grafana/mock"
 	conf.ExternalServices.Grafana.ComponentStatus = config.AddonComponentStatus{IsCore: false}
@@ -628,5 +651,20 @@ func addonAddMockUrls(baseUrl string, conf *config.Config) *config.Config {
 	conf.ExternalServices.CustomDashboards.Enabled = true
 	conf.ExternalServices.CustomDashboards.Prometheus.URL = baseUrl + "/prometheus-dashboards/mock"
 	conf.ExternalServices.CustomDashboards.ComponentStatus = config.AddonComponentStatus{IsCore: false}
+
+	if overrideUrl {
+		conf.ExternalServices.Grafana.ComponentStatus.HealthCheckUrl = conf.ExternalServices.Grafana.InClusterURL
+		conf.ExternalServices.Grafana.InClusterURL = baseUrl + "/grafana/wrong"
+
+		conf.ExternalServices.Tracing.ComponentStatus.HealthCheckUrl = conf.ExternalServices.Tracing.InClusterURL
+		conf.ExternalServices.Tracing.InClusterURL = baseUrl + "/jaeger/wrong"
+
+		conf.ExternalServices.Prometheus.ComponentStatus.HealthCheckUrl = conf.ExternalServices.Prometheus.URL
+		conf.ExternalServices.Prometheus.URL = baseUrl + "/prometheus/wrong"
+
+		conf.ExternalServices.CustomDashboards.ComponentStatus.HealthCheckUrl = conf.ExternalServices.CustomDashboards.Prometheus.URL
+		conf.ExternalServices.CustomDashboards.Prometheus.URL = baseUrl + "/prometheus/wrong"
+
+	}
 	return conf
 }

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -640,29 +640,29 @@ func defaultAddOnCalls(jaeger, grafana, prom *int) map[string]addOnsSetup {
 func addonAddMockUrls(baseUrl string, conf *config.Config, overrideUrl bool) *config.Config {
 	conf.ExternalServices.Grafana.Enabled = true
 	conf.ExternalServices.Grafana.InClusterURL = baseUrl + "/grafana/mock"
-	conf.ExternalServices.Grafana.ComponentStatus = config.AddonComponentStatus{IsCore: false}
+	conf.ExternalServices.Grafana.IsCore = false
 
 	conf.ExternalServices.Tracing.Enabled = true
 	conf.ExternalServices.Tracing.InClusterURL = baseUrl + "/jaeger/mock"
-	conf.ExternalServices.Tracing.ComponentStatus = config.AddonComponentStatus{IsCore: false}
+	conf.ExternalServices.Tracing.IsCore = false
 
 	conf.ExternalServices.Prometheus.URL = baseUrl + "/prometheus/mock"
 
 	conf.ExternalServices.CustomDashboards.Enabled = true
 	conf.ExternalServices.CustomDashboards.Prometheus.URL = baseUrl + "/prometheus-dashboards/mock"
-	conf.ExternalServices.CustomDashboards.ComponentStatus = config.AddonComponentStatus{IsCore: false}
+	conf.ExternalServices.CustomDashboards.IsCore = false
 
 	if overrideUrl {
-		conf.ExternalServices.Grafana.ComponentStatus.HealthCheckUrl = conf.ExternalServices.Grafana.InClusterURL
+		conf.ExternalServices.Grafana.HealthCheckUrl = conf.ExternalServices.Grafana.InClusterURL
 		conf.ExternalServices.Grafana.InClusterURL = baseUrl + "/grafana/wrong"
 
-		conf.ExternalServices.Tracing.ComponentStatus.HealthCheckUrl = conf.ExternalServices.Tracing.InClusterURL
+		conf.ExternalServices.Tracing.HealthCheckUrl = conf.ExternalServices.Tracing.InClusterURL
 		conf.ExternalServices.Tracing.InClusterURL = baseUrl + "/jaeger/wrong"
 
-		conf.ExternalServices.Prometheus.ComponentStatus.HealthCheckUrl = conf.ExternalServices.Prometheus.URL
+		conf.ExternalServices.Prometheus.HealthCheckUrl = conf.ExternalServices.Prometheus.URL
 		conf.ExternalServices.Prometheus.URL = baseUrl + "/prometheus/wrong"
 
-		conf.ExternalServices.CustomDashboards.ComponentStatus.HealthCheckUrl = conf.ExternalServices.CustomDashboards.Prometheus.URL
+		conf.ExternalServices.CustomDashboards.Prometheus.HealthCheckUrl = conf.ExternalServices.CustomDashboards.Prometheus.URL
 		conf.ExternalServices.CustomDashboards.Prometheus.URL = baseUrl + "/prometheus/wrong"
 
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -104,11 +104,6 @@ func (a *Auth) Obfuscate() {
 	a.CAFile = "xxx"
 }
 
-type AddonComponentStatus struct {
-	IsCore         bool   `yaml:"is_core,omitempty"`
-	HealthCheckUrl string `yaml:"health_check_url,omitempty"`
-}
-
 // PrometheusConfig describes configuration of the Prometheus component
 type PrometheusConfig struct {
 	Auth Auth `yaml:"auth,omitempty"`
@@ -117,29 +112,31 @@ type PrometheusConfig struct {
 	// Enable cache for Prometheus queries
 	CacheEnabled bool `yaml:"cache_enabled,omitempty"`
 	// Global cache expiration expressed in seconds
-	CacheExpiration int                  `yaml:"cache_expiration,omitempty"`
-	ComponentStatus AddonComponentStatus `yaml:"component_status,omitempty"`
-	URL             string               `yaml:"url,omitempty"`
+	CacheExpiration int    `yaml:"cache_expiration,omitempty"`
+	HealthCheckUrl  string `yaml:"health_check_url,omitempty"`
+	IsCore          bool   `yaml:"is_core,omitempty"`
+	URL             string `yaml:"url,omitempty"`
 }
 
 // CustomDashboardsConfig describes configuration specific to Custom Dashboards
 type CustomDashboardsConfig struct {
-	DiscoveryEnabled       string               `yaml:"discovery_enabled,omitempty"`
-	DiscoveryAutoThreshold int                  `yaml:"discovery_auto_threshold,omitempty"`
-	Enabled                bool                 `yaml:"enabled,omitempty"`
-	ComponentStatus        AddonComponentStatus `yaml:"component_status,omitempty"`
-	NamespaceLabel         string               `yaml:"namespace_label,omitempty"`
-	Prometheus             PrometheusConfig     `yaml:"prometheus,omitempty"`
+	DiscoveryEnabled       string           `yaml:"discovery_enabled,omitempty"`
+	DiscoveryAutoThreshold int              `yaml:"discovery_auto_threshold,omitempty"`
+	Enabled                bool             `yaml:"enabled,omitempty"`
+	IsCore                 bool             `yaml:"is_core,omitempty"`
+	NamespaceLabel         string           `yaml:"namespace_label,omitempty"`
+	Prometheus             PrometheusConfig `yaml:"prometheus,omitempty"`
 }
 
 // GrafanaConfig describes configuration used for Grafana links
 type GrafanaConfig struct {
-	Auth            Auth                     `yaml:"auth"`
-	ComponentStatus AddonComponentStatus     `yaml:"component_status,omitempty"`
-	Dashboards      []GrafanaDashboardConfig `yaml:"dashboards"`
-	Enabled         bool                     `yaml:"enabled"` // Enable or disable Grafana support in Kiali
-	InClusterURL    string                   `yaml:"in_cluster_url"`
-	URL             string                   `yaml:"url"`
+	Auth           Auth                     `yaml:"auth"`
+	Dashboards     []GrafanaDashboardConfig `yaml:"dashboards"`
+	Enabled        bool                     `yaml:"enabled"` // Enable or disable Grafana support in Kiali
+	HealthCheckUrl string                   `yaml:"health_check_url,omitempty"`
+	InClusterURL   string                   `yaml:"in_cluster_url"`
+	IsCore         bool                     `yaml:"is_core,omitempty"`
+	URL            string                   `yaml:"url"`
 }
 
 type GrafanaDashboardConfig struct {
@@ -157,14 +154,15 @@ type GrafanaVariablesConfig struct {
 
 // TracingConfig describes configuration used for tracing links
 type TracingConfig struct {
-	Auth                 Auth                 `yaml:"auth"`
-	ComponentStatus      AddonComponentStatus `yaml:"component_status,omitempty"`
-	Enabled              bool                 `yaml:"enabled"` // Enable Jaeger in Kiali
-	InClusterURL         string               `yaml:"in_cluster_url"`
-	NamespaceSelector    bool                 `yaml:"namespace_selector"`
-	URL                  string               `yaml:"url"`
-	UseGRPC              bool                 `yaml:"use_grpc"`
-	WhiteListIstioSystem []string             `yaml:"whitelist_istio_system"`
+	Auth                 Auth     `yaml:"auth"`
+	Enabled              bool     `yaml:"enabled"` // Enable Jaeger in Kiali
+	HealthCheckUrl       string   `yaml:"health_check_url,omitempty"`
+	InClusterURL         string   `yaml:"in_cluster_url"`
+	IsCore               bool     `yaml:"is_core,omitempty"`
+	NamespaceSelector    bool     `yaml:"namespace_selector"`
+	URL                  string   `yaml:"url"`
+	UseGRPC              bool     `yaml:"use_grpc"`
+	WhiteListIstioSystem []string `yaml:"whitelist_istio_system"`
 }
 
 // IstioConfig describes configuration used for istio links
@@ -416,19 +414,15 @@ func NewConfig() (c *Config) {
 				DiscoveryEnabled:       DashboardsDiscoveryAuto,
 				DiscoveryAutoThreshold: 10,
 				Enabled:                true,
+				IsCore:                 false,
 				NamespaceLabel:         "kubernetes_namespace",
-				ComponentStatus: AddonComponentStatus{
-					IsCore: false,
-				},
 			},
 			Grafana: GrafanaConfig{
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
 				Enabled: true,
-				ComponentStatus: AddonComponentStatus{
-					IsCore: false,
-				},
+				IsCore:  false,
 			},
 			Istio: IstioConfig{
 				ComponentStatuses: ComponentStatuses{
@@ -471,12 +465,10 @@ func NewConfig() (c *Config) {
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
-				ComponentStatus: AddonComponentStatus{
-					IsCore: false,
-				},
 				Enabled:              true,
 				NamespaceSelector:    true,
 				InClusterURL:         "http://tracing.istio-system/jaeger",
+				IsCore:               false,
 				URL:                  "",
 				UseGRPC:              false,
 				WhiteListIstioSystem: []string{"jaeger-query", "istio-ingressgateway"},

--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,11 @@ func (a *Auth) Obfuscate() {
 	a.CAFile = "xxx"
 }
 
+type AddonComponentStatus struct {
+	IsCore         bool   `yaml:"is_core,omitempty"`
+	HealthCheckUrl string `yaml:"health_check_url,omitempty"`
+}
+
 // PrometheusConfig describes configuration of the Prometheus component
 type PrometheusConfig struct {
 	Auth Auth `yaml:"auth,omitempty"`
@@ -112,27 +117,28 @@ type PrometheusConfig struct {
 	// Enable cache for Prometheus queries
 	CacheEnabled bool `yaml:"cache_enabled,omitempty"`
 	// Global cache expiration expressed in seconds
-	CacheExpiration int    `yaml:"cache_expiration:omitempty"`
-	URL             string `yaml:"url,omitempty"`
+	CacheExpiration int                  `yaml:"cache_expiration,omitempty"`
+	ComponentStatus AddonComponentStatus `yaml:"component_status,omitempty"`
+	URL             string               `yaml:"url,omitempty"`
 }
 
 // CustomDashboardsConfig describes configuration specific to Custom Dashboards
 type CustomDashboardsConfig struct {
-	DiscoveryEnabled       string           `yaml:"discovery_enabled,omitempty"`
-	DiscoveryAutoThreshold int              `yaml:"discovery_auto_threshold,omitempty"`
-	Enabled                bool             `yaml:"enabled,omitempty"`
-	IsCoreComponent        bool             `yaml:"is_core_component,omitempty"`
-	NamespaceLabel         string           `yaml:"namespace_label,omitempty"`
-	Prometheus             PrometheusConfig `yaml:"prometheus,omitempty"`
+	DiscoveryEnabled       string               `yaml:"discovery_enabled,omitempty"`
+	DiscoveryAutoThreshold int                  `yaml:"discovery_auto_threshold,omitempty"`
+	Enabled                bool                 `yaml:"enabled,omitempty"`
+	ComponentStatus        AddonComponentStatus `yaml:"component_status,omitempty"`
+	NamespaceLabel         string               `yaml:"namespace_label,omitempty"`
+	Prometheus             PrometheusConfig     `yaml:"prometheus,omitempty"`
 }
 
 // GrafanaConfig describes configuration used for Grafana links
 type GrafanaConfig struct {
 	Auth            Auth                     `yaml:"auth"`
+	ComponentStatus AddonComponentStatus     `yaml:"component_status,omitempty"`
 	Dashboards      []GrafanaDashboardConfig `yaml:"dashboards"`
 	Enabled         bool                     `yaml:"enabled"` // Enable or disable Grafana support in Kiali
 	InClusterURL    string                   `yaml:"in_cluster_url"`
-	IsCoreComponent bool                     `yaml:"is_core_component"`
 	URL             string                   `yaml:"url"`
 }
 
@@ -151,14 +157,14 @@ type GrafanaVariablesConfig struct {
 
 // TracingConfig describes configuration used for tracing links
 type TracingConfig struct {
-	Auth                 Auth     `yaml:"auth"`
-	Enabled              bool     `yaml:"enabled"` // Enable Jaeger in Kiali
-	InClusterURL         string   `yaml:"in_cluster_url"`
-	IsCoreComponent      bool     `yaml:"is_core_component"`
-	NamespaceSelector    bool     `yaml:"namespace_selector"`
-	URL                  string   `yaml:"url"`
-	UseGRPC              bool     `yaml:"use_grpc"`
-	WhiteListIstioSystem []string `yaml:"whitelist_istio_system"`
+	Auth                 Auth                 `yaml:"auth"`
+	ComponentStatus      AddonComponentStatus `yaml:"component_status,omitempty"`
+	Enabled              bool                 `yaml:"enabled"` // Enable Jaeger in Kiali
+	InClusterURL         string               `yaml:"in_cluster_url"`
+	NamespaceSelector    bool                 `yaml:"namespace_selector"`
+	URL                  string               `yaml:"url"`
+	UseGRPC              bool                 `yaml:"use_grpc"`
+	WhiteListIstioSystem []string             `yaml:"whitelist_istio_system"`
 }
 
 // IstioConfig describes configuration used for istio links
@@ -411,13 +417,18 @@ func NewConfig() (c *Config) {
 				DiscoveryAutoThreshold: 10,
 				Enabled:                true,
 				NamespaceLabel:         "kubernetes_namespace",
+				ComponentStatus: AddonComponentStatus{
+					IsCore: false,
+				},
 			},
 			Grafana: GrafanaConfig{
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
-				Enabled:         true,
-				IsCoreComponent: false,
+				Enabled: true,
+				ComponentStatus: AddonComponentStatus{
+					IsCore: false,
+				},
 			},
 			Istio: IstioConfig{
 				ComponentStatuses: ComponentStatuses{
@@ -460,7 +471,9 @@ func NewConfig() (c *Config) {
 				Auth: Auth{
 					Type: AuthTypeNone,
 				},
-				IsCoreComponent:      false,
+				ComponentStatus: AddonComponentStatus{
+					IsCore: false,
+				},
 				Enabled:              true,
 				NamespaceSelector:    true,
 				InClusterURL:         "http://tracing.istio-system/jaeger",


### PR DESCRIPTION
fixes #3631 

This PR allows users to specify which URL should kiali ping to compute the health check for each add-on (jaeger, prom, grafana and custom dashboards).

There are a lot of different deployments for each add-on, so this give flexibility.

This PR needs **operator changes**: https://github.com/kiali/kiali-operator/pull/277