### PR TITLE
Ensure only active ReplicaSets are returned from GetReplicaSets

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -501,7 +501,8 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		// Check if namespace is cached
 		// Namespace access is checked in the upper caller
 		if IsNamespaceCached(namespace) {
-			repset, err = kialiCache.GetReplicaSets(namespace)
+			// repset, err = kialiCache.GetReplicaSets(namespace)
+			repset, err = layer.k8s.GetReplicaSets(namespace)
 		} else {
 			repset, err = layer.k8s.GetReplicaSets(namespace)
 		}
@@ -1081,7 +1082,8 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		// Check if namespace is cached
 		// Namespace access is checked in the upper call
 		if IsNamespaceCached(namespace) {
-			repset, err = kialiCache.GetReplicaSets(namespace)
+			// repset, err = kialiCache.GetReplicaSets(namespace)
+			repset, err = layer.k8s.GetReplicaSets(namespace)
 		} else {
 			repset, err = layer.k8s.GetReplicaSets(namespace)
 		}

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -501,8 +501,7 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 		// Check if namespace is cached
 		// Namespace access is checked in the upper caller
 		if IsNamespaceCached(namespace) {
-			// repset, err = kialiCache.GetReplicaSets(namespace)
-			repset, err = layer.k8s.GetReplicaSets(namespace)
+			repset, err = kialiCache.GetReplicaSets(namespace)
 		} else {
 			repset, err = layer.k8s.GetReplicaSets(namespace)
 		}
@@ -1082,8 +1081,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 		// Check if namespace is cached
 		// Namespace access is checked in the upper call
 		if IsNamespaceCached(namespace) {
-			// repset, err = kialiCache.GetReplicaSets(namespace)
-			repset, err = layer.k8s.GetReplicaSets(namespace)
+			repset, err = kialiCache.GetReplicaSets(namespace)
 		} else {
 			repset, err = layer.k8s.GetReplicaSets(namespace)
 		}

--- a/kubernetes/cache/kubernetes.go
+++ b/kubernetes/cache/kubernetes.go
@@ -332,6 +332,9 @@ func (c *kialiCacheImpl) GetReplicaSets(namespace string) ([]apps_v1.ReplicaSet,
 							}
 						}
 					}
+				} else {
+					// it is it's own controller
+					activeRSMap[rs.Name] = rs
 				}
 			}
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -320,6 +320,9 @@ func (in *K8SClient) GetReplicaSets(namespace string) ([]apps_v1.ReplicaSet, err
 						}
 					}
 				}
+			} else {
+				// it is it's own controller
+				activeRSMap[rs.Name] = rs
 			}
 		}
 


### PR DESCRIPTION
This PR aims to ensure that Kiali does not consider historical replicasets, and ignores their pods when "discovering" workloads.  Kiali identifies workloads using sort-of a bottom-up approach that starts with Pods and looks for thir owners. The owner can be a ReplicaSet. Our list of Pods is cached (as is our list of ReplicaSets) and I think what happens is that we get a cached pod for an old ReplicaSet. Our list of ReplicaSets contains all the ReplicaSets for the namespace, both active and inactive (note that inactive RS can result from Deployments that have revisionHistoryLimit > 0). So we can get a cached pod that is owned by an inactive ReplicaSet. For Kiali, I don't think old ReplicaSets for the same owner (Deployment) are useful. If we filter them away I think the related issue will be resolved.

Fixes #4141 