### PR TITLE
Add workload entry appender to label WE nodes

### DIFF
--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -108,7 +108,7 @@ type NodeData struct {
 	IsOutside             bool                `json:"isOutside,omitempty"`             // true | false
 	IsRoot                bool                `json:"isRoot,omitempty"`                // true | false
 	IsServiceEntry        *graph.SEInfo       `json:"isServiceEntry,omitempty"`        // set static service entry information
-	HasWorkloadEntry      bool                `json:"hasWorkloadEntry,omitempty"`      // true (this nodes has a corresponding WorkloadEntry) | false
+	HasWorkloadEntry      bool                `json:"hasWorkloadEntry,omitempty"`      // true (this node has a corresponding WorkloadEntry) | false
 }
 
 type EdgeData struct {

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -108,6 +108,7 @@ type NodeData struct {
 	IsOutside             bool                `json:"isOutside,omitempty"`             // true | false
 	IsRoot                bool                `json:"isRoot,omitempty"`                // true | false
 	IsServiceEntry        *graph.SEInfo       `json:"isServiceEntry,omitempty"`        // set static service entry information
+	HasWorkloadEntry      bool                `json:"hasWorkloadEntry,omitempty"`      // true (this nodes has a corresponding WorkloadEntry) | false
 }
 
 type EdgeData struct {
@@ -336,6 +337,11 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		// node may have service entry static info
 		if val, ok := n.Metadata[graph.IsServiceEntry]; ok {
 			nd.IsServiceEntry = val.(*graph.SEInfo)
+		}
+
+		// node may have a workload entry associated with it
+		if _, ok := n.Metadata[graph.HasWorkloadEntry]; ok {
+			nd.HasWorkloadEntry = true
 		}
 
 		// node may be an aggregate

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -100,6 +100,7 @@ type NodeData struct {
 	HasTCPTrafficShifting bool                `json:"hasTCPTrafficShifting,omitempty"` // true (vs has tcp traffic shifting) | false
 	HasTrafficShifting    bool                `json:"hasTrafficShifting,omitempty"`    // true (vs has traffic shifting) | false
 	HasVS                 *VSInfo             `json:"hasVS,omitempty"`                 // it can be empty if there is a VS without hostnames
+	HasWorkloadEntry      bool                `json:"hasWorkloadEntry,omitempty"`      // true (this node has a corresponding WorkloadEntry) | false
 	IsBox                 string              `json:"isBox,omitempty"`                 // set for NodeTypeBox, current values: [ 'app', 'cluster', 'namespace' ]
 	IsDead                bool                `json:"isDead,omitempty"`                // true (has no pods) | false
 	IsGateway             *GWInfo             `json:"isGateway,omitempty"`             // Istio ingress/egress gateway information
@@ -108,7 +109,6 @@ type NodeData struct {
 	IsOutside             bool                `json:"isOutside,omitempty"`             // true | false
 	IsRoot                bool                `json:"isRoot,omitempty"`                // true | false
 	IsServiceEntry        *graph.SEInfo       `json:"isServiceEntry,omitempty"`        // set static service entry information
-	HasWorkloadEntry      bool                `json:"hasWorkloadEntry,omitempty"`      // true (this node has a corresponding WorkloadEntry) | false
 }
 
 type EdgeData struct {

--- a/graph/config/cytoscape/cytoscape_test.go
+++ b/graph/config/cytoscape/cytoscape_test.go
@@ -3,6 +3,7 @@ package cytoscape
 import (
 	"testing"
 
+	"github.com/kiali/kiali/graph"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -80,4 +81,18 @@ func TestRateStrings(t *testing.T) {
 	assert.Equal("0.0009", rateToString(2, 0.0009))
 	assert.Equal("0.0009", rateToString(2, 0.00094))
 	assert.Equal("0.0010", rateToString(2, 0.00099))
+}
+
+func TestHasWorkloadEntryAddedToGraph(t *testing.T) {
+	assert := assert.New(t)
+
+	traffic := graph.NewTrafficMap()
+
+	n0 := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	n0.Metadata[graph.HasWorkloadEntry] = true
+	traffic[n0.ID] = &n0
+	cytoConfig := NewConfig(traffic, graph.ConfigOptions{})
+
+	cytoNode := cytoConfig.Elements.Nodes[0]
+	assert.True(cytoNode.Data.HasWorkloadEntry)
 }

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -26,6 +26,7 @@ const (
 	HasRequestRouting     MetadataKey = "hasRequestRouting"
 	HasRequestTimeout     MetadataKey = "hasRequestTimeout"
 	HasVS                 MetadataKey = "hasVS"
+	HasWorkloadEntry      MetadataKey = "hasWorkloadEntry"
 	IsDead                MetadataKey = "isDead"
 	IsEgressCluster       MetadataKey = "isEgressCluster"  // PassthroughCluster or BlackHoleCluster
 	IsIngressGateway      MetadataKey = "isIngressGateway" // Identifies a node that is an Istio ingress gateway

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -41,6 +41,8 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 				requestedAppenders[SidecarsCheckAppenderName] = true
 			case ThroughputAppenderName:
 				requestedAppenders[ThroughputAppenderName] = true
+			case WorkloadEntryAppenderName:
+				requestedAppenders[WorkloadEntryAppenderName] = true
 			case "":
 				// skip
 			default:
@@ -62,6 +64,12 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 		a := ServiceEntryAppender{
 			AccessibleNamespaces: o.AccessibleNamespaces,
 			GraphType:            o.GraphType,
+		}
+		appenders = append(appenders, a)
+	}
+	if _, ok := requestedAppenders[WorkloadEntryAppenderName]; ok || o.Appenders.All {
+		a := WorkloadEntryAppender{
+			GraphType: o.GraphType,
 		}
 		appenders = append(appenders, a)
 	}

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -67,14 +67,14 @@ func ParseAppenders(o graph.TelemetryOptions) []graph.Appender {
 		}
 		appenders = append(appenders, a)
 	}
+	if _, ok := requestedAppenders[DeadNodeAppenderName]; ok || o.Appenders.All {
+		a := DeadNodeAppender{}
+		appenders = append(appenders, a)
+	}
 	if _, ok := requestedAppenders[WorkloadEntryAppenderName]; ok || o.Appenders.All {
 		a := WorkloadEntryAppender{
 			GraphType: o.GraphType,
 		}
-		appenders = append(appenders, a)
-	}
-	if _, ok := requestedAppenders[DeadNodeAppenderName]; ok || o.Appenders.All {
-		a := DeadNodeAppender{}
 		appenders = append(appenders, a)
 	}
 	if _, ok := requestedAppenders[ResponseTimeAppenderName]; ok || o.Appenders.All {

--- a/graph/telemetry/istio/appender/workload_entry.go
+++ b/graph/telemetry/istio/appender/workload_entry.go
@@ -2,6 +2,7 @@ package appender
 
 import (
 	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
 )
@@ -34,6 +35,9 @@ func (a WorkloadEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalIn
 }
 
 func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+	appLabel := config.Get().IstioLabels.AppLabelName
+	versionLabel := config.Get().IstioLabels.VersionLabelName
+
 	for _, n := range trafficMap {
 		// Only a workload or app node can be a workload entry
 		if n.NodeType != graph.NodeTypeWorkload && n.NodeType != graph.NodeTypeApp {
@@ -50,7 +54,7 @@ func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap,
 
 		for _, entry := range istioCfg.WorkloadEntries {
 			if labels, ok := entry.Spec.Labels.(map[string]interface{}); ok {
-				if labels["app"] == n.App && labels["version"] == n.Version {
+				if labels[appLabel] == n.App && labels[versionLabel] == n.Version {
 					n.Metadata[graph.HasWorkloadEntry] = true
 					log.Trace("Found matching WorkloadEntry")
 					// Once a matching workload entry has been found for the workload node,

--- a/graph/telemetry/istio/appender/workload_entry.go
+++ b/graph/telemetry/istio/appender/workload_entry.go
@@ -1,0 +1,64 @@
+package appender
+
+import (
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/log"
+)
+
+const WorkloadEntryAppenderName = "workloadEntry"
+
+// WorkloadEntryAppender correlates trafficMap nodes to corresponding WorkloadEntry
+// Istio objects. If the trafficMap node has a matching WorkloadEntry, a label is
+// added to the node's Metadata. Matching is determined by the "app" and "version"
+// labels on both the trafficMap node and the WorkloadEntry object being equivalent.
+// A workload can have multiple matches.
+type WorkloadEntryAppender struct {
+	GraphType string
+}
+
+// Name implements Appender
+func (a WorkloadEntryAppender) Name() string {
+	return WorkloadEntryAppenderName
+}
+
+// AppendGraph implements Appender
+func (a WorkloadEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+	if len(trafficMap) == 0 {
+		return
+	}
+
+	log.Trace("Running workload entry appender")
+
+	a.applyWorkloadEntries(trafficMap, globalInfo, namespaceInfo)
+}
+
+func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+	for _, n := range trafficMap {
+		// Only a workload or app node can be a workload entry
+		if n.NodeType != graph.NodeTypeWorkload && n.NodeType != graph.NodeTypeApp {
+			continue
+		}
+
+		istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(business.IstioConfigCriteria{
+			IncludeWorkloadEntries: true,
+			Namespace:              n.Namespace,
+		})
+		graph.CheckError(err)
+
+		log.Tracef("WorkloadEntries found: %d", len(istioCfg.WorkloadEntries))
+
+		for _, entry := range istioCfg.WorkloadEntries {
+			if labels, ok := entry.Spec.Labels.(map[string]interface{}); ok {
+				if labels["app"] == n.App && labels["version"] == n.Version {
+					n.Metadata[graph.HasWorkloadEntry] = true
+					log.Trace("Found matching WorkloadEntry")
+					// Once a matching workload entry has been found for the workload node,
+					// the rest of the entries can be ignored because having a single matching
+					// workload entry is enough.
+					break
+				}
+			}
+		}
+	}
+}

--- a/graph/telemetry/istio/appender/workload_entry_test.go
+++ b/graph/telemetry/istio/appender/workload_entry_test.go
@@ -1,0 +1,380 @@
+package appender_test
+
+import (
+	"testing"
+
+	osproject_v1 "github.com/openshift/api/project/v1"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/graph/telemetry/istio/appender"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+)
+
+const (
+	testCluster  = "testCluster"
+	appName      = "ratings"
+	appNamespace = "testNamespace"
+)
+
+func setupBusinessLayer(istioObjects ...kubernetes.IstioObject) *business.Layer {
+	k8s := kubetest.NewK8SClientMock()
+
+	return setupBusinessLayerWithKube(k8s, istioObjects...)
+}
+
+func setupBusinessLayerWithKube(k8s *kubetest.K8SClientMock, istioObjects ...kubernetes.IstioObject) *business.Layer {
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
+	k8s.On("GetIstioObjects", mock.AnythingOfType("string"), "workloadentries", "").Return(istioObjects, nil)
+	config.Set(config.NewConfig())
+
+	businessLayer := business.NewWithBackends(k8s, nil, nil)
+	return businessLayer
+}
+
+func setupWorkloadEntries() *business.Layer {
+	workloadV1 := &kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "workloadA",
+			Namespace: appNamespace,
+		},
+		Spec: map[string]interface{}{
+			"labels": map[string]interface{}{
+				"app":     appName,
+				"version": "v1",
+			},
+		},
+	}
+	workloadV2 := &kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "workloadB",
+			Namespace: appNamespace,
+		},
+		Spec: map[string]interface{}{
+			"labels": map[string]interface{}{
+				"app":     appName,
+				"version": "v2",
+			},
+		},
+	}
+
+	return setupBusinessLayer(workloadV1, workloadV2)
+}
+
+func workloadEntriesTrafficMap() map[string]*graph.Node {
+	// VersionedApp graph
+	trafficMap := make(map[string]*graph.Node)
+
+	// 1 service, 3 workloads. v1 and v2 are workload entries. v3 is not a workload entry e.g. a kube deployment.
+
+	// Service node
+	n0 := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+
+	// v1 Workload
+	n1 := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+
+	// v2 Workload
+	n2 := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+
+	// v3 Workload
+	n3 := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+
+	trafficMap[n0.ID] = &n0
+	trafficMap[n1.ID] = &n1
+	trafficMap[n2.ID] = &n2
+	trafficMap[n3.ID] = &n3
+
+	n0.AddEdge(&n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(&n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(&n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	// Need to put some metadata in here to ensure it gets counted as a workload
+
+	return trafficMap
+}
+
+func TestWorkloadEntry(t *testing.T) {
+	assert := require.New(t)
+
+	businessLayer := setupWorkloadEntries()
+	trafficMap := workloadEntriesTrafficMap()
+
+	assert.Equal(4, len(trafficMap))
+
+	seSVCID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCNode, found := trafficMap[seSVCID]
+	assert.True(found)
+	assert.Equal(3, len(seSVCNode.Edges))
+
+	v1WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	v1Node, found := trafficMap[v1WorkloadID]
+	assert.True(found)
+	assert.NotContains(v1Node.Metadata, graph.HasWorkloadEntry)
+
+	v2WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	v2Node, found := trafficMap[v2WorkloadID]
+	assert.True(found)
+	assert.NotContains(v2Node.Metadata, graph.HasWorkloadEntry)
+
+	v3WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	v3Node, found := trafficMap[v3WorkloadID]
+	assert.True(found)
+	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.HomeCluster = testCluster
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
+
+	// Run the appender...
+	a := appender.WorkloadEntryAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(4, len(trafficMap))
+
+	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	workloadV1Node, found := trafficMap[workloadV1ID]
+	assert.True(found)
+	assert.Equal(workloadV1Node.Metadata[graph.HasWorkloadEntry], true)
+
+	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	workloadV2Node, found := trafficMap[workloadV2ID]
+	assert.True(found)
+	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], true)
+
+	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	workloadV3Node, found := trafficMap[workloadV3ID]
+	assert.True(found)
+	assert.NotContains(workloadV3Node.Metadata, graph.HasWorkloadEntry)
+}
+
+func TestWorkloadEntryAppLabelNotMatching(t *testing.T) {
+	assert := require.New(t)
+
+	workloadV1 := &kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "workloadA",
+			Namespace: appNamespace,
+		},
+		Spec: map[string]interface{}{
+			"labels": map[string]interface{}{
+				"app":     "pastamaker",
+				"version": "v1",
+			},
+		},
+	}
+	workloadV2 := &kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "workloadB",
+			Namespace: appNamespace,
+		},
+		Spec: map[string]interface{}{
+			"labels": map[string]interface{}{
+				"app":     "pastamaker",
+				"version": "v2",
+			},
+		},
+	}
+
+	businessLayer := setupBusinessLayer(workloadV1, workloadV2)
+	trafficMap := workloadEntriesTrafficMap()
+
+	assert.Equal(4, len(trafficMap))
+
+	seSVCID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCNode, found := trafficMap[seSVCID]
+	assert.True(found)
+	assert.Equal(3, len(seSVCNode.Edges))
+
+	v1WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	v1Node, found := trafficMap[v1WorkloadID]
+	assert.True(found)
+	assert.NotContains(v1Node.Metadata, graph.HasWorkloadEntry)
+
+	v2WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	v2Node, found := trafficMap[v2WorkloadID]
+	assert.True(found)
+	assert.NotContains(v2Node.Metadata, graph.HasWorkloadEntry)
+
+	v3WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	v3Node, found := trafficMap[v3WorkloadID]
+	assert.True(found)
+	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.HomeCluster = testCluster
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
+
+	// Run the appender...
+	a := appender.WorkloadEntryAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(4, len(trafficMap))
+
+	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	workloadV1Node, found := trafficMap[workloadV1ID]
+	assert.True(found)
+	assert.NotContains(workloadV1Node.Metadata, graph.HasWorkloadEntry)
+
+	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	workloadV2Node, found := trafficMap[workloadV2ID]
+	assert.True(found)
+	assert.NotContains(workloadV2Node.Metadata, graph.HasWorkloadEntry)
+
+	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	workloadV3Node, found := trafficMap[workloadV3ID]
+	assert.True(found)
+	assert.NotContains(workloadV3Node.Metadata, graph.HasWorkloadEntry)
+}
+
+func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
+	assert := require.New(t)
+
+	workloadV1A := &kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "workloadV1A",
+			Namespace: appNamespace,
+		},
+		Spec: map[string]interface{}{
+			"labels": map[string]interface{}{
+				"app":     appName,
+				"version": "v1",
+			},
+		},
+	}
+	workloadV1B := &kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "workloadV1B",
+			Namespace: appNamespace,
+		},
+		Spec: map[string]interface{}{
+			"labels": map[string]interface{}{
+				"app":     appName,
+				"version": "v1",
+			},
+		},
+	}
+	workloadV2 := &kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "workloadV2",
+			Namespace: appNamespace,
+		},
+		Spec: map[string]interface{}{
+			"labels": map[string]interface{}{
+				"app":     appName,
+				"version": "v2",
+			},
+		},
+	}
+
+	businessLayer := setupBusinessLayer(workloadV1A, workloadV1B, workloadV2)
+	trafficMap := workloadEntriesTrafficMap()
+
+	assert.Equal(4, len(trafficMap))
+
+	seSVCID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCNode, found := trafficMap[seSVCID]
+	assert.True(found)
+	assert.Equal(3, len(seSVCNode.Edges))
+
+	v1WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	v1Node, found := trafficMap[v1WorkloadID]
+	assert.True(found)
+	assert.NotContains(v1Node.Metadata, graph.HasWorkloadEntry)
+
+	v2WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	v2Node, found := trafficMap[v2WorkloadID]
+	assert.True(found)
+	assert.NotContains(v2Node.Metadata, graph.HasWorkloadEntry)
+
+	v3WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	v3Node, found := trafficMap[v3WorkloadID]
+	assert.True(found)
+	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.HomeCluster = testCluster
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
+
+	// Run the appender...
+	a := appender.WorkloadEntryAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(4, len(trafficMap))
+
+	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	workloadV1Node, found := trafficMap[workloadV1ID]
+	assert.True(found)
+	assert.Equal(workloadV1Node.Metadata[graph.HasWorkloadEntry], true)
+
+	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	workloadV2Node, found := trafficMap[workloadV2ID]
+	assert.True(found)
+	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], true)
+
+	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	workloadV3Node, found := trafficMap[workloadV3ID]
+	assert.True(found)
+	assert.NotContains(workloadV3Node.Metadata, graph.HasWorkloadEntry)
+}
+
+func TestWorkloadWithoutWorkloadEntries(t *testing.T) {
+	assert := require.New(t)
+
+	businessLayer := setupBusinessLayer()
+	trafficMap := workloadEntriesTrafficMap()
+
+	assert.Equal(4, len(trafficMap))
+
+	seSVCID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCNode, found := trafficMap[seSVCID]
+	assert.True(found)
+	assert.Equal(3, len(seSVCNode.Edges))
+
+	v1WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	v1Node, found := trafficMap[v1WorkloadID]
+	assert.True(found)
+	assert.NotContains(v1Node.Metadata, graph.HasWorkloadEntry)
+
+	v2WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	v2Node, found := trafficMap[v2WorkloadID]
+	assert.True(found)
+	assert.NotContains(v2Node.Metadata, graph.HasWorkloadEntry)
+
+	v3WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	v3Node, found := trafficMap[v3WorkloadID]
+	assert.True(found)
+	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.HomeCluster = testCluster
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
+
+	// Run the appender...
+	a := appender.WorkloadEntryAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(4, len(trafficMap))
+
+	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	workloadV1Node, found := trafficMap[workloadV1ID]
+	assert.True(found)
+	assert.NotContains(workloadV1Node.Metadata, graph.HasWorkloadEntry)
+
+	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	workloadV2Node, found := trafficMap[workloadV2ID]
+	assert.True(found)
+	assert.NotContains(workloadV2Node.Metadata, graph.HasWorkloadEntry)
+
+	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	workloadV3Node, found := trafficMap[workloadV3ID]
+	assert.True(found)
+	assert.NotContains(workloadV3Node.Metadata, graph.HasWorkloadEntry)
+}

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -7991,6 +7991,7 @@ This type is used to describe a set of objects.
 | HasRequestTimeout | boolean| `bool` |  | |  |  |
 | HasTCPTrafficShifting | boolean| `bool` |  | |  |  |
 | HasTrafficShifting | boolean| `bool` |  | |  |  |
+| HasWorkloadEntry | boolean| `bool` |  | |  |  |
 | ID | string| `string` |  | | Cytoscape Fields |  |
 | IsBox | string| `string` |  | |  |  |
 | IsDead | boolean| `bool` |  | |  |  |

--- a/swagger.json
+++ b/swagger.json
@@ -6016,6 +6016,10 @@
         "hasVS": {
           "$ref": "#/definitions/VSInfo"
         },
+        "hasWorkloadEntry": {
+          "type": "boolean",
+          "x-go-name": "HasWorkloadEntry"
+        },
         "id": {
           "description": "Cytoscape Fields",
           "type": "string",


### PR DESCRIPTION
Creates a `WorkloadEntry` appender that labels graph nodes which have a corresponding `WorkloadEntry` Istio config.

Fixes #4223 

Front-end changes: kiali/kiali-ui#2221

To test this locally, you can use [this hack script](https://github.com/kiali/kiali/blob/master/hack/istio/install-bookinfo-workload-entry.sh). See https://github.com/kiali/kiali/pull/4274 for more instructions on how to use the hack script.