### PR TITLE
Contributor ladder update

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -62,7 +62,7 @@ among current maintainers succeeds.
 
 Kiali testers dedicate time and resources to ensure that the Kiali project is
 delivered with good quality, by actively trying pull requests to find bugs,
-performance issues and any other kind of issues. Testers may also write manual or
+performance issues and any other kind of defect. Testers may also write manual or
 automated tests. The focus is on "System testing" and "Integration testing",
 although it is possible to do simple sanity, smoke and regression testing, or
 simply running existent automated tests if that is enough for a certain code change.
@@ -87,7 +87,7 @@ To become a Tester you need to:
 
 * actively participate in testing code changes of the Kiali project
   * testing pull requests for 3 months or more,
-  * find 5 non trivial issues in Kiali,
+  * find 5 non trivial defects in Kiali,
   * occassionally, do testing over `master` branches to find broken features
 * ability to collaborate with the team,
 * ability to document testing procedures of Kiali features and to update existing documentation if features change,

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,7 +6,7 @@ This document defines governance policies for the Kiali project.
 
 Kiali Maintainers have write access to the [Kiali GitHub repositories](https://github.com/kiali).
 They can merge their own patches or patches from others. Maintainers collectively manage the project's
-resources and contributors. Maintainers are elegible to become admins of specific repositories, or owners
+resources and contributors. If needed, maintainers are elegible to become admins of specific repositories, or owners
 of the Kiali organization.
 
 These privileges are granted with an expectation of responsibility: maintainers care about the Kiali project and want to help it grow and improve. Above the ability to contribute changes, a maintainer has demonstrated the ability to collaborate well with the team, assign appropriate code reviewers, contribute high-quality code, and be thorough and timely with fixes, tests and documentation.
@@ -15,10 +15,10 @@ A maintainer is a contributor to the Kiali project's success and a citizen helpi
 
 Current list of maintainers (alphabetically ordered):
 
-* [aljesusg](https://github.com/aljesusg) - _Owner_
+* [aljesusg](https://github.com/aljesusg)
 * [hhovsepy](https://github.com/hhovsepy)
-* [israel-hdez](https://github.com/israel-hdez) - _Owner_
-* [jmazzitelli](https://github.com/jmazzitelli) - _Owner_
+* [israel-hdez](https://github.com/israel-hdez)
+* [jmazzitelli](https://github.com/jmazzitelli)
 * [leandroberetta](https://github.com/leandroberetta)
 * [nrfox](https://github.com/nrfox)
 * [xeviknal](https://github.com/xeviknal)
@@ -46,17 +46,6 @@ The following information must be provided:
 * a list of links to non-trivial pull requests (top 10) authored by the nominee.
 
 Two other maintainers need to second the nomination. If no one objects in 5 working days (U.S.), the nomination is accepted.  If anyone objects or wants more information, the maintainers discuss and usually come to a consensus (within the 5 working days). If issues can't be resolved, there's a simple majority vote among current maintainers.
-
-To upgrade to _Admin_ of a Kiali repository or _Owner_ of the Kiali organization,
-you must first be a Maintainer (i.e. you cannot directly become an _Admin_ or _Owner_
-without being first a Maintainer). You can propose yourself to apply for admin privileges
-or ownership, or another Maintainer can do it for you. Proposals must be posted by opening a pull request
-modifying the admin or owners list to add the new _Admin_ or _Owner_, or via a
-[GitHub discussion](https://github.com/kiali/kiali/discussions/new) under the
-Governance category. The proposal must mention the GitHub username of the maintainer requiring
-the upgrade and the reason of the need of the upgrade (usually, it is because
-of the need of extra privileges). The new privileges are granted if a simple majority vote
-among current maintainers succeeds.
 
 ## Testers
 
@@ -115,9 +104,9 @@ Thus, they are able to guide and mentor other Maintainers, give direction, and s
 
 Current list of leaders (alphabetically ordered):
 
-* [abonas](https://github.com/abonas) - _Owner_
-* [jshaughn](https://github.com/jshaughn) - _Owner_
-* [lucasponce](https://github.com/lucasponce) - _Owner_
+* [abonas](https://github.com/abonas)
+* [jshaughn](https://github.com/jshaughn)
+* [lucasponce](https://github.com/lucasponce)
 
 ### Becoming a Leader
 
@@ -169,7 +158,7 @@ to the Governance require a 2/3 vote of all Maintainers.
 Kiali Testers also have a voice in voting although their vote is not mandatory.
 
 Unless some process specifies something different, once a vote starts Maintainers (and Testers)
-must give their vote within 5 working days (U.S.)
+must give their vote within 7 working days (U.S.)
 
 ## Other Changes
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,25 +4,39 @@ This document defines governance policies for the Kiali project.
 
 ## Maintainers
 
-Kiali Maintainers have write access to the Kiali GitHub repositories https://github.com/kiali.
-They can merge their own patches or patches from others. The current maintainers can be found in https://github.com/orgs/kiali/teams/maintainers.
+Kiali Maintainers have write access to the [https://github.com/kiali](Kiali GitHub repositories).
+They can merge their own patches or patches from others. Maintainers collectively manage the project's
+resources and contributors.
 
 This privilege is granted with an expectation of responsibility: maintainers care about the Kiali project and want to help it grow and improve. Above the ability to contribute changes, a maintainer has demonstrated the ability to collaborate well with the team, assign appropriate code reviewers, contribute high-quality code, and be thorough and timely with fixes, tests and documentation.
 
 A maintainer is a contributor to the Kiali project's success and a citizen helping the project succeed.
 
-## Becoming a Maintainer
+Current list of maintainers (alphabetically ordered):
+
+* [abonas](https://github.com/abonas)
+* [aljesusg](https://github.com/aljesusg)
+* [hhovsepy](https://github.com/hhovsepy)
+* [israel-hdez](https://github.com/israel-hdez)
+* [jmazzitelli](https://github.com/jmazzitelli)
+* [jshaughn](https://github.com/jshaughn)
+* [leandroberetta](https://github.com/leandroberetta)
+* [lucasponce](https://github.com/lucasponce)
+* [nrfox](https://github.com/nrfox)
+* [xeviknal](https://github.com/xeviknal)
+
+### Becoming a Maintainer
 
 To become a maintainer you need to demonstrate the following:
 
   * commitment to the project
     * participate in discussions, contributions, code reviews for 3 months or more,
     * perform code reviews for 10 non-trivial pull requests,
-    * contribute 10 non-trivial pull requests and have them merged into project branches,
-  * ability to write high quality code,
+    * contribute 10 non-trivial pull requests and have them merged,
+  * ability to write high quality code and/or documentation,
   * ability to collaborate with the team,
   * understanding of team policies and processes,
-  * understanding of the project's code base and coding style.
+  * understanding of the project's code base, and coding and documentation style.
 
 A new maintainer must be proposed by an existing maintainer by sending a message to the
 [kiali-dev@googlegroups.com](https://groups.google.com/forum/#!forum/kiali-dev)
@@ -35,14 +49,25 @@ mailing list containing the following information:
 
 Two other maintainers need to second the nomination. If no one objects in 5 working days (U.S.), the nomination is accepted.  If anyone objects or wants more information, the maintainers discuss and usually come to a consensus (within the 5 working days). If issues can't be resolved, there's a simple majority vote among current maintainers.
 
-## Changes in Maintainership
+### Changes in Maintainership
 
 Maintainers can be removed by a 2/3 majority vote by maintainers, or by resignation.
 
-## GitHub Project Administration
+## Testers
 
-Maintainers will be added to the GitHub @kiali/maintainers team, and made a GitHub maintainer of that team.
-They will be given write permission to the Kiali GitHub repositories https://github.com/kiali.
+Current list of testers (alphabetically ordered):
+
+* [mattmahoneyrh](https://github.com/mattmahoneyrh)
+* [pbajjuri20](https://github.com/pbajjuri20)
+* [prachiyadav](https://github.com/prachiyadav)
+* [skondkar](https://github.com/skondkar)
+
+## Leaders
+
+Current list of maintainers (alphabetically ordered):
+
+* [jshaughn](https://github.com/jshaughn)
+* [lucasponce](https://github.com/lucasponce)
 
 ## Changes in Governance
 
@@ -52,3 +77,28 @@ All changes in Governance require a 2/3 majority vote by maintainers.
 
 Unless specified above, all other changes to the project require a 2/3 majority vote by maintainers.
 Additionally, any maintainer may request that any change require a 2/3 majority vote by maintainers.
+
+## Inactivity
+
+It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
+
+* Inactivity is measured by:
+    * Periods of no contributions for longer than 4 months
+    * Periods of no communication for longer than 4 months
+* Consequences of being inactive include:
+    * Involuntary removal or demotion
+    * Being asked to move to Emeritus status
+
+## Involuntary Removal or Demotion
+
+Involuntary removal/demotion of a contributor happens when responsibilities and requirements aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+
+<!-- TODO: replace with your method of removing/demoting contributors.  If you have a formal governance structure, this would be a good place to assign this to your governance, such as a Steering Committee.
+Again, the example below is for a project without formal governance except the maintainers.-->
+Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.
+
+## Stepping Down/Emeritus Process
+
+If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
+
+Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -76,6 +76,7 @@ both roles aren't mutually exclusive.
 
 Current list of testers (alphabetically ordered):
 
+* [FilipB](https://github.com/FilipB)
 * [mattmahoneyrh](https://github.com/mattmahoneyrh)
 * [pbajjuri20](https://github.com/pbajjuri20)
 * [prachiyadav](https://github.com/prachiyadav)
@@ -166,6 +167,9 @@ Most votes require a simple majority of all Maintainers to succeed. Changes
 to the Governance require a 2/3 vote of all Maintainers.
 
 Kiali Testers also have a voice in voting although their vote is not mandatory.
+
+Unless some process specifies something different, once a vote starts Maintainers (and Testers)
+must give their vote within 5 working days (U.S.)
 
 ## Other Changes
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -19,41 +19,44 @@ Current list of maintainers (alphabetically ordered):
 * [hhovsepy](https://github.com/hhovsepy)
 * [israel-hdez](https://github.com/israel-hdez)
 * [jmazzitelli](https://github.com/jmazzitelli)
-* [jshaughn](https://github.com/jshaughn)
 * [leandroberetta](https://github.com/leandroberetta)
-* [lucasponce](https://github.com/lucasponce)
 * [nrfox](https://github.com/nrfox)
 * [xeviknal](https://github.com/xeviknal)
 
 ### Becoming a Maintainer
 
-To become a maintainer you need to demonstrate the following:
+To become a Maintainer you need to demonstrate the following:
 
-  * commitment to the project
-    * participate in discussions, contributions, code reviews for 3 months or more,
-    * perform code reviews for 10 non-trivial pull requests,
-    * contribute 10 non-trivial pull requests and have them merged,
-  * ability to write high quality code and/or documentation,
-  * ability to collaborate with the team,
-  * understanding of team policies and processes,
-  * understanding of the project's code base, and coding and documentation style.
+* commitment to the project
+  * participate in discussions, contributions, code reviews for 3 months or more,
+  * perform code reviews for 10 non-trivial pull requests,
+  * contribute 10 non-trivial pull requests and have them merged,
+* ability to write high quality code and/or documentation,
+* ability to collaborate with the team,
+* understanding of team policies and processes,
+* understanding of the project's code base, and coding and documentation style.
 
-A new maintainer must be proposed by an existing maintainer by sending a message to the
-[kiali-dev@googlegroups.com](https://groups.google.com/forum/#!forum/kiali-dev)
-mailing list containing the following information:
+A new maintainer must be proposed by an existing maintainer by opening a [GitHub
+discussion](https://github.com/kiali/kiali/discussions/new) under the Governance category.
+The following information must be provided:
 
-  * nominee's first and last name,
-  * nominee's email address and GitHub user name,
-  * an explanation of why the nominee should be a maintainer,
-  * a list of links to non-trivial pull requests (top 10) authored by the nominee.
+* nominee's GitHub user name,
+* an explanation of why the nominee should be a maintainer,
+* a list of links to non-trivial pull requests (top 10) authored by the nominee.
 
 Two other maintainers need to second the nomination. If no one objects in 5 working days (U.S.), the nomination is accepted.  If anyone objects or wants more information, the maintainers discuss and usually come to a consensus (within the 5 working days). If issues can't be resolved, there's a simple majority vote among current maintainers.
 
-### Changes in Maintainership
-
-Maintainers can be removed by a 2/3 majority vote by maintainers, or by resignation.
-
 ## Testers
+
+Kiali testers dedicate time and resources to ensure that the Kiali project is
+delivered with good quality, by actively trying pull requests to find bugs,
+performance issues and any other kind of issues. Testers may also write manual or
+automated tests. The focus is on "System testing" and "Integration testing",
+although it is possible to do simple sanity, smoke and regression testing, or
+simply running existent automated tests if that is enough for a certain pull request.
+
+Testers do not need to be Maintainers. Also, Maintainers do not need to be Testers. Yet,
+both roles aren't mutually exclusive.
 
 Current list of testers (alphabetically ordered):
 
@@ -62,21 +65,39 @@ Current list of testers (alphabetically ordered):
 * [prachiyadav](https://github.com/prachiyadav)
 * [skondkar](https://github.com/skondkar)
 
+### Becoming a Tester
+
+To become a Tester you need to:
+
+* actively participate in testing code changes of the Kiali project
+  * testing pull requests for 3 months or more,
+  * find 5 non trivial issues in Kiali,
+  * occassionally, do testing over `master` branches to find broken features
+* ability to collaborate with the team,
+* ability to document testing procedures of Kiali features and to update existing documentation if features change,
+* understanding of team policies and processes.
+
 ## Leaders
 
-Current list of maintainers (alphabetically ordered):
+Kiali leaders are Maintainers who have a broad knowledge about the Kiali project, its goals and vision.
+They may also be aware on how the ecosystem related to Kiali is evolving, and may also be aware of related projects.
+Thus, they are able to guide and mentor other Maintainers, give direction, and set priorities to the Kiali project.
+
+Current list of leaders (alphabetically ordered):
 
 * [jshaughn](https://github.com/jshaughn)
 * [lucasponce](https://github.com/lucasponce)
 
-## Changes in Governance
+### Becoming a Leader
 
-All changes in Governance require a 2/3 majority vote by maintainers.
+To become a Leader, you must first be a Maintainer. Then, a new Leader must be proposed
+by an existing Maintainer by opening a [GitHub discussion](https://github.com/kiali/kiali/discussions/new)
+under the Governance category. The following information must be provided:
 
-## Other Changes
+* nominee's GitHub user name,
+* an explanation of why the nominee should be a leader.
 
-Unless specified above, all other changes to the project require a 2/3 majority vote by maintainers.
-Additionally, any maintainer may request that any change require a 2/3 majority vote by maintainers.
+Two other maintainers need to second the nomination. If no one objects in 5 working days (U.S.), the nomination is accepted.  If anyone objects or wants more information, the maintainers discuss and usually come to a consensus (within the 5 working days). If issues can't be resolved, there's a simple majority vote among current maintainers.
 
 ## Inactivity
 
@@ -91,14 +112,32 @@ It is important for contributors to be and stay active to set an example and sho
 
 ## Involuntary Removal or Demotion
 
-Involuntary removal/demotion of a contributor happens when responsibilities and requirements aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+Involuntary removal/demotion of a contributor happens when requirements to be on certain role aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
 <!-- TODO: replace with your method of removing/demoting contributors.  If you have a formal governance structure, this would be a good place to assign this to your governance, such as a Steering Committee.
 Again, the example below is for a project without formal governance except the maintainers.-->
-Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.
+Involuntary removal or demotion is handled through a vote by simple majority of the current Maintainers.
 
 ## Stepping Down/Emeritus Process
 
 If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
 
 Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.
+
+## Voting
+
+While most business in Kiali project is conducted by "lazy consensus", periodically
+the Maintainers may need to vote on specific actions or changes.
+A vote can be taken on [the developer mailing list](TODO) or
+[the private Maintainer mailing list](TODO) for security or conduct matters.  
+Votes may also be taken at [the developer meeting](TODO).  Any Maintainer may
+demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed. Maintainers
+can be removed by a 2/3 majority vote of all Maintainers, or by resignation. Changes
+to the Governance require a 2/3 vote of all Maintainers.
+
+## Other Changes
+
+Unless specified above, all other changes to the project require a 2/3 majority vote by maintainers.
+Additionally, any maintainer may request that any change require a 2/3 majority vote by maintainers.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -95,7 +95,7 @@ To become a Tester you need to:
 
 You can propose yourself to apply for the Tester role, or a Maintainer can do it for you.
 Proposals must be posted by opening a pull request
-modifying the testers list to add the new proposed tester, or via a in
+modifying the testers list to add the new proposed tester, or via
 a [GitHub discussion](https://github.com/kiali/kiali/discussions/new) under the
 Governance category. The following information must be provided:
 
@@ -143,7 +143,7 @@ It is important for contributors to be and stay active to set an example and sho
 
 ## Involuntary Removal or Demotion
 
-Involuntary removal/demotion of a contributor happens when requirements to be on certain role aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+Involuntary removal/demotion of a contributor happens when requirements for a certain role aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
 Involuntary removal or demotion is handled through a vote by simple majority of the current Maintainers.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,21 +4,21 @@ This document defines governance policies for the Kiali project.
 
 ## Maintainers
 
-Kiali Maintainers have write access to the [https://github.com/kiali](Kiali GitHub repositories).
+Kiali Maintainers have write access to the [Kiali GitHub repositories](https://github.com/kiali).
 They can merge their own patches or patches from others. Maintainers collectively manage the project's
-resources and contributors.
+resources and contributors. Maintainers are elegible to become admins of specific repositories, or owners
+of the Kiali organization.
 
-This privilege is granted with an expectation of responsibility: maintainers care about the Kiali project and want to help it grow and improve. Above the ability to contribute changes, a maintainer has demonstrated the ability to collaborate well with the team, assign appropriate code reviewers, contribute high-quality code, and be thorough and timely with fixes, tests and documentation.
+These privileges are granted with an expectation of responsibility: maintainers care about the Kiali project and want to help it grow and improve. Above the ability to contribute changes, a maintainer has demonstrated the ability to collaborate well with the team, assign appropriate code reviewers, contribute high-quality code, and be thorough and timely with fixes, tests and documentation.
 
 A maintainer is a contributor to the Kiali project's success and a citizen helping the project succeed.
 
 Current list of maintainers (alphabetically ordered):
 
-* [abonas](https://github.com/abonas)
-* [aljesusg](https://github.com/aljesusg)
+* [aljesusg](https://github.com/aljesusg) - _Owner_
 * [hhovsepy](https://github.com/hhovsepy)
-* [israel-hdez](https://github.com/israel-hdez)
-* [jmazzitelli](https://github.com/jmazzitelli)
+* [israel-hdez](https://github.com/israel-hdez) - _Owner_
+* [jmazzitelli](https://github.com/jmazzitelli) - _Owner_
 * [leandroberetta](https://github.com/leandroberetta)
 * [nrfox](https://github.com/nrfox)
 * [xeviknal](https://github.com/xeviknal)
@@ -36,15 +36,27 @@ To become a Maintainer you need to demonstrate the following:
 * understanding of team policies and processes,
 * understanding of the project's code base, and coding and documentation style.
 
-A new maintainer must be proposed by an existing maintainer by opening a [GitHub
+A new maintainer must be proposed by an existing maintainer by opening a pull request
+modifying the maintainers list to add the new proposed maintainer, or via a [GitHub
 discussion](https://github.com/kiali/kiali/discussions/new) under the Governance category.
 The following information must be provided:
 
-* nominee's GitHub user name,
+* nominee's GitHub username,
 * an explanation of why the nominee should be a maintainer,
 * a list of links to non-trivial pull requests (top 10) authored by the nominee.
 
 Two other maintainers need to second the nomination. If no one objects in 5 working days (U.S.), the nomination is accepted.  If anyone objects or wants more information, the maintainers discuss and usually come to a consensus (within the 5 working days). If issues can't be resolved, there's a simple majority vote among current maintainers.
+
+To upgrade to _Admin_ of a Kiali repository or _Owner_ of the Kiali organization,
+you must first be a Maintainer (i.e. you cannot directly become an _Admin_ or _Owner_
+without being first a Maintainer). You can propose yourself to apply for admin privileges
+or ownership, or another Maintainer can do it for you. Proposals must be posted by opening a pull request
+modifying the admin or owners list to add the new _Admin_ or _Owner_, or via a
+[GitHub discussion](https://github.com/kiali/kiali/discussions/new) under the
+Governance category. The proposal must mention the GitHub username of the maintainer requiring
+the upgrade and the reason of the need of the upgrade (usually, it is because
+of the need of extra privileges). The new privileges are granted if a simple majority vote
+among current maintainers succeeds.
 
 ## Testers
 
@@ -53,7 +65,11 @@ delivered with good quality, by actively trying pull requests to find bugs,
 performance issues and any other kind of issues. Testers may also write manual or
 automated tests. The focus is on "System testing" and "Integration testing",
 although it is possible to do simple sanity, smoke and regression testing, or
-simply running existent automated tests if that is enough for a certain pull request.
+simply running existent automated tests if that is enough for a certain code change.
+
+Testers are granted the same privileges as Maintainers, and are also invited to become
+a member of the Kiali organization. This is in good faith of not performing tasks of a
+Maintainer.
 
 Testers do not need to be Maintainers. Also, Maintainers do not need to be Testers. Yet,
 both roles aren't mutually exclusive.
@@ -77,6 +93,19 @@ To become a Tester you need to:
 * ability to document testing procedures of Kiali features and to update existing documentation if features change,
 * understanding of team policies and processes.
 
+You can propose yourself to apply for the Tester role, or a Maintainer can do it for you.
+Proposals must be posted by opening a pull request
+modifying the testers list to add the new proposed tester, or via a in
+a [GitHub discussion](https://github.com/kiali/kiali/discussions/new) under the
+Governance category. The following information must be provided:
+
+* nominee's GitHub username
+* a list of pull requests (top 5) tested by the nominee.
+* a list of documented test cases (if any)
+
+Formalization of the Tester role is granted if a simple majority vote
+among current maintainers succeeds.
+
 ## Leaders
 
 Kiali leaders are Maintainers who have a broad knowledge about the Kiali project, its goals and vision.
@@ -85,19 +114,21 @@ Thus, they are able to guide and mentor other Maintainers, give direction, and s
 
 Current list of leaders (alphabetically ordered):
 
-* [jshaughn](https://github.com/jshaughn)
-* [lucasponce](https://github.com/lucasponce)
+* [abonas](https://github.com/abonas) - _Owner_
+* [jshaughn](https://github.com/jshaughn) - _Owner_
+* [lucasponce](https://github.com/lucasponce) - _Owner_
 
 ### Becoming a Leader
 
 To become a Leader, you must first be a Maintainer. Then, a new Leader must be proposed
-by an existing Maintainer by opening a [GitHub discussion](https://github.com/kiali/kiali/discussions/new)
+by an existing Maintainer by opening a pull request modifying the leaders list to add the new
+proposed leader, or via a by opening a [GitHub discussion](https://github.com/kiali/kiali/discussions/new)
 under the Governance category. The following information must be provided:
 
-* nominee's GitHub user name,
+* nominee's GitHub username,
 * an explanation of why the nominee should be a leader.
 
-Two other maintainers need to second the nomination. If no one objects in 5 working days (U.S.), the nomination is accepted.  If anyone objects or wants more information, the maintainers discuss and usually come to a consensus (within the 5 working days). If issues can't be resolved, there's a simple majority vote among current maintainers.
+Leadership is granted if a simple majority vote among current maintainers succeeds.
 
 ## Inactivity
 
@@ -114,13 +145,11 @@ It is important for contributors to be and stay active to set an example and sho
 
 Involuntary removal/demotion of a contributor happens when requirements to be on certain role aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
-<!-- TODO: replace with your method of removing/demoting contributors.  If you have a formal governance structure, this would be a good place to assign this to your governance, such as a Steering Committee.
-Again, the example below is for a project without formal governance except the maintainers.-->
 Involuntary removal or demotion is handled through a vote by simple majority of the current Maintainers.
 
 ## Stepping Down/Emeritus Process
 
-If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
+If and when contributors commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
 
 Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.
 
@@ -128,16 +157,17 @@ Contact the Maintainers about changing to Emeritus status, or reducing your cont
 
 While most business in Kiali project is conducted by "lazy consensus", periodically
 the Maintainers may need to vote on specific actions or changes.
-A vote can be taken on [the developer mailing list](TODO) or
-[the private Maintainer mailing list](TODO) for security or conduct matters.  
-Votes may also be taken at [the developer meeting](TODO).  Any Maintainer may
-demand a vote be taken.
+A vote can be taken on pull requests proposing project changes, or via a
+[a GitHub discussion](https://github.com/kiali/kiali/discussions/new).
+If there are security or conduct matters, voting can take place in private meetings.
+Any Maintainer or Tester may demand a vote be taken.
 
-Most votes require a simple majority of all Maintainers to succeed. Maintainers
-can be removed by a 2/3 majority vote of all Maintainers, or by resignation. Changes
+Most votes require a simple majority of all Maintainers to succeed. Changes
 to the Governance require a 2/3 vote of all Maintainers.
+
+Kiali Testers also have a voice in voting although their vote is not mandatory.
 
 ## Other Changes
 
-Unless specified above, all other changes to the project require a 2/3 majority vote by maintainers.
-Additionally, any maintainer may request that any change require a 2/3 majority vote by maintainers.
+Unless specified above, all other changes to the project require a 2/3 majority vote.
+Additionally, any maintainer or tester may request that any change require a 2/3 majority vote.


### PR DESCRIPTION
This is:

* Adding the `leader` and `tester` roles to the contributor ladder, which we have had for quite a long time. This is simply formalizing those roles.
  * As they are "new", I tried to describe them based on how they current behave
  * I added how to apply for these roles. This is mainly based on how to apply for the "maintainer" role. It's quite simplistic. Probably not everybody may agree but, if needed, I want to open here the discussion about if the step-in process makes sense.
* Added how to become an _Owner_ of the Kiali organization. I'm not sure if this is really right to mention.
* Updated channel to propose new contributors or changes to the governance: either by a PR or a GitHub discussion. This removes mentions to the already deprecated mail lists.
* Adding `Inactivity`, `Involuntary Removal or Demotion`, `Stepping Down/Emeritus Process` and `Voting` sections. All based on the [CNCF project template](https://github.com/cncf/project-template).
* Listing current contributors under their relevant role.