### PR TITLE
Remove unnecessary graph boxes

### DIFF
--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -541,13 +541,15 @@ func boxByNamespace(nodes *[]*NodeWrapper) {
 	box := make(map[string][]*NodeData)
 
 	for _, nw := range *nodes {
-		if nw.Data.Parent == "" {
+		// never box unknown
+		if nw.Data.Parent == "" && nw.Data.Namespace != graph.Unknown {
 			k := fmt.Sprintf("box_%s_%s", nw.Data.Cluster, nw.Data.Namespace)
 			box[k] = append(box[k], nw.Data)
 		}
 	}
-
-	generateBoxCompoundNodes(box, nodes, graph.BoxByNamespace)
+	if len(box) > 1 {
+		generateBoxCompoundNodes(box, nodes, graph.BoxByNamespace)
+	}
 }
 
 // boxByCluster adds compound nodes to box nodes in the same cluster
@@ -555,18 +557,20 @@ func boxByCluster(nodes *[]*NodeWrapper) {
 	box := make(map[string][]*NodeData)
 
 	for _, nw := range *nodes {
-		if nw.Data.Parent == "" {
+		// never box unknown
+		if nw.Data.Parent == "" && nw.Data.Cluster != graph.Unknown {
 			k := fmt.Sprintf("box_%s", nw.Data.Cluster)
 			box[k] = append(box[k], nw.Data)
 		}
 	}
-
-	generateBoxCompoundNodes(box, nodes, graph.BoxByCluster)
+	if len(box) > 1 {
+		generateBoxCompoundNodes(box, nodes, graph.BoxByCluster)
+	}
 }
 
 func generateBoxCompoundNodes(box map[string][]*NodeData, nodes *[]*NodeWrapper, boxBy string) {
 	for k, members := range box {
-		if boxBy != graph.BoxByApp || len(members) > 1 {
+		if len(members) > 1 {
 			// create the compound (parent) node for the member nodes
 			nodeID := nodeHash(k)
 			namespace := ""


### PR DESCRIPTION
Closes https://github.com/kiali/kiali/issues/4547

Omit boxes when there is only one member, or only one discriminating value in the graph (i.e. one namespace or one cluster).
Also, never box `unknown`.

Because boxing is now a bit lighter, and it is common to enable boxing, the UI PR makes an additional change and enables cluster and namespace boxing by default.

**UI PR:** https://github.com/kiali/kiali-ui/pull/2277
