### PR TITLE
Set port correctly when validating more than one Gateway for the same host port combination

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -100,7 +100,7 @@ func createError(gatewayRuleName, namespace string, serverIndex, hostIndex int) 
 func parsePortAndHostnames(serverDef *api_networking_v1alpha3.Server) []Host {
 	var port int
 	if serverDef.Port != nil {
-		if n, e := intutil.Convert(serverDef.Port.Number); e != nil {
+		if n, e := intutil.Convert(serverDef.Port.Number); e == nil {
 			port = n
 		}
 	}

--- a/business/checkers/gateways/multi_match_checker_test.go
+++ b/business/checkers/gateways/multi_match_checker_test.go
@@ -152,6 +152,31 @@ func TestSameHostPortConfigInDifferentNamespace(t *testing.T) {
 	assert.Equal(1, len(secValidation.References))
 }
 
+func TestSameHostDifferentPortConfig(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gwObject := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
+		data.CreateEmptyGateway("validgateway", "test", map[string]string{
+			"istio": "istio-ingress",
+		}))
+
+	gwObject2 := data.AddServerToGateway(data.CreateServer([]string{"valid"}, 443, "https", "https"),
+		data.CreateEmptyGateway("validgateway", "test", map[string]string{
+			"istio": "istio-ingress",
+		}))
+
+	gws := [][]networking_v1alpha3.Gateway{{*gwObject, *gwObject2}}
+
+	vals := MultiMatchChecker{
+		GatewaysPerNamespace: gws,
+	}.Check()
+
+	assert.Equal(0, len(vals))
+}
+
 func TestWildCardMatchingHost(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)


### PR DESCRIPTION
This PR makes sure that `port` is set if `intutil.Convert` successfully converts the port from the server definition (no errors), rather than only setting it when it can't convert the port.

Added a test for servers with the same host but different ports, asserting that it is considered valid.

Resolves #4466