### PR TITLE
E2E: Removed_Iter8 api

### DIFF
--- a/tests/e2e/tests/test_api_methods.py
+++ b/tests/e2e/tests/test_api_methods.py
@@ -25,7 +25,7 @@ def before_all_tests(kiali_client):
     swagger = kiali_client.swagger_parser.swagger
     swagger_method_list= []
     tested_method_list = ['root','jaegerInfo', 'grafanaInfo', 'getPermissions', 'getStatus', 'getConfig', 'authenticate',
-                          'namespaceList', 'namespaceMetrics','namespaceHealth','istioStatus','iter8Experiments',
+                          'namespaceList', 'namespaceMetrics','namespaceHealth','istioStatus',
                           'istioConfigList', 'istioConfigDetails', 'istioConfigCreate', 'istioConfigDelete', 'objectValidations', ''
                           'serviceList', 'serviceDetails', 'serviceMetrics', 'serviceHealth',
                           'appHealth', 'appList', 'appDetails', 'appMetrics',
@@ -117,9 +117,6 @@ def test_grafana_info(kiali_client):
     
 def test_get_permissions(kiali_client):
     common_utils.get_response(kiali_client, method_name='getPermissions')
-    
-def test_iter8_experiments(kiali_client):
-    common_utils.get_response(kiali_client, method_name='iter8Experiments')
 
 def test_istio_status(kiali_client):
     common_utils.get_response(kiali_client, method_name='istioStatus')  


### PR DESCRIPTION
https://github.com/kiali/kiali-operator/pull/475.

Iter8 feature has been deleted, that is the resaon. removed that API from test run