### PR TITLE
Show all non existing Gateways errors in VirtualServices

### DIFF
--- a/business/checkers/virtualservices/no_gateway_checker.go
+++ b/business/checkers/virtualservices/no_gateway_checker.go
@@ -51,6 +51,7 @@ func (s NoGatewayChecker) ValidateVirtualServiceGateways(validations *[]*models.
 }
 
 func (s NoGatewayChecker) checkGateways(gateways []string, namespace, clusterName string, validations *[]*models.IstioCheck, location string) bool {
+	result := true
 GatewaySearch:
 	for index, gate := range gateways {
 		if gate == "mesh" {
@@ -70,9 +71,9 @@ GatewaySearch:
 		path := fmt.Sprintf("%s/gateways[%d]", location, index)
 		validation := models.Build("virtualservices.nogateway", path)
 		*validations = append(*validations, &validation)
-		return false
+		result = false
 	}
-	return true
+	return result
 }
 
 func checkNomenclature(gateway string, index int, validations *[]*models.IstioCheck) {

--- a/business/checkers/virtualservices/no_gateway_checker_test.go
+++ b/business/checkers/virtualservices/no_gateway_checker_test.go
@@ -32,6 +32,27 @@ func TestMissingGateway(t *testing.T) {
 	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", vals[0]))
 }
 
+func TestMissingGateways(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	virtualService := data.AddGatewaysToVirtualService([]string{"my-gateway", "my-gateway2", "mesh"}, data.CreateVirtualService())
+	checker := NoGatewayChecker{
+		VirtualService: *virtualService,
+		GatewayNames:   make(map[string]struct{}),
+	}
+
+	vals, valid := checker.Check()
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 2)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", vals[0]))
+	assert.Equal(models.ErrorSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", vals[1]))
+}
+
 func TestMissingGatewayInHTTPMatch(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4645

Create VS and add 2 non existing Gateways into spec, before it was showing error message only on first one.
![Screenshot from 2022-01-11 17-09-09](https://user-images.githubusercontent.com/604313/148980026-5903fdc9-5c62-4423-8754-fc640d47dbe0.png)


Now all non existing Gateways get error messages:
![Screenshot from 2022-01-11 17-08-58](https://user-images.githubusercontent.com/604313/148979993-e9a700cb-9776-4e21-8695-7061541c1d65.png)

