### PR TITLE
Reorganization of the test helpers into testutils

### DIFF
--- a/business/checkers/authorization/mtls_enabled_checker_test.go
+++ b/business/checkers/authorization/mtls_enabled_checker_test.go
@@ -7,8 +7,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/data/validations"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 // Context: AutoMtls enabled
@@ -273,7 +272,7 @@ func testMtlsCheckerPresent(scenario string, t *testing.T, autoMtls bool) {
 	}, models.ErrorSeverity, "spec/rules[0]/source/principals", "authorizationpolicy.mtls.needstobeenabled")
 }
 
-func yamlFixtureLoaderFor(file string) *data.YamlFixtureLoader {
+func yamlFixtureLoaderFor(file string) *validations.YamlFixtureLoader {
 	path := fmt.Sprintf("../../../tests/data/validations/authorization/%s", file)
-	return &data.YamlFixtureLoader{Filename: path}
+	return &validations.YamlFixtureLoader{Filename: path}
 }

--- a/business/checkers/authorization/namespace_method_checker_test.go
+++ b/business/checkers/authorization/namespace_method_checker_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestSourceNamespaceExisting(t *testing.T) {
@@ -28,26 +28,26 @@ func TestSourceNamespaceExisting(t *testing.T) {
 func TestSourceNamespaceNotFound(t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := NamespaceMethodChecker{
+	vals, valid := NamespaceMethodChecker{
 		AuthorizationPolicy: sourceNamespaceAuthPolicy([]interface{}{"wrong1", "wrong2"}),
 		Namespaces:          []string{"bookinfo"},
 	}.Check()
 
 	assert.True(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 2)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", validations[0]))
-	assert.Equal(validations[0].Severity, models.WarningSeverity)
-	assert.Equal(validations[0].Path, "spec/rules[0]/from[0]/source/namespaces[0]")
-	assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", validations[1]))
-	assert.Equal(validations[1].Severity, models.WarningSeverity)
-	assert.Equal(validations[1].Path, "spec/rules[0]/from[0]/source/namespaces[1]")
+	assert.NotEmpty(vals)
+	assert.Len(vals, 2)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", vals[0]))
+	assert.Equal(vals[0].Severity, models.WarningSeverity)
+	assert.Equal(vals[0].Path, "spec/rules[0]/from[0]/source/namespaces[0]")
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.namespacenotfound", vals[1]))
+	assert.Equal(vals[1].Severity, models.WarningSeverity)
+	assert.Equal(vals[1].Path, "spec/rules[0]/from[0]/source/namespaces[1]")
 }
 
 func TestToMethodWrongHTTP(t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := NamespaceMethodChecker{
+	vals, valid := NamespaceMethodChecker{
 		AuthorizationPolicy: toMethodsAuthPolicy([]interface{}{
 			"GET", "/grpc.package/method", "/grpc.package/subpackage/subpackage/method",
 			"GOT", "WRONG", "/grpc.pkg/hello.method", "grpc.pkg/noinitialslash",
@@ -56,12 +56,12 @@ func TestToMethodWrongHTTP(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 4)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 4)
 	for i, m := range []int{3, 4, 5} {
-		assert.NoError(testutils.ConfirmIstioCheckMessage("authorizationpolicy.to.wrongmethod", validations[i]))
-		assert.Equal(validations[i].Severity, models.WarningSeverity)
-		assert.Equal(validations[i].Path, fmt.Sprintf("spec/rules[0]/to[0]/operation/methods[%d]", m))
+		assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.to.wrongmethod", vals[i]))
+		assert.Equal(vals[i].Severity, models.WarningSeverity)
+		assert.Equal(vals[i].Path, fmt.Sprintf("spec/rules[0]/to[0]/operation/methods[%d]", m))
 	}
 }
 

--- a/business/checkers/common/export_to_namespace_checker_test.go
+++ b/business/checkers/common/export_to_namespace_checker_test.go
@@ -8,8 +8,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestDRNamespaceExist(t *testing.T) {
@@ -61,15 +60,15 @@ func assertIstioObjectValid(scenario string, objectType string, t *testing.T) {
 func assertIstioObjectInvalidNamespace(scenario string, objectType string, errorNumbers int, t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := validateIstioObject("dr_exportto_invalid.yaml", "DestinationRule", t)
+	vals, valid := validateIstioObject("dr_exportto_invalid.yaml", "DestinationRule", t)
 
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, errorNumbers)
+	assert.NotEmpty(vals)
+	assert.Len(vals, errorNumbers)
 	for i := 0; i < errorNumbers; i++ {
-		assert.NoError(testutils.ConfirmIstioCheckMessage("generic.exportto.namespacenotfound", validations[i]))
-		assert.Equal(validations[i].Severity, models.ErrorSeverity)
-		assert.Equal(validations[i].Path, fmt.Sprintf("spec/exportTo[%d]", i))
+		assert.NoError(validations.ConfirmIstioCheckMessage("generic.exportto.namespacenotfound", vals[i]))
+		assert.Equal(vals[i].Severity, models.ErrorSeverity)
+		assert.Equal(vals[i].Path, fmt.Sprintf("spec/exportTo[%d]", i))
 	}
 }
 
@@ -94,7 +93,7 @@ func validateIstioObject(scenario string, objectType string, t *testing.T) ([]*m
 	return validations, valid
 }
 
-func yamlFixtureLoaderFor(file string) *data.YamlFixtureLoader {
+func yamlFixtureLoaderFor(file string) *validations.YamlFixtureLoader {
 	path := fmt.Sprintf("../../../tests/data/validations/exportto/%s", file)
-	return &data.YamlFixtureLoader{Filename: path}
+	return &validations.YamlFixtureLoader{Filename: path}
 }

--- a/business/checkers/common/multi_match_selector_checker_test.go
+++ b/business/checkers/common/multi_match_selector_checker_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestTwoSidecarsWithSelector(t *testing.T) {
@@ -68,21 +68,21 @@ func TestTwoSidecarsTargetingOneDeployment(t *testing.T) {
 	assertMultimatchFailure(t, "generic.multimatch.selector", validations, "sidecar4", []string{"sidecar1", "sidecar3"})
 }
 
-func assertMultimatchFailure(t *testing.T, code string, validations models.IstioValidations, item string, references []string) {
+func assertMultimatchFailure(t *testing.T, code string, vals models.IstioValidations, item string, references []string) {
 	assert := assert.New(t)
 
 	// Global assertion
-	assert.NotEmpty(validations)
+	assert.NotEmpty(vals)
 
 	// Assert specific's object validation
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "sidecar", Namespace: "bookinfo", Name: item}]
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "sidecar", Namespace: "bookinfo", Name: item}]
 	assert.True(ok)
 	assert.False(validation.Valid)
 
 	// Assert object's checks
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.ErrorSeverity, validation.Checks[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage(code, validation.Checks[0]))
+	assert.NoError(validations.ConfirmIstioCheckMessage(code, validation.Checks[0]))
 
 	// Assert referenced objects
 	assert.Len(validation.References, len(references))

--- a/business/checkers/common/workload_selector_checker_test.go
+++ b/business/checkers/common/workload_selector_checker_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestPresentWorkloads(t *testing.T) {
@@ -58,16 +58,16 @@ func testFailureWithEmptyWorkloadList(assert *assert.Assertions, selector map[st
 }
 
 func testFailure(assert *assert.Assertions, selector map[string]interface{}, wl models.WorkloadList, code string) {
-	validations, valid := WorkloadSelectorNoWorkloadFoundChecker(
+	vals, valid := WorkloadSelectorNoWorkloadFoundChecker(
 		"sidecar",
 		workloadSelectorSidecar("sidecar", selector),
 		wl,
 	).Check()
 
 	assert.True(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 1)
-	assert.NoError(testutils.ConfirmIstioCheckMessage(code, validations[0]))
-	assert.Equal(validations[0].Severity, models.WarningSeverity)
-	assert.Equal(validations[0].Path, "spec/workloadSelector/labels")
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.NoError(validations.ConfirmIstioCheckMessage(code, vals[0]))
+	assert.Equal(vals[0].Severity, models.WarningSeverity)
+	assert.Equal(vals[0].Path, "spec/workloadSelector/labels")
 }

--- a/business/checkers/destinationrules/disabled_meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/disabled_meshwide_mtls_checker_test.go
@@ -6,8 +6,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/data/validations"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 // Context: DestinationRule at mesh-level disabling mTLS
@@ -71,7 +70,7 @@ func testWithDestRuleDisabledValidations(scenario string, t *testing.T) {
 	tb.AssertValidationAt(0, models.ErrorSeverity, "spec/trafficPolicy/tls/mode", "destinationrules.mtls.meshpolicymtlsenabled")
 }
 
-func yamlFixtureLoaderFor(file string) *data.YamlFixtureLoader {
+func yamlFixtureLoaderFor(file string) *validations.YamlFixtureLoader {
 	path := fmt.Sprintf("../../../tests/data/validations/destinationrules/%s", file)
-	return &data.YamlFixtureLoader{Filename: path}
+	return &validations.YamlFixtureLoader{Filename: path}
 }

--- a/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/disabled_namespacewide_mtls_checker_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 // Context: DestinationRule ns-wide disabling mTLS connections
@@ -202,18 +202,18 @@ func testDisabledMtlsValidationsFound(t *testing.T, validationId string, destina
 
 	mTLSDetails.EnabledAutoMtls = autoMtls
 
-	validations, valid := DisabledNamespaceWideMTLSChecker{
+	vals, valid := DisabledNamespaceWideMTLSChecker{
 		DestinationRule: destinationRule,
 		MTLSDetails:     mTLSDetails,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+	assert.NotEmpty(vals)
+	assert.Equal(1, len(vals))
 	assert.False(valid)
 
-	validation := validations[0]
+	validation := vals[0]
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
-	assert.NoError(testutils.ConfirmIstioCheckMessage(validationId, validation))
+	assert.NoError(validations.ConfirmIstioCheckMessage(validationId, validation))
 }

--- a/business/checkers/destinationrules/meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 // Context: DestinationRule enables mesh-wide mTLS
@@ -122,20 +122,20 @@ func TestMTLSDRDisabledWithMeshPolicyDisabled(t *testing.T) {
 func testReturnsAValidation(t *testing.T, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
 	assert := assert.New(t)
 
-	validations, valid := MeshWideMTLSChecker{
+	vals, valid := MeshWideMTLSChecker{
 		DestinationRule: destinationRule,
 		MTLSDetails:     mTLSDetails,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+	assert.NotEmpty(vals)
+	assert.Equal(1, len(vals))
 	assert.False(valid)
 
-	validation := validations[0]
+	validation := vals[0]
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.mtls.meshpolicymissing", validation))
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.mtls.meshpolicymissing", validation))
 }
 
 func testNoValidationsFound(t *testing.T, destinationRule kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {

--- a/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 // Context: DestinationRule enables namespace-wide mTLS
@@ -97,18 +97,18 @@ func TestMTLSNsWideDREnabledWithoutPolicy(t *testing.T) {
 
 	assert := assert.New(t)
 
-	validations, valid := NamespaceWideMTLSChecker{
+	vals, valid := NamespaceWideMTLSChecker{
 		DestinationRule: destinationRule,
 		MTLSDetails:     mTlsDetails,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+	assert.NotEmpty(vals)
+	assert.Equal(1, len(vals))
 	assert.False(valid)
 
-	validation := validations[0]
+	validation := vals[0]
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.mtls.nspolicymissing", validation))
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.mtls.nspolicymissing", validation))
 }

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func appVersionLabel(app, version string) map[string]string {
@@ -24,7 +24,7 @@ func appVersionLabel(app, version string) map[string]string {
 func TestValidHost(t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -35,13 +35,13 @@ func TestValidHost(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestValidWildcardHost(t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -53,7 +53,7 @@ func TestValidWildcardHost(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestValidMeshWideHost(t *testing.T) {
@@ -62,7 +62,7 @@ func TestValidMeshWideHost(t *testing.T) {
 
 	assert := assert.New(t)
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -73,7 +73,7 @@ func TestValidMeshWideHost(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestValidServiceNamespace(t *testing.T) {
@@ -82,7 +82,7 @@ func TestValidServiceNamespace(t *testing.T) {
 
 	assert := assert.New(t)
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -93,7 +93,7 @@ func TestValidServiceNamespace(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestValidServiceNamespaceInvalid(t *testing.T) {
@@ -102,7 +102,7 @@ func TestValidServiceNamespaceInvalid(t *testing.T) {
 
 	assert := assert.New(t)
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test-namespace"},
@@ -117,10 +117,10 @@ func TestValidServiceNamespaceInvalid(t *testing.T) {
 	}.Check()
 
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", validations[0]))
-	assert.Equal("spec/host", validations[0].Path)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", vals[0]))
+	assert.Equal("spec/host", vals[0].Path)
 }
 
 func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
@@ -133,7 +133,7 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 	registryService := kubernetes.RegistryStatus{}
 	registryService.Hostname = "reviews.outside-ns.svc.cluster.local"
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test-namespace"},
@@ -149,7 +149,7 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestNoValidHost(t *testing.T) {
@@ -159,7 +159,7 @@ func TestNoValidHost(t *testing.T) {
 	assert := assert.New(t)
 
 	// reviews is not part of services
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
@@ -170,10 +170,10 @@ func TestNoValidHost(t *testing.T) {
 	}.Check()
 
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", validations[0]))
-	assert.Equal("spec/host", validations[0].Path)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", vals[0]))
+	assert.Equal("spec/host", vals[0].Path)
 }
 
 func TestNoMatchingSubset(t *testing.T) {
@@ -183,7 +183,7 @@ func TestNoMatchingSubset(t *testing.T) {
 	assert := assert.New(t)
 
 	// reviews does not have v2 in known services
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
@@ -193,10 +193,10 @@ func TestNoMatchingSubset(t *testing.T) {
 	}.Check()
 
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", validations[0]))
-	assert.Equal("spec/subsets[0]", validations[0].Path)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", vals[0]))
+	assert.Equal("spec/subsets[0]", vals[0].Path)
 }
 
 func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
@@ -217,7 +217,7 @@ func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
 				"seek":    "notfound",
 			}}, data.CreateEmptyDestinationRule("test-namespace", "name", "reviews")))
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
@@ -228,10 +228,10 @@ func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
 	}.Check()
 
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", validations[0]))
-	assert.Equal("spec/subsets[0]", validations[0].Path)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", vals[0]))
+	assert.Equal("spec/subsets[0]", vals[0].Path)
 }
 
 func fakeServicesReview() []core_v1.Service {
@@ -259,7 +259,7 @@ func TestFailCrossNamespaceHost(t *testing.T) {
 	registryService := kubernetes.RegistryStatus{}
 	registryService.Hostname = "reviews.different-ns.svc.cluster.local"
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -272,7 +272,7 @@ func TestFailCrossNamespaceHost(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestSNIProxyExample(t *testing.T) {
@@ -286,14 +286,14 @@ func TestSNIProxyExample(t *testing.T) {
 	se := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(8443, "tcp", "TCP"),
 		data.CreateEmptyMeshExternalServiceEntry("sni-proxy", "test", []string{"sni-proxy.local"}))
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace:       "test",
 		ServiceEntries:  kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{se}),
 		DestinationRule: dr,
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestWildcardServiceEntry(t *testing.T) {
@@ -306,20 +306,20 @@ func TestWildcardServiceEntry(t *testing.T) {
 	se := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(8443, "tcp", "TCP"),
 		data.CreateEmptyMeshExternalServiceEntry("sni-proxy", "test", []string{"*.local"}))
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace:       "test",
 		ServiceEntries:  kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{se}),
 		DestinationRule: dr,
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestNoLabelsInSubset(t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace: "test-namespace",
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -330,10 +330,10 @@ func TestNoLabelsInSubset(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.WarningSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.nodest.subsetnolabels", validations[0]))
-	assert.Equal("spec/subsets[0]", validations[0].Path)
+	assert.NotEmpty(vals)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.nodest.subsetnolabels", vals[0]))
+	assert.Equal("spec/subsets[0]", vals[0].Path)
 
 }
 
@@ -345,61 +345,61 @@ func TestValidServiceRegistry(t *testing.T) {
 
 	dr := data.CreateEmptyDestinationRule("test", "test-exported", "ratings.mesh2-bookinfo.svc.mesh1-imports.local")
 
-	validations, valid := NoDestinationChecker{
+	vals, valid := NoDestinationChecker{
 		Namespace:       "test",
 		DestinationRule: dr,
 	}.Check()
 
 	assert.False(valid)
-	assert.NotEmpty(validations)
+	assert.NotEmpty(vals)
 
 	registryService := kubernetes.RegistryStatus{}
 	registryService.Hostname = "ratings.mesh2-bookinfo.svc.mesh1-imports.local"
 
-	validations, valid = NoDestinationChecker{
+	vals, valid = NoDestinationChecker{
 		Namespace:       "test",
 		DestinationRule: dr,
 		RegistryStatus:  []*kubernetes.RegistryStatus{&registryService},
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 
 	registryService = kubernetes.RegistryStatus{}
 	registryService.Hostname = "ratings2.mesh2-bookinfo.svc.mesh1-imports.local"
 
-	validations, valid = NoDestinationChecker{
+	vals, valid = NoDestinationChecker{
 		Namespace:       "test",
 		DestinationRule: dr,
 		RegistryStatus:  []*kubernetes.RegistryStatus{&registryService},
 	}.Check()
 
 	assert.False(valid)
-	assert.NotEmpty(validations)
+	assert.NotEmpty(vals)
 
 	registryService = kubernetes.RegistryStatus{}
 	registryService.Hostname = "ratings.bookinfo.svc.cluster.local"
 
 	dr = data.CreateEmptyDestinationRule("test", "test-exported", "ratings.bookinfo.svc.cluster.local")
 
-	validations, valid = NoDestinationChecker{
+	vals, valid = NoDestinationChecker{
 		Namespace:       "test",
 		DestinationRule: dr,
 		RegistryStatus:  []*kubernetes.RegistryStatus{&registryService},
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 
 	registryService = kubernetes.RegistryStatus{}
 	registryService.Hostname = "ratings2.bookinfo.svc.cluster.local"
 
-	validations, valid = NoDestinationChecker{
+	vals, valid = NoDestinationChecker{
 		Namespace:       "test",
 		DestinationRule: dr,
 		RegistryStatus:  []*kubernetes.RegistryStatus{&registryService},
 	}.Check()
 
 	assert.False(valid)
-	assert.NotEmpty(validations)
+	assert.NotEmpty(vals)
 }

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 // Context: MeshPolicy Enabling mTLS
@@ -241,22 +241,22 @@ func TestCrossNamespaceServiceEntryProtection(t *testing.T) {
 func testValidationAdded(t *testing.T, destinationRules []kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) *models.IstioValidation {
 	assert := assert.New(t)
 
-	validations := TrafficPolicyChecker{
+	vals := TrafficPolicyChecker{
 		DestinationRules: destinationRules,
 		MTLSDetails:      mTLSDetails,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+	assert.NotEmpty(vals)
+	assert.Equal(1, len(vals))
 
-	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews", "bookinfo")]
+	validation, ok := vals[models.BuildKey(DestinationRulesCheckerType, "reviews", "bookinfo")]
 	assert.True(ok)
 	assert.True(validation.Valid)
 
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
 	assert.Equal("spec/trafficPolicy", validation.Checks[0].Path)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("destinationrules.trafficpolicy.notlssettings", validation.Checks[0]))
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.trafficpolicy.notlssettings", validation.Checks[0]))
 
 	assert.True(len(validation.References) > 0)
 	return validation
@@ -265,13 +265,13 @@ func testValidationAdded(t *testing.T, destinationRules []kubernetes.IstioObject
 func testValidationsNotAdded(t *testing.T, destinationRules []kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
 	assert := assert.New(t)
 
-	validations := TrafficPolicyChecker{
+	vals := TrafficPolicyChecker{
 		DestinationRules: destinationRules,
 		MTLSDetails:      mTLSDetails,
 	}.Check()
 
-	assert.Empty(validations)
-	validation, ok := validations[models.BuildKey(DestinationRulesCheckerType, "reviews", "bookinfo")]
+	assert.Empty(vals)
+	validation, ok := vals[models.BuildKey(DestinationRulesCheckerType, "reviews", "bookinfo")]
 
 	assert.False(ok)
 	assert.Nil(validation)

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -24,12 +24,12 @@ func TestCorrectGateways(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.Empty(validations)
-	_, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "validgateway"}]
+	assert.Empty(vals)
+	_, ok := vals[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "validgateway"}]
 	assert.False(ok)
 }
 
@@ -51,13 +51,13 @@ func TestCaseMatching(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "foxxed"}]
+	assert.NotEmpty(vals)
+	assert.Equal(1, len(vals))
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "foxxed"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 }
@@ -80,11 +80,11 @@ func TestDashSubdomainMatching(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 // Two gateways can share port+host unless they use different ingress
@@ -107,11 +107,11 @@ func TestSameHostPortConfigInDifferentIngress(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject}, {gwObject2}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.Equal(0, len(validations))
+	assert.Equal(0, len(vals))
 }
 
 func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
@@ -133,17 +133,17 @@ func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject}, {gwObject2}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(2, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "bookinfo", Name: "stillvalid"}]
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "gateway", Namespace: "bookinfo", Name: "stillvalid"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 
-	secValidation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "validgateway"}]
+	secValidation, ok := vals[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "validgateway"}]
 	assert.True(ok)
 	assert.True(secValidation.Valid)
 
@@ -177,20 +177,20 @@ func TestWildCardMatchingHost(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject}, {gwObject2, gwObject3}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(3, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "stillvalid"}]
+	assert.NotEmpty(vals)
+	assert.Equal(3, len(vals))
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "stillvalid"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 
 	// valid should have "*" as ref
 	// "*" should have valid and *.just as ref
 	// *.just should have "*" as ref
-	for _, v := range validations {
+	for _, v := range vals {
 		if v.Name == "stillvalid" {
 			assert.Equal(2, len(v.References))
 		} else {
@@ -217,13 +217,13 @@ func TestAnotherSubdomainWildcardCombination(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "shouldnotbevalid"}]
+	assert.NotEmpty(vals)
+	assert.Equal(1, len(vals))
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "shouldnotbevalid"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 }
@@ -246,11 +246,11 @@ func TestNoMatchOnSubdomainHost(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestTwoWildCardsMatching(t *testing.T) {
@@ -272,13 +272,13 @@ func TestTwoWildCardsMatching(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject}, {gwObject2}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(2, len(validations))
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "stillvalid"}]
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "stillvalid"}]
 	assert.True(ok)
 	assert.True(validation.Valid)
 	assert.Equal("spec/servers[0]/hosts[0]", validation.Checks[0].Path)
@@ -302,15 +302,15 @@ func TestDuplicateGatewaysErrorCount(t *testing.T) {
 
 	gws := [][]kubernetes.IstioObject{{gwObject, gwObjectIdentical}}
 
-	validations := MultiMatchChecker{
+	vals := MultiMatchChecker{
 		GatewaysPerNamespace: gws,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	validgateway, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "validgateway"}]
+	assert.NotEmpty(vals)
+	validgateway, ok := vals[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "validgateway"}]
 	assert.True(ok)
 
-	duplicatevalidgateway, ok := validations[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "duplicatevalidgateway"}]
+	duplicatevalidgateway, ok := vals[models.IstioValidationKey{ObjectType: "gateway", Namespace: "test", Name: "duplicatevalidgateway"}]
 	assert.True(ok)
 
 	assert.Equal(2, len(validgateway.Checks))

--- a/business/checkers/gateways/port_checker_test.go
+++ b/business/checkers/gateways/port_checker_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestValidPortDefinition(t *testing.T) {
@@ -22,9 +22,9 @@ func TestValidPortDefinition(t *testing.T) {
 		data.CreateEmptyGateway("valid-gw", "test", map[string]string{"istio": "ingressgateway"}),
 	)
 	pc := PortChecker{Gateway: gw}
-	validations, valid := pc.Check()
+	vals, valid := pc.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestInvalidPortDefinition(t *testing.T) {
@@ -38,10 +38,10 @@ func TestInvalidPortDefinition(t *testing.T) {
 		data.CreateEmptyGateway("notvalid-gw", "test", map[string]string{"istio": "ingressgateway"}),
 	)
 	pc := PortChecker{Gateway: gw}
-	validations, valid := pc.Check()
+	vals, valid := pc.Check()
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
-	assert.Equal("spec/servers[0]/port/name", validations[0].Path)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("port.name.mismatch", vals[0]))
+	assert.Equal("spec/servers[0]/port/name", vals[0].Path)
 }

--- a/business/checkers/gateways/selector_checker_test.go
+++ b/business/checkers/gateways/selector_checker_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestValidInternalSelector(t *testing.T) {
@@ -20,7 +20,7 @@ func TestValidInternalSelector(t *testing.T) {
 	ingress := data.CreateEmptyGateway("gwingress", "test", map[string]string{"istio": "ingressgateway"})
 	egress := data.CreateEmptyGateway("gwegress", "test", map[string]string{"istio": "egressgateway"})
 
-	validations, valid := SelectorChecker{
+	vals, valid := SelectorChecker{
 		Gateway: ingress,
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": data.CreateWorkloadList("istio-system",
@@ -29,9 +29,9 @@ func TestValidInternalSelector(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 
-	validations, valid = SelectorChecker{
+	vals, valid = SelectorChecker{
 		Gateway: egress,
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": data.CreateWorkloadList("istio-system",
@@ -40,7 +40,7 @@ func TestValidInternalSelector(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestValidNamespaceSelector(t *testing.T) {
@@ -51,7 +51,7 @@ func TestValidNamespaceSelector(t *testing.T) {
 
 	gw := data.CreateEmptyGateway("gwone", "test", map[string]string{"app": "proxy"})
 
-	validations, valid := SelectorChecker{
+	vals, valid := SelectorChecker{
 		Gateway: gw,
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": data.CreateWorkloadList("test",
@@ -60,7 +60,7 @@ func TestValidNamespaceSelector(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestValidIstioNamespaceSelector(t *testing.T) {
@@ -71,7 +71,7 @@ func TestValidIstioNamespaceSelector(t *testing.T) {
 
 	gw := data.CreateEmptyGateway("gwone", "test", map[string]string{"app": "proxy"})
 
-	validations, valid := SelectorChecker{
+	vals, valid := SelectorChecker{
 		Gateway: gw,
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"testproxy": data.CreateWorkloadList(conf.IstioNamespace,
@@ -80,9 +80,9 @@ func TestValidIstioNamespaceSelector(t *testing.T) {
 	}.Check()
 
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 
-	validations, valid = SelectorChecker{
+	vals, valid = SelectorChecker{
 		Gateway: gw,
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": {
@@ -95,7 +95,7 @@ func TestValidIstioNamespaceSelector(t *testing.T) {
 	}.Check()
 
 	assert.False(valid)
-	assert.NotEmpty(validations)
+	assert.NotEmpty(vals)
 }
 
 func TestMissingSelectorTarget(t *testing.T) {
@@ -106,7 +106,7 @@ func TestMissingSelectorTarget(t *testing.T) {
 
 	gw := data.CreateEmptyGateway("gwone", "test", map[string]string{"app": "proxy"})
 
-	validations, valid := SelectorChecker{
+	vals, valid := SelectorChecker{
 		Gateway: gw,
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": data.CreateWorkloadList("test"),
@@ -114,7 +114,7 @@ func TestMissingSelectorTarget(t *testing.T) {
 	}.Check()
 
 	assert.False(valid)
-	assert.Equal(1, len(validations))
-	assert.NoError(testutils.ConfirmIstioCheckMessage("gateways.selector", validations[0]))
-	assert.Equal(models.WarningSeverity, validations[0].Severity)
+	assert.Equal(1, len(vals))
+	assert.NoError(validations.ConfirmIstioCheckMessage("gateways.selector", vals[0]))
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
 }

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -4,7 +4,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/business/checkers/destinationrules"
-	"github.com/kiali/kiali/business/checkers/virtual_services"
+	"github.com/kiali/kiali/business/checkers/virtualservices"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -46,7 +46,7 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 func runVirtualServiceCheck(virtualService kubernetes.IstioObject, namespace string, serviceNames []string, serviceHosts map[string][]string, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryStatus) models.IstioValidations {
 	key, validations := EmptyValidValidation(virtualService.GetObjectMeta().Name, virtualService.GetObjectMeta().Namespace, VirtualCheckerType)
 
-	result, valid := virtual_services.NoHostChecker{
+	result, valid := virtualservices.NoHostChecker{
 		Namespace:         namespace,
 		Namespaces:        clusterNamespaces,
 		ServiceNames:      serviceNames,
@@ -64,7 +64,7 @@ func runVirtualServiceCheck(virtualService kubernetes.IstioObject, namespace str
 func runGatewayCheck(virtualService kubernetes.IstioObject, gatewayNames map[string]struct{}) models.IstioValidations {
 	key, validations := EmptyValidValidation(virtualService.GetObjectMeta().Name, virtualService.GetObjectMeta().Namespace, VirtualCheckerType)
 
-	result, valid := virtual_services.NoGatewayChecker{
+	result, valid := virtualservices.NoGatewayChecker{
 		VirtualService: virtualService,
 		GatewayNames:   gatewayNames,
 	}.Check()

--- a/business/checkers/peerauthentications/disabled_meshwide_checker_test.go
+++ b/business/checkers/peerauthentications/disabled_meshwide_checker_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/tests/data/validations"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
-// This validations works only with AutoMTls disabled
+// This vals works only with AutoMTls disabled
 
 // Context: MeshPeerAuthn disabled
 // Context: DestinationRule tls mode disabled
@@ -41,12 +41,12 @@ func disabledMeshTestPrep(scenario string, t *testing.T) ([]*models.IstioCheck, 
 		t.Error("Error loading test data.")
 	}
 
-	validations, valid := DisabledMeshWideChecker{
+	vals, valid := DisabledMeshWideChecker{
 		PeerAuthn:        loader.GetFirstResource("PeerAuthentication"),
 		DestinationRules: loader.GetResources("DestinationRule"),
 	}.Check()
 
-	return validations, valid
+	return vals, valid
 }
 
 func testNoDisabledMeshValidations(scenario string, t *testing.T) {

--- a/business/checkers/peerauthentications/disabled_namespacewide_checker_test.go
+++ b/business/checkers/peerauthentications/disabled_namespacewide_checker_test.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/data/validations"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
-// This validations works only with AutoMTls disabled
+// This vals works only with AutoMTls disabled
 
 // Context: PeerAuthn disabled
 // Context: DestinationRule tls mode disabled
@@ -62,7 +61,7 @@ func disabledNamespacetestPrep(scenario string, t *testing.T) ([]*models.IstioCh
 	loader := yamlFixtureLoaderFor(scenario)
 	err := loader.Load()
 
-	validations, valid := DisabledNamespaceWideChecker{
+	vals, valid := DisabledNamespaceWideChecker{
 		PeerAuthn:        loader.GetFirstResource("PeerAuthentication"),
 		DestinationRules: loader.GetResources("DestinationRule"),
 	}.Check()
@@ -71,7 +70,7 @@ func disabledNamespacetestPrep(scenario string, t *testing.T) ([]*models.IstioCh
 		t.Error("Error loading test data.")
 	}
 
-	return validations, valid
+	return vals, valid
 }
 
 func testNoDisabledNsValidations(scenario string, t *testing.T) {
@@ -89,7 +88,7 @@ func testWithDisabledNsValidations(scenario string, t *testing.T) {
 	tb.AssertValidationAt(0, models.ErrorSeverity, "spec/mtls", "peerauthentications.mtls.disabledestinationrulemissing")
 }
 
-func yamlFixtureLoaderFor(file string) *data.YamlFixtureLoader {
+func yamlFixtureLoaderFor(file string) *validations.YamlFixtureLoader {
 	path := fmt.Sprintf("../../../tests/data/validations/peerauthentications/%s", file)
-	return &data.YamlFixtureLoader{Filename: path}
+	return &validations.YamlFixtureLoader{Filename: path}
 }

--- a/business/checkers/peerauthentications/mesh_mtls_checker_test.go
+++ b/business/checkers/peerauthentications/mesh_mtls_checker_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 // Describe the validation of a MeshPolicy that enables mTLS. The validation is risen when there isn't any
@@ -129,30 +129,30 @@ func TestMeshPolicymTLSDisabledDestinationRuleMissing(t *testing.T) {
 func testValidationAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
 	assert := assert.New(t)
 
-	validations, valid := MeshMtlsChecker{
+	vals, valid := MeshMtlsChecker{
 		MeshPolicy:  meshPolicy,
 		MTLSDetails: mTLSDetails,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+	assert.NotEmpty(vals)
+	assert.Equal(1, len(vals))
 	assert.False(valid)
 
-	validation := validations[0]
+	validation := vals[0]
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/mtls", validation.Path)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("peerauthentication.mtls.destinationrulemissing", validation))
+	assert.NoError(validations.ConfirmIstioCheckMessage("peerauthentication.mtls.destinationrulemissing", validation))
 }
 
 func testValidationsNotAdded(t *testing.T, meshPolicy kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails) {
 	assert := assert.New(t)
 
-	validations, valid := MeshMtlsChecker{
+	vals, valid := MeshMtlsChecker{
 		MeshPolicy:  meshPolicy,
 		MTLSDetails: mTLSDetails,
 	}.Check()
 
-	assert.Empty(validations)
+	assert.Empty(vals)
 	assert.True(valid)
 }

--- a/business/checkers/peerauthentications/namespace_mtls_checker_test.go
+++ b/business/checkers/peerauthentications/namespace_mtls_checker_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 // Describe the validation of a PeerAuthn that enables mTLS for one namespace. The validation is risen when there isn't any
@@ -30,20 +30,20 @@ func TestPeerAuthnmTLSEnabled(t *testing.T) {
 		},
 	}
 
-	validations, valid := NamespaceMtlsChecker{
+	vals, valid := NamespaceMtlsChecker{
 		PeerAuthn:   policy,
 		MTLSDetails: mTLSDetails,
 	}.Check()
 
-	assert.NotEmpty(validations)
-	assert.Equal(1, len(validations))
+	assert.NotEmpty(vals)
+	assert.Equal(1, len(vals))
 	assert.False(valid)
 
-	validation := validations[0]
+	validation := vals[0]
 	assert.NotNil(validation)
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/mtls", validation.Path)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("peerauthentications.mtls.destinationrulemissing", validation))
+	assert.NoError(validations.ConfirmIstioCheckMessage("peerauthentications.mtls.destinationrulemissing", validation))
 }
 
 // Context: PeerAuthn enables mTLS for a namespace
@@ -97,11 +97,11 @@ func assertNoValidations(t *testing.T, peerAuth kubernetes.IstioObject, mTLSDeta
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	validations, valid := NamespaceMtlsChecker{
+	vals, valid := NamespaceMtlsChecker{
 		PeerAuthn:   peerAuth,
 		MTLSDetails: mTLSDetails,
 	}.Check()
 
-	assert.Empty(validations)
+	assert.Empty(vals)
 	assert.True(valid)
 }

--- a/business/checkers/serviceentries/port_checker_test.go
+++ b/business/checkers/serviceentries/port_checker_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestValidPortDefinition(t *testing.T) {
@@ -23,9 +23,9 @@ func TestValidPortDefinition(t *testing.T) {
 	)
 
 	pc := PortChecker{ServiceEntry: se}
-	validations, valid := pc.Check()
+	vals, valid := pc.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestInvalidPortDefinition(t *testing.T) {
@@ -40,10 +40,10 @@ func TestInvalidPortDefinition(t *testing.T) {
 	)
 
 	pc := PortChecker{ServiceEntry: se}
-	validations, valid := pc.Check()
+	vals, valid := pc.Check()
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
-	assert.Equal("spec/ports[0]/name", validations[0].Path)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("port.name.mismatch", vals[0]))
+	assert.Equal("spec/ports[0]/name", vals[0].Path)
 }

--- a/business/checkers/services/port_mapping_checker_test.go
+++ b/business/checkers/services/port_mapping_checker_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestPortMappingMatch(t *testing.T) {
@@ -25,9 +25,9 @@ func TestPortMappingMatch(t *testing.T) {
 		Pods:        getPods(true),
 	}
 
-	validations, valid := pmc.Check()
+	vals, valid := pmc.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestTargetPortMappingMatch(t *testing.T) {
@@ -54,16 +54,16 @@ func TestTargetPortMappingMatch(t *testing.T) {
 		Pods:        getPods(true),
 	}
 
-	validations, valid := pmc.Check()
+	vals, valid := pmc.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 
 	// Now check with named port only
 	service.Spec.Ports[0].TargetPort = intstr.FromString("http-container")
 
-	validations, valid = pmc.Check()
+	vals, valid = pmc.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestPortMappingMismatch(t *testing.T) {
@@ -79,11 +79,11 @@ func TestPortMappingMismatch(t *testing.T) {
 		Pods:        getPods(true),
 	}
 
-	validations, valid := pmc.Check()
+	vals, valid := pmc.Check()
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("service.deployment.port.mismatch", validations[0]))
-	assert.Equal("spec/ports[0]", validations[0].Path)
+	assert.NotEmpty(vals)
+	assert.NoError(validations.ConfirmIstioCheckMessage("service.deployment.port.mismatch", vals[0]))
+	assert.Equal("spec/ports[0]", vals[0].Path)
 }
 
 func TestServicePortNaming(t *testing.T) {
@@ -98,11 +98,11 @@ func TestServicePortNaming(t *testing.T) {
 		Pods:        getPods(true),
 	}
 
-	validations, valid := pmc.Check()
+	vals, valid := pmc.Check()
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("port.name.mismatch", validations[0]))
-	assert.Equal("spec/ports[0]", validations[0].Path)
+	assert.NotEmpty(vals)
+	assert.NoError(validations.ConfirmIstioCheckMessage("port.name.mismatch", vals[0]))
+	assert.Equal("spec/ports[0]", vals[0].Path)
 }
 
 func TestServicePortNamingWithoutSidecar(t *testing.T) {
@@ -117,9 +117,9 @@ func TestServicePortNamingWithoutSidecar(t *testing.T) {
 		Pods:        getPods(false),
 	}
 
-	validations, valid := pmc.Check()
+	vals, valid := pmc.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func getService(servicePort int32, portName string) v1.Service {

--- a/business/checkers/sidecars/global_checker_test.go
+++ b/business/checkers/sidecars/global_checker_test.go
@@ -8,18 +8,18 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestSidecarWithoutSelectorOutOfControlPlane(t *testing.T) {
 	assert := assert.New(t)
 	config.Set(config.NewConfig())
 
-	validations, valid := GlobalChecker{
+	vals, valid := GlobalChecker{
 		Sidecar: data.CreateSidecar("sidecar1", "bookinfo"),
 	}.Check()
 
-	assert.Empty(validations)
+	assert.Empty(vals)
 	assert.True(valid)
 }
 
@@ -28,11 +28,11 @@ func TestSidecarWithoutSelectorInControlPlane(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	validations, valid := GlobalChecker{
+	vals, valid := GlobalChecker{
 		Sidecar: data.CreateSidecar("sidecar1", conf.IstioNamespace),
 	}.Check()
 
-	assert.Empty(validations)
+	assert.Empty(vals)
 	assert.True(valid)
 }
 
@@ -40,7 +40,7 @@ func TestSidecarWithSelectorOutOfControlPlane(t *testing.T) {
 	assert := assert.New(t)
 	config.Set(config.NewConfig())
 
-	validations, valid := GlobalChecker{
+	vals, valid := GlobalChecker{
 		Sidecar: data.AddSelectorToSidecar(map[string]interface{}{
 			"labels": map[string]interface{}{
 				"app": "reviews",
@@ -48,7 +48,7 @@ func TestSidecarWithSelectorOutOfControlPlane(t *testing.T) {
 		}, data.CreateSidecar("sidecar1", "bookinfo")),
 	}.Check()
 
-	assert.Empty(validations)
+	assert.Empty(vals)
 	assert.True(valid)
 }
 
@@ -57,7 +57,7 @@ func TestSidecarWithSelectorInControlPlane(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	validations, valid := GlobalChecker{
+	vals, valid := GlobalChecker{
 		Sidecar: data.AddSelectorToSidecar(map[string]interface{}{
 			"labels": map[string]interface{}{
 				"app": "reviews",
@@ -65,10 +65,10 @@ func TestSidecarWithSelectorInControlPlane(t *testing.T) {
 		}, data.CreateSidecar("sidecar1", conf.IstioNamespace)),
 	}.Check()
 
-	assert.NotEmpty(validations)
+	assert.NotEmpty(vals)
 	assert.True(valid)
 
-	assert.Len(validations, 1)
-	assert.Equal(models.WarningSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("sidecar.global.selector", validations[0]))
+	assert.Len(vals, 1)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("sidecar.global.selector", vals[0]))
 }

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -2,7 +2,7 @@ package checkers
 
 import (
 	"github.com/kiali/kiali/business/checkers/common"
-	"github.com/kiali/kiali/business/checkers/virtual_services"
+	"github.com/kiali/kiali/business/checkers/virtualservices"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -45,7 +45,7 @@ func (in VirtualServiceChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	enabledCheckers := []GroupChecker{
-		virtual_services.SingleHostChecker{Namespace: in.Namespace, Namespaces: in.Namespaces, VirtualServices: in.VirtualServices},
+		virtualservices.SingleHostChecker{Namespace: in.Namespace, Namespaces: in.Namespaces, VirtualServices: in.VirtualServices},
 	}
 
 	for _, checker := range enabledCheckers {
@@ -61,8 +61,8 @@ func (in VirtualServiceChecker) runChecks(virtualService kubernetes.IstioObject)
 	key, rrValidation := EmptyValidValidation(virtualServiceName, virtualService.GetObjectMeta().Namespace, VirtualCheckerType)
 
 	enabledCheckers := []Checker{
-		virtual_services.RouteChecker{Route: virtualService},
-		virtual_services.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), DestinationRules: in.DestinationRules, VirtualService: virtualService},
+		virtualservices.RouteChecker{Route: virtualService},
+		virtualservices.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), DestinationRules: in.DestinationRules, VirtualService: virtualService},
 		common.ExportToNamespaceChecker{IstioObject: virtualService, Namespaces: in.Namespaces},
 	}
 

--- a/business/checkers/virtualservices/no_gateway_checker.go
+++ b/business/checkers/virtualservices/no_gateway_checker.go
@@ -1,4 +1,4 @@
-package virtual_services
+package virtualservices
 
 import (
 	"fmt"

--- a/business/checkers/virtualservices/no_gateway_checker_test.go
+++ b/business/checkers/virtualservices/no_gateway_checker_test.go
@@ -1,4 +1,4 @@
-package virtual_services
+package virtualservices
 
 import (
 	"fmt"
@@ -10,7 +10,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestMissingGateway(t *testing.T) {
@@ -24,11 +24,11 @@ func TestMissingGateway(t *testing.T) {
 		GatewayNames:   make(map[string]struct{}),
 	}
 
-	validations, valid := checker.Check()
+	vals, valid := checker.Check()
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", vals[0]))
 }
 
 func TestMissingGatewayInHTTPMatch(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMissingGatewayInHTTPMatch(t *testing.T) {
 			config.Set(conf)
 
 			path := fmt.Sprintf("../../../tests/data/validations/virtualservices/%s", "non-existent-gateway-in-match.yaml")
-			loader := &data.YamlFixtureLoader{Filename: path}
+			loader := &validations.YamlFixtureLoader{Filename: path}
 			err := loader.Load()
 			if err != nil {
 				t.Error("Error loading test data.")
@@ -59,12 +59,12 @@ func TestMissingGatewayInHTTPMatch(t *testing.T) {
 				GatewayNames:   map[string]struct{}{"valid-gateway": {}},
 			}
 
-			validations, valid := checker.Check()
+			vals, valid := checker.Check()
 
 			assert.False(valid)
-			assert.NotEmpty(validations)
-			assert.Equal(models.ErrorSeverity, validations[0].Severity)
-			assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
+			assert.NotEmpty(vals)
+			assert.Equal(models.ErrorSeverity, vals[0].Severity)
+			assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", vals[0]))
 		})
 	}
 }
@@ -82,11 +82,11 @@ func TestValidAndMissingGateway(t *testing.T) {
 		GatewayNames:   map[string]struct{}{"correctgw": empty},
 	}
 
-	validations, valid := checker.Check()
+	vals, valid := checker.Check()
 	assert.False(valid)
-	assert.NotEmpty(validations)
-	assert.Equal(models.ErrorSeverity, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.nogateway", validations[0]))
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", vals[0]))
 }
 
 func TestFoundGateway(t *testing.T) {
@@ -106,9 +106,9 @@ func TestFoundGateway(t *testing.T) {
 		GatewayNames:   gatewayNames,
 	}
 
-	validations, valid := checker.Check()
+	vals, valid := checker.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 func TestFoundGatewayTwoPartNaming(t *testing.T) {
@@ -128,11 +128,11 @@ func TestFoundGatewayTwoPartNaming(t *testing.T) {
 		GatewayNames:   gatewayNames,
 	}
 
-	validations, valid := checker.Check()
+	vals, valid := checker.Check()
 	assert.True(valid)
-	assert.Len(validations, 1)
-	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
+	assert.Len(vals, 1)
+	assert.Equal(models.Unknown, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", vals[0]))
 }
 
 func TestFQDNFoundGateway(t *testing.T) {
@@ -153,11 +153,11 @@ func TestFQDNFoundGateway(t *testing.T) {
 		GatewayNames:   gatewayNames,
 	}
 
-	validations, valid := checker.Check()
+	vals, valid := checker.Check()
 	assert.True(valid)
-	assert.Len(validations, 1)
-	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
+	assert.Len(vals, 1)
+	assert.Equal(models.Unknown, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", vals[0]))
 }
 
 func TestFQDNFoundOtherNamespaceGateway(t *testing.T) {
@@ -179,11 +179,11 @@ func TestFQDNFoundOtherNamespaceGateway(t *testing.T) {
 		GatewayNames:   gatewayNames,
 	}
 
-	validations, valid := checker.Check()
+	vals, valid := checker.Check()
 	assert.True(valid)
-	assert.Len(validations, 1)
-	assert.Equal(models.Unknown, validations[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", validations[0]))
+	assert.Len(vals, 1)
+	assert.Equal(models.Unknown, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.gateway.oldnomenclature", vals[0]))
 }
 
 func TestNewIstioGatewayNameFormat(t *testing.T) {
@@ -205,7 +205,7 @@ func TestNewIstioGatewayNameFormat(t *testing.T) {
 		GatewayNames:   gatewayNames,
 	}
 
-	validations, valid := checker.Check()
+	vals, valid := checker.Check()
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }

--- a/business/checkers/virtualservices/no_host_checker.go
+++ b/business/checkers/virtualservices/no_host_checker.go
@@ -1,4 +1,4 @@
-package virtual_services
+package virtualservices
 
 import (
 	"fmt"

--- a/business/checkers/virtualservices/route_checker.go
+++ b/business/checkers/virtualservices/route_checker.go
@@ -1,4 +1,4 @@
-package virtual_services
+package virtualservices
 
 import (
 	"fmt"

--- a/business/checkers/virtualservices/route_checker_test.go
+++ b/business/checkers/virtualservices/route_checker_test.go
@@ -1,4 +1,4 @@
-package virtual_services
+package virtualservices
 
 import (
 	"testing"
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 // VirtualService has two routes that all the weights sum 100
@@ -16,41 +16,41 @@ func TestServiceWellVirtualServiceValidation(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
-	validations, valid := RouteChecker{fakeValidVirtualService()}.Check()
+	vals, valid := RouteChecker{fakeValidVirtualService()}.Check()
 
 	// Well configured object
 	assert.True(valid)
-	assert.Empty(validations)
+	assert.Empty(vals)
 }
 
 // VirtualService with one route and a weight between 0 and 100
 func TestServiceMultipleChecks(t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := RouteChecker{fakeOneRouteUnder100()}.Check()
+	vals, valid := RouteChecker{fakeOneRouteUnder100()}.Check()
 
 	// wrong weight'ed route rule
 	assert.True(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 1)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.route.singleweight", validations[0]))
-	assert.Equal(validations[0].Severity, models.WarningSeverity)
-	assert.Equal(validations[0].Path, "spec/http[0]/route[0]/weight")
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.route.singleweight", vals[0]))
+	assert.Equal(vals[0].Severity, models.WarningSeverity)
+	assert.Equal(vals[0].Path, "spec/http[0]/route[0]/weight")
 }
 
 func TestVSWithRepeatingSubsets(t *testing.T) {
 	assert := assert.New(t)
 
-	validations, valid := RouteChecker{fakeRepeatedSubset()}.Check()
+	vals, valid := RouteChecker{fakeRepeatedSubset()}.Check()
 	assert.True(valid)
-	assert.NotEmpty(validations)
-	assert.Len(validations, 4)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", validations[0]))
-	assert.Equal(validations[0].Severity, models.WarningSeverity)
-	assert.Regexp(`spec\/http\[0\]\/route\[[0,2]\]\/subset`, validations[0].Path)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", validations[3]))
-	assert.Equal(validations[3].Severity, models.WarningSeverity)
-	assert.Regexp(`spec\/http\[0\]\/route\[[1,3]\]\/subset`, validations[3].Path)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 4)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", vals[0]))
+	assert.Equal(vals[0].Severity, models.WarningSeverity)
+	assert.Regexp(`spec\/http\[0\]\/route\[[0,2]\]\/subset`, vals[0].Path)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.route.repeatedsubset", vals[3]))
+	assert.Equal(vals[3].Severity, models.WarningSeverity)
+	assert.Regexp(`spec\/http\[0\]\/route\[[1,3]\]\/subset`, vals[3].Path)
 }
 
 func fakeValidVirtualService() kubernetes.IstioObject {

--- a/business/checkers/virtualservices/single_host_checker.go
+++ b/business/checkers/virtualservices/single_host_checker.go
@@ -1,4 +1,4 @@
-package virtual_services
+package virtualservices
 
 import (
 	"reflect"

--- a/business/checkers/virtualservices/single_host_checker_test.go
+++ b/business/checkers/virtualservices/single_host_checker_test.go
@@ -1,4 +1,4 @@
-package virtual_services
+package virtualservices
 
 import (
 	"testing"
@@ -8,7 +8,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/testutils"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestOneVirtualServicePerHost(t *testing.T) {
@@ -16,38 +16,38 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 		buildVirtualService("virtual-1", "reviews"),
 		buildVirtualService("virtual-2", "ratings"),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	emptyValidationTest(t, validations)
+	emptyValidationTest(t, vals)
 
 	// First virtual service has a gateway
 	vss = []kubernetes.IstioObject{
 		buildVirtualServiceWithGateway("virtual-1", "reviews", "bookinfo-gateway"),
 		buildVirtualService("virtual-2", "ratings"),
 	}
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	emptyValidationTest(t, validations)
-	emptyValidationTest(t, validations)
+	emptyValidationTest(t, vals)
+	emptyValidationTest(t, vals)
 
 	// Second virtual service has a gateway
 	vss = []kubernetes.IstioObject{
 		buildVirtualService("virtual-1", "reviews"),
 		buildVirtualServiceWithGateway("virtual-2", "ratings", "bookinfo-gateway"),
 	}
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	emptyValidationTest(t, validations)
-	emptyValidationTest(t, validations)
+	emptyValidationTest(t, vals)
+	emptyValidationTest(t, vals)
 
 	// Both virtual services have a gateway
 	vss = []kubernetes.IstioObject{
@@ -55,13 +55,13 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 		buildVirtualServiceWithGateway("virtual-2", "ratings", "bookinfo-gateway"),
 	}
 
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	emptyValidationTest(t, validations)
-	emptyValidationTest(t, validations)
+	emptyValidationTest(t, vals)
+	emptyValidationTest(t, vals)
 }
 
 func TestOneVirtualServicePerFQDNHost(t *testing.T) {
@@ -69,12 +69,12 @@ func TestOneVirtualServicePerFQDNHost(t *testing.T) {
 		buildVirtualService("virtual-1", "reviews.bookinfo.svc.cluster.local"),
 		buildVirtualService("virtual-2", "ratings.bookinfo.svc.cluster.local"),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	emptyValidationTest(t, validations)
+	emptyValidationTest(t, vals)
 }
 
 func TestOneVirtualServicePerFQDNWildcardHost(t *testing.T) {
@@ -82,12 +82,12 @@ func TestOneVirtualServicePerFQDNWildcardHost(t *testing.T) {
 		buildVirtualService("virtual-1", "*.bookinfo.svc.cluster.local"),
 		buildVirtualService("virtual-2", "*.eshop.svc.cluster.local"),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	emptyValidationTest(t, validations)
+	emptyValidationTest(t, vals)
 }
 
 func TestRepeatingSimpleHost(t *testing.T) {
@@ -97,16 +97,16 @@ func TestRepeatingSimpleHost(t *testing.T) {
 		buildVirtualService("virtual-3", "reviews"),
 	}
 
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
-	presentValidationTest(t, validations, "virtual-3")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
+	presentValidationTest(t, vals, "virtual-3")
 
-	for _, validation := range validations {
+	for _, validation := range vals {
 		switch validation.Name {
 		case "virtual-1":
 			presentReferences(t, *validation, []string{"virtual-2", "virtual-3"})
@@ -124,44 +124,44 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 		buildVirtualService("virtual-2", "reviews"),
 	}
 
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	noObjectValidationTest(t, validations, "virtual-1")
-	noObjectValidationTest(t, validations, "virtual-2")
+	noObjectValidationTest(t, vals, "virtual-1")
+	noObjectValidationTest(t, vals, "virtual-2")
 
 	vss = []kubernetes.IstioObject{
 		buildVirtualService("virtual-1", "reviews"),
 		buildVirtualServiceWithGateway("virtual-2", "reviews", "bookinfo"),
 	}
 
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	noObjectValidationTest(t, validations, "virtual-1")
-	noObjectValidationTest(t, validations, "virtual-2")
+	noObjectValidationTest(t, vals, "virtual-1")
+	noObjectValidationTest(t, vals, "virtual-2")
 
 	vss = []kubernetes.IstioObject{
 		buildVirtualServiceWithGateway("virtual-1", "reviews", "bookinfo"),
 		buildVirtualServiceWithGateway("virtual-2", "reviews", "bookinfo"),
 	}
 
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
 	refKey := models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-2"}
-	presentValidationTest(t, validations, "virtual-1")
-	presentReference(t, *(validations[refKey]), "virtual-1")
+	presentValidationTest(t, vals, "virtual-1")
+	presentReference(t, *(vals[refKey]), "virtual-1")
 
 	refKey.Name = "virtual-2"
-	presentValidationTest(t, validations, "virtual-2")
-	presentReference(t, *(validations[refKey]), "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
+	presentReference(t, *(vals[refKey]), "virtual-1")
 }
 
 func TestRepeatingSVCNSHost(t *testing.T) {
@@ -169,7 +169,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		buildVirtualService("virtual-1", "reviews.bookinfo"),
 		buildVirtualService("virtual-2", "reviews.bookinfo"),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
@@ -177,14 +177,14 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
 
 	vss = []kubernetes.IstioObject{
 		buildVirtualService("virtual-1", "reviews"),
 		buildVirtualService("virtual-2", "reviews.bookinfo"),
 	}
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
@@ -192,15 +192,15 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
 
 	vss = []kubernetes.IstioObject{
 		buildVirtualService("virtual-1", "reviews.bookinfo.svc.cluster.local"),
 		buildVirtualService("virtual-2", "reviews.bookinfo"),
 		buildVirtualServiceWithGateway("virtual-3", "reviews", "bookinfo-gateway-auto"),
 	}
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
@@ -208,14 +208,14 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
 
 	vss = []kubernetes.IstioObject{
 		buildVirtualService("virtual-1", "*.bookinfo.svc.cluster.local"),
 		buildVirtualService("virtual-2", "reviews.bookinfo"),
 	}
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
@@ -223,14 +223,14 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
 
 	vss = []kubernetes.IstioObject{
 		buildVirtualService("virtual-1", "reviews"),
 		buildVirtualService("virtual-2", "details.bookinfo"),
 	}
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
@@ -238,15 +238,15 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
-	noObjectValidationTest(t, validations, "virtual-1")
-	noObjectValidationTest(t, validations, "virtual-2")
-	emptyValidationTest(t, validations)
+	noObjectValidationTest(t, vals, "virtual-1")
+	noObjectValidationTest(t, vals, "virtual-2")
+	emptyValidationTest(t, vals)
 
 	vss = []kubernetes.IstioObject{
 		buildVirtualService("virtual-1", "reviews.bookinfo.svc.cluster.local"),
 		buildVirtualService("virtual-2", "details.bookinfo"),
 	}
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
@@ -254,9 +254,9 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		VirtualServices: vss,
 	}.Check()
 
-	noObjectValidationTest(t, validations, "virtual-1")
-	noObjectValidationTest(t, validations, "virtual-2")
-	emptyValidationTest(t, validations)
+	noObjectValidationTest(t, vals, "virtual-1")
+	noObjectValidationTest(t, vals, "virtual-2")
+	emptyValidationTest(t, vals)
 }
 
 func TestRepeatingFQDNHost(t *testing.T) {
@@ -265,16 +265,16 @@ func TestRepeatingFQDNHost(t *testing.T) {
 		buildVirtualService("virtual-2", "reviews.bookinfo.svc.cluster.local"),
 		buildVirtualService("virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
-	presentValidationTest(t, validations, "virtual-3")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
+	presentValidationTest(t, vals, "virtual-3")
 
-	for _, validation := range validations {
+	for _, validation := range vals {
 		switch validation.Name {
 		case "virtual-1":
 			presentReferences(t, *validation, []string{"virtual-2", "virtual-3"})
@@ -292,16 +292,16 @@ func TestRepeatingFQDNWildcardHost(t *testing.T) {
 		buildVirtualService("virtual-2", "*.bookinfo.svc.cluster.local"),
 		buildVirtualService("virtual-3", "*.bookinfo.svc.cluster.local"),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
-	presentValidationTest(t, validations, "virtual-3")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
+	presentValidationTest(t, vals, "virtual-3")
 
-	for _, validation := range validations {
+	for _, validation := range vals {
 		switch validation.Name {
 		case "virtual-1":
 			presentReferences(t, *validation, []string{"virtual-2", "virtual-3"})
@@ -319,16 +319,16 @@ func TestIncludedIntoWildCard(t *testing.T) {
 		buildVirtualService("virtual-2", "reviews.bookinfo.svc.cluster.local"),
 		buildVirtualService("virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
-	presentValidationTest(t, validations, "virtual-3")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
+	presentValidationTest(t, vals, "virtual-3")
 
-	for _, validation := range validations {
+	for _, validation := range vals {
 		switch validation.Name {
 		case "virtual-1":
 			presentReferences(t, *validation, []string{"virtual-2", "virtual-3"})
@@ -345,16 +345,16 @@ func TestIncludedIntoWildCard(t *testing.T) {
 		buildVirtualService("virtual-2", "*.bookinfo.svc.cluster.local"),
 		buildVirtualService("virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
-	validations = SingleHostChecker{
+	vals = SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
-	presentValidationTest(t, validations, "virtual-3")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
+	presentValidationTest(t, vals, "virtual-3")
 
-	for _, validation := range validations {
+	for _, validation := range vals {
 		switch validation.Name {
 		case "virtual-1":
 			presentReferences(t, *validation, []string{"virtual-2", "virtual-3"})
@@ -372,16 +372,16 @@ func TestShortHostNameIncludedIntoWildCard(t *testing.T) {
 		buildVirtualService("virtual-2", "reviews"),
 		buildVirtualService("virtual-3", "reviews"),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
-	presentValidationTest(t, validations, "virtual-3")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
+	presentValidationTest(t, vals, "virtual-3")
 
-	for _, validation := range validations {
+	for _, validation := range vals {
 		switch validation.Name {
 		case "virtual-1":
 			presentReferences(t, *validation, []string{"virtual-2", "virtual-3"})
@@ -399,16 +399,16 @@ func TestWildcardisMarkedInvalid(t *testing.T) {
 		buildVirtualService("virtual-2", "reviews"),
 		buildVirtualService("virtual-3", "reviews"),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
-	presentValidationTest(t, validations, "virtual-3")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
+	presentValidationTest(t, vals, "virtual-3")
 
-	for _, validation := range validations {
+	for _, validation := range vals {
 		switch validation.Name {
 		case "virtual-1":
 			presentReferences(t, *validation, []string{"virtual-2", "virtual-3"})
@@ -426,15 +426,15 @@ func TestMultipleHostsFailing(t *testing.T) {
 		buildVirtualServiceMultipleHosts("virtual-2", []string{"reviews",
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	presentValidationTest(t, validations, "virtual-1")
-	presentValidationTest(t, validations, "virtual-2")
+	presentValidationTest(t, vals, "virtual-1")
+	presentValidationTest(t, vals, "virtual-2")
 
-	for _, validation := range validations {
+	for _, validation := range vals {
 		switch validation.Name {
 		case "virtual-1":
 			presentReference(t, *validation, "virtual-2")
@@ -450,12 +450,12 @@ func TestMultipleHostsPassing(t *testing.T) {
 		buildVirtualServiceMultipleHosts("virtual-2", []string{"ratings",
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
-	validations := SingleHostChecker{
+	vals := SingleHostChecker{
 		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
-	emptyValidationTest(t, validations)
+	emptyValidationTest(t, vals)
 }
 
 func buildVirtualService(name, host string) kubernetes.IstioObject {
@@ -471,38 +471,38 @@ func buildVirtualServiceMultipleHosts(name string, hosts []string) kubernetes.Is
 	return data.CreateEmptyVirtualService(name, "bookinfo", hosts)
 }
 
-func emptyValidationTest(t *testing.T, validations models.IstioValidations) {
+func emptyValidationTest(t *testing.T, vals models.IstioValidations) {
 	assert := assert.New(t)
-	assert.Empty(validations)
+	assert.Empty(vals)
 
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-1"}]
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-1"}]
 	assert.False(ok)
 	assert.Nil(validation)
 
-	validation, ok = validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-2"}]
-	assert.False(ok)
-	assert.Nil(validation)
-}
-
-func noObjectValidationTest(t *testing.T, validations models.IstioValidations, name string) {
-	assert := assert.New(t)
-
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: name}]
+	validation, ok = vals[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-2"}]
 	assert.False(ok)
 	assert.Nil(validation)
 }
 
-func presentValidationTest(t *testing.T, validations models.IstioValidations, serviceName string) {
+func noObjectValidationTest(t *testing.T, vals models.IstioValidations, name string) {
 	assert := assert.New(t)
-	assert.NotEmpty(validations)
 
-	validation, ok := validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: serviceName}]
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: name}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
+func presentValidationTest(t *testing.T, vals models.IstioValidations, serviceName string) {
+	assert := assert.New(t)
+	assert.NotEmpty(vals)
+
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: serviceName}]
 	assert.True(ok)
 
 	assert.True(validation.Valid)
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.NoError(testutils.ConfirmIstioCheckMessage("virtualservices.singlehost", validation.Checks[0]))
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.singlehost", validation.Checks[0]))
 	assert.Equal("spec/hosts", validation.Checks[0].Path)
 }
 

--- a/business/checkers/virtualservices/subset_presence_checker.go
+++ b/business/checkers/virtualservices/subset_presence_checker.go
@@ -1,4 +1,4 @@
-package virtual_services
+package virtualservices
 
 import (
 	"fmt"

--- a/business/checkers/virtualservices/subset_presence_checker_test.go
+++ b/business/checkers/virtualservices/subset_presence_checker_test.go
@@ -1,4 +1,4 @@
-package virtual_services
+package virtualservices
 
 import (
 	"fmt"
@@ -7,8 +7,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/tests/data"
-	"github.com/kiali/kiali/tests/data/validations"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestCheckerWithSubsetMatching(t *testing.T) {
@@ -67,7 +66,7 @@ func subsetPresenceCheckerPrep(scenario string, t *testing.T) ([]*models.IstioCh
 	loader := yamlFixtureLoaderFor(scenario)
 	err := loader.Load()
 
-	validations, valid := SubsetPresenceChecker{
+	vals, valid := SubsetPresenceChecker{
 		Namespace:        "bookinfo",
 		Namespaces:       namespaceNames(loader.GetResources("Namespace")),
 		DestinationRules: loader.GetResources("DestinationRule"),
@@ -78,7 +77,7 @@ func subsetPresenceCheckerPrep(scenario string, t *testing.T) ([]*models.IstioCh
 		t.Error("Error loading test data.")
 	}
 
-	return validations, valid
+	return vals, valid
 }
 
 func namespaceNames(nss []kubernetes.IstioObject) []string {
@@ -89,9 +88,9 @@ func namespaceNames(nss []kubernetes.IstioObject) []string {
 	return namespaces
 }
 
-func yamlFixtureLoaderFor(file string) *data.YamlFixtureLoader {
+func yamlFixtureLoaderFor(file string) *validations.YamlFixtureLoader {
 	path := fmt.Sprintf("../../../tests/data/validations/virtualservices/%s", file)
-	return &data.YamlFixtureLoader{Filename: path}
+	return &validations.YamlFixtureLoader{Filename: path}
 }
 
 func testNoSubsetPresenceValidationsFound(scenario string, t *testing.T) {

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestParseListParams(t *testing.T) {
@@ -734,7 +735,7 @@ func TestFilterIstioObjectsForWorkloadSelector(t *testing.T) {
 	assert := assert.New(t)
 
 	path := fmt.Sprintf("../tests/data/filters/workload-selector-filter.yaml")
-	loader := &data.YamlFixtureLoader{Filename: path}
+	loader := &validations.YamlFixtureLoader{Filename: path}
 	err := loader.Load()
 
 	if err != nil {

--- a/tests/testutils/validations/check_confirmer.go
+++ b/tests/testutils/validations/check_confirmer.go
@@ -1,4 +1,4 @@
-package testutils
+package validations
 
 import (
 	"fmt"

--- a/tests/testutils/validations/check_confirmer_test.go
+++ b/tests/testutils/validations/check_confirmer_test.go
@@ -1,4 +1,4 @@
-package testutils
+package validations
 
 import (
 	"testing"

--- a/tests/testutils/validations/fixture_loader.go
+++ b/tests/testutils/validations/fixture_loader.go
@@ -1,4 +1,4 @@
-package data
+package validations
 
 import (
 	"bytes"

--- a/tests/testutils/validations/fixture_loader_test.go
+++ b/tests/testutils/validations/fixture_loader_test.go
@@ -1,4 +1,4 @@
-package data
+package validations
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 func TestGetResources(t *testing.T) {
 	assert := assert.New(t)
 
-	loader := YamlFixtureLoader{Filename: "./loader/basic.yaml"}
+	loader := YamlFixtureLoader{Filename: "../../data/loader/basic.yaml"}
 	err := loader.Load()
 
 	assert.NoError(err)

--- a/tests/testutils/validations/test_asserter.go
+++ b/tests/testutils/validations/test_asserter.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/tests/testutils"
 )
 
 type IstioCheckTestAsserter struct {
@@ -41,7 +40,7 @@ func (tb IstioCheckTestAsserter) AssertValidationAt(i int, severity models.Sever
 	assert.NotNil(validation)
 	assert.Equal(severity, validation.Severity)
 	assert.Equal(path, validation.Path)
-	assert.NoError(testutils.ConfirmIstioCheckMessage(message, validation))
+	assert.NoError(ConfirmIstioCheckMessage(message, validation))
 }
 
 type ValidationsTestAsserter struct {
@@ -77,5 +76,5 @@ func (vta ValidationsTestAsserter) AssertValidationAt(key models.IstioValidation
 	assert.NotEmpty(validation.Checks)
 	assert.Equal(severity, validation.Checks[0].Severity)
 	assert.Equal(path, validation.Checks[0].Path)
-	assert.NoError(testutils.ConfirmIstioCheckMessage(message, validation.Checks[0]))
+	assert.NoError(ConfirmIstioCheckMessage(message, validation.Checks[0]))
 }


### PR DESCRIPTION
After the addition of the `testutils` folders for the test helpers, I felt that some validations helpers should be living under the same folder now.

Therefore, the situation that this PR aims is:
- `tests/data`: contains all the necessary yamls and the old data builders needed for the tests (istio data object creation)
- `tests/testutils`: contains actual helpers needed for all kinds of purposes.
- `tests/testutils/validations`: contains actual helpers needed for validations