### PR TITLE
Ensure workload_entry appender does not process nodes outside of the requested namespace

### DIFF
--- a/graph/telemetry/istio/appender/workload_entry.go
+++ b/graph/telemetry/istio/appender/workload_entry.go
@@ -39,6 +39,11 @@ func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap,
 	versionLabel := config.Get().IstioLabels.VersionLabelName
 
 	for _, n := range trafficMap {
+		// Skip the check if this node is outside the requested namespace, we limit badging to the requested namespaces
+		if n.Namespace != namespaceInfo.Namespace {
+			continue
+		}
+
 		// Only a workload or app node can be a workload entry
 		if n.NodeType != graph.NodeTypeWorkload && n.NodeType != graph.NodeTypeApp {
 			continue


### PR DESCRIPTION
Ensure workload_entry appender does not process nodes outside of the requested namespace being processed by the appender.  When querying for istio config you may hit a "leaf" node (for the entire graph), that is inaccessible or excluded from the UI.

This issue was introduced in v1.40 with the new workload_entry appender.

Fixes https://github.com/kiali/kiali/issues/4384

To Recreate/Test:
1. install travel demo
2. select `travel-agency` namespace and verify graph includes incoming traffic from `travel-portal` nodes.  And that those `travel-portal` nodes are accessible (you can select, double-click, right-click etc).
3. update the  CR to exclude the `travel-portal` namespace
```
spec:
  api:
    namespaces:
      exclude:
        - istio-operator
        - kube-.*
        - openshift.*
        - ibm.*
        - kiali-operator
        - travel-portal
```
4. After the CR is reconciled the graph generation for `travel-agency` should cause an error.
5. apply the PR
6. graph generation for `travel-agency` should succeed but the `travel-portal` nodes should now be marked as restricted (key background image).

