### PR TITLE
Ensure idle nodes are created in the homecluster

### DIFF
--- a/graph/telemetry/istio/appender/dead_node.go
+++ b/graph/telemetry/istio/appender/dead_node.go
@@ -30,7 +30,9 @@ func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 
 	if globalInfo.HomeCluster == "" {
 		globalInfo.HomeCluster = "unknown"
-		if c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil); c != nil && err == nil {
+		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
+		graph.CheckError(err)
+		if c != nil {
 			globalInfo.HomeCluster = c.Name
 		}
 	}


### PR DESCRIPTION
Adds idle nodes to the graph in the homecluster instead of "unknown".

Behavior before the change:

![Screenshot from 2021-04-23 13-46-10](https://user-images.githubusercontent.com/6226732/115910480-deec0400-a43a-11eb-824d-a4cd56689970.png)

Behavior after the change:

![Screenshot from 2021-04-23 13-39-41](https://user-images.githubusercontent.com/6226732/115910523-ee6b4d00-a43a-11eb-8fb1-469f1778c8a6.png)

Fixes #3917

