### PR TITLE
Added support of exported DestinationRules for SubsetPresenceChecker of VirtualSevices. Added tests.

### DIFF
--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -64,7 +64,7 @@ func (in VirtualServiceChecker) runChecks(virtualService kubernetes.IstioObject)
 
 	enabledCheckers := []Checker{
 		virtualservices.RouteChecker{Route: virtualService},
-		virtualservices.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), DestinationRules: in.DestinationRules, VirtualService: virtualService},
+		virtualservices.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), DestinationRules: in.DestinationRules, VirtualService: virtualService, ExportedDestinationRules: in.ExportedDestinationRules},
 		common.ExportToNamespaceChecker{IstioObject: virtualService, Namespaces: in.Namespaces},
 	}
 

--- a/business/checkers/virtualservices/subset_presence_checker.go
+++ b/business/checkers/virtualservices/subset_presence_checker.go
@@ -9,10 +9,11 @@ import (
 )
 
 type SubsetPresenceChecker struct {
-	Namespace        string
-	Namespaces       []string
-	DestinationRules []kubernetes.IstioObject
-	VirtualService   kubernetes.IstioObject
+	Namespace                string
+	Namespaces               []string
+	DestinationRules         []kubernetes.IstioObject
+	ExportedDestinationRules []kubernetes.IstioObject
+	VirtualService           kubernetes.IstioObject
 }
 
 func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
@@ -93,9 +94,9 @@ func (checker SubsetPresenceChecker) subsetPresent(host string, subset string) b
 }
 
 func (checker SubsetPresenceChecker) getDestinationRules(virtualServiceHost string) ([]kubernetes.IstioObject, bool) {
-	drs := make([]kubernetes.IstioObject, 0, len(checker.DestinationRules))
+	drs := make([]kubernetes.IstioObject, 0, len(checker.DestinationRules)+len(checker.ExportedDestinationRules))
 
-	for _, destinationRule := range checker.DestinationRules {
+	for _, destinationRule := range append(checker.DestinationRules, checker.ExportedDestinationRules...) {
 		host, ok := destinationRule.GetSpec()["host"]
 		if !ok {
 			continue

--- a/tests/data/validations/virtualservices/subset-presence-export-subset.yaml
+++ b/tests/data/validations/virtualservices/subset-presence-export-subset.yaml
@@ -1,0 +1,89 @@
+# No validations found
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo2
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo3
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo
+spec:
+  host: reviews.bookinfo.svc.cluster.local
+  subsets:
+    - labels:
+        version: v2
+      name: v2
+  exportTo:
+    - '.'
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo2
+spec:
+  host: reviews
+  subsets:
+    - labels:
+        version: v1
+      name: v1
+  exportTo:
+    - bookinfo
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo3
+spec:
+  host: reviews
+  subsets:
+    - labels:
+        version: v3
+      name: v3
+  exportTo:
+    - '*'
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: reviews-vs
+  namespace: bookinfo
+spec:
+  hosts:
+    - reviews.bookinfo.svc.cluster.local
+  http:
+    - route:
+        - destination:
+            host: reviews.bookinfo2.svc.cluster.local
+            subset: v1
+          weight: 33
+        - destination:
+            host: reviews.bookinfo.svc.cluster.local
+            subset: v2
+          weight: 33
+        - destination:
+            host: reviews.bookinfo3.svc.cluster.local
+            subset: v3
+          weight: 34

--- a/tests/data/validations/virtualservices/subset-presence-no-matching-export-subset.yaml
+++ b/tests/data/validations/virtualservices/subset-presence-no-matching-export-subset.yaml
@@ -1,0 +1,96 @@
+# No validations found
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo2
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bookinfo3
+  labels:
+    istio-injection: "enabled"
+spec: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo
+spec:
+  host: reviews.bookinfo.svc.cluster.local
+  subsets:
+    - labels:
+        version: v2
+      name: v2
+    - labels:
+        version: v3
+      name: v3
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo2
+spec:
+  host: reviews
+  subsets:
+    - labels:
+        version: v4
+      name: v4
+  exportTo:
+    - '*'
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: testrule
+  namespace: bookinfo3
+spec:
+  host: reviews
+  subsets:
+    - labels:
+        version: v5
+      name: v5
+    - labels:
+        version: v6
+      name: v6
+    - labels:
+        version: v7
+      name: v7
+  exportTo:
+    - '*'
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: reviews-vs
+  namespace: bookinfo
+spec:
+  hosts:
+    - reviews.bookinfo.svc.cluster.local
+  http:
+    - route:
+        - destination:
+            host: reviews.bookinfo2.svc.cluster.local
+            subset: v1
+          weight: 33
+        - destination:
+            host: reviews.bookinfo3.svc.cluster.local
+            subset: v3
+          weight: 34
+        - destination:
+            host: reviews.bookinfo.svc.cluster.local
+            subset: v2
+          weight: 33


### PR DESCRIPTION
Second PR for RFE https://github.com/kiali/kiali/issues/3061

Added Cross Namespace validations for SubsetPresenceChecker of Virtual Services.
Added support of exportTo field for validation "KIA1107 Subset not found".

