### PR TITLE
Be able to ignore one or more validation checks

### DIFF
--- a/business/checkers/authorization/namespace_method_checker_test.go
+++ b/business/checkers/authorization/namespace_method_checker_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestSourceNamespaceExisting(t *testing.T) {
@@ -36,10 +36,10 @@ func TestSourceNamespaceNotFound(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Len(validations, 2)
-	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", validations[0]))
 	assert.Equal(validations[0].Severity, models.WarningSeverity)
 	assert.Equal(validations[0].Path, "spec/rules[0]/from[0]/source/namespaces[0]")
-	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", validations[1]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", validations[1]))
 	assert.Equal(validations[1].Severity, models.WarningSeverity)
 	assert.Equal(validations[1].Path, "spec/rules[0]/from[0]/source/namespaces[1]")
 }
@@ -59,7 +59,7 @@ func TestToMethodWrongHTTP(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 4)
 	for i, m := range []int{3, 4, 5} {
-		assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.to.wrongmethod", validations[i]))
+		assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.to.wrongmethod", validations[i]))
 		assert.Equal(validations[i].Severity, models.WarningSeverity)
 		assert.Equal(validations[i].Path, fmt.Sprintf("spec/rules[0]/to[0]/operation/methods[%d]", m))
 	}

--- a/business/checkers/authorization/namespace_method_checker_test.go
+++ b/business/checkers/authorization/namespace_method_checker_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -35,10 +36,10 @@ func TestSourceNamespaceNotFound(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Len(validations, 2)
-	assert.Equal(validations[0].Message, models.CheckMessage("authorizationpolicy.source.namespacenotfound"))
+	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", validations[0]))
 	assert.Equal(validations[0].Severity, models.WarningSeverity)
 	assert.Equal(validations[0].Path, "spec/rules[0]/from[0]/source/namespaces[0]")
-	assert.Equal(validations[1].Message, models.CheckMessage("authorizationpolicy.source.namespacenotfound"))
+	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", validations[1]))
 	assert.Equal(validations[1].Severity, models.WarningSeverity)
 	assert.Equal(validations[1].Path, "spec/rules[0]/from[0]/source/namespaces[1]")
 }
@@ -58,7 +59,7 @@ func TestToMethodWrongHTTP(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 4)
 	for i, m := range []int{3, 4, 5} {
-		assert.Equal(validations[i].Message, models.CheckMessage("authorizationpolicy.to.wrongmethod"))
+		assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.to.wrongmethod", validations[i]))
 		assert.Equal(validations[i].Severity, models.WarningSeverity)
 		assert.Equal(validations[i].Path, fmt.Sprintf("spec/rules[0]/to[0]/operation/methods[%d]", m))
 	}

--- a/business/checkers/authorization/no_host_checker_test.go
+++ b/business/checkers/authorization/no_host_checker_test.go
@@ -7,10 +7,10 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestPresentService(t *testing.T) {
@@ -45,7 +45,7 @@ func TestNonExistingService(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[1]", validations[0].Path)
 }
 
@@ -80,10 +80,10 @@ func TestWildcardHostOutsideNamespace(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 2)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("validation.unable.cross-namespace", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("validation.unable.cross-namespace", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", validations[0].Path)
 	assert.Equal(models.Unknown, validations[1].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("validation.unable.cross-namespace", validations[1]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("validation.unable.cross-namespace", validations[1]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[1]", validations[1].Path)
 }
 
@@ -122,7 +122,7 @@ func TestServiceEntryNotPresent(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", validations[0].Path)
 }
 
@@ -161,7 +161,7 @@ func TestVirtualServiceNotPresent(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", validations[0].Path)
 }
 
@@ -196,7 +196,7 @@ func TestWildcardServiceEntryHost(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", validations[0].Path)
 }
 

--- a/business/checkers/authorization/no_host_checker_test.go
+++ b/business/checkers/authorization/no_host_checker_test.go
@@ -7,6 +7,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -44,7 +45,7 @@ func TestNonExistingService(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("authorizationpolicy.nodest.matchingregistry"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[1]", validations[0].Path)
 }
 
@@ -79,10 +80,10 @@ func TestWildcardHostOutsideNamespace(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 2)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.Equal(models.CheckMessage("validation.unable.cross-namespace"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("validation.unable.cross-namespace", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", validations[0].Path)
 	assert.Equal(models.Unknown, validations[1].Severity)
-	assert.Equal(models.CheckMessage("validation.unable.cross-namespace"), validations[1].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("validation.unable.cross-namespace", validations[1]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[1]", validations[1].Path)
 }
 
@@ -121,7 +122,7 @@ func TestServiceEntryNotPresent(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("authorizationpolicy.nodest.matchingregistry"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", validations[0].Path)
 }
 
@@ -160,7 +161,7 @@ func TestVirtualServiceNotPresent(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("authorizationpolicy.nodest.matchingregistry"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", validations[0].Path)
 }
 
@@ -195,7 +196,7 @@ func TestWildcardServiceEntryHost(t *testing.T) {
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("authorizationpolicy.nodest.matchingregistry"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", validations[0].Path)
 }
 

--- a/business/checkers/common/check_confirmer.go
+++ b/business/checkers/common/check_confirmer.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/kiali/kiali/models"
+)
+
+// ConfirmIstioCheckMessage can be used by the validation tests to confirm the Istio Check received is what was expected
+func ConfirmIstioCheckMessage(expectedIstioCheckKey string, actualIstioCheck *models.IstioCheck) error {
+	expected := models.CheckMessage(expectedIstioCheckKey)
+	actual := actualIstioCheck.GetFullMessage()
+	if expected == actual {
+		return nil
+	} else {
+		return fmt.Errorf("IstioCheck: expected [%s], actual [%s]", expected, actual)
+	}
+}

--- a/business/checkers/common/check_confirmer_test.go
+++ b/business/checkers/common/check_confirmer_test.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/models"
+)
+
+func TestAssertCheckMessageTestFunction(t *testing.T) {
+	check := models.IstioCheck{
+		Code:     "KIA0003",
+		Message:  "More than one object applied to the same workload",
+		Severity: models.ErrorSeverity,
+	}
+	assert.NoError(t, ConfirmIstioCheckMessage("generic.multimatch.selector", &check))
+}

--- a/business/checkers/common/export_to_namespace_checker.go
+++ b/business/checkers/common/export_to_namespace_checker.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )

--- a/business/checkers/common/export_to_namespace_checker_test.go
+++ b/business/checkers/common/export_to_namespace_checker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestDRNamespaceExist(t *testing.T) {
@@ -54,7 +55,7 @@ func assertIstioObjectInvalidNamespace(scenario string, objectType string, error
 	assert.NotEmpty(validations)
 	assert.Len(validations, errorNumbers)
 	for i := 0; i < errorNumbers; i++ {
-		assert.NoError(ConfirmIstioCheckMessage("generic.exportto.namespacenotfound", validations[i]))
+		assert.NoError(testutils.ConfirmIstioCheckMessage("generic.exportto.namespacenotfound", validations[i]))
 		assert.Equal(validations[i].Severity, models.ErrorSeverity)
 		assert.Equal(validations[i].Path, fmt.Sprintf("spec/exportTo[%d]", i))
 	}

--- a/business/checkers/common/export_to_namespace_checker_test.go
+++ b/business/checkers/common/export_to_namespace_checker_test.go
@@ -2,11 +2,11 @@ package common
 
 import (
 	"fmt"
-	"github.com/kiali/kiali/config"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 )
@@ -54,7 +54,7 @@ func assertIstioObjectInvalidNamespace(scenario string, objectType string, error
 	assert.NotEmpty(validations)
 	assert.Len(validations, errorNumbers)
 	for i := 0; i < errorNumbers; i++ {
-		assert.Equal(validations[i].Message, models.CheckMessage("generic.exportto.namespacenotfound"))
+		assert.NoError(ConfirmIstioCheckMessage("generic.exportto.namespacenotfound", validations[i]))
 		assert.Equal(validations[i].Severity, models.ErrorSeverity)
 		assert.Equal(validations[i].Path, fmt.Sprintf("spec/exportTo[%d]", i))
 	}

--- a/business/checkers/common/multi_match_selector_checker_test.go
+++ b/business/checkers/common/multi_match_selector_checker_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestTwoSidecarsWithSelector(t *testing.T) {
@@ -81,7 +82,7 @@ func assertMultimatchFailure(t *testing.T, code string, validations models.Istio
 	// Assert object's checks
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.ErrorSeverity, validation.Checks[0].Severity)
-	assert.NoError(ConfirmIstioCheckMessage(code, validation.Checks[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage(code, validation.Checks[0]))
 
 	// Assert referenced objects
 	assert.Len(validation.References, len(references))

--- a/business/checkers/common/multi_match_selector_checker_test.go
+++ b/business/checkers/common/multi_match_selector_checker_test.go
@@ -81,7 +81,7 @@ func assertMultimatchFailure(t *testing.T, code string, validations models.Istio
 	// Assert object's checks
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.ErrorSeverity, validation.Checks[0].Severity)
-	assert.Equal(models.CheckMessage(code), validation.Checks[0].Message)
+	assert.NoError(ConfirmIstioCheckMessage(code, validation.Checks[0]))
 
 	// Assert referenced objects
 	assert.Len(validation.References, len(references))

--- a/business/checkers/common/workload_selector_checker_test.go
+++ b/business/checkers/common/workload_selector_checker_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestPresentWorkloads(t *testing.T) {
@@ -66,7 +67,7 @@ func testFailure(assert *assert.Assertions, selector map[string]interface{}, wl 
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
-	assert.NoError(ConfirmIstioCheckMessage(code, validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage(code, validations[0]))
 	assert.Equal(validations[0].Severity, models.WarningSeverity)
 	assert.Equal(validations[0].Path, "spec/workloadSelector/labels")
 }

--- a/business/checkers/common/workload_selector_checker_test.go
+++ b/business/checkers/common/workload_selector_checker_test.go
@@ -66,7 +66,7 @@ func testFailure(assert *assert.Assertions, selector map[string]interface{}, wl 
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
-	assert.Equal(validations[0].Message, models.CheckMessage(code))
+	assert.NoError(ConfirmIstioCheckMessage(code, validations[0]))
 	assert.Equal(validations[0].Severity, models.WarningSeverity)
 	assert.Equal(validations[0].Path, "spec/workloadSelector/labels")
 }

--- a/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -214,5 +215,5 @@ func testDisabledMtlsValidationsFound(t *testing.T, validationId string, destina
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
-	assert.Equal(models.CheckMessage(validationId), validation.Message)
+	assert.NoError(common.ConfirmIstioCheckMessage(validationId, validation))
 }

--- a/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 // Context: DestinationRule ns-wide disabling mTLS connections
@@ -215,5 +215,5 @@ func testDisabledMtlsValidationsFound(t *testing.T, validationId string, destina
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
-	assert.NoError(common.ConfirmIstioCheckMessage(validationId, validation))
+	assert.NoError(testutils.ConfirmIstioCheckMessage(validationId, validation))
 }

--- a/business/checkers/destinationrules/meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -134,7 +135,7 @@ func testReturnsAValidation(t *testing.T, destinationRule kubernetes.IstioObject
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
-	assert.Equal(models.CheckMessage("destinationrules.mtls.meshpolicymissing"), validation.Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.mtls.meshpolicymissing", validation))
 }
 
 func testNoValidationsFound(t *testing.T, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {

--- a/business/checkers/destinationrules/meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 // Context: DestinationRule enables mesh-wide mTLS
@@ -135,7 +135,7 @@ func testReturnsAValidation(t *testing.T, destinationRule kubernetes.IstioObject
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.mtls.meshpolicymissing", validation))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.mtls.meshpolicymissing", validation))
 }
 
 func testNoValidationsFound(t *testing.T, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestMultiHostMatchCorrect(t *testing.T) {
@@ -64,7 +64,7 @@ func validationAssertion(assert *assert.Assertions, validations models.IstioVali
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.multimatch", validation.Checks[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.multimatch", validation.Checks[0]))
 
 	assert.NotEmpty(validation.References)
 	for _, refName := range refNames {
@@ -100,7 +100,7 @@ func TestMultiHostMatchInvalidShortFormat(t *testing.T) {
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.multimatch", validation.Checks[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.multimatch", validation.Checks[0]))
 
 	assert.NotEmpty(validation.References)
 	assert.Equal("rule1", validation.References[0].Name)

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -63,7 +64,7 @@ func validationAssertion(assert *assert.Assertions, validations models.IstioVali
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.multimatch"), validation.Checks[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.multimatch", validation.Checks[0]))
 
 	assert.NotEmpty(validation.References)
 	for _, refName := range refNames {
@@ -99,7 +100,7 @@ func TestMultiHostMatchInvalidShortFormat(t *testing.T) {
 	assert.True(validation.Valid) // As long as it is warning, this is true
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.multimatch"), validation.Checks[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.multimatch", validation.Checks[0]))
 
 	assert.NotEmpty(validation.References)
 	assert.Equal("rule1", validation.References[0].Name)

--- a/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -109,5 +110,5 @@ func TestMTLSNsWideDREnabledWithoutPolicy(t *testing.T) {
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
-	assert.Equal(models.CheckMessage("destinationrules.mtls.nspolicymissing"), validation.Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.mtls.nspolicymissing", validation))
 }

--- a/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 // Context: DestinationRule enables namespace-wide mTLS
@@ -110,5 +110,5 @@ func TestMTLSNsWideDREnabledWithoutPolicy(t *testing.T) {
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.mtls.nspolicymissing", validation))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.mtls.nspolicymissing", validation))
 }

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -7,6 +7,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -118,7 +119,7 @@ func TestValidServiceNamespaceInvalid(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.nodest.matchingregistry"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/host", validations[0].Path)
 }
 
@@ -171,7 +172,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.nodest.matchingregistry"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/host", validations[0].Path)
 }
 
@@ -194,7 +195,7 @@ func TestNoMatchingSubset(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.nodest.subsetlabels"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", validations[0]))
 	assert.Equal("spec/subsets[0]", validations[0].Path)
 }
 
@@ -229,7 +230,7 @@ func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.nodest.subsetlabels"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", validations[0]))
 	assert.Equal("spec/subsets[0]", validations[0].Path)
 }
 
@@ -331,7 +332,7 @@ func TestNoLabelsInSubset(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.WarningSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("destinationrules.nodest.subsetnolabels"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.subsetnolabels", validations[0]))
 	assert.Equal("spec/subsets[0]", validations[0].Path)
 
 }

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -7,11 +7,11 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func appVersionLabel(app, version string) map[string]string {
@@ -119,7 +119,7 @@ func TestValidServiceNamespaceInvalid(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/host", validations[0].Path)
 }
 
@@ -172,7 +172,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", validations[0]))
 	assert.Equal("spec/host", validations[0].Path)
 }
 
@@ -195,7 +195,7 @@ func TestNoMatchingSubset(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", validations[0]))
 	assert.Equal("spec/subsets[0]", validations[0].Path)
 }
 
@@ -230,7 +230,7 @@ func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", validations[0]))
 	assert.Equal("spec/subsets[0]", validations[0].Path)
 }
 
@@ -332,7 +332,7 @@ func TestNoLabelsInSubset(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.WarningSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.subsetnolabels", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.subsetnolabels", validations[0]))
 	assert.Equal("spec/subsets[0]", validations[0].Path)
 
 }

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 // Context: MeshPolicy Enabling mTLS
@@ -256,7 +256,7 @@ func testValidationAdded(t *testing.T, destinationRules []kubernetes.IstioObject
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
 	assert.Equal("spec/trafficPolicy", validation.Checks[0].Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.trafficpolicy.notlssettings", validation.Checks[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.trafficpolicy.notlssettings", validation.Checks[0]))
 
 	assert.True(len(validation.References) > 0)
 	return validation

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -255,7 +256,7 @@ func testValidationAdded(t *testing.T, destinationRules []kubernetes.IstioObject
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
 	assert.Equal("spec/trafficPolicy", validation.Checks[0].Path)
-	assert.Equal(models.CheckMessage("destinationrules.trafficpolicy.notlssettings"), validation.Checks[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.trafficpolicy.notlssettings", validation.Checks[0]))
 
 	assert.True(len(validation.References) > 0)
 	return validation

--- a/business/checkers/gateways/port_checker_test.go
+++ b/business/checkers/gateways/port_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestValidPortDefinition(t *testing.T) {
@@ -42,6 +42,6 @@ func TestInvalidPortDefinition(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
 	assert.Equal("spec/servers[0]/port/name", validations[0].Path)
 }

--- a/business/checkers/gateways/port_checker_test.go
+++ b/business/checkers/gateways/port_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -41,6 +42,6 @@ func TestInvalidPortDefinition(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("port.name.mismatch"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
 	assert.Equal("spec/servers[0]/port/name", validations[0].Path)
 }

--- a/business/checkers/gateways/selector_checker_test.go
+++ b/business/checkers/gateways/selector_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -114,6 +115,6 @@ func TestMissingSelectorTarget(t *testing.T) {
 
 	assert.False(valid)
 	assert.Equal(1, len(validations))
-	assert.Equal(models.CheckMessage("gateways.selector"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("gateways.selector", validations[0]))
 	assert.Equal(models.WarningSeverity, validations[0].Severity)
 }

--- a/business/checkers/gateways/selector_checker_test.go
+++ b/business/checkers/gateways/selector_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestValidInternalSelector(t *testing.T) {
@@ -115,6 +115,6 @@ func TestMissingSelectorTarget(t *testing.T) {
 
 	assert.False(valid)
 	assert.Equal(1, len(validations))
-	assert.NoError(common.ConfirmIstioCheckMessage("gateways.selector", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("gateways.selector", validations[0]))
 	assert.Equal(models.WarningSeverity, validations[0].Severity)
 }

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -7,6 +7,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -82,7 +83,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.False(customerDr.Valid)
 	assert.Equal(1, len(customerDr.Checks))
 	assert.Equal("spec/host", customerDr.Checks[0].Path)
-	assert.Equal(models.CheckMessage("destinationrules.nodest.matchingregistry"), customerDr.Checks[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", customerDr.Checks[0]))
 
 	validations = NoServiceChecker{
 		Namespace: "test",
@@ -105,9 +106,9 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.False(productVs.Valid)
 	assert.Equal(2, len(productVs.Checks))
 	assert.Equal("spec/http[0]/route[0]/destination/host", productVs.Checks[0].Path)
-	assert.Equal(models.CheckMessage("virtualservices.nohost.hostnotfound"), productVs.Checks[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", productVs.Checks[0]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", productVs.Checks[1].Path)
-	assert.Equal(models.CheckMessage("virtualservices.nohost.hostnotfound"), productVs.Checks[1].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", productVs.Checks[1]))
 
 	validations = NoServiceChecker{
 		Namespace: "test",
@@ -167,7 +168,7 @@ func TestObjectWithoutGateway(t *testing.T) {
 
 	productVs := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}]
 	assert.False(productVs.Valid)
-	assert.Equal(models.CheckMessage("virtualservices.nogateway"), productVs.Checks[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[0]))
 }
 
 func fakeIstioDetails() *kubernetes.IstioDetails {

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -7,11 +7,11 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestNoCrashOnNil(t *testing.T) {
@@ -83,7 +83,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.False(customerDr.Valid)
 	assert.Equal(1, len(customerDr.Checks))
 	assert.Equal("spec/host", customerDr.Checks[0].Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", customerDr.Checks[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", customerDr.Checks[0]))
 
 	validations = NoServiceChecker{
 		Namespace: "test",
@@ -106,9 +106,9 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.False(productVs.Valid)
 	assert.Equal(2, len(productVs.Checks))
 	assert.Equal("spec/http[0]/route[0]/destination/host", productVs.Checks[0].Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", productVs.Checks[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", productVs.Checks[0]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", productVs.Checks[1].Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", productVs.Checks[1]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", productVs.Checks[1]))
 
 	validations = NoServiceChecker{
 		Namespace: "test",
@@ -168,7 +168,7 @@ func TestObjectWithoutGateway(t *testing.T) {
 
 	productVs := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}]
 	assert.False(productVs.Valid)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[0]))
 }
 
 func fakeIstioDetails() *kubernetes.IstioDetails {

--- a/business/checkers/peerauthentications/mesh_mtls_checker_test.go
+++ b/business/checkers/peerauthentications/mesh_mtls_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -141,7 +142,7 @@ func testValidationAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDe
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/mtls", validation.Path)
-	assert.Equal(models.CheckMessage("peerauthentication.mtls.destinationrulemissing"), validation.Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("peerauthentication.mtls.destinationrulemissing", validation))
 }
 
 func testValidationsNotAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {

--- a/business/checkers/peerauthentications/mesh_mtls_checker_test.go
+++ b/business/checkers/peerauthentications/mesh_mtls_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 // Describe the validation of a MeshPolicy that enables mTLS. The validation is risen when there isn't any
@@ -142,7 +142,7 @@ func testValidationAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDe
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/mtls", validation.Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("peerauthentication.mtls.destinationrulemissing", validation))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("peerauthentication.mtls.destinationrulemissing", validation))
 }
 
 func testValidationsNotAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {

--- a/business/checkers/peerauthentications/namespace_mtls_checker_test.go
+++ b/business/checkers/peerauthentications/namespace_mtls_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -42,7 +43,7 @@ func TestPeerAuthnmTLSEnabled(t *testing.T) {
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/mtls", validation.Path)
-	assert.Equal(models.CheckMessage("peerauthentications.mtls.destinationrulemissing"), validation.Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("peerauthentications.mtls.destinationrulemissing", validation))
 }
 
 // Context: PeerAuthn enables mTLS for a namespace

--- a/business/checkers/peerauthentications/namespace_mtls_checker_test.go
+++ b/business/checkers/peerauthentications/namespace_mtls_checker_test.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 // Describe the validation of a PeerAuthn that enables mTLS for one namespace. The validation is risen when there isn't any
@@ -43,7 +43,7 @@ func TestPeerAuthnmTLSEnabled(t *testing.T) {
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/mtls", validation.Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("peerauthentications.mtls.destinationrulemissing", validation))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("peerauthentications.mtls.destinationrulemissing", validation))
 }
 
 // Context: PeerAuthn enables mTLS for a namespace

--- a/business/checkers/serviceentries/port_checker_test.go
+++ b/business/checkers/serviceentries/port_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestValidPortDefinition(t *testing.T) {
@@ -44,6 +44,6 @@ func TestInvalidPortDefinition(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
 	assert.Equal("spec/ports[0]/name", validations[0].Path)
 }

--- a/business/checkers/serviceentries/port_checker_test.go
+++ b/business/checkers/serviceentries/port_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -43,6 +44,6 @@ func TestInvalidPortDefinition(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("port.name.mismatch"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
 	assert.Equal("spec/ports[0]/name", validations[0].Path)
 }

--- a/business/checkers/services/port_mapping_checker_test.go
+++ b/business/checkers/services/port_mapping_checker_test.go
@@ -9,8 +9,8 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestPortMappingMatch(t *testing.T) {
@@ -82,7 +82,7 @@ func TestPortMappingMismatch(t *testing.T) {
 	validations, valid := pmc.Check()
 	assert.False(valid)
 	assert.NotEmpty(validations)
-	assert.NoError(common.ConfirmIstioCheckMessage("service.deployment.port.mismatch", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("service.deployment.port.mismatch", validations[0]))
 	assert.Equal("spec/ports[0]", validations[0].Path)
 }
 
@@ -101,7 +101,7 @@ func TestServicePortNaming(t *testing.T) {
 	validations, valid := pmc.Check()
 	assert.False(valid)
 	assert.NotEmpty(validations)
-	assert.NoError(common.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
 	assert.Equal("spec/ports[0]", validations[0].Path)
 }
 

--- a/business/checkers/services/port_mapping_checker_test.go
+++ b/business/checkers/services/port_mapping_checker_test.go
@@ -9,8 +9,8 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/models"
 )
 
 func TestPortMappingMatch(t *testing.T) {
@@ -82,7 +82,7 @@ func TestPortMappingMismatch(t *testing.T) {
 	validations, valid := pmc.Check()
 	assert.False(valid)
 	assert.NotEmpty(validations)
-	assert.Equal(models.CheckMessage("service.deployment.port.mismatch"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("service.deployment.port.mismatch", validations[0]))
 	assert.Equal("spec/ports[0]", validations[0].Path)
 }
 
@@ -101,7 +101,7 @@ func TestServicePortNaming(t *testing.T) {
 	validations, valid := pmc.Check()
 	assert.False(valid)
 	assert.NotEmpty(validations)
-	assert.Equal(models.CheckMessage("port.name.mismatch"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
 	assert.Equal("spec/ports[0]", validations[0].Path)
 }
 

--- a/business/checkers/sidecars/egress_listener_checker_test.go
+++ b/business/checkers/sidecars/egress_listener_checker_test.go
@@ -8,6 +8,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -62,7 +63,7 @@ func TestEgressHostCrossNamespace(t *testing.T) {
 	for i, c := range validations {
 		assert.Equal(models.Unknown, c.Severity)
 		assert.Equal(fmt.Sprintf("spec/egress[0]/hosts[%d]", i), c.Path)
-		assert.Equal(models.CheckMessage("validation.unable.cross-namespace"), c.Message)
+		assert.NoError(common.ConfirmIstioCheckMessage("validation.unable.cross-namespace", c))
 	}
 }
 
@@ -81,7 +82,7 @@ func TestEgressInvalidHostFormat(t *testing.T) {
 
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
 	assert.Equal("spec/egress[0]/hosts[0]", validations[0].Path)
-	assert.Equal(models.CheckMessage("sidecar.egress.invalidhostformat"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("sidecar.egress.invalidhostformat", validations[0]))
 }
 
 func TestEgressServiceNotFound(t *testing.T) {
@@ -101,7 +102,7 @@ func TestEgressServiceNotFound(t *testing.T) {
 	for i, c := range validations {
 		assert.Equal(models.WarningSeverity, c.Severity)
 		assert.Equal(fmt.Sprintf("spec/egress[0]/hosts[%d]", i), c.Path)
-		assert.Equal(models.CheckMessage("sidecar.egress.servicenotfound"), c.Message)
+		assert.NoError(common.ConfirmIstioCheckMessage("sidecar.egress.servicenotfound", c))
 	}
 }
 

--- a/business/checkers/sidecars/egress_listener_checker_test.go
+++ b/business/checkers/sidecars/egress_listener_checker_test.go
@@ -8,10 +8,10 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestEgressHostFormatCorrect(t *testing.T) {
@@ -63,7 +63,7 @@ func TestEgressHostCrossNamespace(t *testing.T) {
 	for i, c := range validations {
 		assert.Equal(models.Unknown, c.Severity)
 		assert.Equal(fmt.Sprintf("spec/egress[0]/hosts[%d]", i), c.Path)
-		assert.NoError(common.ConfirmIstioCheckMessage("validation.unable.cross-namespace", c))
+		assert.NoError(testutils.ConfirmIstioCheckMessage("validation.unable.cross-namespace", c))
 	}
 }
 
@@ -82,7 +82,7 @@ func TestEgressInvalidHostFormat(t *testing.T) {
 
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
 	assert.Equal("spec/egress[0]/hosts[0]", validations[0].Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("sidecar.egress.invalidhostformat", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("sidecar.egress.invalidhostformat", validations[0]))
 }
 
 func TestEgressServiceNotFound(t *testing.T) {
@@ -102,7 +102,7 @@ func TestEgressServiceNotFound(t *testing.T) {
 	for i, c := range validations {
 		assert.Equal(models.WarningSeverity, c.Severity)
 		assert.Equal(fmt.Sprintf("spec/egress[0]/hosts[%d]", i), c.Path)
-		assert.NoError(common.ConfirmIstioCheckMessage("sidecar.egress.servicenotfound", c))
+		assert.NoError(testutils.ConfirmIstioCheckMessage("sidecar.egress.servicenotfound", c))
 	}
 }
 

--- a/business/checkers/sidecars/global_checker_test.go
+++ b/business/checkers/sidecars/global_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestSidecarWithoutSelectorOutOfControlPlane(t *testing.T) {
@@ -70,5 +70,5 @@ func TestSidecarWithSelectorInControlPlane(t *testing.T) {
 
 	assert.Len(validations, 1)
 	assert.Equal(models.WarningSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("sidecar.global.selector", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("sidecar.global.selector", validations[0]))
 }

--- a/business/checkers/sidecars/global_checker_test.go
+++ b/business/checkers/sidecars/global_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -69,5 +70,5 @@ func TestSidecarWithSelectorInControlPlane(t *testing.T) {
 
 	assert.Len(validations, 1)
 	assert.Equal(models.WarningSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("sidecar.global.selector"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("sidecar.global.selector", validations[0]))
 }

--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -27,7 +28,7 @@ func TestMissingGateway(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.nogateway"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
 }
 
 func TestMissingGatewayInHTTPMatch(t *testing.T) {
@@ -63,7 +64,7 @@ func TestMissingGatewayInHTTPMatch(t *testing.T) {
 			assert.False(valid)
 			assert.NotEmpty(validations)
 			assert.Equal(models.ErrorSeverity, validations[0].Severity)
-			assert.Equal(models.CheckMessage("virtualservices.nogateway"), validations[0].Message)
+			assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
 		})
 	}
 }
@@ -85,7 +86,7 @@ func TestValidAndMissingGateway(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.nogateway"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
 }
 
 func TestFoundGateway(t *testing.T) {
@@ -131,7 +132,7 @@ func TestFoundGatewayTwoPartNaming(t *testing.T) {
 	assert.True(valid)
 	assert.Len(validations, 1)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.gateway.oldnomenclature"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
 }
 
 func TestFQDNFoundGateway(t *testing.T) {
@@ -156,7 +157,7 @@ func TestFQDNFoundGateway(t *testing.T) {
 	assert.True(valid)
 	assert.Len(validations, 1)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.gateway.oldnomenclature"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
 }
 
 func TestFQDNFoundOtherNamespaceGateway(t *testing.T) {
@@ -182,7 +183,7 @@ func TestFQDNFoundOtherNamespaceGateway(t *testing.T) {
 	assert.True(valid)
 	assert.Len(validations, 1)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.gateway.oldnomenclature"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
 }
 
 func TestNewIstioGatewayNameFormat(t *testing.T) {

--- a/business/checkers/virtual_services/no_gateway_checker_test.go
+++ b/business/checkers/virtual_services/no_gateway_checker_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestMissingGateway(t *testing.T) {
@@ -28,7 +28,7 @@ func TestMissingGateway(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
 }
 
 func TestMissingGatewayInHTTPMatch(t *testing.T) {
@@ -64,7 +64,7 @@ func TestMissingGatewayInHTTPMatch(t *testing.T) {
 			assert.False(valid)
 			assert.NotEmpty(validations)
 			assert.Equal(models.ErrorSeverity, validations[0].Severity)
-			assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
+			assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
 		})
 	}
 }
@@ -86,7 +86,7 @@ func TestValidAndMissingGateway(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
 }
 
 func TestFoundGateway(t *testing.T) {
@@ -132,7 +132,7 @@ func TestFoundGatewayTwoPartNaming(t *testing.T) {
 	assert.True(valid)
 	assert.Len(validations, 1)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
 }
 
 func TestFQDNFoundGateway(t *testing.T) {
@@ -157,7 +157,7 @@ func TestFQDNFoundGateway(t *testing.T) {
 	assert.True(valid)
 	assert.Len(validations, 1)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
 }
 
 func TestFQDNFoundOtherNamespaceGateway(t *testing.T) {
@@ -183,7 +183,7 @@ func TestFQDNFoundOtherNamespaceGateway(t *testing.T) {
 	assert.True(valid)
 	assert.Len(validations, 1)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
 }
 
 func TestNewIstioGatewayNameFormat(t *testing.T) {

--- a/business/checkers/virtual_services/no_host_checker_test.go
+++ b/business/checkers/virtual_services/no_host_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -41,10 +42,10 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.nohost.hostnotfound"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", validations[0]))
 	assert.Equal("spec/http[0]/route[0]/destination/host", validations[0].Path)
 	assert.Equal(models.ErrorSeverity, validations[1].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.nohost.hostnotfound"), validations[1].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", validations[1]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", validations[1].Path)
 
 	delete(virtualService.GetSpec(), "http")
@@ -58,7 +59,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.nohost.hostnotfound"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", validations[0]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", validations[0].Path)
 
 	delete(virtualService.GetSpec(), "tcp")
@@ -72,7 +73,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.nohost.invalidprotocol"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.invalidprotocol", validations[0]))
 	assert.Equal("", validations[0].Path)
 }
 
@@ -99,7 +100,7 @@ func TestInvalidServiceNamespaceFormatHost(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.Equal(models.CheckMessage("validation.unable.cross-namespace"), validations[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("validation.unable.cross-namespace", validations[0]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", validations[0].Path)
 }
 

--- a/business/checkers/virtual_services/no_host_checker_test.go
+++ b/business/checkers/virtual_services/no_host_checker_test.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestValidHost(t *testing.T) {
@@ -42,10 +42,10 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", validations[0]))
 	assert.Equal("spec/http[0]/route[0]/destination/host", validations[0].Path)
 	assert.Equal(models.ErrorSeverity, validations[1].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", validations[1]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", validations[1]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", validations[1].Path)
 
 	delete(virtualService.GetSpec(), "http")
@@ -59,7 +59,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", validations[0]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", validations[0].Path)
 
 	delete(virtualService.GetSpec(), "tcp")
@@ -73,7 +73,7 @@ func TestNoValidHost(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.nohost.invalidprotocol", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nohost.invalidprotocol", validations[0]))
 	assert.Equal("", validations[0].Path)
 }
 
@@ -100,7 +100,7 @@ func TestInvalidServiceNamespaceFormatHost(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("validation.unable.cross-namespace", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("validation.unable.cross-namespace", validations[0]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", validations[0].Path)
 }
 

--- a/business/checkers/virtual_services/route_checker_test.go
+++ b/business/checkers/virtual_services/route_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -32,7 +33,7 @@ func TestServiceMultipleChecks(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
-	assert.Equal(validations[0].Message, models.CheckMessage("virtualservices.route.singleweight"))
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.route.singleweight", validations[0]))
 	assert.Equal(validations[0].Severity, models.WarningSeverity)
 	assert.Equal(validations[0].Path, "spec/http[0]/route[0]/weight")
 }
@@ -44,10 +45,10 @@ func TestVSWithRepeatingSubsets(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Len(validations, 4)
-	assert.Equal(validations[0].Message, models.CheckMessage("virtualservices.route.repeatedsubset"))
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", validations[0]))
 	assert.Equal(validations[0].Severity, models.WarningSeverity)
 	assert.Regexp(`spec\/http\[0\]\/route\[[0,2]\]\/subset`, validations[0].Path)
-	assert.Equal(validations[3].Message, models.CheckMessage("virtualservices.route.repeatedsubset"))
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", validations[3]))
 	assert.Equal(validations[3].Severity, models.WarningSeverity)
 	assert.Regexp(`spec\/http\[0\]\/route\[[1,3]\]\/subset`, validations[3].Path)
 }

--- a/business/checkers/virtual_services/route_checker_test.go
+++ b/business/checkers/virtual_services/route_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 // VirtualService has two routes that all the weights sum 100
@@ -33,7 +33,7 @@ func TestServiceMultipleChecks(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Len(validations, 1)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.route.singleweight", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.route.singleweight", validations[0]))
 	assert.Equal(validations[0].Severity, models.WarningSeverity)
 	assert.Equal(validations[0].Path, "spec/http[0]/route[0]/weight")
 }
@@ -45,10 +45,10 @@ func TestVSWithRepeatingSubsets(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(validations)
 	assert.Len(validations, 4)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", validations[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", validations[0]))
 	assert.Equal(validations[0].Severity, models.WarningSeverity)
 	assert.Regexp(`spec\/http\[0\]\/route\[[0,2]\]\/subset`, validations[0].Path)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", validations[3]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", validations[3]))
 	assert.Equal(validations[3].Severity, models.WarningSeverity)
 	assert.Regexp(`spec\/http\[0\]\/route\[[1,3]\]\/subset`, validations[3].Path)
 }

--- a/business/checkers/virtual_services/single_host_checker_test.go
+++ b/business/checkers/virtual_services/single_host_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 func TestOneVirtualServicePerHost(t *testing.T) {
@@ -502,7 +502,7 @@ func presentValidationTest(t *testing.T, validations models.IstioValidations, se
 	assert.True(validation.Valid)
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.singlehost", validation.Checks[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.singlehost", validation.Checks[0]))
 	assert.Equal("spec/hosts", validation.Checks[0].Path)
 }
 

--- a/business/checkers/virtual_services/single_host_checker_test.go
+++ b/business/checkers/virtual_services/single_host_checker_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -501,7 +502,7 @@ func presentValidationTest(t *testing.T, validations models.IstioValidations, se
 	assert.True(validation.Valid)
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.Equal(models.CheckMessage("virtualservices.singlehost"), validation.Checks[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage("virtualservices.singlehost", validation.Checks[0]))
 	assert.Equal("spec/hosts", validation.Checks[0].Path)
 }
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -222,6 +222,8 @@ func runObjectCheckers(objectCheckers []ObjectChecker) models.IstioValidations {
 		objectTypeValidations.MergeValidations(objectChecker.Check())
 	}
 
+	objectTypeValidations.StripIgnoredChecks()
+
 	return objectTypeValidations
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -348,11 +348,17 @@ type UIDefaults struct {
 	RefreshInterval   string          `yaml:"refresh_interval,omitempty" json:"refreshInterval,omitempty"`
 }
 
+// Validations defines default settings configured for the Validations subsystem
+type Validations struct {
+	Ignore []string `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+}
+
 // KialiFeatureFlags available from the CR
 type KialiFeatureFlags struct {
-	IstioInjectionAction bool       `yaml:"istio_injection_action,omitempty" json:"istioInjectionAction"`
-	IstioUpgradeAction   bool       `yaml:"istio_upgrade_action,omitempty" json:"istioUpgradeAction"`
-	UIDefaults           UIDefaults `yaml:"ui_defaults,omitempty" json:"uiDefaults,omitempty"`
+	IstioInjectionAction bool        `yaml:"istio_injection_action,omitempty" json:"istioInjectionAction"`
+	IstioUpgradeAction   bool        `yaml:"istio_upgrade_action,omitempty" json:"istioUpgradeAction"`
+	UIDefaults           UIDefaults  `yaml:"ui_defaults,omitempty" json:"uiDefaults,omitempty"`
+	Validations          Validations `yaml:"validations,omitempty" json:"validations,omitempty"`
 }
 
 // Tolerance config
@@ -559,6 +565,9 @@ func NewConfig() (c *Config) {
 				MetricsPerRefresh: "1m",
 				Namespaces:        make([]string, 0),
 				RefreshInterval:   "15s",
+			},
+			Validations: Validations{
+				Ignore: make([]string, 0),
 			},
 		},
 		KubernetesConfig: KubernetesConfig{

--- a/kiali.go
+++ b/kiali.go
@@ -165,7 +165,7 @@ func validateConfig() error {
 
 	// log a warning if the user is ignoring some validations
 	if len(cfg.KialiFeatureFlags.Validations.Ignore) > 0 {
-		log.Warningf("Some validation errors will be ignored %v. If these errors do occur, they will still be logged. If you think these are false errors, please report them to the Kiali team for review.", cfg.KialiFeatureFlags.Validations.Ignore)
+		log.Warningf("Some validation errors will be ignored %v. If these errors do occur, they will still be logged. If you think the validation errors you see are incorrect, please report them to the Kiali team if you have not done so already and provide the details of your scenario. This will keep Kiali validations strong for the whole community.", cfg.KialiFeatureFlags.Validations.Ignore)
 	}
 
 	return nil

--- a/kiali.go
+++ b/kiali.go
@@ -120,19 +120,21 @@ func waitForTermination() {
 }
 
 func validateConfig() error {
-	if config.Get().Server.Port < 0 {
-		return fmt.Errorf("server port is negative: %v", config.Get().Server.Port)
+	cfg := config.Get()
+
+	if cfg.Server.Port < 0 {
+		return fmt.Errorf("server port is negative: %v", cfg.Server.Port)
 	}
 
-	if strings.Contains(config.Get().Server.StaticContentRootDirectory, "..") {
-		return fmt.Errorf("server static content root directory must not contain '..': %v", config.Get().Server.StaticContentRootDirectory)
+	if strings.Contains(cfg.Server.StaticContentRootDirectory, "..") {
+		return fmt.Errorf("server static content root directory must not contain '..': %v", cfg.Server.StaticContentRootDirectory)
 	}
-	if _, err := os.Stat(config.Get().Server.StaticContentRootDirectory); os.IsNotExist(err) {
-		return fmt.Errorf("server static content root directory does not exist: %v", config.Get().Server.StaticContentRootDirectory)
+	if _, err := os.Stat(cfg.Server.StaticContentRootDirectory); os.IsNotExist(err) {
+		return fmt.Errorf("server static content root directory does not exist: %v", cfg.Server.StaticContentRootDirectory)
 	}
 
 	validPathRegEx := regexp.MustCompile(`^\/[a-zA-Z0-9\-\._~!\$&\'()\*\+\,;=:@%/]*$`)
-	webRoot := config.Get().Server.WebRoot
+	webRoot := cfg.Server.WebRoot
 	if !validPathRegEx.MatchString(webRoot) {
 		return fmt.Errorf("web root must begin with a / and contain valid URL path characters: %v", webRoot)
 	}
@@ -144,7 +146,7 @@ func validateConfig() error {
 	}
 
 	// log some messages to let the administrator know when credentials are configured certain ways
-	auth := config.Get().Auth
+	auth := cfg.Auth
 	log.Infof("Using authentication strategy [%v]", auth.Strategy)
 	if auth.Strategy == config.AuthStrategyAnonymous {
 		log.Warningf("Kiali auth strategy is configured for anonymous access - users will not be authenticated.")
@@ -156,9 +158,14 @@ func validateConfig() error {
 	}
 
 	// Check the signing key for the JWT token is valid
-	signingKey := config.Get().LoginToken.SigningKey
+	signingKey := cfg.LoginToken.SigningKey
 	if err := config.ValidateSigningKey(signingKey, auth.Strategy); err != nil {
 		return err
+	}
+
+	// log a warning if the user is ignoring some validations
+	if len(cfg.KialiFeatureFlags.Validations.Ignore) > 0 {
+		log.Warningf("Some validation errors will be ignored %v. If these errors do occur, they will still be logged. If you think these are false errors, please report them to the Kiali team for review.", cfg.KialiFeatureFlags.Validations.Ignore)
 	}
 
 	return nil

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -7096,6 +7096,7 @@ It is false for service.namespace format and service entries. |  |
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
+| Code | string| `string` | ✓ | | The check code used to identify a check | `KIA0001` |
 | Message | string| `string` | ✓ | | Description of the check | `Weight sum should be 100` |
 | Path | string| `string` |  | | String that describes where in the yaml file is the check located | `spec/http[0]/route` |
 | severity | [SeverityLevel](#severity-level)| `SeverityLevel` | ✓ | |  |  |

--- a/swagger.json
+++ b/swagger.json
@@ -4839,10 +4839,17 @@
       "type": "object",
       "title": "IstioCheck represents an individual check.",
       "required": [
+        "code",
         "message",
         "severity"
       ],
       "properties": {
+        "code": {
+          "description": "The check code used to identify a check",
+          "type": "string",
+          "x-go-name": "Code",
+          "example": "KIA0001"
+        },
         "message": {
           "description": "Description of the check",
           "type": "string",

--- a/tests/data/validations/test_asserter.go
+++ b/tests/data/validations/test_asserter.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/testutils"
 )
 
 type IstioCheckTestAsserter struct {
@@ -41,7 +41,7 @@ func (tb IstioCheckTestAsserter) AssertValidationAt(i int, severity models.Sever
 	assert.NotNil(validation)
 	assert.Equal(severity, validation.Severity)
 	assert.Equal(path, validation.Path)
-	assert.NoError(common.ConfirmIstioCheckMessage(message, validation))
+	assert.NoError(testutils.ConfirmIstioCheckMessage(message, validation))
 }
 
 type ValidationsTestAsserter struct {
@@ -77,5 +77,5 @@ func (vta ValidationsTestAsserter) AssertValidationAt(key models.IstioValidation
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(severity, validation.Checks[0].Severity)
 	assert.Equal(path, validation.Checks[0].Path)
-	assert.NoError(common.ConfirmIstioCheckMessage(message, validation.Checks[0]))
+	assert.NoError(testutils.ConfirmIstioCheckMessage(message, validation.Checks[0]))
 }

--- a/tests/data/validations/test_asserter.go
+++ b/tests/data/validations/test_asserter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/models"
 )
 
@@ -40,7 +41,7 @@ func (tb IstioCheckTestAsserter) AssertValidationAt(i int, severity models.Sever
 	assert.NotNil(validation)
 	assert.Equal(severity, validation.Severity)
 	assert.Equal(path, validation.Path)
-	assert.Equal(models.CheckMessage(message), validation.Message)
+	assert.NoError(common.ConfirmIstioCheckMessage(message, validation))
 }
 
 type ValidationsTestAsserter struct {
@@ -76,5 +77,5 @@ func (vta ValidationsTestAsserter) AssertValidationAt(key models.IstioValidation
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(severity, validation.Checks[0].Severity)
 	assert.Equal(path, validation.Checks[0].Path)
-	assert.Equal(models.CheckMessage(message), validation.Checks[0].Message)
+	assert.NoError(common.ConfirmIstioCheckMessage(message, validation.Checks[0]))
 }

--- a/tests/testutils/check_confirmer.go
+++ b/tests/testutils/check_confirmer.go
@@ -1,4 +1,4 @@
-package common
+package testutils
 
 import (
 	"fmt"

--- a/tests/testutils/check_confirmer_test.go
+++ b/tests/testutils/check_confirmer_test.go
@@ -1,4 +1,4 @@
-package common
+package testutils
 
 import (
 	"testing"


### PR DESCRIPTION
Some validations may fail that cannot be corrected (either it is an expected failure for some reason (see the associated issue for one such use-case) or Kiali validation has a bug and it shows an error where there should not be one).

This allows the user to ignore one or more validations (as specified by a validation code such as `KIA0101`) via the Kiali CR:

```
kiali_feature_flags:
  validations:
    ignore:
    - KIA0101
    - KIA0200
```

When a validation is ignored, we still would like users to know about the failure, especially if it is caused by a  Kiali bug because we want them to report it. So this PR will log the validation error at "info" level in the server pod logs. The log message will look like this:

```
2021-07-22T19:14:50-04:00 INF Ignoring validation failure [&{Code:KIA0101 Message:Namespace not found
for this rule Severity:warning Path:spec/rules[0]/from[1]/source/namespaces[1]}] for
object [authorizationpolicy:httpbin] in namespace [default]
```

When ignored, you can see the UI will not indicate any issues (look at spec.rules.from.source.namespaces field):

![image](https://user-images.githubusercontent.com/2029470/126721013-1bd815c7-c632-4143-a0bf-c61208865569.png)

This is what it would have looked like if the validation was not ignored (there were 2 errors of the same kind of validation):

![image](https://user-images.githubusercontent.com/2029470/126721104-8cb5b8ed-5cdd-4ace-8ad4-41484ab86a39.png)

The tooltip will still show the same message (the code will be prefixed with the message):

![image](https://user-images.githubusercontent.com/2029470/126721208-20a5ddbd-6ab5-44ef-a2a1-0d5d00ae6493.png)

(the above examples use the yaml found at https://kiali.io/documentation/latest/validations/#_kia0101_namespace_not_found_for_this_rule)

fixes: https://github.com/kiali/kiali/issues/4197

This will require PRs to both the UI frontend and the operator.
* ui: https://github.com/kiali/kiali-ui/pull/2208
* operator: https://github.com/kiali/kiali-operator/pull/369