### PR TITLE
be able to upload logs to different branches for ci-minikube and ci-openshift scripts

### DIFF
--- a/hack/ci-openshift-molecule-tests.sh
+++ b/hack/ci-openshift-molecule-tests.sh
@@ -97,7 +97,7 @@ Options:
 
 -lb|--logs-branch <branch name>
     The logs branch to clone.
-    Default: master
+    Default: openshift
 
 -lf|--logs-fork <name>
     The logs fork/org to clone.
@@ -212,7 +212,7 @@ KIALI_OPERATOR_BRANCH="${KIALI_OPERATOR_BRANCH:-master}"
 # details about the github repo where the logs are to be stored
 LOGS_PROJECT_NAME="${LOGS_PROJECT_NAME:-kiali-molecule-test-logs}"
 LOGS_FORK="${LOGS_FORK:-jmazzitelli}"
-LOGS_BRANCH="${LOGS_BRANCH:-master}"
+LOGS_BRANCH="${LOGS_BRANCH:-openshift}"
 
 LOGS_LOCAL_DIRNAME="${LOGS_PROJECT_NAME}"
 LOGS_LOCAL_DIRNAME_ABS="${SRC}/${LOGS_LOCAL_DIRNAME}"


### PR DESCRIPTION
This enables the ci-minikube to upload logs to a git repo just like ci-openshift can. In addition, this change allows both scripts to be told what branch to commit the logs to.

This allows us to upload the logs to a single git repo in different branchs. For example, the minikube test logs can go in branch "minikube" and the openshift test logs can go into the "openshift" branch. In fact, this is what I am now doing when running the nightly CI builds on my home machines: [minikube](https://github.com/jmazzitelli/kiali-molecule-test-logs/tree/minikube) and [openshift](https://github.com/jmazzitelli/kiali-molecule-test-logs/tree/openshift) logs.