### PR TITLE
Hostnames for egress gateways nodes

### DIFF
--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -58,6 +58,8 @@ type ProtocolTraffic struct {
 type GWInfo struct {
 	// IngressInfo contains the resolved gateway configuration if the node represents an Istio ingress gateway
 	IngressInfo GWInfoIngress `json:"ingressInfo,omitempty"`
+	// EgressInfo contains the resolved gateway configuration if the node represents an Istio egress gateway
+	EgressInfo GWInfoIngress `json:"egressInfo,omitempty"`
 }
 
 // GWInfoIngress contains the resolved gateway configuration if the node represents an Istio ingress gateway
@@ -278,6 +280,18 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 
 			nd.IsGateway = &GWInfo{
 				IngressInfo: GWInfoIngress{Hostnames: configuredHostnames},
+			}
+		}
+
+		// node may represent an Istio Egress Gateway
+		if gateways, ok := n.Metadata[graph.IsEgressGateway]; ok {
+			var configuredHostnames []string
+			for _, hosts := range gateways.(graph.GatewaysMetadata) {
+				configuredHostnames = append(configuredHostnames, hosts...)
+			}
+
+			nd.IsGateway = &GWInfo{
+				EgressInfo: GWInfoIngress{Hostnames: configuredHostnames},
 			}
 		}
 

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -281,10 +281,8 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 			nd.IsGateway = &GWInfo{
 				IngressInfo: GWInfoIngress{Hostnames: configuredHostnames},
 			}
-		}
-
-		// node may represent an Istio Egress Gateway
-		if gateways, ok := n.Metadata[graph.IsEgressGateway]; ok {
+		} else if gateways, ok := n.Metadata[graph.IsEgressGateway]; ok {
+			// node may represent an Istio Egress Gateway
 			var configuredHostnames []string
 			for _, hosts := range gateways.(graph.GatewaysMetadata) {
 				configuredHostnames = append(configuredHostnames, hosts...)

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -30,6 +30,7 @@ const (
 	HasWorkloadEntry      MetadataKey = "hasWorkloadEntry"
 	IsDead                MetadataKey = "isDead"
 	IsEgressCluster       MetadataKey = "isEgressCluster"  // PassthroughCluster or BlackHoleCluster
+	IsEgressGateway       MetadataKey = "isEgressGateway"  // Identifies a node that is an Istio egress gateway
 	IsIngressGateway      MetadataKey = "isIngressGateway" // Identifies a node that is an Istio ingress gateway
 	IsIdle                MetadataKey = "isIdle"
 	IsInaccessible        MetadataKey = "isInaccessible"

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -7563,6 +7563,7 @@ The exact format is defined in sigs.k8s.io/structured-merge-diff
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
+| egressInfo | [GWInfoIngress](#g-w-info-ingress)| `GWInfoIngress` |  | |  |  |
 | ingressInfo | [GWInfoIngress](#g-w-info-ingress)| `GWInfoIngress` |  | |  |  |
 
 

--- a/swagger.json
+++ b/swagger.json
@@ -5232,6 +5232,9 @@
       "description": "GWInfo contains the resolved gateway configuration if the node represents an Istio gateway",
       "type": "object",
       "properties": {
+        "egressInfo": {
+          "$ref": "#/definitions/GWInfoIngress"
+        },
         "ingressInfo": {
           "$ref": "#/definitions/GWInfoIngress"
         }


### PR DESCRIPTION
This adds the list of configured hosts to the metadata of graph nodes detected as egress gateways. This allows the UI to show the configured hosts in the topology graph.

Related #3765.
