### PR TITLE
Assume a connectivity issue on Prometheus API failures

### DIFF
--- a/graph/telemetry/istio/appender/util.go
+++ b/graph/telemetry/istio/appender/util.go
@@ -26,7 +26,7 @@ func promQuery(query string, queryTime time.Time, ctx context.Context, api prom_
 	if warnings != nil && len(warnings) > 0 {
 		log.Warningf("promQuery. Prometheus Warnings: [%s]", strings.Join(warnings, ","))
 	}
-	graph.CheckError(err)
+	graph.CheckUnavailable(err)
 	promtimer.ObserveDuration() // notice we only collect metrics for successful prom queries
 
 	switch t := value.Type(); t {

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -660,7 +660,7 @@ func promQuery(query string, queryTime time.Time, api prom_v1.API) model.Vector 
 	if warnings != nil && len(warnings) > 0 {
 		log.Warningf("promQuery. Prometheus Warnings: [%s]", strings.Join(warnings, ","))
 	}
-	graph.CheckError(err)
+	graph.CheckUnavailable(err)
 	promtimer.ObserveDuration() // notice we only collect metrics for successful prom queries
 
 	switch t := value.Type(); t {

--- a/graph/util.go
+++ b/graph/util.go
@@ -9,7 +9,7 @@ type Response struct {
 	Code    int
 }
 
-// Error panics with InternalServerError and the provided message
+// Error panics with InternalServerError (500) and the provided message
 func Error(message string) {
 	Panic(message, nethttp.StatusInternalServerError)
 }
@@ -36,6 +36,13 @@ func Panic(message string, code int) Response {
 func CheckError(err error) {
 	if err != nil {
 		panic(err.Error)
+	}
+}
+
+// CheckUnavailable panics with StatusServiceUnavailable (503) and the supplied error if it is non-nil
+func CheckUnavailable(err error) {
+	if err != nil {
+		Panic(err.Error(), nethttp.StatusServiceUnavailable)
 	}
 }
 

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -118,7 +118,7 @@ func AppDashboard(w http.ResponseWriter, r *http.Request) {
 
 	metrics, err := metricsService.GetMetrics(params, business.GetIstioScaler())
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
 	dashboard := business.NewDashboardsService().BuildIstioDashboard(metrics, params.Direction)
@@ -146,7 +146,7 @@ func ServiceDashboard(w http.ResponseWriter, r *http.Request) {
 
 	metrics, err := metricsService.GetMetrics(params, business.GetIstioScaler())
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
 	dashboard := business.NewDashboardsService().BuildIstioDashboard(metrics, params.Direction)
@@ -174,7 +174,7 @@ func WorkloadDashboard(w http.ResponseWriter, r *http.Request) {
 
 	metrics, err := metricsService.GetMetrics(params, business.GetIstioScaler())
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
 	dashboard := business.NewDashboardsService().BuildIstioDashboard(metrics, params.Direction)

--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -23,6 +23,8 @@ func handleErrorResponse(w http.ResponseWriter, err error, extraMesg ...string) 
 		RespondWithError(w, http.StatusForbidden, errorMsg)
 	} else if errors.IsNotFound(err) {
 		RespondWithError(w, http.StatusNotFound, errorMsg)
+	} else if errors.IsServiceUnavailable(err) {
+		RespondWithError(w, http.StatusServiceUnavailable, errorMsg)
 	} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
 		errorMsg = statusError.ErrStatus.Message
 		RespondWithError(w, http.StatusInternalServerError, errorMsg)

--- a/handlers/mesh.go
+++ b/handlers/mesh.go
@@ -15,7 +15,7 @@ func GetClusters(w http.ResponseWriter, r *http.Request) {
 
 	meshClusters, err := business.Mesh.GetClusters(r)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Cannot fetch mesh clusters: "+err.Error())
+		RespondWithError(w, http.StatusServiceUnavailable, "Cannot fetch mesh clusters: "+err.Error())
 		return
 	}
 

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -45,7 +45,7 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClie
 
 	metrics, err := metricsService.GetMetrics(params, nil)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
 	RespondWithJSON(w, http.StatusOK, metrics)
@@ -77,7 +77,7 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 
 	metrics, err := metricsService.GetMetrics(params, nil)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
 	RespondWithJSON(w, http.StatusOK, metrics)
@@ -109,7 +109,7 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 
 	metrics, err := metricsService.GetMetrics(params, nil)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
 	RespondWithJSON(w, http.StatusOK, metrics)
@@ -150,7 +150,7 @@ func getAggregateMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 
 	metrics, err := metricsService.GetMetrics(params, nil)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
 	RespondWithJSON(w, http.StatusOK, metrics)
@@ -182,7 +182,7 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 
 	metrics, err := metricsService.GetMetrics(params, nil)
 	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
 	RespondWithJSON(w, http.StatusOK, metrics)

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -12,7 +12,6 @@ import (
 
 func NamespaceList(w http.ResponseWriter, r *http.Request) {
 	business, err := getBusiness(r)
-
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -108,7 +109,7 @@ func NewClientForConfig(cfg config.PrometheusConfig) (*Client, error) {
 
 	p8s, err := api.NewClient(clientConfig)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewServiceUnavailable(err.Error())
 	}
 	client := Client{p8s: p8s, api: prom_v1.NewAPI(p8s), ctx: context.Background()}
 	return &client, nil
@@ -295,8 +296,9 @@ func (in *Client) GetMetricsForLabels(labels []string) ([]string, error) {
 		log.Warningf("GetMetricsForLabels. Prometheus Warnings: [%s]", strings.Join(warnings, ","))
 	}
 	if err != nil {
-		return nil, err
+		return nil, errors.NewServiceUnavailable(err.Error())
 	}
+
 	var names []string
 	for _, labelSet := range results {
 		if name, ok := labelSet["__name__"]; ok {

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -8,6 +8,7 @@ import (
 
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
@@ -56,7 +57,7 @@ func fetchHistogramValues(ctx context.Context, api prom_v1.API, metricName, labe
 			log.Warningf("fetchHistogramValues. Prometheus Warnings: [%s]", strings.Join(warnings, ","))
 		}
 		if err != nil {
-			return nil, err
+			return nil, errors.NewServiceUnavailable(err.Error())
 		}
 		histogram[k] = result.(model.Vector)
 	}
@@ -181,7 +182,7 @@ func getRequestRatesForLabel(ctx context.Context, api prom_v1.API, time time.Tim
 		log.Warningf("fetchHistogramValues. Prometheus Warnings: [%s]", strings.Join(warnings, ","))
 	}
 	if err != nil {
-		return model.Vector{}, err
+		return model.Vector{}, errors.NewServiceUnavailable(err.Error())
 	}
 	promtimer.ObserveDuration() // notice we only collect metrics for successful prom queries
 	return result.(model.Vector), nil


### PR DESCRIPTION
Assume a connectivity issue on Prometheus API failures. A CX issue is fairly typical, an application error is very unlikely.  This stops stack traces returned to the user on a prom connectivity problem.

Fixes https://github.com/kiali/kiali/issues/4014
