### PR TITLE
Added support of exportTo field's validation for DestimationRule TrafficPolicyChecker.

### DIFF
--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -37,7 +37,7 @@ func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 
 	// Appending validations that only applies to non-autoMTLS meshes
 	if !in.MTLSDetails.EnabledAutoMtls {
-		enabledDRCheckers = append(enabledDRCheckers, destinationrules.TrafficPolicyChecker{DestinationRules: in.DestinationRules, MTLSDetails: in.MTLSDetails})
+		enabledDRCheckers = append(enabledDRCheckers, destinationrules.TrafficPolicyChecker{DestinationRules: in.DestinationRules, ExportedDestinationRules: in.ExportedDestinationRules, MTLSDetails: in.MTLSDetails})
 	}
 
 	for _, checker := range enabledDRCheckers {

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -242,8 +242,9 @@ func testValidationAdded(t *testing.T, destinationRules []kubernetes.IstioObject
 	assert := assert.New(t)
 
 	vals := TrafficPolicyChecker{
-		DestinationRules: destinationRules,
-		MTLSDetails:      mTLSDetails,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
+		MTLSDetails:              mTLSDetails,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -266,8 +267,9 @@ func testValidationsNotAdded(t *testing.T, destinationRules []kubernetes.IstioOb
 	assert := assert.New(t)
 
 	vals := TrafficPolicyChecker{
-		DestinationRules: destinationRules,
-		MTLSDetails:      mTLSDetails,
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: []kubernetes.IstioObject{},
+		MTLSDetails:              mTLSDetails,
 	}.Check()
 
 	assert.Empty(vals)

--- a/business/checkers/destinationrules/traffic_policy_exported_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_exported_checker_test.go
@@ -1,0 +1,574 @@
+package destinationrules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule doesn't specify trafficPolicy
+// Context: ExportedDestinationRule specifies trafficPolicy
+// It returns a validation
+func TestMTLSMeshWideEnabledDRWithoutTrafficPolicyExportedWith(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("istio-system", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that doesn't specify any trafficPolicy
+		data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
+	}
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	presentReferences(t, *validation, "istio-system", []string{"default"})
+	presentReferences(t, *validation, "bookinfo", []string{"default"})
+	presentReferences(t, *validation, "bookinfo2", []string{"reviews"})
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule doesn't specify trafficPolicy
+// Context: ExportedDestinationRule doesn't specify trafficPolicy
+// It returns a validation
+func TestMTLSMeshWideEnabledDRWithoutTrafficPolicyExportedWithout(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("istio-system", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that doesn't specify any trafficPolicy
+		data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local"),
+	}
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	presentReferences(t, *validation, "istio-system", []string{"default"})
+	presentReferences(t, *validation, "bookinfo", []string{"default"})
+	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule doesn't specify mTLS options
+// Context: ExportedDestinationRule doesn't specify mTLS options
+// It returns a validation
+func TestMTLSMeshWideEnabledDRWithoutmTLSOptionsExportedWithout(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
+	}
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	presentReferences(t, *validation, "bookinfo", []string{"default"})
+	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule doesn't specify mTLS options
+// Context: ExportedDestinationRule specifies mTLS options
+// It returns a validation
+func TestMTLSMeshWideEnabledDRWithoutmTLSOptionsExportedWith(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
+	}
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	presentReferences(t, *validation, "bookinfo", []string{"default"})
+	presentReferences(t, *validation, "bookinfo2", []string{"reviews"})
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule doesn't specify port-level mTLS options
+// Context: ExportedDestinationRule doesn't specify port-level mTLS options
+// It returns a validation
+func TestMTLSMeshWideEnabledDRWithoutPortLevelmTLSOptionsExportedWithout(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreatePortLevelTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreatePortLevelTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
+	}
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	presentReferences(t, *validation, "bookinfo", []string{"default"})
+	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule doesn't specify port-level mTLS options
+// Context: ExportedDestinationRule specifies port-level mTLS options
+// It returns a validation
+func TestMTLSMeshWideEnabledDRWithoutPortLevelmTLSOptionsExportedWith(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreatePortLevelTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy with mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
+	}
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	presentReferences(t, *validation, "bookinfo", []string{"default"})
+	presentReferences(t, *validation, "bookinfo2", []string{"reviews"})
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule does specify trafficPolicy and mTLS options
+// Context: ExportedDestinationRule does specify trafficPolicy and mTLS options
+// It doesn't return any validation
+func TestMTLSMeshWideEnabledDRWithTrafficPolicyExportedWith(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify TrafficPolicy
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR that specify TrafficPolicy
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
+	}
+
+	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule does specify trafficPolicy and mTLS options
+// Context: ExportedDestinationRule doesn't specify trafficPolicy
+// It doesn't return any validation
+func TestMTLSMeshWideEnabledDRWithTrafficPolicyExportedWithout(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify TrafficPolicy
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR that doesn't specify TrafficPolicy
+		data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local"),
+	}
+
+	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule does specify trafficPolicy and TLS options
+// Context: ExportedDestinationRule doesn't specify trafficPolicy
+// It doesn't return any validation
+func TestMTLSMeshWideEnabledDRWithPortLevelTLSTrafficPolicyExportedWithout(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify TrafficPolicy
+		data.AddTrafficPolicyToDestinationRule(data.CreateTLSPortLevelTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateEmptyDestinationRule("bookinfo2", "reviews2", "*.bookinfo.svc.cluster.local"),
+	}
+
+	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+}
+
+// Context: MeshPolicy Enabling mTLS
+// Context: DestinationRule does specify trafficPolicy and TLS options
+// Context: ExportedDestinationRule does specify trafficPolicy
+// It doesn't return any validation
+func TestMTLSMeshWideEnabledDRWithPortLevelTLSTrafficPolicyExportedWith(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Mesh-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify TrafficPolicy
+		data.AddTrafficPolicyToDestinationRule(data.CreateTLSPortLevelTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews2", "*.bookinfo.svc.cluster.local")),
+	}
+
+	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule doesn't specify trafficPolicy
+// Context: ExportedDestinationRule doesn't specify trafficPolicy
+// It returns a validation
+func TestNamespacemTLSEnabledDRWithoutTrafficPolicyExportedWithout(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that doesn't specify any trafficPolicy
+		data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR that doesn't specify any trafficPolicy
+		data.CreateEmptyDestinationRule("bookinfo2", "reviews2", "reviews.bookinfo.svc.cluster.local"),
+	}
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	presentReferences(t, *validation, "bookinfo", []string{"default"})
+	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule doesn't specify trafficPolicy
+// Context: ExportedDestinationRule doesn't specify trafficPolicy
+// It returns a validation
+func TestNamespacemTLSEnabledDRWithoutTrafficPolicyExportedWith(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that doesn't specify any trafficPolicy
+		data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews"),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "*.bookinfo.svc.cluster.local")),
+	}
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	presentReferences(t, *validation, "bookinfo", []string{"default"})
+	presentReferences(t, *validation, "bookinfo2", []string{"reviews"})
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule doesn't specify mTLS options
+// Context: ExportedDestinationRule refers to own host
+// It returns a validation
+func TestNamespacemTLSEnabledDRWithoutmTLSOptionsExportedOther(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy but no mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR refers to itself
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo2.svc.cluster.local")),
+	}
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	presentReferences(t, *validation, "bookinfo", []string{"default"})
+	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule does specify trafficPolicy
+// Context: ExportedDestinationRule does specify trafficPolicy
+// It doesn't return any validation
+func TestNamespacemTLSEnabledDRWithTrafficPolicyExportedWith(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy and mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy and mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo2", "reviews2", "reviews.bookinfo.svc.cluster.local")),
+	}
+
+	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule does specify trafficPolicy
+// Context: ExportedDestinationRule doesn't specify trafficPolicy
+// It doesn't return any validation
+func TestNamespacemTLSEnabledDRWithTrafficPolicyExportedWithout(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.local")),
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy and mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("bookinfo", "reviews", "reviews")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.CreateEmptyDestinationRule("bookinfo2", "reviews2", "*.bookinfo.svc.cluster.local"),
+	}
+
+	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule doesn't specify trafficPolicy and host is from other namespace
+// Context: ExportedDestinationRule doesn't specify trafficPolicy and host is from other namespace
+// It doesn't return any validation
+func TestCrossNamespaceProtectionExported(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("other", "reviews", "reviews.other.svc.cluster.local")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("other2", "reviews", "reviews.other2.svc.cluster.local")),
+	}
+
+	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "other")
+}
+
+// Context: Namespace-wide mTLS enabled
+// Context: DestinationRule doesn't specify trafficPolicy and host is from a ServiceEntry
+// It doesn't return any validation
+func TestCrossNamespaceServiceEntryProtectionExported(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []kubernetes.IstioObject{
+			// Namespace-wide DR enabling mTLS communication
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("bookinfo", "default", "*.bookinfo.svc.cluster.local")),
+		},
+	}
+
+	destinationRules := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy and mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("other", "service-entry-dr", "wikipedia.org")),
+	}
+
+	edr := []kubernetes.IstioObject{
+		// Subject DR that specify trafficPolicy and mTLS options
+		data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("other2", "service-entry-dr2", "wikipedia.org")),
+	}
+
+	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "service-entry-dr", "other")
+}
+
+func testValidationAddedExported(t *testing.T, destinationRules []kubernetes.IstioObject, exportedDestinationRules []kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails, name string, namespace string) *models.IstioValidation {
+	assert := assert.New(t)
+
+	vals := TrafficPolicyChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: exportedDestinationRules,
+		MTLSDetails:              mTLSDetails,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(1, len(vals))
+
+	validation, ok := vals[models.BuildKey(DestinationRulesCheckerType, name, namespace)]
+	assert.True(ok)
+	assert.True(validation.Valid)
+
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.Equal("spec/trafficPolicy", validation.Checks[0].Path)
+	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.trafficpolicy.notlssettings", validation.Checks[0]))
+
+	assert.True(len(validation.References) > 0)
+	return validation
+}
+
+func testValidationsNotAddedExported(t *testing.T, destinationRules []kubernetes.IstioObject, exportedDestinationRules []kubernetes.IstioObject, mTLSDetails kubernetes.MTLSDetails, name string, namespace string) {
+	assert := assert.New(t)
+
+	vals := TrafficPolicyChecker{
+		DestinationRules:         destinationRules,
+		ExportedDestinationRules: exportedDestinationRules,
+		MTLSDetails:              mTLSDetails,
+	}.Check()
+
+	assert.Empty(vals)
+	validation, ok := vals[models.BuildKey(DestinationRulesCheckerType, name, namespace)]
+
+	assert.False(ok)
+	assert.Nil(validation)
+}
+
+func notPresentReferences(t *testing.T, validation models.IstioValidation, ns string, serviceNames []string) {
+	assert := assert.New(t)
+
+	for _, sn := range serviceNames {
+		refKey := models.IstioValidationKey{ObjectType: "destinationrule", Namespace: ns, Name: sn}
+		assert.NotContains(validation.References, refKey)
+	}
+}


### PR DESCRIPTION
Added support of exported DestinationRules in validation of TrafficPolicyChecker for message: "KIA0204 mTLS settings of a non-local Destination Rule are overridden."

Epic https://github.com/kiali/kiali/issues/3061
Subtask https://github.com/kiali/kiali/issues/4315

Create a DR in different namespace, having mTLS enabled, exported to local namespace or anywhere and also in host pointing to service from local namespace.
![Screenshot from 2021-09-06 12-51-06](https://user-images.githubusercontent.com/604313/132213734-9bb92554-d470-4cae-a428-12859d7c30e7.png)

Create a DR in local namespace which does not have mTLS enabled, and pointing to the same local service.

Before, the validations does not include exported DRs from different namespace which have the same  host, only the 'default' DR:
![Screenshot from 2021-09-06 12-50-27](https://user-images.githubusercontent.com/604313/132214014-74d541d8-8a73-44ba-bf5d-2c110892d775.png)

Now, validations include cross namespace exported DRs as well:
![Screenshot from 2021-09-06 12-50-31](https://user-images.githubusercontent.com/604313/132214132-6d8b086e-1f89-40f9-bd8d-465e1e214bda.png)


