### PR TITLE
Added validation for "exportTo" fields of VirtualService, ServiceEntry and DestinationRule.

### DIFF
--- a/business/checkers/common/export_to_namespace_checker.go
+++ b/business/checkers/common/export_to_namespace_checker.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"fmt"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type ExportToNamespaceChecker struct {
+	IstioObject kubernetes.IstioObject
+	Namespaces  models.Namespaces
+}
+
+func (p ExportToNamespaceChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	if exportToSpec, found := p.IstioObject.GetSpec()["exportTo"]; found {
+		if namespaces, ok := exportToSpec.([]interface{}); ok {
+			for nsIndex, namespace := range namespaces {
+				if namespace != "." && !p.Namespaces.Includes(namespace.(string)) {
+					validation := models.Build("generic.exportto.namespacenotfound",
+						fmt.Sprintf("spec/exportTo[%d]", nsIndex))
+					validations = append(validations, &validation)
+				}
+			}
+		}
+	}
+
+	return validations, len(validations) == 0
+}

--- a/business/checkers/common/export_to_namespace_checker_test.go
+++ b/business/checkers/common/export_to_namespace_checker_test.go
@@ -1,0 +1,87 @@
+package common
+
+import (
+	"fmt"
+	"github.com/kiali/kiali/config"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+func TestDRNamespaceExist(t *testing.T) {
+	assertIstioObjectValid("dr_exportto_valid.yaml", "DestinationRule", t)
+}
+
+func TestDRNamespaceNotFound(t *testing.T) {
+	assertIstioObjectInvalidNamespace("dr_exportto_invalid.yaml", "DestinationRule", 2, t)
+}
+
+func TestVSNamespaceExist(t *testing.T) {
+	assertIstioObjectValid("vs_exportto_valid.yaml", "VirtualService", t)
+}
+
+func TestVSNamespaceNotFound(t *testing.T) {
+	assertIstioObjectInvalidNamespace("vs_exportto_invalid.yaml", "VirtualService", 2, t)
+}
+
+func TestSENamespaceExist(t *testing.T) {
+	assertIstioObjectValid("se_exportto_valid.yaml", "ServiceEntry", t)
+}
+
+func TestSENamespaceNotFound(t *testing.T) {
+	assertIstioObjectInvalidNamespace("se_exportto_invalid.yaml", "ServiceEntry", 2, t)
+}
+
+func assertIstioObjectValid(scenario string, objectType string, t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := validateIstioObject(scenario, objectType, t)
+
+	// Well configured object
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func assertIstioObjectInvalidNamespace(scenario string, objectType string, errorNumbers int, t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := validateIstioObject("dr_exportto_invalid.yaml", "DestinationRule", t)
+
+	assert.False(valid)
+	assert.NotEmpty(validations)
+	assert.Len(validations, errorNumbers)
+	for i := 0; i < errorNumbers; i++ {
+		assert.Equal(validations[i].Message, models.CheckMessage("generic.exportto.namespacenotfound"))
+		assert.Equal(validations[i].Severity, models.ErrorSeverity)
+		assert.Equal(validations[i].Path, fmt.Sprintf("spec/exportTo[%d]", i))
+	}
+}
+
+func validateIstioObject(scenario string, objectType string, t *testing.T) ([]*models.IstioCheck, bool) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	loader := yamlFixtureLoaderFor(scenario)
+	err := loader.Load()
+	if err != nil {
+		t.Error("Error loading test data.")
+	}
+	validations, valid := ExportToNamespaceChecker{
+		IstioObject: loader.GetFirstResource(objectType),
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "bookinfo"},
+			models.Namespace{Name: "bookinfo2"},
+			models.Namespace{Name: "default"},
+		},
+	}.Check()
+
+	return validations, valid
+}
+
+func yamlFixtureLoaderFor(file string) *data.YamlFixtureLoader {
+	path := fmt.Sprintf("../../../tests/data/validations/exportto/%s", file)
+	return &data.YamlFixtureLoader{Filename: path}
+}

--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -1,6 +1,7 @@
 package checkers
 
 import (
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/business/checkers/destinationrules"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -62,6 +63,7 @@ func (in DestinationRulesChecker) runChecks(destinationRule kubernetes.IstioObje
 	enabledCheckers := []Checker{
 		destinationrules.DisabledNamespaceWideMTLSChecker{DestinationRule: destinationRule, MTLSDetails: in.MTLSDetails},
 		destinationrules.DisabledMeshWideMTLSChecker{DestinationRule: destinationRule, MeshPeerAuthns: in.MTLSDetails.MeshPeerAuthentications},
+		common.ExportToNamespaceChecker{IstioObject: destinationRule, Namespaces: in.Namespaces},
 	}
 
 	// Appending validations that only applies to non-autoMTLS meshes

--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -1,6 +1,7 @@
 package checkers
 
 import (
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -9,6 +10,7 @@ const ServiceEntryCheckerType = "serviceentry"
 
 type ServiceEntryChecker struct {
 	ServiceEntries []kubernetes.IstioObject
+	Namespaces     models.Namespaces
 }
 
 func (s ServiceEntryChecker) Check() models.IstioValidations {
@@ -24,7 +26,9 @@ func (s ServiceEntryChecker) Check() models.IstioValidations {
 func (s ServiceEntryChecker) runSingleChecks(se kubernetes.IstioObject) models.IstioValidations {
 	key, validations := EmptyValidValidation(se.GetObjectMeta().Name, se.GetObjectMeta().Namespace, ServiceEntryCheckerType)
 
-	enabledCheckers := []Checker{}
+	enabledCheckers := []Checker{
+		common.ExportToNamespaceChecker{IstioObject: se, Namespaces: s.Namespaces},
+	}
 
 	for _, checker := range enabledCheckers {
 		checks, validChecker := checker.Check()

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -1,6 +1,7 @@
 package checkers
 
 import (
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/business/checkers/virtual_services"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -62,6 +63,7 @@ func (in VirtualServiceChecker) runChecks(virtualService kubernetes.IstioObject)
 	enabledCheckers := []Checker{
 		virtual_services.RouteChecker{Route: virtualService},
 		virtual_services.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), DestinationRules: in.DestinationRules, VirtualService: virtualService},
+		common.ExportToNamespaceChecker{IstioObject: virtualService, Namespaces: in.Namespaces},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -115,7 +115,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
-		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries},
+		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries, Namespaces: namespaces},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioDetails.VirtualServices, RegistryStatus: registryStatus},
 		checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces, WorkloadList: workloads, Services: services, ServiceEntries: istioDetails.ServiceEntries},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioDetails.RequestAuthentications, WorkloadList: workloads},
@@ -171,7 +171,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		destinationRulesChecker := checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries}
 		objectCheckers = []ObjectChecker{noServiceChecker, destinationRulesChecker}
 	case kubernetes.ServiceEntries:
-		serviceEntryChecker := checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries}
+		serviceEntryChecker := checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries, Namespaces: namespaces}
 		objectCheckers = []ObjectChecker{serviceEntryChecker}
 	case kubernetes.Sidecars:
 		sidecarsChecker := checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces,

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -163,6 +163,10 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "KIA0302 No matching workload found for gateway selector in this namespace",
 		Severity: WarningSeverity,
 	},
+	"generic.exportto.namespacenotfound": {
+		Message:  "KIA0005 No matching namespace found or namespace is not accessible",
+		Severity: ErrorSeverity,
+	},
 	"generic.multimatch.selectorless": {
 		Message:  "KIA0002 More than one selector-less object in the same namespace",
 		Severity: ErrorSeverity,

--- a/tests/data/validations/exportto/dr_exportto_invalid.yaml
+++ b/tests/data/validations/exportto/dr_exportto_invalid.yaml
@@ -1,0 +1,11 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "dr-exportto-valid"
+  namespace: "bookinfo"
+spec:
+  host: "*.local"
+  exportTo:
+    - wrong1
+    - bookinfo3
+    - .

--- a/tests/data/validations/exportto/dr_exportto_valid.yaml
+++ b/tests/data/validations/exportto/dr_exportto_valid.yaml
@@ -1,0 +1,10 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "dr-exportto-valid"
+  namespace: "bookinfo"
+spec:
+  host: "*.local"
+  exportTo:
+    - bookinfo
+    - bookinfo2

--- a/tests/data/validations/exportto/se_exportto_invalid.yaml
+++ b/tests/data/validations/exportto/se_exportto_invalid.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: se_exportto_valid
+  namespace: bookinfo
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - wrong1
+    - bookinfo3
+    - .

--- a/tests/data/validations/exportto/se_exportto_valid.yaml
+++ b/tests/data/validations/exportto/se_exportto_valid.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: se_exportto_valid
+  namespace: bookinfo
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - bookinfo
+    - bookinfo2

--- a/tests/data/validations/exportto/vs_exportto_invalid.yaml
+++ b/tests/data/validations/exportto/vs_exportto_invalid.yaml
@@ -1,0 +1,12 @@
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: vs_exportto_valid
+  namespace: bookinfo
+spec:
+  hosts:
+    - '*'
+  exportTo:
+    - wrong1
+    - bookinfo3
+    - .

--- a/tests/data/validations/exportto/vs_exportto_valid.yaml
+++ b/tests/data/validations/exportto/vs_exportto_valid.yaml
@@ -1,0 +1,11 @@
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: vs_exportto_valid
+  namespace: bookinfo
+spec:
+  hosts:
+    - '*'
+  exportTo:
+    - bookinfo
+    - bookinfo2


### PR DESCRIPTION
Added a validation of the namespace values "exportTo" fields.
Checking if namespace exists and user has access to it.
Validation is added for VirtualService, ServiceEntry and DestinationRule Istio Objects.
Error is displayed when namespace does not exist or is not accessible: "KIA0005 No matching namespace found or namespace is not accessible"

RFE: https://github.com/kiali/kiali/issues/1370

![Screenshot from 2021-07-13 13-37-03](https://user-images.githubusercontent.com/604313/125446225-f7aa549f-38b4-499e-b389-39b38257722b.png)
