### PR TITLE
Fix VS badging

### DIFF
--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -165,7 +165,7 @@ func (n NoDestinationChecker) getVirtualServices(virtualServiceHost string, virt
 						drHost := kubernetes.GetHost(host, n.DestinationRule.Namespace, n.DestinationRule.ClusterName, n.Namespaces.GetNames())
 						vsHost := kubernetes.GetHost(virtualServiceHost, virtualService.Namespace, virtualService.ClusterName, n.Namespaces.GetNames())
 						// TODO Host could be in another namespace (FQDN)
-						if kubernetes.FilterByHost(vsHost.String(), drHost.Service, drHost.Namespace) && subset == virtualServiceSubset {
+						if kubernetes.FilterByHost(vsHost.String(), vsHost.Namespace, drHost.Service, drHost.Namespace) && subset == virtualServiceSubset {
 							vss = append(vss, virtualService)
 						}
 					}
@@ -188,7 +188,7 @@ func (n NoDestinationChecker) getVirtualServices(virtualServiceHost string, virt
 						drHost := kubernetes.GetHost(host, n.DestinationRule.Namespace, n.DestinationRule.ClusterName, n.Namespaces.GetNames())
 						vsHost := kubernetes.GetHost(virtualServiceHost, virtualService.Namespace, virtualService.ClusterName, n.Namespaces.GetNames())
 						// TODO Host could be in another namespace (FQDN)
-						if kubernetes.FilterByHost(vsHost.String(), drHost.Service, drHost.Namespace) && subset == virtualServiceSubset {
+						if kubernetes.FilterByHost(vsHost.String(), vsHost.Namespace, drHost.Service, drHost.Namespace) && subset == virtualServiceSubset {
 							vss = append(vss, virtualService)
 						}
 					}
@@ -211,7 +211,7 @@ func (n NoDestinationChecker) getVirtualServices(virtualServiceHost string, virt
 						drHost := kubernetes.GetHost(host, n.DestinationRule.Namespace, n.DestinationRule.ClusterName, n.Namespaces.GetNames())
 						vsHost := kubernetes.GetHost(virtualServiceHost, virtualService.Namespace, virtualService.ClusterName, n.Namespaces.GetNames())
 						// TODO Host could be in another namespace (FQDN)
-						if kubernetes.FilterByHost(vsHost.String(), drHost.Service, drHost.Namespace) && subset == virtualServiceSubset {
+						if kubernetes.FilterByHost(vsHost.String(), vsHost.Namespace, drHost.Service, drHost.Namespace) && subset == virtualServiceSubset {
 							vss = append(vss, virtualService)
 						}
 					}

--- a/business/checkers/virtualservices/no_gateway_checker.go
+++ b/business/checkers/virtualservices/no_gateway_checker.go
@@ -62,7 +62,8 @@ GatewaySearch:
 
 		hostname := kubernetes.ParseGatewayAsHost(gate, namespace, clusterName)
 		for gw := range s.GatewayNames {
-			if found := kubernetes.FilterByHost(hostname.String(), hostname.Namespace, gw, namespace); found {
+			gwHostname := kubernetes.ParseHost(gw, namespace, clusterName)
+			if found := kubernetes.FilterByHost(hostname.String(), hostname.Namespace, gw, gwHostname.Namespace); found {
 				continue GatewaySearch
 			}
 		}

--- a/business/checkers/virtualservices/no_gateway_checker.go
+++ b/business/checkers/virtualservices/no_gateway_checker.go
@@ -60,9 +60,9 @@ GatewaySearch:
 		// Gateways should be using <namespace>/<gateway>
 		checkNomenclature(gate, index, validations)
 
-		hostname := kubernetes.ParseGatewayAsHost(gate, namespace, clusterName).String()
+		hostname := kubernetes.ParseGatewayAsHost(gate, namespace, clusterName)
 		for gw := range s.GatewayNames {
-			if found := kubernetes.FilterByHost(hostname, gw, namespace); found {
+			if found := kubernetes.FilterByHost(hostname.String(), hostname.Namespace, gw, namespace); found {
 				continue GatewaySearch
 			}
 		}

--- a/business/checkers/virtualservices/no_host_checker.go
+++ b/business/checkers/virtualservices/no_host_checker.go
@@ -94,7 +94,7 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 func (n NoHostChecker) checkDestination(sHost string, itemNamespace string) bool {
 	// We need to check for namespace equivalent so that two services from different namespaces do not collide
 	for _, service := range n.ServiceList.Services {
-		if kubernetes.FilterByHost(sHost, service.Name, service.Namespace) {
+		if kubernetes.FilterByHost(sHost, itemNamespace, service.Name, service.Namespace) {
 			return true
 		}
 	}

--- a/business/checkers/virtualservices/subset_presence_checker.go
+++ b/business/checkers/virtualservices/subset_presence_checker.go
@@ -120,7 +120,7 @@ func (checker SubsetPresenceChecker) getDestinationRules(virtualServiceHost stri
 		vsHost := kubernetes.GetHost(virtualServiceHost, checker.Namespace, checker.VirtualService.ClusterName, checker.Namespaces)
 
 		// TODO Host could be in another namespace (FQDN)
-		if kubernetes.FilterByHost(vsHost.String(), drHost.Service, drHost.Namespace) {
+		if kubernetes.FilterByHost(vsHost.String(), vsHost.Namespace, drHost.Service, drHost.Namespace) {
 			drs = append(drs, destinationRule)
 		}
 	}

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -393,9 +393,9 @@ func TestIsValidHost(t *testing.T) {
 	vs = data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v2", 50), vs)
 	vs = data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v3", 50), vs)
 
-	assert.False(t, models.IsVSValidHost(vs, "", ""))
-	assert.False(t, models.IsVSValidHost(vs, "", "ratings"))
-	assert.True(t, models.IsVSValidHost(vs, "", "reviews"))
+	assert.False(t, models.IsVSValidHost(vs, "test", ""))
+	assert.False(t, models.IsVSValidHost(vs, "test", "ratings"))
+	assert.True(t, models.IsVSValidHost(vs, "test", "reviews"))
 }
 
 func TestHasCircuitBreaker(t *testing.T) {
@@ -418,13 +418,13 @@ func TestHasCircuitBreaker(t *testing.T) {
 	dRule1 = data.AddSubsetToDestinationRule(data.CreateSubset("v1", "v1"), dRule1)
 	dRule1 = data.AddSubsetToDestinationRule(data.CreateSubset("v2", "v2"), dRule1)
 
-	assert.False(t, models.HasDRCircuitBreaker(dRule1, "", "", ""))
-	assert.True(t, models.HasDRCircuitBreaker(dRule1, "", "reviews", ""))
-	assert.False(t, models.HasDRCircuitBreaker(dRule1, "", "reviews-bad", ""))
-	assert.True(t, models.HasDRCircuitBreaker(dRule1, "", "reviews", "v1"))
-	assert.True(t, models.HasDRCircuitBreaker(dRule1, "", "reviews", "v2"))
-	assert.True(t, models.HasDRCircuitBreaker(dRule1, "", "reviews", "v3"))
-	assert.False(t, models.HasDRCircuitBreaker(dRule1, "", "reviews-bad", "v2"))
+	assert.False(t, models.HasDRCircuitBreaker(dRule1, "test", "", ""))
+	assert.True(t, models.HasDRCircuitBreaker(dRule1, "test", "reviews", ""))
+	assert.False(t, models.HasDRCircuitBreaker(dRule1, "test", "reviews-bad", ""))
+	assert.True(t, models.HasDRCircuitBreaker(dRule1, "test", "reviews", "v1"))
+	assert.True(t, models.HasDRCircuitBreaker(dRule1, "test", "reviews", "v2"))
+	assert.True(t, models.HasDRCircuitBreaker(dRule1, "test", "reviews", "v3"))
+	assert.False(t, models.HasDRCircuitBreaker(dRule1, "test", "reviews-bad", "v2"))
 
 	dRule2 := data.CreateEmptyDestinationRule("test", "reviews", "reviews")
 	dRule2 = data.AddSubsetToDestinationRule(data.CreateSubset("v1", "v1"), dRule2)
@@ -442,10 +442,10 @@ func TestHasCircuitBreaker(t *testing.T) {
 		},
 	}
 
-	assert.True(t, models.HasDRCircuitBreaker(dRule2, "", "reviews", ""))
-	assert.False(t, models.HasDRCircuitBreaker(dRule2, "", "reviews", "v1"))
-	assert.True(t, models.HasDRCircuitBreaker(dRule2, "", "reviews", "v2"))
-	assert.False(t, models.HasDRCircuitBreaker(dRule2, "", "reviews-bad", "v2"))
+	assert.True(t, models.HasDRCircuitBreaker(dRule2, "test", "reviews", ""))
+	assert.False(t, models.HasDRCircuitBreaker(dRule2, "test", "reviews", "v1"))
+	assert.True(t, models.HasDRCircuitBreaker(dRule2, "test", "reviews", "v2"))
+	assert.False(t, models.HasDRCircuitBreaker(dRule2, "test", "reviews-bad", "v2"))
 }
 
 func TestDeleteIstioConfigDetails(t *testing.T) {

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -32,6 +32,14 @@ func FilterAuthorizationPoliciesBySelector(workloadSelector string, authorizatio
 	return filtered
 }
 
+// FilterByHost returns true if a (host, hostNamespace) combination is making
+// reference to a (serviceName, svcNamespace) combination.
+// Presumably, the host is part of the definition of some Istio Resource. Thus, it
+// can take the form of "host", "host.namespace" or "host.namespace.svc", or the
+// FQDN "host.namespace.svc.<identity_domain_suffix>". For the cases where
+// the host argument takes the simplistic form of only "host", you need to provide
+// the hostNamespace argument, which should be set to the namespace of the involved Istio Resource.
+// For the other cases, it is safe to omit it. The other arguments are always mandatory.
 func FilterByHost(host, hostNamespace, serviceName, svcNamespace string) bool {
 	// Check single name
 	if host == serviceName && hostNamespace == svcNamespace {

--- a/kubernetes/istio_test.go
+++ b/kubernetes/istio_test.go
@@ -15,33 +15,33 @@ func TestFilterByHost(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	assert.True(t, FilterByHost("reviews", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews-bad", "reviews", "bookinfo"))
+	assert.True(t, FilterByHost("reviews", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews-bad", "bookinfo", "reviews", "bookinfo"))
 
-	assert.True(t, FilterByHost("reviews.bookinfo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews-bad.bookinfo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews.bookinfo-bad", "reviews", "bookinfo"))
+	assert.True(t, FilterByHost("reviews.bookinfo", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews-bad.bookinfo", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews.bookinfo-bad", "bookinfo-bad", "reviews", "bookinfo"))
 
-	assert.True(t, FilterByHost("reviews.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews-bad.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews.bookinfo-bad.svc.cluster.local", "reviews", "bookinfo"))
+	assert.True(t, FilterByHost("reviews.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews-bad.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews.bookinfo-bad.svc.cluster.local", "bookinfo-bad", "reviews", "bookinfo"))
 }
 
 func TestFQDNHostname(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	assert.True(t, FilterByHost("reviews.bookinfo.svc", "reviews", "bookinfo"))
-	assert.True(t, FilterByHost("reviews.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.True(t, FilterByHost("reviews.bookinfo.svc", "bookinfo", "reviews", "bookinfo"))
+	assert.True(t, FilterByHost("reviews.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
 
-	assert.False(t, FilterByHost("reviews.foo.svc", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews.foo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews.foo.svc", "foo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews.foo.svc.cluster.local", "foo", "reviews", "bookinfo"))
 
-	assert.False(t, FilterByHost("ratings.bookinfo.svc", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("ratings.bookinfo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("ratings.bookinfo.svc", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("ratings.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
 
-	assert.False(t, FilterByHost("ratings.foo.svc", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("ratings.foo.svc.cluster.local", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("ratings.foo.svc", "foo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("ratings.foo.svc.cluster.local", "foo", "reviews", "bookinfo"))
 }
 
 func TestExactProtocolNameMatcher(t *testing.T) {

--- a/models/destination_rule.go
+++ b/models/destination_rule.go
@@ -9,7 +9,7 @@ import (
 )
 
 func HasDRCircuitBreaker(dr *networking_v1alpha3.DestinationRule, namespace, serviceName, version string) bool {
-	if kubernetes.FilterByHost(dr.Spec.Host, serviceName, namespace) {
+	if kubernetes.FilterByHost(dr.Spec.Host, dr.Namespace, serviceName, namespace) {
 		if isCB(dr.Spec.TrafficPolicy) {
 			return true
 		}


### PR DESCRIPTION
Badging of VSs was assuming that Istio VirtualServices resources and graph service nodes belong to the same namespace. This is not necessarily true. This fixes VS badging to take into account that a VS can route to a Service in another namespace.

Fixes #4541
