### PR TITLE
While validating port name in Services, consider also appProtocol parameter's value.

### DIFF
--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -28,6 +28,11 @@ func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 		for portIndex, sp := range p.Service.Spec.Ports {
 			if strings.ToLower(string(sp.Protocol)) == "udp" {
 				continue
+			} else if sp.AppProtocol != nil {
+				if !kubernetes.MatchPortAppProtocolWithValidProtocols(sp.AppProtocol) {
+					validation := models.Build("port.appprotocol.mismatch", fmt.Sprintf("spec/ports[%d]", portIndex))
+					validations = append(validations, &validation)
+				}
 			} else if !kubernetes.MatchPortNameWithValidProtocols(sp.Name) {
 				validation := models.Build("port.name.mismatch", fmt.Sprintf("spec/ports[%d]", portIndex))
 				validations = append(validations, &validation)

--- a/business/checkers/services/port_mapping_checker_test.go
+++ b/business/checkers/services/port_mapping_checker_test.go
@@ -20,7 +20,7 @@ func TestPortMappingMatch(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http"),
+		Service:     getService(9080, "http", nil),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -36,7 +36,7 @@ func TestTargetPortMappingMatch(t *testing.T) {
 
 	assert := assert.New(t)
 
-	service := getService(9080, "http")
+	service := getService(9080, "http", nil)
 	service.Spec.Ports[0].TargetPort = intstr.FromInt(8080)
 
 	/*
@@ -74,7 +74,7 @@ func TestPortMappingMismatch(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http"),
+		Service:     getService(9080, "http", nil),
 		Deployments: getDeployment(8080),
 		Pods:        getPods(true),
 	}
@@ -93,7 +93,7 @@ func TestServicePortNaming(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http2foo"),
+		Service:     getService(9080, "http2foo", nil),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -105,6 +105,37 @@ func TestServicePortNaming(t *testing.T) {
 	assert.Equal("spec/ports[0]", vals[0].Path)
 }
 
+func TestServicePortAppProtocol(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	appProtocol := "mysql-wrong"
+	pmc := PortMappingChecker{
+		Service:     getService(9080, "database", &appProtocol),
+		Deployments: getDeployment(9080),
+		Pods:        getPods(true),
+	}
+
+	vals, valid := pmc.Check()
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.NoError(validations.ConfirmIstioCheckMessage("port.appprotocol.mismatch", vals[0]))
+	assert.Equal("spec/ports[0]", vals[0].Path)
+
+	appProtocol = "mysql"
+	pmc = PortMappingChecker{
+		Service:     getService(9080, "database", &appProtocol),
+		Deployments: getDeployment(9080),
+		Pods:        getPods(true),
+	}
+
+	vals, valid = pmc.Check()
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
 func TestServicePortNamingWithoutSidecar(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -112,7 +143,7 @@ func TestServicePortNamingWithoutSidecar(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http2foo"),
+		Service:     getService(9080, "http2foo", nil),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(false),
 	}
@@ -122,7 +153,7 @@ func TestServicePortNamingWithoutSidecar(t *testing.T) {
 	assert.Empty(vals)
 }
 
-func getService(servicePort int32, portName string) v1.Service {
+func getService(servicePort int32, portName string, appProtocol *string) v1.Service {
 	return v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "service1",
@@ -130,8 +161,9 @@ func getService(servicePort int32, portName string) v1.Service {
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				{
-					Port: servicePort,
-					Name: portName,
+					Port:        servicePort,
+					Name:        portName,
+					AppProtocol: appProtocol,
 				},
 			},
 			Selector: map[string]string{

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -344,6 +344,18 @@ func MatchPortNameWithValidProtocols(portName string) bool {
 	return false
 }
 
+func MatchPortAppProtocolWithValidProtocols(appProtocol *string) bool {
+	if appProtocol == nil || *appProtocol == "" {
+		return false
+	}
+	for _, protocol := range portProtocols {
+		if strings.ToLower(*appProtocol) == protocol {
+			return true
+		}
+	}
+	return false
+}
+
 // GatewayNames extracts the gateway names for easier matching
 func GatewayNames(gateways [][]networking_v1alpha3.Gateway) map[string]struct{} {
 	var empty struct{}

--- a/kubernetes/istio_test.go
+++ b/kubernetes/istio_test.go
@@ -87,6 +87,25 @@ func TestInvalidPortNameMatcher(t *testing.T) {
 	assert.False(t, MatchPortNameWithValidProtocols("name"))
 }
 
+func TestValidPortAppProtocolMatcher(t *testing.T) {
+	s1 := "http"
+	s2 := "mysql"
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s1))
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s2))
+}
+
+func TestInvalidPortAppProtocolMatcher(t *testing.T) {
+	s1 := "httpname"
+	s2 := "name"
+	s3 := "http-name"
+	s4 := ""
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s1))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s2))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s3))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s4))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(nil))
+}
+
 func TestPolicyHasMtlsEnabledStructMode(t *testing.T) {
 	policy := createPeerAuthn("default", "bookinfo", nil)
 

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -226,6 +226,11 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "Destination Rule disabling mesh-wide mTLS is missing",
 		Severity: ErrorSeverity,
 	},
+	"port.appprotocol.mismatch": {
+		Code:     "KIA0602",
+		Message:  "Port appProtocol must follow <protocol> form",
+		Severity: ErrorSeverity,
+	},
 	"port.name.mismatch": {
 		Code:     "KIA0601",
 		Message:  "Port name must follow <protocol>[-suffix] form",

--- a/models/port.go
+++ b/models/port.go
@@ -4,10 +4,10 @@ import core_v1 "k8s.io/api/core/v1"
 
 type Ports []Port
 type Port struct {
-	Name        string `json:"name"`
-	Protocol    string `json:"protocol"`
-	AppProtocol string `json:"appProtocol"`
-	Port        int32  `json:"port"`
+	Name        string  `json:"name"`
+	Protocol    string  `json:"protocol"`
+	AppProtocol *string `json:"appProtocol,omitempty"`
+	Port        int32   `json:"port"`
 }
 
 func (ports *Ports) Parse(ps []core_v1.ServicePort) {
@@ -21,9 +21,7 @@ func (ports *Ports) Parse(ps []core_v1.ServicePort) {
 func (port *Port) Parse(p core_v1.ServicePort) {
 	port.Name = p.Name
 	port.Protocol = string(p.Protocol)
-	if p.AppProtocol != nil {
-		port.AppProtocol = *p.AppProtocol
-	}
+	port.AppProtocol = p.AppProtocol
 	port.Port = p.Port
 }
 

--- a/models/port.go
+++ b/models/port.go
@@ -4,9 +4,10 @@ import core_v1 "k8s.io/api/core/v1"
 
 type Ports []Port
 type Port struct {
-	Name     string `json:"name"`
-	Protocol string `json:"protocol"`
-	Port     int32  `json:"port"`
+	Name        string `json:"name"`
+	Protocol    string `json:"protocol"`
+	AppProtocol string `json:"appProtocol"`
+	Port        int32  `json:"port"`
 }
 
 func (ports *Ports) Parse(ps []core_v1.ServicePort) {
@@ -20,6 +21,9 @@ func (ports *Ports) Parse(ps []core_v1.ServicePort) {
 func (port *Port) Parse(p core_v1.ServicePort) {
 	port.Name = p.Name
 	port.Protocol = string(p.Protocol)
+	if p.AppProtocol != nil {
+		port.AppProtocol = *p.AppProtocol
+	}
 	port.Port = p.Port
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -7055,6 +7055,10 @@
     "Port": {
       "type": "object",
       "properties": {
+        "appProtocol": {
+          "type": "string",
+          "x-go-name": "AppProtocol"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4486

The https://kiali.io/docs/features/validations/#kia0601---port-name-must-follow-protocol-suffix-form validation was checking only the port name in protocol [-suffix] format, but name can be not in that format and instead appProtocol parameter has the format of protocol. As described in https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection.

So now these both formats of ports are correct for Services. 
```
  ports:
  - port: 9080
    name: http-correct
  - port: 3306
    name: database
    appProtocol: http
```