### PR TITLE
Handle workloads with direct pod controllers

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -957,11 +957,9 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 				cnFound = false
 			}
 		default:
-			// ReplicaSet should be used to link Pods with a custom controller type i.e. Argo Rollout
+			// Assuming that if the controller is not a known type then the controller is controlling pods itself
+			// i.e. the pod's have an owner ref directly to the controller type.
 			childType := ctype
-			if _, unknownType := controllerOrder[ctype]; !unknownType {
-				childType = kubernetes.ReplicaSetType
-			}
 			cPods := kubernetes.FilterPodsForController(cname, childType, pods)
 			w.SetPods(cPods)
 			rsParsed := false
@@ -1491,13 +1489,12 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 				cnFound = false
 			}
 		default:
-			// ReplicaSet should be used to link Pods with a custom controller type i.e. Argo Rollout
+			// Assuming that if the controller is not a known type then the controller is controlling pods itself
+			// i.e. the pod's have an owner ref directly to the controller type.
+
 			// Note, we will use the controller found in the Pod resolution, instead that the passed by parameter
 			// This will cover cornercase for https://github.com/kiali/kiali/issues/3830
 			childType := ctype
-			if _, unknownType := controllerOrder[ctype]; !unknownType {
-				childType = kubernetes.ReplicaSetType
-			}
 			cPods := kubernetes.FilterPodsForController(workloadName, childType, pods)
 			w.SetPods(cPods)
 			rsParsed := false

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -957,11 +957,15 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 				cnFound = false
 			}
 		default:
-			// Assuming that if the controller is not a known type then the controller is controlling pods itself
-			// i.e. the pod's have an owner ref directly to the controller type.
-			childType := ctype
-			cPods := kubernetes.FilterPodsForController(cname, childType, pods)
+			// ReplicaSet should be used to link Pods with a custom controller type i.e. Argo Rollout
+			cPods := kubernetes.FilterPodsForController(cname, kubernetes.ReplicaSetType, pods)
+			if len(cPods) == 0 {
+				// If no pods we're found for a ReplicaSet type, it's possible the controller
+				// is managing the pods itself i.e. the pod's have an owner ref directly to the controller type.
+				cPods = kubernetes.FilterPodsForController(cname, ctype, pods)
+			}
 			w.SetPods(cPods)
+
 			rsParsed := false
 			for _, rs := range repset {
 				if strings.HasPrefix(rs.Name, cname) {
@@ -971,7 +975,7 @@ func fetchWorkloads(layer *Layer, namespace string, labelSelector string) (model
 				}
 			}
 			if !rsParsed {
-				log.Warningf("Workload %s of type %s has not a ReplicaSet as a child controller, it may need a revisit", cname, ctype)
+				log.Debugf("Workload %s of type %s has not a ReplicaSet as a child controller, it may need a revisit", cname, ctype)
 				w.ParsePods(cname, ctype, cPods)
 			}
 		}
@@ -1489,14 +1493,17 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 				cnFound = false
 			}
 		default:
-			// Assuming that if the controller is not a known type then the controller is controlling pods itself
-			// i.e. the pod's have an owner ref directly to the controller type.
-
+			// ReplicaSet should be used to link Pods with a custom controller type i.e. Argo Rollout
 			// Note, we will use the controller found in the Pod resolution, instead that the passed by parameter
 			// This will cover cornercase for https://github.com/kiali/kiali/issues/3830
-			childType := ctype
-			cPods := kubernetes.FilterPodsForController(workloadName, childType, pods)
+			cPods := kubernetes.FilterPodsForController(workloadName, kubernetes.ReplicaSetType, pods)
+			if len(cPods) == 0 {
+				// If no pods we're found for a ReplicaSet type, it's possible the controller
+				// is managing the pods itself i.e. the pod's have an owner ref directly to the controller type.
+				cPods = kubernetes.FilterPodsForController(workloadName, ctype, pods)
+			}
 			w.SetPods(cPods)
+
 			rsParsed := false
 			for _, rs := range repset {
 				if strings.HasPrefix(rs.Name, workloadName) {
@@ -1506,7 +1513,7 @@ func fetchWorkload(layer *Layer, namespace string, workloadName string, workload
 				}
 			}
 			if !rsParsed {
-				log.Warningf("Workload %s of type %s has not a ReplicaSet as a child controller, it may need a revisit", workloadName, ctype)
+				log.Debugf("Workload %s of type %s has not a ReplicaSet as a child controller, it may need a revisit", workloadName, ctype)
 				w.ParsePods(workloadName, ctype, cPods)
 			}
 		}

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -719,12 +719,12 @@ func TestGetWorkloadListFromGenericPodController(t *testing.T) {
 	assert := assert.New(t)
 
 	pods := FakePodsSyncedWithDeployments()
-	
+
 	// Doesn't matter what the type is as long as kiali doesn't recognize it.
 	owner := &core_v1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "testing",
-			UID: types.UID("f9952f02-5552-4b2c-afdb-441d859dbb36"),
+			UID:  types.UID("f9952f02-5552-4b2c-afdb-441d859dbb36"),
 		},
 	}
 	ref := v1.NewControllerRef(owner, core_v1.SchemeGroupVersion.WithKind("ConfigMap"))


### PR DESCRIPTION
When composing the workloads response, assume that if the controller is a type unknown to Kiali, the workload is directly controlling the pods i.e. the pods have an owner ref to the workload type.

Fixes #3733 