### PR TITLE
Global sidecar validation using the root namespace 

### DIFF
--- a/business/checkers/sidecars/global_checker.go
+++ b/business/checkers/sidecars/global_checker.go
@@ -14,7 +14,7 @@ type GlobalChecker struct {
 func (gc GlobalChecker) Check() ([]*models.IstioCheck, bool) {
 	checks, valid := make([]*models.IstioCheck, 0), true
 
-	if !config.IsIstioNamespace(gc.Sidecar.Namespace) {
+	if !config.IsRootNamespace(gc.Sidecar.Namespace) {
 		return checks, valid
 	}
 

--- a/business/checkers/sidecars/global_checker_test.go
+++ b/business/checkers/sidecars/global_checker_test.go
@@ -29,7 +29,7 @@ func TestSidecarWithoutSelectorInControlPlane(t *testing.T) {
 	config.Set(conf)
 
 	vals, valid := GlobalChecker{
-		Sidecar: *data.CreateSidecar("sidecar1", conf.IstioNamespace),
+		Sidecar: *data.CreateSidecar("sidecar1", conf.ExternalServices.Istio.RootNamespace),
 	}.Check()
 
 	assert.Empty(vals)
@@ -58,7 +58,7 @@ func TestSidecarWithSelectorInControlPlane(t *testing.T) {
 	vals, valid := GlobalChecker{
 		Sidecar: *data.AddSelectorToSidecar(map[string]string{
 			"app": "reviews",
-		}, data.CreateSidecar("sidecar1", conf.IstioNamespace)),
+		}, data.CreateSidecar("sidecar1", conf.ExternalServices.Istio.RootNamespace)),
 	}.Check()
 
 	assert.NotEmpty(vals)


### PR DESCRIPTION
This PR updates the global sidecar validation to honor the root namespace instead of the istio namespace.

Depends on #4465 

Fixes #4449

In the following example, the global validation applies to the Sidecar created in istio-config namespace (the root namespace).

![root_namespace_sidecar](https://user-images.githubusercontent.com/1286393/140095407-fbe83a46-9e70-4d1f-96b1-c1c2a99513ee.png)
