### PR TITLE
Iter8 Info Endpoint changes

### DIFF
--- a/kiali_api.md
+++ b/kiali_api.md
@@ -7468,6 +7468,7 @@ It is false for service.namespace format and service entries. |  |
 | AnalyticsImageVersion | string| `string` |  | |  |  |
 | ControllerImageVersion | string| `string` |  | |  |  |
 | Enabled | boolean| `bool` |  | |  |  |
+| Namespace | string| `string` |  | |  |  |
 | SupportedVersion | boolean| `bool` |  | |  |  |
 
 

--- a/models/iter8.go
+++ b/models/iter8.go
@@ -11,6 +11,7 @@ type Iter8Info struct {
 	SupportedVersion       bool   `json:"supportedVersion"`
 	ControllerImageVersion string `json:"controllerImgVersion"`
 	AnalyticsImageVersion  string `json:"analyticsImgVersion"`
+	Namespace              string `json:"namespace"`
 }
 
 type Iter8CandidateStatus struct {

--- a/swagger.json
+++ b/swagger.json
@@ -5170,6 +5170,10 @@
           "type": "boolean",
           "x-go-name": "Enabled"
         },
+        "namespace": {
+          "type": "string",
+          "x-go-name": "Namespace"
+        },
         "supportedVersion": {
           "type": "boolean",
           "x-go-name": "SupportedVersion"


### PR DESCRIPTION
Iter8 Info endpoint now contains namespace and version info, preparing for the support for Iter8 v2.x

the /iter8Info endpoints now also return namespace of where iter8 is installed. And if the Iter8 version is 2.x, the `supportedVersion` field will be false, indicating 2.x version is yet supported.
The namespace info is retrieved from Kiali CR.  
```
{
    "enabled": true,
    "supportedVersion": false,
    "controllerImgVersion": "",
    "analyticsImgVersion": "2.1.0",
    "namespace": "iter8-system"
}
```

