### PR TITLE
Fix invalid workload types

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1302,7 +1302,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		cnFound := true
 		switch ctype {
 		case kubernetes.DeploymentType:
-			if dep.Name == workloadName {
+			if dep != nil && dep.Name == workloadName {
 				selector := labels.Set(dep.Spec.Template.Labels).AsSelector()
 				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
 				w.ParseDeployment(dep)
@@ -1347,7 +1347,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 				cnFound = false
 			}
 		case kubernetes.DeploymentConfigType:
-			if depcon.Name == workloadName {
+			if depcon != nil && depcon.Name == workloadName {
 				selector := labels.Set(depcon.Spec.Template.Labels).AsSelector()
 				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
 				w.ParseDeploymentConfig(depcon)
@@ -1356,7 +1356,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 				cnFound = false
 			}
 		case kubernetes.StatefulSetType:
-			if fulset.Name == workloadName {
+			if fulset != nil && fulset.Name == workloadName {
 				selector := labels.Set(fulset.Spec.Template.Labels).AsSelector()
 				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
 				w.ParseStatefulSet(fulset)
@@ -1418,7 +1418,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 				cnFound = false
 			}
 		case kubernetes.DaemonSetType:
-			if ds.Name == workloadName {
+			if ds != nil && ds.Name == workloadName {
 				selector := labels.Set(ds.Spec.Template.Labels).AsSelector()
 				w.SetPods(kubernetes.FilterPodsForSelector(selector, pods))
 				w.ParseDaemonSet(ds)


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3830

This fix will provide better support for custom controllers and invalid types.

QE:
- Test a invalid/valid query:

```
GET http://admin:admin@localhost:8000/api/namespaces/default/workloads/reviews-v3/health?rateInterval=60s&type=invalid
```
404 expected

```
GET http://admin:admin@localhost:8000/api/namespaces/default/workloads/reviews-v3/health?rateInterval=60s&type=Deployment
```

200 expected

- Regression testing for custom controllers:

https://github.com/argoproj/argo-rollouts
https://github.com/argoproj/argo-rollouts/blob/master/docs/getting-started.md

Check that RollOut controllers are seeing in Kiali as Workloads without any crash

cc @hhovsepy I'm starting to adding you on PR as Dev role :) just with the aim to get you familiar with the code.

Note, the workloads logic is more complex as expected as it has to deal with:
- Controllers with no pods.
- Workloads that are created from a controllers A (ReplicaSet) that is also created from controller B (Deployment) (two levels).
- Custom controllers; pods created by a controller A (ReplicaSet) that is also created from a controller C (not known).
- Invalid situations.

So, those are some reason why the business logic have several edges cases (no to get in detail into this PR but just to share knowledge and context about why it has that design).


