### PR TITLE
Replace ServiceList usage by RegistryServices

### DIFF
--- a/business/checkers/authorization/no_host_checker_test.go
+++ b/business/checkers/authorization/no_host_checker_test.go
@@ -16,12 +16,15 @@ import (
 func TestPresentService(t *testing.T) {
 	assert := assert.New(t)
 
+	registryService1 := data.CreateFakeRegistryServices("details.bookinfo.svc.cluster.local", "bookinfo", "*")
+	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
+
 	validations, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"details", "reviews"}),
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
-		ServiceList:         fakeServices([]string{"details", "reviews"}),
+		RegistryServices:    append(registryService1, registryService2...),
 	}.Check()
 
 	// Well configured object
@@ -32,12 +35,15 @@ func TestPresentService(t *testing.T) {
 func TestNonExistingService(t *testing.T) {
 	assert := assert.New(t)
 
+	registryService1 := data.CreateFakeRegistryServices("details.bookinfo.svc.cluster.local", "bookinfo", "*")
+	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
+
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"details", "wrong"}),
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
-		ServiceList:         fakeServices([]string{"details", "reviews"}),
+		RegistryServices:    append(registryService1, registryService2...),
 	}.Check()
 
 	// Wrong host is not present
@@ -52,12 +58,15 @@ func TestNonExistingService(t *testing.T) {
 func TestWildcardHost(t *testing.T) {
 	assert := assert.New(t)
 
+	registryService1 := data.CreateFakeRegistryServices("details.bookinfo.svc.cluster.local", "bookinfo", "*")
+	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
+
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"*", "*.bookinfo", "*.bookinfo.svc.cluster.local"}),
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
-		ServiceList:         fakeServices([]string{"details", "reviews"}),
+		RegistryServices:    append(registryService1, registryService2...),
 	}.Check()
 
 	// Well configured object
@@ -68,12 +77,15 @@ func TestWildcardHost(t *testing.T) {
 func TestWildcardHostOutsideNamespace(t *testing.T) {
 	assert := assert.New(t)
 
+	registryService1 := data.CreateFakeRegistryServices("details.bookinfo.svc.cluster.local", "bookinfo", "*")
+	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
+
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"*.outside", "*.outside.svc.cluster.local"}),
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
-		ServiceList:         fakeServices([]string{"details", "reviews"}),
+		RegistryServices:    append(registryService1, registryService2...),
 	}.Check()
 
 	assert.False(valid)
@@ -97,7 +109,6 @@ func TestServiceEntryPresent(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// Well configured object
@@ -115,7 +126,6 @@ func TestExportedInternalServiceEntryPresent(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// Well configured object
@@ -133,7 +143,6 @@ func TestExportedExternalServiceEntryPresent(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// Well configured object
@@ -151,7 +160,6 @@ func TestExportedExternalServiceEntryFail(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// www.wrong.com host is not present
@@ -173,7 +181,6 @@ func TestWildcardExportedInternalServiceEntryPresent(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// Well configured object
@@ -191,7 +198,6 @@ func TestWildcardExportedInternalServiceEntryFail(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// details.bookinfo3.svc.cluster.local host is not present
@@ -213,7 +219,6 @@ func TestExportedNonFQDNInternalServiceEntryFail(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// details.bookinfo2.svc.cluster.local host is not present
@@ -234,7 +239,6 @@ func TestServiceEntryNotPresent(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// Wrong.org host is not present
@@ -255,7 +259,6 @@ func TestExportedInternalServiceEntryNotPresent(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// Wrong.org host is not present
@@ -276,7 +279,6 @@ func TestVirtualServicePresent(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
-		ServiceList:         models.ServiceList{},
 		VirtualServices:     []networking_v1alpha3.VirtualService{virtualService},
 	}.Check()
 
@@ -293,7 +295,6 @@ func TestVirtualServiceNotPresent(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
-		ServiceList:         models.ServiceList{},
 		VirtualServices:     []networking_v1alpha3.VirtualService{virtualService},
 	}.Check()
 
@@ -316,7 +317,6 @@ func TestWildcardServiceEntryHost(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// Well configured object
@@ -329,7 +329,6 @@ func TestWildcardServiceEntryHost(t *testing.T) {
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{serviceEntry}),
-		ServiceList:         models.ServiceList{},
 	}.Check()
 
 	// apple.com host is not present
@@ -379,53 +378,49 @@ func TestValidServiceRegistry(t *testing.T) {
 	assert.False(valid)
 	assert.NotEmpty(validations)
 
-	registryService := kubernetes.RegistryService{}
-	registryService.Hostname = "ratings.mesh2-bookinfo.svc.mesh1-imports.local"
+	registryService := data.CreateFakeRegistryServices("ratings.mesh2-bookinfo.svc.mesh1-imports.local", "bookinfo", "*")
 
 	validations, valid = NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"ratings.mesh2-bookinfo.svc.mesh1-imports.local"}),
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
-		RegistryServices:    []*kubernetes.RegistryService{&registryService},
+		RegistryServices:    registryService,
 	}.Check()
 
 	assert.True(valid)
 	assert.Empty(validations)
 
-	registryService = kubernetes.RegistryService{}
-	registryService.Hostname = "ratings2.mesh2-bookinfo.svc.mesh1-imports.local"
+	registryService = data.CreateFakeRegistryServices("ratings2.mesh2-bookinfo.svc.mesh1-imports.local", "bookinfo", "*")
 
 	validations, valid = NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"ratings.mesh2-bookinfo.svc.mesh1-imports.local"}),
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
-		RegistryServices:    []*kubernetes.RegistryService{&registryService},
+		RegistryServices:    registryService,
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(validations)
 
-	registryService = kubernetes.RegistryService{}
-	registryService.Hostname = "ratings.bookinfo.svc.cluster.local"
+	registryService = data.CreateFakeRegistryServices("ratings.bookinfo.svc.cluster.local", "bookinfo", "*")
 
 	validations, valid = NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"ratings.bookinfo.svc.cluster.local"}),
 		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
-		RegistryServices:    []*kubernetes.RegistryService{&registryService},
+		RegistryServices:    registryService,
 	}.Check()
 
 	assert.True(valid)
 	assert.Empty(validations)
 
-	registryService = kubernetes.RegistryService{}
-	registryService.Hostname = "ratings.bookinfo.svc.cluster.local"
+	registryService = data.CreateFakeRegistryServices("ratings.bookinfo.svc.cluster.local", "bookinfo", "*")
 
 	validations, valid = NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"ratings2.bookinfo.svc.cluster.local"}),
 		Namespace:           "test",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
-		RegistryServices:    []*kubernetes.RegistryService{&registryService},
+		RegistryServices:    registryService,
 	}.Check()
 
 	assert.False(valid)

--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -58,7 +58,7 @@ func (a AuthorizationPolicyChecker) runChecks(authPolicy security_v1beta.Authori
 		common.SelectorNoWorkloadFoundChecker(AuthorizationPolicyCheckerType, matchLabels, a.WorkloadList),
 		authorization.NamespaceMethodChecker{AuthorizationPolicy: authPolicy, Namespaces: a.Namespaces.GetNames()},
 		authorization.NoHostChecker{AuthorizationPolicy: authPolicy, Namespace: a.Namespace, Namespaces: a.Namespaces,
-			ServiceEntries: serviceHosts, ServiceList: a.ServiceList, VirtualServices: a.VirtualServices, RegistryServices: a.RegistryServices},
+			ServiceEntries: serviceHosts, VirtualServices: a.VirtualServices, RegistryServices: a.RegistryServices},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -49,7 +49,6 @@ func runVirtualServiceCheck(virtualService networking_v1alpha3.VirtualService, n
 	result, valid := virtualservices.NoHostChecker{
 		Namespace:         namespace,
 		Namespaces:        clusterNamespaces,
-		ServiceList:       services,
 		VirtualService:    virtualService,
 		ServiceEntryHosts: serviceHosts,
 		RegistryServices:  registryStatus,

--- a/business/checkers/virtualservices/no_host_checker.go
+++ b/business/checkers/virtualservices/no_host_checker.go
@@ -6,6 +6,7 @@ import (
 
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -13,7 +14,6 @@ import (
 type NoHostChecker struct {
 	Namespace         string
 	Namespaces        models.Namespaces
-	ServiceList       models.ServiceList
 	VirtualService    networking_v1alpha3.VirtualService
 	ServiceEntryHosts map[string][]string
 	RegistryServices  []*kubernetes.RegistryService
@@ -22,6 +22,10 @@ type NoHostChecker struct {
 func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 	valid := true
+	namespace, clusterName := n.VirtualService.Namespace, n.VirtualService.ClusterName
+	if clusterName == "" {
+		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
+	}
 
 	for k, httpRoute := range n.VirtualService.Spec.Http {
 		if httpRoute != nil {
@@ -31,8 +35,8 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 					if host == "" {
 						continue
 					}
-					fqdn := kubernetes.GetHost(host, n.VirtualService.Namespace, n.VirtualService.ClusterName, n.Namespaces.GetNames())
-					if !n.checkDestination(fqdn.String(), n.VirtualService.Namespace) {
+					fqdn := kubernetes.GetHost(host, namespace, clusterName, n.Namespaces.GetNames())
+					if !n.checkDestination(fqdn.String(), namespace) {
 						path := fmt.Sprintf("spec/http[%d]/route[%d]/destination/host", k, i)
 						validation := models.Build("virtualservices.nohost.hostnotfound", path)
 						validations = append(validations, &validation)
@@ -51,8 +55,8 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 					if host == "" {
 						continue
 					}
-					fqdn := kubernetes.GetHost(host, n.VirtualService.Namespace, n.VirtualService.ClusterName, n.Namespaces.GetNames())
-					if !n.checkDestination(fqdn.String(), n.VirtualService.Namespace) {
+					fqdn := kubernetes.GetHost(host, namespace, clusterName, n.Namespaces.GetNames())
+					if !n.checkDestination(fqdn.String(), namespace) {
 						path := fmt.Sprintf("spec/tcp[%d]/route[%d]/destination/host", k, i)
 						validation := models.Build("virtualservices.nohost.hostnotfound", path)
 						validations = append(validations, &validation)
@@ -71,8 +75,8 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 					if host == "" {
 						continue
 					}
-					fqdn := kubernetes.GetHost(host, n.VirtualService.Namespace, n.VirtualService.ClusterName, n.Namespaces.GetNames())
-					if !n.checkDestination(fqdn.String(), n.VirtualService.Namespace) {
+					fqdn := kubernetes.GetHost(host, namespace, clusterName, n.Namespaces.GetNames())
+					if !n.checkDestination(fqdn.String(), namespace) {
 						path := fmt.Sprintf("spec/tls[%d]/route[%d]/destination/host", k, i)
 						validation := models.Build("virtualservices.nohost.hostnotfound", path)
 						validations = append(validations, &validation)
@@ -93,11 +97,11 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 
 func (n NoHostChecker) checkDestination(sHost string, itemNamespace string) bool {
 	// We need to check for namespace equivalent so that two services from different namespaces do not collide
-	for _, service := range n.ServiceList.Services {
+	/**for _, service := range n.ServiceList.Services {
 		if kubernetes.FilterByHost(sHost, itemNamespace, service.Name, service.Namespace) {
 			return true
 		}
-	}
+	}*/
 	// Check ServiceEntries
 	for k := range n.ServiceEntryHosts {
 		hostKey := k

--- a/business/checkers/virtualservices/no_host_checker.go
+++ b/business/checkers/virtualservices/no_host_checker.go
@@ -96,12 +96,6 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 }
 
 func (n NoHostChecker) checkDestination(sHost string, itemNamespace string) bool {
-	// We need to check for namespace equivalent so that two services from different namespaces do not collide
-	/**for _, service := range n.ServiceList.Services {
-		if kubernetes.FilterByHost(sHost, itemNamespace, service.Name, service.Namespace) {
-			return true
-		}
-	}*/
 	// Check ServiceEntries
 	for k := range n.ServiceEntryHosts {
 		hostKey := k

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -173,7 +173,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		objectCheckers = []ObjectChecker{sidecarsChecker}
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
-			Namespace: namespace, Namespaces: namespaces, ServiceList: services, ExportedServiceEntries: exportedResources.ServiceEntries,
+			Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries,
 			WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{authPoliciesChecker}
 	case kubernetes.PeerAuthentications:

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -102,7 +102,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioC
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioConfigList: istioConfigList, ExportedResources: &exportedResources, ServiceList: services, WorkloadList: workloads, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices},
 		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices},
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: exportedResources.ServiceEntries},
-		checkers.GatewayChecker{Gateways: istioConfigList.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
+		checkers.GatewayChecker{Gateways: exportedResources.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: exportedResources.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices},

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -173,8 +173,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		objectCheckers = []ObjectChecker{sidecarsChecker}
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
-			Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries,
-			WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices}
+			Namespace: namespace, Namespaces: namespaces, ServiceList: services, ExportedServiceEntries: exportedResources.ServiceEntries,
+			WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{authPoliciesChecker}
 	case kubernetes.PeerAuthentications:
 		// Validations on PeerAuthentications

--- a/kubernetes/cache/registry_test_helper.go
+++ b/kubernetes/cache/registry_test_helper.go
@@ -28,3 +28,22 @@ func FakeGatewaysKialiCache(gws []networking_v1alpha3.Gateway) KialiCache {
 
 	return &kialiCacheImpl
 }
+
+// Fake KialiCache used for RegistryServices Scenarios
+// It populates the Namespaces, Informers and Registry information needed
+func FakeServicesKialiCache(rss []*kubernetes.RegistryService) KialiCache {
+	kialiCacheImpl := kialiCacheImpl{
+		tokenNamespaces: make(map[string]namespaceCache),
+		// ~ long duration for unit testing
+		refreshDuration: time.Hour,
+	}
+
+	// Populate all DestinationRules using the Registry
+	registryStatus := kubernetes.RegistryStatus{
+		Services: rss,
+	}
+
+	kialiCacheImpl.SetRegistryStatus(&registryStatus)
+
+	return &kialiCacheImpl
+}

--- a/tests/data/service_data.go
+++ b/tests/data/service_data.go
@@ -32,3 +32,12 @@ func CreateFakeRegistryServices(host string, namespace string, exportToNamespace
 
 	return []*kubernetes.RegistryService{&registryService}
 }
+
+func CreateFakeMultiRegistryServices(hosts []string, namespace string, exportToNamespace string) []*kubernetes.RegistryService {
+	result := make([]*kubernetes.RegistryService, 0)
+	for _, host := range hosts {
+		result = append(result, CreateFakeRegistryServices(host, namespace, exportToNamespace)...)
+	}
+
+	return result
+}

--- a/tests/data/virtual_service_data.go
+++ b/tests/data/virtual_service_data.go
@@ -13,6 +13,7 @@ func CreateEmptyVirtualService(name string, namespace string, hosts []string) *n
 	vs.Name = name
 	vs.Namespace = namespace
 	vs.Spec.Hosts = hosts
+	vs.ClusterName = "svc.cluster.local"
 	return &vs
 }
 


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4528

Changed several validations to use ServiceRegistry Instead of ServiceList to decrease the validation time and optimize the validation logic

Touched validation messages:
AuthPolicy: "KIA0104 This host has no matching entry in the service registry"
VirtualService: "KIA1101 DestinationWeight on route doesn't have a valid service (host not found)"

Full regression testing is required for those validations.
Regression testing is required for all other validations.

