### PR TITLE
Fix ServiceEntry not grouped in app box

### DIFF
--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -1,6 +1,7 @@
 package appender
 
 import (
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -168,7 +169,16 @@ func addLabels(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo
 			if _, ok := n.Metadata[graph.IsServiceEntry]; ok {
 				seInfo := n.Metadata[graph.IsServiceEntry].(*graph.SEInfo)
 				for _, host := range seInfo.Hosts {
-					if svc, found := svcMap[host]; found {
+					var hostToTest string
+
+					hostSplitted := strings.Split(host, ".")
+					if len(hostSplitted) == 3 && hostSplitted[2] == config.IstioMultiClusterHostSuffix {
+						hostToTest = host
+					} else {
+						hostToTest = hostSplitted[0]
+					}
+
+					if svc, found := svcMap[hostToTest]; found {
 						if app, ok := svc.Labels[appLabelName]; ok {
 							n.App = app
 						}

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -163,8 +163,18 @@ func addLabels(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo
 	for _, n := range trafficMap {
 		// make sure service nodes have the defined app label so it can be used for app grouping in the UI.
 		if n.NodeType == graph.NodeTypeService && n.Namespace == sdl.Namespace.Name && n.App == "" {
-			// A service node that is a service entry will not have a service definition
+			// For service nodes that are a service entries, use the `hosts` property of the SE to find
+			// a matching Kubernetes Svc for adding missing labels
 			if _, ok := n.Metadata[graph.IsServiceEntry]; ok {
+				seInfo := n.Metadata[graph.IsServiceEntry].(*graph.SEInfo)
+				for _, host := range seInfo.Hosts {
+					if svc, found := svcMap[host]; found {
+						if app, ok := svc.Labels[appLabelName]; ok {
+							n.App = app
+						}
+						continue
+					}
+				}
 				continue
 			}
 			// A service node that is an Istio egress cluster will not have a service definition

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -81,7 +81,7 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, g
 		}
 
 		// To match, a service entry must be exported to the source namespace, and the requested
-		// service must match a defined host.  Note that teh source namespace is assumed to be the
+		// service must match a defined host.  Note that the source namespace is assumed to be the
 		// the same as the appender namespace as all requests for the service entry should be coming
 		// from workloads in the current namespace being processed for the graph.
 		if se, ok := a.getServiceEntry(namespaceInfo.Namespace, n.Service, globalInfo); ok {


### PR DESCRIPTION
Istio appender was skipping further adding missing labels of ServiceEntries. Probably, it made sense at that moment that code was introduced. However, nowdays Istio doc tells that SE resources can be used to "decorate" services from other registries. See https://istio.io/v1.10/docs/reference/config/networking/service-entry/#ServiceEntry.

So, we no longer can simply skip adding missing labels for SEs. We should check if a SE is augmenting a regular service and add missing labels if needed.

Fixes kiali/kiali#4295.
