### PR TITLE
Add additional kiali scenarios to node metadata

### DIFF
--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -63,27 +63,32 @@ type NodeData struct {
 	Parent string `json:"parent,omitempty"` // Compound Node parent ID
 
 	// App Fields (not required by Cytoscape)
-	NodeType        string              `json:"nodeType"`
-	Cluster         string              `json:"cluster"`
-	Namespace       string              `json:"namespace"`
-	Workload        string              `json:"workload,omitempty"`
-	App             string              `json:"app,omitempty"`
-	Version         string              `json:"version,omitempty"`
-	Service         string              `json:"service,omitempty"`         // requested service for NodeTypeService
-	Aggregate       string              `json:"aggregate,omitempty"`       // set like "<aggregate>=<aggregateVal>"
-	DestServices    []graph.ServiceName `json:"destServices,omitempty"`    // requested services for [dest] node
-	Traffic         []ProtocolTraffic   `json:"traffic,omitempty"`         // traffic rates for all detected protocols
-	HasCB           bool                `json:"hasCB,omitempty"`           // true (has circuit breaker) | false
-	HasHealthConfig HealthConfig        `json:"hasHealthConfig,omitempty"` // set to the health config override
-	HasMissingSC    bool                `json:"hasMissingSC,omitempty"`    // true (has missing sidecar) | false
-	HasVS           bool                `json:"hasVS,omitempty"`           // true (has route rule) | false
-	IsBox           string              `json:"isBox,omitempty"`           // set for NodeTypeBox, current values: [ 'app', 'cluster', 'namespace' ]
-	IsDead          bool                `json:"isDead,omitempty"`          // true (has no pods) | false
-	IsIdle          bool                `json:"isIdle,omitempty"`          // true | false
-	IsInaccessible  bool                `json:"isInaccessible,omitempty"`  // true if the node exists in an inaccessible namespace
-	IsOutside       bool                `json:"isOutside,omitempty"`       // true | false
-	IsRoot          bool                `json:"isRoot,omitempty"`          // true | false
-	IsServiceEntry  *graph.SEInfo       `json:"isServiceEntry,omitempty"`  // set static service entry information
+	NodeType              string              `json:"nodeType"`
+	Cluster               string              `json:"cluster"`
+	Namespace             string              `json:"namespace"`
+	Workload              string              `json:"workload,omitempty"`
+	App                   string              `json:"app,omitempty"`
+	Version               string              `json:"version,omitempty"`
+	Service               string              `json:"service,omitempty"`               // requested service for NodeTypeService
+	Aggregate             string              `json:"aggregate,omitempty"`             // set like "<aggregate>=<aggregateVal>"
+	DestServices          []graph.ServiceName `json:"destServices,omitempty"`          // requested services for [dest] node
+	Traffic               []ProtocolTraffic   `json:"traffic,omitempty"`               // traffic rates for all detected protocols
+	HasCB                 bool                `json:"hasCB,omitempty"`                 // true (has circuit breaker) | false
+	HasFaultInjection     bool                `json:"hasFaultInjection,omitempty"`     // true (vs has fault injection) | false
+	HasHealthConfig       HealthConfig        `json:"hasHealthConfig,omitempty"`       // set to the health config override
+	HasMissingSC          bool                `json:"hasMissingSC,omitempty"`          // true (has missing sidecar) | false
+	HasRequestRouting     bool                `json:"hasRequestRouting,omitempty"`     // true (vs has request routing) | false
+	HasRequestTimeout     bool                `json:"hasRequestTimeout,omitempty"`     // true (vs has request timeout) | false
+	HasTCPTrafficShifting bool                `json:"hasTCPTrafficShifting,omitempty"` // true (vs has tcp traffic shifting) | false
+	HasTrafficShifting    bool                `json:"hasTrafficShifting,omitempty"`    // true (vs has traffic shifting) | false
+	HasVS                 bool                `json:"hasVS,omitempty"`                 // true (has route rule) | false
+	IsBox                 string              `json:"isBox,omitempty"`                 // set for NodeTypeBox, current values: [ 'app', 'cluster', 'namespace' ]
+	IsDead                bool                `json:"isDead,omitempty"`                // true (has no pods) | false
+	IsIdle                bool                `json:"isIdle,omitempty"`                // true | false
+	IsInaccessible        bool                `json:"isInaccessible,omitempty"`        // true if the node exists in an inaccessible namespace
+	IsOutside             bool                `json:"isOutside,omitempty"`             // true | false
+	IsRoot                bool                `json:"isRoot,omitempty"`                // true | false
+	IsServiceEntry        *graph.SEInfo       `json:"isServiceEntry,omitempty"`        // set static service entry information
 }
 
 type EdgeData struct {
@@ -260,6 +265,26 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		// check if node is on another namespace
 		if val, ok := n.Metadata[graph.IsOutside]; ok {
 			nd.IsOutside = val.(bool)
+		}
+
+		if val, ok := n.Metadata[graph.HasRequestRouting]; ok {
+			nd.HasRequestRouting = val.(bool)
+		}
+
+		if val, ok := n.Metadata[graph.HasFaultInjection]; ok {
+			nd.HasFaultInjection = val.(bool)
+		}
+
+		if val, ok := n.Metadata[graph.HasTrafficShifting]; ok {
+			nd.HasTrafficShifting = val.(bool)
+		}
+
+		if val, ok := n.Metadata[graph.HasTCPTrafficShifting]; ok {
+			nd.HasTCPTrafficShifting = val.(bool)
+		}
+
+		if val, ok := n.Metadata[graph.HasRequestTimeout]; ok {
+			nd.HasRequestTimeout = val.(bool)
 		}
 
 		// node may have destination service info

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -13,25 +13,30 @@ func NewMetadata() Metadata {
 
 // Metadata keys to be used instead of literal strings
 const (
-	Aggregate       MetadataKey = "aggregate" // the prom attribute used for aggregation
-	AggregateValue  MetadataKey = "aggregateValue"
-	DestPrincipal   MetadataKey = "destPrincipal"
-	DestServices    MetadataKey = "destServices"
-	HasCB           MetadataKey = "hasCB"
-	HasHealthConfig MetadataKey = "hasHealthConfig"
-	HasMissingSC    MetadataKey = "hasMissingSC"
-	HasVS           MetadataKey = "hasVS"
-	IsDead          MetadataKey = "isDead"
-	IsEgressCluster MetadataKey = "isEgressCluster" // PassthroughCluster or BlackHoleCluster
-	IsIdle          MetadataKey = "isIdle"
-	IsInaccessible  MetadataKey = "isInaccessible"
-	IsMTLS          MetadataKey = "isMTLS"
-	IsOutside       MetadataKey = "isOutside"
-	IsRoot          MetadataKey = "isRoot"
-	IsServiceEntry  MetadataKey = "isServiceEntry"
-	ProtocolKey     MetadataKey = "protocol"
-	ResponseTime    MetadataKey = "responseTime"
-	SourcePrincipal MetadataKey = "sourcePrincipal"
+	Aggregate             MetadataKey = "aggregate" // the prom attribute used for aggregation
+	AggregateValue        MetadataKey = "aggregateValue"
+	DestPrincipal         MetadataKey = "destPrincipal"
+	DestServices          MetadataKey = "destServices"
+	HasCB                 MetadataKey = "hasCB"
+	HasFaultInjection     MetadataKey = "hasFaultInjection"
+	HasHealthConfig       MetadataKey = "hasHealthConfig"
+	HasMissingSC          MetadataKey = "hasMissingSC"
+	HasTCPTrafficShifting MetadataKey = "hasTCPTrafficShifting"
+	HasTrafficShifting    MetadataKey = "hasTrafficShifting"
+	HasRequestRouting     MetadataKey = "hasRequestRouting"
+	HasRequestTimeout     MetadataKey = "hasRequestTimeout"
+	HasVS                 MetadataKey = "hasVS"
+	IsDead                MetadataKey = "isDead"
+	IsEgressCluster       MetadataKey = "isEgressCluster" // PassthroughCluster or BlackHoleCluster
+	IsIdle                MetadataKey = "isIdle"
+	IsInaccessible        MetadataKey = "isInaccessible"
+	IsMTLS                MetadataKey = "isMTLS"
+	IsOutside             MetadataKey = "isOutside"
+	IsRoot                MetadataKey = "isRoot"
+	IsServiceEntry        MetadataKey = "isServiceEntry"
+	ProtocolKey           MetadataKey = "protocol"
+	ResponseTime          MetadataKey = "responseTime"
+	SourcePrincipal       MetadataKey = "sourcePrincipal"
 )
 
 // DestServicesMetadata key=Service.Key()

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -105,6 +105,22 @@ NODES:
 		for _, virtualService := range istioCfg.VirtualServices.Items {
 			if virtualService.IsValidHost(namespace, n.Service) {
 				n.Metadata[graph.HasVS] = true
+
+				// Check if the VS also has one of the Kiali scenarios created by the wizard.
+				// TODO: Get this info from the VS spec in case the Istio object was not created by a wizard.
+				switch virtualService.Metadata.Labels[graph.WizardLabelKey] {
+				case graph.WizardRequestRoutingLabel:
+					n.Metadata[graph.HasRequestRouting] = true
+				case graph.WizardFaultInjectionLabel:
+					n.Metadata[graph.HasFaultInjection] = true
+				case graph.WizardTrafficShiftingLabel:
+					n.Metadata[graph.HasTrafficShifting] = true
+				case graph.WizardTCPTrafficShiftingLabel:
+					n.Metadata[graph.HasTCPTrafficShifting] = true
+				case graph.WizardRequestTimeoutsLabel:
+					n.Metadata[graph.HasRequestTimeout] = true
+				}
+
 				continue NODES
 			}
 		}

--- a/graph/types.go
+++ b/graph/types.go
@@ -8,18 +8,24 @@ import (
 )
 
 const (
-	GraphTypeApp          string = "app"
-	GraphTypeService      string = "service" // Treated as graphType Workload, with service injection, and then condensed
-	GraphTypeVersionedApp string = "versionedApp"
-	GraphTypeWorkload     string = "workload"
-	NodeTypeAggregate     string = "aggregate" // The special "aggregate" traffic node
-	NodeTypeApp           string = "app"
-	NodeTypeBox           string = "box" // The special "box" node. isBox will be set to "app" | "cluster" | "namespace"
-	NodeTypeService       string = "service"
-	NodeTypeUnknown       string = "unknown" // The special "unknown" traffic gen node
-	NodeTypeWorkload      string = "workload"
-	TF                    string = "2006-01-02 15:04:05" // TF is the TimeFormat for timestamps
-	Unknown               string = "unknown"             // Istio unknown label value
+	GraphTypeApp                  string = "app"
+	GraphTypeService              string = "service" // Treated as graphType Workload, with service injection, and then condensed
+	GraphTypeVersionedApp         string = "versionedApp"
+	GraphTypeWorkload             string = "workload"
+	NodeTypeAggregate             string = "aggregate" // The special "aggregate" traffic node
+	NodeTypeApp                   string = "app"
+	NodeTypeBox                   string = "box" // The special "box" node. isBox will be set to "app" | "cluster" | "namespace"
+	NodeTypeService               string = "service"
+	NodeTypeUnknown               string = "unknown" // The special "unknown" traffic gen node
+	NodeTypeWorkload              string = "workload"
+	TF                            string = "2006-01-02 15:04:05" // TF is the TimeFormat for timestamps
+	Unknown                       string = "unknown"             // Istio unknown label value
+	WizardFaultInjectionLabel     string = "fault_injection"
+	WizardLabelKey                string = "kiali_wizard" // Label the front-end wizards add to objects created by them
+	WizardRequestRoutingLabel     string = "request_routing"
+	WizardRequestTimeoutsLabel    string = "request_timeouts"
+	WizardTCPTrafficShiftingLabel string = "tcp_traffic_shifting"
+	WizardTrafficShiftingLabel    string = "traffic_shifting"
 	// private
 	passthroughCluster string = "PassthroughCluster"
 	blackHoleCluster   string = "BlackHoleCluster"

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -7917,7 +7917,12 @@ This type is used to describe a set of objects.
 | Cluster | string| `string` |  | |  |  |
 | DestServices | [][ServiceName](#service-name)| `[]*ServiceName` |  | |  |  |
 | HasCB | boolean| `bool` |  | |  |  |
+| HasFaultInjection | boolean| `bool` |  | |  |  |
 | HasMissingSC | boolean| `bool` |  | |  |  |
+| HasRequestRouting | boolean| `bool` |  | |  |  |
+| HasRequestTimeout | boolean| `bool` |  | |  |  |
+| HasTCPTrafficShifting | boolean| `bool` |  | |  |  |
+| HasTrafficShifting | boolean| `bool` |  | |  |  |
 | HasVS | boolean| `bool` |  | |  |  |
 | ID | string| `string` |  | | Cytoscape Fields |  |
 | IsBox | string| `string` |  | |  |  |

--- a/swagger.json
+++ b/swagger.json
@@ -5726,12 +5726,32 @@
           "type": "boolean",
           "x-go-name": "HasCB"
         },
+        "hasFaultInjection": {
+          "type": "boolean",
+          "x-go-name": "HasFaultInjection"
+        },
         "hasHealthConfig": {
           "$ref": "#/definitions/HealthConfig"
         },
         "hasMissingSC": {
           "type": "boolean",
           "x-go-name": "HasMissingSC"
+        },
+        "hasRequestRouting": {
+          "type": "boolean",
+          "x-go-name": "HasRequestRouting"
+        },
+        "hasRequestTimeout": {
+          "type": "boolean",
+          "x-go-name": "HasRequestTimeout"
+        },
+        "hasTCPTrafficShifting": {
+          "type": "boolean",
+          "x-go-name": "HasTCPTrafficShifting"
+        },
+        "hasTrafficShifting": {
+          "type": "boolean",
+          "x-go-name": "HasTrafficShifting"
         },
         "hasVS": {
           "type": "boolean",


### PR DESCRIPTION
Adds all supported kiali traffic wizard scenarios to the service node metadata if they have the `kiali_wizard` label.

Relates to: #1477 
Front end changes: https://github.com/kiali/kiali-ui/pull/2165