### PR TITLE
VirtualService's exportTo field's value is restricted to “.” or “*”.

### DIFF
--- a/business/checkers/common/export_to_namespace_checker.go
+++ b/business/checkers/common/export_to_namespace_checker.go
@@ -17,7 +17,7 @@ func (p ExportToNamespaceChecker) Check() ([]*models.IstioCheck, bool) {
 	if exportToSpec, found := p.IstioObject.GetSpec()["exportTo"]; found {
 		if namespaces, ok := exportToSpec.([]interface{}); ok {
 			for nsIndex, namespace := range namespaces {
-				if namespace != "." && !p.Namespaces.Includes(namespace.(string)) {
+				if namespace != "." && namespace != "*" && !p.Namespaces.Includes(namespace.(string)) {
 					validation := models.Build("generic.exportto.namespacenotfound",
 						fmt.Sprintf("spec/exportTo[%d]", nsIndex))
 					validations = append(validations, &validation)

--- a/business/checkers/common/export_to_namespace_checker_test.go
+++ b/business/checkers/common/export_to_namespace_checker_test.go
@@ -19,6 +19,10 @@ func TestDRNamespaceNotFound(t *testing.T) {
 	assertIstioObjectInvalidNamespace("dr_exportto_invalid.yaml", "DestinationRule", 2, t)
 }
 
+func TestDRAllNamespaces(t *testing.T) {
+	assertIstioObjectValid("dr_exportto_all_valid.yaml", "DestinationRule", t)
+}
+
 func TestVSNamespaceExist(t *testing.T) {
 	assertIstioObjectValid("vs_exportto_valid.yaml", "VirtualService", t)
 }
@@ -27,12 +31,20 @@ func TestVSNamespaceNotFound(t *testing.T) {
 	assertIstioObjectInvalidNamespace("vs_exportto_invalid.yaml", "VirtualService", 2, t)
 }
 
+func TestVSAllNamespaces(t *testing.T) {
+	assertIstioObjectValid("vs_exportto_all_valid.yaml", "VirtualService", t)
+}
+
 func TestSENamespaceExist(t *testing.T) {
 	assertIstioObjectValid("se_exportto_valid.yaml", "ServiceEntry", t)
 }
 
 func TestSENamespaceNotFound(t *testing.T) {
 	assertIstioObjectInvalidNamespace("se_exportto_invalid.yaml", "ServiceEntry", 2, t)
+}
+
+func TestSEAllNamespaces(t *testing.T) {
+	assertIstioObjectValid("se_exportto_all_valid.yaml", "ServiceEntry", t)
 }
 
 func assertIstioObjectValid(scenario string, objectType string, t *testing.T) {

--- a/tests/data/validations/exportto/dr_exportto_all_valid.yaml
+++ b/tests/data/validations/exportto/dr_exportto_all_valid.yaml
@@ -1,0 +1,9 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "dr-exportto-all-valid"
+  namespace: "bookinfo"
+spec:
+  host: "*.local"
+  exportTo:
+    - "*"

--- a/tests/data/validations/exportto/se_exportto_all_valid.yaml
+++ b/tests/data/validations/exportto/se_exportto_all_valid.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: se_exportto_all_valid
+  namespace: bookinfo
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - "*"

--- a/tests/data/validations/exportto/vs_exportto_all_valid.yaml
+++ b/tests/data/validations/exportto/vs_exportto_all_valid.yaml
@@ -1,0 +1,10 @@
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: vs_exportto_all_valid
+  namespace: bookinfo
+spec:
+  hosts:
+    - '*'
+  exportTo:
+    - '*'


### PR DESCRIPTION
Fix for the issue https://github.com/kiali/kiali/issues/4203

Currently for VirtualService, in the current Istio release, the exportTo value is restricted to “.” or “*” (i.e., the current namespace or all namespaces).
![Screenshot from 2021-07-22 18-37-02](https://user-images.githubusercontent.com/604313/126676682-0124cff4-b92a-4941-b370-5acb9c299db1.png)

Modified according to Istio requirements.
Modified the tests.

For QE:
Verify that: VS now shows warning when exportTo is something different than "." or "*".
Regression test existing 'exportTo' scenarios for VS, SE and DR.
"*" is now explicitly supported and means that exporting to all namespaces.
"." is still supported for all.