### PR TITLE
Display throughput on the graph edges

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -187,12 +187,22 @@ type WorkloadParam struct {
 
 // swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
 type AppendersParam struct {
-	// Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck].
+	// Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput].
 	//
 	// in: query
 	// required: false
 	// default: run all appenders
 	Name string `json:"appenders"`
+}
+
+// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
+type BoxByParam struct {
+	// Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].
+	//
+	// in: query
+	// required: false
+	// default: none
+	Name string `json:"boxBy"`
 }
 
 // swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
@@ -213,16 +223,6 @@ type GraphTypeParam struct {
 	// required: false
 	// default: workload
 	Name string `json:"graphType"`
-}
-
-// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
-type BoxByParam struct {
-	// Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].
-	//
-	// in: query
-	// required: false
-	// default: none
-	Name string `json:"boxBy"`
 }
 
 // swagger:parameters graphApp graphAppVersion graphNamespaces graphWorkload
@@ -262,6 +262,26 @@ type QueryTimeParam struct {
 	// required: false
 	// default: now
 	Name string `json:"queryTime"`
+}
+
+// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
+type ResponseTimeParam struct {
+	// Used only with responseTime appender. One of: avg | 50 | 95 | 99.
+	//
+	// in: query
+	// required: false
+	// default: 95
+	Name string `json:"responseTime"`
+}
+
+// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
+type ThroughputParam struct {
+	// Used only with throughput appender. One of: request | response.
+	//
+	// in: query
+	// required: false
+	// default: request
+	Name string `json:"throughput"`
 }
 
 /////////////////////

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -102,6 +102,7 @@ type EdgeData struct {
 	IsMTLS          string          `json:"isMTLS,omitempty"`          // set to the percentage of traffic using a mutual TLS connection
 	ResponseTime    string          `json:"responseTime,omitempty"`    // in millis
 	SourcePrincipal string          `json:"sourcePrincipal,omitempty"` // principal used for the edge source
+	Throughput      string          `json:"throughput,omitempty"`      // in bytes/sec (request or response, depends on client request)
 	Traffic         ProtocolTraffic `json:"traffic,omitempty"`         // traffic rates for the edge protocol
 }
 
@@ -370,6 +371,10 @@ func addEdgeTelemetry(e *graph.Edge, ed *EdgeData) {
 	if val, ok := e.Metadata[graph.ResponseTime]; ok {
 		responseTime := val.(float64)
 		ed.ResponseTime = fmt.Sprintf("%.0f", responseTime)
+	}
+	if val, ok := e.Metadata[graph.Throughput]; ok {
+		throughput := val.(float64)
+		ed.Throughput = fmt.Sprintf("%.0f", throughput)
 	}
 
 	// an edge represents traffic for at most one protocol

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -37,6 +37,7 @@ const (
 	ProtocolKey           MetadataKey = "protocol"
 	ResponseTime          MetadataKey = "responseTime"
 	SourcePrincipal       MetadataKey = "sourcePrincipal"
+	Throughput            MetadataKey = "throughput"
 )
 
 // DestServicesMetadata key=Service.Key()

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -99,7 +99,7 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 		throughputType := o.Params.Get("throughputType")
 		if throughputType != "" {
 			if throughputType != "request" && throughputType != "response" {
-				graph.BadRequest(fmt.Sprintf("Invalid throughputType, expecting one of (request, response). [%s]", throughputTypeString))
+				graph.BadRequest(fmt.Sprintf("Invalid throughputType, expecting one of (request, response). [%s]", throughputType))
 			}
 		} else {
 			throughputType = defaultThroughputType

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -40,6 +40,8 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 				requestedAppenders[ServiceEntryAppenderName] = true
 			case SidecarsCheckAppenderName:
 				requestedAppenders[SidecarsCheckAppenderName] = true
+			case ThroughputAppenderName:
+				requestedAppenders[ThroughputAppenderName] = true
 			case "":
 				// skip
 			default:

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	defaultAggregate = "request_operation"
-	defaultQuantile  = 0.95
+	defaultAggregate      = "request_operation"
+	defaultQuantile       = 0.95
+	defaultThroughputType = "response"
 )
 
 // ParseAppenders determines which appenders should run for this graphing request
@@ -91,6 +92,24 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 			InjectServiceNodes: o.InjectServiceNodes,
 			Namespaces:         o.Namespaces,
 			QueryTime:          o.QueryTime,
+		}
+		appenders = append(appenders, a)
+	}
+	if _, ok := requestedAppenders[ThroughputAppenderName]; ok || o.Appenders.All {
+		throughputType := o.Params.Get("throughputType")
+		if throughputType != "" {
+			if throughputType != "request" && throughputType != "response" {
+				graph.BadRequest(fmt.Sprintf("Invalid throughputType, expecting one of (request, response). [%s]", throughputTypeString))
+			}
+		} else {
+			throughputType = defaultThroughputType
+		}
+		a := ThroughputAppender{
+			GraphType:          o.GraphType,
+			InjectServiceNodes: o.InjectServiceNodes,
+			Namespaces:         o.Namespaces,
+			QueryTime:          o.QueryTime,
+			ThroughputType:     throughputType,
 		}
 		appenders = append(appenders, a)
 	}

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -2,7 +2,6 @@ package appender
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
@@ -72,11 +71,19 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 	}
 	if _, ok := requestedAppenders[ResponseTimeAppenderName]; ok || o.Appenders.All {
 		quantile := defaultQuantile
-		quantileString := o.Params.Get("responseTimeQuantile")
-		if quantileString != "" {
-			var err error
-			if quantile, err = strconv.ParseFloat(quantileString, 64); err != nil {
-				graph.BadRequest(fmt.Sprintf("Invalid quantile, expecting float between 0.0 and 100.0 [%s]", quantileString))
+		responseTimeString := o.Params.Get("responseTime")
+		if responseTimeString != "" {
+			switch responseTimeString {
+			case "avg":
+				quantile = 0.0
+			case "50":
+				quantile = 0.5
+			case "95":
+				quantile = 0.95
+			case "99":
+				quantile = 0.99
+			default:
+				graph.BadRequest(fmt.Sprintf(`Invalid responseTime, must be one of: avg | 50 | 95 | 99: [%s]`, responseTimeString))
 			}
 		}
 		a := ResponseTimeAppender{

--- a/graph/telemetry/istio/appender/security_policy.go
+++ b/graph/telemetry/istio/appender/security_policy.go
@@ -114,7 +114,7 @@ func (a SecurityPolicyAppender) populateSecurityPolicyMap(securityPolicyMap map[
 		lCsp, cspOk := m["connection_security_policy"]
 
 		if !sourceWlNsOk || !sourceWlOk || !sourceAppOk || !sourceVerOk || !destSvcNsOk || !destSvcNameOk || !destWlNsOk || !destWlOk || !destAppOk || !destVerOk || !sourcePrincipalOk || !destPrincipalOk || !cspOk {
-			log.Warningf("Skipping %v, missing expected labels", m.String())
+			log.Warningf("populateSecurityPolicyMap: Skipping %s, missing expected labels", m.String())
 			continue
 		}
 

--- a/graph/telemetry/istio/appender/throughput.go
+++ b/graph/telemetry/istio/appender/throughput.go
@@ -1,0 +1,195 @@
+package appender
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/graph/telemetry/istio/util"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/prometheus"
+)
+
+const (
+	// ThroughputAppenderName uniquely identifies the appender: responseTime
+	ThroughputAppenderName = "throughput"
+)
+
+var (
+	regexpHTTPFailure, _ = regexp.Compile(`^0$|^[4|5]\d\d$`) // include 0, Istio's flag for no response received
+)
+
+// ThroughputAppender is responsible for adding throughput information to the graph. Throughput
+// is represented as bytes/sec.  Throughput may be for request bytes or response bytes depending
+// on the options.  Request throughput will be reported using source telemetry, response throughput
+// using destination telemetry.
+// Name: responseTime
+type ThroughputAppender struct {
+	GraphType          string
+	InjectServiceNodes bool
+	Namespaces         graph.NamespaceInfoMap
+	QueryTime          int64 // unix time in seconds
+	ThroughputType     string
+}
+
+// Name implements Appender
+func (a ThroughputAppender) Name() string {
+	return ThroughputAppenderName
+}
+
+// AppendGraph implements Appender
+func (a ThroughputAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+	if len(trafficMap) == 0 {
+		return
+	}
+
+	if globalInfo.PromClient == nil {
+		var err error
+		globalInfo.PromClient, err = prometheus.NewClient()
+		graph.CheckError(err)
+	}
+
+	a.appendGraph(trafficMap, namespaceInfo.Namespace, globalInfo.PromClient)
+}
+
+func (a ThroughputAppender) appendGraph(trafficMap graph.TrafficMap, namespace string, client *prometheus.Client) {
+	log.Tracef("Generating [%s] throughput; namespace = %v", a.ThroughputType, namespace)
+
+	// create map to quickly look up responseTime
+	responseTimeMap := make(map[string]float64)
+	duration := a.Namespaces[namespace].Duration
+
+	// query prometheus for the responseTime info in four queries:
+	groupBy := "le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_code,grpc_response_status"
+
+	// 1) Incoming: query destination telemetry to capture namespace services' incoming traffic
+	// note - the query order is important as both queries may have overlapping results for edges within
+	//        the namespace.  This query uses destination proxy and so must come first.
+	query := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="destination",destination_service_namespace="%s"}[%vs])) by (%s)) > 0`,
+		quantile,
+		"istio_request_duration_milliseconds_bucket",
+		namespace,
+		int(duration.Seconds()), // range duration for the query
+		groupBy)
+	incomingVector := promQuery(query, time.Unix(a.QueryTime, 0), client.GetContext(), client.API(), a)
+	a.populateResponseTimeMap(responseTimeMap, &incomingVector)
+
+	// 2) Outgoing: query source telemetry to capture namespace workloads' outgoing traffic
+	query = fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace="%s"}[%vs])) by (%s)) > 0`,
+		quantile,
+		"istio_request_duration_milliseconds_bucket",
+		namespace,
+		int(duration.Seconds()), // range duration for the query
+		groupBy)
+	outgoingVector := promQuery(query, time.Unix(a.QueryTime, 0), client.GetContext(), client.API(), a)
+	a.populateResponseTimeMap(responseTimeMap, &outgoingVector)
+
+	applyResponseTime(trafficMap, responseTimeMap)
+}
+
+func applyResponseTime(trafficMap graph.TrafficMap, responseTimeMap map[string]float64) {
+	for _, n := range trafficMap {
+		for _, e := range n.Edges {
+			key := fmt.Sprintf("%s %s", e.Source.ID, e.Dest.ID)
+			if val, ok := responseTimeMap[key]; ok {
+				e.Metadata[graph.ResponseTime] = val
+			}
+		}
+	}
+}
+
+func (a ThroughputAppender) populateResponseTimeMap(responseTimeMap map[string]float64, vector *model.Vector) {
+	for _, s := range *vector {
+		m := s.Metric
+		lSourceCluster, sourceClusterOk := m["source_cluster"]
+		lSourceWlNs, sourceWlNsOk := m["source_workload_namespace"]
+		lSourceWl, sourceWlOk := m["source_workload"]
+		lSourceApp, sourceAppOk := m["source_canonical_service"]
+		lSourceVer, sourceVerOk := m["source_canonical_revision"]
+		lDestCluster, destClusterOk := m["destination_cluster"]
+		lDestSvcNs, destSvcNsOk := m["destination_service_namespace"]
+		lDestSvc, destSvcOk := m["destination_service"]
+		lDestSvcName, destSvcNameOk := m["destination_service_name"]
+		lDestWlNs, destWlNsOk := m["destination_workload_namespace"]
+		lDestWl, destWlOk := m["destination_workload"]
+		lDestApp, destAppOk := m["destination_canonical_service"]
+		lDestVer, destVerOk := m["destination_canonical_revision"]
+		lResponseCode, responseCodeOk := m["response_code"]
+		lGrpcResponseStatus, grpcReponseStatusOk := m["grpc_response_status"]
+
+		if !sourceWlNsOk || !sourceWlOk || !sourceAppOk || !sourceVerOk || !destSvcNsOk || !destSvcNameOk || !destSvcOk || !destWlNsOk || !destWlOk || !destAppOk || !destVerOk || !responseCodeOk {
+			log.Warningf("Skipping %v, missing expected labels", m.String())
+			continue
+		}
+
+		sourceWlNs := string(lSourceWlNs)
+		sourceWl := string(lSourceWl)
+		sourceApp := string(lSourceApp)
+		sourceVer := string(lSourceVer)
+		destSvc := string(lDestSvc)
+		responseCode := string(lResponseCode)
+
+		// handle clusters
+		sourceCluster, destCluster := util.HandleClusters(lSourceCluster, sourceClusterOk, lDestCluster, destClusterOk)
+
+		if util.IsBadSourceTelemetry(sourceCluster, sourceClusterOk, sourceWlNs, sourceWl, sourceApp) {
+			continue
+		}
+
+		// This was added in istio 1.5, handle in a backward compatible way
+		grpcReponseStatus := "0"
+		if grpcReponseStatusOk {
+			grpcReponseStatus = string(lGrpcResponseStatus)
+		}
+
+		// Only valid requests contribute to response time so as not to skew RT when a failed request returns immediately
+		// TODO: Maybe we should control this behavior with a queryParam?
+		if grpcReponseStatus != "0" || regexpHTTPFailure.MatchString(responseCode) {
+			continue
+		}
+
+		val := float64(s.Value)
+
+		// handle unusual destinations
+		destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, _ := util.HandleDestination(sourceCluster, sourceWlNs, sourceWl, destCluster, string(lDestSvcNs), string(lDestSvc), string(lDestSvcName), string(lDestWlNs), string(lDestWl), string(lDestApp), string(lDestVer))
+
+		if util.IsBadDestTelemetry(destCluster, destClusterOk, destSvcNs, destSvc, destSvcName, destWl) {
+			continue
+		}
+
+		// It is possible to get a NaN if there is no traffic (or possibly other reasons). Just skip it
+		if math.IsNaN(val) {
+			continue
+		}
+
+		// don't inject a service node if destSvcName is not set or the dest node is already a service node.
+		inject := false
+		if a.InjectServiceNodes && graph.IsOK(destSvcName) {
+			_, destNodeType := graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType)
+			inject = (graph.NodeTypeService != destNodeType)
+		}
+
+		if inject {
+			// Do not set response time on the incoming edge, we can't validly aggregate response times of the outgoing edges (kiali-2297)
+			a.addResponseTime(responseTimeMap, val, destCluster, destSvcNs, destSvcName, "", "", "", destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
+		} else {
+			a.addResponseTime(responseTimeMap, val, sourceCluster, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer)
+		}
+	}
+}
+
+func (a ThroughputAppender) addResponseTime(responseTimeMap map[string]float64, val float64, sourceCluster, sourceNs, sourceSvc, sourceWl, sourceApp, sourceVer, destCluster, destSvcNs, destSvc, destWlNs, destWl, destApp, destVer string) {
+	sourceID, _ := graph.Id(sourceCluster, sourceNs, sourceSvc, sourceNs, sourceWl, sourceApp, sourceVer, a.GraphType)
+	destID, _ := graph.Id(destCluster, destSvcNs, destSvc, destWlNs, destWl, destApp, destVer, a.GraphType)
+	key := fmt.Sprintf("%s %s", sourceID, destID)
+
+	// For edges within the namespace we may get a responseTime reported from both the incoming and outgoing
+	// traffic queries.  We assume here the first reported value is preferred (i.e. defer to query order)
+	if _, found := responseTimeMap[key]; !found {
+		responseTimeMap[key] = val
+	}
+}

--- a/graph/telemetry/istio/appender/throughput_test.go
+++ b/graph/telemetry/istio/appender/throughput_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/kiali/kiali/graph"
 )
 
-func TestResponseTime(t *testing.T) {
+func TestResponseThroughput(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision)) > 0,0.001)`
+	q0 := `round((sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace!="%s",destination_service_namespace="%s"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision)) > 0,0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -26,73 +26,13 @@ func TestResponseTime(t *testing.T) {
 		"destination_workload":           "productpage-v1",
 		"destination_canonical_service":  "productpage",
 		"destination_canonical_revision": "v1"}
-	q0m1 := model.Metric{
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "productpage-v1",
-		"source_canonical_service":       "productpage",
-		"source_canonical_revision":      "v1",
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "reviews.bookinfo.svc.cluster.local",
-		"destination_service_name":       "reviews",
-		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "reviews-v1",
-		"destination_canonical_service":  "reviews",
-		"destination_canonical_revision": "v1"}
-	q0m2 := model.Metric{
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "productpage-v1",
-		"source_canonical_service":       "productpage",
-		"source_canonical_revision":      "v1",
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "reviews.bookinfo.svc.cluster.local",
-		"destination_service_name":       "reviews",
-		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "reviews-v2",
-		"destination_canonical_service":  "reviews",
-		"destination_canonical_revision": "v2"}
-	q0m3 := model.Metric{
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "reviews-v1",
-		"source_canonical_service":       "reviews",
-		"source_canonical_revision":      "v1",
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "ratings.bookinfo.svc.cluster.local",
-		"destination_service_name":       "ratings",
-		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "ratings-v1",
-		"destination_canonical_service":  "ratings",
-		"destination_canonical_revision": "v1"}
-	q0m4 := model.Metric{
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "reviews-v2",
-		"source_canonical_service":       "reviews",
-		"source_canonical_revision":      "v2",
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "ratings.bookinfo.svc.cluster.local",
-		"destination_service_name":       "ratings",
-		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "ratings-v1",
-		"destination_canonical_service":  "ratings",
-		"destination_canonical_revision": "v1"}
 	v0 := model.Vector{
 		&model.Sample{
 			Metric: q0m0,
-			Value:  0.010},
-		&model.Sample{
-			Metric: q0m1,
-			Value:  0.020},
-		&model.Sample{
-			Metric: q0m2,
-			Value:  0.020},
-		&model.Sample{
-			Metric: q0m3,
-			Value:  0.030}, // same edge reported by outgoing (q1), this > value should be preferred
-		&model.Sample{
-			Metric: q0m4,
-			Value:  0.030}, // same edge reported by outgoing (q1), this > value should be preferred
+			Value:  1000},
 	}
 
-	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision)) > 0,0.001)`
+	q1 := `round((sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace="%s"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision)) > 0,0.001)`
 	q1m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -102,22 +42,10 @@ func TestResponseTime(t *testing.T) {
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
 		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "reviews-v1",
-		"destination_canonical_service":  "reviews",
-		"destination_canonical_revision": "v1"}
-	q1m1 := model.Metric{
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "productpage-v1",
-		"source_canonical_service":       "productpage",
-		"source_canonical_revision":      "v1",
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "reviews.bookinfo.svc.cluster.local",
-		"destination_service_name":       "reviews",
-		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "reviews-v2",
 		"destination_canonical_service":  "reviews",
 		"destination_canonical_revision": "v2"}
-	q1m2 := model.Metric{
+	q1m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
@@ -129,7 +57,7 @@ func TestResponseTime(t *testing.T) {
 		"destination_workload":           "ratings-v1",
 		"destination_canonical_service":  "ratings",
 		"destination_canonical_revision": "v1"}
-	q1m3 := model.Metric{
+	q1m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
@@ -141,20 +69,16 @@ func TestResponseTime(t *testing.T) {
 		"destination_workload":           "ratings-v1",
 		"destination_canonical_service":  "ratings",
 		"destination_canonical_revision": "v1"}
-
 	v1 := model.Vector{
 		&model.Sample{
 			Metric: q1m0,
-			Value:  0.020},
+			Value:  1000},
 		&model.Sample{
 			Metric: q1m1,
-			Value:  0.020},
+			Value:  2000},
 		&model.Sample{
 			Metric: q1m2,
-			Value:  0.040}, // same edge reported by incoming (q0), this > value should get ignored
-		&model.Sample{
-			Metric: q1m3,
-			Value:  0.040}, // same edge reported by incoming (q0), this > value should get ignored
+			Value:  3000},
 	}
 
 	client, api, err := setupMocked()
@@ -165,16 +89,16 @@ func TestResponseTime(t *testing.T) {
 	mockQuery(api, q0, &v0)
 	mockQuery(api, q1, &v1)
 
-	trafficMap := responseTimeTestTraffic()
+	trafficMap := throughputTestTraffic()
 	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
 	assert.Equal(1, len(ingress.Edges))
-	assert.Equal(nil, ingress.Edges[0].Metadata[graph.ResponseTime])
+	assert.Equal(nil, ingress.Edges[0].Metadata[graph.Throughput])
 
 	duration, _ := time.ParseDuration("60s")
-	appender := ResponseTimeAppender{
+	appender := ThroughputAppender{
 		GraphType:          graph.GraphTypeVersionedApp,
 		InjectServiceNodes: true,
 		Namespaces: map[string]graph.NamespaceInfo{
@@ -183,8 +107,8 @@ func TestResponseTime(t *testing.T) {
 				Duration: duration,
 			},
 		},
-		Quantile:  0.95,
-		QueryTime: time.Now().Unix(),
+		QueryTime:      time.Now().Unix(),
+		ThroughputType: "response",
 	}
 
 	appender.appendGraph(trafficMap, "bookinfo", client)
@@ -193,53 +117,53 @@ func TestResponseTime(t *testing.T) {
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
 	assert.Equal(1, len(ingress.Edges))
-	_, ok = ingress.Edges[0].Metadata[graph.ResponseTime]
+	_, ok = ingress.Edges[0].Metadata[graph.Throughput]
 	assert.Equal(false, ok)
 
 	productpageService := ingress.Edges[0].Dest
 	assert.Equal(graph.NodeTypeService, productpageService.NodeType)
 	assert.Equal("productpage", productpageService.Service)
-	assert.Equal(nil, productpageService.Metadata[graph.ResponseTime])
+	assert.Equal(nil, productpageService.Metadata[graph.Throughput])
 	assert.Equal(1, len(productpageService.Edges))
-	assert.Equal(0.01, productpageService.Edges[0].Metadata[graph.ResponseTime])
+	assert.Equal(0.01, productpageService.Edges[0].Metadata[graph.Throughput])
 
 	productpage := productpageService.Edges[0].Dest
 	assert.Equal("productpage", productpage.App)
 	assert.Equal("v1", productpage.Version)
-	assert.Equal(nil, productpage.Metadata[graph.ResponseTime])
+	assert.Equal(nil, productpage.Metadata[graph.Throughput])
 	assert.Equal(1, len(productpage.Edges))
-	_, ok = productpage.Edges[0].Metadata[graph.ResponseTime]
+	_, ok = productpage.Edges[0].Metadata[graph.Throughput]
 	assert.Equal(false, ok)
 
 	reviewsService := productpage.Edges[0].Dest
 	assert.Equal(graph.NodeTypeService, reviewsService.NodeType)
 	assert.Equal("reviews", reviewsService.Service)
-	assert.Equal(nil, reviewsService.Metadata[graph.ResponseTime])
+	assert.Equal(nil, reviewsService.Metadata[graph.Throughput])
 	assert.Equal(2, len(reviewsService.Edges))
-	assert.Equal(0.02, reviewsService.Edges[0].Metadata[graph.ResponseTime])
-	assert.Equal(0.02, reviewsService.Edges[1].Metadata[graph.ResponseTime])
+	assert.Equal(0.02, reviewsService.Edges[0].Metadata[graph.Throughput])
+	assert.Equal(0.02, reviewsService.Edges[1].Metadata[graph.Throughput])
 
 	reviews1 := reviewsService.Edges[0].Dest
 	assert.Equal("reviews", reviews1.App)
 	assert.Equal("v1", reviews1.Version)
-	assert.Equal(nil, reviews1.Metadata[graph.ResponseTime])
+	assert.Equal(nil, reviews1.Metadata[graph.Throughput])
 	assert.Equal(1, len(reviews1.Edges))
-	_, ok = reviews1.Edges[0].Metadata[graph.ResponseTime]
+	_, ok = reviews1.Edges[0].Metadata[graph.Throughput]
 	assert.Equal(false, ok)
 
 	ratingsService := reviews1.Edges[0].Dest
 	assert.Equal(graph.NodeTypeService, ratingsService.NodeType)
 	assert.Equal("ratings", ratingsService.Service)
-	assert.Equal(nil, ratingsService.Metadata[graph.ResponseTime])
+	assert.Equal(nil, ratingsService.Metadata[graph.Throughput])
 	assert.Equal(1, len(ratingsService.Edges))
-	assert.Equal(0.03, ratingsService.Edges[0].Metadata[graph.ResponseTime])
+	assert.Equal(0.03, ratingsService.Edges[0].Metadata[graph.Throughput])
 
 	reviews2 := reviewsService.Edges[1].Dest
 	assert.Equal("reviews", reviews2.App)
 	assert.Equal("v2", reviews2.Version)
-	assert.Equal(nil, reviews2.Metadata[graph.ResponseTime])
+	assert.Equal(nil, reviews2.Metadata[graph.Throughput])
 	assert.Equal(1, len(reviews2.Edges))
-	_, ok = reviews2.Edges[0].Metadata[graph.ResponseTime]
+	_, ok = reviews2.Edges[0].Metadata[graph.Throughput]
 	assert.False(ok)
 
 	assert.Equal(ratingsService, reviews2.Edges[0].Dest)
@@ -247,11 +171,11 @@ func TestResponseTime(t *testing.T) {
 	ratings := ratingsService.Edges[0].Dest
 	assert.Equal("ratings", ratings.App)
 	assert.Equal("v1", ratings.Version)
-	assert.Equal(nil, ratings.Metadata[graph.ResponseTime])
+	assert.Equal(nil, ratings.Metadata[graph.Throughput])
 	assert.Equal(0, len(ratings.Edges))
 }
 
-func responseTimeTestTraffic() graph.TrafficMap {
+func throughputTestTraffic() graph.TrafficMap {
 	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	productpageService := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
 	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)

--- a/graph/telemetry/istio/appender/throughput_test.go
+++ b/graph/telemetry/istio/appender/throughput_test.go
@@ -13,7 +13,7 @@ import (
 func TestResponseThroughput(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round((sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace!="%s",destination_service_namespace="%s"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision)) > 0,0.001)`
+	q0 := `round(sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q0m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -29,11 +29,23 @@ func TestResponseThroughput(t *testing.T) {
 	v0 := model.Vector{
 		&model.Sample{
 			Metric: q0m0,
-			Value:  1000},
+			Value:  1000.0},
 	}
 
-	q1 := `round((sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace="%s"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision)) > 0,0.001)`
+	q1 := `round(sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews.bookinfo.svc.cluster.local",
+		"destination_service_name":       "reviews",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "reviews-v1",
+		"destination_canonical_service":  "reviews",
+		"destination_canonical_revision": "v1"}
+	q1m1 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
@@ -45,7 +57,7 @@ func TestResponseThroughput(t *testing.T) {
 		"destination_workload":           "reviews-v2",
 		"destination_canonical_service":  "reviews",
 		"destination_canonical_revision": "v2"}
-	q1m1 := model.Metric{
+	q1m2 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
@@ -57,7 +69,7 @@ func TestResponseThroughput(t *testing.T) {
 		"destination_workload":           "ratings-v1",
 		"destination_canonical_service":  "ratings",
 		"destination_canonical_revision": "v1"}
-	q1m2 := model.Metric{
+	q1m3 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
@@ -72,14 +84,16 @@ func TestResponseThroughput(t *testing.T) {
 	v1 := model.Vector{
 		&model.Sample{
 			Metric: q1m0,
-			Value:  1000},
+			Value:  1000.0},
 		&model.Sample{
 			Metric: q1m1,
-			Value:  2000},
+			Value:  2000.0},
 		&model.Sample{
 			Metric: q1m2,
-			Value:  3000},
-	}
+			Value:  1000.0},
+		&model.Sample{
+			Metric: q1m3,
+			Value:  2000.0}}
 
 	client, api, err := setupMocked()
 	if err != nil {
@@ -89,7 +103,7 @@ func TestResponseThroughput(t *testing.T) {
 	mockQuery(api, q0, &v0)
 	mockQuery(api, q1, &v1)
 
-	trafficMap := throughputTestTraffic()
+	trafficMap := responseThroughputTestTraffic()
 	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
@@ -125,7 +139,7 @@ func TestResponseThroughput(t *testing.T) {
 	assert.Equal("productpage", productpageService.Service)
 	assert.Equal(nil, productpageService.Metadata[graph.Throughput])
 	assert.Equal(1, len(productpageService.Edges))
-	assert.Equal(0.01, productpageService.Edges[0].Metadata[graph.Throughput])
+	assert.Equal(1000.0, productpageService.Edges[0].Metadata[graph.Throughput])
 
 	productpage := productpageService.Edges[0].Dest
 	assert.Equal("productpage", productpage.App)
@@ -140,8 +154,8 @@ func TestResponseThroughput(t *testing.T) {
 	assert.Equal("reviews", reviewsService.Service)
 	assert.Equal(nil, reviewsService.Metadata[graph.Throughput])
 	assert.Equal(2, len(reviewsService.Edges))
-	assert.Equal(0.02, reviewsService.Edges[0].Metadata[graph.Throughput])
-	assert.Equal(0.02, reviewsService.Edges[1].Metadata[graph.Throughput])
+	assert.Equal(1000.0, reviewsService.Edges[0].Metadata[graph.Throughput])
+	assert.Equal(2000.0, reviewsService.Edges[1].Metadata[graph.Throughput])
 
 	reviews1 := reviewsService.Edges[0].Dest
 	assert.Equal("reviews", reviews1.App)
@@ -151,13 +165,6 @@ func TestResponseThroughput(t *testing.T) {
 	_, ok = reviews1.Edges[0].Metadata[graph.Throughput]
 	assert.Equal(false, ok)
 
-	ratingsService := reviews1.Edges[0].Dest
-	assert.Equal(graph.NodeTypeService, ratingsService.NodeType)
-	assert.Equal("ratings", ratingsService.Service)
-	assert.Equal(nil, ratingsService.Metadata[graph.Throughput])
-	assert.Equal(1, len(ratingsService.Edges))
-	assert.Equal(0.03, ratingsService.Edges[0].Metadata[graph.Throughput])
-
 	reviews2 := reviewsService.Edges[1].Dest
 	assert.Equal("reviews", reviews2.App)
 	assert.Equal("v2", reviews2.Version)
@@ -165,6 +172,13 @@ func TestResponseThroughput(t *testing.T) {
 	assert.Equal(1, len(reviews2.Edges))
 	_, ok = reviews2.Edges[0].Metadata[graph.Throughput]
 	assert.False(ok)
+
+	ratingsService := reviews1.Edges[0].Dest
+	assert.Equal(graph.NodeTypeService, ratingsService.NodeType)
+	assert.Equal("ratings", ratingsService.Service)
+	assert.Equal(nil, ratingsService.Metadata[graph.Throughput])
+	assert.Equal(1, len(ratingsService.Edges))
+	assert.Equal(3000.0, ratingsService.Edges[0].Metadata[graph.Throughput])
 
 	assert.Equal(ratingsService, reviews2.Edges[0].Dest)
 
@@ -175,7 +189,7 @@ func TestResponseThroughput(t *testing.T) {
 	assert.Equal(0, len(ratings.Edges))
 }
 
-func throughputTestTraffic() graph.TrafficMap {
+func responseThroughputTestTraffic() graph.TrafficMap {
 	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	productpageService := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
 	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
@@ -203,6 +217,125 @@ func throughputTestTraffic() graph.TrafficMap {
 	reviewsV1.AddEdge(&ratingsService)
 	reviewsV2.AddEdge(&ratingsService)
 	ratingsService.AddEdge(&ratings)
+
+	return trafficMap
+}
+
+func TestRequestThroughput(t *testing.T) {
+	assert := assert.New(t)
+
+	q0 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
+	q0m0 := model.Metric{
+		"source_workload_namespace":      "istio-system",
+		"source_workload":                "ingressgateway-unknown",
+		"source_canonical_service":       "ingressgateway",
+		"source_canonical_revision":      model.LabelValue(graph.Unknown),
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "productpage.bookinfo.svc.cluster.local",
+		"destination_service_name":       "productpage",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "productpage-v1",
+		"destination_canonical_service":  "productpage",
+		"destination_canonical_revision": "v1"}
+	v0 := model.Vector{
+		&model.Sample{
+			Metric: q0m0,
+			Value:  1000.0},
+	}
+
+	q1 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
+	q1m0 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews.bookinfo.svc.cluster.local",
+		"destination_service_name":       "reviews",
+		"destination_workload_namespace": "unknown", // simulate failed requests to reviews service
+		"destination_workload":           "unknown",
+		"destination_canonical_service":  "unknown",
+		"destination_canonical_revision": "unknown"}
+	v1 := model.Vector{
+		&model.Sample{
+			Metric: q1m0,
+			Value:  1000.0}}
+
+	client, api, err := setupMocked()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	mockQuery(api, q0, &v0)
+	mockQuery(api, q1, &v1)
+
+	trafficMap := requestThroughputTestTraffic()
+	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingress, ok := trafficMap[ingressID]
+	assert.Equal(true, ok)
+	assert.Equal("ingressgateway", ingress.App)
+	assert.Equal(1, len(ingress.Edges))
+	assert.Equal(nil, ingress.Edges[0].Metadata[graph.Throughput])
+
+	duration, _ := time.ParseDuration("60s")
+	appender := ThroughputAppender{
+		GraphType:          graph.GraphTypeVersionedApp,
+		InjectServiceNodes: true,
+		Namespaces: map[string]graph.NamespaceInfo{
+			"bookinfo": {
+				Name:     "bookinfo",
+				Duration: duration,
+			},
+		},
+		QueryTime:      time.Now().Unix(),
+		ThroughputType: "request",
+	}
+
+	appender.appendGraph(trafficMap, "bookinfo", client)
+
+	ingress, ok = trafficMap[ingressID]
+	assert.Equal(true, ok)
+	assert.Equal("ingressgateway", ingress.App)
+	assert.Equal(1, len(ingress.Edges))
+	_, ok = ingress.Edges[0].Metadata[graph.Throughput]
+	assert.Equal(false, ok)
+
+	productpageService := ingress.Edges[0].Dest
+	assert.Equal(graph.NodeTypeService, productpageService.NodeType)
+	assert.Equal("productpage", productpageService.Service)
+	assert.Equal(nil, productpageService.Metadata[graph.Throughput])
+	assert.Equal(1, len(productpageService.Edges))
+	assert.Equal(1000.0, productpageService.Edges[0].Metadata[graph.Throughput])
+
+	productpage := productpageService.Edges[0].Dest
+	assert.Equal("productpage", productpage.App)
+	assert.Equal("v1", productpage.Version)
+	assert.Equal(nil, productpage.Metadata[graph.Throughput])
+	assert.Equal(1, len(productpage.Edges))
+	assert.Equal(1000.0, productpage.Edges[0].Metadata[graph.Throughput])
+
+	reviewsService := productpage.Edges[0].Dest
+	assert.Equal(graph.NodeTypeService, reviewsService.NodeType)
+	assert.Equal("reviews", reviewsService.Service)
+	assert.Equal(nil, reviewsService.Metadata[graph.Throughput])
+	assert.Equal(0, len(reviewsService.Edges))
+}
+
+func requestThroughputTestTraffic() graph.TrafficMap {
+	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	trafficMap := graph.NewTrafficMap()
+
+	trafficMap[ingress.ID] = &ingress
+	trafficMap[productpageService.ID] = &productpageService
+	trafficMap[productpage.ID] = &productpage
+	trafficMap[reviewsService.ID] = &reviewsService
+
+	ingress.AddEdge(&productpageService)
+	productpageService.AddEdge(&productpage)
+	productpage.AddEdge(&reviewsService)
 
 	return trafficMap
 }

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -10,9 +10,10 @@ package istio
 //
 //   Second Pass: Apply any requested appenders to alter or append to the graph.
 //
-// Supports two vendor-specific query parameters:
+// Supports three vendor-specific query parameters:
 //   aggregate: Must be a valid metric attribute (default: request_operation)
 //   responseTimeQuantile: Must be a valid quantile (default: 0.95)
+//   throughputType: request | reposnse (default: response)
 //
 import (
 	"context"
@@ -656,6 +657,7 @@ func promQuery(query string, queryTime time.Time, api prom_v1.API) model.Vector 
 	log.Tracef("Graph query:\n%s@time=%v (now=%v, %v)\n", query, queryTime.Format(graph.TF), time.Now().Format(graph.TF), queryTime.Unix())
 
 	promtimer := internalmetrics.GetPrometheusProcessingTimePrometheusTimer("Graph-Generation")
+	log.Infof("GraphGen: %s", query)
 	value, warnings, err := api.Query(ctx, query, queryTime)
 	if warnings != nil && len(warnings) > 0 {
 		log.Warningf("promQuery. Prometheus Warnings: [%s]", strings.Join(warnings, ","))

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -13,7 +13,7 @@ package istio
 // Supports three vendor-specific query parameters:
 //   aggregate: Must be a valid metric attribute (default: request_operation)
 //   responseTimeQuantile: Must be a valid quantile (default: 0.95)
-//   throughputType: request | reposnse (default: response)
+//   throughputType: request | response (default: response)
 //
 import (
 	"context"

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -12,7 +12,7 @@ package istio
 //
 // Supports three vendor-specific query parameters:
 //   aggregate: Must be a valid metric attribute (default: request_operation)
-//   responseTimeQuantile: Must be a valid quantile (default: 0.95)
+//   responseTime: Must be one of: avg | 50 | 95 | 99
 //   throughputType: request | response (default: response)
 //
 import (

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -657,7 +657,6 @@ func promQuery(query string, queryTime time.Time, api prom_v1.API) model.Vector 
 	log.Tracef("Graph query:\n%s@time=%v (now=%v, %v)\n", query, queryTime.Format(graph.TF), time.Now().Format(graph.TF), queryTime.Unix())
 
 	promtimer := internalmetrics.GetPrometheusProcessingTimePrometheusTimer("Graph-Generation")
-	log.Infof("GraphGen: %s", query)
 	value, warnings, err := api.Query(ctx, query, queryTime)
 	if warnings != nil && len(warnings) > 0 {
 		log.Warningf("promQuery. Prometheus Warnings: [%s]", strings.Join(warnings, ","))

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -1903,7 +1903,7 @@ The backing JSON for an app node detail graph. (supported graphTypes: app | vers
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | app | `path` | string | `string` |  | ✓ |  | The app name (label value). |
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
-| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck]. |
+| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput]. |
 | boxBy | `query` | string | `string` |  |  | `"none"` | Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none]. |
 | container | `query` | string | `string` |  |  |  | The cluster name. If not supplied queries/results will not be constrained by cluster. |
 | duration | `query` | string | `string` |  |  | `"10m"` | Query time-range duration (Golang string duration). |
@@ -1911,6 +1911,8 @@ The backing JSON for an app node detail graph. (supported graphTypes: app | vers
 | includeIdleEdges | `query` | string | `string` |  |  | `"false"` | Flag for including edges that have no request traffic for the time period. |
 | injectServiceNodes | `query` | string | `string` |  |  | `"false"` | Flag for injecting the requested service node between source and destination nodes. |
 | queryTime | `query` | string | `string` |  |  | `"now"` | Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now. |
+| responseTime | `query` | string | `string` |  |  | `"95"` | Used only with responseTime appender. One of: avg | 50 | 95 | 99. |
+| throughput | `query` | string | `string` |  |  | `"request"` | Used only with throughput appender. One of: request | response. |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -2005,7 +2007,7 @@ The backing JSON for a versioned app node detail graph. (supported graphTypes: a
 | app | `path` | string | `string` |  | ✓ |  | The app name (label value). |
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | version | `path` | string | `string` |  | ✓ |  | The app version (label value). |
-| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck]. |
+| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput]. |
 | boxBy | `query` | string | `string` |  |  | `"none"` | Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none]. |
 | container | `query` | string | `string` |  |  |  | The cluster name. If not supplied queries/results will not be constrained by cluster. |
 | duration | `query` | string | `string` |  |  | `"10m"` | Query time-range duration (Golang string duration). |
@@ -2013,6 +2015,8 @@ The backing JSON for a versioned app node detail graph. (supported graphTypes: a
 | includeIdleEdges | `query` | string | `string` |  |  | `"false"` | Flag for including edges that have no request traffic for the time period. |
 | injectServiceNodes | `query` | string | `string` |  |  | `"false"` | Flag for injecting the requested service node between source and destination nodes. |
 | queryTime | `query` | string | `string` |  |  | `"now"` | Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now. |
+| responseTime | `query` | string | `string` |  |  | `"95"` | Used only with responseTime appender. One of: avg | 50 | 95 | 99. |
+| throughput | `query` | string | `string` |  |  | `"request"` | Used only with throughput appender. One of: request | response. |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -2102,7 +2106,7 @@ GET /api/namespaces/graph
 
 | Name | Source | Type | Go type | Separator | Required | Default | Description |
 |------|--------|------|---------|-----------| :------: |---------|-------------|
-| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck]. |
+| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput]. |
 | boxBy | `query` | string | `string` |  |  | `"none"` | Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none]. |
 | duration | `query` | string | `string` |  |  | `"10m"` | Query time-range duration (Golang string duration). |
 | graphType | `query` | string | `string` |  |  | `"workload"` | Graph type. Available graph types: [app, service, versionedApp, workload]. |
@@ -2110,6 +2114,8 @@ GET /api/namespaces/graph
 | injectServiceNodes | `query` | string | `string` |  |  | `"false"` | Flag for injecting the requested service node between source and destination nodes. |
 | namespaces | `query` | string | `string` |  | ✓ |  | Comma-separated list of namespaces to include in the graph. The namespaces must be accessible to the client. |
 | queryTime | `query` | string | `string` |  |  | `"now"` | Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now. |
+| responseTime | `query` | string | `string` |  |  | `"95"` | Used only with responseTime appender. One of: avg | 50 | 95 | 99. |
+| throughput | `query` | string | `string` |  |  | `"request"` | Used only with throughput appender. One of: request | response. |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -2201,12 +2207,14 @@ GET /api/namespaces/{namespace}/services/{service}/graph
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | service | `path` | string | `string` |  | ✓ |  | The service name. |
-| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck]. |
+| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput]. |
 | boxBy | `query` | string | `string` |  |  | `"none"` | Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none]. |
 | container | `query` | string | `string` |  |  |  | The cluster name. If not supplied queries/results will not be constrained by cluster. |
 | duration | `query` | string | `string` |  |  | `"10m"` | Query time-range duration (Golang string duration). |
 | graphType | `query` | string | `string` |  |  | `"workload"` | Graph type. Available graph types: [app, service, versionedApp, workload]. |
 | queryTime | `query` | string | `string` |  |  | `"now"` | Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now. |
+| responseTime | `query` | string | `string` |  |  | `"95"` | Used only with responseTime appender. One of: avg | 50 | 95 | 99. |
+| throughput | `query` | string | `string` |  |  | `"request"` | Used only with throughput appender. One of: request | response. |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -2298,7 +2306,7 @@ GET /api/namespaces/{namespace}/workloads/{workload}/graph
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | workload | `path` | string | `string` |  | ✓ |  | The workload name. |
-| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck]. |
+| appenders | `query` | string | `string` |  |  | `"run all appenders"` | Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput]. |
 | boxBy | `query` | string | `string` |  |  | `"none"` | Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none]. |
 | container | `query` | string | `string` |  |  |  | The cluster name. If not supplied queries/results will not be constrained by cluster. |
 | duration | `query` | string | `string` |  |  | `"10m"` | Query time-range duration (Golang string duration). |
@@ -2306,6 +2314,8 @@ GET /api/namespaces/{namespace}/workloads/{workload}/graph
 | includeIdleEdges | `query` | string | `string` |  |  | `"false"` | Flag for including edges that have no request traffic for the time period. |
 | injectServiceNodes | `query` | string | `string` |  |  | `"false"` | Flag for injecting the requested service node between source and destination nodes. |
 | queryTime | `query` | string | `string` |  |  | `"now"` | Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now. |
+| responseTime | `query` | string | `string` |  |  | `"95"` | Used only with responseTime appender. One of: avg | 50 | 95 | 99. |
+| throughput | `query` | string | `string` |  |  | `"request"` | Used only with throughput appender. One of: request | response. |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -6725,6 +6735,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 | Source | string| `string` |  | |  |  |
 | SourcePrincipal | string| `string` |  | |  |  |
 | Target | string| `string` |  | |  |  |
+| Throughput | string| `string` |  | |  |  |
 | traffic | [ProtocolTraffic](#protocol-traffic)| `ProtocolTraffic` |  | |  |  |
 
 

--- a/swagger.json
+++ b/swagger.json
@@ -575,8 +575,16 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput].",
             "name": "appenders",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "none",
+            "x-go-name": "Name",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -593,14 +601,6 @@
             "x-go-name": "Name",
             "description": "Graph type. Available graph types: [app, service, versionedApp, workload].",
             "name": "graphType",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "none",
-            "x-go-name": "Name",
-            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
-            "name": "boxBy",
             "in": "query"
           },
           {
@@ -633,6 +633,22 @@
             "x-go-name": "Name",
             "description": "Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now.",
             "name": "queryTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "95",
+            "x-go-name": "Name",
+            "description": "Used only with responseTime appender. One of: avg | 50 | 95 | 99.",
+            "name": "responseTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "request",
+            "x-go-name": "Name",
+            "description": "Used only with throughput appender. One of: request | response.",
+            "name": "throughput",
             "in": "query"
           }
         ],
@@ -1021,8 +1037,16 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput].",
             "name": "appenders",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "none",
+            "x-go-name": "Name",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -1039,14 +1063,6 @@
             "x-go-name": "Name",
             "description": "Graph type. Available graph types: [app, service, versionedApp, workload].",
             "name": "graphType",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "none",
-            "x-go-name": "Name",
-            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
-            "name": "boxBy",
             "in": "query"
           },
           {
@@ -1071,6 +1087,22 @@
             "x-go-name": "Name",
             "description": "Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now.",
             "name": "queryTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "95",
+            "x-go-name": "Name",
+            "description": "Used only with responseTime appender. One of: avg | 50 | 95 | 99.",
+            "name": "responseTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "request",
+            "x-go-name": "Name",
+            "description": "Used only with throughput appender. One of: request | response.",
+            "name": "throughput",
             "in": "query"
           }
         ],
@@ -1137,8 +1169,16 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput].",
             "name": "appenders",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "none",
+            "x-go-name": "Name",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -1155,14 +1195,6 @@
             "x-go-name": "Name",
             "description": "Graph type. Available graph types: [app, service, versionedApp, workload].",
             "name": "graphType",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "none",
-            "x-go-name": "Name",
-            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
-            "name": "boxBy",
             "in": "query"
           },
           {
@@ -1187,6 +1219,22 @@
             "x-go-name": "Name",
             "description": "Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now.",
             "name": "queryTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "95",
+            "x-go-name": "Name",
+            "description": "Used only with responseTime appender. One of: avg | 50 | 95 | 99.",
+            "name": "responseTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "request",
+            "x-go-name": "Name",
+            "description": "Used only with throughput appender. One of: request | response.",
+            "name": "throughput",
             "in": "query"
           }
         ],
@@ -2738,8 +2786,16 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput].",
             "name": "appenders",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "none",
+            "x-go-name": "Name",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -2760,18 +2816,26 @@
           },
           {
             "type": "string",
-            "default": "none",
-            "x-go-name": "Name",
-            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
-            "name": "boxBy",
-            "in": "query"
-          },
-          {
-            "type": "string",
             "default": "now",
             "x-go-name": "Name",
             "description": "Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now.",
             "name": "queryTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "95",
+            "x-go-name": "Name",
+            "description": "Used only with responseTime appender. One of: avg | 50 | 95 | 99.",
+            "name": "responseTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "request",
+            "x-go-name": "Name",
+            "description": "Used only with throughput appender. One of: request | response.",
+            "name": "throughput",
             "in": "query"
           }
         ],
@@ -3463,8 +3527,16 @@
             "type": "string",
             "default": "run all appenders",
             "x-go-name": "Name",
-            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck].",
+            "description": "Comma-separated list of Appenders to run. Available appenders: [aggregateNode, deadNode, healthConfig, idleNode, istio, responseTime, securityPolicy, serviceEntry, sidecarsCheck, throughput].",
             "name": "appenders",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "none",
+            "x-go-name": "Name",
+            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
+            "name": "boxBy",
             "in": "query"
           },
           {
@@ -3481,14 +3553,6 @@
             "x-go-name": "Name",
             "description": "Graph type. Available graph types: [app, service, versionedApp, workload].",
             "name": "graphType",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "default": "none",
-            "x-go-name": "Name",
-            "description": "Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none].",
-            "name": "boxBy",
             "in": "query"
           },
           {
@@ -3513,6 +3577,22 @@
             "x-go-name": "Name",
             "description": "Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now.",
             "name": "queryTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "95",
+            "x-go-name": "Name",
+            "description": "Used only with responseTime appender. One of: avg | 50 | 95 | 99.",
+            "name": "responseTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "request",
+            "x-go-name": "Name",
+            "description": "Used only with throughput appender. One of: request | response.",
+            "name": "throughput",
             "in": "query"
           }
         ],
@@ -4396,6 +4476,10 @@
         "target": {
           "type": "string",
           "x-go-name": "Target"
+        },
+        "throughput": {
+          "type": "string",
+          "x-go-name": "Throughput"
         },
         "traffic": {
           "$ref": "#/definitions/ProtocolTraffic"


### PR DESCRIPTION
Add "throughput" appender to support new throughput edge labeling. 

Also
- Some changes to responseTime appender for "option" support analogous to Throughput
  - update queryParam support for responseTime appender (it was broken anyway)
  - change param from responseTimeQuantile to responseTime
  - now support fixed [percentile] values only: avg | 50 | 95 | 99
  - add support for average response time (prevuiously only supported quantiles
- add to doc.go, including some previously missed API stuff

PartOf: https://github.com/kiali/kiali/issues/2897

**UI PR:** https://github.com/kiali/kiali-ui/pull/2177 (see the UI PR for more detail on the issue)