### PR TITLE
Service Entry validation: SE must have listed all address from its matching WorkingEntries

### DIFF
--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -4,6 +4,7 @@ import (
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
 	"github.com/kiali/kiali/business/checkers/common"
+	"github.com/kiali/kiali/business/checkers/serviceentries"
 	"github.com/kiali/kiali/models"
 )
 
@@ -13,23 +14,27 @@ type ServiceEntryChecker struct {
 	ServiceEntries         []networking_v1alpha3.ServiceEntry
 	ExportedServiceEntries []networking_v1alpha3.ServiceEntry
 	Namespaces             models.Namespaces
+	WorkloadEntries        []networking_v1alpha3.WorkloadEntry
 }
 
 func (s ServiceEntryChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
+	weMap := serviceentries.GroupServiceEntriesByWorkloadSelector(s.WorkloadEntries)
+
 	for _, se := range s.ServiceEntries {
-		validations.MergeValidations(s.runSingleChecks(se))
+		validations.MergeValidations(s.runSingleChecks(se, weMap))
 	}
 
 	return validations
 }
 
-func (s ServiceEntryChecker) runSingleChecks(se networking_v1alpha3.ServiceEntry) models.IstioValidations {
+func (s ServiceEntryChecker) runSingleChecks(se networking_v1alpha3.ServiceEntry, workloadEntriesMap map[string][]string) models.IstioValidations {
 	key, validations := EmptyValidValidation(se.Name, se.Namespace, ServiceEntryCheckerType)
 
 	enabledCheckers := []Checker{
 		common.ExportToNamespaceChecker{ExportTo: se.Spec.ExportTo, Namespaces: s.Namespaces},
+		serviceentries.HasMatchingWorkloadEntryAddress{ServiceEntry: se, WorkloadEntries: workloadEntriesMap},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -20,7 +20,7 @@ type ServiceEntryChecker struct {
 func (s ServiceEntryChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
-	weMap := serviceentries.GroupServiceEntriesByWorkloadSelector(s.WorkloadEntries)
+	weMap := serviceentries.GroupWorkloadEntriesByLabels(s.WorkloadEntries)
 
 	for _, se := range s.ServiceEntries {
 		validations.MergeValidations(s.runSingleChecks(se, weMap))

--- a/business/checkers/serviceentries/workload_entry_address_match.go
+++ b/business/checkers/serviceentries/workload_entry_address_match.go
@@ -1,0 +1,77 @@
+package serviceentries
+
+import (
+	"fmt"
+
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kiali/kiali/models"
+)
+
+type HasMatchingWorkloadEntryAddress struct {
+	ServiceEntry    v1alpha3.ServiceEntry
+	WorkloadEntries map[string][]string
+}
+
+const MeshInternal = 1
+
+func (in HasMatchingWorkloadEntryAddress) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	if in.ServiceEntry.Spec.Location != MeshInternal {
+		return validations, true
+	}
+
+	if in.ServiceEntry.Spec.WorkloadSelector == nil {
+		return validations, true
+	}
+
+	var targetAddresses []string
+	seSelector := labels.Set(in.ServiceEntry.Spec.WorkloadSelector.Labels).AsSelector()
+
+	for labelsMap, weAddressMap := range in.WorkloadEntries {
+		workloadLabelsSet, err := labels.ConvertSelectorToLabelsMap(labelsMap)
+		if err != nil {
+			continue
+		}
+
+		if seSelector.Matches(workloadLabelsSet) {
+			targetAddresses = append(targetAddresses, weAddressMap...)
+		}
+	}
+
+	if targetAddresses == nil {
+		return validations, true
+	}
+
+	seAddresses := in.ServiceEntryAddressMap()
+
+	for _, weAddress := range targetAddresses {
+		if _, found := seAddresses[weAddress]; !found {
+			// Add validation: WorkloadEntry.Address should be part of the Service Entry Addresses list
+			validation := models.Build("serviceentries.workloadentries.addressmatch",
+				fmt.Sprint("spec/addresses"))
+			validations = append(validations, &validation)
+		}
+	}
+
+	return validations, true
+}
+
+func GroupServiceEntriesByWorkloadSelector(workloads []v1alpha3.WorkloadEntry) map[string][]string {
+	workloadEntriesMap := map[string][]string{}
+	for _, we := range workloads {
+		selector := labels.Set(we.Spec.Labels).String()
+		workloadEntriesMap[selector] = append(workloadEntriesMap[selector], we.Spec.Address)
+	}
+	return workloadEntriesMap
+}
+
+func (in HasMatchingWorkloadEntryAddress) ServiceEntryAddressMap() map[string]bool {
+	addrMap := map[string]bool{}
+	for _, addr := range in.ServiceEntry.Spec.Addresses {
+		addrMap[addr] = false
+	}
+	return addrMap
+}

--- a/business/checkers/serviceentries/workload_entry_address_match.go
+++ b/business/checkers/serviceentries/workload_entry_address_match.go
@@ -59,7 +59,7 @@ func (in HasMatchingWorkloadEntryAddress) Check() ([]*models.IstioCheck, bool) {
 	return validations, true
 }
 
-func GroupServiceEntriesByWorkloadSelector(workloads []v1alpha3.WorkloadEntry) map[string][]string {
+func GroupWorkloadEntriesByLabels(workloads []v1alpha3.WorkloadEntry) map[string][]string {
 	workloadEntriesMap := map[string][]string{}
 	for _, we := range workloads {
 		selector := labels.Set(we.Spec.Labels).String()

--- a/business/checkers/serviceentries/workload_entry_address_match_test.go
+++ b/business/checkers/serviceentries/workload_entry_address_match_test.go
@@ -81,7 +81,7 @@ func checksFor(serviceEntryName, namespace string, t *testing.T) ([]*models.Isti
 
 	return HasMatchingWorkloadEntryAddress{
 		ServiceEntry:    *serviceEntry,
-		WorkloadEntries: GroupServiceEntriesByWorkloadSelector(loader.GetResources().WorkloadEntries),
+		WorkloadEntries: GroupWorkloadEntriesByLabels(loader.GetResources().WorkloadEntries),
 	}.Check()
 }
 

--- a/business/checkers/serviceentries/workload_entry_address_match_test.go
+++ b/business/checkers/serviceentries/workload_entry_address_match_test.go
@@ -1,0 +1,91 @@
+package serviceentries
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+// ServiceEntry points to ratings.internal.cloud
+// and has workloadSelector: app=ratings
+// WorkloadEntry points to ratings.internal.cloud
+// and has labels app=ratings,version=v1
+func TestServiceEntryAddressMatch(t *testing.T) {
+	noValidationsShown(t, "ratings", "bookinfo")
+}
+
+// ServiceEntry points to an external host
+// and its location is MESH_EXTERNAL
+func TestExternalServiceEntry(t *testing.T) {
+	noValidationsShown(t, "ratings-external", "bookinfo")
+}
+
+// ServiceEntry hasn't got any workload matching
+func TestServiceEntryUnmatchingAddress(t *testing.T) {
+	noValidationsShown(t, "ratings-wrong-labels", "bookinfo")
+}
+
+// ServiceEntry points to ADDR1
+// and has workloadSelector: app=ratings-unmatching
+// WorkloadEntry points to ADDR2 (!= ADDR1)
+// and has labels app=ratings-unmatching,version=v1
+func TestServiceEntryWithNoMatchingWorkloads(t *testing.T) {
+	validationsShown(t, "ratings-unmatching-address", "bookinfo")
+}
+
+// ServiceEntry only has one address
+// There are two WorkloadEntries pointing to 2 different addresses
+func TestServiceEntryMissesWorkloadAddress(t *testing.T) {
+	validationsShown(t, "ratings-missing", "bookinfo")
+}
+
+// ServiceEntry points to 2 addresses
+// There is one WorkloadEntry. It's IP is in the ServiceEntry addresses list
+func TestServiceEntryMoreAddresses(t *testing.T) {
+	noValidationsShown(t, "ratings-surplus", "bookinfo")
+}
+
+func noValidationsShown(t *testing.T, serviceEntryName, namespace string) {
+	asserter := assert.New(t)
+	checks, valid := checksFor(serviceEntryName, namespace, t)
+	asserter.Empty(checks)
+	asserter.True(valid)
+}
+
+func validationsShown(t *testing.T, serviceEntryName, namespace string) {
+	asserter := assert.New(t)
+	checks, valid := checksFor(serviceEntryName, namespace, t)
+
+	asserter.NotEmpty(checks)
+	asserter.True(valid)
+	asserter.Equal(models.WarningSeverity, checks[0].Severity)
+	asserter.NoError(validations.ConfirmIstioCheckMessage("serviceentries.workloadentries.addressmatch", checks[0]))
+	asserter.Equal("spec/addresses", checks[0].Path)
+}
+
+func checksFor(serviceEntryName, namespace string, t *testing.T) ([]*models.IstioCheck, bool) {
+	loader := yamlFixtureLoaderFor("workload_entry_address_match.yaml")
+	if err := loader.Load(); err != nil {
+		t.Fatalf("Error loading tests manifests")
+	}
+
+	serviceEntry := loader.FindServiceEntry(serviceEntryName, namespace)
+	if serviceEntry == nil {
+		t.Fatalf("ServieEntry not found: %s/%s", serviceEntryName, namespace)
+		return []*models.IstioCheck{}, true
+	}
+
+	return HasMatchingWorkloadEntryAddress{
+		ServiceEntry:    *serviceEntry,
+		WorkloadEntries: GroupServiceEntriesByWorkloadSelector(loader.GetResources().WorkloadEntries),
+	}.Check()
+}
+
+func yamlFixtureLoaderFor(file string) *validations.YamlFixtureLoader {
+	path := fmt.Sprintf("../../../tests/data/validations/serviceentries/%s", file)
+	return &validations.YamlFixtureLoader{Filename: path}
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -106,7 +106,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioC
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioConfigList.ServiceEntries},
 		checkers.GatewayChecker{GatewaysPerNamespace: gatewaysPerNamespace, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
-		checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces},
+		checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryStatus: registryStatus},
 		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloads, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadList: workloads},
@@ -169,7 +169,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		destinationRulesChecker := checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioConfigList.ServiceEntries}
 		objectCheckers = []ObjectChecker{noServiceChecker, destinationRulesChecker}
 	case kubernetes.ServiceEntries:
-		serviceEntryChecker := checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces}
+		serviceEntryChecker := checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries}
 		objectCheckers = []ObjectChecker{serviceEntryChecker}
 	case kubernetes.Sidecars:
 		sidecarsChecker := checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces,
@@ -356,6 +356,7 @@ func (in *IstioValidationsService) fetchIstioConfigList(rValue *models.IstioConf
 			IncludeSidecars:               true,
 			IncludeVirtualServices:        true,
 			IncludeRequestAuthentications: true,
+			IncludeWorkloadEntries:        true,
 		}
 		istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigList(criteria)
 		if err != nil {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -236,6 +236,11 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "Deployment exposing same port as Service not found",
 		Severity: WarningSeverity,
 	},
+	"serviceentries.workloadentries.addressmatch": {
+		Code:     "KIA1201",
+		Message:  "Missing one or more addresses from matching WorkloadEntries",
+		Severity: WarningSeverity,
+	},
 	"servicerole.invalid.services": {
 		Code:     "KIA0901",
 		Message:  "Unable to find all the defined services",

--- a/tests/data/validations/serviceentries/workload_entry_address_match.yaml
+++ b/tests/data/validations/serviceentries/workload_entry_address_match.yaml
@@ -1,0 +1,167 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: ratings
+  namespace: bookinfo
+spec:
+  addresses:
+    - 2.2.2.2
+    - 3.3.3.3
+  hosts:
+    - ratings
+  location: MESH_INTERNAL
+  resolution: STATIC
+  ports:
+    - number: 9080
+      name: http
+      protocol: HTTP
+      targetPort: 9080
+  workloadSelector:
+    labels:
+      app: ratings
+---
+apiVersion: networking.istio.io/v1beta1
+kind: WorkloadEntry
+metadata:
+  name: ratings-v2
+  namespace: bookinfo
+spec:
+  serviceAccount: ratings-vm
+  address: 2.2.2.2
+  labels:
+    app: ratings
+    version: v2
+  ports:
+    http: 9080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: WorkloadEntry
+metadata:
+  name: ratings-v1
+  namespace: bookinfo
+spec:
+  serviceAccount: ratings-vm
+  address: 3.3.3.3
+  labels:
+    app: ratings
+    version: v1
+  ports:
+    http: 9080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: ratings-external
+  namespace: bookinfo
+spec:
+  hosts:
+    - ratings
+  location: MESH_EXTERNAL # External entries are not considered
+  resolution: STATIC
+  ports:
+    - number: 9080
+      name: http
+      protocol: HTTP
+      targetPort: 9080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: ratings-wrong-labels
+  namespace: bookinfo
+spec:
+  addresses:
+    - 2.2.2.2
+  hosts:
+    - ratings
+  location: MESH_INTERNAL
+  resolution: STATIC
+  ports:
+    - number: 9080
+      name: http
+      protocol: HTTP
+      targetPort: 9080
+  workloadSelector:
+    labels:
+      app: ratings-bogus # There are no workloads associated
+---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: ratings-unmatching-address
+  namespace: bookinfo
+spec:
+  addresses:
+    - 4.4.4.4 # This IP is not in any WorkloadEntry. It needs 2.2.2.2 to work.
+  hosts:
+    - ratings
+  location: MESH_INTERNAL
+  resolution: STATIC
+  ports:
+    - number: 9080
+      name: http
+      protocol: HTTP
+      targetPort: 9080
+  workloadSelector:
+    labels:
+      app: ratings-unmatching
+---
+apiVersion: networking.istio.io/v1beta1
+kind: WorkloadEntry
+metadata:
+  name: ratings-unmatching-v1
+  namespace: bookinfo
+spec:
+  serviceAccount: ratings-vm
+  address: 2.2.2.2
+  labels:
+    app: ratings-unmatching
+    version: v1
+  ports:
+    http: 9080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: ratings-missing
+  namespace: bookinfo
+spec:
+  addresses:
+    - 2.2.2.2 # should have 3.3.3.3 as well
+  hosts:
+    - ratings
+  location: MESH_INTERNAL
+  resolution: STATIC
+  ports:
+    - number: 9080
+      name: http
+      protocol: HTTP
+      targetPort: 9080
+  workloadSelector:
+    labels:
+      app: ratings
+---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: ratings-surplus
+  namespace: bookinfo
+spec:
+  addresses:
+    - 2.2.2.2
+    - 3.3.3.3
+    - 4.4.4.4
+    - 5.5.5.5
+  hosts:
+    - ratings
+  location: MESH_INTERNAL
+  resolution: STATIC
+  ports:
+    - number: 9080
+      name: http
+      protocol: HTTP
+      targetPort: 9080
+  workloadSelector:
+    labels:
+      app: ratings
+---

--- a/tests/testutils/validations/fixture_loader.go
+++ b/tests/testutils/validations/fixture_loader.go
@@ -2,6 +2,9 @@ package validations
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
 	"io/ioutil"
 
 	"gopkg.in/yaml.v2"
@@ -9,11 +12,8 @@ import (
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 
-	"encoding/json"
-	"fmt"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
-	"io"
 )
 
 type FixtureLoader interface {
@@ -149,6 +149,24 @@ func (l YamlFixtureLoader) FindDestinationRule(name, namespace string) *networki
 
 func (l YamlFixtureLoader) FindVirtualService(name, namespace string) *networking_v1alpha3.VirtualService {
 	for _, v := range l.istioConfigList.VirtualServices {
+		if v.Name == name && v.Namespace == namespace {
+			return &v
+		}
+	}
+	return nil
+}
+
+func (l YamlFixtureLoader) FindServiceEntry(name, namespace string) *networking_v1alpha3.ServiceEntry {
+	for _, v := range l.istioConfigList.ServiceEntries {
+		if v.Name == name && v.Namespace == namespace {
+			return &v
+		}
+	}
+	return nil
+}
+
+func (l YamlFixtureLoader) FindWorkloadEntry(name, namespace string) *networking_v1alpha3.WorkloadEntry {
+	for _, v := range l.istioConfigList.WorkloadEntries {
 		if v.Name == name && v.Namespace == namespace {
 			return &v
 		}


### PR DESCRIPTION
fix https://github.com/kiali/kiali/issues/4339

Adding validation on ServiceEntries.Addresses field. There should be list all the addresses from all Workloads matching ServiceEntry.workloadSelector labels.

I've prepared a yaml with tests that might help the testing:
https://github.com/kiali/kiali/pull/4489/files#diff-22ff27b34bdc7a01afc5a03561bbaa6b48c3e8e2fcebf70b247587a40ebc65cd