### PR TITLE
Add graph generator for creating mock graph data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -55,6 +56,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.2.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/vjeantet/grok v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,7 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=

--- a/graph/config/cytoscape/cytoscape_test.go
+++ b/graph/config/cytoscape/cytoscape_test.go
@@ -110,3 +110,34 @@ func TestHasWorkloadEntryEmpty(t *testing.T) {
 	cytoNode := cytoConfig.Elements.Nodes[0]
 	assert.Empty(cytoNode.Data.HasWorkloadEntry)
 }
+
+func TestHTTPToTrafficRate(t *testing.T) {
+	assert := assert.New(t)
+
+	traffic := graph.NewTrafficMap()
+
+	svc := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "", "ratings", "", graph.GraphTypeVersionedApp)
+	traffic[svc.ID] = &svc
+
+	v1 := graph.NewNode("testCluster", "appNamespace", "", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	traffic[v1.ID] = &v1
+
+	e := svc.AddEdge(&v1)
+	e.Metadata[graph.HTTP.EdgeResponses] = graph.Responses{
+		"200": &graph.ResponseDetail{
+			Flags: graph.ResponseFlags{
+				"-": 0.3333999999,
+			},
+			Hosts: graph.ResponseHosts{
+				svc.Service: 0.3333999999,
+			},
+		},
+	}
+	e.Metadata[graph.MetadataKey("http")] = 1.00
+
+	cytoConfig := NewConfig(traffic, graph.ConfigOptions{})
+
+	cytoNode := cytoConfig.Elements.Edges[0]
+	assert.NotNil(cytoNode.Data.Traffic)
+	assert.NotNil(cytoNode.Data.Traffic.Rates)
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,41 @@
+# Tools for Kiali maintainers
+
+This folder contains tools for maintainers of the Kiali project.
+
+## Mock graph data
+
+There's two cli tools to help with testing large graph topologies without needing to deploy the underlying resources.
+
+**Note:** You do not need to run the generator before running the proxy. The proxy server will run the generator itself and serve up the mock data from memory by default. If you are testing locally, you probably want to use the proxy. If you want to output the mock data as a json file, then run the generator.
+
+### proxy server
+
+The proxy server runs an http proxy that intercepts all `/api/namespaces/graph` calls and returns mock graph data. The rest of the api calls are passed through to the kiali api. To test the kiali ui using the proxy server, you should start the proxy server then, in the kiali ui's `package.json`, replace the `proxy` field with the address of the proxy server e.g. `"proxy": "https://localhost:10201"`. Finally run `yarn start` and navigate to local node server endpoint: `http://localhost:3000`. When you navigate to the graph page, you should see graph rendered with the mock data.
+
+Running the following command will start the proxy server in https mode.
+
+```bash
+go run tools/cmd/proxy/main.go <kiali-url> --apps 50 --box --https
+```
+
+For more usage information:
+
+```bash
+go run tools/cmd/proxy/main.go --help
+```
+
+### generator
+
+The generator creates a json file with a mock `/api/namespaces/graph` response.
+
+Running the following command will create a json file with 50 apps (workloads + services). There is some randomness in the graph generation so running the command multiple times with the same options will yield different results.
+
+```bash
+go run tools/cmd/generate/main.go --apps 50 --box
+```
+
+For more usage information:
+
+```bash
+go run tools/cmd/generate/main.go --help
+```

--- a/tools/cmd/generate/main.go
+++ b/tools/cmd/generate/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/tools/cmd"
+	"github.com/kiali/kiali/tools/generator"
+)
+
+const (
+	defaultOutputLocation = "_output"
+)
+
+var (
+	boxFlag          bool
+	clusterFlag      string
+	numAppsFlag      int
+	numIngressesFlag int
+	outputFlag       string
+	popStratFlag     generator.PopStratValue = generator.Sparse
+)
+
+func init() {
+	flag.BoolVar(&boxFlag, "box", false, "adds boxing to the graph")
+	flag.StringVar(&clusterFlag, "cluster", "test", "nodes' cluster name")
+	flag.IntVar(&numAppsFlag, "apps", 5, "number of apps to create")
+	flag.IntVar(&numIngressesFlag, "ingresses", 1, "number of ingresses to create")
+	flag.StringVar(&outputFlag, "output", path.Join(cmd.KialiProjectRoot, defaultOutputLocation), "path to output the generated json")
+	flag.Var(&popStratFlag, "population-strategy", "whether the graph should have many or few connections")
+}
+
+func filename() string {
+	return "generated_graph_data.json"
+}
+
+// writeJSONToFile writes the contents to a JSON encoded file.
+func writeJSONToFile(fpath string, contents interface{}) error {
+	// If the file doesn't exist, create it, or append to the file
+	outputPath := path.Join(fpath, filename())
+	log.Infof("Outputting graph data to file: %s", outputPath)
+
+	b, err := json.Marshal(contents)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(outputPath, b, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Usage = cmd.Usage("generate")
+	flag.Parse()
+	cmd.ConfigureKialiLogger()
+
+	kubeCfg, err := cmd.GetKubeConfig()
+	if err != nil {
+		log.Errorf("Unable to get kube config because: '%s'. Using generator without kubeclient works but some functionality such as automatic namespace creation won't be available.", err)
+	}
+
+	popStrat := string(popStratFlag)
+	opts := generator.Options{
+		Cluster:            &clusterFlag,
+		IncludeBoxing:      &boxFlag,
+		NumberOfApps:       &numAppsFlag,
+		NumberOfIngress:    &numIngressesFlag,
+		PopulationStrategy: &popStrat,
+	}
+
+	if kubeCfg != nil {
+		kubeClient, err := kubernetes.NewForConfig(kubeCfg)
+		if err != nil {
+			log.Errorf("Unable to create kube client because: '%s'. Using generator without kubeclient works but some functionality such as automatic namespace creation won't be available.", err)
+		} else {
+			opts.KubeClient = kubeClient
+		}
+	}
+
+	g, err := generator.New(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Info("Generating graph...")
+	graph := g.Generate()
+
+	err = writeJSONToFile(outputFlag, graph)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Info("Success!!")
+}

--- a/tools/cmd/proxy/main.go
+++ b/tools/cmd/proxy/main.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kiali/kiali/graph/config/cytoscape"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/tools/cmd"
+	"github.com/kiali/kiali/tools/generator"
+)
+
+var homeDir, _ = os.UserHomeDir()
+
+// Generate flags
+var (
+	boxFlag          bool
+	clusterFlag      string
+	numAppsFlag      int
+	numIngressesFlag int
+	popStratFlag     generator.PopStratValue = generator.Sparse
+)
+
+// Proxy specific flags
+var (
+	certFileFlag string
+	dataDirFlag  string
+	httpsFlag    bool
+	keyFileFlag  string
+)
+
+func init() {
+	// Proxy specific flags
+	flag.StringVar(&certFileFlag, "cert-file", filepath.Join(homeDir, ".minikube/ca.crt"), "path to cert file for https")
+	flag.StringVar(&dataDirFlag, "data-dir", "", "path to dir where json graph data is.")
+	flag.BoolVar(&httpsFlag, "https", false, "use https. Uses minikube certs by default")
+	flag.StringVar(&keyFileFlag, "key-file", filepath.Join(homeDir, ".minikube/ca.key"), "path to key file for https")
+
+	// Generate flags
+	flag.BoolVar(&boxFlag, "box", false, "adds boxing to the graph")
+	flag.StringVar(&clusterFlag, "cluster", "test", "nodes' cluster name")
+	flag.IntVar(&numAppsFlag, "apps", 5, "number of apps to create")
+	flag.IntVar(&numIngressesFlag, "ingresses", 1, "number of ingresses to create")
+	flag.Var(&popStratFlag, "population-strategy", "whether the graph should have many or few connections")
+}
+
+func loadGraphFromFile(filename string) (*cytoscape.Config, error) {
+	contents, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	cyGraph := &cytoscape.Config{}
+	err = json.Unmarshal(contents, cyGraph)
+	if err != nil {
+		return nil, err
+	}
+
+	return cyGraph, nil
+}
+
+type graphProxy struct {
+	httpProxy *httputil.ReverseProxy
+	generator *generator.Generator
+	graph     *cytoscape.Config
+}
+
+func (p graphProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == "/api/namespaces/graph" {
+		log.Debug("Serving mock graph data...")
+		content, err := json.Marshal(p.graph)
+		if err != nil {
+			log.Errorf("Unable to marshal graph to JSON. Err: %s", err)
+			rw.WriteHeader(500)
+			return
+		}
+
+		_, err = rw.Write(content)
+		if err != nil {
+			log.Errorf("Unable to write content. Err: %s", err)
+			rw.WriteHeader(500)
+		}
+
+		return
+	}
+
+	p.httpProxy.ServeHTTP(rw, req)
+}
+
+func exitWithUsage(msg string) {
+	if !strings.HasSuffix(msg, "\n\n") {
+		msg = msg + "\n"
+	}
+	fmt.Fprint(flag.CommandLine.Output(), msg)
+	flag.Usage()
+	os.Exit(1)
+}
+
+func extractPosArgFromArgs() (string, []string) {
+	args := os.Args[1:]
+	for i, arg := range args {
+		if !strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
+			return arg, append(args[:i], args[i+1:]...)
+		}
+	}
+	return "", args
+}
+
+func main() {
+	cmd.ConfigureKialiLogger()
+
+	flag.Usage = cmd.Usage("proxy", "<kiali-url>")
+	if len(os.Args) < 2 {
+		exitWithUsage("Error: Not enough arguments\n\n")
+	}
+
+	// The default flag.Parse() does not handle posargs interspersed with flags well
+	// so extract out the url pos arg first before passing the args to Parse.
+	urlArg, args := extractPosArgFromArgs()
+	_ = flag.CommandLine.Parse(args)
+	// Parse first in case '-help' is passed.
+	if urlArg == "" {
+		exitWithUsage("Error: 'kiali-url' is a required positional arg\n\n")
+	}
+
+	u, err := url.Parse(urlArg)
+	if err != nil {
+		log.Fatalf("unable to parse kiali url. Err: '%s'", err)
+	}
+
+	opts := generator.Options{
+		NumberOfApps:    &numAppsFlag,
+		NumberOfIngress: &numIngressesFlag,
+		IncludeBoxing:   &boxFlag,
+	}
+
+	kubeCfg, err := cmd.GetKubeConfig()
+	if err != nil {
+		log.Warningf("Unable to construct kube config because error: '%s'. Some functionality such as namespace creation may not work.", err)
+	}
+	if kubeCfg != nil {
+		opts.KubeClient = kubernetes.NewForConfigOrDie(kubeCfg)
+	}
+
+	gen, err := generator.New(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var graph *cytoscape.Config
+	if dataDirFlag == "" {
+		log.Info("Populating graph data...")
+		g := gen.Generate()
+		graph = &g
+	} else {
+		graph, err = loadGraphFromFile(dataDirFlag)
+		if err != nil {
+			log.Fatalf("Unable to load graph from file. Err: %s", err)
+		}
+
+		err = gen.EnsureNamespaces(*graph)
+		if err != nil {
+			log.Fatalf("Unable to ensure namespaces. Err: %s", err)
+		}
+	}
+
+	proxy := graphProxy{
+		httpProxy: httputil.NewSingleHostReverseProxy(u),
+		generator: gen,
+		graph:     graph,
+	}
+
+	serveMsgTmpl := "Ready to handle requests on: '%s://localhost:10201'."
+	if httpsFlag {
+		log.Infof(serveMsgTmpl, "https")
+		customTransport := http.DefaultTransport.(*http.Transport)
+		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		proxy.httpProxy.Transport = customTransport
+		log.Fatal(http.ListenAndServeTLS(":10201", certFileFlag, keyFileFlag, proxy))
+	} else {
+		log.Infof(serveMsgTmpl, "http")
+		log.Fatal(http.ListenAndServe(":10201", proxy))
+	}
+}

--- a/tools/cmd/util.go
+++ b/tools/cmd/util.go
@@ -1,0 +1,95 @@
+// Shared helpers across commands.
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/kiali/kiali/log"
+)
+
+var (
+	// Adapted from: https://stackoverflow.com/a/38644571
+	_, b, _, _ = runtime.Caller(0)
+	basepath   = filepath.Dir(b)
+	// This works so long as the current dir structure stays the same.
+	// This should be the base of the project e.g. '/home/user1/kiali'.
+	// If the location of this file changes, this needs to be updated as well.
+	KialiProjectRoot = path.Dir(path.Dir(basepath))
+)
+
+// GetKubeConfig constructs a kube config from either the user's local kube config
+// or the KUBECONFIG env var.
+func GetKubeConfig() (*rest.Config, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+
+	if len(kubeconfig) == 0 {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("Unable to find user home dir. Err: %w", err)
+		}
+		kubeconfig = fmt.Sprintf("%s/.kube/config", home)
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to build config from flags: %w", err)
+	}
+
+	return restConfig, nil
+}
+
+func ConfigureKialiLogger() {
+	// Kiali logger is configured through env vars and the default format is json which isn't very nice for cmdline.
+	if err := os.Setenv("LOG_FORMAT", "text"); err != nil {
+		log.Errorf("Unable to configure logger. Err: %s", err)
+	} else {
+		log.InitializeLogger()
+	}
+}
+
+// Usage creates a custom usage function that allows you to specify position
+// arguments and prints flags with two dashes instead of one e.g. '--url'
+// instead of '-url'.
+//
+// You can assign this to flag.Usage directly or any other FlagSet.Usage
+// e.g. 'flag.Usage = Usage(requiredFlag1)'.
+//
+// The resulting Usage will look like:
+// Usage: cmd <pos-arg1> <pos-arg2> ... [Options]
+//
+// Options:
+//  --opt1 string
+//        opt description (default "")
+// ...
+func Usage(cmd string, posArgs ...string) func() {
+	return func() {
+		var b strings.Builder
+		fmt.Fprintf(&b, "Usage: %s ", cmd)
+		for _, arg := range posArgs {
+			b.WriteString(arg + " ")
+		}
+		b.WriteString("[Options]\n\n")
+		b.WriteString("Options:\n")
+		flag.VisitAll(func(f *flag.Flag) {
+			fType, _ := flag.UnquoteUsage(f)
+			fmt.Fprintf(&b, "  --%s %s\n", f.Name, fType)
+
+			b.WriteString("\t" + f.Usage)
+			if f.DefValue == "" {
+				fmt.Fprintf(&b, " (default %q)\n", f.DefValue)
+			} else {
+				fmt.Fprintf(&b, " (default %s)\n", f.DefValue)
+			}
+		})
+		fmt.Fprint(flag.CommandLine.Output(), b.String())
+	}
+}

--- a/tools/generator/generator.go
+++ b/tools/generator/generator.go
@@ -1,0 +1,323 @@
+package generator
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/graph/config/cytoscape"
+	"github.com/kiali/kiali/log"
+)
+
+const (
+	// Dense creates a graph with many nodes.
+	Dense = "dense"
+	// Sparse creates a graph with few nodes.
+	Sparse = "sparse"
+
+	maxWorkloadVersions = 3
+)
+
+type app struct {
+	Box       string
+	Cluster   string
+	Name      string
+	Namespace string
+	IsIngress bool
+}
+
+// Generator creates cytoscape graph data based on the options provided.
+// It is used for testing a variety of graph layouts, large dense graphs in particular,
+// without needing to deploy the actual resources. It is not intended to be used for
+// anything other than testing.
+type Generator struct {
+	// Cluster is the name of the cluster all nodes will live in.
+	Cluster string
+
+	// Type of graph to render e.g. Versioned App Graph.
+	GraphType string
+
+	// IncludeBoxing determines whether nodes will include boxing or not.
+	IncludeBoxing bool
+
+	// NumberOfApps sets how many apps to create.
+	NumberOfApps int
+
+	// NumberOfIngress sets how many ingress to create.
+	NumberOfIngress int
+
+	// PopulationStrategy determines how many connections from ingress i.e. dense or sparse.
+	PopulationStrategy string
+
+	kubeClient      kubernetes.Interface
+	namespaceLister corev1listers.NamespaceLister
+}
+
+// New create a new Generator. Options can be nil.
+func New(opts Options) (*Generator, error) {
+	g := Generator{
+		Cluster:            "test",
+		GraphType:          graph.GraphTypeVersionedApp,
+		IncludeBoxing:      true,
+		NumberOfApps:       10,
+		NumberOfIngress:    1,
+		PopulationStrategy: Dense,
+	}
+
+	// Kube specific options
+	if opts.KubeClient != nil {
+		g.kubeClient = opts.KubeClient
+
+		kubeInformerFactory := kubeinformers.NewSharedInformerFactory(g.kubeClient, time.Second*30)
+		g.namespaceLister = kubeInformerFactory.Core().V1().Namespaces().Lister()
+		namespacesSynced := kubeInformerFactory.Core().V1().Namespaces().Informer().HasSynced
+
+		stopCh := make(<-chan struct{})
+		kubeInformerFactory.Start(stopCh)
+
+		if ok := cache.WaitForCacheSync(stopCh, namespacesSynced); !ok {
+			log.Fatalf("Failed waiting for caches to sync")
+		}
+	}
+
+	if opts.Cluster != nil {
+		g.Cluster = *opts.Cluster
+	}
+	if opts.IncludeBoxing != nil {
+		g.IncludeBoxing = *opts.IncludeBoxing
+	}
+	if opts.NumberOfApps != nil {
+		g.NumberOfApps = *opts.NumberOfApps
+	}
+	if opts.NumberOfIngress != nil {
+		g.NumberOfIngress = *opts.NumberOfIngress
+	}
+	if opts.PopulationStrategy != nil {
+		g.PopulationStrategy = *opts.PopulationStrategy
+	}
+
+	return &g, nil
+}
+
+// EnsureNamespaces makes sure a kube namespace exists for the nodes.
+// The namespaces need to actually exist in order for the UI to render the graph.
+// Does nothing if a kubeclient is not configured.
+func (g *Generator) EnsureNamespaces(cyGraph cytoscape.Config) error {
+	if g.kubeClient != nil {
+		log.Info("Ensuring namespaces exist for graph...")
+		for _, node := range cyGraph.Elements.Nodes {
+			if err := g.ensureNamespace(node.Data.Namespace); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Generate creates a graph response object based on the generator's options.
+// The generated graph assumes that:
+// 1. Workloads send requests to services.
+// 2. Services send requests to the workloads in their app.
+// 3. Ingress workloads are root nodes.
+func (g *Generator) Generate() cytoscape.Config {
+	nodes := g.generate()
+	traffic := graph.NewTrafficMap()
+	for _, node := range nodes {
+		traffic[node.ID] = node
+	}
+
+	// Hard coding some of these for now. In the future, the generator can
+	// support multiple graph types.
+	opts := graph.ConfigOptions{
+		CommonOptions: graph.CommonOptions{
+			Duration:  time.Minute * 15,
+			GraphType: g.GraphType,
+			QueryTime: int64(15),
+		},
+		BoxBy: strings.Join([]string{graph.BoxByApp, graph.BoxByNamespace}, ","),
+	}
+	cyGraph := cytoscape.NewConfig(traffic, opts)
+
+	if err := g.EnsureNamespaces(cyGraph); err != nil {
+		log.Errorf("unable to ensure namespaces exist. Err: %s", err)
+	}
+
+	return cyGraph
+}
+
+func (g *Generator) strategyLimit() int {
+	switch g.PopulationStrategy {
+	case Dense:
+		return g.NumberOfApps
+	case Sparse:
+		return g.NumberOfApps / 2
+	}
+
+	return -1
+}
+
+func (g *Generator) genAppsWithIngress(index int, numApps int) []*graph.Node {
+	var nodes []*graph.Node
+
+	// Create ingress workload first.
+	ingress := app{
+		Cluster:   g.Cluster,
+		Name:      fmt.Sprintf("istio-ingressgateway-%d", index),
+		Namespace: "istio-system",
+		IsIngress: true,
+	}
+	iNodes := []*graph.Node{g.newWorkloadNode(ingress, "latest")}
+
+	// Then create the rest of them.
+	for i := 1; i <= numApps; i++ {
+		app := app{
+			Cluster: g.Cluster,
+			Name:    fmt.Sprintf("app-%d", i),
+			// Creates at most a namespace per app.
+			// Multiple apps can land in the same namespace.
+			// TODO: Provide option to control this.
+			Namespace: getRandomNamespace(1, g.NumberOfApps),
+		}
+		appNodes := g.genApp(app)
+		nodes = append(nodes, appNodes...)
+	}
+
+	// Add edges from the ingress workload to each of the app's service node.
+	// This simulates traffic coming in from ingress and going out to each of
+	// the service nodes in the graph.
+	iWorkloads := filterByApp(iNodes)
+	svcs := filterByService(nodes)
+
+	for _, wk := range iWorkloads {
+		for i := 0; i < g.strategyLimit() && i < len(svcs); i++ {
+			svc := svcs[i]
+			e := wk.AddEdge(svc)
+			addFakeEdgeTraffic(e, svc.Service)
+		}
+	}
+
+	nodes = append(nodes, iNodes...)
+
+	return nodes
+}
+
+func (g *Generator) generate() []*graph.Node {
+	rand.Seed(time.Now().UnixNano())
+	var nodes []*graph.Node
+
+	appsPerIngress := g.NumberOfApps / g.NumberOfIngress
+	for i := 0; i < g.NumberOfIngress; i++ {
+		n := g.genAppsWithIngress(i, appsPerIngress)
+		nodes = append(nodes, n...)
+	}
+	// TODO: Random connections to other services
+
+	return nodes
+}
+
+func (g *Generator) genApp(app app) []*graph.Node {
+	var nodes []*graph.Node
+
+	svc := g.newServiceNode(app)
+	nodes = append(nodes, svc)
+
+	// Determine how many workload versions there will be.
+	numVersions := rand.Intn(maxWorkloadVersions) + 1 // Start at v1 instead of 0
+	for i := 1; i <= numVersions; i++ {
+		workload := g.newWorkloadNode(app, fmt.Sprintf("v%d", i))
+		nodes = append(nodes, workload)
+		e := svc.AddEdge(workload)
+		addFakeEdgeTraffic(e, svc.Service)
+	}
+
+	return nodes
+}
+
+func addFakeEdgeTraffic(e *graph.Edge, destination string) {
+	e.Metadata[graph.ProtocolKey] = "http"
+	e.Metadata[graph.HTTP.EdgeResponses] = graph.Responses{
+		"200": &graph.ResponseDetail{
+			Flags: graph.ResponseFlags{
+				"-": 0.3333999999,
+			},
+			Hosts: graph.ResponseHosts{
+				destination: 0.3333999999,
+			},
+		},
+	}
+	e.Metadata[graph.MetadataKey("http")] = 1.00
+}
+
+func (g *Generator) newServiceNode(app app) *graph.Node {
+	// It is important to leave app name blank here, otherwise this node will be considered a workload.
+	s := graph.NewNode(app.Cluster, app.Namespace, app.Name, app.Namespace, "", "", "", g.GraphType)
+	return &s
+}
+
+func (g *Generator) newWorkloadNode(app app, version string) *graph.Node {
+	workload := app.Name + "-" + version
+	node := graph.NewNode(app.Cluster, app.Namespace, "", app.Namespace, workload, app.Name, version, g.GraphType)
+	if app.IsIngress {
+		node.Metadata[graph.IsRoot] = true
+		node.Metadata[graph.IsIngressGateway] = graph.GatewaysMetadata{node.Workload: []string{"*"}}
+		node.Metadata[graph.IsOutside] = true
+	}
+	return &node
+}
+
+func (g *Generator) ensureNamespace(name string) error {
+	if _, err := g.namespaceLister.Get(name); err != nil {
+		if kubeerrors.IsNotFound(err) {
+			log.Infof("Namespace: '%s' does not exist. Creating...", name)
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			_, err = g.kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+			if err != nil && !kubeerrors.IsAlreadyExists(err) {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func filterByApp(nodes []*graph.Node) []*graph.Node {
+	var workloads []*graph.Node
+	for i, n := range nodes {
+		if n.NodeType == graph.NodeTypeApp {
+			workloads = append(workloads, nodes[i])
+		}
+	}
+	return workloads
+}
+
+func filterByService(nodes []*graph.Node) []*graph.Node {
+	var services []*graph.Node
+	for i, n := range nodes {
+		if n.NodeType == graph.NodeTypeService {
+			services = append(services, nodes[i])
+		}
+	}
+	return services
+}
+
+func generateNamespaceName(numNamespace int) string {
+	return fmt.Sprintf("n%d", numNamespace)
+}
+
+func getRandomNamespace(from, to int) string {
+	numNamespace := from + rand.Intn(to)
+	return generateNamespaceName(numNamespace)
+}

--- a/tools/generator/options.go
+++ b/tools/generator/options.go
@@ -1,0 +1,43 @@
+package generator
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// Options used to configure a Generator.
+type Options struct {
+	// Cluster is the name of the cluster all nodes will live in.
+	Cluster *string
+
+	// IncludeBoxing determines whether nodes will include boxing or not.
+	IncludeBoxing *bool
+
+	// KubeClient if passed enables talking to the kube api to get/create namespaces.
+	KubeClient kubernetes.Interface
+
+	// NumberOfApps sets how many apps to create.
+	NumberOfApps *int
+
+	// NumberOfIngress sets how many ingress to create.
+	NumberOfIngress *int
+
+	// PopulationStrategy determines how many connections from ingress i.e. dense or sparse.
+	PopulationStrategy *string
+}
+
+// PopStratValue implements flag.Value interface so pop strategy can be used
+// as a flag.
+type PopStratValue string
+
+func (p *PopStratValue) String() string {
+	return fmt.Sprint(*p)
+}
+
+func (i *PopStratValue) Set(value string) error {
+	if value != Dense && value != Sparse {
+		return fmt.Errorf("%s is not valid. Use: '%s' or '%s'", value, Dense, Sparse)
+	}
+	return nil
+}


### PR DESCRIPTION
The generator creates a very basic graph but has a few configurable knobs. This was primarily tested with [this patch](https://github.com/nrfox/kiali/compare/kiali-4585...nrfox:patch-graph-generator?expand=1) but the eventual goal is to use something like cypress from https://github.com/kiali/kiali-ui/pull/2264 when it's ready to mock out the request and return the json data generated by the generator.

Also adds a simple proxy server to serve the generated graph data from memory. See [here](https://github.com/kiali/kiali/blob/d5ee726d0859886cd978cd74a9d3a3e37344f87d/tools/README.md) for instructions on running/testing both.

Sample output:
![Screenshot from 2022-01-14 13-06-03](https://user-images.githubusercontent.com/6226732/149563877-0ae2218b-2977-4f82-89e1-064347802a70.png)

Relates to #4585 
