### PR TITLE
Added support of Exported Registry Services in Sidecar's host egress listener checker.

### DIFF
--- a/business/checkers/sidecars/egress_listener_checker.go
+++ b/business/checkers/sidecars/egress_listener_checker.go
@@ -11,9 +11,10 @@ import (
 )
 
 type EgressHostChecker struct {
-	Sidecar        networking_v1alpha3.Sidecar
-	ServiceEntries map[string][]string
-	ServiceList    models.ServiceList
+	Sidecar          networking_v1alpha3.Sidecar
+	ServiceEntries   map[string][]string
+	ServiceList      models.ServiceList
+	RegistryServices []*kubernetes.RegistryService
 }
 
 type HostWithIndex struct {
@@ -94,7 +95,10 @@ func (elc EgressHostChecker) HasMatchingService(host kubernetes.Host, itemNamesp
 	if elc.ServiceList.HasMatchingServices(host.Service) {
 		return true
 	}
-	return kubernetes.HasMatchingServiceEntries(host.String(), elc.ServiceEntries)
+	if kubernetes.HasMatchingServiceEntries(host.String(), elc.ServiceEntries) {
+		return true
+	}
+	return kubernetes.HasMatchingRegistryService(itemNamespace, host.String(), elc.RegistryServices)
 }
 
 func getHostComponents(host string) (string, string, bool) {

--- a/business/checkers/sidecars/egress_listener_checker.go
+++ b/business/checkers/sidecars/egress_listener_checker.go
@@ -92,7 +92,7 @@ func (elc EgressHostChecker) HasMatchingService(host kubernetes.Host, itemNamesp
 	if host.IsWildcard() && host.Namespace == itemNamespace {
 		return true
 	}
-	if elc.ServiceList.HasMatchingServices(host.Service) {
+	if host.Namespace == itemNamespace && elc.ServiceList.HasMatchingServices(host.Service) {
 		return true
 	}
 	if kubernetes.HasMatchingServiceEntries(host.String(), elc.ServiceEntries) {

--- a/business/checkers/sidecars/egress_listener_checker_test.go
+++ b/business/checkers/sidecars/egress_listener_checker_test.go
@@ -37,6 +37,24 @@ func TestEgressHostFormatCorrect(t *testing.T) {
 	assert.True(valid)
 }
 
+func TestEgressHostNotFoundService(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := EgressHostChecker{
+		ServiceList:    fakeServiceList([]string{"reviews"}),
+		ServiceEntries: kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{data.CreateExternalServiceEntry()}),
+		Sidecar: *sidecarWithHosts([]string{
+			"bookinfo2/reviews.bookinfo2.svc.cluster.local",
+		}),
+	}.Check()
+
+	assert.NotEmpty(vals)
+	assert.True(valid)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.Equal("spec/egress[0]/hosts[0]", vals[0].Path)
+	assert.NoError(validations.ConfirmIstioCheckMessage("sidecar.egress.servicenotfound", vals[0]))
+}
+
 func TestEgressExportedInternalServiceEntryPresent(t *testing.T) {
 	assert := assert.New(t)
 

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -18,6 +18,7 @@ type SidecarChecker struct {
 	ServiceList            models.ServiceList
 	Namespaces             models.Namespaces
 	WorkloadList           models.WorkloadList
+	RegistryServices       []*kubernetes.RegistryService
 }
 
 func (s SidecarChecker) Check() models.IstioValidations {
@@ -64,7 +65,7 @@ func (s SidecarChecker) runChecks(sidecar networking_v1alpha3.Sidecar) models.Is
 
 	enabledCheckers := []Checker{
 		common.WorkloadSelectorNoWorkloadFoundChecker(SidecarCheckerType, selectorLabels, s.WorkloadList),
-		sidecars.EgressHostChecker{Sidecar: sidecar, ServiceList: s.ServiceList, ServiceEntries: serviceHosts},
+		sidecars.EgressHostChecker{Sidecar: sidecar, ServiceList: s.ServiceList, ServiceEntries: serviceHosts, RegistryServices: s.RegistryServices},
 		sidecars.GlobalChecker{Sidecar: sidecar},
 	}
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -108,7 +108,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioC
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices},
-		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloads, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries},
+		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloads, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadList: workloads},
 	}
 }
@@ -173,7 +173,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		objectCheckers = []ObjectChecker{serviceEntryChecker}
 	case kubernetes.Sidecars:
 		sidecarsChecker := checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces,
-			WorkloadList: workloads, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries}
+			WorkloadList: workloads, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{sidecarsChecker}
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4546

Sidecar's egress listener host now supports checking services from current namespaces and exported services from Registry.

So when service from different namespace is exported to all namespaces. then host "productpage.bookinfo2" is recognized.
![Screenshot from 2021-12-07 09-13-36](https://user-images.githubusercontent.com/604313/144991955-b633ec0e-dd2d-40f1-becb-f2ab33859711.png)
![Screenshot from 2021-12-07 09-13-49](https://user-images.githubusercontent.com/604313/144991961-b7d4c274-32ad-4548-a69f-ff7ad733e83d.png)

But try to export the 'productpage.bookinfo2' Service into namespaces other than 'bookinfo', then the 'bookinfo' namespce's Sidecar's host will fail to recognize the service from different namespace.
![Screenshot from 2021-12-07 09-14-44](https://user-images.githubusercontent.com/604313/144992382-ed9eb49c-2902-47e1-b2f0-d397ae8c7877.png)
![Screenshot from 2021-12-07 09-18-35](https://user-images.githubusercontent.com/604313/144992385-575bba88-31a4-4c83-8bd7-dbbd1226ee96.png)
