### PR TITLE
Add configuration for IstioD pod monitoring port

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -186,6 +186,7 @@ type IstioConfig struct {
 	IstioSidecarInjectorConfigMapName string              `yaml:"istio_sidecar_injector_config_map_name,omitempty"`
 	IstioSidecarAnnotation            string              `yaml:"istio_sidecar_annotation,omitempty"`
 	IstiodDeploymentName              string              `yaml:"istiod_deployment_name,omitempty"`
+	IstiodPodMonitoringPort           int                 `yaml:"istiod_pod_monitoring_port,omitempty"`
 	RootNamespace                     string              `yaml:"root_namespace,omitempty"`
 	UrlServiceVersion                 string              `yaml:"url_service_version"`
 }
@@ -534,6 +535,7 @@ func NewConfig() (c *Config) {
 				IstioSidecarInjectorConfigMapName: "istio-sidecar-injector",
 				IstioSidecarAnnotation:            "sidecar.istio.io/status",
 				IstiodDeploymentName:              "istiod",
+				IstiodPodMonitoringPort:           15014,
 				RootNamespace:                     "istio-system",
 				UrlServiceVersion:                 "http://istiod:15014/version",
 			},

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -98,7 +98,7 @@ func (in *K8SClient) getIstiodDebugStatus(debugPath string) (map[string][]byte, 
 			// The 15014 port on Istiod is open for control plane monitoring.
 			// Here's the Istio doc page about the port usage by istio:
 			// https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio
-			res, err := in.ForwardGetRequest(namespace, name, freePort, 15014, debugPath)
+			res, err := in.ForwardGetRequest(namespace, name, freePort, c.ExternalServices.Istio.IstiodPodMonitoringPort, debugPath)
 			if err != nil {
 				errChan <- fmt.Errorf("%s: %s", name, err.Error())
 			} else {


### PR DESCRIPTION
Because sometimes people need to change the monitoring port on the IstioD pod when using host network mode.

Operator PR: https://github.com/kiali/kiali-operator/pull/455

Fixes kiali/kiali#4462
