### PR TITLE
Fix empty service list instead of nil value

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -184,7 +184,7 @@ func getDRKialiScenario(dr []networking_v1alpha3.DestinationRule) string {
 }
 
 func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []core_v1.Service, rSvcs []*kubernetes.RegistryService, pods []core_v1.Pod, deployments []apps_v1.Deployment, istioConfigList models.IstioConfigList) *models.ServiceList {
-	var services []models.ServiceOverview
+	services := []models.ServiceOverview{}
 	validations := in.getServiceValidations(svcs, deployments, pods)
 
 	kubernetesServices := in.buildKubernetesServices(svcs, pods, istioConfigList)


### PR DESCRIPTION
Related to https://github.com/kiali/kiali/issues/4589 and https://github.com/kiali/kiali-ui/pull/2283

A regression was introduced as the services linked with a workload were reset to a nil pointer instead of an empty list when a workload has no services.