### PR TITLE
Added cross-namespace validation support on validation KIA0202 for exportTo field of ServiceEntry

### DIFF
--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -49,7 +49,7 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 											stringLabels[k] = s
 										}
 									}
-									if !n.hasMatchingWorkload(fqdn.Service, stringLabels) {
+									if !n.hasMatchingWorkload(fqdn.String(), stringLabels) {
 										validation := models.Build("destinationrules.nodest.subsetlabels",
 											"spec/subsets["+strconv.Itoa(i)+"]")
 										if n.isSubsetReferenced(dHost, innerSubset["name"].(string)) {
@@ -122,7 +122,7 @@ func (n NoDestinationChecker) hasMatchingWorkload(service string, subsetLabels m
 
 func (n NoDestinationChecker) hasMatchingService(host kubernetes.Host, itemNamespace string) bool {
 	// Check wildcard hosts - needs to match "*" and "*.suffix" also..
-	if strings.HasPrefix(host.Service, "*") {
+	if host.IsWildcard() {
 		return true
 	}
 
@@ -142,7 +142,7 @@ func (n NoDestinationChecker) hasMatchingService(host kubernetes.Host, itemNames
 	}
 
 	// Check ServiceEntries
-	if kubernetes.HasMatchingServiceEntries(host.Service, n.ServiceEntries) {
+	if kubernetes.HasMatchingServiceEntries(host.String(), n.ServiceEntries) {
 		return true
 	}
 

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -15,6 +15,7 @@ type NoServiceChecker struct {
 	Namespace            string
 	Namespaces           models.Namespaces
 	IstioDetails         *kubernetes.IstioDetails
+	ExportedResources    *kubernetes.ExportedResources
 	Services             []core_v1.Service
 	WorkloadList         models.WorkloadList
 	GatewaysPerNamespace [][]kubernetes.IstioObject
@@ -30,7 +31,7 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 	}
 
 	serviceNames := getServiceNames(in.Services)
-	serviceHosts := kubernetes.ServiceEntryHostnames(in.IstioDetails.ServiceEntries)
+	serviceHosts := kubernetes.ServiceEntryHostnames(append(in.IstioDetails.ServiceEntries, in.ExportedResources.ServiceEntries...))
 	gatewayNames := kubernetes.GatewayNames(in.GatewaysPerNamespace)
 
 	for _, virtualService := range in.IstioDetails.VirtualServices {

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -18,9 +18,10 @@ func TestNoCrashOnNil(t *testing.T) {
 	assert := assert.New(t)
 
 	typeValidations := NoServiceChecker{
-		Namespace:    "test",
-		IstioDetails: nil,
-		Services:     nil,
+		Namespace:         "test",
+		IstioDetails:      nil,
+		ExportedResources: nil,
+		Services:          nil,
 	}.Check()
 
 	assert.Empty(typeValidations)
@@ -45,6 +46,7 @@ func TestAllIstioObjectWithServices(t *testing.T) {
 			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
 		),
 		IstioDetails:         fakeIstioDetails(),
+		ExportedResources:    emptyExportedResources(),
 		Services:             fakeServiceDetails([]string{"reviews", "details", "product", "customer"}),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 	}.Check()
@@ -63,8 +65,9 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert := assert.New(t)
 
 	vals := NoServiceChecker{
-		Namespace:    "test",
-		IstioDetails: fakeIstioDetails(),
+		Namespace:         "test",
+		IstioDetails:      fakeIstioDetails(),
+		ExportedResources: emptyExportedResources(),
 		WorkloadList: data.CreateWorkloadList("test",
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
@@ -96,6 +99,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
 		),
 		IstioDetails:         fakeIstioDetails(),
+		ExportedResources:    emptyExportedResources(),
 		Services:             fakeServiceDetails([]string{"reviews", "details", "customer"}),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 	}.Check()
@@ -121,6 +125,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
 		),
 		IstioDetails:         fakeIstioDetails(),
+		ExportedResources:    emptyExportedResources(),
 		Services:             fakeServiceDetails([]string{"reviews", "product", "customer"}),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 	}.Check()
@@ -139,6 +144,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
 		),
 		IstioDetails:         fakeIstioDetails(),
+		ExportedResources:    emptyExportedResources(),
 		Services:             fakeServiceDetails([]string{"details", "product", "customer"}),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 	}.Check()
@@ -160,6 +166,7 @@ func TestObjectWithoutGateway(t *testing.T) {
 	vals := NoServiceChecker{
 		Namespace:            "test",
 		IstioDetails:         istioDetails,
+		ExportedResources:    emptyExportedResources(),
 		Services:             fakeServiceDetails([]string{"reviews", "product", "customer"}),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 	}.Check()
@@ -186,6 +193,10 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 	}
 
 	return &istioDetails
+}
+
+func emptyExportedResources() *kubernetes.ExportedResources {
+	return &kubernetes.ExportedResources{}
 }
 
 func fakeServiceDetails(services []string) []core_v1.Service {

--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -9,8 +9,9 @@ import (
 const ServiceEntryCheckerType = "serviceentry"
 
 type ServiceEntryChecker struct {
-	ServiceEntries []kubernetes.IstioObject
-	Namespaces     models.Namespaces
+	ServiceEntries         []kubernetes.IstioObject
+	ExportedServiceEntries []kubernetes.IstioObject
+	Namespaces             models.Namespaces
 }
 
 func (s ServiceEntryChecker) Check() models.IstioValidations {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -118,7 +118,7 @@ func (in *IstioValidationsService) getServiceCheckers(namespace string, services
 
 func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioDetails kubernetes.IstioDetails, exportedResources kubernetes.ExportedResources, services []core_v1.Service, workloadsPerNamespace map[string]models.WorkloadList, workloads models.WorkloadList, gatewaysPerNamespace [][]kubernetes.IstioObject, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace, registryStatus []*kubernetes.RegistryStatus) []ObjectChecker {
 	return []ObjectChecker{
-		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails, RegistryStatus: registryStatus},
+		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, ExportedResources: &exportedResources, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails, RegistryStatus: registryStatus},
 		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, VirtualServices: istioDetails.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices},
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioDetails.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioDetails.ServiceEntries},
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
@@ -172,7 +172,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	go in.fetchRegistryStatus(&registryStatus, errChan, &wg)
 	wg.Wait()
 
-	noServiceChecker := checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails, RegistryStatus: registryStatus}
+	noServiceChecker := checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioDetails: &istioDetails, ExportedResources: &exportedResources, Services: services, WorkloadList: workloads, GatewaysPerNamespace: gatewaysPerNamespace, AuthorizationDetails: &rbacDetails, RegistryStatus: registryStatus}
 
 	switch objectType {
 	case kubernetes.Gateways:

--- a/tests/data/service_entry_data.go
+++ b/tests/data/service_entry_data.go
@@ -47,6 +47,24 @@ func CreateEmptyMeshExternalServiceEntry(name, namespace string, hosts []string)
 	}).DeepCopyIstioObject()
 }
 
+func CreateEmptyMeshInternalServiceEntry(name, namespace string, hosts []string) kubernetes.IstioObject {
+	hostsI := make([]interface{}, len(hosts))
+	for i, h := range hosts {
+		hostsI[i] = interface{}(h)
+	}
+	return (&kubernetes.GenericIstioObject{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: map[string]interface{}{
+			"hosts":      hostsI,
+			"location":   "MESH_INTERNAL",
+			"resolution": "NONE",
+		},
+	}).DeepCopyIstioObject()
+}
+
 func AddPortDefinitionToServiceEntry(portDef map[string]interface{}, se kubernetes.IstioObject) kubernetes.IstioObject {
 	if portsSpec, found := se.GetSpec()["ports"]; found {
 		if portsSlice, ok := portsSpec.([]interface{}); ok {


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/3061
Subtask : https://github.com/kiali/kiali/issues/4316

On validation message "KIA0202 This host has no matching entry in the service registry (service, workload or service entries)" is now added a support of cross-namespace checking of ServiceEntries.

So create a ServiceEntry:
![Screenshot from 2021-09-16 10-46-24](https://user-images.githubusercontent.com/604313/133585557-f9187a59-8f81-4a07-9892-eded744d719d.png)

Before when linking from DR to that SE which was in different namespace, it was showing an error:
![Screenshot from 2021-09-16 08-40-52](https://user-images.githubusercontent.com/604313/133585678-222e2317-d7b1-46f5-8a0b-f47d2646b52a.png)

Now error on host is not shown:
![Screenshot from 2021-09-16 10-48-11](https://user-images.githubusercontent.com/604313/133585861-9673da97-1327-4f2e-85d5-8f4903e42fec.png)

But try to export SE into local namespace only:
![Screenshot from 2021-09-16 11-17-51](https://user-images.githubusercontent.com/604313/133585971-5548f781-a761-4b25-a0ac-b94805de9ae4.png)

The error is shown, as SE is not available into DR's namespace:
![Screenshot from 2021-09-16 11-18-46](https://user-images.githubusercontent.com/604313/133586164-a63e9ce4-c23f-4010-8858-ebea76b3f972.png)
![Screenshot from 2021-09-16 11-19-04](https://user-images.githubusercontent.com/604313/133586167-1b5511e2-72b3-48bc-847e-68196a6475c9.png)


