### PR TITLE
Jaeger v1.20+ uses new port for grpc. Default url points to it

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -514,7 +514,7 @@ func NewConfig() (c *Config) {
 				},
 				Enabled:              true,
 				NamespaceSelector:    true,
-				InClusterURL:         "http://tracing.istio-system/jaeger",
+				InClusterURL:         "http://tracing.istio-system:16685/jaeger",
 				IsCore:               false,
 				URL:                  "",
 				UseGRPC:              false,


### PR DESCRIPTION
fix https://github.com/kiali/kiali/issues/4238
related https://github.com/kiali/kiali-operator/pull/370

The default in_cluster_url should point to the new grpc port of jaeger.
Notice that kiali default installation will fail for older jaeger releases than 1.20. However, users will only need to change the configmap/kiali-cr fixing the port.

@jmazzitelli do we need to update any other thing to have all the installations covered?
I guess that  https://github.com/kiali/kiali-operator/pull/370 covered the installation through the operator, and with this PR we are covering helm and addons, right?