### PR TITLE
Added support of exported Services into VirtualService validation NoHostChecker

### DIFF
--- a/business/checkers/authorization/no_host_checker.go
+++ b/business/checkers/authorization/no_host_checker.go
@@ -107,7 +107,7 @@ func (n NoHostChecker) hasMatchingService(host kubernetes.Host, itemNamespace st
 
 	// Use RegistryService to check destinations that may not be covered with previous check
 	// i.e. Multi-cluster or Federation validations
-	if kubernetes.HasMatchingRegistryService(host.String(), n.RegistryServices) {
+	if kubernetes.HasMatchingRegistryService(itemNamespace, host.String(), n.RegistryServices) {
 		return true
 	}
 

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -130,7 +130,7 @@ func (n NoDestinationChecker) hasMatchingService(host kubernetes.Host, itemNames
 
 	// Use RegistryService to check destinations that may not be covered with previous check
 	// i.e. Multi-cluster or Federation validations
-	if kubernetes.HasMatchingRegistryService(host.String(), n.RegistryServices) {
+	if kubernetes.HasMatchingRegistryService(itemNamespace, host.String(), n.RegistryServices) {
 		return true
 	}
 	return false

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -48,6 +48,7 @@ func TestAllIstioObjectWithServices(t *testing.T) {
 		ExportedResources:    emptyExportedResources(),
 		ServiceList:          fakeServiceList([]string{"reviews", "details", "product", "customer"}),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
+		RegistryServices:     data.CreateFakeRegistryServices("product.test.svc.cluster.local", "test", "test"),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -77,6 +78,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 		),
 		ServiceList:          fakeServiceList([]string{"reviews", "details", "product"}),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
+		RegistryServices:     data.CreateFakeRegistryServices("product.test.svc.cluster.local", "test", "."),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -174,7 +176,7 @@ func TestObjectWithoutGateway(t *testing.T) {
 
 	productVs := vals[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}]
 	assert.False(productVs.Valid)
-	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[0]))
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[2]))
 }
 
 func fakeIstioConfigList() *models.IstioConfigList {

--- a/business/checkers/virtualservices/no_host_checker_test.go
+++ b/business/checkers/virtualservices/no_host_checker_test.go
@@ -16,10 +16,36 @@ import (
 func TestValidHost(t *testing.T) {
 	assert := assert.New(t)
 
+	virtualService := data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v1", -1),
+		data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("reviews", "v1", -1),
+			data.CreateEmptyVirtualService("reviews", "bookinfo", []string{"reviews"}),
+		),
+	)
+
 	vals, valid := NoHostChecker{
-		Namespace:      "test-namespace",
-		ServiceNames:   []string{"reviews", "other"},
-		VirtualService: *data.CreateVirtualService(),
+		Namespace:      "bookinfo",
+		ServiceList:    data.CreateFakeServiceList([]string{"reviews", "other"}, "bookinfo"),
+		VirtualService: *virtualService,
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
+func TestValidHostExported(t *testing.T) {
+	assert := assert.New(t)
+
+	virtualService := data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("ratings.bookinfo2", "v1", -1),
+		data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("ratings.bookinfo2", "v1", -1),
+			data.CreateEmptyVirtualService("ratings", "bookinfo2", []string{"ratings"}),
+		),
+	)
+
+	vals, valid := NoHostChecker{
+		Namespace:        "bookinfo",
+		ServiceList:      data.CreateFakeServiceList([]string{"other"}, "bookinfo"),
+		VirtualService:   *virtualService,
+		RegistryServices: data.CreateFakeRegistryServices("ratings.bookinfo2", "bookinfo2", "bookinfo2"),
 	}.Check()
 
 	assert.True(valid)
@@ -36,7 +62,7 @@ func TestNoValidHost(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		Namespace:      "test-namespace",
-		ServiceNames:   []string{"details", "other"},
+		ServiceList:    data.CreateFakeServiceList([]string{"details", "other"}, "bookinfo"),
 		VirtualService: *virtualService,
 	}.Check()
 
@@ -53,7 +79,7 @@ func TestNoValidHost(t *testing.T) {
 
 	vals, valid = NoHostChecker{
 		Namespace:      "test-namespace",
-		ServiceNames:   []string{"details", "other"},
+		ServiceList:    data.CreateFakeServiceList([]string{"details", "other"}, "bookinfo"),
 		VirtualService: *virtualService,
 	}.Check()
 
@@ -67,8 +93,67 @@ func TestNoValidHost(t *testing.T) {
 
 	vals, valid = NoHostChecker{
 		Namespace:      "test-namespace",
-		ServiceNames:   []string{"details", "other"},
+		ServiceList:    data.CreateFakeServiceList([]string{"details", "other"}, "bookinfo"),
 		VirtualService: *virtualService,
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.invalidprotocol", vals[0]))
+	assert.Equal("", vals[0].Path)
+}
+
+func TestNoValidExportedHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	virtualService := data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("ratings.bookinfo", "v1", -1),
+		data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("ratings", "v1", -1),
+			data.CreateEmptyVirtualService("ratings", "bookinfo", []string{"ratings"}),
+		),
+	)
+
+	vals, valid := NoHostChecker{
+		Namespace:        "bookinfo",
+		ServiceList:      data.CreateFakeServiceList([]string{"details", "other"}, "bookinfo"),
+		VirtualService:   *virtualService,
+		RegistryServices: data.CreateFakeRegistryServices("ratings", "bookinfo2", "*"),
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", vals[0]))
+	assert.Equal("spec/http[0]/route[0]/destination/host", vals[0].Path)
+	assert.Equal(models.ErrorSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", vals[1]))
+	assert.Equal("spec/tcp[0]/route[0]/destination/host", vals[1].Path)
+
+	virtualService.Spec.Http = nil
+
+	vals, valid = NoHostChecker{
+		Namespace:        "bookinfo",
+		ServiceList:      data.CreateFakeServiceList([]string{"details", "other"}, "bookinfo"),
+		VirtualService:   *virtualService,
+		RegistryServices: data.CreateFakeRegistryServices("ratings", "bookinfo2", "."),
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", vals[0]))
+	assert.Equal("spec/tcp[0]/route[0]/destination/host", vals[0].Path)
+
+	virtualService.Spec.Tcp = nil
+
+	vals, valid = NoHostChecker{
+		Namespace:        "bookinfo",
+		ServiceList:      data.CreateFakeServiceList([]string{"details", "other"}, "bookinfo"),
+		VirtualService:   *virtualService,
+		RegistryServices: data.CreateFakeRegistryServices("ratings", "bookinfo2", "bookinfo2"),
 	}.Check()
 
 	assert.False(valid)
@@ -94,14 +179,63 @@ func TestInvalidServiceNamespaceFormatHost(t *testing.T) {
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "outside-namespace"},
 		},
-		ServiceNames:   []string{"details", "other"},
+		ServiceList:    data.CreateFakeServiceList([]string{"details", "other"}, "bookinfo"),
 		VirtualService: *virtualService,
 	}.Check()
 
-	assert.True(valid)
+	assert.False(valid)
 	assert.NotEmpty(vals)
-	assert.Equal(models.Unknown, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("validation.unable.cross-namespace", vals[0]))
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", vals[0]))
+	assert.Equal("spec/tcp[0]/route[0]/destination/host", vals[0].Path)
+}
+
+func TestInvalidServiceNamespaceFormatExportedHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	virtualService := data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("ratings.outside-namespace", "v1", -1),
+		data.CreateEmptyVirtualService("ratings", "test", []string{"ratings"}),
+	)
+
+	vals, valid := NoHostChecker{
+		Namespace: "test-namespace",
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "test"},
+			models.Namespace{Name: "outside-namespace"},
+		},
+		ServiceList:      data.CreateFakeServiceList([]string{"details", "other"}, "bookinfo"),
+		VirtualService:   *virtualService,
+		RegistryServices: data.CreateFakeRegistryServices("ratings", "bookinfo2", "*"),
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", vals[0]))
+	assert.Equal("spec/tcp[0]/route[0]/destination/host", vals[0].Path)
+
+	virtualService = data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("ratings", "v1", -1),
+		data.CreateEmptyVirtualService("ratings", "bookinfo", []string{"ratings"}),
+	)
+
+	vals, valid = NoHostChecker{
+		Namespace: "bookinfo",
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "bookinfo"},
+			models.Namespace{Name: "bookinfo2"},
+		},
+		ServiceList:      data.CreateFakeServiceList([]string{"details", "other"}, "bookinfo"),
+		VirtualService:   *virtualService,
+		RegistryServices: data.CreateFakeRegistryServices("ratings", "bookinfo2", "."),
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", vals[0]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", vals[0].Path)
 }
 
@@ -115,7 +249,7 @@ func TestValidServiceEntryHost(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		Namespace:      "wikipedia",
-		ServiceNames:   []string{"my-wiki-rule"},
+		ServiceList:    data.CreateFakeServiceList([]string{"my-wiki-rule"}, "bookinfo"),
 		VirtualService: *virtualService,
 	}.Check()
 
@@ -127,7 +261,7 @@ func TestValidServiceEntryHost(t *testing.T) {
 
 	vals, valid = NoHostChecker{
 		Namespace:         "wikipedia",
-		ServiceNames:      []string{"my-wiki-rule"},
+		ServiceList:       data.CreateFakeServiceList([]string{"my-wiki-rule"}, "bookinfo"),
 		VirtualService:    *virtualService,
 		ServiceEntryHosts: kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{serviceEntry}),
 	}.Check()
@@ -147,7 +281,7 @@ func TestValidWildcardServiceEntryHost(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		Namespace:      "google",
-		ServiceNames:   []string{"duckduckgo"},
+		ServiceList:    data.CreateFakeServiceList([]string{"duckduckgo"}, "bookinfo"),
 		VirtualService: *virtualService,
 	}.Check()
 
@@ -159,7 +293,7 @@ func TestValidWildcardServiceEntryHost(t *testing.T) {
 
 	vals, valid = NoHostChecker{
 		Namespace:         "google",
-		ServiceNames:      []string{"duckduckgo"},
+		ServiceList:       data.CreateFakeServiceList([]string{"duckduckgo"}, "bookinfo"),
 		VirtualService:    *virtualService,
 		ServiceEntryHosts: kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*serviceEntry}),
 	}.Check()
@@ -180,32 +314,28 @@ func TestValidServiceRegistry(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		Namespace:      "bookinfo",
-		ServiceNames:   []string{""},
+		ServiceList:    data.CreateFakeServiceList([]string{""}, "bookinfo"),
 		VirtualService: *virtualService,
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(vals)
 
-	registryService := kubernetes.RegistryService{}
-	registryService.Hostname = "ratings.mesh2-bookinfo.svc.mesh1-imports.local"
 	vals, valid = NoHostChecker{
 		Namespace:        "bookinfo",
-		ServiceNames:     []string{""},
+		ServiceList:      data.CreateFakeServiceList([]string{""}, "bookinfo"),
 		VirtualService:   *virtualService,
-		RegistryServices: []*kubernetes.RegistryService{&registryService},
+		RegistryServices: data.CreateFakeRegistryServices("ratings.mesh2-bookinfo.svc.mesh1-imports.local", "bookinfo", "bookinfo"),
 	}.Check()
 
 	assert.True(valid)
 	assert.Empty(vals)
 
-	registryService = kubernetes.RegistryService{}
-	registryService.Hostname = "ratings2.mesh2-bookinfo.svc.mesh1-imports.local"
 	vals, valid = NoHostChecker{
 		Namespace:        "bookinfo",
-		ServiceNames:     []string{""},
+		ServiceList:      data.CreateFakeServiceList([]string{""}, "bookinfo"),
 		VirtualService:   *virtualService,
-		RegistryServices: []*kubernetes.RegistryService{&registryService},
+		RegistryServices: data.CreateFakeRegistryServices("ratings2.mesh2-bookinfo.svc.mesh1-imports.local", "bookinfo", "."),
 	}.Check()
 
 	assert.False(valid)

--- a/business/services.go
+++ b/business/services.go
@@ -41,6 +41,7 @@ func (in *SvcService) GetServiceList(criteria ServiceCriteria) (*models.ServiceL
 	var deployments []apps_v1.Deployment
 	var istioConfigList models.IstioConfigList
 	var err error
+
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
 	if _, err = in.businessLayer.Namespace.GetNamespace(criteria.Namespace); err != nil {

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -205,8 +205,8 @@ func HasMatchingVirtualServices(host Host, virtualServices []networking_v1alpha3
 	return false
 }
 
-// HasMatchingRegistryService returns true when the FDQN of the host param matches
-// with one registry status of the registryStatus param.
+// HasMatchingRegistryService returns true when the FDQN of the host (from given namespace) param matches
+// with one registry service of the registryServices param.
 func HasMatchingRegistryService(namespace string, host string, registryServices []*RegistryService) bool {
 	for _, rStatus := range registryServices {
 		// We assume that on these cases the host.Service is provided in FQDN

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -207,11 +207,11 @@ func HasMatchingVirtualServices(host Host, virtualServices []networking_v1alpha3
 
 // HasMatchingRegistryService returns true when the FDQN of the host param matches
 // with one registry status of the registryStatus param.
-func HasMatchingRegistryService(host string, registryServices []*RegistryService) bool {
+func HasMatchingRegistryService(namespace string, host string, registryServices []*RegistryService) bool {
 	for _, rStatus := range registryServices {
 		// We assume that on these cases the host.Service is provided in FQDN
 		// i.e. ratings.mesh2-bookinfo.svc.mesh1-imports.local
-		if FilterByRegistryService(host, rStatus) {
+		if FilterByRegistryService(namespace, host, rStatus) {
 			return true
 		}
 	}

--- a/tests/data/service_data.go
+++ b/tests/data/service_data.go
@@ -1,0 +1,34 @@
+package data
+
+import (
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+func CreateFakeServiceList(serviceNames []string, namespace string) models.ServiceList {
+	serviceList := models.ServiceList{
+		Services: []models.ServiceOverview{},
+	}
+	for _, sName := range serviceNames {
+		serviceList.Services = append(serviceList.Services, models.ServiceOverview{
+			Name:      sName,
+			Namespace: namespace,
+			AppLabel:  true,
+			Labels: map[string]string{
+				"app":     sName,
+				"version": "v1"},
+			Selector: map[string]string{"app": sName},
+		})
+	}
+	return serviceList
+}
+
+func CreateFakeRegistryServices(host string, namespace string, exportToNamespace string) []*kubernetes.RegistryService {
+	registryService := kubernetes.RegistryService{}
+	registryService.Hostname = host
+	registryService.IstioService.Attributes.Namespace = namespace
+	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
+	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = true
+
+	return []*kubernetes.RegistryService{&registryService}
+}


### PR DESCRIPTION
RFE #3061 
Subtask: https://github.com/kiali/kiali/issues/4317

In NoHostChecker of VirtualService, now it supports exported Services from other namespaces set into route -> destination -> host.
Exporting of Service is done via "networking.istio.io/exportTo" annotation on Service in Kubernetes.
![Screenshot from 2021-10-19 08-43-33](https://user-images.githubusercontent.com/604313/137898425-5cdced04-cd4c-46c9-ac5f-ca33979f3c58.png)

Before, it was showing message that cross-namespace validations for hosts are not supported:
![Screenshot from 2021-10-18 12-09-01](https://user-images.githubusercontent.com/604313/137898806-eb575a6d-3a0c-46e3-8100-9f40b4336197.png)

Now if Service is available it does not show any warning or error:
![Screenshot from 2021-10-19 08-43-04](https://user-images.githubusercontent.com/604313/137898895-c7fa7b25-3748-4700-a00b-df5b06b69dfe.png)

But when Service is exported only to own namespace, thus not available in other namespaces, error is shown on hosts of VS:

![Screenshot from 2021-10-19 08-43-57](https://user-images.githubusercontent.com/604313/137898452-20663a6a-e3c8-430f-ba8c-081ff94a94ee.png)

![Screenshot from 2021-10-19 08-44-15](https://user-images.githubusercontent.com/604313/137898993-9e683a80-a5fb-4753-8f8b-e380f8da916b.png)

