### PR TITLE
custom dashboard discovery - only look for discoverOn metrics

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -315,7 +315,7 @@ func runDiscoveryMatcher(metrics []string, allDashboards map[string]dashboards.M
 		matchReference := strings.TrimSpace(dashboard.DiscoverOn)
 		if matchReference != "" {
 			for _, metric := range metrics {
-				if matchReference == strings.TrimSpace(metric) {
+				if matchReference == metric {
 					if _, exists := runtimesMap[dashboard.Name]; !exists {
 						runtimesMap[dashboard.Name] = &dashboard
 					}

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -305,10 +305,18 @@ func (in *Client) GetMetricsForLabels(metricNames []string, labelQueryString str
 		return nil, errors.NewServiceUnavailable(err.Error())
 	}
 
-	names := make([]string, 0, 5)
+	// We will get one timeseries per pod for each metric family name. We don't need duplicates, so
+	// store the metric name in a map and convert to an array to remove those duplicates.
+
+	namesMap := make(map[string]bool)
 	for _, item := range results.(model.Vector) {
-		names = append(names, string(item.Metric["__name__"]))
+		namesMap[string(item.Metric["__name__"])] = true
 	}
+	names := make([]string, 0, 5)
+	for n := range namesMap {
+		names = append(names, n)
+	}
+
 	return names, nil
 }
 

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -302,22 +302,20 @@ func (in *Client) GetMetricsForLabels(metricNames []string, labelQueryString str
 		return nil, errors.NewServiceUnavailable(err.Error())
 	}
 
-	// Put the metric family names in a map so we can do quick lookups
-	// haystack - the list of all metric families associated with the given labels
-	// needles - the metrics we are looking for that we found in the haystack
-	haystack := make(map[string]bool)
-	for _, item := range results.(model.Vector) {
-		haystack[string(item.Metric["__name__"])] = true
-	}
-	needles := make([]string, 0, 5)
+	metricsWeAreLookingFor := make(map[string]bool, len(metricNames))
 	for i := 0; i < len(metricNames); i++ {
-		needle := metricNames[i]
-		if haystack[needle] {
-			needles = append(needles, needle)
+		metricsWeAreLookingFor[metricNames[i]] = true
+	}
+
+	metricsWeFound := make([]string, 0, 5)
+	for _, item := range results.(model.Vector) {
+		n := string(item.Metric["__name__"])
+		if metricsWeAreLookingFor[n] {
+			metricsWeFound = append(metricsWeFound, n)
 		}
 	}
 
-	return needles, nil
+	return metricsWeFound, nil
 }
 
 // SanitizeLabelName replaces anything that doesn't match invalidLabelCharRE with an underscore.

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -299,13 +299,20 @@ func (in *Client) GetMetricsForLabels(labels []string) ([]string, error) {
 		return nil, errors.NewServiceUnavailable(err.Error())
 	}
 
-	var names []string
+	// there will be duplicate __name__ values for histograms and summaries - strip the dups out by storing in a map
+	names := make(map[string]bool, 400)
 	for _, labelSet := range results {
 		if name, ok := labelSet["__name__"]; ok {
-			names = append(names, string(name))
+			names[strings.TrimSpace(string(name))] = true
 		}
 	}
-	return names, nil
+	namesArray := make([]string, len(names))
+	i := 0
+	for k := range names {
+		namesArray[i] = k
+		i++
+	}
+	return namesArray, nil
 }
 
 // SanitizeLabelName replaces anything that doesn't match invalidLabelCharRE with an underscore.

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -293,6 +293,7 @@ func (in *Client) GetMetricsForLabels(metricNames []string, labelQueryString str
 	}
 
 	log.Tracef("[Prom] GetMetricsForLabels: labels=[%v] metricNames=[%v]", labelQueryString, metricNames)
+	startT := time.Now()
 	queryString := fmt.Sprintf("count(%v) by (__name__)", labelQueryString)
 	results, warnings, err := in.api.Query(in.ctx, queryString, time.Now())
 	if warnings != nil && len(warnings) > 0 {
@@ -315,6 +316,7 @@ func (in *Client) GetMetricsForLabels(metricNames []string, labelQueryString str
 		}
 	}
 
+	log.Tracef("[Prom] GetMetricsForLabels: exec time=[%v], results count=[%v], looking for count=[%v], found count=[%v]", time.Since(startT), len(results.(model.Vector)), len(metricsWeAreLookingFor), len(metricsWeFound))
 	return metricsWeFound, nil
 }
 

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -263,7 +263,7 @@ func (o *PromClientMock) MockWorkloadRequestRates(namespace, wkld string, in, ou
 
 // MockMetricsForLabels mocks GetMetricsForLabels
 func (o *PromClientMock) MockMetricsForLabels(metrics []string) {
-	o.On("GetMetricsForLabels", mock.AnythingOfType("[]string")).Return(metrics, nil)
+	o.On("GetMetricsForLabels", mock.AnythingOfType("[]string"), mock.AnythingOfType("string")).Return(metrics, nil)
 }
 
 func (o *PromClientMock) GetAllRequestRates(namespace, ratesInterval string, queryTime time.Time) (model.Vector, error) {
@@ -321,8 +321,8 @@ func (o *PromClientMock) FetchHistogramValues(metricName, labels, grouping, rate
 	return args.Get(0).(map[string]model.Vector), args.Error((1))
 }
 
-func (o *PromClientMock) GetMetricsForLabels(labels []string) ([]string, error) {
-	args := o.Called(labels)
+func (o *PromClientMock) GetMetricsForLabels(metricNames []string, labels string) ([]string, error) {
+	args := o.Called(metricNames, labels)
 	return args.Get(0).([]string), args.Error(1)
 }
 


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3704

This is trying to work around the problem where api.Series is being called during dashboard discovery, which could return a huge amount of data.

We want to only look for specific metric names - those metrics listed as "discoverOn" metrics in the dashboards. Those are the only ones we care about.