### PR TITLE
[v1.38] Using gRPC or HTTP methods to check health of the jaeger component

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -237,7 +237,7 @@ func (iss *IstioStatusService) getAddonComponentStatus() IstioComponentStatus {
 
 	go getAddonStatus("prometheus", true, extServices.Prometheus.IsCore, &extServices.Prometheus.Auth, extServices.Prometheus.URL, extServices.Prometheus.HealthCheckUrl, staChan, &wg)
 	go getAddonStatus("grafana", extServices.Grafana.Enabled, extServices.Grafana.IsCore, &extServices.Grafana.Auth, extServices.Grafana.InClusterURL, extServices.Grafana.HealthCheckUrl, staChan, &wg)
-	go getAddonStatus("jaeger", extServices.Tracing.Enabled, extServices.Tracing.IsCore, &extServices.Tracing.Auth, extServices.Tracing.InClusterURL, extServices.Tracing.HealthCheckUrl, staChan, &wg)
+	go iss.getTracingStatus("jaeger", extServices.Tracing.Enabled, extServices.Tracing.IsCore, staChan, &wg)
 
 	// Custom dashboards may use the main Prometheus config
 	customProm := extServices.CustomDashboards.Prometheus
@@ -327,6 +327,25 @@ func getAddonStatus(name string, enabled bool, isCore bool, auth *config.Auth, u
 	// Call the addOn service endpoint to find out whether is reachable or not
 	_, statusCode, err := httputil.HttpGet(url, auth, 10*time.Second)
 	if err != nil || statusCode > 399 {
+		staChan <- IstioComponentStatus{
+			ComponentStatus{
+				Name:   name,
+				Status: Unreachable,
+				IsCore: isCore,
+			},
+		}
+	}
+}
+
+func (iss *IstioStatusService) getTracingStatus(name string, enabled bool, isCore bool, staChan chan<- IstioComponentStatus, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	if !enabled {
+		return
+	}
+
+	if accessible, err := iss.businessLayer.Jaeger.GetStatus(); !accessible {
+		log.Errorf("Error fetching availability of the tracing service: %v", err)
 		staChan <- IstioComponentStatus{
 			ComponentStatus{
 				Name:   name,

--- a/business/jaeger.go
+++ b/business/jaeger.go
@@ -239,6 +239,14 @@ func (in *JaegerService) GetErrorTraces(ns, app string, duration time.Duration) 
 	return client.GetErrorTraces(ns, app, duration)
 }
 
+func (in *JaegerService) GetStatus() (accessible bool, err error) {
+	client, err := in.client()
+	if err != nil {
+		return false, err
+	}
+	return client.GetServiceStatus()
+}
+
 func matchesWorkload(trace *jaegerModels.Trace, namespace, workload string) bool {
 	for _, span := range trace.Spans {
 		if process, ok := trace.Processes[span.ProcessID]; ok {

--- a/config/config.go
+++ b/config/config.go
@@ -158,7 +158,6 @@ type GrafanaVariablesConfig struct {
 type TracingConfig struct {
 	Auth                 Auth     `yaml:"auth"`
 	Enabled              bool     `yaml:"enabled"` // Enable Jaeger in Kiali
-	HealthCheckUrl       string   `yaml:"health_check_url,omitempty"`
 	InClusterURL         string   `yaml:"in_cluster_url"`
 	IsCore               bool     `yaml:"is_core,omitempty"`
 	NamespaceSelector    bool     `yaml:"namespace_selector"`
@@ -513,11 +512,11 @@ func NewConfig() (c *Config) {
 					Type: AuthTypeNone,
 				},
 				Enabled:              true,
-				NamespaceSelector:    true,
 				InClusterURL:         "http://tracing.istio-system:16685/jaeger",
 				IsCore:               false,
+				NamespaceSelector:    true,
 				URL:                  "",
-				UseGRPC:              false,
+				UseGRPC:              true,
 				WhiteListIstioSystem: []string{"jaeger-query", "istio-ingressgateway"},
 			},
 		},

--- a/jaeger/http_client.go
+++ b/jaeger/http_client.go
@@ -53,6 +53,13 @@ func getTraceDetailHTTP(client http.Client, endpoint *url.URL, traceID string) (
 	}, nil
 }
 
+func getServiceStatusHTTP(client http.Client, baseURL *url.URL) (bool, error) {
+	url := *baseURL
+	url.Path = path.Join(url.Path, "/api/services")
+	_, _, reqError := makeRequest(client, url.String(), nil)
+	return reqError == nil, reqError
+}
+
 func queryTracesHTTP(client http.Client, u *url.URL) (*JaegerResponse, error) {
 	// HTTP and GRPC requests co-exist, but when minDuration is present, for HTTP it requires a unit (ms)
 	// https://github.com/kiali/kiali/issues/3939

--- a/jaeger/jaegertest/mock.go
+++ b/jaeger/jaegertest/mock.go
@@ -1,30 +1,34 @@
 package jaegertest
 
 import (
-	jaegerModels "github.com/jaegertracing/jaeger/model/json"
+	"time"
+
 	"github.com/stretchr/testify/mock"
+
+	"github.com/kiali/kiali/jaeger"
+	"github.com/kiali/kiali/models"
 )
 
 type JaegerClientMock struct {
 	mock.Mock
 }
 
-func (j *JaegerClientMock) GetJaegerServices() (services []string, code int, err error) {
-	args := j.Called()
-	return args.Get(0).([]string), 200, args.Error(1)
+func (j *JaegerClientMock) GetAppTraces(ns, app string, query models.TracingQuery) (traces *jaeger.JaegerResponse, err error) {
+	args := j.Called(ns, app, query)
+	return args.Get(0).(*jaeger.JaegerResponse), args.Error(1)
 }
 
-func (j *JaegerClientMock) GetTraces(namespace string, service string, rawQuery string) (traces []*jaegerModels.Trace, code int, err error) {
-	args := j.Called(namespace, service, rawQuery)
-	return args.Get(0).([]*jaegerModels.Trace), 200, args.Error(1)
-}
-
-func (j *JaegerClientMock) GetTraceDetail(traceId string) (trace []*jaegerModels.Trace, code int, err error) {
+func (j *JaegerClientMock) GetTraceDetail(traceId string) (trace *jaeger.JaegerSingleTrace, err error) {
 	args := j.Called(traceId)
-	return args.Get(0).([]*jaegerModels.Trace), 200, args.Error(1)
+	return args.Get(0).(*jaeger.JaegerSingleTrace), args.Error(1)
 }
 
-func (j *JaegerClientMock) GetErrorTraces(ns string, srv string) (errorTraces int, err error) {
-	args := j.Called(ns, srv)
+func (j *JaegerClientMock) GetErrorTraces(ns string, app string, duration time.Duration) (errorTraces int, err error) {
+	args := j.Called(ns, app, duration)
 	return args.Get(0).(int), args.Error(1)
+}
+
+func (j *JaegerClientMock) GetServiceStatus() (available bool, err error) {
+	args := j.Called()
+	return args.Get(0).(bool), args.Error(1)
 }


### PR DESCRIPTION
backport of https://github.com/kiali/kiali/pull/4249