### PR TITLE
Support for custom CA certificate for OpenID auth

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -293,6 +293,7 @@ type OpenIdConfig struct {
 	AuthenticationTimeout   int               `yaml:"authentication_timeout,omitempty"`
 	ApiToken                string            `yaml:"api_token,omitempty"`
 	AuthorizationEndpoint   string            `yaml:"authorization_endpoint,omitempty"`
+	CAFile                  string            `yaml:"ca_file,omitempty"`
 	ClientId                string            `yaml:"client_id,omitempty"`
 	ClientSecret            string            `yaml:"client_secret,omitempty"`
 	DisableRBAC             bool              `yaml:"disable_rbac,omitempty"`
@@ -632,6 +633,7 @@ func (conf Config) String() (str string) {
 	obf.ExternalServices.Tracing.Auth.Obfuscate()
 	obf.Identity.Obfuscate()
 	obf.LoginToken.Obfuscate()
+	obf.Auth.OpenId.CAFile = "xxx"
 	obf.Auth.OpenId.ClientSecret = "xxx"
 	str, err := Marshal(&obf)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -293,7 +293,6 @@ type OpenIdConfig struct {
 	AuthenticationTimeout   int               `yaml:"authentication_timeout,omitempty"`
 	ApiToken                string            `yaml:"api_token,omitempty"`
 	AuthorizationEndpoint   string            `yaml:"authorization_endpoint,omitempty"`
-	CAFile                  string            `yaml:"ca_file,omitempty"`
 	ClientId                string            `yaml:"client_id,omitempty"`
 	ClientSecret            string            `yaml:"client_secret,omitempty"`
 	DisableRBAC             bool              `yaml:"disable_rbac,omitempty"`
@@ -633,7 +632,6 @@ func (conf Config) String() (str string) {
 	obf.ExternalServices.Tracing.Auth.Obfuscate()
 	obf.Identity.Obfuscate()
 	obf.LoginToken.Obfuscate()
-	obf.Auth.OpenId.CAFile = "xxx"
 	obf.Auth.OpenId.ClientSecret = "xxx"
 	str, err := Marshal(&obf)
 	if err != nil {


### PR DESCRIPTION
Adding support for custom CA certificate for the OpenID authentication.

The CA certificate is provided through a volume mount. Thus, this checks for existence of the certificate file and uses it, if available.

Related operator PR: https://github.com/kiali/kiali-operator/pull/333

Related #4050
