### PR TITLE
Use FQDN in Istiod Registry validations

### DIFF
--- a/business/checkers/authorization/no_host_checker.go
+++ b/business/checkers/authorization/no_host_checker.go
@@ -129,7 +129,7 @@ func (n NoHostChecker) hasMatchingService(host kubernetes.Host, itemNamespace st
 	for _, rStatus := range n.RegistryStatus {
 		// We assume that on these cases the host.Service is provided in FQDN
 		// i.e. ratings.mesh2-bookinfo.svc.mesh1-imports.local
-		if kubernetes.FilterByRegistryStatus(host.Service, rStatus) {
+		if kubernetes.FilterByRegistryStatus(host.String(), rStatus) {
 			return true
 		}
 	}

--- a/business/checkers/authorization/no_host_checker_test.go
+++ b/business/checkers/authorization/no_host_checker_test.go
@@ -267,4 +267,30 @@ func TestValidServiceRegistry(t *testing.T) {
 
 	assert.False(valid)
 	assert.NotEmpty(validations)
+
+	registryService = kubernetes.RegistryStatus{}
+	registryService.Hostname = "ratings.bookinfo.svc.cluster.local"
+
+	validations, valid = NoHostChecker{
+		AuthorizationPolicy: authPolicyWithHost([]interface{}{"ratings.bookinfo.svc.cluster.local"}),
+		Namespace:           "bookinfo",
+		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
+		RegistryStatus:      []*kubernetes.RegistryStatus{&registryService},
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+
+	registryService = kubernetes.RegistryStatus{}
+	registryService.Hostname = "ratings.bookinfo.svc.cluster.local"
+
+	validations, valid = NoHostChecker{
+		AuthorizationPolicy: authPolicyWithHost([]interface{}{"ratings2.bookinfo.svc.cluster.local"}),
+		Namespace:           "test",
+		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
+		RegistryStatus:      []*kubernetes.RegistryStatus{&registryService},
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
 }

--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -37,8 +37,7 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 				if fqdn.Namespace != dr.GetObjectMeta().Namespace && !strings.HasPrefix(fqdn.Service, "*") && fqdn.Namespace != "" {
 					// Unable to verify if the same host+subset combination is targeted from different namespace DRs
 					// "*" check removes the prefix errors
-					key, rrValidation := createError("validation.unable.cross-namespace", destinationRulesNamespace, destinationRulesName, true)
-					validations.MergeValidations(models.IstioValidations{key: rrValidation})
+					// NoDestinationChecker will check cross-namespace validations
 					continue
 				}
 

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -145,12 +145,8 @@ func TestMultiHostMatchValidShortFormatDiffNamespace(t *testing.T) {
 		DestinationRules: destinationRules,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
-	assert.True(ok)
-	assert.True(validation.Valid)
-	assert.NotEmpty(validation.Checks)
-	assert.Equal(models.Unknown, validation.Checks[0].Severity)
+	// MultiMatchChecker shouldn't fail if a host is in a different namespace
+	assert.Empty(validations)
 }
 
 func TestMultiHostMatchWildcardInvalid(t *testing.T) {

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -128,6 +128,10 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 
 	assert := assert.New(t)
 
+	// Note that a cross-namespace service should be visible in the registry, otherwise won't be visible
+	registryService := kubernetes.RegistryStatus{}
+	registryService.Hostname = "reviews.outside-ns.svc.cluster.local"
+
 	validations, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		Namespaces: models.Namespaces{
@@ -139,14 +143,12 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
 		Services:        fakeServicesReview(),
-		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews.outside-ns"),
+		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews.outside-ns.svc.cluster.local"),
+		RegistryStatus: []*kubernetes.RegistryStatus{&registryService},
 	}.Check()
 
 	assert.True(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.Equal(models.CheckMessage("validation.unable.cross-namespace"), validations[0].Message)
-	assert.Equal("spec/host", validations[0].Path)
+	assert.Empty(validations)
 }
 
 func TestNoValidHost(t *testing.T) {
@@ -252,6 +254,10 @@ func fakeServicesReview() []core_v1.Service {
 func TestFailCrossNamespaceHost(t *testing.T) {
 	assert := assert.New(t)
 
+	// Note that a cross-namespace service should be visible in the registry, otherwise won't be visible
+	registryService := kubernetes.RegistryStatus{}
+	registryService.Hostname = "reviews.different-ns.svc.cluster.local"
+
 	validations, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
@@ -261,13 +267,11 @@ func TestFailCrossNamespaceHost(t *testing.T) {
 		Services: fakeServicesReview(),
 		// Intentionally using the same serviceName, but different NS. This shouldn't fail to match the above workloads
 		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews.different-ns.svc.cluster.local"),
+		RegistryStatus: []*kubernetes.RegistryStatus{&registryService},
 	}.Check()
 
 	assert.True(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.Equal(models.CheckMessage("validation.unable.cross-namespace"), validations[0].Message)
-	assert.Equal("spec/host", validations[0].Path)
+	assert.Empty(validations)
 }
 
 func TestSNIProxyExample(t *testing.T) {
@@ -362,6 +366,32 @@ func TestValidServiceRegistry(t *testing.T) {
 
 	registryService = kubernetes.RegistryStatus{}
 	registryService.Hostname = "ratings2.mesh2-bookinfo.svc.mesh1-imports.local"
+
+	validations, valid = NoDestinationChecker{
+		Namespace:       "test",
+		DestinationRule: dr,
+		RegistryStatus:  []*kubernetes.RegistryStatus{&registryService},
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+
+	registryService = kubernetes.RegistryStatus{}
+	registryService.Hostname = "ratings.bookinfo.svc.cluster.local"
+
+	dr = data.CreateEmptyDestinationRule("test", "test-exported", "ratings.bookinfo.svc.cluster.local")
+
+	validations, valid = NoDestinationChecker{
+		Namespace:       "test",
+		DestinationRule: dr,
+		RegistryStatus:  []*kubernetes.RegistryStatus{&registryService},
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+
+	registryService = kubernetes.RegistryStatus{}
+	registryService.Hostname = "ratings2.bookinfo.svc.cluster.local"
 
 	validations, valid = NoDestinationChecker{
 		Namespace:       "test",

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -144,7 +144,7 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 		),
 		Services:        fakeServicesReview(),
 		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews.outside-ns.svc.cluster.local"),
-		RegistryStatus: []*kubernetes.RegistryStatus{&registryService},
+		RegistryStatus:  []*kubernetes.RegistryStatus{&registryService},
 	}.Check()
 
 	assert.True(valid)
@@ -267,7 +267,7 @@ func TestFailCrossNamespaceHost(t *testing.T) {
 		Services: fakeServicesReview(),
 		// Intentionally using the same serviceName, but different NS. This shouldn't fail to match the above workloads
 		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews.different-ns.svc.cluster.local"),
-		RegistryStatus: []*kubernetes.RegistryStatus{&registryService},
+		RegistryStatus:  []*kubernetes.RegistryStatus{&registryService},
 	}.Check()
 
 	assert.True(valid)

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -157,7 +157,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	go in.fetchRegistryStatus(&registryStatus, errChan, &wg)
 	wg.Wait()
 
-	noServiceChecker := checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails}
+	noServiceChecker := checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails, RegistryStatus: registryStatus}
 
 	switch objectType {
 	case kubernetes.Gateways:


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4049

This PRs fixes the use of FQDN when validating if a host is present in the Istiod registry.
This work also "adjusts" the behaviour of several cross-namespace validation on the DestinationRules, now that the registry has all services available, a DR can detect when a host is present or not.

How to test:

- Check that a scenario like https://github.com/kiali/kiali/issues/4049 is supported.
- Check that a service defined in a ns1 namespace is validated in a DR/VS if it's defined in a ns2 namespace.
- Validate that the only changes/regressions will be the "cross-namespace" ones that now should be adjusted in the integration tests.

@skondkar @hhovsepy I expect that this PR may be not 100% complete and some corner case may be missed, let me know if you find some missing scenario or don't hesitate to ask me more details if the QE description is not complete. (thx !)

cc @xeviknal 