### PR TITLE
Enhance visualization of label validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -229,10 +229,9 @@ type LabelValidation struct {
 
 // IstioLabels holds configuration about the labels required by Istio
 type IstioLabels struct {
-	AppLabelName       string            `yaml:"app_label_name,omitempty" json:"appLabelName"`
-	InjectionLabelName string            `yaml:"injection_label,omitempty" json:"injectionLabelName"`
-	VersionLabelName   string            `yaml:"version_label_name,omitempty" json:"versionLabelName"`
-	LabelValidation    []LabelValidation `yaml:"label_validation,omitempty" json:"labelValidation"`
+	AppLabelName       string `yaml:"app_label_name,omitempty" json:"appLabelName"`
+	InjectionLabelName string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
+	VersionLabelName   string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
 // AdditionalDisplayItem holds some display-related configuration, like which annotations are to be displayed
@@ -371,6 +370,7 @@ type Config struct {
 	IstioNamespace           string                   `yaml:"istio_namespace,omitempty"` // default component namespace
 	KialiFeatureFlags        KialiFeatureFlags        `yaml:"kiali_feature_flags,omitempty"`
 	KubernetesConfig         KubernetesConfig         `yaml:"kubernetes_config,omitempty"`
+	LabelValidation          []LabelValidation        `yaml:"label_validation,omitempty" json:"labelValidation"`
 	LoginToken               LoginToken               `yaml:"login_token,omitempty"`
 	Server                   Server                   `yaml:",omitempty"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -218,11 +218,21 @@ func (lt *LoginToken) Obfuscate() {
 	lt.SigningKey = "xxx"
 }
 
+type LabelKeyRegex map[string]string
+type LabelValidation struct {
+	Namespace   string        `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Kind        string        `yaml:"kind,omitempty" json:"kind,omitempty"`
+	Name        string        `yaml:"name,omitempty" json:"name,omitempty"`
+	Presence    []string      `yaml:"presence,omitempty" json:"presence"`
+	FilterLabel LabelKeyRegex `yaml:"filter_label,omitempty" json:"filterLabel"`
+}
+
 // IstioLabels holds configuration about the labels required by Istio
 type IstioLabels struct {
-	AppLabelName       string `yaml:"app_label_name,omitempty" json:"appLabelName"`
-	InjectionLabelName string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
-	VersionLabelName   string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
+	AppLabelName       string            `yaml:"app_label_name,omitempty" json:"appLabelName"`
+	InjectionLabelName string            `yaml:"injection_label,omitempty" json:"injectionLabelName"`
+	VersionLabelName   string            `yaml:"version_label_name,omitempty" json:"versionLabelName"`
+	LabelValidation    []LabelValidation `yaml:"label_validation,omitempty" json:"labelValidation"`
 }
 
 // AdditionalDisplayItem holds some display-related configuration, like which annotations are to be displayed

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -59,6 +59,7 @@ type PublicConfig struct {
 	IstioLabels              config.IstioLabels              `json:"istioLabels,omitempty"`
 	IstioConfigMap           string                          `json:"istioConfigMap"`
 	KialiFeatureFlags        config.KialiFeatureFlags        `json:"kialiFeatureFlags,omitempty"`
+	LabelValidation          []config.LabelValidation        `json:"labelValidation"`
 	Prometheus               PrometheusConfig                `json:"prometheus,omitempty"`
 }
 
@@ -90,6 +91,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 		IstioLabels:              config.IstioLabels,
 		IstioConfigMap:           config.ExternalServices.Istio.ConfigMapName,
 		KialiFeatureFlags:        config.KialiFeatureFlags,
+		LabelValidation:          config.LabelValidation,
 		Prometheus: PrometheusConfig{
 			GlobalScrapeInterval: promConfig.GlobalScrapeInterval,
 			StorageTsdbRetention: promConfig.StorageTsdbRetention,


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/1404
Ui https://github.com/kiali/kiali-ui/pull/2128

Configuration require example

```yaml
label_validation:
  - namespace: "alpha"
    presence:
      - hello
    filter_label:
      app: "avion"
      version: "v1"
```
The configuration like health let granularity like namespace, kind and name by regex.
After that we have 2 checks:

- Presence of label (array of strings)
- filter of label (map key => regex)
