### PR TITLE
Fix wrong pointer in jaeger http client

### DIFF
--- a/jaeger/http_client.go
+++ b/jaeger/http_client.go
@@ -29,7 +29,7 @@ func getAppTracesHTTP(client http.Client, baseURL *url.URL, namespace, app strin
 }
 
 func getTraceDetailHTTP(client http.Client, endpoint *url.URL, traceID string) (*JaegerSingleTrace, error) {
-	u := endpoint
+	u := *endpoint
 	u.Path = path.Join(u.Path, "/api/traces/"+traceID)
 	resp, code, reqError := makeRequest(client, u.String(), nil)
 	if reqError != nil {
@@ -40,7 +40,7 @@ func getTraceDetailHTTP(client http.Client, endpoint *url.URL, traceID string) (
 	if len(resp) == 0 {
 		return nil, nil
 	}
-	response, err := unmarshal(resp, u)
+	response, err := unmarshal(resp, &u)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4636

When using the HTTP configuration to access jaeger from Kiali:
```
  tracing:
    enabled: true
    use_grpc: false
    in_cluster_url: http://localhost:16686/jaeger
    url: http://localhost:16686/jaeger
    namespace: istio-system
    port: 443
    service: jaeger-query
```

There was a bug when access to a trace detail, the base URL was overwritten, which produced that following queries would fail. The problem is only visible in the HTTP mode, not GRPC.