### PR TITLE
Openid allowed domains.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -308,6 +308,7 @@ type OpenIdConfig struct {
 	IssuerUri               string            `yaml:"issuer_uri,omitempty"`
 	Scopes                  []string          `yaml:"scopes,omitempty"`
 	UsernameClaim           string            `yaml:"username_claim,omitempty"`
+	AllowedDomains          []string          `yaml:"allowed_domains,omitempty"`
 }
 
 // DeploymentConfig provides details on how Kiali was deployed.

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -261,7 +261,7 @@ func performOpenIdAuthentication(w http.ResponseWriter, r *http.Request) bool {
 				//fields, so we try to get the domain on email claim
 				log.Debugf("Host Domain not found, trying to discover the host domain over e-mail")
 				var email string
-				if v, ok := tokenClaims["email"];ok {
+				if v, ok := tokenClaims["email"]; ok {
 					email = v.(string)
 				}
 				log.Debugf("Token claim email: %s", email)
@@ -958,7 +958,7 @@ func OpenIdCodeFlowHandler(w http.ResponseWriter, r *http.Request) bool {
 				//fields, so we try to get the domain on email claim
 				log.Debugf("Host Domain not found, trying to discover the host domain over e-mail")
 				var email string
-				if v, ok := tokenClaims["email"];ok {
+				if v, ok := tokenClaims["email"]; ok {
 					email = v.(string)
 				}
 				log.Debugf("Token claim email: %s", email)


### PR DESCRIPTION
** Describe the change **

Add a new field on config file.
This field will allow login from defined domains. Otherwise, the login will be rejected.

New field:

```yaml
    auth:
      openid:
        client_id: xxxxxxxxxxx.apps.googleusercontent.com
        disable_rbac: true
        issuer_uri: "https://accounts.google.com"
        scopes: ["openid", "email"]
        username_claim: "email"
        allowed_domains:
        - sartori.eti.br
```

** Issue reference **

https://github.com/kiali/kiali/issues/4288

Fixes: #4288 

** Backwards incompatible? **

There no changes in behaviour since the field `allowed_domains` is not filled.

** Documentation **

