### PR TITLE
Consider Registry Services in Workload MTLS Status check alongside with local namespace Services.

### DIFF
--- a/business/checkers/authorization/mtls_enabled_checker.go
+++ b/business/checkers/authorization/mtls_enabled_checker.go
@@ -22,6 +22,7 @@ type MtlsEnabledChecker struct {
 	MtlsDetails           kubernetes.MTLSDetails
 	ServiceList           models.ServiceList
 	ServiceEntries        []networking_v1alpha3.ServiceEntry
+	RegistryServices      []*kubernetes.RegistryService
 }
 
 // Checks if mTLS is enabled, mark all Authz Policies with error
@@ -135,6 +136,7 @@ func (c MtlsEnabledChecker) IsMtlsEnabledFor(labels labels.Set) bool {
 		Namespace:           c.Namespace,
 		PeerAuthentications: c.MtlsDetails.PeerAuthentications,
 		ServiceList:         c.ServiceList,
+		RegistryServices:    c.RegistryServices,
 	}.WorkloadMtlsStatus()
 
 	if workloadmTlsStatus == mtls.MTLSEnabled {

--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -39,6 +39,8 @@ func (a AuthorizationPolicyChecker) Check() models.IstioValidations {
 		Namespace:             a.Namespace,
 		AuthorizationPolicies: a.AuthorizationPolicies,
 		MtlsDetails:           a.MtlsDetails,
+		ServiceList:           a.ServiceList,
+		RegistryServices:      a.RegistryServices,
 	}.Check())
 
 	return validations

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -79,6 +79,7 @@ func TestFilterExportToNamespacesVS(t *testing.T) {
 	v := mockEmptyValidationService()
 	filteredVSs := v.filterVSExportToNamespaces("bookinfo", currentIstioObjects)
 	var expectedVS []networking_v1alpha3.VirtualService
+	expectedVS = append(expectedVS, vs1tothis)
 	expectedVS = append(expectedVS, vs2to1)
 	expectedVS = append(expectedVS, vs3toall)
 	filteredKeys := []string{}

--- a/business/tls.go
+++ b/business/tls.go
@@ -103,6 +103,7 @@ func (in *TLSService) getAllDestinationRules(namespaces []string) ([]networking_
 		for _, ns := range namespaces {
 			if dr.Namespace == ns {
 				found = true
+				break
 			}
 		}
 		if found {

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -276,6 +276,7 @@ func FilterRegistryServicesByServices(registryServices []*RegistryService, servi
 }
 
 func FilterRegistryServicesBySelector(selector labels.Selector, namespace string, registryServices []*RegistryService) []*RegistryService {
+	// From given Registry Services, this method filters those services which are exported to given namespace and have labels matching the given selector
 	filtered := []*RegistryService{}
 	for _, rSvc := range registryServices {
 		// here is a hack with providing own hostname

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -275,6 +275,16 @@ func FilterRegistryServicesByServices(registryServices []*RegistryService, servi
 	return filtered
 }
 
+func FilterRegistryServicesBySelector(selector labels.Selector, registryServices []*RegistryService) []*RegistryService {
+	filtered := []*RegistryService{}
+	for _, rSvc := range registryServices {
+		if selector.Matches(labels.Set(rSvc.IstioService.Attributes.Labels)) {
+			filtered = append(filtered, rSvc)
+		}
+	}
+	return filtered
+}
+
 func FilterByRegistryService(namespace string, hostname string, registryService *RegistryService) bool {
 	// Basic filter using Hostname, also consider exported Namespaces of Service
 	// but for a first iteration if it's found in the registry it will be considered "valid" to reduce the number of false validation errors

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -275,10 +275,11 @@ func FilterRegistryServicesByServices(registryServices []*RegistryService, servi
 	return filtered
 }
 
-func FilterRegistryServicesBySelector(selector labels.Selector, registryServices []*RegistryService) []*RegistryService {
+func FilterRegistryServicesBySelector(selector labels.Selector, namespace string, registryServices []*RegistryService) []*RegistryService {
 	filtered := []*RegistryService{}
 	for _, rSvc := range registryServices {
-		if selector.Matches(labels.Set(rSvc.IstioService.Attributes.Labels)) {
+		// here is a hack with providing own hostname
+		if FilterByRegistryService(namespace, rSvc.Hostname, rSvc) && selector.Matches(labels.Set(rSvc.IstioService.Attributes.Labels)) {
 			filtered = append(filtered, rSvc)
 		}
 	}

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -86,6 +86,7 @@ func FilterDestinationRulesByNamespaces(namespaces []string, allDr []networking_
 		for _, ns := range namespaces {
 			if dr.Namespace == ns {
 				found = true
+				break
 			}
 		}
 		if found {


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4546

Depends on https://github.com/kiali/kiali/pull/4536

What is changed in AuthorizationPolicy validations:
It now supports exported DestinationRules belonging to Services from different namespaces alongside with local namespace's Services and DestinationRules.

Originally mTLS validation functionality was added in PR https://github.com/kiali/kiali/pull/2938