### PR TITLE
[hack] some tweaks to k8s-minikube.sh

### DIFF
--- a/hack/ci-minikube-molecule-tests.sh
+++ b/hack/ci-minikube-molecule-tests.sh
@@ -61,7 +61,7 @@ if [ "$(${CLIENT_EXE} config current-context)" != "${minikube_profile}" ]; then
 fi
 
 if ! ${minikube_sh} status; then
-  ${minikube_sh} start --dex-enabled true -kv 1.18.0 -kdr kvm2
+  ${minikube_sh} start --dex-enabled true
   if ! ${minikube_sh} status; then
     echo "Failed to install the minikube cluster."
     exit 1


### PR DESCRIPTION
In older versions of minikube, our molecule tests that needed Dex would fail. So we always had to use an older version of k8s (v1.18).
But now it seems things work with the latest minikube and the latest stable k8s that it uses (v1.20).
Once this is merged, the nightly molecule test runs no longer have to ask minikube to start an older version of k8s.

I confirmed the molecule tests involving authentication work with this. Run this:

```
hack/run-molecule-tests.sh --client-exe $(which kubectl) -dorp podman --cluster-type minikube -at "header-auth-test openid-test token-test"
```

and you get:

```
                        header-auth-test... success [2m 34s]
                             openid-test... success [2m 1s]
                              token-test... success [2m 21s]
```

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-13T13:20:00Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}

$ minikube version
minikube version: v1.19.0
commit: 15cede53bdc5fe242228853e737333b09d4336b5
```
