### PR TITLE
Add kiali scenarios to graph node from VS spec

### DIFF
--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -105,7 +105,7 @@ NODES:
 		for _, virtualService := range istioCfg.VirtualServices.Items {
 			if virtualService.IsValidHost(namespace, n.Service) {
 				n.Metadata[graph.HasVS] = true
-				
+
 				if virtualService.HasRequestRouting() {
 					n.Metadata[graph.HasRequestRouting] = true
 				}
@@ -113,15 +113,15 @@ NODES:
 				if virtualService.HasRequestTimeout() {
 					n.Metadata[graph.HasRequestTimeout] = true
 				}
-				
+
 				if virtualService.HasFaultInjection() {
 					n.Metadata[graph.HasFaultInjection] = true
 				}
-				
+
 				if virtualService.HasTrafficShifting() {
 					n.Metadata[graph.HasTrafficShifting] = true
 				}
-				
+
 				if virtualService.HasTCPTrafficShifting() {
 					n.Metadata[graph.HasTCPTrafficShifting] = true
 				}

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -105,20 +105,25 @@ NODES:
 		for _, virtualService := range istioCfg.VirtualServices.Items {
 			if virtualService.IsValidHost(namespace, n.Service) {
 				n.Metadata[graph.HasVS] = true
-
-				// Check if the VS also has one of the Kiali scenarios created by the wizard.
-				// TODO: Get this info from the VS spec in case the Istio object was not created by a wizard.
-				switch virtualService.Metadata.Labels[graph.WizardLabelKey] {
-				case graph.WizardRequestRoutingLabel:
+				
+				if virtualService.HasRequestRouting() {
 					n.Metadata[graph.HasRequestRouting] = true
-				case graph.WizardFaultInjectionLabel:
-					n.Metadata[graph.HasFaultInjection] = true
-				case graph.WizardTrafficShiftingLabel:
-					n.Metadata[graph.HasTrafficShifting] = true
-				case graph.WizardTCPTrafficShiftingLabel:
-					n.Metadata[graph.HasTCPTrafficShifting] = true
-				case graph.WizardRequestTimeoutsLabel:
+				}
+
+				if virtualService.HasRequestTimeout() {
 					n.Metadata[graph.HasRequestTimeout] = true
+				}
+				
+				if virtualService.HasFaultInjection() {
+					n.Metadata[graph.HasFaultInjection] = true
+				}
+				
+				if virtualService.HasTrafficShifting() {
+					n.Metadata[graph.HasTrafficShifting] = true
+				}
+				
+				if virtualService.HasTCPTrafficShifting() {
+					n.Metadata[graph.HasTCPTrafficShifting] = true
 				}
 
 				continue NODES

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -252,13 +252,13 @@ func TestVSWithRoutingBadges(t *testing.T) {
 					"route": []interface{}{
 						map[string]interface{}{
 							"destination": map[string]interface{}{
-								"host": "foo",
+								"host":   "foo",
 								"weight": 20,
 							},
 						},
 						map[string]interface{}{
 							"destination": map[string]interface{}{
-								"host": "bar",
+								"host":   "bar",
 								"weight": 80,
 							},
 						},

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -242,9 +242,6 @@ func TestVSWithRoutingBadges(t *testing.T) {
 	vService := kubernetes.GenericIstioObject{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "vService-1",
-			Labels: map[string]string{
-				graph.WizardLabelKey: graph.WizardTrafficShiftingLabel,
-			},
 		},
 		Spec: map[string]interface{}{
 			"hosts": []interface{}{
@@ -256,6 +253,13 @@ func TestVSWithRoutingBadges(t *testing.T) {
 						map[string]interface{}{
 							"destination": map[string]interface{}{
 								"host": "foo",
+								"weight": 20,
+							},
+						},
+						map[string]interface{}{
+							"destination": map[string]interface{}{
+								"host": "bar",
+								"weight": 80,
 							},
 						},
 					},
@@ -276,6 +280,7 @@ func TestVSWithRoutingBadges(t *testing.T) {
 
 	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
 	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasTrafficShifting])
+	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasRequestRouting])
 
 	globalInfo := graph.NewAppenderGlobalInfo()
 	globalInfo.Business = businessLayer

--- a/graph/types.go
+++ b/graph/types.go
@@ -20,12 +20,6 @@ const (
 	NodeTypeWorkload              string = "workload"
 	TF                            string = "2006-01-02 15:04:05" // TF is the TimeFormat for timestamps
 	Unknown                       string = "unknown"             // Istio unknown label value
-	WizardFaultInjectionLabel     string = "fault_injection"
-	WizardLabelKey                string = "kiali_wizard" // Label the front-end wizards add to objects created by them
-	WizardRequestRoutingLabel     string = "request_routing"
-	WizardRequestTimeoutsLabel    string = "request_timeouts"
-	WizardTCPTrafficShiftingLabel string = "tcp_traffic_shifting"
-	WizardTrafficShiftingLabel    string = "traffic_shifting"
 	// private
 	passthroughCluster string = "PassthroughCluster"
 	blackHoleCluster   string = "BlackHoleCluster"

--- a/graph/types.go
+++ b/graph/types.go
@@ -8,18 +8,18 @@ import (
 )
 
 const (
-	GraphTypeApp                  string = "app"
-	GraphTypeService              string = "service" // Treated as graphType Workload, with service injection, and then condensed
-	GraphTypeVersionedApp         string = "versionedApp"
-	GraphTypeWorkload             string = "workload"
-	NodeTypeAggregate             string = "aggregate" // The special "aggregate" traffic node
-	NodeTypeApp                   string = "app"
-	NodeTypeBox                   string = "box" // The special "box" node. isBox will be set to "app" | "cluster" | "namespace"
-	NodeTypeService               string = "service"
-	NodeTypeUnknown               string = "unknown" // The special "unknown" traffic gen node
-	NodeTypeWorkload              string = "workload"
-	TF                            string = "2006-01-02 15:04:05" // TF is the TimeFormat for timestamps
-	Unknown                       string = "unknown"             // Istio unknown label value
+	GraphTypeApp          string = "app"
+	GraphTypeService      string = "service" // Treated as graphType Workload, with service injection, and then condensed
+	GraphTypeVersionedApp string = "versionedApp"
+	GraphTypeWorkload     string = "workload"
+	NodeTypeAggregate     string = "aggregate" // The special "aggregate" traffic node
+	NodeTypeApp           string = "app"
+	NodeTypeBox           string = "box" // The special "box" node. isBox will be set to "app" | "cluster" | "namespace"
+	NodeTypeService       string = "service"
+	NodeTypeUnknown       string = "unknown" // The special "unknown" traffic gen node
+	NodeTypeWorkload      string = "workload"
+	TF                    string = "2006-01-02 15:04:05" // TF is the TimeFormat for timestamps
+	Unknown               string = "unknown"             // Istio unknown label value
 	// private
 	passthroughCluster string = "PassthroughCluster"
 	blackHoleCluster   string = "BlackHoleCluster"

--- a/models/virtual_service.go
+++ b/models/virtual_service.go
@@ -67,3 +67,131 @@ func (vService *VirtualService) IsValidHost(namespace string, serviceName string
 
 	return kubernetes.FilterByRoute(protocols, protocolNames, serviceName, namespace, nil)
 }
+
+// HasRequestTimeout determines if the spec has an http timeout set.
+func (vService *VirtualService) HasRequestTimeout() bool {
+	if vService == nil {
+		return false
+	}
+
+	if routes, isSlice := vService.Spec.Http.([]interface{}); isSlice {
+		for _, route := range routes {
+			if routeMap, isMap := route.(map[string]interface{}); isMap {
+				if _, hasTimeout := routeMap["timeout"]; hasTimeout {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// HasFaultInjection determines if the spec has http fault injection set.
+func (vService *VirtualService) HasFaultInjection() bool {
+	if vService == nil {
+		return false
+	}
+
+	if routes, isSlice := vService.Spec.Http.([]interface{}); isSlice {
+		for _, route := range routes {
+			if routeMap, isMap := route.(map[string]interface{}); isMap {
+				if _, hasFault := routeMap["fault"]; hasFault {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// HasTrafficShifting determines if the spec has http traffic shifting set.
+// If there are routes with multiple destinations then it is assumed that
+// the spec has traffic shifting regardless of weights.
+func (vService *VirtualService) HasTrafficShifting() bool {
+	if vService == nil {
+		return false
+	}
+
+	if routes, isSlice := vService.Spec.Http.([]interface{}); isSlice {
+		for _, route := range routes {
+			if routeMap, isMap := route.(map[string]interface{}); isMap {
+				if destinationRoutes, hasDRRoutes := routeMap["route"]; hasDRRoutes {
+					if drRoutes, isSlice := destinationRoutes.([]interface{}); isSlice {
+						// If there's only a single destination then there's no weighted split.
+						// If there's multiple destinations, it's assumed that there's traffic
+						// splitting even if one destination has 100 weight and the rest have 0.
+						return len(drRoutes) > 1
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+
+// HasTCPTrafficShifting determines if the spec has tcp traffic shifting set.
+// If there are routes with multiple destinations then it is assumed that
+// the spec has traffic shifting regardless of weights.
+func (vService *VirtualService) HasTCPTrafficShifting() bool {
+	if vService == nil {
+		return false
+	}
+	
+	if routes, isSlice := vService.Spec.Tcp.([]interface{}); isSlice {
+		for _, route := range routes {
+			if routeMap, isMap := route.(map[string]interface{}); isMap {
+				if destinationRoutes, hasDRRoutes := routeMap["route"]; hasDRRoutes {
+					if drRoutes, isSlice := destinationRoutes.([]interface{}); isSlice {
+						// If there's only a single destination then there's no weighted split.
+						// If there's multiple destinations, it's assumed that there's traffic
+						// splitting even if one destination has 100 weight and the rest have 0.
+						return len(drRoutes) > 1
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// IsValidHost returns true if VirtualService hosts applies to the service
+func (vService *VirtualService) HasRequestRouting() bool {
+	if vService == nil {
+		return false
+	}
+
+	hasRoute := func(routes []interface{}) bool {
+		for _, route := range routes {
+			if routeMap, isMap := route.(map[string]interface{}); isMap {
+				if _, hasRoute := routeMap["route"]; hasRoute {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	
+	if routes, isSlice := vService.Spec.Tcp.([]interface{}); isSlice {
+		if hasRoute(routes) {
+			return true
+		}
+	}
+	if routes, isSlice := vService.Spec.Http.([]interface{}); isSlice {
+		if hasRoute(routes) {
+			return true
+		}
+	}
+	if routes, isSlice := vService.Spec.Tls.([]interface{}); isSlice {
+		if hasRoute(routes) {
+			return true
+		}
+	}
+
+	return false
+}
+

--- a/models/virtual_service.go
+++ b/models/virtual_service.go
@@ -132,7 +132,6 @@ func (vService *VirtualService) HasTrafficShifting() bool {
 	return false
 }
 
-
 // HasTCPTrafficShifting determines if the spec has tcp traffic shifting set.
 // If there are routes with multiple destinations then it is assumed that
 // the spec has traffic shifting regardless of weights.
@@ -140,7 +139,7 @@ func (vService *VirtualService) HasTCPTrafficShifting() bool {
 	if vService == nil {
 		return false
 	}
-	
+
 	if routes, isSlice := vService.Spec.Tcp.([]interface{}); isSlice {
 		for _, route := range routes {
 			if routeMap, isMap := route.(map[string]interface{}); isMap {
@@ -175,7 +174,7 @@ func (vService *VirtualService) HasRequestRouting() bool {
 		}
 		return false
 	}
-	
+
 	if routes, isSlice := vService.Spec.Tcp.([]interface{}); isSlice {
 		if hasRoute(routes) {
 			return true
@@ -194,4 +193,3 @@ func (vService *VirtualService) HasRequestRouting() bool {
 
 	return false
 }
-

--- a/models/virtual_service_test.go
+++ b/models/virtual_service_test.go
@@ -1,0 +1,522 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/kiali/kiali/models"
+)
+
+func TestVirtualServiceHasRequestTimeout(t *testing.T) {
+	cases := map[string]struct {
+		vsYAML          []byte
+		expectedTimeout bool
+	}{
+		"Has timeout": {
+			expectedTimeout: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+  - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v2
+    timeout: 0.5s
+`),
+		},
+		"No timeout": {
+			expectedTimeout: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+  - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v2
+`),
+		},
+		"Multiple timeouts": {
+			expectedTimeout: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+  - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v2
+    timeout: 0.5s
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+    timeout: 2.5s
+`),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			
+			var vs models.VirtualService
+			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
+
+			assert.Equal(vs.HasRequestTimeout(), tc.expectedTimeout)
+		})
+	}
+
+	// Testing nil case
+	var vs *models.VirtualService
+	assert.False(t, vs.HasRequestTimeout())
+}
+
+func TestVirtualServiceHasFaultInjection(t *testing.T) {
+	cases := map[string]struct {
+		vsYAML          []byte
+		expectedFaultInjection bool
+	}{
+		"Has fault": {
+			expectedFaultInjection: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ratings
+spec:
+  hosts:
+  - ratings
+  http:
+  - fault:
+      delay:
+        fixedDelay: 7s
+        percentage:
+          value: 100
+    match:
+    - headers:
+        end-user:
+          exact: jason
+    route:
+    - destination:
+        host: ratings
+        subset: v1
+  - route:
+    - destination:
+        host: ratings
+        subset: v1
+`),
+		},
+		"No fault": {
+			expectedFaultInjection: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ratings
+spec:
+  hosts:
+  - ratings
+  http:
+  - match:
+    - headers:
+        end-user:
+          exact: jason
+    route:
+    - destination:
+        host: ratings
+        subset: v1
+  - route:
+    - destination:
+        host: ratings
+        subset: v1
+`),
+		},
+		"Multiple faults": {
+			expectedFaultInjection: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ratings
+spec:
+  hosts:
+  - ratings
+  http:
+  - fault:
+      delay:
+        fixedDelay: 7s
+        percentage:
+          value: 100
+    match:
+    - headers:
+        end-user:
+          exact: jason
+    route:
+    - destination:
+        host: ratings
+        subset: v1
+  - route:
+    - destination:
+        host: ratings
+        subset: v1
+    fault:
+      delay:
+        fixedDelay: 5s
+        percentage:
+          value: 10
+`),
+		},
+	}
+	
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			
+			var vs models.VirtualService
+			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
+
+			assert.Equal(vs.HasFaultInjection(), tc.expectedFaultInjection)
+		})
+	}
+
+	// Testing nil case
+	var vs *models.VirtualService
+	assert.False(t, vs.HasFaultInjection())
+}
+
+func TestVirtualServiceHasTrafficShifting(t *testing.T) {
+	cases := map[string]struct {
+		vsYAML          []byte
+		expectedTrafficShifting bool
+	}{
+		"Has traffic shifting": {
+			expectedTrafficShifting: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v2
+      weight: 25
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v1
+      weight: 75
+`),
+		},
+		"Single destination with no weight": {
+			expectedTrafficShifting: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+`),
+		},
+		"Single destination with weight": {
+			expectedTrafficShifting: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v1
+      weight: 100
+`),
+		},
+		"No routes": {
+			expectedTrafficShifting: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+`),
+		},
+	}
+	
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			
+			var vs models.VirtualService
+			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
+
+			assert.Equal(vs.HasTrafficShifting(), tc.expectedTrafficShifting)
+		})
+	}
+
+	// Testing nil case
+	var vs *models.VirtualService
+	assert.False(t, vs.HasTrafficShifting())
+}
+
+func TestVirtualServiceHasTCPTrafficShifting(t *testing.T) {
+	cases := map[string]struct {
+		vsYAML          []byte
+		expectedTCPTrafficShifting bool
+	}{
+		"Has traffic shifting": {
+			expectedTCPTrafficShifting: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: tcp-echo-route
+spec:
+  hosts:
+  - tcp-echo
+  tcp:
+  - match:
+    - port: 31400
+    route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v1
+      weight: 80
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v2
+      weight: 20
+`),
+		},
+		"Single destination with no weight": {
+			expectedTCPTrafficShifting: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: tcp-echo-route
+spec:
+  hosts:
+  - tcp-echo
+  tcp:
+  - match:
+    - port: 31400
+    route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v1
+`),
+		},
+		"Single destination with weight": {
+			expectedTCPTrafficShifting: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: tcp-echo-route
+spec:
+  hosts:
+  - tcp-echo
+  tcp:
+  - match:
+    - port: 31400
+    route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v1
+      weight: 100
+`),
+		},
+		"No routes": {
+			expectedTCPTrafficShifting: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: tcp-echo-route
+spec:
+  hosts:
+  - tcp-echo
+`),
+		},
+	}
+	
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			
+			var vs models.VirtualService
+			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
+
+			assert.Equal(vs.HasTCPTrafficShifting(), tc.expectedTCPTrafficShifting)
+		})
+	}
+
+	// Testing nil case
+	var vs *models.VirtualService
+	assert.False(t, vs.HasTCPTrafficShifting())
+}
+
+func TestVirtualServiceHasRequestRouting(t *testing.T) {
+	cases := map[string]struct {
+		vsYAML          []byte
+		expectedRequestRouting bool
+	}{
+		"Has http request routing": {
+			expectedRequestRouting: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+`),
+		},
+		"Has tcp request routing": {
+			expectedRequestRouting: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  tcp:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+`),
+		},
+		"Has tls request routing": {
+			expectedRequestRouting: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  tls:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+`),
+		},
+		"Has multiple forms of request routing": {
+			expectedRequestRouting: true,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+  tcp:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+  tls:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+`),
+		},
+		"Has no request routing": {
+			expectedRequestRouting: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+`),
+		},
+		"Has no request routing but has other options": {
+			expectedRequestRouting: false,
+			vsYAML: []byte(`
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - timeout: 5s
+`),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			
+			var vs models.VirtualService
+			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
+
+			assert.Equal(vs.HasRequestRouting(), tc.expectedRequestRouting)
+		})
+	}
+
+	// Testing nil case
+	var vs *models.VirtualService
+	assert.False(t, vs.HasRequestRouting())
+}

--- a/models/virtual_service_test.go
+++ b/models/virtual_service_test.go
@@ -77,7 +77,7 @@ spec:
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			
+
 			var vs models.VirtualService
 			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
 
@@ -92,7 +92,7 @@ spec:
 
 func TestVirtualServiceHasFaultInjection(t *testing.T) {
 	cases := map[string]struct {
-		vsYAML          []byte
+		vsYAML                 []byte
 		expectedFaultInjection bool
 	}{
 		"Has fault": {
@@ -186,11 +186,11 @@ spec:
 `),
 		},
 	}
-	
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			
+
 			var vs models.VirtualService
 			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
 
@@ -205,7 +205,7 @@ spec:
 
 func TestVirtualServiceHasTrafficShifting(t *testing.T) {
 	cases := map[string]struct {
-		vsYAML          []byte
+		vsYAML                  []byte
 		expectedTrafficShifting bool
 	}{
 		"Has traffic shifting": {
@@ -277,11 +277,11 @@ spec:
 `),
 		},
 	}
-	
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			
+
 			var vs models.VirtualService
 			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
 
@@ -296,7 +296,7 @@ spec:
 
 func TestVirtualServiceHasTCPTrafficShifting(t *testing.T) {
 	cases := map[string]struct {
-		vsYAML          []byte
+		vsYAML                     []byte
 		expectedTCPTrafficShifting bool
 	}{
 		"Has traffic shifting": {
@@ -383,11 +383,11 @@ spec:
 `),
 		},
 	}
-	
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			
+
 			var vs models.VirtualService
 			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
 
@@ -402,7 +402,7 @@ spec:
 
 func TestVirtualServiceHasRequestRouting(t *testing.T) {
 	cases := map[string]struct {
-		vsYAML          []byte
+		vsYAML                 []byte
 		expectedRequestRouting bool
 	}{
 		"Has http request routing": {
@@ -508,7 +508,7 @@ spec:
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			
+
 			var vs models.VirtualService
 			assert.NoError(yaml.Unmarshal(tc.vsYAML, &vs))
 


### PR DESCRIPTION
Updates the istio appender to add the kiali scenario node metadata labels based on the VS spec instead of the presence of the wizard label.

Fixes: #4090 