### PR TITLE
Fix root URL not loading with URL parameters

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -53,9 +53,14 @@ func NewRouter() *mux.Router {
 	}
 
 	fileServerHandler := func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == webRootWithSlash || r.RequestURI == webRoot || r.RequestURI == webRootWithSlash+"index.html" {
+		urlPath := r.RequestURI
+		if r.URL != nil {
+			urlPath = r.URL.Path
+		}
+
+		if urlPath == webRootWithSlash || urlPath == webRoot || urlPath == webRootWithSlash+"index.html" {
 			serveIndexFile(w)
-		} else if r.RequestURI == webRootWithSlash+"env.js" {
+		} else if urlPath == webRootWithSlash+"env.js" {
 			serveEnvJsFile(w)
 		} else {
 			staticFileServer.ServeHTTP(w, r)


### PR DESCRIPTION
Fix non '/' root url failing to load if there are URL parameters (i.e. there is a ? symbol in the URL)

Fixes kiali/kiali#4215
