### PR TITLE
Use AllNamespaces flag in IstioConfig for TLS validation

### DIFF
--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -3,20 +3,19 @@ package business
 import (
 	"testing"
 
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/tests/data"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	api_security_v1beta1 "istio.io/api/security/v1beta1"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/kubernetes/kubetest"
-	"github.com/kiali/kiali/tests/data"
 	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMeshStatusEnabled(t *testing.T) {
@@ -24,22 +23,22 @@ func TestMeshStatusEnabled(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	dr := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("test", "default", "*.local"))
+	ns := []string{"test"}
+	pa := fakeStrictMeshPeerAuthentication("default")
+	dr := []networking_v1alpha3.DestinationRule{
+		*data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("test", "default", "*.local"))}
 
 	k8s := new(kubetest.K8SClientMock)
-	fakeIstioObjects := []runtime.Object{}
-	fakeIstioObjects = append(fakeIstioObjects, dr)
-	for _, p := range fakeStrictMeshPeerAuthentication("default") {
-		fakeIstioObjects = append(fakeIstioObjects, p.DeepCopyObject())
-	}
-	k8s.MockIstio(fakeIstioObjects...)
 	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("IsOpenShift").Return(false)
-	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
+	k8s.On("GetNamespaces", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
+	k8s.On("GetToken").Return("token")
 
-	tlsService := getTLSService(k8s, false)
-	status, err := (tlsService).MeshWidemTLSStatus([]string{"test"})
+	tlsService := getTLSService(k8s, false, ns, pa, dr)
+	status, err := (tlsService).MeshWidemTLSStatus(ns)
+
+	cleanTestGlobals()
 
 	assert.NoError(err)
 	assert.Equal(MTLSEnabled, status.Status)
@@ -50,19 +49,19 @@ func TestMeshStatusEnabledAutoMtls(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
+	ns := []string{"test"}
+	pa := fakeStrictMeshPeerAuthentication("default")
+	dr := []networking_v1alpha3.DestinationRule{}
+
 	k8s := new(kubetest.K8SClientMock)
 
-	fakeIstioObjects := []runtime.Object{}
-	for _, p := range fakeStrictMeshPeerAuthentication("default") {
-		fakeIstioObjects = append(fakeIstioObjects, &p)
-	}
-	k8s.MockIstio(fakeIstioObjects...)
 	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("IsOpenShift").Return(false)
-	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
 
-	tlsService := getTLSService(k8s, true)
-	status, err := (tlsService).MeshWidemTLSStatus([]string{"test"})
+	tlsService := getTLSService(k8s, true, ns, pa, dr)
+	status, err := (tlsService).MeshWidemTLSStatus(ns)
+
+	cleanTestGlobals()
 
 	assert.NoError(err)
 	assert.Equal(MTLSEnabled, status.Status)
@@ -73,22 +72,20 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	dr := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
+	ns := []string{"test"}
+	pa := fakeStrictMeshPeerAuthentication("default")
+	dr := []networking_v1alpha3.DestinationRule{
+		*data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))}
 
 	k8s := new(kubetest.K8SClientMock)
-	fakeIstioObjects := []runtime.Object{}
-	fakeIstioObjects = append(fakeIstioObjects, dr)
-	for _, p := range fakeStrictMeshPeerAuthentication("default") {
-		fakeIstioObjects = append(fakeIstioObjects, &p)
-	}
-	k8s.MockIstio(fakeIstioObjects...)
 	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("IsOpenShift").Return(false)
-	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
 
-	tlsService := getTLSService(k8s, false)
-	status, err := (tlsService).MeshWidemTLSStatus([]string{"test"})
+	tlsService := getTLSService(k8s, false, ns, pa, dr)
+	status, err := (tlsService).MeshWidemTLSStatus(ns)
+
+	cleanTestGlobals()
 
 	assert.NoError(err)
 	assert.Equal(MTLSPartiallyEnabled, status.Status)
@@ -99,19 +96,21 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	dr := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))
+	ns := []string{"test"}
+	pa := []security_v1beta1.PeerAuthentication{}
+	dr := []networking_v1alpha3.DestinationRule{
+		*data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("istio-system", "default", "sleep.foo.svc.cluster.local"))}
 
 	k8s := new(kubetest.K8SClientMock)
-	fakeIstioObjects := []runtime.Object{}
-	fakeIstioObjects = append(fakeIstioObjects, dr)
-	k8s.MockIstio(fakeIstioObjects...)
 	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("IsOpenShift").Return(false)
 	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
 
-	tlsService := getTLSService(k8s, false)
-	status, err := (tlsService).MeshWidemTLSStatus([]string{"test"})
+	tlsService := getTLSService(k8s, false, ns, pa, dr)
+	status, err := (tlsService).MeshWidemTLSStatus(ns)
+
+	cleanTestGlobals()
 
 	assert.NoError(err)
 	assert.Equal(MTLSNotEnabled, status.Status)
@@ -122,22 +121,21 @@ func TestMeshStatusDisabled(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	dr := data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
-		data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))
+	ns := []string{"test"}
+	pa := fakeMeshPeerAuthenticationWithMtlsMode("default", "DISABLE")
+	dr := []networking_v1alpha3.DestinationRule{
+		*data.AddTrafficPolicyToDestinationRule(data.CreateDisabledMTLSTrafficPolicyForDestinationRules(),
+			data.CreateEmptyDestinationRule("istio-system", "default", "*.local"))}
 
 	k8s := new(kubetest.K8SClientMock)
-	fakeIstioObjects := []runtime.Object{}
-	fakeIstioObjects = append(fakeIstioObjects, dr)
-	for _, p := range fakeMeshPeerAuthenticationWithMtlsMode("default", "DISABLE") {
-		fakeIstioObjects = append(fakeIstioObjects, &p)
-	}
-	k8s.MockIstio(fakeIstioObjects...)
 	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("IsOpenShift").Return(false)
 	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
 
-	tlsService := getTLSService(k8s, false)
-	status, err := (tlsService).MeshWidemTLSStatus([]string{"test"})
+	tlsService := getTLSService(k8s, false, ns, pa, dr)
+	status, err := (tlsService).MeshWidemTLSStatus(ns)
+
+	cleanTestGlobals()
 
 	assert.NoError(err)
 	assert.Equal(MTLSDisabled, status.Status)
@@ -148,15 +146,18 @@ func TestMeshStatusNotEnabledAutoMtls(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
+	ns := []string{"test"}
+	pa := []security_v1beta1.PeerAuthentication{}
+	dr := []networking_v1alpha3.DestinationRule{}
+
 	k8s := new(kubetest.K8SClientMock)
-	fakeIstioObjects := []runtime.Object{}
-	k8s.MockIstio(fakeIstioObjects...)
 	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("IsOpenShift").Return(false)
-	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
 
-	tlsService := getTLSService(k8s, true)
-	status, err := (tlsService).MeshWidemTLSStatus([]string{"test"})
+	tlsService := getTLSService(k8s, true, ns, pa, dr)
+	status, err := (tlsService).MeshWidemTLSStatus(ns)
+
+	cleanTestGlobals()
 
 	assert.NoError(err)
 	assert.Equal(MTLSNotEnabled, status.Status)
@@ -271,23 +272,23 @@ func TestNamespaceHasDestinationRuleEnabledDifferentNs(t *testing.T) {
 	}
 
 	k8s := new(kubetest.K8SClientMock)
-	fakeIstioObjects := []runtime.Object{}
-	for _, d := range drs {
-		fakeIstioObjects = append(fakeIstioObjects, &d)
-	}
-	for _, p := range ps {
-		fakeIstioObjects = append(fakeIstioObjects, &p)
-	}
-	k8s.MockIstio(fakeIstioObjects...)
 	projects := fakeProjects()
+	nss := []string{}
+	for _, p := range projects {
+		nss = append(nss, p.Name)
+	}
 	k8s.On("IsOpenShift").Return(true)
 	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("GetProjects", mock.AnythingOfType("string")).Return(projects, nil)
 	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&projects[0], nil)
+	k8s.On("GetToken").Return("token")
 
 	autoMtls := false
+	kialiCache = cache.FakeTlsKialiCache("token", nss, ps, drs)
 	tlsService := TLSService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil), enabledAutoMtls: &autoMtls}
 	status, err := (tlsService).NamespaceWidemTLSStatus("bookinfo")
+
+	cleanTestGlobals()
 
 	assert.NoError(err)
 	assert.Equal(MTLSEnabled, status.Status)
@@ -299,25 +300,25 @@ func testNamespaceScenario(exStatus string, drs []networking_v1alpha3.Destinatio
 	config.Set(conf)
 
 	k8s := new(kubetest.K8SClientMock)
-	fakeIstioObjects := []runtime.Object{}
-	for _, d := range drs {
-		fakeIstioObjects = append(fakeIstioObjects, &d)
-	}
-	for _, p := range ps {
-		fakeIstioObjects = append(fakeIstioObjects, &p)
-	}
-	k8s.MockIstio(fakeIstioObjects...)
 	projects := fakeProjects()
+	nss := []string{}
+	for _, p := range projects {
+		nss = append(nss, p.Name)
+	}
 	k8s.On("IsOpenShift").Return(true)
 	k8s.On("IsMaistraApi").Return(false)
 	k8s.On("GetProjects", mock.AnythingOfType("string")).Return(projects, nil)
 	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&projects[0], nil)
+	k8s.On("GetToken").Return("token")
 
 	config.Set(config.NewConfig())
 
+	kialiCache = cache.FakeTlsKialiCache("token", nss, ps, drs)
 	tlsService := TLSService{k8s: k8s, enabledAutoMtls: &autoMtls, businessLayer: NewWithBackends(k8s, nil, nil)}
 	tlsService.businessLayer.Namespace.isAccessibleNamespaces["**"] = true
 	status, err := (tlsService).NamespaceWidemTLSStatus("bookinfo")
+
+	cleanTestGlobals()
 
 	assert.NoError(err)
 	assert.Equal(exStatus, status.Status)
@@ -358,7 +359,8 @@ func fakePeerAuthn(name, namespace string, peers *api_security_v1beta1.PeerAuthe
 	return []security_v1beta1.PeerAuthentication{*data.CreateEmptyPeerAuthentication(name, namespace, peers)}
 }
 
-func getTLSService(k8s kubernetes.ClientInterface, autoMtls bool) *TLSService {
+func getTLSService(k8s kubernetes.ClientInterface, autoMtls bool, namespaces []string, pa []security_v1beta1.PeerAuthentication, dr []networking_v1alpha3.DestinationRule) *TLSService {
+	kialiCache = cache.FakeTlsKialiCache("token", namespaces, pa, dr)
 	return &TLSService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil), enabledAutoMtls: &autoMtls}
 }
 
@@ -375,4 +377,9 @@ func fakeMeshPeerAuthenticationWithMtlsMode(name, mTLSmode string) []security_v1
 
 func fakeMeshPeerAuthentication(name string, mtls *api_security_v1beta1.PeerAuthentication_MutualTLS) []security_v1beta1.PeerAuthentication {
 	return []security_v1beta1.PeerAuthentication{*data.CreateEmptyMeshPeerAuthentication(name, mtls)}
+}
+
+// Global variables should be updated after a test is finished
+func cleanTestGlobals() {
+	kialiCache = nil
 }

--- a/kubernetes/cache/istio_test.go
+++ b/kubernetes/cache/istio_test.go
@@ -13,15 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 )
 
-type fakeInformer struct {
-	cache.SharedIndexInformer
-	Store *cache.FakeCustomStore
-}
-
-func (f *fakeInformer) GetStore() cache.Store {
-	return f.Store
-}
-
 func TestGetSidecar(t *testing.T) {
 	sidecar := &networking_v1alpha3.Sidecar{}
 	sidecar.Name = "moto-sidecar"
@@ -121,8 +112,4 @@ func createIstioIndexInformer(getter cache.Getter, resourceType string, refreshD
 		refreshDuration,
 		cache.Indexers{},
 	)
-}
-
-func TestInformer(t *testing.T) {
-
 }

--- a/kubernetes/cache/tls_test_helper.go
+++ b/kubernetes/cache/tls_test_helper.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type fakeInformer struct {
+	cache.SharedIndexInformer
+	Store *cache.FakeCustomStore
+}
+
+func (f *fakeInformer) GetStore() cache.Store {
+	return f.Store
+}
+
+// Fake KialiCache used for TLS Scenarios
+// It populates the Namespaces, Informers and Registry information needed
+func FakeTlsKialiCache(token string, namespaces []string, pa []security_v1beta1.PeerAuthentication, dr []networking_v1alpha3.DestinationRule) KialiCache {
+	kialiCacheImpl := kialiCacheImpl{
+		tokenNamespaces: make(map[string]namespaceCache),
+		// ~ long duration for unit testing
+		refreshDuration: time.Hour,
+	}
+	// Populate namespaces and PeerAuthentication informers
+	nss := []models.Namespace{}
+	for _, ns := range namespaces {
+		nss = append(nss, models.Namespace{Name: ns})
+	}
+	kialiCacheImpl.SetNamespaces(token, nss)
+
+	// Populate all DestinationRules using the Registry
+	registryStatus := kubernetes.RegistryStatus{
+		Configuration: &kubernetes.RegistryConfiguration{
+			DestinationRules:    []networking_v1alpha3.DestinationRule{},
+			PeerAuthentications: []security_v1beta1.PeerAuthentication{},
+		},
+	}
+	registryStatus.Configuration.DestinationRules = append(registryStatus.Configuration.DestinationRules, dr...)
+	registryStatus.Configuration.PeerAuthentications = append(registryStatus.Configuration.PeerAuthentications, pa...)
+	kialiCacheImpl.SetRegistryStatus(&registryStatus)
+
+	return &kialiCacheImpl
+}

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -71,6 +71,22 @@ func FilterDestinationRulesByHostname(allDr []networking_v1alpha3.DestinationRul
 	return destinationRules
 }
 
+func FilterDestinationRulesByNamespaces(namespaces []string, allDr []networking_v1alpha3.DestinationRule) []networking_v1alpha3.DestinationRule {
+	destinationRules := []networking_v1alpha3.DestinationRule{}
+	for _, dr := range allDr {
+		found := false
+		for _, ns := range namespaces {
+			if dr.Namespace == ns {
+				found = true
+			}
+		}
+		if found {
+			destinationRules = append(destinationRules, dr)
+		}
+	}
+	return destinationRules
+}
+
 func FilterDestinationRulesByService(allDr []networking_v1alpha3.DestinationRule, namespace string, serviceName string) []networking_v1alpha3.DestinationRule {
 	destinationRules := []networking_v1alpha3.DestinationRule{}
 	for _, destinationRule := range allDr {
@@ -155,6 +171,16 @@ func FilterPodsByController(controllerName string, controllerType string, allPod
 		}
 	}
 	return pods
+}
+
+func FilterPeerAuthenticationByNamespace(namespace string, peerauthentications []security_v1beta1.PeerAuthentication) []security_v1beta1.PeerAuthentication {
+	filtered := []security_v1beta1.PeerAuthentication{}
+	for _, pa := range peerauthentications {
+		if pa.Namespace == namespace {
+			filtered = append(filtered, pa)
+		}
+	}
+	return filtered
 }
 
 func FilterPeerAuthenticationsBySelector(workloadSelector string, peerauthentications []security_v1beta1.PeerAuthentication) []security_v1beta1.PeerAuthentication {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4224

Improve the getAllDestinationRules to use the AllNamespaces flag that queries directly the Istio Registry to collect the DestinationRules needed for this cross-namespace validation.

It's still in a draft mode, tests need to be updated and registry cache can be indexed per type to reduce the O(N) -> O(1) using memory.

Also related with https://github.com/kiali/kiali/discussions/4509 discussion