### PR TITLE
Removed duplications for VS, DR and SE in Istio Validations.

### DIFF
--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -16,7 +16,6 @@ type AuthorizationPolicyChecker struct {
 	AuthorizationPolicies   []security_v1beta.AuthorizationPolicy
 	Namespace               string
 	Namespaces              models.Namespaces
-	ServiceEntries          []networking_v1alpha3.ServiceEntry
 	ExportedServiceEntries  []networking_v1alpha3.ServiceEntry
 	ServiceList             models.ServiceList
 	WorkloadList            models.WorkloadList
@@ -50,7 +49,7 @@ func (a AuthorizationPolicyChecker) Check() models.IstioValidations {
 func (a AuthorizationPolicyChecker) runChecks(authPolicy security_v1beta.AuthorizationPolicy) models.IstioValidations {
 	policyName := authPolicy.Name
 	key, rrValidation := EmptyValidValidation(policyName, authPolicy.Namespace, AuthorizationPolicyCheckerType)
-	serviceHosts := kubernetes.ServiceEntryHostnames(append(a.ServiceEntries, a.ExportedServiceEntries...))
+	serviceHosts := kubernetes.ServiceEntryHostnames(a.ExportedServiceEntries)
 	matchLabels := make(map[string]string)
 	if authPolicy.Spec.Selector != nil {
 		matchLabels = authPolicy.Spec.Selector.MatchLabels

--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -15,7 +15,6 @@ type DestinationRulesChecker struct {
 	DestinationRules         []networking_v1alpha3.DestinationRule
 	ExportedDestinationRules []networking_v1alpha3.DestinationRule
 	MTLSDetails              kubernetes.MTLSDetails
-	ServiceEntries           []networking_v1alpha3.ServiceEntry
 	ExportedServiceEntries   []networking_v1alpha3.ServiceEntry
 	Namespaces               []models.Namespace
 }
@@ -32,10 +31,10 @@ func (in DestinationRulesChecker) Check() models.IstioValidations {
 func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
-	seHosts := kubernetes.ServiceEntryHostnames(append(in.ServiceEntries, in.ExportedServiceEntries...))
+	seHosts := kubernetes.ServiceEntryHostnames(in.ExportedServiceEntries)
 
 	enabledDRCheckers := []GroupChecker{
-		destinationrules.MultiMatchChecker{Namespaces: in.Namespaces, DestinationRules: in.DestinationRules, ServiceEntries: seHosts, ExportedDestinationRules: in.ExportedDestinationRules},
+		destinationrules.MultiMatchChecker{Namespaces: in.Namespaces, ServiceEntries: seHosts, ExportedDestinationRules: in.ExportedDestinationRules},
 	}
 
 	// Appending validations that only applies to non-autoMTLS meshes

--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -13,7 +13,6 @@ import (
 const DestinationRulesCheckerType = "destinationrule"
 
 type MultiMatchChecker struct {
-	DestinationRules         []networking_v1alpha3.DestinationRule
 	ExportedDestinationRules []networking_v1alpha3.DestinationRule
 	ServiceEntries           map[string][]string
 	Namespaces               models.Namespaces
@@ -37,7 +36,7 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 	// Equality search is: [fqdn.String()][subset] except for ServiceEntry targets which use [host][subset]
 	seenHostSubsets := make(map[string]map[string][]rule)
 
-	for _, dr := range append(m.DestinationRules, m.ExportedDestinationRules...) {
+	for _, dr := range m.ExportedDestinationRules {
 		destinationRulesName := dr.Name
 		destinationRulesNamespace := dr.Namespace
 		fqdn := kubernetes.GetHost(dr.Spec.Host, dr.Namespace, dr.ClusterName, m.Namespaces.GetNames())

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -25,8 +25,7 @@ func TestMultiHostMatchCorrect(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -48,8 +47,7 @@ func TestMultiHostMatchInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -93,8 +91,7 @@ func TestMultiHostMatchInvalidShortFormat(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -122,8 +119,7 @@ func TestMultiHostMatchValidShortFormat(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -148,8 +144,7 @@ func TestMultiHostMatchValidShortFormatDiffNamespace(t *testing.T) {
 			models.Namespace{Name: "bookinfo"},
 			models.Namespace{Name: "test"},
 		},
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	// MultiMatchChecker shouldn't fail if a host is in a different namespace
@@ -168,8 +163,7 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -188,8 +182,7 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -215,8 +208,7 @@ func TestMultiHostMatchBothWildcardInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -235,8 +227,7 @@ func TestMultiHostMatchBothWildcardInvalid(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -263,8 +254,7 @@ func TestMultiHostMatchingMeshWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -286,8 +276,7 @@ func TestMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -310,8 +299,7 @@ func TestMultiHostMatchDifferentSubsets(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -322,8 +310,7 @@ func TestMultiHostMatchDifferentSubsets(t *testing.T) {
 	)
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -342,8 +329,7 @@ func TestReviewsExample(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -352,8 +338,7 @@ func TestReviewsExample(t *testing.T) {
 	destinationRules = append(destinationRules, *allMatch)
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -381,8 +366,7 @@ func TestMultiServiceEntry(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test", "service-b", "api.service_b.com")
 
 	vals := MultiMatchChecker{
-		DestinationRules:         []networking_v1alpha3.DestinationRule{*drA, *drB},
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
 		ServiceEntries:           kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA, *seB}),
 	}.Check()
 
@@ -401,8 +385,7 @@ func TestMultiServiceEntryInvalid(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test", "service-a2", "api.service_a.com")
 
 	vals := MultiMatchChecker{
-		DestinationRules:         []networking_v1alpha3.DestinationRule{*drA, *drB},
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
+		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
 		ServiceEntries:           kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA}),
 	}.Check()
 

--- a/business/checkers/destinationrules/multi_match_exported_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_exported_checker_test.go
@@ -28,8 +28,7 @@ func TestExportMultiHostMatchCorrect(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -54,8 +53,7 @@ func TestExportMultiHostMatchInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "test2"},
@@ -92,8 +90,7 @@ func TestExportMultiHostMatchInvalid2(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "test2"},
@@ -145,8 +142,7 @@ func TestExportMultiHostMatchValidShortFormat(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -170,8 +166,7 @@ func TestExportMultiHostMatchValidShortFormat2(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -200,8 +195,7 @@ func TestExportMultiHostMatchValidShortFormatDiffNamespace(t *testing.T) {
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "test2"},
 		},
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	// MultiMatchChecker shouldn't fail if a host is in a different namespace
@@ -223,8 +217,7 @@ func TestExportMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -246,8 +239,7 @@ func TestExportMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -276,8 +268,7 @@ func TestExportMultiHostMatchBothWildcardInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -299,8 +290,7 @@ func TestExportMultiHostMatchBothWildcardInvalid(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -329,8 +319,7 @@ func TestExportMultiHostMatchBothWildcardInvalid2(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -352,8 +341,7 @@ func TestExportMultiHostMatchBothWildcardInvalid2(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -382,8 +370,7 @@ func TestExportMultiHostMatchBothWildcardInvalid3(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -405,8 +392,7 @@ func TestExportMultiHostMatchBothWildcardInvalid3(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -436,8 +422,7 @@ func TestExportMultiHostMatchingMeshWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -462,8 +447,7 @@ func TestExportMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -489,8 +473,7 @@ func TestExportMultiHostMatchDifferentSubsets(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -501,8 +484,7 @@ func TestExportMultiHostMatchDifferentSubsets(t *testing.T) {
 	)
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -524,8 +506,7 @@ func TestExportReviewsExample(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -534,8 +515,7 @@ func TestExportReviewsExample(t *testing.T) {
 	edr = append(edr, *allMatch)
 
 	vals = MultiMatchChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: edr,
+		ExportedDestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -563,8 +543,7 @@ func TestExportMultiServiceEntry(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test2", "service-b", "api.service_b.com")
 
 	vals := MultiMatchChecker{
-		DestinationRules:         []networking_v1alpha3.DestinationRule{*drA},
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drB},
+		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
 		ServiceEntries:           kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA, *seB}),
 	}.Check()
 
@@ -583,8 +562,7 @@ func TestExportMultiServiceEntryInvalid(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test2", "service-a2", "api.service_a.com")
 
 	vals := MultiMatchChecker{
-		DestinationRules:         []networking_v1alpha3.DestinationRule{*drA},
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drB},
+		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
 		ServiceEntries:           kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA}),
 	}.Check()
 

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -30,7 +30,7 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 	}
 
 	serviceHosts := kubernetes.ServiceEntryHostnames(append(in.IstioConfigList.ServiceEntries, in.ExportedResources.ServiceEntries...))
-	gatewayNames := kubernetes.GatewayNames(in.IstioConfigList.Gateways)
+	gatewayNames := kubernetes.GatewayNames(in.ExportedResources.Gateways)
 
 	for _, virtualService := range in.IstioConfigList.VirtualServices {
 		validations.MergeValidations(runVirtualServiceCheck(virtualService, in.Namespace, in.ServiceList, serviceHosts, in.Namespaces, in.RegistryServices))

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -13,7 +13,6 @@ const SidecarCheckerType = "sidecar"
 
 type SidecarChecker struct {
 	Sidecars               []networking_v1alpha3.Sidecar
-	ServiceEntries         []networking_v1alpha3.ServiceEntry
 	ExportedServiceEntries []networking_v1alpha3.ServiceEntry
 	ServiceList            models.ServiceList
 	Namespaces             models.Namespaces
@@ -57,7 +56,7 @@ func (s SidecarChecker) runIndividualChecks() models.IstioValidations {
 func (s SidecarChecker) runChecks(sidecar networking_v1alpha3.Sidecar) models.IstioValidations {
 	policyName := sidecar.Name
 	key, rrValidation := EmptyValidValidation(policyName, sidecar.Namespace, SidecarCheckerType)
-	serviceHosts := kubernetes.ServiceEntryHostnames(append(s.ServiceEntries, s.ExportedServiceEntries...))
+	serviceHosts := kubernetes.ServiceEntryHostnames(s.ExportedServiceEntries)
 	selectorLabels := make(map[string]string)
 	if sidecar.Spec.WorkloadSelector != nil {
 		selectorLabels = sidecar.Spec.WorkloadSelector.Labels

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -13,7 +13,6 @@ const VirtualCheckerType = "virtualservice"
 type VirtualServiceChecker struct {
 	Namespace                string
 	Namespaces               models.Namespaces
-	DestinationRules         []networking_v1alpha3.DestinationRule
 	VirtualServices          []networking_v1alpha3.VirtualService
 	ExportedVirtualServices  []networking_v1alpha3.VirtualService
 	ExportedDestinationRules []networking_v1alpha3.DestinationRule
@@ -48,7 +47,7 @@ func (in VirtualServiceChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	enabledCheckers := []GroupChecker{
-		virtualservices.SingleHostChecker{Namespace: in.Namespace, Namespaces: in.Namespaces, VirtualServices: in.VirtualServices, ExportedVirtualServices: in.ExportedVirtualServices},
+		virtualservices.SingleHostChecker{Namespace: in.Namespace, Namespaces: in.Namespaces, ExportedVirtualServices: in.ExportedVirtualServices},
 	}
 
 	for _, checker := range enabledCheckers {
@@ -65,7 +64,7 @@ func (in VirtualServiceChecker) runChecks(virtualService networking_v1alpha3.Vir
 
 	enabledCheckers := []Checker{
 		virtualservices.RouteChecker{VirtualService: virtualService, Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames()},
-		virtualservices.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), DestinationRules: in.DestinationRules, VirtualService: virtualService, ExportedDestinationRules: in.ExportedDestinationRules},
+		virtualservices.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), VirtualService: virtualService, ExportedDestinationRules: in.ExportedDestinationRules},
 		common.ExportToNamespaceChecker{ExportTo: virtualService.Spec.ExportTo, Namespaces: in.Namespaces},
 	}
 

--- a/business/checkers/virtual_service_checker_test.go
+++ b/business/checkers/virtual_service_checker_test.go
@@ -20,9 +20,9 @@ func prepareTestForVirtualService(vs *networking_v1alpha3.VirtualService) models
 	}
 
 	virtualServiceChecker := VirtualServiceChecker{
-		Namespace:        "bookinfo",
-		DestinationRules: destinationList,
-		VirtualServices:  vss,
+		Namespace:                "bookinfo",
+		ExportedDestinationRules: destinationList,
+		VirtualServices:          vss,
 	}
 
 	return virtualServiceChecker.Check()
@@ -87,9 +87,9 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 	}
 
 	virtualServiceChecker := VirtualServiceChecker{
-		Namespace:        "bookinfo",
-		DestinationRules: destinationList,
-		VirtualServices:  fakeVirtualServiceMultipleIstioObjects(),
+		Namespace:                "bookinfo",
+		ExportedDestinationRules: destinationList,
+		VirtualServices:          fakeVirtualServiceMultipleIstioObjects(),
 	}
 
 	validations := virtualServiceChecker.Check()

--- a/business/checkers/virtualservices/single_exported_host_checker_test.go
+++ b/business/checkers/virtualservices/single_exported_host_checker_test.go
@@ -21,8 +21,7 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -37,8 +36,7 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 	}
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -53,8 +51,7 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 	}
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -69,8 +66,7 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 	}
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -86,8 +82,7 @@ func TestOneVirtualServicePerFQDNHostExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -103,8 +98,7 @@ func TestOneVirtualServicePerFQDNWildcardHostExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -124,8 +118,7 @@ func TestRepeatingSimpleHostExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -156,8 +149,7 @@ func TestRepeatingSimpleHostWithGatewayExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	noObjectValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -171,8 +163,7 @@ func TestRepeatingSimpleHostWithGatewayExported(t *testing.T) {
 	}
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	noObjectValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -186,8 +177,7 @@ func TestRepeatingSimpleHostWithGatewayExported(t *testing.T) {
 	}
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	refKey := models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo2", Name: "virtual-2"}
@@ -212,8 +202,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -231,8 +220,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -251,8 +239,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -270,8 +257,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -289,8 +275,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	noObjectValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -310,8 +295,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	noObjectValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -330,8 +314,7 @@ func TestRepeatingFQDNHostExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -363,8 +346,7 @@ func TestRepeatingFQDNWildcardHostExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -396,8 +378,7 @@ func TestIncludedIntoWildCardExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -428,8 +409,7 @@ func TestIncludedIntoWildCardExported(t *testing.T) {
 	}
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -461,8 +441,7 @@ func TestShortHostNameIncludedIntoWildCardExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -494,8 +473,7 @@ func TestWildcardisMarkedInvalidExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -527,8 +505,7 @@ func TestMultipleHostsFailingExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -554,8 +531,7 @@ func TestMultipleHostsPassingExported(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: evss,
+		ExportedVirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")

--- a/business/checkers/virtualservices/single_host_checker.go
+++ b/business/checkers/virtualservices/single_host_checker.go
@@ -11,7 +11,6 @@ import (
 type SingleHostChecker struct {
 	Namespace               string
 	Namespaces              models.Namespaces
-	VirtualServices         []networking_v1alpha3.VirtualService
 	ExportedVirtualServices []networking_v1alpha3.VirtualService
 }
 
@@ -19,7 +18,7 @@ func (s SingleHostChecker) Check() models.IstioValidations {
 	hostCounter := make(map[string]map[string]map[string]map[string][]*networking_v1alpha3.VirtualService)
 	validations := models.IstioValidations{}
 
-	for _, vs := range append(s.VirtualServices, s.ExportedVirtualServices...) {
+	for _, vs := range s.ExportedVirtualServices {
 		for _, host := range s.getHosts(vs) {
 			storeHost(hostCounter, vs, host)
 		}

--- a/business/checkers/virtualservices/single_host_checker_test.go
+++ b/business/checkers/virtualservices/single_host_checker_test.go
@@ -18,8 +18,7 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -31,8 +30,7 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 	}
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -45,8 +43,7 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 	}
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -60,8 +57,7 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -75,8 +71,7 @@ func TestOneVirtualServicePerFQDNHost(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -89,8 +84,7 @@ func TestOneVirtualServicePerFQDNWildcardHost(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -105,8 +99,7 @@ func TestRepeatingSimpleHost(t *testing.T) {
 
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -133,8 +126,7 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	noObjectValidationTest(t, vals, "virtual-1")
@@ -147,8 +139,7 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	noObjectValidationTest(t, vals, "virtual-1")
@@ -161,8 +152,7 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	refKey := models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-2"}
@@ -184,8 +174,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -200,8 +189,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -217,8 +205,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -233,8 +220,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -249,8 +235,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	noObjectValidationTest(t, vals, "virtual-1")
@@ -266,8 +251,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	noObjectValidationTest(t, vals, "virtual-1")
@@ -283,8 +267,7 @@ func TestRepeatingFQDNHost(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -311,8 +294,7 @@ func TestRepeatingFQDNWildcardHost(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -339,8 +321,7 @@ func TestIncludedIntoWildCard(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -366,8 +347,7 @@ func TestIncludedIntoWildCard(t *testing.T) {
 	}
 	vals = SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -394,8 +374,7 @@ func TestShortHostNameIncludedIntoWildCard(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -422,8 +401,7 @@ func TestWildcardisMarkedInvalid(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -450,8 +428,7 @@ func TestMultipleHostsFailing(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -475,8 +452,7 @@ func TestMultipleHostsPassing(t *testing.T) {
 	}
 	vals := SingleHostChecker{
 		Namespace:               "bookinfo",
-		VirtualServices:         vss,
-		ExportedVirtualServices: []networking_v1alpha3.VirtualService{},
+		ExportedVirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)

--- a/business/checkers/virtualservices/subset_presence_checker.go
+++ b/business/checkers/virtualservices/subset_presence_checker.go
@@ -12,7 +12,6 @@ import (
 type SubsetPresenceChecker struct {
 	Namespace                string
 	Namespaces               []string
-	DestinationRules         []networking_v1alpha3.DestinationRule
 	ExportedDestinationRules []networking_v1alpha3.DestinationRule
 	VirtualService           networking_v1alpha3.VirtualService
 }
@@ -111,9 +110,9 @@ func (checker SubsetPresenceChecker) subsetPresent(host string, subset string) b
 }
 
 func (checker SubsetPresenceChecker) getDestinationRules(virtualServiceHost string) ([]networking_v1alpha3.DestinationRule, bool) {
-	drs := make([]networking_v1alpha3.DestinationRule, 0, len(checker.DestinationRules)+len(checker.ExportedDestinationRules))
+	drs := make([]networking_v1alpha3.DestinationRule, 0, len(checker.ExportedDestinationRules))
 
-	for _, destinationRule := range append(checker.DestinationRules, checker.ExportedDestinationRules...) {
+	for _, destinationRule := range checker.ExportedDestinationRules {
 		host := destinationRule.Spec.Host
 
 		drHost := kubernetes.GetHost(host, destinationRule.Namespace, destinationRule.ClusterName, checker.Namespaces)

--- a/business/checkers/virtualservices/subset_presence_checker_test.go
+++ b/business/checkers/virtualservices/subset_presence_checker_test.go
@@ -83,8 +83,7 @@ func subsetPresenceCheckerPrep(scenario string, t *testing.T) ([]*models.IstioCh
 	vals, valid := SubsetPresenceChecker{
 		Namespace:                "bookinfo",
 		Namespaces:               namespaceNames(loader.GetNamespaces()),
-		DestinationRules:         loader.FindDestinationRuleIn("bookinfo"),
-		ExportedDestinationRules: loader.FindDestinationRuleNotIn("bookinfo"),
+		ExportedDestinationRules: append(loader.FindDestinationRuleIn("bookinfo"), loader.FindDestinationRuleNotIn("bookinfo")...),
 		VirtualService:           loader.GetResources().VirtualServices[0],
 	}.Check()
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -102,7 +102,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioC
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioConfigList: istioConfigList, ExportedResources: &exportedResources, ServiceList: services, WorkloadList: workloads, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices},
 		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices},
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ExportedServiceEntries: exportedResources.ServiceEntries},
-		checkers.GatewayChecker{Gateways: istioConfigList.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
+		checkers.GatewayChecker{Gateways: exportedResources.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ExportedServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices},
@@ -156,7 +156,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	switch objectType {
 	case kubernetes.Gateways:
 		objectCheckers = []ObjectChecker{
-			checkers.GatewayChecker{Gateways: istioConfigList.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
+			checkers.GatewayChecker{Gateways: exportedResources.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		}
 	case kubernetes.VirtualServices:
 		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices}
@@ -338,6 +338,7 @@ func (in *IstioValidationsService) fetchExportedResources(exportedResources *kub
 
 	criteria := IstioConfigCriteria{
 		AllNamespaces:           true,
+		IncludeGateways:         true,
 		IncludeDestinationRules: true,
 		IncludeServiceEntries:   true,
 		IncludeVirtualServices:  true,
@@ -358,6 +359,9 @@ func (in *IstioValidationsService) fetchExportedResources(exportedResources *kub
 	// Filter SE
 	filteredSEs := in.filterSEExportToNamespaces(namespace, istioConfigList.ServiceEntries)
 	exportedResources.ServiceEntries = append(exportedResources.ServiceEntries, filteredSEs...)
+
+	// All Gateways
+	exportedResources.Gateways = istioConfigList.Gateways
 }
 
 func (in *IstioValidationsService) filterVSExportToNamespaces(namespace string, vs []networking_v1alpha3.VirtualService) []networking_v1alpha3.VirtualService {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -100,13 +100,13 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioConfigList models.IstioConfigList, exportedResources kubernetes.ExportedResources, services models.ServiceList, workloadsPerNamespace map[string]models.WorkloadList, workloads models.WorkloadList, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace, registryServices []*kubernetes.RegistryService) []ObjectChecker {
 	return []ObjectChecker{
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioConfigList: istioConfigList, ExportedResources: &exportedResources, ServiceList: services, WorkloadList: workloads, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices},
-		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, VirtualServices: istioConfigList.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices},
-		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioConfigList.ServiceEntries},
+		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices},
+		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ExportedServiceEntries: exportedResources.ServiceEntries},
 		checkers.GatewayChecker{Gateways: istioConfigList.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
-		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices},
-		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloads, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices},
+		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ExportedServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices},
+		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloads, ServiceList: services, ExportedServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadList: workloads},
 	}
 }
@@ -159,21 +159,21 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 			checkers.GatewayChecker{Gateways: istioConfigList.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		}
 	case kubernetes.VirtualServices:
-		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices}
+		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices}
 		objectCheckers = []ObjectChecker{noServiceChecker, virtualServiceChecker}
 	case kubernetes.DestinationRules:
-		destinationRulesChecker := checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioConfigList.ServiceEntries}
+		destinationRulesChecker := checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ExportedServiceEntries: exportedResources.ServiceEntries}
 		objectCheckers = []ObjectChecker{noServiceChecker, destinationRulesChecker}
 	case kubernetes.ServiceEntries:
 		serviceEntryChecker := checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries}
 		objectCheckers = []ObjectChecker{serviceEntryChecker}
 	case kubernetes.Sidecars:
 		sidecarsChecker := checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces,
-			WorkloadList: workloads, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices}
+			WorkloadList: workloads, ServiceList: services, ExportedServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{sidecarsChecker}
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
-			Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: istioConfigList.ServiceEntries, ExportedServiceEntries: exportedResources.ServiceEntries,
+			Namespace: namespace, Namespaces: namespaces, ServiceList: services, ExportedServiceEntries: exportedResources.ServiceEntries,
 			WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices}
 		objectCheckers = []ObjectChecker{authPoliciesChecker}
 	case kubernetes.PeerAuthentications:

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -32,6 +32,7 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 	conf := config.NewConfig()
 	conf.InCluster = false
 	conf.KubernetesConfig.CacheEnabled = false
+	kialiCache = nil
 	config.Set(conf)
 
 	// As we are not interested in caches in this test, make sure

--- a/kubernetes/cache/registry_test_helper.go
+++ b/kubernetes/cache/registry_test_helper.go
@@ -1,0 +1,30 @@
+package cache
+
+import (
+	"time"
+
+	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+// Fake KialiCache used for Gateway Scenarios
+// It populates the Namespaces, Informers and Gateway information needed
+func FakeGatewaysKialiCache(gws []networking_v1alpha3.Gateway) KialiCache {
+	kialiCacheImpl := kialiCacheImpl{
+		tokenNamespaces: make(map[string]namespaceCache),
+		// ~ long duration for unit testing
+		refreshDuration: time.Hour,
+	}
+
+	// Populate all Gateways using the Registry
+	registryStatus := kubernetes.RegistryStatus{
+		Configuration: &kubernetes.RegistryConfiguration{
+			Gateways: gws,
+		},
+	}
+
+	kialiCacheImpl.SetRegistryStatus(&registryStatus)
+
+	return &kialiCacheImpl
+}

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -166,6 +166,7 @@ type ExportedResources struct {
 	VirtualServices  []networking_v1alpha3.VirtualService  `json:"virtualservices"`
 	DestinationRules []networking_v1alpha3.DestinationRule `json:"destinationrules"`
 	ServiceEntries   []networking_v1alpha3.ServiceEntry    `json:"serviceentries"`
+	Gateways         []networking_v1alpha3.Gateway         `json:"gateways"`
 }
 
 type ProxyStatus struct {


### PR DESCRIPTION
As now the exported resources contains all objects, skip using Istio Objects from IstioConfigList for local namespace.
Exported resources fortains Istio Objects from IstioConfigList for AllNamespaces, so using any other list will cause duplicates.

Fix for issue https://github.com/kiali/kiali/issues/4641

For QE:
Full manual regression testing is required for VirtualServices, DestinationRules and ServiceEntries validations from https://kiali.io/docs/features/validations/
Full UI/E2E automation regression testing is required.