### PR TITLE
fix(metrics): add restrictions to queries

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -433,7 +433,7 @@ type RequestProtocolParam struct {
 	//
 	// in: query
 	// required: false
-	// default: all protocols
+	// default: http
 	Name string `json:"requestProtocol"`
 }
 

--- a/handlers/metrics_test.go
+++ b/handlers/metrics_test.go
@@ -96,6 +96,12 @@ func TestExtractMetricsQueryParamsWithInvalidStep(t *testing.T) {
 	mq := models.IstioMetricsQuery{Namespace: "ns"}
 	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
 	assert.EqualError(t, err, "bad request, cannot parse query parameter 'step'")
+
+	q.Add("step", "0")
+	req.URL.RawQuery = q.Encode()
+
+	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
+	assert.EqualError(t, err, "bad request, cannot parse query parameter 'step'")
 }
 
 func TestExtractMetricsQueryParamsWithInvalidDuration(t *testing.T) {
@@ -110,6 +116,12 @@ func TestExtractMetricsQueryParamsWithInvalidDuration(t *testing.T) {
 	mq := models.IstioMetricsQuery{Namespace: "ns"}
 	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
 	assert.EqualError(t, err, "bad request, cannot parse query parameter 'duration'")
+
+	q.Add("duration", "0")
+	req.URL.RawQuery = q.Encode()
+
+	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
+	assert.EqualError(t, err, "bad request, cannot parse query parameter 'duration'")
 }
 
 func TestExtractMetricsQueryParamsWithInvalidQuerytime(t *testing.T) {
@@ -122,6 +134,12 @@ func TestExtractMetricsQueryParamsWithInvalidQuerytime(t *testing.T) {
 	req.URL.RawQuery = q.Encode()
 
 	mq := models.IstioMetricsQuery{Namespace: "ns"}
+	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
+	assert.EqualError(t, err, "bad request, cannot parse query parameter 'queryTime'")
+
+	q.Add("queryTime", "0")
+	req.URL.RawQuery = q.Encode()
+
 	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
 	assert.EqualError(t, err, "bad request, cannot parse query parameter 'queryTime'")
 }

--- a/swagger.json
+++ b/swagger.json
@@ -931,7 +931,7 @@
           },
           {
             "type": "string",
-            "default": "all protocols",
+            "default": "http",
             "x-go-name": "Name",
             "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
             "name": "requestProtocol",
@@ -1522,7 +1522,7 @@
           },
           {
             "type": "string",
-            "default": "all protocols",
+            "default": "http",
             "x-go-name": "Name",
             "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
             "name": "requestProtocol",
@@ -1771,7 +1771,7 @@
           },
           {
             "type": "string",
-            "default": "all protocols",
+            "default": "http",
             "x-go-name": "Name",
             "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
             "name": "requestProtocol",
@@ -2868,7 +2868,7 @@
           },
           {
             "type": "string",
-            "default": "all protocols",
+            "default": "http",
             "x-go-name": "Name",
             "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
             "name": "requestProtocol",
@@ -3204,7 +3204,7 @@
           },
           {
             "type": "string",
-            "default": "all protocols",
+            "default": "http",
             "x-go-name": "Name",
             "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
             "name": "requestProtocol",
@@ -3633,7 +3633,7 @@
           },
           {
             "type": "string",
-            "default": "all protocols",
+            "default": "http",
             "x-go-name": "Name",
             "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
             "name": "requestProtocol",
@@ -3991,7 +3991,7 @@
           },
           {
             "type": "string",
-            "default": "all protocols",
+            "default": "http",
             "x-go-name": "Name",
             "description": "Desired request protocol for the telemetry: For example, 'http' or 'grpc'.",
             "name": "requestProtocol",


### PR DESCRIPTION
add some restrictions to queries

(a) what are broken and missing:
1. the default value for `requestProtocol` is not `all protocols`
2. when getting query of `requestProtocol`, we did not restrict the values, just take any values which are not ""
3. when getting query of `rateInterval` , we did not check it formats, just take any values which are not "", which should be formated like `10s`, `5m`, `3h`, `1h20s`...
4. when getting query of `queryTime ` `duration` and `step `, we do not check it if it is < 0, just take values which are not "".
5. Add test cases to test the changes I make.