### PR TITLE
While validating VS subsets repeatings, consider hosts and subset combinations

### DIFF
--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -64,7 +64,7 @@ func (in VirtualServiceChecker) runChecks(virtualService networking_v1alpha3.Vir
 	key, rrValidation := EmptyValidValidation(virtualServiceName, virtualService.Namespace, VirtualCheckerType)
 
 	enabledCheckers := []Checker{
-		virtualservices.RouteChecker{VirtualService: virtualService},
+		virtualservices.RouteChecker{VirtualService: virtualService, Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames()},
 		virtualservices.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), DestinationRules: in.DestinationRules, VirtualService: virtualService, ExportedDestinationRules: in.ExportedDestinationRules},
 		common.ExportToNamespaceChecker{ExportTo: virtualService.Spec.ExportTo, Namespaces: in.Namespaces},
 	}

--- a/business/checkers/virtualservices/route_checker.go
+++ b/business/checkers/virtualservices/route_checker.go
@@ -97,7 +97,7 @@ func (route RouteChecker) checkTcpRoutes() ([]*models.IstioCheck, bool) {
 			}
 		}
 
-		route.trackTcpTlsSubset(routeIdx, "http", destinationWeights, &validations)
+		route.trackTcpTlsSubset(routeIdx, "tcp", destinationWeights, &validations)
 	}
 
 	return validations, valid
@@ -128,7 +128,7 @@ func (route RouteChecker) checkTlsRoutes() ([]*models.IstioCheck, bool) {
 			}
 		}
 
-		route.trackTcpTlsSubset(routeIdx, "http", destinationWeights, &validations)
+		route.trackTcpTlsSubset(routeIdx, "tls", destinationWeights, &validations)
 	}
 
 	return validations, valid

--- a/business/checkers/virtualservices/route_checker.go
+++ b/business/checkers/virtualservices/route_checker.go
@@ -6,10 +6,13 @@ import (
 	api_networking_v1alpha3 "istio.io/api/networking/v1alpha3"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
 
 type RouteChecker struct {
+	Namespace      string
+	Namespaces     []string
 	VirtualService networking_v1alpha3.VirtualService
 }
 
@@ -63,7 +66,7 @@ func (route RouteChecker) checkHttpRoutes() ([]*models.IstioCheck, bool) {
 			}
 		}
 
-		trackHttpSubset(routeIdx, "http", destinationWeights, &validations)
+		route.trackHttpSubset(routeIdx, "http", destinationWeights, &validations)
 	}
 
 	return validations, valid
@@ -94,7 +97,7 @@ func (route RouteChecker) checkTcpRoutes() ([]*models.IstioCheck, bool) {
 			}
 		}
 
-		trackTcpTlsSubset(routeIdx, "http", destinationWeights, &validations)
+		route.trackTcpTlsSubset(routeIdx, "http", destinationWeights, &validations)
 	}
 
 	return validations, valid
@@ -125,13 +128,13 @@ func (route RouteChecker) checkTlsRoutes() ([]*models.IstioCheck, bool) {
 			}
 		}
 
-		trackTcpTlsSubset(routeIdx, "http", destinationWeights, &validations)
+		route.trackTcpTlsSubset(routeIdx, "http", destinationWeights, &validations)
 	}
 
 	return validations, valid
 }
 
-func trackHttpSubset(routeIdx int, kind string, destinationWeights []*api_networking_v1alpha3.HTTPRouteDestination, checks *[]*models.IstioCheck) {
+func (route RouteChecker) trackHttpSubset(routeIdx int, kind string, destinationWeights []*api_networking_v1alpha3.HTTPRouteDestination, checks *[]*models.IstioCheck) {
 	subsetCollitions := map[string][]int{}
 
 	for destWeightIdx, destinationWeight := range destinationWeights {
@@ -141,18 +144,20 @@ func trackHttpSubset(routeIdx int, kind string, destinationWeights []*api_networ
 		if destinationWeight.Destination == nil {
 			return
 		}
+		fqdn := kubernetes.GetHost(destinationWeight.Destination.Host, route.Namespace, route.VirtualService.ClusterName, route.Namespaces)
 		subset := destinationWeight.Destination.Subset
-		collisions := subsetCollitions[subset]
+		key := fmt.Sprintf("%s%s", fqdn.String(), subset)
+		collisions := subsetCollitions[key]
 		if collisions == nil {
 			collisions = make([]int, 0, len(destinationWeights))
 		}
-		subsetCollitions[subset] = append(collisions, destWeightIdx)
+		subsetCollitions[key] = append(collisions, destWeightIdx)
 
 	}
 	appendSubsetDuplicity(routeIdx, kind, subsetCollitions, checks)
 }
 
-func trackTcpTlsSubset(routeIdx int, kind string, destinationWeights []*api_networking_v1alpha3.RouteDestination, checks *[]*models.IstioCheck) {
+func (route RouteChecker) trackTcpTlsSubset(routeIdx int, kind string, destinationWeights []*api_networking_v1alpha3.RouteDestination, checks *[]*models.IstioCheck) {
 	subsetCollitions := map[string][]int{}
 
 	for destWeightIdx, destinationWeight := range destinationWeights {
@@ -162,12 +167,14 @@ func trackTcpTlsSubset(routeIdx int, kind string, destinationWeights []*api_netw
 		if destinationWeight.Destination == nil {
 			return
 		}
+		fqdn := kubernetes.GetHost(destinationWeight.Destination.Host, route.Namespace, route.VirtualService.ClusterName, route.Namespaces)
 		subset := destinationWeight.Destination.Subset
-		collisions := subsetCollitions[subset]
+		key := fmt.Sprintf("%s%s", fqdn.String(), subset)
+		collisions := subsetCollitions[key]
 		if collisions == nil {
 			collisions = make([]int, 0, len(destinationWeights))
 		}
-		subsetCollitions[subset] = append(collisions, destWeightIdx)
+		subsetCollitions[key] = append(collisions, destWeightIdx)
 
 	}
 	appendSubsetDuplicity(routeIdx, kind, subsetCollitions, checks)
@@ -177,7 +184,7 @@ func appendSubsetDuplicity(routeIdx int, kind string, collistionsMap map[string]
 	for _, dups := range collistionsMap {
 		if len(dups) > 1 {
 			for _, dup := range dups {
-				path := fmt.Sprintf("spec/%s[%d]/route[%d]/subset", kind, routeIdx, dup)
+				path := fmt.Sprintf("spec/%s[%d]/route[%d]/host", kind, routeIdx, dup)
 				validation := models.Build("virtualservices.route.repeatedsubset", path)
 				*checks = append(*checks, &validation)
 			}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -303,7 +303,7 @@ var checkDescriptors = map[string]IstioCheck{
 	},
 	"virtualservices.route.repeatedsubset": {
 		Code:     "KIA1105",
-		Message:  "This subset is already referenced in another route destination",
+		Message:  "This host subset combination is already referenced in another route destination",
 		Severity: WarningSeverity,
 	},
 	"virtualservices.singlehost": {


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4458.

Create a VS without a subsets in route, like this:
```
      route:
        - destination:
            host: reviews
          weight: 80
        - destination:
            host: reviews.bookinfo2.svc.cluster.local
          weight: 10
        - destination:
            host: reviews.bookinfo.svc.cluster.local
          weight: 10
```

Before it was showing warning message in wrong place because validation was tightened to only subset:
![Screenshot from 2021-11-23 10-02-14](https://user-images.githubusercontent.com/604313/142996080-43ea8394-6e43-4390-8087-eab81a943a31.png)

Now it validates host+subset combination and considers host in fqdn and puts validation message on the host line:
![Screenshot from 2021-11-23 09-06-35](https://user-images.githubusercontent.com/604313/142996346-54054d12-0789-4493-817c-d6585739a2c2.png)
