### PR TITLE
Omit intermediate PassthroughCluster nodes in the graph

### DIFF
--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -3508,6 +3508,24 @@ func TestMultiClusterSourceGraph(t *testing.T) {
 		"source_cluster":                 "kukulcan",
 		"source_workload":                "productpage-v1",
 		"source_workload_namespace":      "bookinfo"}
+	// This is an additional test for #4488, done here because, unlike the other tests, this test is injecting service nodes
+	q2m6 := model.Metric{
+		"destination_canonical_revision": "v1",
+		"destination_canonical_service":  "kiali#4488-dest",
+		"destination_cluster":            "tzotz",
+		"destination_service":            "10.2.3.4:8080",
+		"destination_service_name":       "PassthroughCluster",
+		"destination_service_namespace":  "bookinfo",
+		"destination_workload":           "kiali#4488-dest-v1",
+		"destination_workload_namespace": "bookinfo",
+		"request_protocol":               "http",
+		"response_code":                  "200",
+		"response_flags":                 "-",
+		"source_canonical_revision":      "v1",
+		"source_canonical_service":       "kiali#4488-source",
+		"source_cluster":                 "tzotz",
+		"source_workload":                "kiali#4488-source-v1",
+		"source_workload_namespace":      "bookinfo"}
 	v2 := model.Vector{
 		&model.Sample{
 			Metric: q2m0,
@@ -3526,6 +3544,9 @@ func TestMultiClusterSourceGraph(t *testing.T) {
 			Value:  100},
 		&model.Sample{
 			Metric: q2m5,
+			Value:  100},
+		&model.Sample{
+			Metric: q2m6,
 			Value:  100},
 	}
 

--- a/graph/api/testdata/test_mc_source_graph.expected
+++ b/graph/api/testdata/test_mc_source_graph.expected
@@ -280,6 +280,52 @@
       },
       {
         "data": {
+          "id": "a4dbaf34b838d0ade625d37c4a8b990e",
+          "nodeType": "app",
+          "cluster": "tzotz",
+          "namespace": "bookinfo",
+          "workload": "kiali#4488-dest-v1",
+          "app": "kiali#4488-dest",
+          "version": "v1",
+          "destServices": [
+            {
+              "cluster": "tzotz",
+              "namespace": "bookinfo",
+              "name": "PassthroughCluster"
+            }
+          ],
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "100.00"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "data": {
+          "id": "a246ad10e3abcc5b72f1d1b7f7ce735b",
+          "nodeType": "app",
+          "cluster": "tzotz",
+          "namespace": "bookinfo",
+          "workload": "kiali#4488-source-v1",
+          "app": "kiali#4488-source",
+          "version": "v1",
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "100.00"
+              }
+            }
+          ],
+          "isRoot": true
+        }
+      },
+      {
+        "data": {
           "id": "91e5b39a176fbba2e97a8fcccb474095",
           "nodeType": "app",
           "cluster": "tzotz",
@@ -522,6 +568,30 @@
                 },
                 "hosts": {
                   "details.bookinfo.svc.cluster.local": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "cff7f5ca632018a2a8cc8df280d40d3e",
+          "source": "a246ad10e3abcc5b72f1d1b7f7ce735b",
+          "target": "a4dbaf34b838d0ade625d37c4a8b990e",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "100.00",
+              "httpPercentReq": "100.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "10.2.3.4:8080": "100.0"
                 }
               }
             }

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -201,9 +201,12 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 			continue
 		}
 
-		// don't inject a service node if destSvcName is not set or the dest node is already a service node.
+		// don't inject a service node if any of:
+		// - destSvcName is not set
+		// - destSvcName is PassthroughCluster (see https://github.com/kiali/kiali/issues/4488)
+		// - dest node is already a service node
 		inject := false
-		if a.InjectServiceNodes && graph.IsOK(destSvcName) {
+		if a.InjectServiceNodes && graph.IsOK(destSvcName) && destSvcName != graph.PassthroughCluster {
 			_, destNodeType := graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType)
 			inject = (graph.NodeTypeService != destNodeType)
 		}

--- a/graph/telemetry/istio/appender/security_policy.go
+++ b/graph/telemetry/istio/appender/security_policy.go
@@ -237,9 +237,12 @@ func (a SecurityPolicyAppender) populateSecurityPolicyMap(securityPolicyMap map[
 		// handle clusters
 		sourceCluster, destCluster := util.HandleClusters(lSourceCluster, sourceClusterOk, lDestCluster, destClusterOk)
 
-		// don't inject a service node if destSvcName is not set or the dest node is already a service node.
+		// don't inject a service node if any of:
+		// - destSvcName is not set
+		// - destSvcName is PassthroughCluster (see https://github.com/kiali/kiali/issues/4488)
+		// - dest node is already a service node
 		inject := false
-		if a.InjectServiceNodes && graph.IsOK(destSvcName) {
+		if a.InjectServiceNodes && graph.IsOK(destSvcName) && destSvcName != graph.PassthroughCluster {
 			_, destNodeType := graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType)
 			inject = (graph.NodeTypeService != destNodeType)
 		}

--- a/graph/telemetry/istio/appender/throughput.go
+++ b/graph/telemetry/istio/appender/throughput.go
@@ -157,9 +157,12 @@ func (a ThroughputAppender) populateThroughputMap(throughputMap map[string]float
 			continue
 		}
 
-		// don't inject a service node if destSvcName is not set or the dest node is already a service node.
+		// don't inject a service node if any of:
+		// - destSvcName is not set
+		// - destSvcName is PassthroughCluster (see https://github.com/kiali/kiali/issues/4488)
+		// - dest node is already a service node
 		inject := false
-		if a.InjectServiceNodes && graph.IsOK(destSvcName) {
+		if a.InjectServiceNodes && graph.IsOK(destSvcName) && destSvcName != graph.PassthroughCluster {
 			_, destNodeType := graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType)
 			inject = (graph.NodeTypeService != destNodeType)
 		}

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -318,9 +318,12 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, metri
 		// make code more readable by setting "host" because "destSvc" holds destination.service.host | request.host | "unknown"
 		host := destSvc
 
-		// don't inject a service node if destSvcName is not set or the dest node is already a service node.
+		// don't inject a service node if any of:
+		// - destSvcName is not set
+		// - destSvcName is PassthroughCluster (see https://github.com/kiali/kiali/issues/4488)
+		// - dest node is already a service node
 		inject := false
-		if o.InjectServiceNodes && graph.IsOK(destSvcName) {
+		if o.InjectServiceNodes && graph.IsOK(destSvcName) && destSvcName != graph.PassthroughCluster {
 			_, destNodeType := graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o.GraphType)
 			inject = (graph.NodeTypeService != destNodeType)
 		}

--- a/graph/types.go
+++ b/graph/types.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	BlackHoleCluster      string = "BlackHoleCluster"
 	GraphTypeApp          string = "app"
 	GraphTypeService      string = "service" // Treated as graphType Workload, with service injection, and then condensed
 	GraphTypeVersionedApp string = "versionedApp"
@@ -18,11 +19,9 @@ const (
 	NodeTypeService       string = "service"
 	NodeTypeUnknown       string = "unknown" // The special "unknown" traffic gen node
 	NodeTypeWorkload      string = "workload"
+	PassthroughCluster    string = "PassthroughCluster"
 	TF                    string = "2006-01-02 15:04:05" // TF is the TimeFormat for timestamps
 	Unknown               string = "unknown"             // Istio unknown label value
-	// private
-	passthroughCluster string = "PassthroughCluster"
-	blackHoleCluster   string = "BlackHoleCluster"
 )
 
 type Node struct {
@@ -119,7 +118,7 @@ func NewNodeExplicit(id, cluster, namespace, workload, app, version, service, no
 		workload = ""
 		version = ""
 
-		if service == passthroughCluster || service == blackHoleCluster {
+		if service == PassthroughCluster || service == BlackHoleCluster {
 			metadata[IsEgressCluster] = true
 		}
 	case NodeTypeWorkload:


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4488

For direct pod requests that travel through the default handler (PassthroughCluster),
improve the visualization by omitting the intermediate PassthroughCluster service node,
thus leaving only the direct edge.  Note, this is only relevant when
service injection is enabled.  Note also that it is still possible, and
desirable, to have PassthoughCluster as a terminal node.


