### PR TITLE
Added cross-namespace validation support for DestinationRule's MultiMatch checker message KIA0201

### DIFF
--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -10,10 +10,11 @@ import (
 const DestinationRuleCheckerType = "destinationrule"
 
 type DestinationRulesChecker struct {
-	DestinationRules []kubernetes.IstioObject
-	MTLSDetails      kubernetes.MTLSDetails
-	ServiceEntries   []kubernetes.IstioObject
-	Namespaces       []models.Namespace
+	DestinationRules         []kubernetes.IstioObject
+	ExportedDestinationRules []kubernetes.IstioObject
+	MTLSDetails              kubernetes.MTLSDetails
+	ServiceEntries           []kubernetes.IstioObject
+	Namespaces               []models.Namespace
 }
 
 func (in DestinationRulesChecker) Check() models.IstioValidations {
@@ -31,7 +32,7 @@ func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 	seHosts := kubernetes.ServiceEntryHostnames(in.ServiceEntries)
 
 	enabledDRCheckers := []GroupChecker{
-		destinationrules.MultiMatchChecker{Namespaces: in.Namespaces, DestinationRules: in.DestinationRules, ServiceEntries: seHosts},
+		destinationrules.MultiMatchChecker{Namespaces: in.Namespaces, DestinationRules: in.DestinationRules, ServiceEntries: seHosts, ExportedDestinationRules: in.ExportedDestinationRules},
 	}
 
 	// Appending validations that only applies to non-autoMTLS meshes

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -24,7 +24,8 @@ func TestMultiHostMatchCorrect(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.Empty(vals)
@@ -46,7 +47,8 @@ func TestMultiHostMatchInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -90,7 +92,8 @@ func TestMultiHostMatchInvalidShortFormat(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -118,7 +121,8 @@ func TestMultiHostMatchValidShortFormat(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.Empty(vals)
@@ -143,7 +147,8 @@ func TestMultiHostMatchValidShortFormatDiffNamespace(t *testing.T) {
 			models.Namespace{Name: "bookinfo"},
 			models.Namespace{Name: "test"},
 		},
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	// MultiMatchChecker shouldn't fail if a host is in a different namespace
@@ -162,7 +167,8 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -181,7 +187,55 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok = vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule1"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule2", validation.References[0].Name)
+}
+
+func TestMultiHostMatchBothWildcardInvalid(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "*"),
+		data.CreateTestDestinationRule("test", "rule2", "*.test.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule2"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule1", validation.References[0].Name)
+
+	destinationRules = []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule2", "*.test.svc.cluster.local"),
+		data.CreateTestDestinationRule("test", "rule1", "*"),
+	}
+
+	vals = MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -208,7 +262,8 @@ func TestMultiHostMatchingMeshWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.Empty(vals)
@@ -230,7 +285,8 @@ func TestMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.Empty(vals)
@@ -253,7 +309,8 @@ func TestMultiHostMatchDifferentSubsets(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.Empty(vals)
@@ -264,7 +321,8 @@ func TestMultiHostMatchDifferentSubsets(t *testing.T) {
 	)
 
 	vals = MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -283,7 +341,8 @@ func TestReviewsExample(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.Empty(vals)
@@ -293,7 +352,8 @@ func TestReviewsExample(t *testing.T) {
 	destinationRules = append(destinationRules, allMatch)
 
 	vals = MultiMatchChecker{
-		DestinationRules: destinationRules,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -321,8 +381,9 @@ func TestMultiServiceEntry(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test", "service-b", "api.service_b.com")
 
 	vals := MultiMatchChecker{
-		DestinationRules: []kubernetes.IstioObject{drA, drB},
-		ServiceEntries:   kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{seA, seB}),
+		DestinationRules:         []kubernetes.IstioObject{drA, drB},
+		ExportedDestinationRules: []kubernetes.IstioObject{},
+		ServiceEntries:           kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{seA, seB}),
 	}.Check()
 
 	assert.Empty(vals)
@@ -340,8 +401,9 @@ func TestMultiServiceEntryInvalid(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test", "service-a2", "api.service_a.com")
 
 	vals := MultiMatchChecker{
-		DestinationRules: []kubernetes.IstioObject{drA, drB},
-		ServiceEntries:   kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{seA}),
+		DestinationRules:         []kubernetes.IstioObject{drA, drB},
+		ExportedDestinationRules: []kubernetes.IstioObject{},
+		ServiceEntries:           kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{seA}),
 	}.Check()
 
 	assert.NotEmpty(vals)

--- a/business/checkers/destinationrules/multi_match_exported_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_exported_checker_test.go
@@ -1,0 +1,601 @@
+package destinationrules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+func TestExportMultiHostMatchCorrect(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "host2.test2.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.Empty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "rule2"}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
+func TestExportMultiHostMatchInvalid(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1.test.svc.cluster.local"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "host1.test.svc.cluster.local"),
+		data.CreateTestDestinationRule("test3", "rule3", "host1.test.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "test"},
+			models.Namespace{Name: "test2"},
+			models.Namespace{Name: "test3"},
+			models.Namespace{Name: "default"},
+		},
+	}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(3, len(vals))
+
+	// Rule1 assertions
+	validationExportAssertion(assert, vals, "test", "test2", "rule1", []string{"rule2"})
+	validationExportAssertion(assert, vals, "test", "test3", "rule1", []string{"rule3"})
+	validationExportAssertion(assert, vals, "test2", "test", "rule2", []string{"rule1"})
+	validationExportAssertion(assert, vals, "test2", "test3", "rule2", []string{"rule3"})
+	validationExportAssertion(assert, vals, "test3", "test", "rule3", []string{"rule1"})
+	validationExportAssertion(assert, vals, "test3", "test2", "rule3", []string{"rule2"})
+}
+
+func TestExportMultiHostMatchInvalid2(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1.test.svc.cluster.local"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "host1.test.svc.cluster.local"),
+		data.CreateTestDestinationRule("test3", "rule3", "host1.test2.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "test"},
+			models.Namespace{Name: "test2"},
+			models.Namespace{Name: "test3"},
+			models.Namespace{Name: "default"},
+		},
+	}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+
+	// Rule1 assertions
+	validationExportAssertion(assert, vals, "test", "test2", "rule1", []string{"rule2"})
+	validationExportAssertion(assert, vals, "test2", "test", "rule2", []string{"rule1"})
+}
+
+func validationExportAssertion(assert *assert.Assertions, vals models.IstioValidations, namespace, refNamespace, drName string, refNames []string) {
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: namespace, Name: drName}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.multimatch", validation.Checks[0]))
+
+	assert.NotEmpty(validation.References)
+	for _, refName := range refNames {
+		assert.Contains(validation.References,
+			models.IstioValidationKey{
+				ObjectType: "destinationrule",
+				Namespace:  refNamespace,
+				Name:       refName,
+			},
+		)
+	}
+}
+
+func TestExportMultiHostMatchValidShortFormat(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "host1.test"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.Empty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "rule2"}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
+func TestExportMultiHostMatchValidShortFormat2(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "host2.test"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.Empty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "rule2"}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
+func TestExportMultiHostMatchValidShortFormatDiffNamespace(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "host2.bookinfo"),
+	}
+
+	vals := MultiMatchChecker{
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "bookinfo"},
+			models.Namespace{Name: "test"},
+			models.Namespace{Name: "test2"},
+		},
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	// MultiMatchChecker shouldn't fail if a host is in a different namespace
+	assert.Empty(vals)
+}
+
+func TestExportMultiHostMatchWildcardInvalid(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1.test.svc.cluster.local"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "*.test.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "rule2"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule1", validation.References[0].Name)
+
+	destinationRules = []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "*.test2.svc.cluster.local"),
+	}
+
+	edr = []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1.test2.svc.cluster.local"),
+	}
+
+	vals = MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok = vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule1"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule2", validation.References[0].Name)
+}
+
+func TestExportMultiHostMatchBothWildcardInvalid(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "*"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "*.test.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "rule2"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule1", validation.References[0].Name)
+
+	destinationRules = []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "*.test.svc.cluster.local"),
+	}
+
+	edr = []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "*"),
+	}
+
+	vals = MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok = vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule1"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule2", validation.References[0].Name)
+}
+
+func TestExportMultiHostMatchBothWildcardInvalid2(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "*.test.svc.cluster.local"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "*.test.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "rule2"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule1", validation.References[0].Name)
+
+	destinationRules = []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "*.test2.svc.cluster.local"),
+	}
+
+	edr = []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "*.test2.svc.cluster.local"),
+	}
+
+	vals = MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok = vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule1"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule2", validation.References[0].Name)
+}
+
+func TestExportMultiHostMatchBothWildcardInvalid3(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "*.wikipedia.org"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "*.wikipedia.org"),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "rule2"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule1", validation.References[0].Name)
+
+	destinationRules = []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test2", "rule2", "*.wikipedia.org"),
+	}
+
+	edr = []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "*.wikipedia.org"),
+	}
+
+	vals = MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	validation, ok = vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "rule1"}]
+	assert.True(ok)
+	assert.True(validation.Valid) // As long as it is warning, this is true
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+
+	assert.NotEmpty(validation.References)
+	assert.Equal("rule2", validation.References[0].Name)
+}
+
+func TestExportMultiHostMatchingMeshWideMTLSDestinationRule(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateTestDestinationRule("test2", "rule2", "*.local")),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.Empty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "rule2"}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
+func TestExportMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.CreateTestDestinationRule("test", "rule1", "host1"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateTestDestinationRule("test2", "rule2", "*.test.svc.cluster.local")),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.Empty(vals)
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "rule2"}]
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
+func TestExportMultiHostMatchDifferentSubsets(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.AddSubsetToDestinationRule(data.CreateSubset("v1", "v1"),
+			data.AddSubsetToDestinationRule(data.CreateSubset("v2", "v2"), data.CreateEmptyDestinationRule("test", "rule1", "host1"))),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.AddSubsetToDestinationRule(data.CreateSubset("v3", "v3"),
+			data.AddSubsetToDestinationRule(data.CreateSubset("v4", "v4"), data.CreateEmptyDestinationRule("test2", "rule2", "host1"))),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.Empty(vals)
+
+	edr = append(edr,
+		data.AddSubsetToDestinationRule(data.CreateSubset("v1", "v1"),
+			data.AddSubsetToDestinationRule(data.CreateSubset("v5", "v5"), data.CreateEmptyDestinationRule("test3", "rule5", "*.test.svc.cluster.local"))),
+	)
+
+	vals = MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+}
+
+func TestExportReviewsExample(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []kubernetes.IstioObject{
+		data.AddSubsetToDestinationRule(data.CreateSubset("v2", "v2"),
+			data.AddSubsetToDestinationRule(data.CreateSubset("v3", "v3"), data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews.bookinfo.svc.cluster.local"))),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.AddSubsetToDestinationRule(data.CreateSubset("v1", "v1"), data.CreateEmptyDestinationRule("bookinfo2", "reviews2", "reviews.bookinfo.svc.cluster.local")),
+	}
+
+	vals := MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.Empty(vals)
+
+	allMatch := data.CreateEmptyDestinationRule("bookinfo3", "reviews3", "reviews.bookinfo.svc.cluster.local")
+	allMatch.GetSpec()["subsets"] = "~"
+	edr = append(edr, allMatch)
+
+	vals = MultiMatchChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: edr,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(3, len(vals))
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "bookinfo3", Name: "reviews3"}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.Equal(1, len(validation.Checks))
+
+	assert.Equal(2, len(validation.References)) // Both reviews and reviews2 is faulty
+}
+
+func TestExportMultiServiceEntry(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	seA := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-a", "test", []string{"api.service_a.com"}))
+	seB := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-b", "test2", []string{"api.service_b.com"}))
+
+	drA := data.CreateEmptyDestinationRule("test", "service-a", "api.service_a.com")
+	drB := data.CreateEmptyDestinationRule("test2", "service-b", "api.service_b.com")
+
+	vals := MultiMatchChecker{
+		DestinationRules:         []kubernetes.IstioObject{drA},
+		ExportedDestinationRules: []kubernetes.IstioObject{drB},
+		ServiceEntries:           kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{seA, seB}),
+	}.Check()
+
+	assert.Empty(vals)
+}
+
+func TestExportMultiServiceEntryInvalid(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	seA := data.AddPortDefinitionToServiceEntry(data.CreateEmptyPortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-a", "test", []string{"api.service_a.com"}))
+
+	drA := data.CreateEmptyDestinationRule("test", "service-a", "api.service_a.com")
+	drB := data.CreateEmptyDestinationRule("test2", "service-a2", "api.service_a.com")
+
+	vals := MultiMatchChecker{
+		DestinationRules:         []kubernetes.IstioObject{drA},
+		ExportedDestinationRules: []kubernetes.IstioObject{drB},
+		ServiceEntries:           kubernetes.ServiceEntryHostnames([]kubernetes.IstioObject{seA}),
+	}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test2", Name: "service-a2"}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.Equal(1, len(validation.Checks))
+
+	assert.Equal(1, len(validation.References)) // Both reviews and reviews2 is faulty
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -120,7 +120,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 	return []ObjectChecker{
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails, RegistryStatus: registryStatus},
 		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices},
-		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
+		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries, Namespaces: namespaces},
@@ -183,7 +183,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioDetails.VirtualServices, DestinationRules: istioDetails.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices}
 		objectCheckers = []ObjectChecker{noServiceChecker, virtualServiceChecker}
 	case kubernetes.DestinationRules:
-		destinationRulesChecker := checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries}
+		destinationRulesChecker := checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries}
 		objectCheckers = []ObjectChecker{noServiceChecker, destinationRulesChecker}
 	case kubernetes.ServiceEntries:
 		serviceEntryChecker := checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries, Namespaces: namespaces}

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -103,6 +103,10 @@ func (h Host) String() string {
 	return hostname
 }
 
+func (h Host) IsWildcard() bool {
+	return strings.HasPrefix(h.Service, "*")
+}
+
 func ParseTwoPartHost(host Host) (string, string) {
 	localSvc, localNs := host.Service, host.Namespace
 	if !host.CompleteInput {


### PR DESCRIPTION
Third PR for https://github.com/kiali/kiali/issues/3061

Covering cross-namespace support of DestinationRule's '"exportTo" field in a scope of validation error "KIA0201 More than one DestinationRules for the same host subset combination"

Before:
![Screenshot from 2021-08-26 20-11-23](https://user-images.githubusercontent.com/604313/131014410-9a2b90c7-d863-403a-9b84-55056574c713.png)

After:
![Screenshot from 2021-08-26 20-12-09](https://user-images.githubusercontent.com/604313/131014424-14f8e083-a5c8-4228-9f39-07b91532f273.png)
