### PR TITLE
Cache compiled regexes in multi match checker

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -151,24 +151,24 @@ func (m MultiMatchChecker) findMatch(host Host, selector string) (bool, []Host) 
 						continue
 					}
 
-				    // lazily compile hostname Regex
-				    if host.hostnameRegexp == nil {
-				    	host.hostnameRegexp = regexpFromHostname(host.Hostname)
-				    }
-				    if h.hostnameRegexp == nil {
-				    	h.hostnameRegexp = regexpFromHostname(h.Hostname)
-				    }
+					// DNS is case-insensitive
+					current := strings.ToLower(host.Hostname)
+					previous := strings.ToLower(h.Hostname)
 
-				    // Either one could include wildcards, so we need to check both ways and fix "*" -> ".*" for regexp engine
-				    current := strings.ToLower(strings.Replace(host.Hostname, "*", ".*", -1))
-				    previous := strings.ToLower(strings.Replace(h.Hostname, "*", ".*", -1))
+					// lazily compile hostname Regex
+					if host.hostnameRegexp == nil {
+						host.hostnameRegexp = regexpFromHostname(current)
+					}
+					if h.hostnameRegexp == nil {
+						h.hostnameRegexp = regexpFromHostname(previous)
+					}
 
-				    if host.hostnameRegexp.MatchString(previous) ||
-				    	h.hostnameRegexp.MatchString(current) {
-				    	duplicates = append(duplicates, host)
-				    	duplicates = append(duplicates, h)
-				    	continue
-				    }
+					if host.hostnameRegexp.MatchString(previous) ||
+						h.hostnameRegexp.MatchString(current) {
+						duplicates = append(duplicates, host)
+						duplicates = append(duplicates, h)
+						continue
+					}
 				}
 			}
 		}


### PR DESCRIPTION
** Describe the change **

When checking for duplicate hosts, `regexp.Compile()` is currently called twice per comparison. This is a costly operation, which is fine for clusters with few gateway hosts. In our setup we heavily utilize the namespacing of hosts, though, so we have many repeating host entries, causing many regexp Compilations on the same hosts.

This PR implements a caching mechanism for compiled `regexp.Regexp` that lives as long as the Validation is running. The change heavily reduces CPU load in our setup, and should have minimal impact on memory.

In this change I also extracted the String manipulations for converting hosts to regexes into their own function and found, that the replacement of `*` -> `.*` was never actually used in the regex and had no effect, so I removed it altogether.

** Issue reference **

https://github.com/kiali/kiali/issues/4592

** Backwards incompatible? **

No.

** Documentation **

I don't think its necessary.
