### PR TITLE
Fix missing Grafana Workload and Service links

### DIFF
--- a/config/dashboards/dashboards_config.go
+++ b/config/dashboards/dashboards_config.go
@@ -79,11 +79,11 @@ type MonitoringDashboardExternalLink struct {
 }
 
 type MonitoringDashboardExternalLinkVariables struct {
-	Namespace string `yaml:"namespace,omitempty"`
-	App       string `yaml:"app,omitempty"`
-	Service   string `yaml:"service,omitempty"`
-	Version   string `yaml:"version,omitempty"`
-	Workload  string `yaml:"workload,omitempty"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	App       string `json:"app,omitempty" yaml:"app,omitempty"`
+	Service   string `json:"service,omitempty" yaml:"service,omitempty"`
+	Version   string `json:"version,omitempty" yaml:"version,omitempty"`
+	Workload  string `json:"workload,omitempty" yaml:"workload,omitempty"`
 }
 
 // GetMetrics provides consistent MonitoringDashboardMetric slice in a backward-compatible way, if deprecated field MetricName is used instead of Metrics in Spec.

--- a/swagger.json
+++ b/swagger.json
@@ -5901,20 +5901,25 @@
     "MonitoringDashboardExternalLinkVariables": {
       "type": "object",
       "properties": {
-        "App": {
-          "type": "string"
+        "app": {
+          "type": "string",
+          "x-go-name": "App"
         },
-        "Namespace": {
-          "type": "string"
+        "namespace": {
+          "type": "string",
+          "x-go-name": "Namespace"
         },
-        "Service": {
-          "type": "string"
+        "service": {
+          "type": "string",
+          "x-go-name": "Service"
         },
-        "Version": {
-          "type": "string"
+        "version": {
+          "type": "string",
+          "x-go-name": "Version"
         },
-        "Workload": {
-          "type": "string"
+        "workload": {
+          "type": "string",
+          "x-go-name": "Workload"
         }
       },
       "x-go-package": "github.com/kiali/kiali/config/dashboards"


### PR DESCRIPTION
This PR fixes the missing Grafana links in Workloads and Service metrics pages.

