### PR TITLE
Service Details sidecar is now checked in workload's sidecars.

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -109,7 +109,7 @@ func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []core_v
 		/** Check if Service has istioSidecar deployed */
 		mPods := models.Pods{}
 		mPods.Parse(sPods)
-		hasSidecar := mPods.HasIstioSidecar()
+		hasSidecar := mPods.HasAnyIstioSidecar()
 		/** Check if Service has the label app required by Istio */
 		_, appLabel := item.Spec.Selector[conf.IstioLabels.AppLabelName]
 		/** Check if Service has additional item icon */
@@ -265,6 +265,7 @@ func (in *SvcService) GetService(namespace, service, interval string, queryTime 
 	s := models.ServiceDetails{Workloads: wo, Health: hth, NamespaceMTLS: nsmtls, AdditionalDetails: additionalDetails}
 	s.SetService(svc)
 	s.SetPods(kubernetes.FilterPodsForEndpoints(eps, pods))
+	s.SetIstioSidecar(wo)
 	s.SetEndpoints(eps)
 	s.SetVirtualServices(vs, vsCreate, vsUpdate, vsDelete)
 	s.SetDestinationRules(dr, drCreate, drUpdate, drDelete)

--- a/models/pod.go
+++ b/models/pod.go
@@ -168,6 +168,18 @@ func (pods Pods) HasIstioSidecar() bool {
 	return true
 }
 
+// HasAnyIstioSidecar returns true if there are pods and any of pods have a sidecar
+func (pods Pods) HasAnyIstioSidecar() bool {
+	if len(pods) > 0 {
+		for _, p := range pods {
+			if p.HasIstioSidecar() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // HasIstioSidecar returns true if the pod has an Istio proxy sidecar
 func (pod Pod) HasIstioSidecar() bool {
 	return len(pod.IstioContainers) > 0

--- a/models/service.go
+++ b/models/service.go
@@ -107,7 +107,10 @@ func (s *ServiceDetails) SetEndpoints(eps *core_v1.Endpoints) {
 func (s *ServiceDetails) SetPods(pods []core_v1.Pod) {
 	mPods := Pods{}
 	mPods.Parse(pods)
-	s.IstioSidecar = mPods.HasIstioSidecar()
+}
+
+func (s *ServiceDetails) SetIstioSidecar(workloads WorkloadOverviews) {
+	s.IstioSidecar = workloads.HasIstioSidecar()
 }
 
 func (s *ServiceDetails) SetVirtualServices(vs []kubernetes.IstioObject, canCreate, canUpdate, canDelete bool) {

--- a/models/service_test.go
+++ b/models/service_test.go
@@ -20,6 +20,7 @@ func TestServiceDetailParsing(t *testing.T) {
 	service.SetService(fakeService())
 	service.SetEndpoints(fakeEndpoints())
 	service.SetPods(fakePods())
+	service.SetIstioSidecar(fakeWorkloads())
 	service.SetVirtualServices(fakeVirtualServices(), false, false, false)
 	service.SetDestinationRules(fakeDestinationRules(), false, false, false)
 
@@ -32,6 +33,7 @@ func TestServiceDetailParsing(t *testing.T) {
 	assert.Equal(service.Service.Type, "ClusterIP")
 	assert.Equal(service.Service.Ip, "127.0.0.9")
 	assert.Equal(service.Service.Labels, map[string]string{"label1": "labelName1", "label2": "labelName2"})
+	assert.Equal(service.IstioSidecar, true)
 	assert.Equal(service.Service.Ports, Ports{
 		Port{Name: "http", Protocol: "TCP", Port: 3001},
 		Port{Name: "http", Protocol: "TCP", Port: 3000}})
@@ -378,4 +380,13 @@ func fakeDestinationRules() []kubernetes.IstioObject {
 	}
 
 	return []kubernetes.IstioObject{&destinationRule1, &destinationRule2}
+}
+
+func fakeWorkloads() WorkloadOverviews {
+	wo := WorkloadOverviews{}
+	w1 := &WorkloadListItem{IstioSidecar: false}
+	w2 := &WorkloadListItem{IstioSidecar: true}
+	wo = append(wo, w1)
+	wo = append(wo, w2)
+	return wo
 }

--- a/models/workload.go
+++ b/models/workload.go
@@ -365,6 +365,18 @@ func (workload *Workload) HasIstioSidecar() bool {
 	return workload.Pods.HasIstioSidecar()
 }
 
+// HasIstioSidecar returns true if there is at least one workload which has a sidecar
+func (workloads WorkloadOverviews) HasIstioSidecar() bool {
+	if len(workloads) > 0 {
+		for _, w := range workloads {
+			if w.IstioSidecar {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (wl WorkloadList) GetLabels() []labels.Set {
 	wLabels := make([]labels.Set, 0, len(wl.Workloads))
 	for _, w := range wl.Workloads {


### PR DESCRIPTION
Fix for issue https://github.com/kiali/kiali/issues/3904.

When counting sidecar persistence on service via logic that all pods have sidecars of this service, then health of the service is not shown.
But service can have some workloads which have all pods with sidecars. For those workloads the health exists and should be shown for service.
The purpose of this change is to consider the workloads sidecars existence for service sidecar.