### PR TITLE
sync(validate): add validate query in swagger

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -116,6 +116,15 @@ type ObjectTypeParam struct {
 	Name string `json:"object_type"`
 }
 
+// swagger:parameters istioConfigList istioConfigDetails serviceDetails serviceUpdate
+type ValidateParam struct {
+	// Enable validation or not
+	//
+	// in: query
+	// required: false
+	Name string `json:"validate"`
+}
+
 // swagger:parameters podDetails podLogs podProxyDump podProxyResource podProxyLogging
 type PodParam struct {
 	// The pod name.

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -4563,14 +4563,7 @@ Endpoint to set pod proxy log level
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | pod | `path` | string | `string` |  | ✓ |  | The pod name. |
-| level | `query` | string | `string` |  | ✓ |  | The log level for the pod's proxy.
-off ProxyLogLevelOff
-trace ProxyLogLevelTrace
-debug ProxyLogLevelDebug
-info ProxyLogLevelInfo
-warning ProxyLogLevelWarning
-error ProxyLogLevelError
-critical ProxyLogLevelCritical |
+| level | `query` | string | `string` |  | ✓ |  | The log level for the pod's proxy. |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -2731,6 +2731,7 @@ Endpoint to get the Istio Config of an Istio object
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | object | `path` | string | `string` |  | ✓ |  | The Istio object name. |
 | object_type | `path` | string | `string` |  | ✓ |  | The Istio object type. |
+| validate | `query` | string | `string` |  |  |  | Enable validation or not |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -2849,6 +2850,7 @@ Endpoint to get the list of Istio Config of a namespace
 | Name | Source | Type | Go type | Separator | Required | Default | Description |
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
+| validate | `query` | string | `string` |  |  |  | Enable validation or not |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -4561,7 +4563,14 @@ Endpoint to set pod proxy log level
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | pod | `path` | string | `string` |  | ✓ |  | The pod name. |
-| level | `query` | string | `string` |  | ✓ |  | The log level for the pod's proxy. |
+| level | `query` | string | `string` |  | ✓ |  | The log level for the pod's proxy.
+off ProxyLogLevelOff
+trace ProxyLogLevelTrace
+debug ProxyLogLevelDebug
+info ProxyLogLevelInfo
+warning ProxyLogLevelWarning
+error ProxyLogLevelError
+critical ProxyLogLevelCritical |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -5018,6 +5027,7 @@ Endpoint to get the details of a given service
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | service | `path` | string | `string` |  | ✓ |  | The service name. |
+| validate | `query` | string | `string` |  |  |  | Enable validation or not |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -5538,6 +5548,7 @@ PATCH /api/namespaces/{namespace}/services/{service}
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | service | `path` | string | `string` |  | ✓ |  | The service name. |
+| validate | `query` | string | `string` |  |  |  | Enable validation or not |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |

--- a/swagger.json
+++ b/swagger.json
@@ -2108,6 +2108,13 @@
             "name": "namespace",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Enable validation or not",
+            "name": "validate",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2208,6 +2215,13 @@
             "name": "object_type",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Enable validation or not",
+            "name": "validate",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2539,8 +2553,9 @@
               "critical"
             ],
             "type": "string",
+            "x-go-enum-desc": "off ProxyLogLevelOff\ntrace ProxyLogLevelTrace\ndebug ProxyLogLevelDebug\ninfo ProxyLogLevelInfo\nwarning ProxyLogLevelWarning\nerror ProxyLogLevelError\ncritical ProxyLogLevelCritical",
             "x-go-name": "Level",
-            "description": "The log level for the pod's proxy.",
+            "description": "The log level for the pod's proxy.\noff ProxyLogLevelOff\ntrace ProxyLogLevelTrace\ndebug ProxyLogLevelDebug\ninfo ProxyLogLevelInfo\nwarning ProxyLogLevelWarning\nerror ProxyLogLevelError\ncritical ProxyLogLevelCritical",
             "name": "level",
             "in": "query",
             "required": true
@@ -2704,6 +2719,13 @@
           {
             "type": "string",
             "x-go-name": "Name",
+            "description": "Enable validation or not",
+            "name": "validate",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
             "description": "The service name.",
             "name": "service",
             "in": "path",
@@ -2746,6 +2768,13 @@
             "name": "namespace",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Enable validation or not",
+            "name": "validate",
+            "in": "query"
           },
           {
             "type": "string",

--- a/swagger.json
+++ b/swagger.json
@@ -2553,9 +2553,8 @@
               "critical"
             ],
             "type": "string",
-            "x-go-enum-desc": "off ProxyLogLevelOff\ntrace ProxyLogLevelTrace\ndebug ProxyLogLevelDebug\ninfo ProxyLogLevelInfo\nwarning ProxyLogLevelWarning\nerror ProxyLogLevelError\ncritical ProxyLogLevelCritical",
             "x-go-name": "Level",
-            "description": "The log level for the pod's proxy.\noff ProxyLogLevelOff\ntrace ProxyLogLevelTrace\ndebug ProxyLogLevelDebug\ninfo ProxyLogLevelInfo\nwarning ProxyLogLevelWarning\nerror ProxyLogLevelError\ncritical ProxyLogLevelCritical",
+            "description": "The log level for the pod's proxy.",
             "name": "level",
             "in": "query",
             "required": true


### PR DESCRIPTION
(a) what is broken or missing?
validate query is missing in some routes: `istioConfigList, istioConfigDetails, serviceDetails, serviceUpdate`

(b) what the new code is doing to fix it?
add missing validate query in swagger and update swagger.json