### PR TITLE
Use goimports for linting in CI

### DIFF
--- a/.github/workflows/config/.golangci.yml
+++ b/.github/workflows/config/.golangci.yml
@@ -1,0 +1,7 @@
+linters:
+  enable:
+    - goimports
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/kiali/kiali

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -2,17 +2,15 @@ name: Kiali Go CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -26,12 +24,6 @@ jobs:
 
       - name: Lint Install
         run: make lint-install
-
-      - name: Gofmt
-        run: |
-          GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/) # All the .go files, excluding vendor/
-          if [ ! -z "$(gofmt -l ${GO_FILES})" ]; then echo "These files need to be formatted:" "$(gofmt -l ${GO_FILES})";echo "Diff files:"; gofmt -d ${GO_FILES}; exit 1; fi # Gofmt Linter
-          echo "Done gofmt"
 
       - name: Verify code linting
         run: make lint

--- a/business/checkers/destinationrules/traffic_policy_exported_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_exported_checker_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 	"github.com/kiali/kiali/tests/testutils/validations"
-	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 )
 
 // Context: MeshPolicy Enabling mTLS

--- a/business/checkers/peerauthentications/disabled_namespacewide_checker.go
+++ b/business/checkers/peerauthentications/disabled_namespacewide_checker.go
@@ -1,10 +1,11 @@
 package peerauthentications
 
 import (
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/models"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
 )
 
 type DisabledNamespaceWideChecker struct {

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1,6 +1,7 @@
 package business
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,8 +13,6 @@ import (
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api_types "k8s.io/apimachinery/pkg/types"
-
-	"context"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -4,22 +4,21 @@ import (
 	"fmt"
 	"testing"
 
-	api_networking_v1alpha3 "istio.io/api/networking/v1alpha3"
-	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
-
+	"github.com/gogo/protobuf/types"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	api_networking_v1alpha3 "istio.io/api/networking/v1alpha3"
+	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	auth_v1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 	"github.com/kiali/kiali/tests/testutils/validations"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestParseListParams(t *testing.T) {

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -14,13 +14,13 @@ import (
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 	"github.com/kiali/kiali/tests/testutils/validations"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestGetNamespaceValidations(t *testing.T) {

--- a/business/jaeger_test.go
+++ b/business/jaeger_test.go
@@ -3,10 +3,10 @@ package business
 import (
 	"testing"
 
-	jaegerModels "github.com/kiali/kiali/jaeger/model/json"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/jaeger"
+	jaegerModels "github.com/kiali/kiali/jaeger/model/json"
 )
 
 var trace1 = jaegerModels.Trace{

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -4,14 +4,14 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	core_v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/models"
 )
 
 func TestServiceListParsing(t *testing.T) {

--- a/business/tls_perf_test.go
+++ b/business/tls_perf_test.go
@@ -6,15 +6,16 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes/cache"
-	"github.com/kiali/kiali/kubernetes/kubetest"
-	"github.com/kiali/kiali/tests/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/cache"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/tests/data"
 )
 
 func TestTlsPerfNsDr(t *testing.T) {

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -3,11 +3,6 @@ package business
 import (
 	"testing"
 
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/kubernetes/cache"
-	"github.com/kiali/kiali/kubernetes/kubetest"
-	"github.com/kiali/kiali/tests/data"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -16,6 +11,12 @@ import (
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/tests/data"
 )
 
 func TestMeshStatusEnabled(t *testing.T) {

--- a/jaeger/client.go
+++ b/jaeger/client.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/kiali/kiali/config"
 	jaegerModel "github.com/kiali/kiali/jaeger/model"
@@ -23,8 +25,6 @@ import (
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/grpcutil"
 	"github.com/kiali/kiali/util/httputil"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ClientInterface for mocks (only mocked function are necessary here)

--- a/kubernetes/cache/istio_test.go
+++ b/kubernetes/cache/istio_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/kiali/kiali/kubernetes"
-	"k8s.io/apimachinery/pkg/fields"
 )
 
 func TestGetSidecar(t *testing.T) {

--- a/kubernetes/cache/tls_test_helper.go
+++ b/kubernetes/cache/tls_test_helper.go
@@ -3,11 +3,12 @@ package cache
 import (
 	"time"
 
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/models"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
 )
 
 type fakeInformer struct {

--- a/kubernetes/kubetest/mock_istio.go
+++ b/kubernetes/kubetest/mock_istio.go
@@ -1,16 +1,16 @@
 package kubetest
 
 import (
+	"context"
+
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istio "istio.io/client-go/pkg/clientset/versioned"
 	istio_fake "istio.io/client-go/pkg/clientset/versioned/fake"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"context"
-
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
-	istio "istio.io/client-go/pkg/clientset/versioned"
 )
 
 func (o *K8SClientMock) MockIstio(objects ...runtime.Object) {

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -129,4 +129,4 @@ lint-install:
 ## lint: Runs golangci-lint
 # doc.go is ommited for linting, because it generates lots of warnings.
 lint:
-	golangci-lint run --skip-files "doc\.go" --tests --timeout 5m
+	golangci-lint run -c ./.github/workflows/config/.golangci.yml --skip-files "doc\.go" --tests --timeout 5m

--- a/models/endpoint.go
+++ b/models/endpoint.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	"github.com/kiali/kiali/kubernetes"
 	core_v1 "k8s.io/api/core/v1"
+
+	"github.com/kiali/kiali/kubernetes"
 )
 
 type Endpoints []Endpoint

--- a/models/port.go
+++ b/models/port.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	"github.com/kiali/kiali/kubernetes"
 	core_v1 "k8s.io/api/core/v1"
+
+	"github.com/kiali/kiali/kubernetes"
 )
 
 type Ports []Port

--- a/models/service.go
+++ b/models/service.go
@@ -1,11 +1,12 @@
 package models
 
 import (
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 )
 
 type ServiceOverview struct {

--- a/tests/data/virtual_service_data.go
+++ b/tests/data/virtual_service_data.go
@@ -1,11 +1,11 @@
 package data
 
 import (
-	api_networking_v1alpha3 "istio.io/api/networking/v1alpha3"
-	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"time"
 
 	"github.com/gogo/protobuf/types"
-	"time"
+	api_networking_v1alpha3 "istio.io/api/networking/v1alpha3"
+	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 )
 
 func CreateEmptyVirtualService(name string, namespace string, hosts []string) *networking_v1alpha3.VirtualService {


### PR DESCRIPTION
Adds `goimports` to the list of linters run by CI. This detects that the imports are sorted properly for most cases.

Fixes #4442