### PR TITLE
Introduce Graph Find/Hide presets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -313,8 +313,8 @@ type IstioComponentNamespaces map[string]string
 
 // GraphFindOption defines a single Graph Find/Hide Option
 type GraphFindOption struct {
-	Expression  string `yaml:"expression,omitempty" json:"expression,omitempty"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	Expression  string `yaml:"expression,omitempty" json:"expression,omitempty"`
 }
 
 // GraphUIDefaults defines UI Defaults specific to the UI Graph

--- a/config/config.go
+++ b/config/config.go
@@ -507,26 +507,26 @@ func NewConfig() (c *Config) {
 				Graph: GraphUIDefaults{
 					FindOptions: []GraphFindOption{
 						{
-							Expression:  "rt > 1000",
 							Description: "Find: slow edges (> 1s)",
+							Expression:  "rt > 1000",
 						},
 						{
-							Expression:  "! healthy",
 							Description: "Find: unhealthy nodes",
+							Expression:  "! healthy",
 						},
 						{
-							Expression:  "name = unknown",
 							Description: "Find: unknown nodes",
+							Expression:  "name = unknown",
 						},
 					},
 					HideOptions: []GraphFindOption{
 						{
-							Expression:  "healthy",
 							Description: "Hide: healthy nodes",
+							Expression:  "healthy",
 						},
 						{
-							Expression:  "name = unknown",
 							Description: "Hide: unknown nodes",
+							Expression:  "name = unknown",
 						},
 					},
 				},

--- a/config/config.go
+++ b/config/config.go
@@ -504,6 +504,32 @@ func NewConfig() (c *Config) {
 		KialiFeatureFlags: KialiFeatureFlags{
 			IstioInjectionAction: true,
 			UIDefaults: UIDefaults{
+				Graph: GraphUIDefaults{
+					FindOptions: []GraphFindOption{
+						{
+							Expression:  "rt > 1000",
+							Description: "Find: slow edges (> 1s)",
+						},
+						{
+							Expression:  "! healthy",
+							Description: "Find: unhealthy nodes",
+						},
+						{
+							Expression:  "name = unknown",
+							Description: "Find: unknown nodes",
+						},
+					},
+					HideOptions: []GraphFindOption{
+						{
+							Expression:  "healthy",
+							Description: "Hide: healthy nodes",
+						},
+						{
+							Expression:  "name = unknown",
+							Description: "Hide: unknown nodes",
+						},
+					},
+				},
 				MetricsPerRefresh: "1m",
 				Namespaces:        make([]string, 0),
 				RefreshInterval:   "15s",

--- a/config/config.go
+++ b/config/config.go
@@ -311,11 +311,24 @@ type DeploymentConfig struct {
 // defaults to the namespace configured for IstioNamespace (which itself defaults to 'istio-system').
 type IstioComponentNamespaces map[string]string
 
+// GraphFindOption defines a single Graph Find/Hide Option
+type GraphFindOption struct {
+	Expression  string `yaml:"expression,omitempty" json:"expression,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}
+
+// GraphUIDefaults defines UI Defaults specific to the UI Graph
+type GraphUIDefaults struct {
+	FindOptions []GraphFindOption `yaml:"find_options,omitempty" json:"findOptions,omitempty"`
+	HideOptions []GraphFindOption `yaml:"hide_options,omitempty" json:"hideOptions,omitempty"`
+}
+
 // UIDefaults defines default settings configured for the UI
 type UIDefaults struct {
-	MetricsPerRefresh string   `yaml:"metrics_per_refresh,omitempty" json:"metricsPerRefresh,omitempty"`
-	Namespaces        []string `yaml:"namespaces,omitempty" json:"namespaces,omitempty"`
-	RefreshInterval   string   `yaml:"refresh_interval,omitempty" json:"refreshInterval,omitempty"`
+	Graph             GraphUIDefaults `yaml:"graph,omitempty" json:"graph,omitempty"`
+	MetricsPerRefresh string          `yaml:"metrics_per_refresh,omitempty" json:"metricsPerRefresh,omitempty"`
+	Namespaces        []string        `yaml:"namespaces,omitempty" json:"namespaces,omitempty"`
+	RefreshInterval   string          `yaml:"refresh_interval,omitempty" json:"refreshInterval,omitempty"`
 }
 
 // KialiFeatureFlags available from the CR


### PR DESCRIPTION
Graph Find/Hide now offers preset expressions via new dropdowns on each input. The preset expressions are supplied via the UIDefaults supplied by the server, and so can be configured by users via the CR.

Part-Of kiali/kiali#3708

UI PR: https://github.com/kiali/kiali-ui/pull/2159
Operator PR: https://github.com/kiali/kiali-operator/pull/315