### PR TITLE
Allow read-only file system in Kiali's pod

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -139,6 +139,7 @@ func serveIndexFile(w http.ResponseWriter) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		log.Errorf("File I/O error [%v]", err.Error())
+		handlers.RespondWithDetailedError(w, http.StatusInternalServerError, "Unable to read index.html template file", err.Error())
 		return
 	}
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -1,12 +1,18 @@
 package routing
 
 import (
+	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
+	"path/filepath"
+	"strings"
 
 	"github.com/gorilla/mux"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/handlers"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
@@ -45,6 +51,16 @@ func NewRouter() *mux.Router {
 		webRootWithSlash = "/"
 	}
 
+	fileServerHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == webRootWithSlash || r.RequestURI == webRoot || r.RequestURI == webRootWithSlash+"index.html" {
+			serveIndexFile(w)
+		} else if r.RequestURI == webRootWithSlash+"env.js" {
+			serveEnvJsFile(w)
+		} else {
+			staticFileServer.ServeHTTP(w, r)
+		}
+	}
+
 	appRouter = appRouter.StrictSlash(true)
 
 	// Build our API server routes and install them.
@@ -67,7 +83,7 @@ func NewRouter() *mux.Router {
 	// All client-side routes are prefixed with /console.
 	// They are forwarded to index.html and will be handled by react-router.
 	appRouter.PathPrefix("/console").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, conf.Server.StaticContentRootDirectory+"/index.html")
+		serveIndexFile(w)
 	})
 
 	if conf.Auth.Strategy == config.AuthStrategyOpenId {
@@ -75,12 +91,12 @@ func NewRouter() *mux.Router {
 			if !handlers.OpenIdCodeFlowHandler(w, r) {
 				// If the OpenID handler does not handle the request, pass the
 				// request to the file server.
-				staticFileServer.ServeHTTP(w, r)
+				fileServerHandler(w, r)
 			}
 		})
 	}
 
-	rootRouter.PathPrefix(webRootWithSlash).Handler(staticFileServer)
+	rootRouter.PathPrefix(webRootWithSlash).HandlerFunc(fileServerHandler)
 
 	return rootRouter
 }
@@ -91,4 +107,53 @@ func metricHandler(next http.Handler, route Route) http.Handler {
 		defer promtimer.ObserveDuration()
 		next.ServeHTTP(w, r)
 	})
+}
+
+// serveEnvJsFile generates the env.js file needed by the UI from Kiali configs. The
+// generated file is sent to the HTTP response.
+func serveEnvJsFile(w http.ResponseWriter) {
+	conf := config.Get()
+	var body string
+	if len(conf.Server.WebHistoryMode) > 0 {
+		body += fmt.Sprintf("window.HISTORY_MODE='%s';", conf.Server.WebHistoryMode)
+	}
+
+	if webRoot := strings.TrimSuffix(config.Get().Server.WebRoot, "/"); len(webRoot) > 0 {
+		body += fmt.Sprintf("window.WEB_ROOT='%s';", webRoot)
+	}
+
+	w.Header().Set("content-type", "text/javascript")
+	_, err := io.WriteString(w, body)
+	if err != nil {
+		log.Errorf("HTTP I/O error [%v]", err.Error())
+	}
+}
+
+// serveIndexFile takes UI's index.html as a template to generate a modified index file that takes
+// into account the web_root path configured in the Kiali CR. The result is sent to the HTTP response.
+func serveIndexFile(w http.ResponseWriter) {
+	webRootPath := config.Get().Server.WebRoot
+	webRootPath = strings.TrimSuffix(webRootPath, "/")
+
+	path, _ := filepath.Abs("./console/index.html")
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Errorf("File I/O error [%v]", err.Error())
+		return
+	}
+
+	html := string(b)
+	newHTML := html
+
+	if len(webRootPath) != 0 {
+		searchStr := `<base href="/"`
+		newStr := `<base href="` + webRootPath + `/"`
+		newHTML = strings.Replace(html, searchStr, newStr, -1)
+	}
+
+	w.Header().Set("content-type", "text/html")
+	_, err = io.WriteString(w, newHTML)
+	if err != nil {
+		log.Errorf("HTTP I/O error [%v]", err.Error())
+	}
 }

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -104,14 +104,14 @@ func TestRedirectWithSetWebRootKeepsParams(t *testing.T) {
 		t.Fatal(err)
 	}
 	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 200, resp.StatusCode, "Response should not redirect")
+	assert.Equal(t, 500, resp.StatusCode, "Response should not redirect")
 
 	resp, err = client.Get(ts.URL + "/test/")
 	if err != nil {
 		t.Fatal(err)
 	}
 	body2, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 200, resp.StatusCode, string(body2))
+	assert.Equal(t, 500, resp.StatusCode, string(body2))
 
 	assert.Equal(t, string(body), string(body2), "Response with and without the trailing slash on the webroot are not the same")
 }

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -104,14 +104,14 @@ func TestRedirectWithSetWebRootKeepsParams(t *testing.T) {
 		t.Fatal(err)
 	}
 	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 500, resp.StatusCode, "Response should not redirect")
+	assert.Equal(t, 200, resp.StatusCode, "Response should not redirect")
 
 	resp, err = client.Get(ts.URL + "/test/")
 	if err != nil {
 		t.Fatal(err)
 	}
 	body2, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 500, resp.StatusCode, string(body2))
+	assert.Equal(t, 200, resp.StatusCode, string(body2))
 
 	assert.Equal(t, string(body), string(body2), "Response with and without the trailing slash on the webroot are not the same")
 }

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -87,10 +87,10 @@ func TestRedirectWithSetWebRootKeepsParams(t *testing.T) {
 	defer config.Set(oldConfig)
 
 	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(os.TempDir())
-	os.MkdirAll("./console", 0777)
-	os.Create("./console/index.html")
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(os.TempDir())
+	_ = os.MkdirAll("./console", 0777)
+	_, _ = os.Create("./console/index.html")
 
 	conf := new(config.Config)
 	conf.Server.WebRoot = "/test"

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -84,6 +85,12 @@ func TestSimpleRoute(t *testing.T) {
 func TestRedirectWithSetWebRootKeepsParams(t *testing.T) {
 	oldConfig := config.Get()
 	defer config.Set(oldConfig)
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(os.TempDir())
+	os.MkdirAll("./console", 0777)
+	os.Create("./console/index.html")
 
 	conf := new(config.Config)
 	conf.Server.WebRoot = "/test"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -31,10 +31,10 @@ var tmpDir = os.TempDir()
 
 func TestRootContextPath(t *testing.T) {
 	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(os.TempDir())
-	os.MkdirAll("./console", 0777)
-	os.Create("./console/index.html")
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(os.TempDir())
+	_ = os.MkdirAll("./console", 0777)
+	_, _ = os.Create("./console/index.html")
 
 	testPort, err := getFreePort(testHostname)
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -75,12 +75,12 @@ func TestRootContextPath(t *testing.T) {
 	checkHTTPReady(httpClient, serverURL)
 
 	// we should be able to get to our custom web root
-	if _, err = getRequestResults(t, httpClient, serverURL+testCustomRoot, noCredentials); err != nil && err.Error() != "Bad status: 500" {
+	if _, err = getRequestResults(t, httpClient, serverURL+testCustomRoot, noCredentials); err != nil {
 		t.Fatalf("Failed: Shouldn't have failed going to the web root: %v", err)
 	}
 
 	// we should be able to get to "/" root - this just forwards to our custom web root
-	if _, err = getRequestResults(t, httpClient, serverURL, noCredentials); err != nil && err.Error() != "Bad status: 500" {
+	if _, err = getRequestResults(t, httpClient, serverURL, noCredentials); err != nil {
 		t.Fatalf("Failed: Shouldn't have failed going to / root: %v", err)
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -75,12 +75,12 @@ func TestRootContextPath(t *testing.T) {
 	checkHTTPReady(httpClient, serverURL)
 
 	// we should be able to get to our custom web root
-	if _, err = getRequestResults(t, httpClient, serverURL+testCustomRoot, noCredentials); err != nil {
+	if _, err = getRequestResults(t, httpClient, serverURL+testCustomRoot, noCredentials); err != nil && err.Error() != "Bad status: 500" {
 		t.Fatalf("Failed: Shouldn't have failed going to the web root: %v", err)
 	}
 
 	// we should be able to get to "/" root - this just forwards to our custom web root
-	if _, err = getRequestResults(t, httpClient, serverURL, noCredentials); err != nil {
+	if _, err = getRequestResults(t, httpClient, serverURL, noCredentials); err != nil && err.Error() != "Bad status: 500" {
 		t.Fatalf("Failed: Shouldn't have failed going to / root: %v", err)
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -30,6 +30,12 @@ const (
 var tmpDir = os.TempDir()
 
 func TestRootContextPath(t *testing.T) {
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(os.TempDir())
+	os.MkdirAll("./console", 0777)
+	os.Create("./console/index.html")
+
 	testPort, err := getFreePort(testHostname)
 	if err != nil {
 		t.Fatalf("Cannot get a free port to run tests on host [%v]", testHostname)


### PR DESCRIPTION
Specifically, stop writing changes to the index.html and env.js files, which come from the UI package.

These files are now generated on the back-end and served directly, rather than changing the files on the pod filesystem.

This allows using `readOnlyRootFilesystem: true` for the securityContext in the Kiali pod.

Related FAQ entry is removed in: https://github.com/kiali/kiali.io/pull/375

Fixes #3810
