### PR TITLE
Changed the loading App to first load Workloads then Services.

### DIFF
--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -263,5 +263,5 @@ func TestAppDetailsEndpoint(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode, string(actual))
 	k8s.AssertNumberOfCalls(t, "GetDeployments", 1)
 	k8s.AssertNumberOfCalls(t, "GetPods", 1)
-	k8s.AssertNumberOfCalls(t, "GetServices", 1)
+	k8s.AssertNumberOfCalls(t, "GetServices", 2)
 }

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -49,7 +49,7 @@ func TestNamespaceAppHealth(t *testing.T) {
 
 	assert.NotEmpty(t, actual)
 	assert.Equal(t, 200, resp.StatusCode, string(actual))
-	k8s.AssertNumberOfCalls(t, "GetServices", 1)
+	k8s.AssertNumberOfCalls(t, "GetServices", 3)
 	k8s.AssertNumberOfCalls(t, "GetPods", 1)
 	k8s.AssertNumberOfCalls(t, "GetDeployments", 1)
 	k8s.AssertNumberOfCalls(t, "GetReplicaSets", 1)


### PR DESCRIPTION
Fix for issue https://github.com/kiali/kiali/issues/4608

Before Kiali was loading Services for App pages by "app" label name using in Service selector, and in a case when AppLabelName and Service selector were not equal, the Services for App details page was showing empty.

Now with this change the Workloads for App are loaded first, then per workload the Services are loaded by using Workload labels as Service Selector.

One thing in this PR to discuss is loading Services in the loop of workloads then adding them into Service list of results after checking their duplicity.

![Screenshot from 2021-12-20 12-11-59](https://user-images.githubusercontent.com/604313/146758506-85a0d1dd-3645-4fdd-a59d-485f1e4a966a.png)


