### PR TITLE
Gateways linked in VirtualServices are listed in Service/App Lists 'Details' columns.

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -126,9 +126,10 @@ func (in *AppService) GetAppList(namespace string, linkIstioResources bool) (mod
 			if linkIstioResources {
 				svcVirtualServices := kubernetes.FilterVirtualServices(*linkedResources[kubernetes.VirtualServices], srv.Namespace, srv.Name)
 				svcDestinationRules := kubernetes.FilterDestinationRules(*linkedResources[kubernetes.DestinationRules], srv.Namespace, srv.Name)
-				allFiltered := append(svcVirtualServices, svcDestinationRules...)
+				svcGateways := kubernetes.FilterGateways(*linkedResources[kubernetes.Gateways], svcVirtualServices)
+				allFiltered := append(append(svcVirtualServices, svcDestinationRules...), svcGateways...)
 				for _, a := range allFiltered {
-					ref := models.BuildKey(a.GetTypeMeta().Kind, a.GetObjectMeta().Namespace, a.GetObjectMeta().Name)
+					ref := models.BuildKey(a.GetTypeMeta().Kind, a.GetObjectMeta().Name, a.GetObjectMeta().Namespace)
 					svcReferences = append(svcReferences, &ref)
 				}
 			}

--- a/kubernetes/filters_test.go
+++ b/kubernetes/filters_test.go
@@ -63,3 +63,83 @@ func TestFilterPodsForEndpoints(t *testing.T) {
 	assert.Equal("pod-2", filtered[1].Name)
 	assert.Equal("pod-3", filtered[2].Name)
 }
+
+func TestFilterGateways(t *testing.T) {
+	assert := assert.New(t)
+
+	virtualServices := []IstioObject{
+		&GenericIstioObject{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:        "reviews",
+				Namespace:   "bookinfo",
+				ClusterName: "svc.cluster.local",
+			},
+			Spec: map[string]interface{}{
+				"hosts":    []interface{}{"reviews"},
+				"gateways": []interface{}{"bookinfo/gateway1", "bookinfo2/gateway2", "wronggateway", "bookinfo2/wronggateway2"},
+			},
+		},
+		&GenericIstioObject{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:        "ratings",
+				Namespace:   "bookinfo",
+				ClusterName: "svc.cluster.local",
+			},
+			Spec: map[string]interface{}{
+				"hosts":    []interface{}{"ratings"},
+				"gateways": []interface{}{"gateway4", "gateway2"},
+			},
+		},
+		&GenericIstioObject{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:        "details",
+				Namespace:   "bookinfo",
+				ClusterName: "svc.cluster.local",
+			},
+			Spec: map[string]interface{}{
+				"hosts":    []interface{}{"details"},
+				"gateways": []interface{}{"gateway1", "bookinfo3/gateway3", "wronggateway2"},
+			},
+		},
+	}
+
+	gateways := []IstioObject{
+		&GenericIstioObject{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "gateway1",
+				Namespace: "bookinfo",
+			},
+		},
+		&GenericIstioObject{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "gateway2",
+				Namespace: "bookinfo2",
+			},
+		},
+		&GenericIstioObject{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "gateway3",
+				Namespace: "bookinfo3",
+			},
+		},
+		&GenericIstioObject{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "gateway4",
+				Namespace: "bookinfo",
+			},
+		},
+		&GenericIstioObject{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "gateway5",
+				Namespace: "bookinfo2",
+			},
+		},
+	}
+
+	filtered := FilterGateways(gateways, virtualServices)
+	assert.Len(filtered, 4)
+	assert.Equal("gateway1", filtered[0].GetObjectMeta().Name)
+	assert.Equal("gateway2", filtered[1].GetObjectMeta().Name)
+	assert.Equal("gateway3", filtered[2].GetObjectMeta().Name)
+	assert.Equal("gateway4", filtered[3].GetObjectMeta().Name)
+}


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4326

When VirtualService have linked Gateways, then these Gateways are listed in Details column of ServiceLists and AppLists pagea.
Also Services they can be filtered by Gateways.
Gateways can be linked for instance while creating Routing via Wizard.

![Screenshot from 2021-09-30 20-22-36](https://user-images.githubusercontent.com/604313/135510392-f015ac8d-f9ec-4daf-93d6-a2ccf9241f02.png)

![Screenshot from 2021-10-04 12-17-15](https://user-images.githubusercontent.com/604313/135834447-45630911-6ed5-4fa0-8d21-f5ee555efacf.png)

