### PR TITLE
fix(swagger): add --no-open flag to fix no screen found error

### DIFF
--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -107,7 +107,7 @@ swagger-gen:
 
 ## swagger-serve: Serve the swagger.json in a website in local. Runs `swagger serve` internally
 swagger-serve: swagger-validate
-	@swagger serve ./swagger.json
+	@swagger serve ./swagger.json --no-open
 
 ## swagger-ci: Check that swagger.json is the correct one
 swagger-ci: swagger-validate


### PR DESCRIPTION
 **Describe the change** 

add --no-open flag to fix no screen found error

 **Issue reference** 

``` bash
The swagger spec at "./swagger.json" is valid against swagger specification 2.0
webbrowser: tried to open "http://localhost:44497/docs", no screen found
make: *** [make/Makefile.build.mk:110: swagger-serve] Error 1
```
