### PR TITLE
Validate gateways contained by HTTPMatchRequests objects

### DIFF
--- a/business/checkers/virtual_services/no_gateway_checker.go
+++ b/business/checkers/virtual_services/no_gateway_checker.go
@@ -31,32 +31,51 @@ func (s NoGatewayChecker) ValidateVirtualServiceGateways(spec map[string]interfa
 	}
 	if gatewaysSpec, found := spec["gateways"]; found {
 		if gateways, ok := gatewaysSpec.([]interface{}); ok {
-		GatewaySearch:
-			for index, g := range gateways {
-				if gate, ok := g.(string); ok {
-					if gate == "mesh" {
-						continue GatewaySearch
-					}
-
-					// Gateways should be using <namespace>/<gateway>
-					checkNomenclature(gate, index, validations)
-
-					hostname := kubernetes.ParseGatewayAsHost(gate, namespace, clusterName).String()
-					for gw := range s.GatewayNames {
-						if found := kubernetes.FilterByHost(hostname, gw, namespace); found {
-							continue GatewaySearch
+			valid = s.checkGateways(gateways, namespace, clusterName, validations, "spec")
+		}
+	}
+	if httpSpec, found := spec["http"]; found {
+		if https, ok := httpSpec.([]interface{}); ok {
+			for index, http := range https {
+				if https, ok := http.(map[string]interface{}); ok {
+					if match, ok := https["match"]; ok {
+						for _, m := range match.([]interface{}) {
+							if gateways, found := m.(map[string]interface{})["gateways"]; found {
+								valid = s.checkGateways(gateways.([]interface{}), namespace, clusterName, validations, fmt.Sprintf("spec/http[%d]/match", index))
+							}
 						}
 					}
-					path := fmt.Sprintf("spec/gateways[%d]", index)
-					validation := models.Build("virtualservices.nogateway", path)
-					*validations = append(*validations, &validation)
-					valid = false
 				}
 			}
 		}
 	}
-
 	return valid
+}
+
+func (s NoGatewayChecker) checkGateways(gateways []interface{}, namespace, clusterName string, validations *[]*models.IstioCheck, location string) bool {
+GatewaySearch:
+	for index, g := range gateways {
+		if gate, ok := g.(string); ok {
+			if gate == "mesh" {
+				continue GatewaySearch
+			}
+
+			// Gateways should be using <namespace>/<gateway>
+			checkNomenclature(gate, index, validations)
+
+			hostname := kubernetes.ParseGatewayAsHost(gate, namespace, clusterName).String()
+			for gw := range s.GatewayNames {
+				if found := kubernetes.FilterByHost(hostname, gw, namespace); found {
+					continue GatewaySearch
+				}
+			}
+			path := fmt.Sprintf("%s/gateways[%d]", location, index)
+			validation := models.Build("virtualservices.nogateway", path)
+			*validations = append(*validations, &validation)
+			return false
+		}
+	}
+	return true
 }
 
 func checkNomenclature(gateway string, index int, validations *[]*models.IstioCheck) {

--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -1,6 +1,7 @@
 package virtual_services
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,28 @@ func TestMissingGateway(t *testing.T) {
 		GatewayNames:   make(map[string]struct{}),
 	}
 
+	validations, valid := checker.Check()
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Equal(models.ErrorSeverity, validations[0].Severity)
+	assert.Equal(models.CheckMessage("virtualservices.nogateway"), validations[0].Message)
+}
+
+func TestMissingGatewayInMatch(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+	path := fmt.Sprintf("../../../tests/data/validations/virtualservices/%s", "non-existent-gateway-in-match.yaml")
+	loader := &data.YamlFixtureLoader{Filename: path}
+	err := loader.Load()
+	if err != nil {
+		t.Error("Error loading test data.")
+	}
+	virtualService := loader.GetResource("VirtualService", "test", "default")
+	checker := NoGatewayChecker{
+		VirtualService: virtualService,
+		GatewayNames:   map[string]struct{}{"valid-gateway": {}},
+	}
 	validations, valid := checker.Check()
 	assert.False(valid)
 	assert.NotEmpty(validations)

--- a/tests/data/validations/virtualservices/non-existent-gateway-in-match.yaml
+++ b/tests/data/validations/virtualservices/non-existent-gateway-in-match.yaml
@@ -1,0 +1,34 @@
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: test
+  namespace: default
+spec:
+  hosts:
+    - '*'
+  gateways:
+    - valid-gateway
+  http:
+    - match:
+        - gateways:
+            - valid-gateway
+        - uri:
+            exact: /static        
+      route:
+        - destination:
+            host: test
+            port:
+              number: 9080
+    - match:
+        - gateways:
+            - valid-gateway
+            - non-existent-bookinfo-gateway        
+        - uri:            
+            exact: /login
+        - uri:
+            exact: /logout       
+      route:
+        - destination:
+            host: test
+            port:
+              number: 9080

--- a/tests/data/validations/virtualservices/non-existent-ns-gateway-in-match.yaml
+++ b/tests/data/validations/virtualservices/non-existent-ns-gateway-in-match.yaml
@@ -1,0 +1,34 @@
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: test
+  namespace: default
+spec:
+  hosts:
+    - '*'
+  gateways:
+    - valid-gateway
+  http:
+    - match:
+        - gateways:
+            - valid-gateway
+        - uri:
+            exact: /static        
+      route:
+        - destination:
+            host: test
+            port:
+              number: 9080
+    - match:
+        - gateways:
+            - valid-gateway
+            - istio-system/non-existent-bookinfo-gateway        
+        - uri:            
+            exact: /login
+        - uri:
+            exact: /logout       
+      route:
+        - destination:
+            host: test
+            port:
+              number: 9080


### PR DESCRIPTION
**Description**

This PR enhances the validation of gateways in VirtualServices, specifically the gateways contained by HTTPMatchRequests objects.

**Issue**

[2932](https://github.com/kiali/kiali/issues/2932)

**Documentation**

The following VirtualService will have 2 errors during validation:

```yaml
kind: VirtualService
apiVersion: networking.istio.io/v1alpha3
metadata:
  name: bookinfo
  namespace: default
spec:
  hosts:
    - '*'
  gateways:
    - nonexistent-bookinfo-gateway
  http:
    - match:
        - gateways:
            - bookinfo-gateway
        - uri:
            exact: /productpage
        - uri:
            prefix: /static
        - uri:
            exact: /login
        - uri:
            exact: /logout
        - uri:
            prefix: /api/v1/products
      route:
        - destination:
            host: productpage
            port:
              number: 9080
    - match:
        - gateways:
            - bookinfo-gateway
            - nonexistent-bookinfo-gateway
        - uri:
            exact: /productpage
        - uri:
            prefix: /static
        - uri:
            exact: /login
        - uri:
            exact: /logout
        - uri:
            prefix: /api/v1/products
      route:
        - destination:
            host: productpage
            port:
              number: 9080
```

The following image is a result of the validation process:

![validations](https://user-images.githubusercontent.com/1286393/124669548-f149db80-de88-11eb-851b-c2400483f0bd.png)
