### PR TITLE
Fix graph with spurious cluster boxes and a crash

### DIFF
--- a/graph/telemetry/istio/appender/aggregate_node_test.go
+++ b/graph/telemetry/istio/appender/aggregate_node_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -18,10 +19,12 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -34,10 +37,12 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 		"request_protocol":               "http",
 		"request_operation":              "Top"}
 	q1m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -66,7 +71,7 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -141,10 +146,12 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -157,10 +164,12 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 		"request_protocol":               "http",
 		"request_operation":              "Top"}
 	q1m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -189,7 +198,7 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(false)
-	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -254,10 +263,12 @@ func TestNodeGraphWithServiceInjection(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top",destination_service_name="reviews"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -282,7 +293,7 @@ func TestNodeGraphWithServiceInjection(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -342,10 +353,12 @@ func TestNamespacesGraphWithServiceInjectionSkipRates(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -358,10 +371,12 @@ func TestNamespacesGraphWithServiceInjectionSkipRates(t *testing.T) {
 		"request_protocol":               "http",
 		"request_operation":              "Top"}
 	q1m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -390,7 +405,7 @@ func TestNamespacesGraphWithServiceInjectionSkipRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -437,10 +452,12 @@ func TestNodeGraphNoServiceInjection(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -465,7 +482,7 @@ func TestNodeGraphNoServiceInjection(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(false)
-	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -516,10 +533,12 @@ func TestNodeGraphWithServiceInjectionSkipRates(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top",destination_service_name="reviews"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -544,7 +563,7 @@ func TestNodeGraphWithServiceInjectionSkipRates(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -589,9 +608,9 @@ func TestNodeGraphWithServiceInjectionSkipRates(t *testing.T) {
 }
 
 func aggregateNodeTestTraffic(injectServices bool) graph.TrafficMap {
-	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviews := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviews := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
 
 	trafficMap := graph.NewTrafficMap()
 	trafficMap[productpage.ID] = &productpage

--- a/graph/telemetry/istio/appender/dead_node.go
+++ b/graph/telemetry/istio/appender/dead_node.go
@@ -1,6 +1,7 @@
 package appender
 
 import (
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
 )
@@ -29,7 +30,7 @@ func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 	}
 
 	if globalInfo.HomeCluster == "" {
-		globalInfo.HomeCluster = "unknown"
+		globalInfo.HomeCluster = business.DefaultClusterID
 		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
 		graph.CheckError(err)
 		if c != nil {

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -115,13 +115,13 @@ func TestDeadNode(t *testing.T) {
 	trafficMap := testTrafficMap()
 
 	assert.Equal(12, len(trafficMap))
-	unknownID, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _ := graph.Id(business.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found := trafficMap[unknownID]
 	assert.Equal(true, found)
 	assert.Equal(graph.Unknown, unknownNode.Workload)
 	assert.Equal(10, len(unknownNode.Edges))
 
-	ingressID, _ := graph.Id(graph.Unknown, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(business.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingressNode, found := trafficMap[ingressID]
 	assert.Equal(true, found)
 	assert.Equal("istio-ingressgateway", ingressNode.Workload)
@@ -151,7 +151,7 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal("testNodeWithTcpSentTraffic-v1", ingressNode.Edges[5].Dest.Workload)
 	assert.Equal("testNodeWithTcpSentOutTraffic-v1", ingressNode.Edges[6].Dest.Workload)
 
-	id, _ := graph.Id(graph.Unknown, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	id, _ := graph.Id(business.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 	noPodsNoTraffic, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	isDead, ok := noPodsNoTraffic.Metadata[graph.IsDead]
@@ -159,7 +159,7 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal(true, isDead)
 
 	// Check that external services are not removed
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	_, okExternal := trafficMap[id]
 	assert.Equal(true, okExternal)
 }
@@ -167,39 +167,39 @@ func TestDeadNode(t *testing.T) {
 func testTrafficMap() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(business.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n00 := graph.NewNode(graph.Unknown, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	n00 := graph.NewNode(business.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	n00.Metadata["httpOut"] = 4.8
 
-	n1 := graph.NewNode(graph.Unknown, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n1.Metadata["httpIn"] = 0.8
 
-	n2 := graph.NewNode(graph.Unknown, "testNamespace", "testPodsNoTraffic", "testNamespace", "testPodsNoTraffic-v1", "testPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsNoTraffic", "testNamespace", "testPodsNoTraffic-v1", "testPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n3 := graph.NewNode(graph.Unknown, "testNamespace", "testNoPodsWithTraffic", "testNamespace", "testNoPodsWithTraffic-v1", "testNoPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n3 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoPodsWithTraffic", "testNamespace", "testNoPodsWithTraffic-v1", "testNoPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n3.Metadata["httpIn"] = 0.8
 
-	n4 := graph.NewNode(graph.Unknown, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n4 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n5 := graph.NewNode(graph.Unknown, "testNamespace", "testNoDeploymentWithTraffic", "testNamespace", "testNoDeploymentWithTraffic-v1", "testNoDeploymentWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n5 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoDeploymentWithTraffic", "testNamespace", "testNoDeploymentWithTraffic-v1", "testNoDeploymentWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n5.Metadata["httpIn"] = 0.8
 
-	n6 := graph.NewNode(graph.Unknown, "testNamespace", "testNoDeploymentNoTraffic", "testNamespace", "testNoDeploymentNoTraffic-v1", "testNoDeploymentNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n6 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoDeploymentNoTraffic", "testNamespace", "testNoDeploymentNoTraffic-v1", "testNoDeploymentNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n7 := graph.NewNode(graph.Unknown, "testNamespace", "testNodeWithTcpSentTraffic", "testNamespace", "testNodeWithTcpSentTraffic-v1", "testNodeWithTcpSentTraffic", "v1", graph.GraphTypeVersionedApp)
+	n7 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNodeWithTcpSentTraffic", "testNamespace", "testNodeWithTcpSentTraffic-v1", "testNodeWithTcpSentTraffic", "v1", graph.GraphTypeVersionedApp)
 	n7.Metadata["tcpIn"] = 74.1
 
-	n8 := graph.NewNode(graph.Unknown, "testNamespace", "testNodeWithTcpSentOutTraffic", "testNamespace", "testNodeWithTcpSentOutTraffic-v1", "testNodeWithTcpSentOutTraffic", "v1", graph.GraphTypeVersionedApp)
+	n8 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNodeWithTcpSentOutTraffic", "testNamespace", "testNodeWithTcpSentOutTraffic-v1", "testNodeWithTcpSentOutTraffic", "v1", graph.GraphTypeVersionedApp)
 	n8.Metadata["tcpOut"] = 74.1
 
-	n9 := graph.NewNode(graph.Unknown, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n9 := graph.NewNode(business.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n9.Metadata["httpIn"] = 0.8
 	n9.Metadata[graph.IsServiceEntry] = &graph.SEInfo{
 		Location: "MESH_EXTERNAL",
 	}
 
-	n10 := graph.NewNode(graph.Unknown, "testNamespace", "egress.not.defined", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n10 := graph.NewNode(business.DefaultClusterID, "testNamespace", "egress.not.defined", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n10.Metadata["httpIn"] = 0.8
 
 	trafficMap[n0.ID] = &n0
@@ -265,17 +265,17 @@ func TestDeadNodeIssue2783(t *testing.T) {
 	trafficMap := testTrafficMapIssue2783()
 
 	assert.Equal(3, len(trafficMap))
-	aID, _ := graph.Id(graph.Unknown, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	aID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
 	aNode, found := trafficMap[aID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(aNode.Edges))
 
-	bSvcID, _ := graph.Id(graph.Unknown, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	bSvcID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	bSvcNode, found := trafficMap[bSvcID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(bSvcNode.Edges))
 
-	bID, _ := graph.Id(graph.Unknown, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	bID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 	bNode, found := trafficMap[bID]
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
@@ -294,11 +294,11 @@ func TestDeadNodeIssue2783(t *testing.T) {
 func testTrafficMapIssue2783() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode(graph.Unknown, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(business.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
 
-	n1 := graph.NewNode(graph.Unknown, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n2 := graph.NewNode(graph.Unknown, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 
 	trafficMap[n0.ID] = &n0
 	trafficMap[n1.ID] = &n1
@@ -317,17 +317,17 @@ func TestDeadNodeIssue2982(t *testing.T) {
 	trafficMap := testTrafficMapIssue2982()
 
 	assert.Equal(3, len(trafficMap))
-	aID, _ := graph.Id(graph.Unknown, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	aID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "a", "v1", graph.GraphTypeVersionedApp)
 	aNode, found := trafficMap[aID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(aNode.Edges))
 
-	bSvcID, _ := graph.Id(graph.Unknown, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	bSvcID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	bSvcNode, found := trafficMap[bSvcID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(bSvcNode.Edges))
 
-	bID, _ := graph.Id(graph.Unknown, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	bID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 	bNode, found := trafficMap[bID]
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
@@ -348,12 +348,12 @@ func TestDeadNodeIssue2982(t *testing.T) {
 func testTrafficMapIssue2982() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode(graph.Unknown, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n0 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n0.Metadata["httpIn"] = 0.8
 
-	n1 := graph.NewNode(graph.Unknown, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n1 := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n2 := graph.NewNode(graph.Unknown, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	n2 := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 
 	trafficMap[n0.ID] = &n0
 	trafficMap[n1.ID] = &n1

--- a/graph/telemetry/istio/appender/idle_node.go
+++ b/graph/telemetry/istio/appender/idle_node.go
@@ -1,6 +1,7 @@
 package appender
 
 import (
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
@@ -32,7 +33,7 @@ func (a IdleNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 	services := []models.ServiceDetails{}
 	workloads := []models.WorkloadListItem{}
 	if globalInfo.HomeCluster == "" {
-		globalInfo.HomeCluster = "unknown"
+		globalInfo.HomeCluster = business.DefaultClusterID
 		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
 		graph.CheckError(err)
 		if c != nil {

--- a/graph/telemetry/istio/appender/idle_node_test.go
+++ b/graph/telemetry/istio/appender/idle_node_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/models"
@@ -26,10 +27,10 @@ func TestNonTrafficScenario(t *testing.T) {
 	services := mockServices(a)
 	workloads := mockWorkloads(a)
 
-	a.addIdleNodes(trafficMap, graph.Unknown, "testNamespace", services, workloads)
+	a.addIdleNodes(trafficMap, business.DefaultClusterID, "testNamespace", services, workloads)
 	assert.Equal(7, len(trafficMap))
 
-	id, _ := graph.Id(graph.Unknown, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	id, _ := graph.Id(business.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
 	n, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("customer-v1", n.Workload)
@@ -37,7 +38,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("preference-v1", n.Workload)
@@ -45,7 +46,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v1", n.Workload)
@@ -53,7 +54,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v2", n.Workload)
@@ -61,21 +62,21 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v2", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "customer", "", "", "", "", a.GraphType)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "customer", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
 	assert.Equal("customer", n.Service)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "preference", "", "", "", "", a.GraphType)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
 	assert.Equal("preference", n.Service)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "", "", "", "", a.GraphType)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
@@ -98,7 +99,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	services := mockServices(a)
 	workloads := mockWorkloads(a)
 
-	a.addIdleNodes(trafficMap, graph.Unknown, "testNamespace", services, workloads)
+	a.addIdleNodes(trafficMap, business.DefaultClusterID, "testNamespace", services, workloads)
 
 	assert.Equal(5, len(trafficMap))
 	id, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
@@ -115,7 +116,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(nil, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("preference-v1", n.Workload)
@@ -123,7 +124,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v1", n.Workload)
@@ -131,7 +132,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(graph.Unknown, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
+	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v2", n.Workload)
@@ -160,7 +161,7 @@ func TestVersionWithNoTrafficScenario(t *testing.T) {
 	a.addIdleNodes(trafficMap, cluster, "testNamespace", services, workloads)
 
 	assert.Equal(5, len(trafficMap))
-	id, _ := graph.Id(cluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	id, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
 	unknown, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.Unknown, unknown.Workload)
@@ -261,7 +262,7 @@ func (a *IdleNodeAppender) oneNodeTraffic() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
 	unknown := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
-	customer := graph.NewNode(graph.Unknown, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	customer := graph.NewNode(business.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
 	trafficMap[unknown.ID] = &unknown
 	trafficMap[customer.ID] = &customer
 	edge := unknown.AddEdge(&customer)
@@ -275,7 +276,7 @@ func (a *IdleNodeAppender) oneNodeTraffic() map[string]*graph.Node {
 func (a *IdleNodeAppender) v1Traffic(cluster string) map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	unknown := graph.NewNode(cluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	unknown := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
 	customer := graph.NewNode(cluster, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
 	preference := graph.NewNode(cluster, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
 	recommendation := graph.NewNode(cluster, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -19,26 +19,26 @@ import (
 func setupTrafficMap() (map[string]*graph.Node, string, string, string, string, string, string) {
 	trafficMap := graph.NewTrafficMap()
 
-	appNode := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
+	appNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
 	appNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNode.ID] = &appNode
 
-	appNodeV1 := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	appNodeV1 := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	appNodeV1.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV1.ID] = &appNodeV1
 
-	appNodeV2 := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
+	appNodeV2 := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
 	appNodeV2.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV2.ID] = &appNodeV2
 
-	serviceNode := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	serviceNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[serviceNode.ID] = &serviceNode
 
-	workloadNode := graph.NewNode(graph.Unknown, "testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+	workloadNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
 	workloadNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[workloadNode.ID] = &workloadNode
 
-	fooServiceNode := graph.NewNode(graph.Unknown, "testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	fooServiceNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[fooServiceNode.ID] = &fooServiceNode
 
 	return trafficMap, appNode.ID, appNodeV1.ID, appNodeV2.ID, serviceNode.ID, workloadNode.ID, fooServiceNode.ID

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -15,10 +16,12 @@ func TestResponseTimeP95(t *testing.T) {
 
 	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol)) > 0,0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -28,10 +31,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -41,10 +46,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m2 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -54,10 +61,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q0m3 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -67,10 +76,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m4 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -99,10 +110,12 @@ func TestResponseTimeP95(t *testing.T) {
 
 	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol)) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -112,10 +125,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -125,10 +140,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q1m2 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -138,10 +155,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m3 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -175,7 +194,7 @@ func TestResponseTimeP95(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -270,10 +289,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_request_duration_milliseconds_sum{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) / sum(rate(istio_request_duration_milliseconds_count{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) > 0,0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -283,10 +304,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -296,10 +319,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m2 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -309,10 +334,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q0m3 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -322,10 +349,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m4 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -354,10 +383,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_request_duration_milliseconds_sum{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) / sum(rate(istio_request_duration_milliseconds_count{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -367,10 +398,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -380,10 +413,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q1m2 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -393,10 +428,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m3 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -430,7 +467,7 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -525,10 +562,12 @@ func TestResponseTimeAvg(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_request_duration_milliseconds_sum{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) / sum(rate(istio_request_duration_milliseconds_count{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) > 0,0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -538,10 +577,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -551,10 +592,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m2 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -564,10 +607,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q0m3 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -577,10 +622,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m4 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -609,10 +656,12 @@ func TestResponseTimeAvg(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_request_duration_milliseconds_sum{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) / sum(rate(istio_request_duration_milliseconds_count{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -622,10 +671,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -635,10 +686,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q1m2 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -648,10 +701,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m3 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -685,7 +740,7 @@ func TestResponseTimeAvg(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -776,14 +831,14 @@ func TestResponseTimeAvg(t *testing.T) {
 }
 
 func responseTimeTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
-	reviewsV1 := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsV2 := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
-	ratingsService := graph.NewNode(graph.Unknown, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
-	ratings := graph.NewNode(graph.Unknown, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	reviewsV1 := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsV2 := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
+	ratingsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
+	ratings := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
 	trafficMap[ingress.ID] = &ingress

--- a/graph/telemetry/istio/appender/security_policy_test.go
+++ b/graph/telemetry/istio/appender/security_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -19,11 +20,13 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 
 	q1 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -33,11 +36,13 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 		"destination_principal":          "destination-principal-test",
 		"connection_security_policy":     "mutual_tls"}
 	q1m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -63,7 +68,7 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTraffic()
-	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -120,11 +125,13 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 		`sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
 		`sum(rate(istio_tcp_received_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`)
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -134,11 +141,13 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 		"destination_principal":          "destination-principal-test",
 		"connection_security_policy":     "mutual_tls"}
 	q1m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -164,7 +173,7 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTraffic()
-	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -211,11 +220,13 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 
 	q1 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -238,7 +249,7 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTrafficWithServiceNodes()
-	ingressId, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressId, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressId]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -282,8 +293,8 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 }
 
 func securityPolicyTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 	trafficMap[ingress.ID] = &ingress
 	trafficMap[productpage.ID] = &productpage
@@ -294,9 +305,9 @@ func securityPolicyTestTraffic() graph.TrafficMap {
 }
 
 func securityPolicyTestTrafficWithServiceNodes() graph.TrafficMap {
-	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpagesvc := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpagesvc := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "", "", "", graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 	trafficMap[ingress.ID] = &ingress
 	trafficMap[productpagesvc.ID] = &productpagesvc

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -55,7 +55,7 @@ func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInf
 	}
 
 	if globalInfo.HomeCluster == "" {
-		globalInfo.HomeCluster = "unknown"
+		globalInfo.HomeCluster = business.DefaultClusterID
 		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
 		graph.CheckError(err)
 		if c != nil {

--- a/graph/telemetry/istio/appender/sidecars_check_test.go
+++ b/graph/telemetry/istio/appender/sidecars_check_test.go
@@ -164,7 +164,7 @@ func TestServicesAreAlwaysValid(t *testing.T) {
 func buildWorkloadTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode(graph.Unknown, "testNamespace", "", "testNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+	node := graph.NewNode(business.DefaultClusterID, "testNamespace", "", "testNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
 	trafficMap[node.ID] = &node
 
 	return trafficMap
@@ -173,7 +173,7 @@ func buildWorkloadTrafficMap() graph.TrafficMap {
 func buildInaccessibleWorkloadTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode(graph.Unknown, "inaccessibleNamespace", "", "inaccessibleNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	node := graph.NewNode(business.DefaultClusterID, "inaccessibleNamespace", "", "inaccessibleNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[node.ID] = &node
 
 	return trafficMap
@@ -182,7 +182,7 @@ func buildInaccessibleWorkloadTrafficMap() graph.TrafficMap {
 func buildAppTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode(graph.Unknown, "testNamespace", "", "testNamespace", graph.Unknown, "myTest", graph.Unknown, graph.GraphTypeVersionedApp)
+	node := graph.NewNode(business.DefaultClusterID, "testNamespace", "", "testNamespace", graph.Unknown, "myTest", graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[node.ID] = &node
 
 	return trafficMap
@@ -191,7 +191,7 @@ func buildAppTrafficMap() graph.TrafficMap {
 func buildServiceTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode(graph.Unknown, "testNamespace", "svc", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	node := graph.NewNode(business.DefaultClusterID, "testNamespace", "svc", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[node.ID] = &node
 
 	return trafficMap

--- a/graph/telemetry/istio/appender/throughput_test.go
+++ b/graph/telemetry/istio/appender/throughput_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -15,10 +16,12 @@ func TestResponseThroughput(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -34,10 +37,12 @@ func TestResponseThroughput(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -46,10 +51,12 @@ func TestResponseThroughput(t *testing.T) {
 		"destination_canonical_service":  "reviews",
 		"destination_canonical_revision": "v1"}
 	q1m1 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -58,10 +65,12 @@ func TestResponseThroughput(t *testing.T) {
 		"destination_canonical_service":  "reviews",
 		"destination_canonical_revision": "v2"}
 	q1m2 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -70,10 +79,12 @@ func TestResponseThroughput(t *testing.T) {
 		"destination_canonical_service":  "ratings",
 		"destination_canonical_revision": "v1"}
 	q1m3 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -104,7 +115,7 @@ func TestResponseThroughput(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseThroughputTestTraffic()
-	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -195,14 +206,14 @@ func TestResponseThroughput(t *testing.T) {
 }
 
 func responseThroughputTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
-	reviewsV1 := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsV2 := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
-	ratingsService := graph.NewNode(graph.Unknown, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
-	ratings := graph.NewNode(graph.Unknown, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	reviewsV1 := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsV2 := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
+	ratingsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
+	ratings := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
 	trafficMap[ingress.ID] = &ingress
@@ -231,10 +242,12 @@ func TestRequestThroughput(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -250,10 +263,12 @@ func TestRequestThroughput(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -275,7 +290,7 @@ func TestRequestThroughput(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := requestThroughputTestTraffic()
-	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -336,10 +351,12 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q0m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -355,10 +372,12 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q1m0 := model.Metric{
+		"source_cluster":                 business.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
+		"destination_cluster":            business.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -380,7 +399,7 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := requestThroughputTestTraffic()
-	ingressID, _ := graph.Id(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -437,10 +456,10 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 }
 
 func requestThroughputTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode(graph.Unknown, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(graph.Unknown, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode(graph.Unknown, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
 	trafficMap[ingress.ID] = &ingress


### PR DESCRIPTION
* Provide better defaults when ClusterID cannot be found.
* Avoid a crash if the configured sidecar injector configmap does not exist.

Fixes kiali/kiali#4221
