### PR TITLE
Filter pods based on full owner ref name

### DIFF
--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -785,6 +785,104 @@ func TestGetWorkloadListFromGenericPodController(t *testing.T) {
 	assert.Equal(len(pods), len(workload.Pods))
 }
 
+func TestGetWorkloadListKindsWithSameName(t *testing.T) {
+	assert := assert.New(t)
+
+	rs := FakeRSSyncedWithPods()
+	pods := FakePodsSyncedWithDeployments()
+	pods[0].OwnerReferences[0].APIVersion = "shiny.new.apps/v1"
+	pods[0].OwnerReferences[0].Kind = "ReplicaSet"
+
+	// Setup mocks
+	k8s := new(kubetest.K8SClientMock)
+	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
+	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
+	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
+	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(rs, nil)
+	k8s.On("GetReplicationControllers", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]core_v1.ReplicationController{}, nil)
+	k8s.On("GetStatefulSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.StatefulSet{}, nil)
+	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
+	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
+	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(pods, nil)
+	k8s.On("GetPod", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(pods[0], nil)
+	k8s.On("GetPodLogs", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.Anything).Return(pods, nil)
+
+	notfound := fmt.Errorf("not found")
+	k8s.On("GetDeployment", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&apps_v1.Deployment{}, nil)
+	k8s.On("GetDeploymentConfig", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&osapps_v1.DeploymentConfig{}, notfound)
+	k8s.On("GetStatefulSet", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&apps_v1.StatefulSet{}, nil)
+	k8s.On("GetDaemonSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.DaemonSet{}, nil)
+	k8s.On("GetDaemonSet", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&apps_v1.DaemonSet{}, notfound)
+
+	// Disabling CustomDashboards on Workload details testing
+	conf := config.Get()
+	conf.ExternalServices.CustomDashboards.Enabled = false
+	config.Set(conf)
+
+	svc := setupWorkloadService(k8s)
+
+	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
+	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloads := workloadList.Workloads
+
+	assert.Equal(0, len(workloads))
+}
+
+func TestGetWorkloadListRSWithoutPrefix(t *testing.T) {
+	assert := assert.New(t)
+
+	rs := FakeRSSyncedWithPods()
+	// Doesn't matter what the type is as long as kiali doesn't recognize it as a workload.
+	owner := &core_v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			// Random prefix
+			Name: "h79a3h-controlling-workload",
+			UID:  types.UID("f9952f02-5552-4b2c-afdb-441d859dbb36"),
+		},
+		TypeMeta: v1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+	}
+	rs[0].OwnerReferences = []v1.OwnerReference{*v1.NewControllerRef(owner, core_v1.SchemeGroupVersion.WithKind(owner.Kind))}
+	pods := FakePodsSyncedWithDeployments()
+
+	// Setup mocks
+	k8s := new(kubetest.K8SClientMock)
+	k8s.On("IsOpenShift").Return(true)
+	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
+	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.Deployment{}, nil)
+	k8s.On("GetDeploymentConfigs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]osapps_v1.DeploymentConfig{}, nil)
+	k8s.On("GetReplicaSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(rs, nil)
+	k8s.On("GetReplicationControllers", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]core_v1.ReplicationController{}, nil)
+	k8s.On("GetStatefulSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.StatefulSet{}, nil)
+	k8s.On("GetJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1.Job{}, nil)
+	k8s.On("GetCronJobs", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]batch_v1beta1.CronJob{}, nil)
+	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(pods, nil)
+	k8s.On("GetPod", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(pods[0], nil)
+	k8s.On("GetPodLogs", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.Anything).Return(pods, nil)
+
+	notfound := fmt.Errorf("not found")
+	k8s.On("GetDeployment", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&apps_v1.Deployment{}, nil)
+	k8s.On("GetDeploymentConfig", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&osapps_v1.DeploymentConfig{}, notfound)
+	k8s.On("GetStatefulSet", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&apps_v1.StatefulSet{}, nil)
+	k8s.On("GetDaemonSets", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return([]apps_v1.DaemonSet{}, nil)
+	k8s.On("GetDaemonSet", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&apps_v1.DaemonSet{}, notfound)
+
+	// Disabling CustomDashboards on Workload details testing
+	conf := config.Get()
+	conf.ExternalServices.CustomDashboards.Enabled = false
+	config.Set(conf)
+
+	svc := setupWorkloadService(k8s)
+
+	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
+	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloads := workloadList.Workloads
+
+	assert.Equal(1, len(workloads))
+}
+
 func TestGetWorkloadListRSOwnedByCustom(t *testing.T) {
 	assert := assert.New(t)
 
@@ -793,13 +891,14 @@ func TestGetWorkloadListRSOwnedByCustom(t *testing.T) {
 	// Doesn't matter what the type is as long as kiali doesn't recognize it as a workload.
 	owner := &core_v1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
-			// The name matters to the implementation.
-			// RS name must have this as a prefix to match.
-			Name: replicaSets[0].OwnerReferences[0].Name,
+			Name: "controlling-workload",
 			UID:  types.UID("f9952f02-5552-4b2c-afdb-441d859dbb36"),
 		},
+		TypeMeta: v1.TypeMeta{
+			Kind: "ConfigMap",
+		},
 	}
-	ref := v1.NewControllerRef(owner, core_v1.SchemeGroupVersion.WithKind("ConfigMap"))
+	ref := v1.NewControllerRef(owner, core_v1.SchemeGroupVersion.WithKind(owner.Kind))
 
 	for i := range replicaSets {
 		replicaSets[i].OwnerReferences = []v1.OwnerReference{*ref}

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -164,7 +164,8 @@ func FilterPodsByController(controllerName string, controllerType string, allPod
 	var pods []core_v1.Pod
 	for _, pod := range allPods {
 		for _, ref := range pod.OwnerReferences {
-			if ref.Controller != nil && *ref.Controller && strings.HasPrefix(ref.Name, controllerName) && ref.Kind == controllerType {
+			// TODO: Kind is not a definitive reference. Need to include check for API version as well.
+			if ref.Controller != nil && *ref.Controller && ref.Name == controllerName && ref.Kind == controllerType {
 				pods = append(pods, pod)
 				break
 			}

--- a/kubernetes/filters_test.go
+++ b/kubernetes/filters_test.go
@@ -5,8 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestFilterPodsForEndpoints(t *testing.T) {
@@ -119,4 +123,83 @@ func TestFilterGateways(t *testing.T) {
 	assert.Equal("gateway2", filtered[1].Name)
 	assert.Equal("gateway3", filtered[2].Name)
 	assert.Equal("gateway4", filtered[3].Name)
+}
+
+// ownerRefFrom generates an owner ref for the owner object. owner obj needs to have
+// ObjectMeta and TypeMeta set to be a valid ref.
+func ownerRefFrom(t *testing.T, owner runtime.Object) meta_v1.OwnerReference {
+	t.Helper()
+	m, err := meta.Accessor(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gvk := owner.GetObjectKind().GroupVersionKind()
+
+	return *meta_v1.NewControllerRef(m, gvk)
+}
+
+func TestFilterPodsByController(t *testing.T) {
+	rs := &apps_v1.ReplicaSet{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "Testing-RS",
+			UID:  types.UID("e07b722f-c922-4046-8d98-7aa8487d41c1"),
+		},
+		TypeMeta: meta_v1.TypeMeta{
+			Kind:       "ReplicaSet",
+			APIVersion: apps_v1.SchemeGroupVersion.String(),
+		},
+	}
+	cases := map[string]struct {
+		controllerName string
+		controllerType string
+		pods           []core_v1.Pod
+		expectedLen    int
+	}{
+		"Filters by kind and full name": {
+			controllerName: rs.Name,
+			controllerType: "ReplicaSet",
+			pods: []core_v1.Pod{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:            "rs-pod-1",
+						OwnerReferences: []meta_v1.OwnerReference{ownerRefFrom(t, rs)},
+					},
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name: "rs-pod-2",
+					},
+				},
+			},
+			expectedLen: 1,
+		},
+		"Includes APIVersion": {
+			controllerName: rs.Name,
+			controllerType: "ReplicaSet",
+			pods: []core_v1.Pod{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name: "rs-pod-1",
+						OwnerReferences: func() []meta_v1.OwnerReference {
+							badAPIVersionRS := rs.DeepCopy()
+							badAPIVersionRS.APIVersion = "strange.group.io/v10"
+							return []meta_v1.OwnerReference{ownerRefFrom(t, badAPIVersionRS)}
+						}(),
+					},
+				},
+			},
+			// TODO: This should be 0
+			expectedLen: 1,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			pods := FilterPodsByController(tc.controllerName, tc.controllerType, tc.pods)
+			assert.Equal(tc.expectedLen, len(pods))
+		})
+	}
 }


### PR DESCRIPTION
When fetching workloads, Kiali should match the replicaset owner ref's full name instead of relying on a prefix.

Fixes #4477 