### PR TITLE
Configurable label aggregations in metric tabs

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -501,14 +501,14 @@ func GetIstioScaler() func(name string) float64 {
 	}
 }
 
-// GetIstioDashboard returns Istio dashboard (currently hard-coded) filled-in with metrics
+// BuildIstioDashboard returns Istio dashboard filled-in with metrics
 func (in *DashboardsService) BuildIstioDashboard(metrics models.MetricsMap, direction string) *models.MonitoringDashboard {
 	var dashboard models.MonitoringDashboard
 	// Copy dashboard
 	if direction == "inbound" {
-		dashboard = models.PrepareIstioDashboard("Inbound", "destination", "source")
+		dashboard = models.PrepareIstioDashboard("Inbound")
 	} else {
-		dashboard = models.PrepareIstioDashboard("Outbound", "source", "destination")
+		dashboard = models.PrepareIstioDashboard("Outbound")
 	}
 
 	istioCharts := getIstioCharts()

--- a/business/istio_certs_test.go
+++ b/business/istio_certs_test.go
@@ -3,14 +3,15 @@ package business
 import (
 	"testing"
 
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/stretchr/testify/assert"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
 func TestCertificatesInformationIndicatorsDisabled(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -586,8 +586,8 @@ func NewConfig() (c *Config) {
 						Tcp:  "sent",
 					},
 				},
-				MetricsInbound:    metricsInboundDefaults(),
-				MetricsOutbound:   metricsOutboundDefaults(),
+				MetricsInbound:    MetricsDefaults{},
+				MetricsOutbound:   MetricsDefaults{},
 				MetricsPerRefresh: "1m",
 				Namespaces:        make([]string, 0),
 				RefreshInterval:   "15s",
@@ -705,63 +705,6 @@ func (conf Config) String() (str string) {
 	}
 
 	return
-}
-
-// metricsDefaults builds the default label aggregations for either inbound or outbound metric pages.
-func metricsDefaults(local, remote string) []Aggregation {
-	aggs := []Aggregation{
-		{
-			Label:       fmt.Sprintf("%s_canonical_revision", local),
-			DisplayName: "Local version",
-		},
-		{
-			Label:       fmt.Sprintf("%s_workload_namespace", remote),
-			DisplayName: "Remote namespace",
-		},
-	}
-	if remote == "destination" {
-		aggs = append(aggs, Aggregation{
-			Label:       "destination_service_name",
-			DisplayName: "Remote service",
-		})
-	}
-	aggs = append(aggs, []Aggregation{
-		{
-			Label:       fmt.Sprintf("%s_canonical_service", remote),
-			DisplayName: "Remote app",
-		},
-		{
-			Label:       fmt.Sprintf("%s_canonical_revision", remote),
-			DisplayName: "Remote version",
-		},
-		{
-			Label:       "response_code",
-			DisplayName: "Response code",
-		},
-		{
-			Label:       "grpc_response_status",
-			DisplayName: "GRPC status",
-		},
-		{
-			Label:       "response_flags",
-			DisplayName: "Response flags",
-		},
-	}...)
-	return aggs
-}
-
-// metricsInboundDefaults builds the default label aggregations for inbound metric pages.
-func metricsInboundDefaults() MetricsDefaults {
-	return MetricsDefaults{
-		Aggregations: metricsDefaults("destination", "source"),
-	}
-}
-
-// metricsOutboundDefaults builds the default label aggregations for outbound metric pages.
-func metricsOutboundDefaults() MetricsDefaults {
-	return MetricsDefaults{
-		Aggregations: metricsDefaults("source", "destination"),
-	}
 }
 
 // prepareDashboards will ensure conf.CustomDashboards contains only the dashboards that are enabled

--- a/graph/config/cytoscape/cytoscape_test.go
+++ b/graph/config/cytoscape/cytoscape_test.go
@@ -3,8 +3,9 @@ package cytoscape
 import (
 	"testing"
 
-	"github.com/kiali/kiali/graph"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/graph"
 )
 
 func TestRateStrings(t *testing.T) {

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -6517,7 +6517,7 @@ Status: Internal Server Error
 ### <span id="aggregation"></span> Aggregation
 
 
-> Aggregation is the model representing label's allowed aggregation, transformed from aggregation in MonitoringDashboard config resource
+> Aggregation represents label's allowed aggregations, transformed from aggregation in MonitoringDashboard config resource
   
 
 

--- a/models/dashboards_test.go
+++ b/models/dashboards_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
 )
 
 func TestPrepareIstioDashboard(t *testing.T) {
 	assert := assert.New(t)
+	config.Set(config.NewConfig())
 
-	dashboard := PrepareIstioDashboard("Outbound", "source", "destination")
+	dashboard := PrepareIstioDashboard("Outbound")
 
 	assert.Equal(dashboard.Title, "Outbound Metrics")
 	assert.Len(dashboard.Aggregations, 8)

--- a/swagger.json
+++ b/swagger.json
@@ -4268,7 +4268,7 @@
       "x-go-package": "github.com/kiali/kiali/models"
     },
     "Aggregation": {
-      "description": "Aggregation is the model representing label's allowed aggregation, transformed from aggregation in MonitoringDashboard config resource",
+      "description": "Aggregation represents label's allowed aggregations, transformed from aggregation in MonitoringDashboard config resource",
       "type": "object",
       "properties": {
         "displayName": {
@@ -4284,7 +4284,7 @@
           "x-go-name": "SingleSelection"
         }
       },
-      "x-go-package": "github.com/kiali/kiali/models"
+      "x-go-package": "github.com/kiali/kiali/config"
     },
     "App": {
       "type": "object",


### PR DESCRIPTION
Adding possibility to configure _additional_ label aggregations in metric tabs.

For example, a Kiali CR with the following configuration:

```yaml
spec:
  kiali_feature_flags:
    ui_defaults:
      metrics_inbound:
        aggregations:
        - display_name: Istio Network
          label: topology_istio_io_network
        - display_name: Istio Revision
          label: istio_io_rev

```

will generate the following options in the metrics menu:

![image](https://user-images.githubusercontent.com/23639005/134701221-1953fd88-0bb9-4058-ac78-7e7b25fae669.png)

Fixes kiali/kiali#2911.