### PR TITLE
Adds a check to the makefile to see if OC is ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ KIND_NAME ?= kind
 
 # Determine if the OC is operational or not. Useful for other commands that might timeout if the OC exists but is not responding.
 ifeq ($(CLUSTER_TYPE),minikube)
-OC_READY ?= $(shell if minikube -p ${MINIKUBE_PROFILE} status &>/dev/null ; then echo "true" ; else echo "false" ; fi)
+OC_READY ?= $(shell if ${MINIKUBE} -p ${MINIKUBE_PROFILE} status &>/dev/null ; then echo "true" ; else echo "false" ; fi)
 else ifeq ($(CLUSTER_TYPE),kind)
 OC_READY ?= $(shell if ${OC} cluster-info --context=kind-${KIND_NAME} --request-timeout=1s &>/dev/null ; then echo "true" ; else echo "false" ; fi)
 else


### PR DESCRIPTION
Adds an additional env var to the makefile to check if the cluster is ready. Useful if other env vars need to talk to the cluster to determine their value and might otherwise timeout such as with `IS_MAISTRA`.

Should also help speed up unit tests run in CI where there isn't a working cluster.

Fixes #3910 