### PR TITLE
Make DRs subset validation error to info when no VS created for this subsets. Tests added.

### DIFF
--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -38,7 +38,7 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 		validations.MergeValidations(runGatewayCheck(virtualService, gatewayNames))
 	}
 	for _, destinationRule := range in.IstioDetails.DestinationRules {
-		validations.MergeValidations(runDestinationRuleCheck(destinationRule, in.Namespace, in.WorkloadList, in.Services, serviceHosts, in.Namespaces, in.RegistryStatus))
+		validations.MergeValidations(runDestinationRuleCheck(destinationRule, in.Namespace, in.WorkloadList, in.Services, serviceHosts, in.Namespaces, in.RegistryStatus, in.IstioDetails.VirtualServices))
 	}
 	return validations
 }
@@ -76,7 +76,7 @@ func runGatewayCheck(virtualService kubernetes.IstioObject, gatewayNames map[str
 }
 
 func runDestinationRuleCheck(destinationRule kubernetes.IstioObject, namespace string, workloads models.WorkloadList,
-	services []core_v1.Service, serviceHosts map[string][]string, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryStatus) models.IstioValidations {
+	services []core_v1.Service, serviceHosts map[string][]string, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryStatus, virtualServices []kubernetes.IstioObject) models.IstioValidations {
 	key, validations := EmptyValidValidation(destinationRule.GetObjectMeta().Name, destinationRule.GetObjectMeta().Namespace, DestinationRuleCheckerType)
 
 	result, valid := destinationrules.NoDestinationChecker{
@@ -84,6 +84,7 @@ func runDestinationRuleCheck(destinationRule kubernetes.IstioObject, namespace s
 		Namespaces:      clusterNamespaces,
 		WorkloadList:    workloads,
 		DestinationRule: destinationRule,
+		VirtualServices: virtualServices,
 		Services:        services,
 		ServiceEntries:  serviceHosts,
 		RegistryStatus:  registryStatus,

--- a/tests/data/validations/virtualservices/subset-presence-matching-not-referenced.yaml
+++ b/tests/data/validations/virtualservices/subset-presence-matching-not-referenced.yaml
@@ -1,0 +1,43 @@
+# No validations found
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo
+spec:
+  host: reviews
+  subsets:
+    - name: v1
+      labels:
+        version: v1
+    - name: v2
+      labels:
+        version: v2
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: testvs
+  namespace: bookinfo
+spec:
+  hosts:
+    - reviews
+  http:
+    - route:
+        - destination:
+            host: reviews.bookinfo
+            subset: v3
+          weight: 55
+    - route:
+        - destination:
+            host: reviews
+            subset: v4
+          weight: 45

--- a/tests/data/validations/virtualservices/subset-presence-not-referenced.yaml
+++ b/tests/data/validations/virtualservices/subset-presence-not-referenced.yaml
@@ -1,0 +1,23 @@
+# No validations found
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo
+spec:
+  host: reviews
+  subsets:
+    - name: wrong-v1
+      labels:
+        version: wrong-v1
+    - name: wrong-v2
+      labels:
+        version: wrong-v2

--- a/tests/data/validations/virtualservices/subset-presence-referenced.yaml
+++ b/tests/data/validations/virtualservices/subset-presence-referenced.yaml
@@ -1,0 +1,43 @@
+# No validations found
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo
+spec:
+  host: reviews
+  subsets:
+    - name: wrong-v1
+      labels:
+        version: wrong-v1
+    - name: wrong-v2
+      labels:
+        version: wrong-v2
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: testvs
+  namespace: bookinfo
+spec:
+  hosts:
+    - reviews
+  http:
+    - route:
+        - destination:
+            host: reviews.bookinfo
+            subset: wrong-v1
+          weight: 55
+    - route:
+        - destination:
+            host: reviews
+            subset: wrong-v2
+          weight: 45

--- a/tests/data/validations/virtualservices/subset-presence-wrongly-referenced.yaml
+++ b/tests/data/validations/virtualservices/subset-presence-wrongly-referenced.yaml
@@ -1,0 +1,43 @@
+# No validations found
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo
+spec:
+  host: reviews
+  subsets:
+    - name: wrong-v1
+      labels:
+        version: wrong-v1
+    - name: wrong-v2
+      labels:
+        version: wrong-v2
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: testvs
+  namespace: bookinfo
+spec:
+  hosts:
+    - reviews
+  http:
+    - route:
+        - destination:
+            host: reviews.bookinfo
+            subset: very-wrong-v1
+          weight: 55
+    - route:
+        - destination:
+            host: reviews
+            subset: very-wrong-v2
+          weight: 45


### PR DESCRIPTION
POC for RFE: https://github.com/kiali/kiali/issues/4218
Documentation changes: https://github.com/kiali/kiali.io/pull/402

Make DestinationRules subset validations "Error" to "Info" when no VirtualService is referencing to that DestinationRule.

Before:
Error was displayed always when DR subset workload was not found.
![Screenshot from 2021-08-09 14-48-26](https://user-images.githubusercontent.com/604313/128716615-2f55794a-0e14-4853-acec-203a59acbcf4.png)


After:
When DR subset workload is not found but that subset is not linked in any VS, Info severity is shown.
![Screenshot from 2021-08-18 19-58-29](https://user-images.githubusercontent.com/604313/129948724-2c12600a-1e7e-49a5-80c2-0df232d3f982.png)



