### PR TITLE
Support multiple rows in metrics dashboards

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -222,12 +222,18 @@ func (in *DashboardsService) GetDashboard(authInfo *api.AuthInfo, params models.
 	}()
 
 	wg.Wait()
+	// A dashboard can define the rows used, if not defined, by default it will use 2 rows
+	rows := dashboard.Rows
+	if rows == 0 {
+		rows = 2
+	}
 	return &models.MonitoringDashboard{
 		Name:          dashboard.Name,
 		Title:         dashboard.Title,
 		Charts:        filledCharts,
 		Aggregations:  aggLabels,
 		ExternalLinks: externalLinks,
+		Rows:          rows,
 	}, nil
 }
 

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -224,7 +224,7 @@ func (in *DashboardsService) GetDashboard(authInfo *api.AuthInfo, params models.
 	wg.Wait()
 	// A dashboard can define the rows used, if not defined, by default it will use 2 rows
 	rows := dashboard.Rows
-	if rows == 0 {
+	if rows < 1 {
 		rows = 2
 	}
 	return &models.MonitoringDashboard{

--- a/config/dashboards/dashboards_config.go
+++ b/config/dashboards/dashboards_config.go
@@ -29,6 +29,7 @@ type MonitoringDashboard struct {
 	DiscoverOn    string                            `yaml:"discoverOn"`
 	Items         []MonitoringDashboardItem         `yaml:"items"`
 	ExternalLinks []MonitoringDashboardExternalLink `yaml:"externalLinks"`
+	Rows          int                               `yaml:"rows"`
 }
 
 type MonitoringDashboardItem struct {

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -7862,6 +7862,7 @@ There is currently only one possible value: "FieldsV1" |  |
 | Charts | [][Chart](#chart)| `[]*Chart` |  | |  |  |
 | ExternalLinks | [][ExternalLink](#external-link)| `[]*ExternalLink` |  | |  |  |
 | Name | string| `string` |  | |  |  |
+| Rows | int64 (formatted integer)| `int64` |  | |  |  |
 | Title | string| `string` |  | |  |  |
 
 

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -159,7 +159,7 @@ func PrepareIstioDashboard(direction, local, remote string) MonitoringDashboard 
 		Title:        fmt.Sprintf("%s Metrics", direction),
 		Aggregations: buildIstioAggregations(local, remote),
 		Charts:       []Chart{},
-		Rows:         2,	// Rows layout used for Inbound Metrics and Outbound Metrics
+		Rows:         2, // Rows layout used for Inbound Metrics and Outbound Metrics
 	}
 }
 

--- a/models/dashboards.go
+++ b/models/dashboards.go
@@ -32,6 +32,7 @@ type MonitoringDashboard struct {
 	Charts        []Chart        `json:"charts"`
 	Aggregations  []Aggregation  `json:"aggregations"`
 	ExternalLinks []ExternalLink `json:"externalLinks"`
+	Rows          int            `json:"rows"`
 }
 
 // Chart is the model representing a custom chart, transformed from charts in MonitoringDashboard config resource
@@ -152,10 +153,13 @@ func buildIstioAggregations(local, remote string) []Aggregation {
 
 // PrepareIstioDashboard prepares the Istio dashboard title and aggregations dynamically for input values
 func PrepareIstioDashboard(direction, local, remote string) MonitoringDashboard {
+	// Istio dashboards are predefined
+	// It uses two rows by default, columns are defined using the spans of the charts
 	return MonitoringDashboard{
 		Title:        fmt.Sprintf("%s Metrics", direction),
 		Aggregations: buildIstioAggregations(local, remote),
 		Charts:       []Chart{},
+		Rows:         2,	// Rows layout used for Inbound Metrics and Outbound Metrics
 	}
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -5759,6 +5759,11 @@
           "type": "string",
           "x-go-name": "Name"
         },
+        "rows": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Rows"
+        },
         "title": {
           "type": "string",
           "x-go-name": "Title"


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4156

With the refactoring of the Metrics tabs and the MonitoringDashboard definitions there was introduced the lack to allow users to define multiple rows in the new layout.
This PR (and the UI one https://github.com/kiali/kiali-ui/pull/2200) adds flexibility of the rows definition.
So, a dashboard may optionally define the rows, by default it will be a setup of two rows.
But user can define that, columns will be populated in a flex manner using spans to fill the grid (as used today).

So, using an example based on namespace:

```
apiVersion: v1
kind: Namespace
metadata:
  name: default
  annotations:
    dashboards.kiali.io/templates: |
      - name: custom_envoy
        title: Custom_Envoy
        discoverOn: "envoy_server_uptime"
        rows: 4
        items:
          - chart:
              name: "Pods uptime"
              spans: 3
              metricName: "envoy_server_uptime"
              dataType: "raw"
          - chart:
              name: "Pods uptime"
              spans: 3
              metricName: "envoy_server_uptime"
              dataType: "raw"
          - chart:
              name: "Pods uptime"
              spans: 3
              metricName: "envoy_server_uptime"
              dataType: "raw"
          - chart:
              name: "Pods uptime"
              spans: 3
              metricName: "envoy_server_uptime"
              dataType: "raw"
          - chart:
              name: "Pods uptime"
              spans: 4
              metricName: "envoy_server_uptime"
              dataType: "raw"
          - chart:
              name: "Pods uptime"
              spans: 4
              metricName: "envoy_server_uptime"
              dataType: "raw"
          - chart:
              name: "Pods uptime"
              spans: 4
              metricName: "envoy_server_uptime"
              dataType: "raw"
          - chart:
              name: "Pods uptime"
              spans: 6
              metricName: "envoy_server_uptime"
              dataType: "raw"
          - chart:
              name: "Pods uptime"
              spans: 6
              metricName: "envoy_server_uptime"
              dataType: "raw"
          - chart:
              name: "Pods uptime"
              spans: 12
              metricName: "envoy_server_uptime"
              dataType: "raw"
```

would provide a layout like:

![image](https://user-images.githubusercontent.com/1662329/125651615-266f93e7-cb66-4521-965f-93986188aa01.png)

The new style of the grid won't change, the goal is to show all metrics available to the user.


