### PR TITLE
Peer authentication validations using the root namespace

### DIFF
--- a/business/checkers/peer_authentication_checker.go
+++ b/business/checkers/peer_authentication_checker.go
@@ -42,7 +42,7 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn security_v1beta.PeerAuthe
 		matchLabels = peerAuthn.Spec.Selector.MatchLabels
 	}
 	enabledCheckers = append(enabledCheckers, common.SelectorNoWorkloadFoundChecker(PeerAuthenticationCheckerType, matchLabels, m.WorkloadList))
-	if peerAuthn.Namespace == config.Get().IstioNamespace {
+	if peerAuthn.Namespace == config.Get().ExternalServices.Istio.RootNamespace {
 		enabledCheckers = append(enabledCheckers, peerauthentications.DisabledMeshWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
 	} else {
 		enabledCheckers = append(enabledCheckers, peerauthentications.DisabledNamespaceWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
@@ -51,7 +51,7 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn security_v1beta.PeerAuthe
 	// MeshWide and NamespaceWide validations are only needed with autoMtls disabled
 	if !m.MTLSDetails.EnabledAutoMtls {
 		// PeerAuthentications into istio control plane namespace are considered Mesh-wide objects
-		if peerAuthn.Namespace == config.Get().IstioNamespace {
+		if peerAuthn.Namespace == config.Get().ExternalServices.Istio.RootNamespace {
 			enabledCheckers = append(enabledCheckers,
 				peerauthentications.MeshMtlsChecker{MeshPolicy: peerAuthn, MTLSDetails: m.MTLSDetails, IsServiceMesh: false})
 		} else {

--- a/business/checkers/peer_authentication_checker.go
+++ b/business/checkers/peer_authentication_checker.go
@@ -42,7 +42,7 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn security_v1beta.PeerAuthe
 		matchLabels = peerAuthn.Spec.Selector.MatchLabels
 	}
 	enabledCheckers = append(enabledCheckers, common.SelectorNoWorkloadFoundChecker(PeerAuthenticationCheckerType, matchLabels, m.WorkloadList))
-	if peerAuthn.Namespace == config.Get().ExternalServices.Istio.RootNamespace {
+	if config.IsRootNamespace(peerAuthn.Namespace) {
 		enabledCheckers = append(enabledCheckers, peerauthentications.DisabledMeshWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
 	} else {
 		enabledCheckers = append(enabledCheckers, peerauthentications.DisabledNamespaceWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
@@ -50,8 +50,8 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn security_v1beta.PeerAuthe
 
 	// MeshWide and NamespaceWide validations are only needed with autoMtls disabled
 	if !m.MTLSDetails.EnabledAutoMtls {
-		// PeerAuthentications into istio control plane namespace are considered Mesh-wide objects
-		if peerAuthn.Namespace == config.Get().ExternalServices.Istio.RootNamespace {
+		// PeerAuthentications into  the root namespace namespace are considered Mesh-wide objects
+		if config.IsRootNamespace(peerAuthn.Namespace) {
 			enabledCheckers = append(enabledCheckers,
 				peerauthentications.MeshMtlsChecker{MeshPolicy: peerAuthn, MTLSDetails: m.MTLSDetails, IsServiceMesh: false})
 		} else {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -474,7 +474,7 @@ func (in *IstioValidationsService) fetchNonLocalmTLSConfigs(mtlsDetails *kuberne
 	go func(details *kubernetes.MTLSDetails) {
 		defer wg.Done()
 		criteria := IstioConfigCriteria{
-			Namespace:                  config.Get().IstioNamespace,
+			Namespace:                  config.Get().ExternalServices.Istio.RootNamespace,
 			IncludePeerAuthentications: true,
 		}
 		istioConfig, err := in.businessLayer.IstioConfig.GetIstioConfigList(criteria)

--- a/business/tls.go
+++ b/business/tls.go
@@ -130,7 +130,7 @@ func (in TLSService) NamespaceWidemTLSStatus(namespace string) (models.MTLSStatu
 }
 
 func (in TLSService) getPeerAuthentications(namespace string) ([]security_v1beta1.PeerAuthentication, error) {
-	if namespace == config.Get().ExternalServices.Istio.RootNamespace {
+	if config.IsRootNamespace(namespace) {
 		return []security_v1beta1.PeerAuthentication{}, nil
 	}
 	criteria := IstioConfigCriteria{

--- a/business/tls.go
+++ b/business/tls.go
@@ -51,7 +51,7 @@ func (in *TLSService) MeshWidemTLSStatus(namespaces []string) (models.MTLSStatus
 
 func (in *TLSService) getMeshPeerAuthentications() ([]security_v1beta1.PeerAuthentication, error) {
 	criteria := IstioConfigCriteria{
-		Namespace:                  config.Get().IstioNamespace,
+		Namespace:                  config.Get().ExternalServices.Istio.RootNamespace,
 		IncludePeerAuthentications: true,
 	}
 	istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigList(criteria)
@@ -130,7 +130,7 @@ func (in TLSService) NamespaceWidemTLSStatus(namespace string) (models.MTLSStatu
 }
 
 func (in TLSService) getPeerAuthentications(namespace string) ([]security_v1beta1.PeerAuthentication, error) {
-	if namespace == config.Get().IstioNamespace {
+	if namespace == config.Get().ExternalServices.Istio.RootNamespace {
 		return []security_v1beta1.PeerAuthentication{}, nil
 	}
 	criteria := IstioConfigCriteria{


### PR DESCRIPTION
This PR updates the peer authentication validations to honor the root namespace instead of the istio namespace.

Depends on #4465

Fixes #4450 