### PR TITLE
Make sure Istio gateways are captured as proxies

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -185,6 +185,7 @@ type ComponentStatuses struct {
 type ComponentStatus struct {
 	AppLabel  string `yaml:"app_label,omitempty"`
 	IsCore    bool   `yaml:"is_core,omitempty"`
+	IsProxy   bool   `yaml:"is_proxy,omitempty"`
 	Namespace string `yaml:"namespace,omitempty"`
 }
 
@@ -435,14 +436,17 @@ func NewConfig() (c *Config) {
 						{
 							AppLabel: "istio-egressgateway",
 							IsCore:   false,
+							IsProxy:  true,
 						},
 						{
 							AppLabel: "istio-ingressgateway",
 							IsCore:   true,
+							IsProxy:  true,
 						},
 						{
 							AppLabel: "istiod",
 							IsCore:   true,
+							IsProxy:  false,
 						},
 					},
 				},

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -6579,6 +6579,7 @@ part of the mesh.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | Image | string| `string` |  | |  |  |
+| IsProxy | boolean| `bool` |  | |  |  |
 | Name | string| `string` |  | |  |  |
 
 

--- a/models/pod.go
+++ b/models/pod.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"strings"
 
 	core_v1 "k8s.io/api/core/v1"
 
@@ -117,7 +118,7 @@ func (pod *Pod) Parse(p *core_v1.Pod) {
 }
 
 func isIstioProxy(pod *core_v1.Pod, container *core_v1.Container, conf *config.Config) bool {
-	return pod.Namespace == conf.IstioNamespace && (pod.Name == "istio-ingressgateway" || pod.Name == "istio-egressgateway" || container.Name == "istio-proxy")
+	return pod.Namespace == conf.IstioNamespace && (container.Name == "istio-proxy" || strings.HasPrefix(pod.Name, "istio-ingressgateway") || strings.HasPrefix(pod.Name,"istio-egressgateway")
 }
 
 func lookupImage(containerName string, containers []core_v1.Container) string {

--- a/models/pod.go
+++ b/models/pod.go
@@ -118,7 +118,7 @@ func (pod *Pod) Parse(p *core_v1.Pod) {
 }
 
 func isIstioProxy(pod *core_v1.Pod, container *core_v1.Container, conf *config.Config) bool {
-	return pod.Namespace == conf.IstioNamespace && (container.Name == "istio-proxy" || strings.HasPrefix(pod.Name, "istio-ingressgateway") || strings.HasPrefix(pod.Name,"istio-egressgateway")
+	return pod.Namespace == conf.IstioNamespace && (container.Name == "istio-proxy" || strings.HasPrefix(pod.Name, "istio-ingressgateway") || strings.HasPrefix(pod.Name, "istio-egressgateway"))
 }
 
 func lookupImage(containerName string, containers []core_v1.Container) string {

--- a/models/pod.go
+++ b/models/pod.go
@@ -85,7 +85,7 @@ func (pod *Pod) Parse(p *core_v1.Pod) {
 				container := ContainerInfo{
 					Name:    name,
 					Image:   lookupImage(name, p.Spec.InitContainers),
-					IsProxy: false,
+					IsProxy: true,
 				}
 				pod.IstioInitContainers = append(pod.IstioInitContainers, &container)
 				istioContainerNames[name] = true

--- a/swagger.json
+++ b/swagger.json
@@ -4298,6 +4298,10 @@
           "type": "string",
           "x-go-name": "Image"
         },
+        "isProxy": {
+          "type": "boolean",
+          "x-go-name": "IsProxy"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"


### PR DESCRIPTION
@lucasponce Here is a server-side solution to #3977.  It could also be solved client-side, either way requires some special-casing of the istio pods (gateways) that are themselves proxies, not injected, but native.  This change allows clients to treat them as proxies, in particular the workload logs can then offer the special handling of the access logs.

So, let me know if this solution seems OK to you, or if you think a client-side solution would be better.

Fixes https://github.com/kiali/kiali/issues/3977

REQUIRES UI PR: https://github.com/kiali/kiali-ui/pull/2155
Related Operator PR: https://github.com/kiali/kiali-operator/pull/314