### PR TITLE
Replace PodProxy calls by plain HTTP GET calls

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -275,14 +275,14 @@ func (iss *IstioStatusService) getIstiodReachingCheck() (IstioComponentStatus, e
 	wg.Add(len(healthyIstiods))
 	syncChan := make(chan ComponentStatus, len(healthyIstiods))
 
-	for _, istiod := range healthyIstiods {
+	for i, istiod := range healthyIstiods {
 		go func(name, namespace string) {
 			defer wg.Done()
 			// Using the proxy method to make sure that K8s API has access to the Istio Control Plane namespace.
 			// By proxying one Istiod, we ensure that the following connection is allowed:
 			// Kiali -> K8s API (proxy) -> istiod
 			// This scenario is no obvious for private clusters (like GKE private cluster)
-			_, err := httputil.ForwardGetRequest(iss.k8s, namespace, name, 8080, 8080, "/ready")
+			_, err := iss.k8s.ForwardGetRequest(namespace, name, 15014 + i, 15021, "/healthz/ready")
 			if err != nil {
 				syncChan <- ComponentStatus{
 					Name:   name,

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -266,7 +266,7 @@ func (iss *IstioStatusService) getIstiodReachingCheck() (IstioComponentStatus, e
 
 	healthyIstiods := make([]*core_v1.Pod, 0, len(istiods))
 	for i, istiod := range istiods {
-		if istiod.Status.Phase == "Running" {
+		if istiod.Status.Phase == core_v1.PodRunning {
 			healthyIstiods = append(healthyIstiods, &istiods[i])
 		}
 	}

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -282,7 +282,7 @@ func (iss *IstioStatusService) getIstiodReachingCheck() (IstioComponentStatus, e
 			// By proxying one Istiod, we ensure that the following connection is allowed:
 			// Kiali -> K8s API (proxy) -> istiod
 			// This scenario is no obvious for private clusters (like GKE private cluster)
-			_, err := iss.k8s.GetPodProxy(namespace, name, "/ready")
+			_, err := httputil.ForwardGetRequest(iss.k8s, namespace, name, 8080, 8080, "/ready")
 			if err != nil {
 				syncChan <- ComponentStatus{
 					Name:   name,

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -275,14 +275,14 @@ func (iss *IstioStatusService) getIstiodReachingCheck() (IstioComponentStatus, e
 	wg.Add(len(healthyIstiods))
 	syncChan := make(chan ComponentStatus, len(healthyIstiods))
 
-	for i, istiod := range healthyIstiods {
+	for _, istiod := range healthyIstiods {
 		go func(name, namespace string) {
 			defer wg.Done()
 			// Using the proxy method to make sure that K8s API has access to the Istio Control Plane namespace.
 			// By proxying one Istiod, we ensure that the following connection is allowed:
 			// Kiali -> K8s API (proxy) -> istiod
 			// This scenario is no obvious for private clusters (like GKE private cluster)
-			_, err := iss.k8s.ForwardGetRequest(namespace, name, 15014 + i, 15021, "/healthz/ready")
+			_, err := iss.k8s.ForwardGetRequest(namespace, name, httputil.GetFreePort(), 8080, "/ready")
 			if err != nil {
 				syncChan <- ComponentStatus{
 					Name:   name,

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -282,7 +282,7 @@ func (iss *IstioStatusService) getIstiodReachingCheck() (IstioComponentStatus, e
 			// By proxying one Istiod, we ensure that the following connection is allowed:
 			// Kiali -> K8s API (proxy) -> istiod
 			// This scenario is no obvious for private clusters (like GKE private cluster)
-			_, err := iss.k8s.ForwardGetRequest(namespace, name, httputil.GetFreePort(), 8080, "/ready")
+			_, err := iss.k8s.ForwardGetRequest(namespace, name, httputil.Pool.GetFreePort(), 8080, "/ready")
 			if err != nil {
 				syncChan <- ComponentStatus{
 					Name:   name,

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -684,7 +684,7 @@ func mockDeploymentCall(deployments []apps_v1.Deployment, daemonSets []apps_v1.D
 	if !isIstioReachable {
 		err = fmt.Errorf("the Istio pods are unreachable")
 	}
-	k8s.On("GetPodProxy", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]byte{}, err)
+	k8s.On("GetPodPortForwarder", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return([]byte{}, err)
 
 	return k8s
 }

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -684,7 +684,7 @@ func mockDeploymentCall(deployments []apps_v1.Deployment, daemonSets []apps_v1.D
 	if !isIstioReachable {
 		err = fmt.Errorf("the Istio pods are unreachable")
 	}
-	k8s.On("GetPodPortForwarder", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return([]byte{}, err)
+	k8s.On("ForwardGetRequest", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return([]byte{}, err)
 
 	return k8s
 }

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -321,7 +321,11 @@ func parseRegistryServices(registries map[string][]byte) ([]*RegistryStatus, err
 }
 
 func (in *K8SClient) GetConfigDump(namespace, podName string) (*ConfigDump, error) {
-	// Fetching the config_dump data, raw.
+	// Fetching the Config Dump from the pod's Envoy.
+	// The port 15000 is open on each Envoy Sidecar (managed by Istio) to serve the Envoy Admin  interface.
+	// This port can only be accessed by inside the pod.
+	// See the Istio's doc page about its port usage:
+	// https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio
 	resp, err := in.ForwardGetRequest(namespace, podName, httputil.Pool.GetFreePort(), 15000, "/config_dump")
 	if err != nil {
 		log.Errorf("Error forwarding the /config_dump request: %v", err)

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -322,9 +322,9 @@ func parseRegistryServices(registries map[string][]byte) ([]*RegistryStatus, err
 
 func (in *K8SClient) GetConfigDump(namespace, podName string) (*ConfigDump, error) {
 	// Fetching the config_dump data, raw.
-	resp, err := in.ForwardGetRequest(namespace, podName, httputil.GetFreePort(), 15014, "/config_dump")
+	resp, err := in.ForwardGetRequest(namespace, podName, httputil.GetFreePort(), 15000, "/config_dump")
 	if err != nil {
-		log.Errorf("Error fetching config_map: %v", err)
+		log.Errorf("Error forwarding the /config_dump request: %v", err)
 		return nil, err
 	}
 

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -216,7 +216,7 @@ func (in *K8SClient) getIstiodDebugStatus(debugPath string) (map[string][]byte, 
 	// Using the port-forwarding, the call is made as it was in the pod itself, as a localhost call.
 	// Also the port-forwarding to a pod is done via the KubeAPI. Therefore if the call doesn't return any error,
 	// it means that Kiali has access to the KubeAPI and that the KubeAPI has access to the Istiod (control plane).
-	_, err = in.ForwardGetRequest(c.IstioNamespace, istiods[0].Name, httputil.GetFreePort(), 8080, "/ready")
+	_, err = in.ForwardGetRequest(c.IstioNamespace, istiods[0].Name, httputil.Pool.GetFreePort(), 8080, "/ready")
 	if err != nil {
 		return nil, fmt.Errorf("unable to proxy Istiod pods. " +
 			"Make sure your Kubernetes API server has access to the Istio control plane through 8080 port")
@@ -235,7 +235,7 @@ func (in *K8SClient) getIstiodDebugStatus(debugPath string) (map[string][]byte, 
 			// The 15014 port on Istiod is open for control plane monitoring.
 			// Here's the Istio doc page about the port usage by istio:
 			// https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio
-			res, err := in.ForwardGetRequest(namespace, name, httputil.GetFreePort(), 15014, debugPath)
+			res, err := in.ForwardGetRequest(namespace, name, httputil.Pool.GetFreePort(), 15014, debugPath)
 			if err != nil {
 				errChan <- fmt.Errorf("%s: %s", name, err.Error())
 			} else {
@@ -322,7 +322,7 @@ func parseRegistryServices(registries map[string][]byte) ([]*RegistryStatus, err
 
 func (in *K8SClient) GetConfigDump(namespace, podName string) (*ConfigDump, error) {
 	// Fetching the config_dump data, raw.
-	resp, err := in.ForwardGetRequest(namespace, podName, httputil.GetFreePort(), 15000, "/config_dump")
+	resp, err := in.ForwardGetRequest(namespace, podName, httputil.Pool.GetFreePort(), 15000, "/config_dump")
 	if err != nil {
 		log.Errorf("Error forwarding the /config_dump request: %v", err)
 		return nil, err

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -368,10 +368,15 @@ func (in *K8SClient) GetPodPortForwarder(namespace, name, portMap string) (*http
 	}
 
 	// First try whether the pod exist or not
-	_, err = in.GetPod(namespace, name)
+	pod, err := in.GetPod(namespace, name)
 	if err != nil {
 		log.Errorf("Couldn't fetch the Pod: %v", err)
 		return nil, err
+	}
+
+	// Prevent the forward if the pod is not running
+	if pod.Status.Phase != core_v1.PodRunning {
+		return nil, fmt.Errorf("error creating a pod forwarder for a non-running pod: %s/%s", namespace, name)
 	}
 
 	// Create a Port Forwarder

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -69,7 +69,6 @@ type OSClientInterface interface {
 	UpdateProject(project string, jsonPatch string) (*osproject_v1.Project, error)
 }
 
-
 func (in *K8SClient) ForwardGetRequest(namespace, podName string, localPort, destinationPort int, path string) ([]byte, error) {
 	f, err := in.GetPodPortForwarder(namespace, podName, fmt.Sprintf("%d:%d", localPort, destinationPort))
 	if err != nil {

--- a/kubernetes/kubetest/mock_kubernetes.go
+++ b/kubernetes/kubetest/mock_kubernetes.go
@@ -8,6 +8,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/util/httputil"
 )
 
 func (o *K8SClientMock) GetClusterServicesByLabels(labelsSelector string) ([]core_v1.Service, error) {
@@ -85,9 +86,9 @@ func (o *K8SClientMock) GetPodLogs(namespace, name string, opts *core_v1.PodLogO
 	return args.Get(0).(*kubernetes.PodLogs), args.Error(1)
 }
 
-func (o *K8SClientMock) GetPodProxy(namespace, name, path string) ([]byte, error) {
-	args := o.Called(namespace, name, path)
-	return args.Get(0).([]byte), args.Error(1)
+func (o *K8SClientMock) GetPodPortForwarder(namespace, name, portMap string) (*httputil.PortForwarder, error) {
+	args := o.Called(namespace, name, portMap)
+	return args.Get(0).(*httputil.PortForwarder), args.Error(1)
 }
 
 func (o *K8SClientMock) GetReplicationControllers(namespace string) ([]core_v1.ReplicationController, error) {

--- a/kubernetes/kubetest/mock_kubernetes.go
+++ b/kubernetes/kubetest/mock_kubernetes.go
@@ -11,6 +11,11 @@ import (
 	"github.com/kiali/kiali/util/httputil"
 )
 
+func (o *K8SClientMock) ForwardGetRequest(namespace, podName string, localPort, destinationPort int, path string) ([]byte, error) {
+	args := o.Called(namespace, podName, localPort, destinationPort, path)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 func (o *K8SClientMock) GetClusterServicesByLabels(labelsSelector string) ([]core_v1.Service, error) {
 	args := o.Called(labelsSelector)
 	return args.Get(0).([]core_v1.Service), args.Error(1)

--- a/util/httputil/port_forwarder.go
+++ b/util/httputil/port_forwarder.go
@@ -1,14 +1,17 @@
-package config_dump
+package httputil
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 )
 
@@ -46,7 +49,7 @@ func (f forwarder) Stop() {
 	close(f.StopCh)
 }
 
-func NewPortForwarder(client rest.Interface, clientConfig *rest.Config, namespace, pod, address, portMap string, writer io.Writer) (forwarder, error) {
+func NewPortForwarder(client rest.Interface, clientConfig *rest.Config, namespace, pod, address, portMap string, writer io.Writer) (*PortForwarder, error) {
 	stopCh := make(chan struct{})
 	readyCh := make(chan struct{})
 
@@ -59,7 +62,7 @@ func NewPortForwarder(client rest.Interface, clientConfig *rest.Config, namespac
 	transport, upgrader, err := spdy.RoundTripperFor(clientConfig)
 	if err != nil {
 		log.Errorf("Error creating a RoundTripper: %v", err)
-		return forwarder{}, err
+		return nil, err
 	}
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, forwarderUrl)
@@ -68,12 +71,37 @@ func NewPortForwarder(client rest.Interface, clientConfig *rest.Config, namespac
 
 	if err != nil {
 		log.Errorf("Error creating the port-forwarder: %v", err)
-		return forwarder{}, err
+		return nil, err
 	}
 
-	return forwarder{
+	f := PortForwarder(forwarder{
 		forwarder: fwer,
 		ReadyCh:   readyCh,
 		StopCh:    stopCh,
-	}, nil
+	})
+
+	return &f, nil
+}
+
+func ForwardGetRequest(client kubernetes.ClientInterface, namespace, podName string, localPort, destinationPort int, path string) ([]byte, error) {
+	f, err := client.GetPodPortForwarder(namespace, podName, fmt.Sprintf("%d:%d", localPort, destinationPort))
+	if err != nil {
+		return nil, err
+	}
+
+	// Start the forwarding
+	if err := (*f).Start(); err != nil {
+		return nil, err
+	}
+
+	// Defering the finish of the port-forwarding
+	defer (*f).Stop()
+
+	// Ready to create a request
+	resp, code, err := HttpGet(fmt.Sprintf("http://localhost:%d%s", localPort, path), nil, 10*time.Second)
+	if code >= 400 {
+		return resp, fmt.Errorf("error fetching the /config_dump for the Envoy. Response code: %d", code)
+	}
+
+	return resp, err
 }

--- a/util/httputil/port_forwarder.go
+++ b/util/httputil/port_forwarder.go
@@ -47,7 +47,7 @@ func (f forwarder) Start() error {
 func (f forwarder) Stop() {
 	// Closing the StopCh channel is closing the forwarding
 	close(f.StopCh)
-	err := FreePort(f.localPort)
+	err := Pool.FreePort(f.localPort)
 	if err != nil {
 		log.Errorf("Error stopping a port-forwarder: %v", err)
 	}

--- a/util/httputil/port_pool.go
+++ b/util/httputil/port_pool.go
@@ -1,0 +1,1 @@
+package httputil

--- a/util/httputil/port_pool.go
+++ b/util/httputil/port_pool.go
@@ -5,71 +5,72 @@ import (
 	"sync"
 )
 
-// lastBusyPort is a pointer to the last free port given, therefore is in use.
-var lastBusyPort = portRangeInit - 1
+type PortPool struct {
+	// lastBusyPort is a pointer to the last free port given, therefore is in use.
+	LastBusyPort int
 
-// mutex is the mutex used to solve concurrency problems while managing the port
-var mutex sync.Mutex
+	// mutex is the mutex used to solve concurrency problems while managing the port
+	Mutex sync.Mutex
 
-// portsMap tracks whether an specific port is busy
-// portsMap[14100] = true => means that port 14100 is busy
-// portsMap[14101] = false => means that port 14101 is free
-var portsMap = map[int]bool{}
+	// portsMap tracks whether an specific port is busy
+	// portsMap[14100] = true => means that port 14100 is busy
+	// portsMap[14101] = false => means that port 14101 is free
+	PortsMap map[int]bool
 
-// portRangeInit is the first port number managed in the pool
-var portRangeInit = 14100
+	// portRangeInit is the first port number managed in the pool
+	PortRangeInit int
 
-// portRangeSize is the size of the port range.
-// for example, the pool with portRangeSize 100 and portRangeInit 14000 manages
-// the ports from 14000 to 14099.
-var portRangeSize = 100
+	// portRangeSize is the size of the port range.
+	// for example, the pool with portRangeSize 100 and portRangeInit 14000 manages
+	// the ports from 14000 to 14099.
+	PortRangeSize int
+}
+
+var Pool = &PortPool{
+	LastBusyPort:  13999,
+	Mutex:         sync.Mutex{},
+	PortsMap:      map[int]bool{},
+	PortRangeInit: 14000,
+	PortRangeSize: 1000,
+}
 
 // GetFreePort returns a non-busy port available within the reserved port range (14100 - 14199).
 // The returned port is instantaneously marked as busy until is not freed using the FreePort method.
-func GetFreePort() int {
-	mutex.Lock()
+func (pool *PortPool) GetFreePort() int {
+	pool.Mutex.Lock()
 
 	busy := true
 	freePortFound := 0
 	attempts := 0
-	for busy && attempts < portRangeSize {
+	for busy && attempts < pool.PortRangeSize {
 		// If the pointer is getting out of range, restart from the beginning
-		if lastBusyPort >= portRangeInit+portRangeSize-1 {
-			lastBusyPort = portRangeInit
+		if pool.LastBusyPort >= pool.PortRangeInit+pool.PortRangeSize-1 {
+			pool.LastBusyPort = pool.PortRangeInit
 			// If the pointer is inside the range, increment by 1
 		} else {
-			lastBusyPort++
+			pool.LastBusyPort++
 		}
 
-		busy = portsMap[lastBusyPort]
+		busy = pool.PortsMap[pool.LastBusyPort]
 		attempts++
 	}
 
 	if !busy {
-		portsMap[lastBusyPort] = true
-		freePortFound = lastBusyPort
+		pool.PortsMap[pool.LastBusyPort] = true
+		freePortFound = pool.LastBusyPort
 	}
 
-	mutex.Unlock()
+	pool.Mutex.Unlock()
 	return freePortFound
 }
 
 // FreePort frees the port and makes it available for being pick to use.
-func FreePort(port int) (err error) {
-	if port < portRangeInit || port > portRangeInit+portRangeSize {
+func (pool *PortPool) FreePort(port int) (err error) {
+	if port < pool.PortRangeInit || port > pool.PortRangeInit+pool.PortRangeSize {
 		return fmt.Errorf("port %d is out of range", port)
 	}
-	mutex.Lock()
-	portsMap[port] = false
-	mutex.Unlock()
+	pool.Mutex.Lock()
+	pool.PortsMap[port] = false
+	pool.Mutex.Unlock()
 	return err
-}
-
-func ResetPool() {
-	mutex.Lock()
-
-	lastBusyPort = portRangeInit - 1
-	portsMap = map[int]bool{}
-
-	mutex.Unlock()
 }

--- a/util/httputil/port_pool.go
+++ b/util/httputil/port_pool.go
@@ -1,1 +1,66 @@
 package httputil
+
+import (
+	"fmt"
+	"sync"
+)
+
+// [1500] => true // busy
+// [1501] => true // busy
+// [1502] => false // free
+// last port assigned => 1501
+var portRangeInit = 15000
+var portRangeSize = 100
+var portsMap = map[int]bool{}
+var lastFreePort = portRangeInit
+var mutex sync.Mutex
+
+// GetFreePort returns a non-busy port available within the reserved port range (15000 - 15099).
+// The returned port is instantaneously marked as busy until is not freed using the FreePort method.
+func GetFreePort() int {
+	mutex.Lock()
+
+	busy := portsMap[lastFreePort]
+	freePortFound := 0
+	attempts := 0
+	for busy && attempts < portRangeSize {
+		// If the pointer is getting out of range, restart from the beginning
+		if lastFreePort >= portRangeInit+portRangeSize-1 {
+			lastFreePort = portRangeInit
+			// If the pointer is inside the range, increment by 1
+		} else {
+			lastFreePort++
+		}
+
+		busy = portsMap[lastFreePort]
+		attempts++
+	}
+
+	if !busy {
+		portsMap[lastFreePort] = true
+		freePortFound = lastFreePort
+	}
+
+	mutex.Unlock()
+	return freePortFound
+}
+
+// FreePort frees the port and makes it available for being pick to use.
+func FreePort(port int) (err error) {
+	if port < portRangeInit || port > portRangeInit+portRangeSize {
+		return fmt.Errorf("port %d is out of range", port)
+	}
+	mutex.Lock()
+	portsMap[port] = false
+	mutex.Unlock()
+	return err
+}
+
+func ResetPool() {
+	mutex.Lock()
+
+	lastFreePort = portRangeInit
+	portsMap = map[int]bool{}
+
+	mutex.Unlock()
+}

--- a/util/httputil/port_pool.go
+++ b/util/httputil/port_pool.go
@@ -5,15 +5,21 @@ import (
 	"sync"
 )
 
-// [1500] => true // busy
-// [1501] => true // busy
-// [1502] => false // free
-// last port assigned => 1501
-var portRangeInit = 14100
-var portRangeSize = 100
-var portsMap = map[int]bool{}
+// lastBusyPort is a pointer to the last free port given, therefore is in use.
 var lastBusyPort = portRangeInit - 1
+// mutex is the mutex used to solve concurrency problems while managing the port
 var mutex sync.Mutex
+// portsMap tracks whether an specific port is busy
+// portsMap[14100] = true => means that port 14100 is busy
+// portsMap[14101] = false => means that port 14101 is free
+var portsMap = map[int]bool{}
+// portRangeInit is the first port number managed in the pool
+var portRangeInit = 14100
+// portRangeSize is the size of the port range.
+// for example, the pool with portRangeSize 100 and portRangeInit 14000 manages
+// the ports from 14000 to 14099.
+var portRangeSize = 100
+
 
 // GetFreePort returns a non-busy port available within the reserved port range (14100 - 14199).
 // The returned port is instantaneously marked as busy until is not freed using the FreePort method.

--- a/util/httputil/port_pool.go
+++ b/util/httputil/port_pool.go
@@ -7,19 +7,22 @@ import (
 
 // lastBusyPort is a pointer to the last free port given, therefore is in use.
 var lastBusyPort = portRangeInit - 1
+
 // mutex is the mutex used to solve concurrency problems while managing the port
 var mutex sync.Mutex
+
 // portsMap tracks whether an specific port is busy
 // portsMap[14100] = true => means that port 14100 is busy
 // portsMap[14101] = false => means that port 14101 is free
 var portsMap = map[int]bool{}
+
 // portRangeInit is the first port number managed in the pool
 var portRangeInit = 14100
+
 // portRangeSize is the size of the port range.
 // for example, the pool with portRangeSize 100 and portRangeInit 14000 manages
 // the ports from 14000 to 14099.
 var portRangeSize = 100
-
 
 // GetFreePort returns a non-busy port available within the reserved port range (14100 - 14199).
 // The returned port is instantaneously marked as busy until is not freed using the FreePort method.

--- a/util/httputil/port_pool.go
+++ b/util/httputil/port_pool.go
@@ -9,36 +9,36 @@ import (
 // [1501] => true // busy
 // [1502] => false // free
 // last port assigned => 1501
-var portRangeInit = 15000
+var portRangeInit = 14100
 var portRangeSize = 100
 var portsMap = map[int]bool{}
-var lastFreePort = portRangeInit
+var lastBusyPort = portRangeInit - 1
 var mutex sync.Mutex
 
-// GetFreePort returns a non-busy port available within the reserved port range (15000 - 15099).
+// GetFreePort returns a non-busy port available within the reserved port range (14100 - 14199).
 // The returned port is instantaneously marked as busy until is not freed using the FreePort method.
 func GetFreePort() int {
 	mutex.Lock()
 
-	busy := portsMap[lastFreePort]
+	busy := true
 	freePortFound := 0
 	attempts := 0
 	for busy && attempts < portRangeSize {
 		// If the pointer is getting out of range, restart from the beginning
-		if lastFreePort >= portRangeInit+portRangeSize-1 {
-			lastFreePort = portRangeInit
+		if lastBusyPort >= portRangeInit+portRangeSize-1 {
+			lastBusyPort = portRangeInit
 			// If the pointer is inside the range, increment by 1
 		} else {
-			lastFreePort++
+			lastBusyPort++
 		}
 
-		busy = portsMap[lastFreePort]
+		busy = portsMap[lastBusyPort]
 		attempts++
 	}
 
 	if !busy {
-		portsMap[lastFreePort] = true
-		freePortFound = lastFreePort
+		portsMap[lastBusyPort] = true
+		freePortFound = lastBusyPort
 	}
 
 	mutex.Unlock()
@@ -59,7 +59,7 @@ func FreePort(port int) (err error) {
 func ResetPool() {
 	mutex.Lock()
 
-	lastFreePort = portRangeInit
+	lastBusyPort = portRangeInit - 1
 	portsMap = map[int]bool{}
 
 	mutex.Unlock()

--- a/util/httputil/port_pool_test.go
+++ b/util/httputil/port_pool_test.go
@@ -1,0 +1,1 @@
+package httputil

--- a/util/httputil/port_pool_test.go
+++ b/util/httputil/port_pool_test.go
@@ -1,1 +1,93 @@
 package httputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFreePort(t *testing.T) {
+	assert := assert.New(t)
+
+	ResetPool()
+
+	port := GetFreePort()
+	assert.Equal(15000, port)
+
+	port = GetFreePort()
+	assert.Equal(15001, port)
+
+	port = GetFreePort()
+	assert.Equal(15002, port)
+}
+
+func TestGetFreePort_NoPortsAvailable(t *testing.T) {
+	assert := assert.New(t)
+
+	ResetPool()
+
+	for i := 0; i < 100; i++ {
+		port := GetFreePort()
+		assert.Equal(15000+i, port)
+	}
+
+	port := GetFreePort()
+	assert.Equal(0, port)
+}
+
+func TestFreePort(t *testing.T) {
+	assert := assert.New(t)
+
+	ResetPool()
+
+	for i := 0; i < portRangeSize; i++ {
+		port := GetFreePort()
+		assert.Equal(portRangeInit+i, port)
+	}
+
+	// No free port available (out of range)
+	port := GetFreePort()
+	assert.Equal(0, port)
+
+	// Once you free one port, this is
+	err := FreePort(15004)
+	port = GetFreePort()
+	assert.NoError(err)
+	assert.Equal(15004, port)
+
+	port = GetFreePort()
+	assert.NoError(err)
+	assert.Equal(0, port)
+
+	err = FreePort(15004)
+	port = GetFreePort()
+	assert.NoError(err)
+	assert.Equal(15004, port)
+
+	err = FreePort(15099)
+	port = GetFreePort()
+	assert.NoError(err)
+	assert.Equal(15099, port)
+
+	err = FreePort(15000)
+	port = GetFreePort()
+	assert.NoError(err)
+	assert.Equal(15000, port)
+}
+
+func TestFreePort_OutOfRange(t *testing.T) {
+	err := FreePort(8080)
+	assert.Errorf(t, err, "Port %d is out of range", 8080)
+}
+
+func TestResetPortPool(t *testing.T) {
+	ResetPool()
+
+	port := GetFreePort()
+	assert.Equal(t, 15000, port)
+
+	ResetPool()
+
+	port = GetFreePort()
+	assert.Equal(t, 15000, port)
+}

--- a/util/httputil/port_pool_test.go
+++ b/util/httputil/port_pool_test.go
@@ -12,13 +12,13 @@ func TestGetFreePort(t *testing.T) {
 	ResetPool()
 
 	port := GetFreePort()
-	assert.Equal(15000, port)
+	assert.Equal(14100, port)
 
 	port = GetFreePort()
-	assert.Equal(15001, port)
+	assert.Equal(14101, port)
 
 	port = GetFreePort()
-	assert.Equal(15002, port)
+	assert.Equal(14102, port)
 }
 
 func TestGetFreePort_NoPortsAvailable(t *testing.T) {
@@ -28,10 +28,13 @@ func TestGetFreePort_NoPortsAvailable(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		port := GetFreePort()
-		assert.Equal(15000+i, port)
+		assert.Equal(14100+i, port)
 	}
 
 	port := GetFreePort()
+	assert.Equal(0, port)
+
+	port = GetFreePort()
 	assert.Equal(0, port)
 }
 
@@ -50,29 +53,29 @@ func TestFreePort(t *testing.T) {
 	assert.Equal(0, port)
 
 	// Once you free one port, this is
-	err := FreePort(15004)
+	err := FreePort(14104)
 	port = GetFreePort()
 	assert.NoError(err)
-	assert.Equal(15004, port)
+	assert.Equal(14104, port)
 
 	port = GetFreePort()
 	assert.NoError(err)
 	assert.Equal(0, port)
 
-	err = FreePort(15004)
+	err = FreePort(14104)
 	port = GetFreePort()
 	assert.NoError(err)
-	assert.Equal(15004, port)
+	assert.Equal(14104, port)
 
-	err = FreePort(15099)
+	err = FreePort(14199)
 	port = GetFreePort()
 	assert.NoError(err)
-	assert.Equal(15099, port)
+	assert.Equal(14199, port)
 
-	err = FreePort(15000)
+	err = FreePort(14100)
 	port = GetFreePort()
 	assert.NoError(err)
-	assert.Equal(15000, port)
+	assert.Equal(14100, port)
 }
 
 func TestFreePort_OutOfRange(t *testing.T) {
@@ -84,10 +87,10 @@ func TestResetPortPool(t *testing.T) {
 	ResetPool()
 
 	port := GetFreePort()
-	assert.Equal(t, 15000, port)
+	assert.Equal(t, 14100, port)
 
 	ResetPool()
 
 	port = GetFreePort()
-	assert.Equal(t, 15000, port)
+	assert.Equal(t, 14100, port)
 }


### PR DESCRIPTION
fix https://github.com/kiali/kiali/issues/4054
needs https://github.com/kiali/helm-charts/pull/84
needs https://github.com/kiali/kiali-operator/pull/336

What do you think if we replace the usage of the sub-resource `pod/proxy` by simple HTTP Get calls?
The idea is instead of using the Kube API to send GET requests to each IstioD pods, use the associated IP of each IstioD pod and send the request. This change would remove the requirement of opening the port 8080 from control plane to the istio system.

The initial rationale of using the sub-resource was basically following the steps of the istioctl. However, tried to consume the debug endpoints at service level or using pod names, but didn't work. It seems that using pod's IPs works.

However, I don't know how robust is the usage of POD's IPs networkwise. Thinking of different cloud providers (GCP, AWS..) or kube flavours (k8s, ocp ...). Any idea?

This change would also trigger a reduction of permissions by removing the pod/proxy from the roles. Implying that no one could proxy any pod of the mesh.

What do you think?

This PR is fully working on my env. However, I put this on draft, not only for seeking opinion, but also because it should need the removal of the GetPodProxy method from the interface, remove the role binding from operator and also remove/update the kiali.io FAQ entry.