### PR TITLE
While validating port name, consider also appProtocol parameter, as is done in Istio.

### DIFF
--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -28,7 +28,7 @@ func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 		for portIndex, sp := range p.Service.Spec.Ports {
 			if strings.ToLower(string(sp.Protocol)) == "udp" {
 				continue
-			} else if !kubernetes.MatchPortNameWithValidProtocols(sp.Name) {
+			} else if !kubernetes.MatchPortNameWithValidProtocols(sp.Name) && !kubernetes.MatchPortAppProtocolWithValidProtocols(sp.AppProtocol) {
 				validation := models.Build("port.name.mismatch", fmt.Sprintf("spec/ports[%d]", portIndex))
 				validations = append(validations, &validation)
 			}

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -344,6 +344,18 @@ func MatchPortNameWithValidProtocols(portName string) bool {
 	return false
 }
 
+func MatchPortAppProtocolWithValidProtocols(appProtocol *string) bool {
+	if appProtocol == nil || *appProtocol == "" {
+		return false
+	}
+	for _, protocol := range portProtocols {
+		if strings.ToLower(*appProtocol) == protocol {
+			return true
+		}
+	}
+	return false
+}
+
 // GatewayNames extracts the gateway names for easier matching
 func GatewayNames(gateways [][]networking_v1alpha3.Gateway) map[string]struct{} {
 	var empty struct{}

--- a/kubernetes/istio_test.go
+++ b/kubernetes/istio_test.go
@@ -87,6 +87,25 @@ func TestInvalidPortNameMatcher(t *testing.T) {
 	assert.False(t, MatchPortNameWithValidProtocols("name"))
 }
 
+func TestValidPortAppProtocolMatcher(t *testing.T) {
+	s1 := "http"
+	s2 := "mysql"
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s1))
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s2))
+}
+
+func TestInvalidPortAppProtocolMatcher(t *testing.T) {
+	s1 := "httpname"
+	s2 := "name"
+	s3 := "http-name"
+	s4 := ""
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s1))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s2))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s3))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s4))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(nil))
+}
+
 func TestPolicyHasMtlsEnabledStructMode(t *testing.T) {
 	policy := createPeerAuthn("default", "bookinfo", nil)
 


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4486

The https://kiali.io/docs/features/validations/#kia0601---port-name-must-follow-protocol-suffix-form validation was checking only the port name in protocol [-suffix] format, but name can be not in that format and instead appProtocol parameter has the format of protocol. As described in https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection.

So now these both formats of ports are correct for Services. 
```
  ports:
  - port: 9080
    name: http-correct
  - port: 3306
    name: database
    appProtocol: http
```