### PR TITLE
Fix Service list bug on multi-cluster scenarios

### DIFF
--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -21,6 +21,7 @@ import (
 func setupAppService(k8s *kubetest.K8SClientMock) AppService {
 	prom := new(prometheustest.PromClientMock)
 	layer := NewWithBackends(k8s, prom, nil)
+	setupGlobalMeshConfig()
 	return AppService{k8s: k8s, prom: prom, businessLayer: layer}
 }
 

--- a/business/health_test.go
+++ b/business/health_test.go
@@ -36,6 +36,7 @@ func TestGetServiceHealth(t *testing.T) {
 	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Service{}, nil)
 
+	setupGlobalMeshConfig()
 	hs := HealthService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
 
 	health, _ := hs.GetServiceHealth("ns", "httpbin", "1m", queryTime)

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -195,6 +195,8 @@ func mockCombinedValidationService(istioConfigList *models.IstioConfigList, serv
 
 	mockWorkLoadService(k8s)
 
+	setupGlobalMeshConfig()
+
 	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
 }
 

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -178,6 +178,12 @@ var kialiControlPlaneClusterCached bool
 // kialiControlPlaneCluster holds the cached home cluster (it may be nil when mesh is not configured)
 var kialiControlPlaneCluster *Cluster
 
+// Global helper used for test mockup
+func SetKialiControlPlaneCluster(cluster *Cluster) {
+	kialiControlPlaneClusterCached = true
+	kialiControlPlaneCluster = cluster
+}
+
 // ResolveKialiControlPlaneCluster tries to resolve the metadata about the cluster where
 // Kiali is installed. This assumes that the mesh Control Plane is installed in the
 // same cluster as Kiali.

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -18,6 +18,13 @@ import (
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
+// Setup Mesh cache to avoid duplicate mesh_test.go logic into other business/*_test.go
+func setupGlobalMeshConfig() {
+	SetKialiControlPlaneCluster(&Cluster{
+		Name: DefaultClusterID,
+	})
+}
+
 func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 	check := assert.New(t)
 

--- a/graph/telemetry/istio/appender/health_config_test.go
+++ b/graph/telemetry/istio/appender/health_config_test.go
@@ -145,7 +145,9 @@ func setupHealthConfig(services []core_v1.Service, deployments []apps_v1.Deploym
 	k8s.On("GetDaemonSets", mock.AnythingOfType("string")).Return([]apps_v1.DaemonSet{}, nil)
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return(services, nil)
 	config.Set(config.NewConfig())
-
+	business.SetKialiControlPlaneCluster(&business.Cluster{
+		Name: business.DefaultClusterID,
+	})
 	businessLayer := business.NewWithBackends(k8s, nil, nil)
 	return businessLayer
 }

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -186,6 +186,7 @@ func setupAppListEndpoint() (*httptest.Server, *kubetest.K8SClientMock, *prometh
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	business.SetWithBackends(mockClientFactory, prom)
+	business.SetKialiControlPlaneCluster(&business.Cluster{Name: business.DefaultClusterID})
 
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/apps", http.HandlerFunc(

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -62,6 +62,7 @@ func setupNamespaceHealthEndpoint(t *testing.T) (*httptest.Server, *kubetest.K8S
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	business.SetWithBackends(mockClientFactory, prom)
+	business.SetKialiControlPlaneCluster(&business.Cluster{Name: business.DefaultClusterID})
 
 	setupMockData(k8s)
 

--- a/tests/data/registry/istio-east-registryz.json
+++ b/tests/data/registry/istio-east-registryz.json
@@ -1,0 +1,81 @@
+[
+  {
+    "Attributes": {
+      "ServiceRegistry": "Kubernetes",
+      "Name": "zipkin",
+      "Namespace": "istio-system",
+      "Labels": {
+        "name": "zipkin"
+      },
+      "ExportTo": null,
+      "LabelSelectors": {
+        "app": "jaeger"
+      },
+      "ClusterExternalAddresses": {
+        "Addresses": null
+      },
+      "ClusterExternalPorts": null
+    },
+    "ports": [
+      {
+        "name": "http-query",
+        "port": 9411,
+        "protocol": "HTTP"
+      }
+    ],
+    "creationTime": "2021-12-13T09:37:04Z",
+    "hostname": "zipkin.istio-system.svc.cluster.local",
+    "clusterVIPs": {
+      "Addresses": {
+        "istio-east": [
+          "10.105.195.30"
+        ],
+        "istio-west": [
+          "10.96.208.234"
+        ]
+      }
+    },
+    "defaultAddress": "10.105.195.30",
+    "Resolution": 0,
+    "MeshExternal": false,
+    "ResourceVersion": "1068"
+  },
+  {
+    "Attributes": {
+      "ServiceRegistry": "Kubernetes",
+      "Name": "bookstore",
+      "Namespace": "electronic-shop",
+      "Labels": {
+        "app": "bookstore"
+      },
+      "ExportTo": null,
+      "LabelSelectors": {
+        "app": "bookstore"
+      },
+      "ClusterExternalAddresses": {
+        "Addresses": null
+      },
+      "ClusterExternalPorts": null
+    },
+    "ports": [
+      {
+        "name": "http",
+        "port": 8888,
+        "protocol": "HTTP"
+      }
+    ],
+    "creationTime": "2021-12-13T11:43:57Z",
+    "hostname": "bookstore.electronic-shop.svc.cluster.local",
+    "clusterVIPs": {
+      "Addresses": {
+        "istio-west": [
+          "10.100.251.249"
+        ]
+      }
+    },
+    "defaultAddress": "10.100.251.249",
+    "Resolution": 0,
+    "MeshExternal": false,
+    "ResourceVersion": "11880"
+  }
+]


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4570

This PRs address two potential problems:
- During Istio Registry call, the assignment is protected but not the call to registry, so due https://github.com/istio/istio/issues/36448 now the refresh operation should be protected.
- In multi-cluster scenarios, the Istio Registry replicates the Kubernetes services, so, Istio registry services should be filtered to only used based on the istiod cluster he is connected to (probably this needs to be revisited when a Kiali instance may connect multiple control planes).

How to test:
- This issue requires a multi-cluster setup in https://github.com/kiali/kiali/discussions/3699 there are some good helpers to define one in minikube.
- Create a namespaces in both istio-east and istio-west, populates only services in one namespace.
- Before this fix, one of the Kiali UI would fail, as it's not filtering correctly the services, with the fix check that there are no errors when navigating to the Service list page.