### PR TITLE
Update Istio Cache + Include WorkloadGroup resources

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -266,7 +266,14 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.Include(kubernetes.WorkloadEntries) {
-			if we, weErr := in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.WorkloadEntries, criteria.LabelSelector); weErr == nil {
+			var we []kubernetes.IstioObject
+			var weErr error
+			if IsResourceCached(criteria.Namespace, kubernetes.WorkloadEntries) {
+				we, weErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.WorkloadEntries, criteria.LabelSelector)
+			} else {
+				we, weErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.WorkloadEntries, criteria.LabelSelector)
+			}
+			if weErr == nil {
 				(&istioConfigList.WorkloadEntries).Parse(we)
 			} else {
 				errChan <- weErr
@@ -298,7 +305,14 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 	go func(errChan chan error) {
 		defer wg.Done()
 		if criteria.Include(kubernetes.EnvoyFilters) {
-			if ef, efErr := in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.EnvoyFilters, criteria.LabelSelector); efErr == nil {
+			var ef []kubernetes.IstioObject
+			var efErr error
+			if IsResourceCached(criteria.Namespace, kubernetes.EnvoyFilters) {
+				ef, efErr = kialiCache.GetIstioObjects(criteria.Namespace, kubernetes.EnvoyFilters, criteria.LabelSelector)
+			} else {
+				ef, efErr = in.k8s.GetIstioObjects(criteria.Namespace, kubernetes.EnvoyFilters, criteria.LabelSelector)
+			}
+			if efErr == nil {
 				if isWorkloadSelector {
 					ef = kubernetes.FilterIstioObjectsForWorkloadSelector(workloadSelector, ef)
 				}

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -103,6 +103,7 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 		AuthorizationPolicies:  models.AuthorizationPolicies{},
 		PeerAuthentications:    models.PeerAuthentications{},
 		WorkloadEntries:        models.WorkloadEntries{},
+		WorkloadGroups:         models.WorkloadGroups{},
 		RequestAuthentications: models.RequestAuthentications{},
 		EnvoyFilters:           models.EnvoyFilters{},
 	}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -193,6 +193,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		objectCheckers = []ObjectChecker{peerAuthnChecker}
 	case kubernetes.WorkloadEntries:
 		// Validation on WorkloadEntries are not yet in place
+	case kubernetes.WorkloadGroups:
+		// Validation on WorkloadGroups are not yet in place
 	case kubernetes.RequestAuthentications:
 		// Validation on RequestAuthentications are not yet in place
 		requestAuthnChecker := checkers.RequestAuthenticationChecker{RequestAuthentications: istioDetails.RequestAuthentications, WorkloadList: workloads}

--- a/config/config.go
+++ b/config/config.go
@@ -496,7 +496,7 @@ func NewConfig() (c *Config) {
 			Burst:                       200,
 			CacheDuration:               5 * 60,
 			CacheEnabled:                true,
-			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService",  "WorkloadEntry", "WorkloadGroup"},
+			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},

--- a/config/config.go
+++ b/config/config.go
@@ -496,7 +496,7 @@ func NewConfig() (c *Config) {
 			Burst:                       200,
 			CacheDuration:               5 * 60,
 			CacheEnabled:                true,
-			CacheIstioTypes:             []string{"DestinationRule", "Gateway", "ServiceEntry", "VirtualService", "Sidecar", "PeerAuthentication", "RequestAuthentication", "AuthorizationPolicy"},
+			CacheIstioTypes:             []string{"DestinationRule", "Gateway", "ServiceEntry", "VirtualService", "Sidecar", "WorkloadEntry", "EnvoyFilter", "PeerAuthentication", "RequestAuthentication", "AuthorizationPolicy"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},

--- a/config/config.go
+++ b/config/config.go
@@ -496,7 +496,7 @@ func NewConfig() (c *Config) {
 			Burst:                       200,
 			CacheDuration:               5 * 60,
 			CacheEnabled:                true,
-			CacheIstioTypes:             []string{"DestinationRule", "Gateway", "ServiceEntry", "VirtualService", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "PeerAuthentication", "RequestAuthentication", "AuthorizationPolicy"},
+			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService",  "WorkloadEntry", "WorkloadGroup"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},

--- a/config/config.go
+++ b/config/config.go
@@ -496,7 +496,7 @@ func NewConfig() (c *Config) {
 			Burst:                       200,
 			CacheDuration:               5 * 60,
 			CacheEnabled:                true,
-			CacheIstioTypes:             []string{"DestinationRule", "Gateway", "ServiceEntry", "VirtualService", "Sidecar", "WorkloadEntry", "EnvoyFilter", "PeerAuthentication", "RequestAuthentication", "AuthorizationPolicy"},
+			CacheIstioTypes:             []string{"DestinationRule", "Gateway", "ServiceEntry", "VirtualService", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "PeerAuthentication", "RequestAuthentication", "AuthorizationPolicy"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -7105,6 +7105,7 @@ It is false for service.namespace format and service entries. |  |
 | validation | [IstioValidation](#istio-validation)| `IstioValidation` |  | |  |  |
 | virtualService | [VirtualService](#virtual-service)| `VirtualService` |  | |  |  |
 | workloadEntry | [WorkloadEntry](#workload-entry)| `WorkloadEntry` |  | |  |  |
+| workloadGroup | [WorkloadGroup](#workload-group)| `WorkloadGroup` |  | |  |  |
 
 
 
@@ -7134,6 +7135,7 @@ It is false for service.namespace format and service entries. |  |
 | validations | [IstioValidations](#istio-validations)| `IstioValidations` |  | |  |  |
 | virtualServices | [VirtualServices](#virtual-services)| `VirtualServices` |  | |  |  |
 | workloadEntries | [WorkloadEntries](#workload-entries)| `WorkloadEntries` |  | |  |  |
+| workloadGroups | [WorkloadGroups](#workload-groups)| `WorkloadGroups` |  | |  |  |
 
 
 
@@ -9196,6 +9198,67 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 | Weight | [interface{}](#interface)| `interface{}` |  | |  |  |
 
 
+
+### <span id="workload-group"></span> WorkloadGroup
+
+
+> This is used for returning a WorkloadGroup
+  
+
+
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| APIVersion | string| `string` |  | | APIVersion defines the versioned schema of this representation of an object.
+Servers should convert recognized schemas to the latest internal value, and
+may reject unrecognized values.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
++optional |  |
+| Kind | string| `string` |  | | Kind is a string value representing the REST resource this object represents.
+Servers may infer this from the endpoint the client submits requests to.
+Cannot be updated.
+In CamelCase.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
++optional |  |
+| Status | map of any | `map[string]interface{}` |  | |  |  |
+| metadata | [ObjectMeta](#object-meta)| `ObjectMeta` |  | |  |  |
+| spec | [Spec](#spec)| `Spec` |  | |  |  |
+
+
+
+#### Inlined models
+
+**<span id="spec"></span> Spec**
+
+
+  
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| Metadata | [interface{}](#interface)| `interface{}` |  | | This is not an error, the WorkloadGroup has a Metadata inside the Spec
+https://istio.io/latest/docs/reference/config/networking/workload-group/#WorkloadGroup |  |
+| Probe | [interface{}](#interface)| `interface{}` |  | |  |  |
+| Template | [interface{}](#interface)| `interface{}` |  | |  |  |
+
+
+
+### <span id="workload-groups"></span> WorkloadGroups
+
+
+> This is used for returning an array of WorkloadGroup
+  
+
+
+
+[][WorkloadGroup](#workload-group)
 
 ### <span id="workload-health"></span> WorkloadHealth
 

--- a/kubernetes/cache/istio.go
+++ b/kubernetes/cache/istio.go
@@ -46,6 +46,9 @@ func (c *kialiCacheImpl) createIstioInformers(namespace string, informer *typeCa
 	if c.CheckIstioResource(kubernetes.WorkloadEntries) {
 		(*informer)[kubernetes.WorkloadEntries] = createIstioIndexInformer(c.istioNetworkingGetter, kubernetes.WorkloadEntries, c.refreshDuration, namespace)
 	}
+	if c.CheckIstioResource(kubernetes.WorkloadGroups) {
+		(*informer)[kubernetes.WorkloadGroups] = createIstioIndexInformer(c.istioNetworkingGetter, kubernetes.WorkloadGroups, c.refreshDuration, namespace)
+	}
 	if c.CheckIstioResource(kubernetes.EnvoyFilters) {
 		(*informer)[kubernetes.EnvoyFilters] = createIstioIndexInformer(c.istioNetworkingGetter, kubernetes.EnvoyFilters, c.refreshDuration, namespace)
 	}

--- a/kubernetes/cache/istio.go
+++ b/kubernetes/cache/istio.go
@@ -43,6 +43,12 @@ func (c *kialiCacheImpl) createIstioInformers(namespace string, informer *typeCa
 	if c.CheckIstioResource(kubernetes.Sidecars) {
 		(*informer)[kubernetes.Sidecars] = createIstioIndexInformer(c.istioNetworkingGetter, kubernetes.Sidecars, c.refreshDuration, namespace)
 	}
+	if c.CheckIstioResource(kubernetes.WorkloadEntries) {
+		(*informer)[kubernetes.WorkloadEntries] = createIstioIndexInformer(c.istioNetworkingGetter, kubernetes.WorkloadEntries, c.refreshDuration, namespace)
+	}
+	if c.CheckIstioResource(kubernetes.EnvoyFilters) {
+		(*informer)[kubernetes.EnvoyFilters] = createIstioIndexInformer(c.istioNetworkingGetter, kubernetes.EnvoyFilters, c.refreshDuration, namespace)
+	}
 	if c.CheckIstioResource(kubernetes.PeerAuthentications) {
 		(*informer)[kubernetes.PeerAuthentications] = createIstioIndexInformer(c.istioSecurityGetter, kubernetes.PeerAuthentications, c.refreshDuration, namespace)
 	}

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -194,7 +194,7 @@ var (
 		Gateways:               NetworkingGroupVersion.Group,
 		Sidecars:               NetworkingGroupVersion.Group,
 		WorkloadEntries:        NetworkingGroupVersion.Group,
-		WorkloadGroups: 		NetworkingGroupVersion.Group,
+		WorkloadGroups:         NetworkingGroupVersion.Group,
 		EnvoyFilters:           NetworkingGroupVersion.Group,
 		AuthorizationPolicies:  SecurityGroupVersion.Group,
 		PeerAuthentications:    SecurityGroupVersion.Group,

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -53,6 +53,10 @@ const (
 	WorkloadEntryType     = "WorkloadEntry"
 	WorkloadEntryTypeList = "WorkloadEntryList"
 
+	WorkloadGroups        = "workloadgroups"
+	WorkloadGroupType     = "WorkloadGroup"
+	WorkloadGroupTypeList = "WorkloadGroupList"
+
 	// Authorization PeerAuthentications
 	AuthorizationPolicies         = "authorizationpolicies"
 	AuthorizationPoliciesType     = "AuthorizationPolicy"
@@ -125,6 +129,10 @@ var (
 			collectionKind: WorkloadEntryTypeList,
 		},
 		{
+			objectKind:     WorkloadGroupType,
+			collectionKind: WorkloadGroupTypeList,
+		},
+		{
 			objectKind:     EnvoyFilterType,
 			collectionKind: EnvoyFilterTypeList,
 		},
@@ -167,6 +175,7 @@ var (
 		ServiceEntries:   ServiceEntryType,
 		Sidecars:         SidecarType,
 		WorkloadEntries:  WorkloadEntryType,
+		WorkloadGroups:   WorkloadGroupType,
 		EnvoyFilters:     EnvoyFilterType,
 
 		// Security
@@ -185,6 +194,7 @@ var (
 		Gateways:               NetworkingGroupVersion.Group,
 		Sidecars:               NetworkingGroupVersion.Group,
 		WorkloadEntries:        NetworkingGroupVersion.Group,
+		WorkloadGroups: 		NetworkingGroupVersion.Group,
 		EnvoyFilters:           NetworkingGroupVersion.Group,
 		AuthorizationPolicies:  SecurityGroupVersion.Group,
 		PeerAuthentications:    SecurityGroupVersion.Group,
@@ -233,15 +243,6 @@ type ServiceList struct {
 	Services    *core_v1.ServiceList
 	Pods        *core_v1.PodList
 	Deployments *apps_v1.DeploymentList
-}
-
-// ServiceDetails is a wrapper to group full Service description, Endpoints and Pods.
-// Used to fetch all details in a single operation instead to invoke individual APIs per each group.
-type ServiceDetails struct {
-	Service     *core_v1.Service        `json:"service"`
-	Endpoints   *core_v1.Endpoints      `json:"endpoints"`
-	Deployments *apps_v1.DeploymentList `json:"deployments"`
-	Pods        []core_v1.Pod           `json:"pods"`
 }
 
 // IstioDetails is a wrapper to group all Istio objects related to a Service.

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -15,6 +15,7 @@ type IstioConfigList struct {
 	DestinationRules       DestinationRules       `json:"destinationRules"`
 	ServiceEntries         ServiceEntries         `json:"serviceEntries"`
 	WorkloadEntries        WorkloadEntries        `json:"workloadEntries"`
+	WorkloadGroups         WorkloadGroups         `json:"workloadGroups"`
 	EnvoyFilters           EnvoyFilters           `json:"envoyFilters"`
 	Sidecars               Sidecars               `json:"sidecars"`
 	AuthorizationPolicies  AuthorizationPolicies  `json:"authorizationPolicies"`
@@ -31,6 +32,7 @@ type IstioConfigDetails struct {
 	DestinationRule       *DestinationRule       `json:"destinationRule"`
 	ServiceEntry          *ServiceEntry          `json:"serviceEntry"`
 	WorkloadEntry         *WorkloadEntry         `json:"workloadEntry"`
+	WorkloadGroup         *WorkloadGroup         `json:"workloadGroup"`
 	EnvoyFilter           *EnvoyFilter           `json:"envoyFilter"`
 	Sidecar               *Sidecar               `json:"sidecar"`
 	AuthorizationPolicy   *AuthorizationPolicy   `json:"authorizationPolicy"`

--- a/models/workload_group.go
+++ b/models/workload_group.go
@@ -1,0 +1,42 @@
+package models
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WorkloadGroups workloadGroups
+//
+// This is used for returning an array of WorkloadGroup
+//
+// swagger:model workloadGroups
+// An array of workloadGroup
+// swagger:allOf
+type WorkloadGroups []WorkloadGroup
+
+// WorkloadGroup workloadGroup
+//
+// This is used for returning a WorkloadGroup
+//
+// swagger:model workloadGroup
+type WorkloadGroup struct {
+	IstioBase
+	Spec struct {
+		Metadata meta_v1.ObjectMeta     `json:"metadata"`
+		Template WorkloadEntry          `json:"template"`
+		Probe interface{}               `json:"probe"`
+	} `json:"spec"`
+}
+
+func (wgs *WorkloadGroups) Parse(workloadGroups []kubernetes.IstioObject) {
+	for _, wg := range workloadGroups {
+		workloadGroup := WorkloadGroup{}
+		workloadGroup.Parse(wg)
+		*wgs = append(*wgs, workloadGroup)
+	}
+}
+
+func (wg *WorkloadGroup) Parse(workloadGroup kubernetes.IstioObject) {
+	wg.IstioBase.Parse(workloadGroup)
+	workloadGroup.SetSpec(workloadGroup.GetSpec())
+}

--- a/models/workload_group.go
+++ b/models/workload_group.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"github.com/kiali/kiali/kubernetes"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // WorkloadGroups workloadGroups
@@ -22,8 +21,10 @@ type WorkloadGroups []WorkloadGroup
 type WorkloadGroup struct {
 	IstioBase
 	Spec struct {
-		Metadata meta_v1.ObjectMeta     `json:"metadata"`
-		Template WorkloadEntry          `json:"template"`
+		// This is not an error, the WorkloadGroup has a Metadata inside the Spec
+		// https://istio.io/latest/docs/reference/config/networking/workload-group/#WorkloadGroup
+		Metadata interface{}     		`json:"metadata"`
+		Template interface{}          	`json:"template"`
 		Probe interface{}               `json:"probe"`
 	} `json:"spec"`
 }
@@ -38,5 +39,7 @@ func (wgs *WorkloadGroups) Parse(workloadGroups []kubernetes.IstioObject) {
 
 func (wg *WorkloadGroup) Parse(workloadGroup kubernetes.IstioObject) {
 	wg.IstioBase.Parse(workloadGroup)
-	workloadGroup.SetSpec(workloadGroup.GetSpec())
+	wg.Spec.Metadata = workloadGroup.GetSpec()["metadata"]
+	wg.Spec.Template = workloadGroup.GetSpec()["template"]
+	wg.Spec.Probe = workloadGroup.GetSpec()["probe"]
 }

--- a/models/workload_group.go
+++ b/models/workload_group.go
@@ -23,9 +23,9 @@ type WorkloadGroup struct {
 	Spec struct {
 		// This is not an error, the WorkloadGroup has a Metadata inside the Spec
 		// https://istio.io/latest/docs/reference/config/networking/workload-group/#WorkloadGroup
-		Metadata interface{}     		`json:"metadata"`
-		Template interface{}          	`json:"template"`
-		Probe interface{}               `json:"probe"`
+		Metadata interface{} `json:"metadata"`
+		Template interface{} `json:"template"`
+		Probe    interface{} `json:"probe"`
 	} `json:"spec"`
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -4693,6 +4693,9 @@
         },
         "workloadEntry": {
           "$ref": "#/definitions/workloadEntry"
+        },
+        "workloadGroup": {
+          "$ref": "#/definitions/workloadGroup"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -4740,6 +4743,9 @@
         },
         "workloadEntries": {
           "$ref": "#/definitions/workloadEntries"
+        },
+        "workloadGroups": {
+          "$ref": "#/definitions/workloadGroups"
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
@@ -7678,6 +7684,64 @@
         }
       },
       "x-go-name": "WorkloadEntry",
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "workloadGroup": {
+      "description": "This is used for returning a WorkloadGroup",
+      "type": "object",
+      "title": "WorkloadGroup workloadGroup",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\n+optional",
+          "type": "string",
+          "x-go-name": "APIVersion"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "metadata": {
+          "$ref": "#/definitions/ObjectMeta"
+        },
+        "spec": {
+          "type": "object",
+          "properties": {
+            "metadata": {
+              "description": "This is not an error, the WorkloadGroup has a Metadata inside the Spec\nhttps://istio.io/latest/docs/reference/config/networking/workload-group/#WorkloadGroup",
+              "type": "object",
+              "x-go-name": "Metadata"
+            },
+            "probe": {
+              "type": "object",
+              "x-go-name": "Probe"
+            },
+            "template": {
+              "type": "object",
+              "x-go-name": "Template"
+            }
+          },
+          "x-go-name": "Spec"
+        },
+        "status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Status"
+        }
+      },
+      "x-go-name": "WorkloadGroup",
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "workloadGroups": {
+      "description": "This is used for returning an array of WorkloadGroup",
+      "type": "array",
+      "title": "WorkloadGroups workloadGroups",
+      "items": {
+        "$ref": "#/definitions/workloadGroup"
+      },
+      "x-go-name": "WorkloadGroups",
       "x-go-package": "github.com/kiali/kiali/models"
     }
   },


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4019
Fixes https://github.com/kiali/kiali/issues/4025
Fixes https://github.com/kiali/kiali/issues/4015

UI needed https://github.com/kiali/kiali-ui/pull/2160
Operator https://github.com/kiali/kiali-operator/pull/319

This group of PRs (backend, frontend and operator) has two goals:
- Unify the caching of Istio resources.
- Add missed WorkloadGroup Istio resource into Kiali.

How to test:

- The https://github.com/kiali/kiali/issues/4019 scenario applies only on OpenShift platform, in the case where a user has accesss to a project/namespace BUT it has not access to the Istio resources, Kiali would be able to show the list of resources if cache is enabled; when a user tries to access to a particular resource, it will throw an error as it has not rights to access. When cache is disabled, user shouldn't be able to list this page and it will receive same errors as CLI (note, this scenario is expected, as cached is done per SA token not per user token, User with admin role cannot list configs, the whole scenario is a corner case).
- Also test that WorkloadGroups are visible and editable from Istio Config list + details with common features: sorting, filtering, etc.
- Worth to perform a regression tests as several components have been modified.