### PR TITLE
fix(healthz): add '/api' prefix to '/healthz' route

### DIFF
--- a/kiali_api.md
+++ b/kiali_api.md
@@ -9306,7 +9306,7 @@ hosts: ["another-host.com"]
 ```
 
 You can fine tune the authorization policy to set different requirement per path. For example,
-to require JWT on all paths, except /healthz, the same `RequestAuthentication` can be used, but the
+to require JWT on all paths, except /api/healthz, the same `RequestAuthentication` can be used, but the
 authorization policy could be:
 
 ```yaml
@@ -9325,7 +9325,7 @@ source:
 requestPrincipals: ["*"]
 to:
 operation:
-paths: ["/healthz"]
+paths: ["/api/healthz"]
 ```
 
 <!-- crd generation tags

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -74,7 +74,7 @@ func TestSimpleRoute(t *testing.T) {
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/healthz")
+	resp, err := http.Get(ts.URL + "/api/healthz")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -40,7 +40,7 @@ func NewRoutes() (r *Routes) {
 		{
 			"Healthz",
 			"GET",
-			"/healthz",
+			"/api/healthz",
 			handlers.Healthz,
 			false,
 		},


### PR DESCRIPTION
**Describe the change** 

`healthz` api is designed to test if kiali is healthy, I strongly suggest adding '/api' prefix to '/healthz' route.

Reasons are below:

1. In swagger doc, there is a `/api` base url, generated routes for `/healthz` actually is `/api/health`, while it is actually `/healthz`. It will be a always confilct, because we can not remove `/api` baseURL.

2. And according to api doc: https://github.com/kiali/kiali/blob/master/kiali_api.md#healthz, this route is actually designed as `/api/healthz` not `/healthz`.

3. And **I check that in kiali-ui, there is no place using `/healthz` api, so this update is compatible.** :), but need some changes in helm-chart and operator, where I will give PRs to update too.
