### PR TITLE
Add additional context to configmap 404 message

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -137,6 +137,9 @@ func (in *MeshService) IsMeshConfigured() (bool, error) {
 
 	istioConfig, err := in.k8s.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			err = fmt.Errorf("%w in namespace \"%s\"", err, cfg.IstioNamespace)
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
Adds the namespace as additional context to the 404 error message returned from the `MessageService.IsMeshConfigured` method. This error gets directly surfaced to the UI on the graph page.

New error message with additional context added
![Screenshot from 2021-04-20 17-30-05](https://user-images.githubusercontent.com/6226732/115467291-49b0fb80-a1ff-11eb-9bc2-cb9e14d65788.png)


Fixes #3821