### PR TITLE
Create service entry nodes in homecluster

### DIFF
--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -53,6 +53,15 @@ func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInf
 		return
 	}
 
+	if globalInfo.HomeCluster == "" {
+		globalInfo.HomeCluster = "unknown"
+		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
+		graph.CheckError(err)
+		if c != nil {
+			globalInfo.HomeCluster = c.Name
+		}
+	}
+
 	a.applyServiceEntries(trafficMap, globalInfo, namespaceInfo)
 }
 
@@ -91,7 +100,7 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 
 	// Replace "se-service" nodes with an "se-aggregate" serviceEntry node
 	for se, seServiceNodes := range seMap {
-		serviceEntryNode := graph.NewNode(graph.Unknown, namespaceInfo.Namespace, se.name, "", "", "", "", a.GraphType)
+		serviceEntryNode := graph.NewNode(globalInfo.HomeCluster, namespaceInfo.Namespace, se.name, "", "", "", "", a.GraphType)
 		serviceEntryNode.Metadata[graph.IsServiceEntry] = &graph.SEInfo{
 			Location: se.location,
 			Hosts:    se.hosts,

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
+const testCluster = "testcluster"
+
 func setupServiceEntries(exportTo interface{}) *business.Layer {
 	k8s := kubetest.NewK8SClientMock()
 
@@ -61,16 +63,16 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
 	// unknownNode
-	n0 := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
 	// NotSE serviceNode
-	n1 := graph.NewNode(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// NotSE appNode
-	n2 := graph.NewNode(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 
 	// externalSE host1 serviceNode
-	n3 := graph.NewNode(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n3 := graph.NewNode(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n3.Metadata = graph.NewMetadata()
 	destServices := graph.NewDestServicesMetadata()
 	destService := graph.ServiceName{Namespace: n3.Namespace, Name: n3.Service}
@@ -78,7 +80,7 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	n3.Metadata[graph.DestServices] = destServices
 
 	// externalSE host2 serviceNode
-	n4 := graph.NewNode(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n4 := graph.NewNode(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n4.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n4.Namespace, Name: n4.Service}
@@ -86,10 +88,10 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	n4.Metadata[graph.DestServices] = destServices
 
 	// non-service-entry (ALLOW_ANY) serviceNode
-	n5 := graph.NewNode(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n5 := graph.NewNode(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// internalSE host1 serviceNode
-	n6 := graph.NewNode(graph.Unknown, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n6 := graph.NewNode(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n6.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n6.Namespace, Name: n6.Service}
@@ -97,7 +99,7 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	n6.Metadata[graph.DestServices] = destServices
 
 	// internalSE host2 serviceNode (test prefix)
-	n7 := graph.NewNode(graph.Unknown, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n7 := graph.NewNode(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n7.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n7.Namespace, Name: n7.Service}
@@ -132,55 +134,56 @@ func TestServiceEntry(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
 	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.HomeCluster = testCluster
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -192,25 +195,25 @@ func TestServiceEntry(t *testing.T) {
 
 	assert.Equal(6, len(trafficMap))
 
-	unknownID, _ = graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
@@ -220,13 +223,13 @@ func TestServiceEntry(t *testing.T) {
 	assert.Equal("host2.external.com", externalHosts[1])
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -245,49 +248,49 @@ func TestServiceEntryExportAll(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -295,6 +298,7 @@ func TestServiceEntryExportAll(t *testing.T) {
 
 	globalInfo := graph.NewAppenderGlobalInfo()
 	globalInfo.Business = businessLayer
+	globalInfo.HomeCluster = testCluster
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
 	// Run the appender...
@@ -305,38 +309,38 @@ func TestServiceEntryExportAll(t *testing.T) {
 
 	assert.Equal(6, len(trafficMap))
 
-	unknownID, _ = graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
 	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -352,49 +356,49 @@ func TestServiceEntryExportNamespaceFound(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -402,6 +406,7 @@ func TestServiceEntryExportNamespaceFound(t *testing.T) {
 
 	globalInfo := graph.NewAppenderGlobalInfo()
 	globalInfo.Business = businessLayer
+	globalInfo.HomeCluster = testCluster
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
 	// Run the appender...
@@ -412,38 +417,38 @@ func TestServiceEntryExportNamespaceFound(t *testing.T) {
 
 	assert.Equal(6, len(trafficMap))
 
-	unknownID, _ = graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
 	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -459,49 +464,49 @@ func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -509,6 +514,7 @@ func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
 
 	globalInfo := graph.NewAppenderGlobalInfo()
 	globalInfo.Business = businessLayer
+	globalInfo.HomeCluster = testCluster
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
 	// Run the appender...
@@ -519,38 +525,38 @@ func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
 
 	assert.Equal(6, len(trafficMap))
 
-	unknownID, _ = graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
 	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -566,49 +572,49 @@ func TestServiceEntryExportNamespaceNotFound(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -616,6 +622,7 @@ func TestServiceEntryExportNamespaceNotFound(t *testing.T) {
 
 	globalInfo := graph.NewAppenderGlobalInfo()
 	globalInfo.Business = businessLayer
+	globalInfo.HomeCluster = testCluster
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
 	// Run the appender...
@@ -626,35 +633,35 @@ func TestServiceEntryExportNamespaceNotFound(t *testing.T) {
 
 	assert.Equal(7, len(trafficMap))
 
-	unknownID, _ = graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(graph.Unknown, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	_, found3 = trafficMap[externalSEServiceEntryID]
 	assert.Equal(false, found3)
 
-	externalHostXServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(graph.Unknown, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -693,9 +700,9 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 	// Create a VersionedApp traffic map where a workload is calling a remote service entry and also an internal one
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode(graph.Unknown, "namespace", "source", "namespace", "wk0", "source", "v0", graph.GraphTypeVersionedApp)
-	n1 := graph.NewNode(graph.Unknown, "namespace", "svc1.namespace.global", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
-	n2 := graph.NewNode(graph.Unknown, "namespace", "svc1", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(testCluster, "namespace", "source", "namespace", "wk0", "source", "v0", graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(testCluster, "namespace", "svc1.namespace.global", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(testCluster, "namespace", "svc1", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
 
 	trafficMap[n0.ID] = &n0
 	trafficMap[n1.ID] = &n1
@@ -707,6 +714,7 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 	// Run the appender
 	globalInfo := graph.NewAppenderGlobalInfo()
 	globalInfo.Business = businessLayer
+	globalInfo.HomeCluster = testCluster
 	namespaceInfo := graph.NewAppenderNamespaceInfo("namespace")
 
 	a := ServiceEntryAppender{
@@ -784,13 +792,13 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 	trafficMap := make(map[string]*graph.Node)
 
 	// unknownNode
-	n0 := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
 	// NotSE host3 serviceNode
-	n1 := graph.NewNode(graph.Unknown, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// SE2 host1 serviceNode
-	n2 := graph.NewNode(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n2.Metadata = graph.NewMetadata()
 	destServices := graph.NewDestServicesMetadata()
 	destService := graph.ServiceName{Namespace: n2.Namespace, Name: n2.Service}
@@ -798,7 +806,7 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 	n2.Metadata[graph.DestServices] = destServices
 
 	// SE2 host2 serviceNode
-	n3 := graph.NewNode(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n3 := graph.NewNode(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n3.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n3.Namespace, Name: n3.Service}
@@ -816,25 +824,25 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 
 	assert.Equal(4, len(trafficMap))
 
-	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(3, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(0, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE2Host1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE2Host1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE2Host1ServiceNode, found2 := trafficMap[SE2Host1ServiceID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE2Host1ServiceNode.Edges))
 	assert.Equal(nil, SE2Host1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE2Host2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE2Host2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE2Host2ServiceNode, found3 := trafficMap[SE2Host2ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(SE2Host2ServiceNode.Edges))
@@ -842,6 +850,7 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 
 	globalInfo := graph.NewAppenderGlobalInfo()
 	globalInfo.Business = businessLayer
+	globalInfo.HomeCluster = testCluster
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
 	// Run the appender...
@@ -852,19 +861,19 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 
 	assert.Equal(3, len(trafficMap))
 
-	unknownID, _ = graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(2, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(0, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE2ID, _ := graph.Id(graph.Unknown, "testNamespace", "SE2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE2ID, _ := graph.Id(testCluster, "testNamespace", "SE2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE2Node, found2 := trafficMap[SE2ID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE2Node.Edges))
@@ -917,13 +926,13 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 	trafficMap := make(map[string]*graph.Node)
 
 	// unknownNode
-	n0 := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
 	// NotSE host3 serviceNode
-	n1 := graph.NewNode(graph.Unknown, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// SE1 host1 serviceNode
-	n2 := graph.NewNode(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n2.Metadata = graph.NewMetadata()
 	destServices := graph.NewDestServicesMetadata()
 	destService := graph.ServiceName{Namespace: n2.Namespace, Name: n2.Service}
@@ -931,7 +940,7 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 	n2.Metadata[graph.DestServices] = destServices
 
 	// Not SE host2 serviceNode
-	n3 := graph.NewNode(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n3 := graph.NewNode(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	trafficMap[n0.ID] = &n0
 	trafficMap[n1.ID] = &n1
@@ -944,25 +953,25 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 
 	assert.Equal(4, len(trafficMap))
 
-	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(3, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEHost3ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost3ServiceID, _ := graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEHost3ServiceNode, found1 := trafficMap[notSEHost3ServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(0, len(notSEHost3ServiceNode.Edges))
 	assert.Equal(nil, notSEHost3ServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE1Host1ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE1Host1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE1Host1ServiceNode, found2 := trafficMap[SE1Host1ServiceID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE1Host1ServiceNode.Edges))
 	assert.Equal(nil, SE1Host1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEHost2ServiceID, _ := graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEHost2ServiceNode, found3 := trafficMap[notSEHost2ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(notSEHost2ServiceNode.Edges))
@@ -970,6 +979,7 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 
 	globalInfo := graph.NewAppenderGlobalInfo()
 	globalInfo.Business = businessLayer
+	globalInfo.HomeCluster = testCluster
 	namespaceInfo := graph.NewAppenderNamespaceInfo("otherNamespace")
 
 	// Run the appender...
@@ -980,26 +990,26 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 
 	assert.Equal(4, len(trafficMap))
 
-	unknownID, _ = graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(3, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEHost3ServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost3ServiceID, _ = graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEHost3ServiceNode, found1 = trafficMap[notSEHost3ServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(0, len(notSEHost3ServiceNode.Edges))
 	assert.Equal(nil, notSEHost3ServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE1ID, _ := graph.Id(graph.Unknown, "otherNamespace", "SE1", "otherNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE1ID, _ := graph.Id(testCluster, "otherNamespace", "SE1", "otherNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE1Node, found2 := trafficMap[SE1ID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE1Node.Edges))
 	assert.Equal("MESH_EXTERNAL", SE1Node.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(1, len(SE1Node.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	notSEHost2ServiceID, _ = graph.Id(graph.Unknown, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost2ServiceID, _ = graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEHost2ServiceNode, found3 = trafficMap[notSEHost2ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(notSEHost2ServiceNode.Edges))


### PR DESCRIPTION
Fixes #3938 

Creates Service Entry nodes in the homecluster instead of `unknown`.

Before change:
![Screenshot from 2021-04-28 16-46-15](https://user-images.githubusercontent.com/6226732/116473426-26acca00-a845-11eb-8ad9-086979594e22.png)

After:
![Screenshot from 2021-04-28 17-10-08](https://user-images.githubusercontent.com/6226732/116473466-30363200-a845-11eb-8bd8-98b44bc56615.png)


