### PR TITLE
Add viewOnlyMode property into config object

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -314,6 +314,7 @@ type OpenIdConfig struct {
 type DeploymentConfig struct {
 	AccessibleNamespaces []string `yaml:"accessible_namespaces"`
 	Namespace            string   `yaml:"namespace,omitempty"` // Kiali deployment namespace
+	ViewOnlyMode         bool     `yaml:"view_only_mode,omitempty"`
 }
 
 // GraphFindOption defines a single Graph Find/Hide Option
@@ -444,6 +445,7 @@ func NewConfig() (c *Config) {
 		Deployment: DeploymentConfig{
 			AccessibleNamespaces: []string{"**"},
 			Namespace:            "istio-system",
+			ViewOnlyMode:         false,
 		},
 		Extensions: Extensions{
 			Iter8: Iter8Config{

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -48,12 +48,17 @@ type PrometheusConfig struct {
 	StorageTsdbRetention int64 `json:"storageTsdbRetention,omitempty"`
 }
 
+type DeploymentConfig struct {
+	ViewOnlyMode bool `json:"viewOnlyMode,omitempty"`
+}
+
 // PublicConfig is a subset of Kiali configuration that can be exposed to clients to
 // help them interact with the system.
 type PublicConfig struct {
 	ClusterInfo         ClusterInfo                 `json:"clusterInfo,omitempty"`
 	Clusters            map[string]business.Cluster `json:"clusters,omitempty"`
 	Extensions          Extensions                  `json:"extensions,omitempty"`
+	Deployment          DeploymentConfig            `json:"deployment,omitempty"`
 	HealthConfig        config.HealthConfig         `json:"healthConfig,omitempty"`
 	InstallationTag     string                      `json:"installationTag,omitempty"`
 	IstioAnnotations    IstioAnnotations            `json:"istioAnnotations,omitempty"`
@@ -82,6 +87,9 @@ func Config(w http.ResponseWriter, r *http.Request) {
 				Enabled:   config.Extensions.Iter8.Enabled,
 				Namespace: config.Extensions.Iter8.Namespace,
 			},
+		},
+		Deployment: DeploymentConfig{
+			ViewOnlyMode: config.Deployment.ViewOnlyMode,
 		},
 		InstallationTag: config.InstallationTag,
 		IstioAnnotations: IstioAnnotations{


### PR DESCRIPTION
**Description**

This PR adds the property viewOnlyMode into the server configuration. 

This property can be used to avoid doing validations with k8s API and return faster from methods that manage resources.

**Documentation**

```
http://localhost:20001/kiali/api/config
```

```json
{
  ...
  "deployment": {
    "viewOnlyMode": true
  },
  ...
}
```

Frontend PR https://github.com/kiali/kiali-ui/pull/2219 