### PR TITLE
Fix missing units in jaeger query

### DIFF
--- a/jaeger/http_client.go
+++ b/jaeger/http_client.go
@@ -53,7 +53,14 @@ func getTraceDetailHTTP(client http.Client, endpoint *url.URL, traceID string) (
 }
 
 func queryTracesHTTP(client http.Client, u *url.URL) (*JaegerResponse, error) {
-	resp, code, reqError := makeRequest(client, u.String(), nil)
+	// HTTP and GRPC requests co-exist, but when minDuration is present, for HTTP it requires a unit (ms)
+	// https://github.com/kiali/kiali/issues/3939
+	if u.Query().Get("minDuration") != "" {
+		query := u.Query()
+		query.Set("minDuration", u.Query().Get("minDuration") + "ms")
+		u.RawQuery = query.Encode()
+	}
+ 	resp, code, reqError := makeRequest(client, u.String(), nil)
 	if reqError != nil {
 		log.Errorf("Jaeger query error: %s [code: %d, URL: %v]", reqError, code, u)
 		return &JaegerResponse{}, reqError

--- a/jaeger/http_client.go
+++ b/jaeger/http_client.go
@@ -57,10 +57,10 @@ func queryTracesHTTP(client http.Client, u *url.URL) (*JaegerResponse, error) {
 	// https://github.com/kiali/kiali/issues/3939
 	if u.Query().Get("minDuration") != "" {
 		query := u.Query()
-		query.Set("minDuration", u.Query().Get("minDuration") + "ms")
+		query.Set("minDuration", u.Query().Get("minDuration")+"ms")
 		u.RawQuery = query.Encode()
 	}
- 	resp, code, reqError := makeRequest(client, u.String(), nil)
+	resp, code, reqError := makeRequest(client, u.String(), nil)
 	if reqError != nil {
 		log.Errorf("Jaeger query error: %s [code: %d, URL: %v]", reqError, code, u)
 		return &JaegerResponse{}, reqError

--- a/jaeger/http_client.go
+++ b/jaeger/http_client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"strings"
 )
 
 func getAppTracesHTTP(client http.Client, baseURL *url.URL, namespace, app string, q models.TracingQuery) (response *JaegerResponse, err error) {
@@ -55,9 +56,10 @@ func getTraceDetailHTTP(client http.Client, endpoint *url.URL, traceID string) (
 func queryTracesHTTP(client http.Client, u *url.URL) (*JaegerResponse, error) {
 	// HTTP and GRPC requests co-exist, but when minDuration is present, for HTTP it requires a unit (ms)
 	// https://github.com/kiali/kiali/issues/3939
-	if u.Query().Get("minDuration") != "" {
+	minDuration := u.Query().Get("minDuration")
+	if minDuration != "" && !strings.HasSuffix(minDuration, "ms") {
 		query := u.Query()
-		query.Set("minDuration", u.Query().Get("minDuration")+"ms")
+		query.Set("minDuration", minDuration+"ms")
 		u.RawQuery = query.Encode()
 	}
 	resp, code, reqError := makeRequest(client, u.String(), nil)


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3939

cc @brendarearden 

Kiali is using GRPC and HTTP clients to connect Jaeger.
It keeps both because some systems may use an OAuth sidecar to protect Jaeger and we've found that GRPC + OAuth sidecars may introduce some problems.

So, in short, there is a bug in the legacy HTTP query that it was missing a unit in the backend code when present a parameter.

How to test:
- Navigate into the traces tab in any of the demos examples we use with traces enabled and set the percentile options.
- Validate that no errors are found and Traces tab is stable.

![image](https://user-images.githubusercontent.com/1662329/116226535-5ed3e000-a753-11eb-8624-bcc182db5e65.png)

