### PR TITLE
Reusing Filter method for Service Registry loopup

### DIFF
--- a/business/checkers/authorization/no_host_checker.go
+++ b/business/checkers/authorization/no_host_checker.go
@@ -126,12 +126,9 @@ func (n NoHostChecker) hasMatchingService(host kubernetes.Host, itemNamespace st
 
 	// Use RegistryStatus to check destinations that may not be covered with previous check
 	// i.e. Multi-cluster or Federation validations
-	for _, rStatus := range n.RegistryStatus {
-		// We assume that on these cases the host.Service is provided in FQDN
-		// i.e. ratings.mesh2-bookinfo.svc.mesh1-imports.local
-		if kubernetes.FilterByRegistryStatus(host.String(), rStatus) {
-			return true
-		}
+	if kubernetes.HasMatchingRegistryStatus(host.String(), n.RegistryStatus) {
+		return true
 	}
+
 	return false
 }

--- a/business/checkers/authorization/no_host_checker_test.go
+++ b/business/checkers/authorization/no_host_checker_test.go
@@ -230,14 +230,6 @@ func fakeServices(serviceNames []string) []core_v1.Service {
 	return services
 }
 
-func fakeRegistryStatus(hosts []string) []*kubernetes.RegistryStatus {
-	rss := make([]*kubernetes.RegistryStatus, 0, len(hosts))
-	for _, h := range hosts {
-		rss = append(rss, &kubernetes.RegistryStatus{RegistryService: kubernetes.RegistryService{ Hostname: h } })
-	}
-	return rss
-}
-
 func TestValidServiceRegistry(t *testing.T) {
 	assert := assert.New(t)
 

--- a/business/checkers/authorization/no_host_checker_test.go
+++ b/business/checkers/authorization/no_host_checker_test.go
@@ -230,6 +230,14 @@ func fakeServices(serviceNames []string) []core_v1.Service {
 	return services
 }
 
+func fakeRegistryStatus(hosts []string) []*kubernetes.RegistryStatus {
+	rss := make([]*kubernetes.RegistryStatus, 0, len(hosts))
+	for _, h := range hosts {
+		rss = append(rss, &kubernetes.RegistryStatus{RegistryService: kubernetes.RegistryService{ Hostname: h } })
+	}
+	return rss
+}
+
 func TestValidServiceRegistry(t *testing.T) {
 	assert := assert.New(t)
 

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -142,12 +142,8 @@ func (n NoDestinationChecker) hasMatchingService(host kubernetes.Host, itemNames
 
 	// Use RegistryStatus to check destinations that may not be covered with previous check
 	// i.e. Multi-cluster or Federation validations
-	for _, rStatus := range n.RegistryStatus {
-		// We assume that on these cases the host.Service is provided in FQDN
-		// i.e. ratings.mesh2-bookinfo.svc.mesh1-imports.local
-		if kubernetes.FilterByRegistryStatus(host.String(), rStatus) {
-			return true
-		}
+	if kubernetes.HasMatchingRegistryStatus(host.String(), n.RegistryStatus) {
+		return true
 	}
 	return false
 }

--- a/business/checkers/virtual_services/no_host_checker.go
+++ b/business/checkers/virtual_services/no_host_checker.go
@@ -104,8 +104,5 @@ func (n NoHostChecker) checkDestination(sHost string) bool {
 
 	// Use RegistryStatus to check destinations that may not be covered with previous check
 	// i.e. Multi-cluster or Federation validations
-	if kubernetes.HasMatchingRegistryStatus(sHost, n.RegistryStatus) {
-		return true
-	}
-	return false
+	return kubernetes.HasMatchingRegistryStatus(sHost, n.RegistryStatus)
 }

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -214,6 +214,19 @@ func HasMatchingVirtualServices(host Host, virtualServices []IstioObject) bool {
 	return false
 }
 
+// HasMatchingRegistryStatus returns true when the FDQN of the host param matches
+// with one registry status of the registryStatus param.
+func HasMatchingRegistryStatus(host string, registryStatus []*RegistryStatus) bool {
+	for _, rStatus := range registryStatus {
+		// We assume that on these cases the host.Service is provided in FQDN
+		// i.e. ratings.mesh2-bookinfo.svc.mesh1-imports.local
+		if FilterByRegistryStatus(host, rStatus) {
+			return true
+		}
+	}
+	return false
+}
+
 func HostWithinWildcardHost(subdomain, wildcardDomain string) bool {
 	if !strings.HasPrefix(wildcardDomain, "*") {
 		return false


### PR DESCRIPTION
Tiny DRY refactor that I found while reviewing PRs related to the introduction of the service registry consumption.
And also making it a bit more consistent with the `HasMatching[Workloads|Services|ServiceEntries|VirtualServices]` methods already in place in the same package and for similar purposes.