### PR TITLE
fix: remove -i flag for its deprecated

### DIFF
--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -56,7 +56,7 @@ build-system-test:
 ## build-test: Run tests and install test deps, excluding third party tests under vendor. Runs `go test -i`
 build-test:
 	@echo Building and installing test dependencies to help speed up test runs.
-	${GO} test -i $(shell ${GO} list ./... | grep -v -e /vendor/)
+	${GO} test $(shell ${GO} list ./... | grep -v -e /vendor/)
 
 ## test: Run tests, excluding third party tests under vendor. Runs `go test` internally
 test:

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -53,11 +53,6 @@ build-system-test:
 	${GO} test -c -covermode=count -coverpkg $(shell ${GO} list ./... | grep -v test |  awk -vORS=, "{ print $$1 }" | sed "s/,$$//") \
 	  -o ${GOPATH}/bin/kiali -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
-## build-test: Run tests and install test deps, excluding third party tests under vendor. Runs `go test -i`
-build-test:
-	@echo Building and installing test dependencies to help speed up test runs.
-	${GO} test $(shell ${GO} list ./... | grep -v -e /vendor/)
-
 ## test: Run tests, excluding third party tests under vendor. Runs `go test` internally
 test:
 	@echo Running tests, excluding third party tests under vendor


### PR DESCRIPTION
**Describe the change**

fix: remove -i flag for its deprecated

The -i flag is deprecated. Compiled packages are cached automatically.

![image](https://user-images.githubusercontent.com/48784001/146780013-372c23e5-e9ce-43f9-a039-5034c6ee5f58.png)
