### PR TITLE
fix(app/versionApp): graphType is required and types are different

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -116,6 +116,15 @@ type ObjectTypeParam struct {
 	Name string `json:"object_type"`
 }
 
+// swagger:parameters istioConfigList istioConfigDetails serviceDetails serviceUpdate
+type ValidateParam struct {
+	// Enable validation or not
+	//
+	// in: query
+	// required: false
+	Name string `json:"validate"`
+}
+
 // swagger:parameters podDetails podLogs podProxyDump podProxyResource podProxyLogging
 type PodParam struct {
 	// The pod name.
@@ -224,13 +233,22 @@ type DurationGraphParam struct {
 	Name string `json:"duration"`
 }
 
-// swagger:parameters graphApp graphAppVersion graphNamespaces graphService graphWorkload
+// swagger:parameters graphNamespaces graphService graphWorkload
 type GraphTypeParam struct {
 	// Graph type. Available graph types: [app, service, versionedApp, workload].
 	//
 	// in: query
 	// required: false
 	// default: workload
+	Name string `json:"graphType"`
+}
+
+// swagger:parameters graphApp graphAppVersion
+type AppGraphTypeParam struct {
+	// Graph type. Available graph types: [app, versionedApp].
+	//
+	// in: query
+	// required: true
 	Name string `json:"graphType"`
 }
 

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -1916,7 +1916,7 @@ The backing JSON for an app node detail graph. (supported graphTypes: app | vers
 | boxBy | `query` | string | `string` |  |  | `"none"` | Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none]. |
 | container | `query` | string | `string` |  |  |  | The cluster name. If not supplied queries/results will not be constrained by cluster. |
 | duration | `query` | string | `string` |  |  | `"10m"` | Query time-range duration (Golang string duration). |
-| graphType | `query` | string | `string` |  |  | `"workload"` | Graph type. Available graph types: [app, service, versionedApp, workload]. |
+| graphType | `query` | string | `string` |  | ✓ |  | Graph type. Available graph types: [app, versionedApp]. |
 | includeIdleEdges | `query` | string | `string` |  |  | `"false"` | Flag for including edges that have no request traffic for the time period. |
 | injectServiceNodes | `query` | string | `string` |  |  | `"false"` | Flag for injecting the requested service node between source and destination nodes. |
 | queryTime | `query` | string | `string` |  |  | `"now"` | Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now. |
@@ -2023,7 +2023,7 @@ The backing JSON for a versioned app node detail graph. (supported graphTypes: a
 | boxBy | `query` | string | `string` |  |  | `"none"` | Comma-separated list of desired node boxing. Available boxings: [app, cluster, namespace, none]. |
 | container | `query` | string | `string` |  |  |  | The cluster name. If not supplied queries/results will not be constrained by cluster. |
 | duration | `query` | string | `string` |  |  | `"10m"` | Query time-range duration (Golang string duration). |
-| graphType | `query` | string | `string` |  |  | `"workload"` | Graph type. Available graph types: [app, service, versionedApp, workload]. |
+| graphType | `query` | string | `string` |  | ✓ |  | Graph type. Available graph types: [app, versionedApp]. |
 | includeIdleEdges | `query` | string | `string` |  |  | `"false"` | Flag for including edges that have no request traffic for the time period. |
 | injectServiceNodes | `query` | string | `string` |  |  | `"false"` | Flag for injecting the requested service node between source and destination nodes. |
 | queryTime | `query` | string | `string` |  |  | `"now"` | Unix time (seconds) for query such that time range is [queryTime-duration..queryTime]. Default is now. |
@@ -2731,6 +2731,7 @@ Endpoint to get the Istio Config of an Istio object
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | object | `path` | string | `string` |  | ✓ |  | The Istio object name. |
 | object_type | `path` | string | `string` |  | ✓ |  | The Istio object type. |
+| validate | `query` | string | `string` |  |  |  | Enable validation or not |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -2849,6 +2850,7 @@ Endpoint to get the list of Istio Config of a namespace
 | Name | Source | Type | Go type | Separator | Required | Default | Description |
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
+| validate | `query` | string | `string` |  |  |  | Enable validation or not |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -5018,6 +5020,7 @@ Endpoint to get the details of a given service
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | service | `path` | string | `string` |  | ✓ |  | The service name. |
+| validate | `query` | string | `string` |  |  |  | Enable validation or not |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |
@@ -5538,6 +5541,7 @@ PATCH /api/namespaces/{namespace}/services/{service}
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | The namespace name. |
 | service | `path` | string | `string` |  | ✓ |  | The service name. |
+| validate | `query` | string | `string` |  |  |  | Enable validation or not |
 
 #### All responses
 | Code | Status | Description | Has headers | Schema |

--- a/swagger.json
+++ b/swagger.json
@@ -1107,11 +1107,11 @@
           },
           {
             "type": "string",
-            "default": "workload",
             "x-go-name": "Name",
-            "description": "Graph type. Available graph types: [app, service, versionedApp, workload].",
+            "description": "Graph type. Available graph types: [app, versionedApp].",
             "name": "graphType",
-            "in": "query"
+            "in": "query",
+            "required": true
           },
           {
             "type": "string",
@@ -1263,11 +1263,11 @@
           },
           {
             "type": "string",
-            "default": "workload",
             "x-go-name": "Name",
-            "description": "Graph type. Available graph types: [app, service, versionedApp, workload].",
+            "description": "Graph type. Available graph types: [app, versionedApp].",
             "name": "graphType",
-            "in": "query"
+            "in": "query",
+            "required": true
           },
           {
             "type": "string",
@@ -2108,6 +2108,13 @@
             "name": "namespace",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Enable validation or not",
+            "name": "validate",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2208,6 +2215,13 @@
             "name": "object_type",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Enable validation or not",
+            "name": "validate",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2704,6 +2718,13 @@
           {
             "type": "string",
             "x-go-name": "Name",
+            "description": "Enable validation or not",
+            "name": "validate",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
             "description": "The service name.",
             "name": "service",
             "in": "path",
@@ -2746,6 +2767,13 @@
             "name": "namespace",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Enable validation or not",
+            "name": "validate",
+            "in": "query"
           },
           {
             "type": "string",


### PR DESCRIPTION
(a) what is broken or missing?
In app and versionApp graph
+ graphType is required 
+ workload and service are not supported types 

(b) what the new code is doing to fix it?
separate graphApp graphAppVersion from graphParam and create a new param for app.