### PR TITLE
[hack] Support non-openshift clusters and add --print-images option

### DIFF
--- a/hack/docker-io-auth.sh
+++ b/hack/docker-io-auth.sh
@@ -4,15 +4,19 @@
 # docker-io-auth.sh
 #
 # Due to docker.io introducing rate limiting, many times you will be unable
-# to have your OpenShift cluster pull images from docker.io.[1]
+# to have your cluster pull images from docker.io.[1]
 #
-# This script creates the necessary OpenShift resources (mainly the pull
-# secret) in order to get OpenShift to authenticate with docker.io with
-# your own docker.io credentials thus providing your OpenShift cluster
-# with more (though not unlimited) capacity to pull images.[2]
+# This script creates the necessary resources (mainly the pull secret)
+# in order to get your cluster to authenticate itself on docker.io with
+# your own docker.io credentials thus providing your cluster
+# with more (though not unlimited) capacity to pull images.[2][3]
 #
-# It is recommended that you create a docker.io access token[3] and use that
-# instead of using your docker.io password in the OpenShift pull secret.
+# If you pass in "oc" for the client, this will assume you are on an
+# OpenShift cluster. If you pass in "kubectl" for the client, this will
+# assume you are on a non-OpenShift cluster (e.g. minikube).
+#
+# It is recommended that you create a docker.io access token[4] and use that
+# instead of using your docker.io password for --docker-password.
 #
 # For each pod that you know will need to pull down images from docker.io,
 # you need to obtain the name of that pod's service account and provide the name
@@ -22,13 +26,15 @@
 # For more details see:
 #   [1] https://developers.redhat.com/blog/2021/02/18/how-to-work-around-dockers-new-download-rate-limit-on-red-hat-openshift#authenticate_to_your_docker_hub_account
 #   [2] https://docs.openshift.com/container-platform/4.6/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets
-#   [3] https://docs.docker.com/docker-hub/access-tokens/
+#   [3] https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+#   [4] https://docs.docker.com/docker-hub/access-tokens/
 #
 ##############################################################################
 
+DEFAULT_CLIENT="oc"
 DEFAULT_DOCKER_SERVER="docker.io"
 DEFAULT_NAMESPACE="istio-system"
-DEFAULT_OC="oc"
+DEFAULT_PRINT_IMAGES="false"
 DEFAULT_SECRET_NAME="docker"
 DEFAULT_SERVICE_ACCOUNTS="prometheus grafana default"
 
@@ -39,12 +45,13 @@ _CMD=""
 while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in
+    -c|--client)            CLIENT="$2";           shift;shift ;;
     -de|--docker-email)     DOCKER_EMAIL="$2";     shift;shift ;;
     -dp|--docker-password)  DOCKER_PASSWORD="$2";  shift;shift ;;
     -ds|--docker-server)    DOCKER_SERVER="$2";    shift;shift ;;
     -du|--docker-username)  DOCKER_USERNAME="$2";  shift;shift ;;
     -n|--namespace)         NAMESPACE="$2";        shift;shift ;;
-    -oc)                    OC="$2";               shift;shift ;;
+    -pi|--print-images)     PRINT_IMAGES="$2";     shift;shift ;;
     -sa|--service-accounts) SERVICE_ACCOUNTS="$2"; shift;shift ;;
     -sn|--secret-name)      SECRET_NAME="$2";      shift;shift ;;
     -h|--help)
@@ -53,6 +60,9 @@ while [[ $# -gt 0 ]]; do
 $0 [option...] command
 
 Valid options:
+  -c|--client
+      The OpenShift 'oc' client executable or the 'kubectl" client executable.
+      Default: ${DEFAULT_CLIENT}
   -de|--docker-email
       Your email used by your docker account. This is required and has no default.
   -dp|--docker-password
@@ -66,9 +76,10 @@ Valid options:
   -n|--namespace
       The namespace where the pull secret will be created and where the service accounts are located.
       Default: ${DEFAULT_NAMESPACE}
-  -oc
-      The OpenShift 'oc' client executable.
-      Default: ${DEFAULT_OC}
+  -pi|--print-images
+      If "true" this will print all images currently deployed in the cluster that come from docker.io.
+      When enabled, nothing is created in your cluster - use this just to see what images are from docker.io.
+      Default: ${DEFAULT_PRINT_IMAGES}
   -sa|--service-accounts
       The service accounts that will be able to authenticate with docker with the credentials you provide.
       You can specify more than one service account separated with spaces.
@@ -87,33 +98,51 @@ HELPMSG
   esac
 done
 
+: ${CLIENT:=${DEFAULT_CLIENT}}
 : ${DOCKER_SERVER:=${DEFAULT_DOCKER_SERVER}}
 : ${NAMESPACE:=${DEFAULT_NAMESPACE}}
-: ${OC:=${DEFAULT_OC}}
+: ${PRINT_IMAGES:=${DEFAULT_PRINT_IMAGES}}
 : ${SERVICE_ACCOUNTS:=${DEFAULT_SERVICE_ACCOUNTS}}
 : ${SECRET_NAME:=${DEFAULT_SECRET_NAME}}
 
-[ -z "$DOCKER_EMAIL" ] && echo "You must specify --docker-email" && exit 1
-[ -z "$DOCKER_PASSWORD" ] && echo "You must specify --docker-password" && exit 1
-[ -z "$DOCKER_USERNAME" ] && echo "You must specify --docker-username" && exit 1
-
+echo "CLIENT=$CLIENT"
 echo "DOCKER_EMAIL=$DOCKER_EMAIL"
 echo "DOCKER_PASSWORD=..."
 echo "DOCKER_SERVER=$DOCKER_SERVER"
 echo "DOCKER_USERNAME=$DOCKER_USERNAME"
 echo "NAMESPACE=$NAMESPACE"
-echo "OC=$OC"
+echo "PRINT_IMAGES=$PRINT_IMAGES"
 echo "SERVICE_ACCOUNTS=$SERVICE_ACCOUNTS"
 echo "SECRET_NAME=$SECRET_NAME"
 
-set -u
+[ "$PRINT_IMAGES" != "true" -a "$PRINT_IMAGES" != "false" ] && echo "--print-images must be 'true' or 'false'" && exit 1
+
+if [ "${PRINT_IMAGES}" == "true" ]; then
+  all_ns="$(${CLIENT} get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" | tr -s '[[:space:]]' '\n') | sort | uniq"
+  echo "============================================="
+  echo "All container images that are from docker.io:"
+  echo "============================================="
+  printf "%s" "$all_ns" | grep -v "[^.]*[:.].*/"
+  printf "%s" "$all_ns" | grep "^docker.io"
+  exit 0
+fi
+
+[ -z "$DOCKER_EMAIL" ] && echo "You must specify --docker-email" && exit 1
+[ -z "$DOCKER_PASSWORD" ] && echo "You must specify --docker-password" && exit 1
+[ -z "$DOCKER_USERNAME" ] && echo "You must specify --docker-username" && exit 1
+
+set -ue
 
 echo "Creating the pull secret [${SECRET_NAME}] in namespace [${NAMESPACE}]"
-${OC} create secret docker-registry ${SECRET_NAME} -n ${NAMESPACE} --docker-server=${DOCKER_SERVER} --docker-username=${DOCKER_USERNAME} --docker-password=${DOCKER_PASSWORD} --docker-email=${DOCKER_EMAIL}
+${CLIENT} create secret docker-registry ${SECRET_NAME} -n ${NAMESPACE} --docker-server=${DOCKER_SERVER} --docker-username=${DOCKER_USERNAME} --docker-password=${DOCKER_PASSWORD} --docker-email=${DOCKER_EMAIL}
 
 for sa in ${SERVICE_ACCOUNTS}; do
   echo "Linking the pull secret [${SECRET_NAME}] with service account [${sa}]"
-  ${OC} secrets link -n ${NAMESPACE} ${sa} ${SECRET_NAME} --for=pull
+  if [[ "${CLIENT}" = *"oc" ]]; then
+    ${CLIENT} secrets link -n ${NAMESPACE} ${sa} ${SECRET_NAME} --for=pull
+  else
+    ${CLIENT} patch serviceaccount -n ${NAMESPACE} ${sa} -p "{\"imagePullSecrets\": [{\"name\": \"${SECRET_NAME}\"}]}"
+  fi
 done
 
 echo "========== NOTICE =========="


### PR DESCRIPTION
If you are hitting the docker.io rate limiting on your non-openshift clusters (e.g. minikube), this should help work around it.

Note also you can now pass in `-pi true` and get a list of all the images in your cluster that comes from docker.io (these are the ones that will potentially be rate-limited). On my minikube with Istio 1.10 installed and bookinfo installed (both using our hack scripts), those images are:

```
kiali/kiali-test-mesh-traffic-generator:latest
grafana/grafana:7.4.3
jimmidyson/configmap-reload:v0.5.0
prom/prometheus:v2.24.0
registry:2.7.1@sha256:d5459fcb27aecc752520df4b492b08358a1912fcdfa454f7d2101d4b09991daa
docker.io/istio/examples-bookinfo-details-v1:1.16.2
docker.io/istio/examples-bookinfo-mongodb:1.16.2
docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
docker.io/istio/examples-bookinfo-ratings-v2:1.16.2
docker.io/istio/examples-bookinfo-reviews-v1:1.16.2
docker.io/istio/examples-bookinfo-reviews-v2:1.16.2
docker.io/istio/examples-bookinfo-reviews-v3:1.16.2
docker.io/jettech/kube-webhook-certgen:v1.5.1@sha256:950833e19ade18cd389d647efb88992a7cc077abedef343fa59e012d376d79b7
docker.io/jettech/kube-webhook-certgen:v1.5.1@sha256:950833e19ade18cd389d647efb88992a7cc077abedef343fa59e012d376d79b7
docker.io/jaegertracing/all-in-one:1.20

```