### PR TITLE
Added cross-namespace support for ServiceEntry in AuthorizationPolicy validations

### DIFF
--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -12,15 +12,17 @@ import (
 const AuthorizationPolicyCheckerType = "authorizationpolicy"
 
 type AuthorizationPolicyChecker struct {
-	AuthorizationPolicies []kubernetes.IstioObject
-	Namespace             string
-	Namespaces            models.Namespaces
-	ServiceEntries        []kubernetes.IstioObject
-	Services              []core_v1.Service
-	WorkloadList          models.WorkloadList
-	MtlsDetails           kubernetes.MTLSDetails
-	VirtualServices       []kubernetes.IstioObject
-	RegistryStatus        []*kubernetes.RegistryStatus
+	AuthorizationPolicies   []kubernetes.IstioObject
+	Namespace               string
+	Namespaces              models.Namespaces
+	ServiceEntries          []kubernetes.IstioObject
+	ExportedServiceEntries  []kubernetes.IstioObject
+	Services                []core_v1.Service
+	WorkloadList            models.WorkloadList
+	MtlsDetails             kubernetes.MTLSDetails
+	VirtualServices         []kubernetes.IstioObject
+	ExportedVirtualServices []kubernetes.IstioObject
+	RegistryStatus          []*kubernetes.RegistryStatus
 }
 
 func (a AuthorizationPolicyChecker) Check() models.IstioValidations {
@@ -45,7 +47,7 @@ func (a AuthorizationPolicyChecker) Check() models.IstioValidations {
 func (a AuthorizationPolicyChecker) runChecks(authPolicy kubernetes.IstioObject) models.IstioValidations {
 	policyName := authPolicy.GetObjectMeta().Name
 	key, rrValidation := EmptyValidValidation(policyName, authPolicy.GetObjectMeta().Namespace, AuthorizationPolicyCheckerType)
-	serviceHosts := kubernetes.ServiceEntryHostnames(a.ServiceEntries)
+	serviceHosts := kubernetes.ServiceEntryHostnames(append(a.ServiceEntries, a.ExportedServiceEntries...))
 
 	enabledCheckers := []Checker{
 		common.SelectorNoWorkloadFoundChecker(AuthorizationPolicyCheckerType, authPolicy, a.WorkloadList),

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -124,7 +124,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioD
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: istioDetails.ServiceEntries, Namespaces: namespaces},
-		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioDetails.VirtualServices, RegistryStatus: registryStatus},
+		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioDetails.VirtualServices, RegistryStatus: registryStatus},
 		checkers.SidecarChecker{Sidecars: istioDetails.Sidecars, Namespaces: namespaces, WorkloadList: workloads, Services: services, ServiceEntries: istioDetails.ServiceEntries},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioDetails.RequestAuthentications, WorkloadList: workloads},
 	}
@@ -194,7 +194,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		objectCheckers = []ObjectChecker{sidecarsChecker}
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
-			Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries,
+			Namespace: namespace, Namespaces: namespaces, Services: services, ServiceEntries: istioDetails.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries,
 			WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioDetails.VirtualServices}
 		objectCheckers = []ObjectChecker{authPoliciesChecker}
 	case kubernetes.PeerAuthentications:


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/3061
Subtask : https://github.com/kiali/kiali/issues/4316

On validation message of AuthorizationPolicy "KIA0104 This host has no matching entry in the service registry", is now added a support of cross-namespace checking of ServiceEntries.

With created ServiceEntry:
![Screenshot from 2021-09-23 19-18-06](https://user-images.githubusercontent.com/604313/134554593-64061485-47f6-4ffd-9de0-63271a7b14b8.png)

AuthorizationPolicy was not supporting cross-namespaces validations:
![Screenshot from 2021-09-23 19-20-01](https://user-images.githubusercontent.com/604313/134554654-58cb5ba0-8f8d-4e9e-8658-95e1e574504b.png)

Now it supports:
![Screenshot from 2021-09-23 19-20-18](https://user-images.githubusercontent.com/604313/134554686-2fa3984c-59fe-4e16-ab32-b88081d6146a.png)

And when wrong host is set in "to" field, it shows a error:
![Screenshot from 2021-09-23 19-24-56](https://user-images.githubusercontent.com/604313/134555027-3574745d-0248-4ac0-895e-07ae4bb07ac4.png)

