### PR TITLE
Adds configuration for the istio-sidecar-injector configmap name

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -341,7 +341,7 @@ func (in *MeshService) findRemoteKiali(clusterName string, kubeconfig *kubernete
 func (in *MeshService) resolveKialiNetwork() (string, error) {
 	conf := config.Get()
 
-	istioSidecarConfig, err := in.k8s.GetConfigMap(conf.IstioNamespace, "istio-sidecar-injector")
+	istioSidecarConfig, err := in.k8s.GetConfigMap(conf.IstioNamespace, conf.ExternalServices.Istio.IstioInjectorName)
 	if err != nil {
 		// Don't return an error, as this may mean that Kiali is not installed along the control plane.
 		// This setup is OK, it's just that it's not within our multi-cluster assumptions.

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -341,7 +341,7 @@ func (in *MeshService) findRemoteKiali(clusterName string, kubeconfig *kubernete
 func (in *MeshService) resolveKialiNetwork() (string, error) {
 	conf := config.Get()
 
-	istioSidecarConfig, err := in.k8s.GetConfigMap(conf.IstioNamespace, conf.ExternalServices.Istio.IstioInjectorName)
+	istioSidecarConfig, err := in.k8s.GetConfigMap(conf.IstioNamespace, conf.ExternalServices.Istio.IstioSidecarInjectorConfigBapName)
 	if err != nil {
 		// Don't return an error, as this may mean that Kiali is not installed along the control plane.
 		// This setup is OK, it's just that it's not within our multi-cluster assumptions.

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -341,7 +341,7 @@ func (in *MeshService) findRemoteKiali(clusterName string, kubeconfig *kubernete
 func (in *MeshService) resolveKialiNetwork() (string, error) {
 	conf := config.Get()
 
-	istioSidecarConfig, err := in.k8s.GetConfigMap(conf.IstioNamespace, conf.ExternalServices.Istio.IstioSidecarInjectorConfigBapName)
+	istioSidecarConfig, err := in.k8s.GetConfigMap(conf.IstioNamespace, conf.ExternalServices.Istio.IstioSidecarInjectorConfigMapName)
 	if err != nil {
 		// Don't return an error, as this may mean that Kiali is not installed along the control plane.
 		// This setup is OK, it's just that it's not within our multi-cluster assumptions.

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -80,7 +80,7 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 	k8s.On("IsOpenShift").Return(false)
 	k8s.On("GetSecrets", conf.IstioNamespace, "istio/multiCluster=true").Return([]core_v1.Secret{}, nil)
 	k8s.On("GetDeployment", conf.IstioNamespace, conf.ExternalServices.Istio.IstiodDeploymentName).Return(&istioDeploymentMock, nil)
-	k8s.On("GetConfigMap", conf.IstioNamespace, conf.ExternalServices.Istio.IstioInjectorName).Return(&sidecarConfigMapMock, nil)
+	k8s.On("GetConfigMap", conf.IstioNamespace, conf.ExternalServices.Istio.IstioSidecarInjectorConfigMapName).Return(&sidecarConfigMapMock, nil)
 
 	k8s.On("GetNamespace", "foo").Return(&kialiNs, nil)
 	k8s.On("GetServicesByLabels", "foo", "app.kubernetes.io/name=kiali").Return(kialiSvc, nil)
@@ -318,7 +318,7 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 	var nilNamespace *core_v1.Namespace
 
 	k8s.On("GetDeployment", "foo", "bar").Return(&istioDeploymentMock, nil)
-	k8s.On("GetConfigMap", "foo", conf.ExternalServices.Istio.IstioInjectorName).Return(nilConfigMap, &notFoundErr)
+	k8s.On("GetConfigMap", "foo", conf.ExternalServices.Istio.IstioSidecarInjectorConfigMapName).Return(nilConfigMap, &notFoundErr)
 	k8s.On("GetNamespace", "foo").Return(nilNamespace, &notFoundErr)
 
 	// Create a MeshService and invoke IsMeshConfigured

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -79,8 +79,8 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 
 	k8s.On("IsOpenShift").Return(false)
 	k8s.On("GetSecrets", conf.IstioNamespace, "istio/multiCluster=true").Return([]core_v1.Secret{}, nil)
-	k8s.On("GetDeployment", conf.IstioNamespace, "istiod").Return(&istioDeploymentMock, nil)
-	k8s.On("GetConfigMap", conf.IstioNamespace, "istio-sidecar-injector").Return(&sidecarConfigMapMock, nil)
+	k8s.On("GetDeployment", conf.IstioNamespace, conf.ExternalServices.Istio.IstiodDeploymentName).Return(&istioDeploymentMock, nil)
+	k8s.On("GetConfigMap", conf.IstioNamespace, conf.ExternalServices.Istio.IstioInjectorName).Return(&sidecarConfigMapMock, nil)
 
 	k8s.On("GetNamespace", "foo").Return(&kialiNs, nil)
 	k8s.On("GetServicesByLabels", "foo", "app.kubernetes.io/name=kiali").Return(kialiSvc, nil)
@@ -318,7 +318,7 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 	var nilNamespace *core_v1.Namespace
 
 	k8s.On("GetDeployment", "foo", "bar").Return(&istioDeploymentMock, nil)
-	k8s.On("GetConfigMap", "foo", "istio-sidecar-injector").Return(nilConfigMap, &notFoundErr)
+	k8s.On("GetConfigMap", "foo", conf.ExternalServices.Istio.IstioInjectorName).Return(nilConfigMap, &notFoundErr)
 	k8s.On("GetNamespace", "foo").Return(nilNamespace, &notFoundErr)
 
 	// Create a MeshService and invoke IsMeshConfigured

--- a/config/config.go
+++ b/config/config.go
@@ -166,15 +166,15 @@ type TracingConfig struct {
 
 // IstioConfig describes configuration used for istio links
 type IstioConfig struct {
-	ComponentStatuses        ComponentStatuses `yaml:"component_status,omitempty"`
-	ConfigMapName            string            `yaml:"config_map_name,omitempty"`
-	EnvoyAdminLocalPort      int               `yaml:"envoy_admin_local_port,omitempty"`
-	IstioIdentityDomain      string            `yaml:"istio_identity_domain,omitempty"`
-	IstioInjectionAnnotation string            `yaml:"istio_injection_annotation,omitempty"`
-	IstioInjectorName        string            `yaml:"istio_injector_name,omitempty"`
-	IstioSidecarAnnotation   string            `yaml:"istio_sidecar_annotation,omitempty"`
-	IstiodDeploymentName     string            `yaml:"istiod_deployment_name,omitempty"`
-	UrlServiceVersion        string            `yaml:"url_service_version"`
+	ComponentStatuses                 ComponentStatuses `yaml:"component_status,omitempty"`
+	ConfigMapName                     string            `yaml:"config_map_name,omitempty"`
+	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty"`
+	IstioIdentityDomain               string            `yaml:"istio_identity_domain,omitempty"`
+	IstioInjectionAnnotation          string            `yaml:"istio_injection_annotation,omitempty"`
+	IstioSidecarInjectorConfigMapName string            `yaml:"istio_sidecar_injector_config_map_name,omitempty"`
+	IstioSidecarAnnotation            string            `yaml:"istio_sidecar_annotation,omitempty"`
+	IstiodDeploymentName              string            `yaml:"istiod_deployment_name,omitempty"`
+	UrlServiceVersion                 string            `yaml:"url_service_version"`
 }
 
 type ComponentStatuses struct {
@@ -446,14 +446,14 @@ func NewConfig() (c *Config) {
 						},
 					},
 				},
-				ConfigMapName:            "istio",
-				EnvoyAdminLocalPort:      15000,
-				IstioIdentityDomain:      "svc.cluster.local",
-				IstioInjectionAnnotation: "sidecar.istio.io/inject",
-				IstioInjectorName:        "istio-sidecar-injector",
-				IstioSidecarAnnotation:   "sidecar.istio.io/status",
-				IstiodDeploymentName:     "istiod",
-				UrlServiceVersion:        "http://istiod:15014/version",
+				ConfigMapName:                     "istio",
+				EnvoyAdminLocalPort:               15000,
+				IstioIdentityDomain:               "svc.cluster.local",
+				IstioInjectionAnnotation:          "sidecar.istio.io/inject",
+				IstioSidecarInjectorConfigMapName: "istio-sidecar-injector",
+				IstioSidecarAnnotation:            "sidecar.istio.io/status",
+				IstiodDeploymentName:              "istiod",
+				UrlServiceVersion:                 "http://istiod:15014/version",
 			},
 			Prometheus: PrometheusConfig{
 				Auth: Auth{

--- a/config/config.go
+++ b/config/config.go
@@ -171,6 +171,7 @@ type IstioConfig struct {
 	EnvoyAdminLocalPort      int               `yaml:"envoy_admin_local_port,omitempty"`
 	IstioIdentityDomain      string            `yaml:"istio_identity_domain,omitempty"`
 	IstioInjectionAnnotation string            `yaml:"istio_injection_annotation,omitempty"`
+	IstioInjectorName        string            `yaml:"istio_injector_name,omitempty"`
 	IstioSidecarAnnotation   string            `yaml:"istio_sidecar_annotation,omitempty"`
 	IstiodDeploymentName     string            `yaml:"istiod_deployment_name,omitempty"`
 	UrlServiceVersion        string            `yaml:"url_service_version"`
@@ -449,6 +450,7 @@ func NewConfig() (c *Config) {
 				EnvoyAdminLocalPort:      15000,
 				IstioIdentityDomain:      "svc.cluster.local",
 				IstioInjectionAnnotation: "sidecar.istio.io/inject",
+				IstioInjectorName:        "istio-sidecar-injector",
 				IstioSidecarAnnotation:   "sidecar.istio.io/status",
 				IstiodDeploymentName:     "istiod",
 				UrlServiceVersion:        "http://istiod:15014/version",


### PR DESCRIPTION
** Describe the change **

This change addresses #3923 by adding a new configuration attribute for istio_sidecar_injector_config_map_name

** Issue reference **

#3923 

** Backwards incompatible? **

- Is your change introducing backwards incompatible changes?

Should be backwards compatible

** Documentation **

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
Updated kiali_cr.yaml in https://github.com/kiali/kiali-operator/pull/295
