### PR TITLE
Pass empty custom headers

### DIFF
--- a/util/httputil/http_util.go
+++ b/util/httputil/http_util.go
@@ -52,7 +52,7 @@ func HttpPost(url string, auth *config.Auth, body io.Reader, timeout time.Durati
 		return nil, 0, err
 	}
 
-	transport, err := CreateTransport(auth, &http.Transport{}, timeout)
+	transport, err := CreateTransport(auth, &http.Transport{}, timeout, map[string]string{})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/util/httputil/http_util.go
+++ b/util/httputil/http_util.go
@@ -52,7 +52,7 @@ func HttpPost(url string, auth *config.Auth, body io.Reader, timeout time.Durati
 		return nil, 0, err
 	}
 
-	transport, err := CreateTransport(auth, &http.Transport{}, timeout, map[string]string{})
+	transport, err := CreateTransport(auth, &http.Transport{}, timeout, nil)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
Fixes args not being passed to `CreateTransport` correctly as a result of merging #4312.