### PR TITLE
Add all associated WorkloadEntries to node metadata

### DIFF
--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -100,7 +100,7 @@ type NodeData struct {
 	HasTCPTrafficShifting bool                `json:"hasTCPTrafficShifting,omitempty"` // true (vs has tcp traffic shifting) | false
 	HasTrafficShifting    bool                `json:"hasTrafficShifting,omitempty"`    // true (vs has traffic shifting) | false
 	HasVS                 *VSInfo             `json:"hasVS,omitempty"`                 // it can be empty if there is a VS without hostnames
-	HasWorkloadEntry      bool                `json:"hasWorkloadEntry,omitempty"`      // true (this node has a corresponding WorkloadEntry) | false
+	HasWorkloadEntry      []graph.WEInfo      `json:"hasWorkloadEntry,omitempty"`      // static workload entry information | empty if there are no workload entries
 	IsBox                 string              `json:"isBox,omitempty"`                 // set for NodeTypeBox, current values: [ 'app', 'cluster', 'namespace' ]
 	IsDead                bool                `json:"isDead,omitempty"`                // true (has no pods) | false
 	IsGateway             *GWInfo             `json:"isGateway,omitempty"`             // Istio ingress/egress gateway information
@@ -340,8 +340,11 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		}
 
 		// node may have a workload entry associated with it
-		if _, ok := n.Metadata[graph.HasWorkloadEntry]; ok {
-			nd.HasWorkloadEntry = true
+		if val, ok := n.Metadata[graph.HasWorkloadEntry]; ok {
+			nd.HasWorkloadEntry = []graph.WEInfo{}
+			if weInfo, ok := val.([]graph.WEInfo); ok {
+				nd.HasWorkloadEntry = append(nd.HasWorkloadEntry, weInfo...)
+			}
 		}
 
 		// node may be an aggregate

--- a/graph/config/cytoscape/cytoscape_test.go
+++ b/graph/config/cytoscape/cytoscape_test.go
@@ -89,10 +89,23 @@ func TestHasWorkloadEntryAddedToGraph(t *testing.T) {
 	traffic := graph.NewTrafficMap()
 
 	n0 := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
-	n0.Metadata[graph.HasWorkloadEntry] = true
+	n0.Metadata[graph.HasWorkloadEntry] = []graph.WEInfo{{Name: "ratings-v1", Namespace: "appNamespace"}}
 	traffic[n0.ID] = &n0
 	cytoConfig := NewConfig(traffic, graph.ConfigOptions{})
 
 	cytoNode := cytoConfig.Elements.Nodes[0]
-	assert.True(cytoNode.Data.HasWorkloadEntry)
+	assert.Equal(cytoNode.Data.HasWorkloadEntry, n0.Metadata[graph.HasWorkloadEntry])
+}
+
+func TestHasWorkloadEntryEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	traffic := graph.NewTrafficMap()
+
+	n0 := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	traffic[n0.ID] = &n0
+	cytoConfig := NewConfig(traffic, graph.ConfigOptions{})
+
+	cytoNode := cytoConfig.Elements.Nodes[0]
+	assert.Empty(cytoNode.Data.HasWorkloadEntry)
 }

--- a/graph/config/cytoscape/cytoscape_test.go
+++ b/graph/config/cytoscape/cytoscape_test.go
@@ -89,7 +89,7 @@ func TestHasWorkloadEntryAddedToGraph(t *testing.T) {
 	traffic := graph.NewTrafficMap()
 
 	n0 := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
-	n0.Metadata[graph.HasWorkloadEntry] = []graph.WEInfo{{Name: "ratings-v1", Namespace: "appNamespace"}}
+	n0.Metadata[graph.HasWorkloadEntry] = []graph.WEInfo{{Name: "ratings-v1" }}
 	traffic[n0.ID] = &n0
 	cytoConfig := NewConfig(traffic, graph.ConfigOptions{})
 

--- a/graph/config/cytoscape/cytoscape_test.go
+++ b/graph/config/cytoscape/cytoscape_test.go
@@ -89,7 +89,7 @@ func TestHasWorkloadEntryAddedToGraph(t *testing.T) {
 	traffic := graph.NewTrafficMap()
 
 	n0 := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
-	n0.Metadata[graph.HasWorkloadEntry] = []graph.WEInfo{{Name: "ratings-v1" }}
+	n0.Metadata[graph.HasWorkloadEntry] = []graph.WEInfo{{Name: "ratings-v1"}}
 	traffic[n0.ID] = &n0
 	cytoConfig := NewConfig(traffic, graph.ConfigOptions{})
 

--- a/graph/telemetry/istio/appender/workload_entry.go
+++ b/graph/telemetry/istio/appender/workload_entry.go
@@ -59,7 +59,7 @@ func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap,
 						n.Metadata[graph.HasWorkloadEntry] = []graph.WEInfo{}
 					}
 
-					we := graph.WEInfo{Name: entry.Metadata.Name, Namespace: entry.Metadata.Namespace}
+					we := graph.WEInfo{Name: entry.Metadata.Name}
 					weMetadata := n.Metadata[graph.HasWorkloadEntry].([]graph.WEInfo)
 					weMetadata = append(weMetadata, we)
 					n.Metadata[graph.HasWorkloadEntry] = weMetadata

--- a/graph/telemetry/istio/appender/workload_entry.go
+++ b/graph/telemetry/istio/appender/workload_entry.go
@@ -55,12 +55,15 @@ func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap,
 		for _, entry := range istioCfg.WorkloadEntries {
 			if labels, ok := entry.Spec.Labels.(map[string]interface{}); ok {
 				if labels[appLabel] == n.App && labels[versionLabel] == n.Version {
-					n.Metadata[graph.HasWorkloadEntry] = true
+					if n.Metadata[graph.HasWorkloadEntry] == nil {
+						n.Metadata[graph.HasWorkloadEntry] = []graph.WEInfo{}
+					}
+
+					we := graph.WEInfo{Name: entry.Metadata.Name, Namespace: entry.Metadata.Namespace}
+					weMetadata := n.Metadata[graph.HasWorkloadEntry].([]graph.WEInfo)
+					weMetadata = append(weMetadata, we)
+					n.Metadata[graph.HasWorkloadEntry] = weMetadata
 					log.Trace("Found matching WorkloadEntry")
-					// Once a matching workload entry has been found for the workload node,
-					// the rest of the entries can be ignored because having a single matching
-					// workload entry is enough.
-					break
 				}
 			}
 		}

--- a/graph/telemetry/istio/appender/workload_entry_test.go
+++ b/graph/telemetry/istio/appender/workload_entry_test.go
@@ -139,12 +139,12 @@ func TestWorkloadEntry(t *testing.T) {
 	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	workloadV1Node, found := trafficMap[workloadV1ID]
 	assert.True(found)
-	assert.Equal(workloadV1Node.Metadata[graph.HasWorkloadEntry], true)
+	assert.Equal(workloadV1Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadA", Namespace: appNamespace}})
 
 	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	workloadV2Node, found := trafficMap[workloadV2ID]
 	assert.True(found)
-	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], true)
+	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadB", Namespace: appNamespace}})
 
 	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	workloadV3Node, found := trafficMap[workloadV3ID]
@@ -311,12 +311,15 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	workloadV1Node, found := trafficMap[workloadV1ID]
 	assert.True(found)
-	assert.Equal(workloadV1Node.Metadata[graph.HasWorkloadEntry], true)
+	assert.Equal(
+		workloadV1Node.Metadata[graph.HasWorkloadEntry],
+		[]graph.WEInfo{{Name: "workloadV1A", Namespace: appNamespace}, {Name: "workloadV1B", Namespace: appNamespace}},
+	)
 
 	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	workloadV2Node, found := trafficMap[workloadV2ID]
 	assert.True(found)
-	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], true)
+	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadV2", Namespace: appNamespace}})
 
 	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	workloadV3Node, found := trafficMap[workloadV3ID]

--- a/graph/telemetry/istio/appender/workload_entry_test.go
+++ b/graph/telemetry/istio/appender/workload_entry_test.go
@@ -313,7 +313,7 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 	assert.True(found)
 	assert.Equal(
 		workloadV1Node.Metadata[graph.HasWorkloadEntry],
-		[]graph.WEInfo{{Name: "workloadV1A"}, {Name: "workloadV1B",}},
+		[]graph.WEInfo{{Name: "workloadV1A"}, {Name: "workloadV1B"}},
 	)
 
 	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)

--- a/graph/telemetry/istio/appender/workload_entry_test.go
+++ b/graph/telemetry/istio/appender/workload_entry_test.go
@@ -139,12 +139,12 @@ func TestWorkloadEntry(t *testing.T) {
 	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	workloadV1Node, found := trafficMap[workloadV1ID]
 	assert.True(found)
-	assert.Equal(workloadV1Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadA", Namespace: appNamespace}})
+	assert.Equal(workloadV1Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadA"}})
 
 	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	workloadV2Node, found := trafficMap[workloadV2ID]
 	assert.True(found)
-	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadB", Namespace: appNamespace}})
+	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadB"}})
 
 	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	workloadV3Node, found := trafficMap[workloadV3ID]
@@ -313,13 +313,13 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 	assert.True(found)
 	assert.Equal(
 		workloadV1Node.Metadata[graph.HasWorkloadEntry],
-		[]graph.WEInfo{{Name: "workloadV1A", Namespace: appNamespace}, {Name: "workloadV1B", Namespace: appNamespace}},
+		[]graph.WEInfo{{Name: "workloadV1A"}, {Name: "workloadV1B",}},
 	)
 
 	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	workloadV2Node, found := trafficMap[workloadV2ID]
 	assert.True(found)
-	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadV2", Namespace: appNamespace}})
+	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadV2"}})
 
 	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	workloadV3Node, found := trafficMap[workloadV3ID]

--- a/graph/types.go
+++ b/graph/types.go
@@ -62,11 +62,10 @@ type ServiceName struct {
 	Name      string `json:"name"`
 }
 
-// WEInfo provides static information about the workload entrie
+// WEInfo provides static information about the workload entry
 // associated with a workload node.
 type WEInfo struct {
 	Name      string `json:"name"`      // name of the workload entry object
-	Namespace string `json:"namespace"` // the definition namespace
 }
 
 // SEInfo provides static information about the service entry

--- a/graph/types.go
+++ b/graph/types.go
@@ -62,10 +62,12 @@ type ServiceName struct {
 	Name      string `json:"name"`
 }
 
-// WEInfo provides static information about the workload entry
+// WEInfo provides static information about a workload entry
 // associated with a workload node.
 type WEInfo struct {
-	Name      string `json:"name"`      // name of the workload entry object
+	// Name of the workload entry object
+	// required:true
+	Name string `json:"name"`
 }
 
 // SEInfo provides static information about the service entry

--- a/graph/types.go
+++ b/graph/types.go
@@ -62,6 +62,13 @@ type ServiceName struct {
 	Name      string `json:"name"`
 }
 
+// WEInfo provides static information about the workload entrie
+// associated with a workload node.
+type WEInfo struct {
+	Name      string `json:"name"`      // name of the workload entry object
+	Namespace string `json:"namespace"` // the definition namespace
+}
+
 // SEInfo provides static information about the service entry
 type SEInfo struct {
 	Hosts     []string `json:"hosts"`     // configured list of hosts

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -8102,7 +8102,7 @@ This type is used to describe a set of objects.
 | HasRequestTimeout | boolean| `bool` |  | |  |  |
 | HasTCPTrafficShifting | boolean| `bool` |  | |  |  |
 | HasTrafficShifting | boolean| `bool` |  | |  |  |
-| HasWorkloadEntry | boolean| `bool` |  | |  |  |
+| HasWorkloadEntry | [][WEInfo](#w-e-info)| `[]*WEInfo` |  | |  |  |
 | ID | string| `string` |  | | Cytoscape Fields |  |
 | IsBox | string| `string` |  | |  |  |
 | IsDead | boolean| `bool` |  | |  |  |
@@ -9301,6 +9301,25 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 |------|------|---------|:--------:| ------- |-------------|---------|
 | Items | [][VirtualService](#virtual-service)| `[]*VirtualService` |  | |  |  |
 | permissions | [ResourcePermissions](#resource-permissions)| `ResourcePermissions` |  | |  |  |
+
+
+
+### <span id="w-e-info"></span> WEInfo
+
+
+> WEInfo provides static information about the workload entry
+associated with a workload node.
+  
+
+
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| Name | string| `string` | ✓ | | Name of the workload entry object |  |
 
 
 

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -9307,7 +9307,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 ### <span id="w-e-info"></span> WEInfo
 
 
-> WEInfo provides static information about the workload entry
+> WEInfo provides static information about a workload entry
 associated with a workload node.
   
 

--- a/swagger.json
+++ b/swagger.json
@@ -7283,7 +7283,7 @@
       "x-go-package": "github.com/jaegertracing/jaeger/model/json"
     },
     "WEInfo": {
-      "description": "WEInfo provides static information about the workload entry\nassociated with a workload node.",
+      "description": "WEInfo provides static information about a workload entry\nassociated with a workload node.",
       "type": "object",
       "required": [
         "name"

--- a/swagger.json
+++ b/swagger.json
@@ -6100,7 +6100,10 @@
           "$ref": "#/definitions/VSInfo"
         },
         "hasWorkloadEntry": {
-          "type": "boolean",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WEInfo"
+          },
           "x-go-name": "HasWorkloadEntry"
         },
         "id": {
@@ -7278,6 +7281,21 @@
       "type": "string",
       "title": "ValueType is the type of a value stored in KeyValue struct.",
       "x-go-package": "github.com/jaegertracing/jaeger/model/json"
+    },
+    "WEInfo": {
+      "description": "WEInfo provides static information about the workload entry\nassociated with a workload node.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the workload entry object",
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/graph"
     },
     "Workload": {
       "description": "Workload has the details of a workload",


### PR DESCRIPTION
Adds all the found `WorkloadEntries` to the associated node's metadata.

Relates to #kiali#4219
Front end: kiali/kiali-ui#2241