### PR TITLE
Assign anyuid scc to correct group

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -260,7 +260,7 @@ if [ "${DELETE_ISTIO}" != "true" ]; then
     fi
 
     echo Performing additional commands for OpenShift
-    ${CLIENT_EXE} adm policy add-scc-to-group anyuid system:serviceaccounts -n ${NAMESPACE}
+    ${CLIENT_EXE} adm policy add-scc-to-group anyuid system:serviceaccounts:${NAMESPACE}
   else
     if ! ${CLIENT_EXE} get namespace ${NAMESPACE}; then
       ${CLIENT_EXE} create namespace ${NAMESPACE}


### PR DESCRIPTION
Assigning anyuid to system:serviceaccounts is too broad and is causing
error in OCP internal openshift-service-ca (The expected SCC for service-ca pods is restricted, any other SCC being applied to it will cause the CreateContainerConfigError issue.) anyuid scc was added to service-ca pod via system:serviceaccounts, now
this script only adds anyuid to system:serviceaccounts:<namespace>

