### PR TITLE
fix(run-kiali-template): set `use_grpc` to false

### DIFF
--- a/hack/run-kiali-config-template.yaml
+++ b/hack/run-kiali-config-template.yaml
@@ -37,6 +37,7 @@ external_services:
     enabled: true
     in_cluster_url: "${TRACING_URL}"
     url: "${TRACING_URL}"
+    use_grpc: false
 
 kubernetes_config:
   cache_enabled: true


### PR DESCRIPTION
when using run_kiali.sh, 

"ERR Error fetching availability of the tracing service: rpc error: code = Unavailable desc = connection closed" occurred.