### PR TITLE
Enforce specific lengths for signing key

### DIFF
--- a/config/token.go
+++ b/config/token.go
@@ -47,10 +47,10 @@ func GetSigningKey() string {
 }
 
 func ValidateSigningKey(signingKey string, authStrategy string) error {
-	if authStrategy != AuthStrategyAnonymous && (len(signingKey) == 0 || signingKey == "kiali") {
-		// "kiali" is a well-known signing key reported in a CVE. We ban it's usage.
-		// An empty key is also just not allowed.
-		return errors.New("signing key for login tokens is invalid")
+	if authStrategy != AuthStrategyAnonymous {
+		if len(signingKey) != 16 && len(signingKey) != 24 && len(signingKey) != 32 {
+			return errors.New("signing key for sessions must be 16, 24 or 32 bytes length")
+		}
 	}
 
 	return nil

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -38,7 +38,7 @@ func TestStrategyTokenAuthentication(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyToken
-	cfg.LoginToken.SigningKey = util.RandomString(10)
+	cfg.LoginToken.SigningKey = util.RandomString(16)
 	cfg.KubernetesConfig.CacheEnabled = false
 	config.Set(cfg)
 
@@ -95,7 +95,7 @@ func TestStrategyTokenInvalidSignature(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyToken
-	cfg.LoginToken.SigningKey = util.RandomString(10)
+	cfg.LoginToken.SigningKey = util.RandomString(16)
 	config.Set(cfg)
 
 	// Mock the clock
@@ -183,7 +183,7 @@ func TestStrategyTokenValidatesExpiration(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyToken
-	cfg.LoginToken.SigningKey = util.RandomString(10)
+	cfg.LoginToken.SigningKey = util.RandomString(16)
 	config.Set(cfg)
 
 	// Mock the clock
@@ -236,7 +236,7 @@ func TestStrategyTokenMissingUser(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.KubernetesConfig.CacheEnabled = false
 	cfg.Auth.Strategy = config.AuthStrategyToken
-	cfg.LoginToken.SigningKey = util.RandomString(10)
+	cfg.LoginToken.SigningKey = util.RandomString(16)
 	config.Set(cfg)
 	mockK8s(false)
 
@@ -288,7 +288,7 @@ func TestStrategyTokenMissingExpiration(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyToken
-	cfg.LoginToken.SigningKey = util.RandomString(10)
+	cfg.LoginToken.SigningKey = util.RandomString(16)
 	config.Set(cfg)
 
 	// Let's create a valid token that does not expire.
@@ -396,7 +396,7 @@ func TestStrategyHeaderOidcAuthentication(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyHeader
-	cfg.LoginToken.SigningKey = util.RandomString(10)
+	cfg.LoginToken.SigningKey = util.RandomString(16)
 	cfg.KubernetesConfig.CacheEnabled = false
 	config.Set(cfg)
 
@@ -456,7 +456,7 @@ func TestStrategyHeaderAuthentication(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyHeader
-	cfg.LoginToken.SigningKey = util.RandomString(10)
+	cfg.LoginToken.SigningKey = util.RandomString(16)
 	cfg.KubernetesConfig.CacheEnabled = false
 	config.Set(cfg)
 
@@ -516,7 +516,7 @@ func TestStrategyHeaderOidcWithImpersonationAuthentication(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyHeader
-	cfg.LoginToken.SigningKey = util.RandomString(10)
+	cfg.LoginToken.SigningKey = util.RandomString(16)
 	cfg.KubernetesConfig.CacheEnabled = false
 	config.Set(cfg)
 

--- a/kiali.go
+++ b/kiali.go
@@ -159,7 +159,7 @@ func validateConfig() error {
 		return fmt.Errorf("Invalid authentication strategy [%v]", auth.Strategy)
 	}
 
-	// Check the signing key for the JWT token is valid
+	// Check the ciphering key for sessions
 	signingKey := cfg.LoginToken.SigningKey
 	if err := config.ValidateSigningKey(signingKey, auth.Strategy); err != nil {
 		return err

--- a/kiali_test.go
+++ b/kiali_test.go
@@ -13,7 +13,7 @@ func TestValidateWebRoot(t *testing.T) {
 	// create a base config that we know is valid
 	rand.Seed(time.Now().UnixNano())
 	conf := config.NewConfig()
-	conf.LoginToken.SigningKey = util.RandomString(10)
+	conf.LoginToken.SigningKey = util.RandomString(16)
 	conf.Server.StaticContentRootDirectory = "."
 	conf.Auth.Strategy = "anonymous"
 
@@ -55,7 +55,7 @@ func TestValidateAuthStrategy(t *testing.T) {
 	// create a base config that we know is valid
 	rand.Seed(time.Now().UnixNano())
 	conf := config.NewConfig()
-	conf.LoginToken.SigningKey = util.RandomString(10)
+	conf.LoginToken.SigningKey = util.RandomString(16)
 	conf.Server.StaticContentRootDirectory = "."
 
 	// now test some auth strategies, both valid ones and invalid ones


### PR DESCRIPTION
This is to support sessions with AES-GCM encryption.

Related to #4542 