### PR TITLE
Replaced ExportedDestinationRules variable with DestinationRules.

### DIFF
--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -13,16 +13,15 @@ import (
 const AuthorizationPolicyCheckerType = "authorizationpolicy"
 
 type AuthorizationPolicyChecker struct {
-	AuthorizationPolicies   []security_v1beta.AuthorizationPolicy
-	Namespace               string
-	Namespaces              models.Namespaces
-	ServiceEntries          []networking_v1alpha3.ServiceEntry
-	ServiceList             models.ServiceList
-	WorkloadList            models.WorkloadList
-	MtlsDetails             kubernetes.MTLSDetails
-	VirtualServices         []networking_v1alpha3.VirtualService
-	ExportedVirtualServices []networking_v1alpha3.VirtualService
-	RegistryServices        []*kubernetes.RegistryService
+	AuthorizationPolicies []security_v1beta.AuthorizationPolicy
+	Namespace             string
+	Namespaces            models.Namespaces
+	ServiceEntries        []networking_v1alpha3.ServiceEntry
+	ServiceList           models.ServiceList
+	WorkloadList          models.WorkloadList
+	MtlsDetails           kubernetes.MTLSDetails
+	VirtualServices       []networking_v1alpha3.VirtualService
+	RegistryServices      []*kubernetes.RegistryService
 }
 
 func (a AuthorizationPolicyChecker) Check() models.IstioValidations {

--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -12,11 +12,10 @@ import (
 const DestinationRuleCheckerType = "destinationrule"
 
 type DestinationRulesChecker struct {
-	DestinationRules         []networking_v1alpha3.DestinationRule
-	ExportedDestinationRules []networking_v1alpha3.DestinationRule
-	MTLSDetails              kubernetes.MTLSDetails
-	ServiceEntries           []networking_v1alpha3.ServiceEntry
-	Namespaces               []models.Namespace
+	DestinationRules []networking_v1alpha3.DestinationRule
+	MTLSDetails      kubernetes.MTLSDetails
+	ServiceEntries   []networking_v1alpha3.ServiceEntry
+	Namespaces       []models.Namespace
 }
 
 func (in DestinationRulesChecker) Check() models.IstioValidations {
@@ -34,12 +33,12 @@ func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 	seHosts := kubernetes.ServiceEntryHostnames(in.ServiceEntries)
 
 	enabledDRCheckers := []GroupChecker{
-		destinationrules.MultiMatchChecker{Namespaces: in.Namespaces, ServiceEntries: seHosts, ExportedDestinationRules: in.ExportedDestinationRules},
+		destinationrules.MultiMatchChecker{Namespaces: in.Namespaces, ServiceEntries: seHosts, DestinationRules: in.DestinationRules},
 	}
 
 	// Appending validations that only applies to non-autoMTLS meshes
 	if !in.MTLSDetails.EnabledAutoMtls {
-		enabledDRCheckers = append(enabledDRCheckers, destinationrules.TrafficPolicyChecker{DestinationRules: in.DestinationRules, ExportedDestinationRules: in.ExportedDestinationRules, MTLSDetails: in.MTLSDetails})
+		enabledDRCheckers = append(enabledDRCheckers, destinationrules.TrafficPolicyChecker{DestinationRules: in.DestinationRules, MTLSDetails: in.MTLSDetails})
 	}
 
 	for _, checker := range enabledDRCheckers {

--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -13,9 +13,9 @@ import (
 const DestinationRulesCheckerType = "destinationrule"
 
 type MultiMatchChecker struct {
-	ExportedDestinationRules []networking_v1alpha3.DestinationRule
-	ServiceEntries           map[string][]string
-	Namespaces               models.Namespaces
+	DestinationRules []networking_v1alpha3.DestinationRule
+	ServiceEntries   map[string][]string
+	Namespaces       models.Namespaces
 }
 
 type subset struct {
@@ -36,7 +36,7 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 	// Equality search is: [fqdn.String()][subset] except for ServiceEntry targets which use [host][subset]
 	seenHostSubsets := make(map[string]map[string][]rule)
 
-	for _, dr := range m.ExportedDestinationRules {
+	for _, dr := range m.DestinationRules {
 		destinationRulesName := dr.Name
 		destinationRulesNamespace := dr.Namespace
 		fqdn := kubernetes.GetHost(dr.Spec.Host, dr.Namespace, dr.ClusterName, m.Namespaces.GetNames())

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -25,7 +25,7 @@ func TestMultiHostMatchCorrect(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -47,7 +47,7 @@ func TestMultiHostMatchInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -91,7 +91,7 @@ func TestMultiHostMatchInvalidShortFormat(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -119,7 +119,7 @@ func TestMultiHostMatchValidShortFormat(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -144,7 +144,7 @@ func TestMultiHostMatchValidShortFormatDiffNamespace(t *testing.T) {
 			models.Namespace{Name: "bookinfo"},
 			models.Namespace{Name: "test"},
 		},
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	// MultiMatchChecker shouldn't fail if a host is in a different namespace
@@ -163,7 +163,7 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -182,7 +182,7 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -208,7 +208,7 @@ func TestMultiHostMatchBothWildcardInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -227,7 +227,7 @@ func TestMultiHostMatchBothWildcardInvalid(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -254,7 +254,7 @@ func TestMultiHostMatchingMeshWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -276,7 +276,7 @@ func TestMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -299,7 +299,7 @@ func TestMultiHostMatchDifferentSubsets(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -310,7 +310,7 @@ func TestMultiHostMatchDifferentSubsets(t *testing.T) {
 	)
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -329,7 +329,7 @@ func TestReviewsExample(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.Empty(vals)
@@ -338,7 +338,7 @@ func TestReviewsExample(t *testing.T) {
 	destinationRules = append(destinationRules, *allMatch)
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: destinationRules,
+		DestinationRules: destinationRules,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -366,8 +366,8 @@ func TestMultiServiceEntry(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test", "service-b", "api.service_b.com")
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
-		ServiceEntries:           kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA, *seB}),
+		DestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
+		ServiceEntries:   kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA, *seB}),
 	}.Check()
 
 	assert.Empty(vals)
@@ -385,8 +385,8 @@ func TestMultiServiceEntryInvalid(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test", "service-a2", "api.service_a.com")
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
-		ServiceEntries:           kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA}),
+		DestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
+		ServiceEntries:   kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA}),
 	}.Check()
 
 	assert.NotEmpty(vals)

--- a/business/checkers/destinationrules/multi_match_exported_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_exported_checker_test.go
@@ -28,7 +28,7 @@ func TestExportMultiHostMatchCorrect(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -53,7 +53,7 @@ func TestExportMultiHostMatchInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "test2"},
@@ -90,7 +90,7 @@ func TestExportMultiHostMatchInvalid2(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "test2"},
@@ -142,7 +142,7 @@ func TestExportMultiHostMatchValidShortFormat(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -166,7 +166,7 @@ func TestExportMultiHostMatchValidShortFormat2(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -195,7 +195,7 @@ func TestExportMultiHostMatchValidShortFormatDiffNamespace(t *testing.T) {
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "test2"},
 		},
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	// MultiMatchChecker shouldn't fail if a host is in a different namespace
@@ -217,7 +217,7 @@ func TestExportMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -239,7 +239,7 @@ func TestExportMultiHostMatchWildcardInvalid(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -268,7 +268,7 @@ func TestExportMultiHostMatchBothWildcardInvalid(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -290,7 +290,7 @@ func TestExportMultiHostMatchBothWildcardInvalid(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -319,7 +319,7 @@ func TestExportMultiHostMatchBothWildcardInvalid2(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -341,7 +341,7 @@ func TestExportMultiHostMatchBothWildcardInvalid2(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -370,7 +370,7 @@ func TestExportMultiHostMatchBothWildcardInvalid3(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -392,7 +392,7 @@ func TestExportMultiHostMatchBothWildcardInvalid3(t *testing.T) {
 	}
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -422,7 +422,7 @@ func TestExportMultiHostMatchingMeshWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -447,7 +447,7 @@ func TestExportMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -473,7 +473,7 @@ func TestExportMultiHostMatchDifferentSubsets(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -484,7 +484,7 @@ func TestExportMultiHostMatchDifferentSubsets(t *testing.T) {
 	)
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -506,7 +506,7 @@ func TestExportReviewsExample(t *testing.T) {
 	}
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.Empty(vals)
@@ -515,7 +515,7 @@ func TestExportReviewsExample(t *testing.T) {
 	edr = append(edr, *allMatch)
 
 	vals = MultiMatchChecker{
-		ExportedDestinationRules: append(destinationRules, edr...),
+		DestinationRules: append(destinationRules, edr...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -543,8 +543,8 @@ func TestExportMultiServiceEntry(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test2", "service-b", "api.service_b.com")
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
-		ServiceEntries:           kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA, *seB}),
+		DestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
+		ServiceEntries:   kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA, *seB}),
 	}.Check()
 
 	assert.Empty(vals)
@@ -562,8 +562,8 @@ func TestExportMultiServiceEntryInvalid(t *testing.T) {
 	drB := data.CreateEmptyDestinationRule("test2", "service-a2", "api.service_a.com")
 
 	vals := MultiMatchChecker{
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
-		ServiceEntries:           kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA}),
+		DestinationRules: []networking_v1alpha3.DestinationRule{*drA, *drB},
+		ServiceEntries:   kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{*seA}),
 	}.Check()
 
 	assert.NotEmpty(vals)

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -243,9 +243,8 @@ func testValidationAdded(t *testing.T, destinationRules []networking_v1alpha3.De
 	assert := assert.New(t)
 
 	vals := TrafficPolicyChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
-		MTLSDetails:              mTLSDetails,
+		DestinationRules: destinationRules,
+		MTLSDetails:      mTLSDetails,
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -268,9 +267,8 @@ func testValidationsNotAdded(t *testing.T, destinationRules []networking_v1alpha
 	assert := assert.New(t)
 
 	vals := TrafficPolicyChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: []networking_v1alpha3.DestinationRule{},
-		MTLSDetails:              mTLSDetails,
+		DestinationRules: destinationRules,
+		MTLSDetails:      mTLSDetails,
 	}.Check()
 
 	assert.Empty(vals)

--- a/business/checkers/destinationrules/traffic_policy_exported_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_exported_checker_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
+type NameNamespace struct {
+	Name      string
+	Namespace string
+}
+
 // Context: MeshPolicy Enabling mTLS
 // Context: DestinationRule doesn't specify trafficPolicy
 // Context: ExportedDestinationRule specifies trafficPolicy
@@ -39,7 +44,10 @@ func TestMTLSMeshWideEnabledDRWithoutTrafficPolicyExportedWith(t *testing.T) {
 			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
 	}
 
-	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo"})
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 	presentReferences(t, *validation, "istio-system", []string{"default"})
 	presentReferences(t, *validation, "bookinfo", []string{"default"})
 	presentReferences(t, *validation, "bookinfo2", []string{"reviews"})
@@ -71,7 +79,11 @@ func TestMTLSMeshWideEnabledDRWithoutTrafficPolicyExportedWithout(t *testing.T) 
 		*data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local"),
 	}
 
-	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo"})
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo2"})
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 	presentReferences(t, *validation, "istio-system", []string{"default"})
 	presentReferences(t, *validation, "bookinfo", []string{"default"})
 	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
@@ -103,8 +115,11 @@ func TestMTLSMeshWideEnabledDRWithoutmTLSOptionsExportedWithout(t *testing.T) {
 		*data.AddTrafficPolicyToDestinationRule(data.CreateLoadBalancerTrafficPolicyForDestinationRules(),
 			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
 	}
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo"})
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo2"})
 
-	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 	presentReferences(t, *validation, "bookinfo", []string{"default"})
 	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
 }
@@ -136,7 +151,10 @@ func TestMTLSMeshWideEnabledDRWithoutmTLSOptionsExportedWith(t *testing.T) {
 			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
 	}
 
-	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo"})
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 	presentReferences(t, *validation, "bookinfo", []string{"default"})
 	presentReferences(t, *validation, "bookinfo2", []string{"reviews"})
 }
@@ -168,7 +186,11 @@ func TestMTLSMeshWideEnabledDRWithoutPortLevelmTLSOptionsExportedWithout(t *test
 			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
 	}
 
-	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo"})
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo2"})
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 	presentReferences(t, *validation, "bookinfo", []string{"default"})
 	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
 }
@@ -200,7 +222,10 @@ func TestMTLSMeshWideEnabledDRWithoutPortLevelmTLSOptionsExportedWith(t *testing
 			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local")),
 	}
 
-	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo"})
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 	presentReferences(t, *validation, "bookinfo", []string{"default"})
 	presentReferences(t, *validation, "bookinfo2", []string{"reviews"})
 }
@@ -261,7 +286,10 @@ func TestMTLSMeshWideEnabledDRWithTrafficPolicyExportedWithout(t *testing.T) {
 		*data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo.svc.cluster.local"),
 	}
 
-	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo2"})
+
+	testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 }
 
 // Context: MeshPolicy Enabling mTLS
@@ -289,7 +317,10 @@ func TestMTLSMeshWideEnabledDRWithPortLevelTLSTrafficPolicyExportedWithout(t *te
 		*data.CreateEmptyDestinationRule("bookinfo2", "reviews2", "*.bookinfo.svc.cluster.local"),
 	}
 
-	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews2", "bookinfo2"})
+
+	testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 }
 
 // Context: MeshPolicy Enabling mTLS
@@ -346,7 +377,11 @@ func TestNamespacemTLSEnabledDRWithoutTrafficPolicyExportedWithout(t *testing.T)
 		*data.CreateEmptyDestinationRule("bookinfo2", "reviews2", "reviews.bookinfo.svc.cluster.local"),
 	}
 
-	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo"})
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews2", "bookinfo2"})
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 	presentReferences(t, *validation, "bookinfo", []string{"default"})
 	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
 }
@@ -376,7 +411,10 @@ func TestNamespacemTLSEnabledDRWithoutTrafficPolicyExportedWith(t *testing.T) {
 			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "*.bookinfo.svc.cluster.local")),
 	}
 
-	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo"})
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 	presentReferences(t, *validation, "bookinfo", []string{"default"})
 	presentReferences(t, *validation, "bookinfo2", []string{"reviews"})
 }
@@ -408,7 +446,10 @@ func TestNamespacemTLSEnabledDRWithoutmTLSOptionsExportedOther(t *testing.T) {
 			data.CreateEmptyDestinationRule("bookinfo2", "reviews", "reviews.bookinfo2.svc.cluster.local")),
 	}
 
-	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews", "bookinfo"})
+
+	validation := testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 	presentReferences(t, *validation, "bookinfo", []string{"default"})
 	notPresentReferences(t, *validation, "bookinfo2", []string{"reviews"})
 }
@@ -468,7 +509,10 @@ func TestNamespacemTLSEnabledDRWithTrafficPolicyExportedWithout(t *testing.T) {
 		*data.CreateEmptyDestinationRule("bookinfo2", "reviews2", "*.bookinfo.svc.cluster.local"),
 	}
 
-	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "reviews", "bookinfo")
+	nameNamespaces := []NameNamespace{}
+	nameNamespaces = append(nameNamespaces, NameNamespace{"reviews2", "bookinfo2"})
+
+	testValidationAddedExported(t, destinationRules, edr, mTLSDetails, nameNamespaces)
 }
 
 // Context: Namespace-wide mTLS enabled
@@ -524,38 +568,41 @@ func TestCrossNamespaceServiceEntryProtectionExported(t *testing.T) {
 	testValidationsNotAddedExported(t, destinationRules, edr, mTLSDetails, "service-entry-dr", "other")
 }
 
-func testValidationAddedExported(t *testing.T, destinationRules []networking_v1alpha3.DestinationRule, exportedDestinationRules []networking_v1alpha3.DestinationRule, mTLSDetails kubernetes.MTLSDetails, name string, namespace string) *models.IstioValidation {
+func testValidationAddedExported(t *testing.T, destinationRules []networking_v1alpha3.DestinationRule, exportedDestinationRules []networking_v1alpha3.DestinationRule, mTLSDetails kubernetes.MTLSDetails, nameNamespaces []NameNamespace) *models.IstioValidation {
 	assert := assert.New(t)
 
 	vals := TrafficPolicyChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: exportedDestinationRules,
-		MTLSDetails:              mTLSDetails,
+		DestinationRules: append(destinationRules, exportedDestinationRules...),
+		MTLSDetails:      mTLSDetails,
 	}.Check()
 
 	assert.NotEmpty(vals)
-	assert.Equal(1, len(vals))
+	assert.Equal(len(nameNamespaces), len(vals))
 
-	validation, ok := vals[models.BuildKey(DestinationRulesCheckerType, name, namespace)]
-	assert.True(ok)
-	assert.True(validation.Valid)
+	result := models.IstioValidation{}
+	for _, nameNamespace := range nameNamespaces {
+		validation, ok := vals[models.BuildKey(DestinationRulesCheckerType, nameNamespace.Name, nameNamespace.Namespace)]
+		assert.True(ok)
+		assert.True(validation.Valid)
 
-	assert.NotEmpty(validation.Checks)
-	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
-	assert.Equal("spec/trafficPolicy", validation.Checks[0].Path)
-	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.trafficpolicy.notlssettings", validation.Checks[0]))
+		assert.NotEmpty(validation.Checks)
+		assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+		assert.Equal("spec/trafficPolicy", validation.Checks[0].Path)
+		assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.trafficpolicy.notlssettings", validation.Checks[0]))
+		assert.True(len(validation.References) > 0)
 
-	assert.True(len(validation.References) > 0)
-	return validation
+		result = *validation
+	}
+
+	return &result
 }
 
 func testValidationsNotAddedExported(t *testing.T, destinationRules []networking_v1alpha3.DestinationRule, exportedDestinationRules []networking_v1alpha3.DestinationRule, mTLSDetails kubernetes.MTLSDetails, name string, namespace string) {
 	assert := assert.New(t)
 
 	vals := TrafficPolicyChecker{
-		DestinationRules:         destinationRules,
-		ExportedDestinationRules: exportedDestinationRules,
-		MTLSDetails:              mTLSDetails,
+		DestinationRules: append(destinationRules, exportedDestinationRules...),
+		MTLSDetails:      mTLSDetails,
 	}.Check()
 
 	assert.Empty(vals)

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -11,11 +11,11 @@ import (
 const VirtualCheckerType = "virtualservice"
 
 type VirtualServiceChecker struct {
-	Namespace                string
-	Namespaces               models.Namespaces
-	VirtualServices          []networking_v1alpha3.VirtualService
-	ExportedVirtualServices  []networking_v1alpha3.VirtualService
-	ExportedDestinationRules []networking_v1alpha3.DestinationRule
+	Namespace               string
+	Namespaces              models.Namespaces
+	VirtualServices         []networking_v1alpha3.VirtualService
+	ExportedVirtualServices []networking_v1alpha3.VirtualService
+	DestinationRules        []networking_v1alpha3.DestinationRule
 }
 
 // An Object Checker runs all checkers for an specific object type (i.e.: pod, route rule,...)
@@ -64,7 +64,7 @@ func (in VirtualServiceChecker) runChecks(virtualService networking_v1alpha3.Vir
 
 	enabledCheckers := []Checker{
 		virtualservices.RouteChecker{VirtualService: virtualService, Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames()},
-		virtualservices.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), VirtualService: virtualService, ExportedDestinationRules: in.ExportedDestinationRules},
+		virtualservices.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), VirtualService: virtualService, DestinationRules: in.DestinationRules},
 		common.ExportToNamespaceChecker{ExportTo: virtualService.Spec.ExportTo, Namespaces: in.Namespaces},
 	}
 

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -11,11 +11,10 @@ import (
 const VirtualCheckerType = "virtualservice"
 
 type VirtualServiceChecker struct {
-	Namespace               string
-	Namespaces              models.Namespaces
-	VirtualServices         []networking_v1alpha3.VirtualService
-	ExportedVirtualServices []networking_v1alpha3.VirtualService
-	DestinationRules        []networking_v1alpha3.DestinationRule
+	Namespace        string
+	Namespaces       models.Namespaces
+	VirtualServices  []networking_v1alpha3.VirtualService
+	DestinationRules []networking_v1alpha3.DestinationRule
 }
 
 // An Object Checker runs all checkers for an specific object type (i.e.: pod, route rule,...)
@@ -47,7 +46,7 @@ func (in VirtualServiceChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	enabledCheckers := []GroupChecker{
-		virtualservices.SingleHostChecker{Namespace: in.Namespace, Namespaces: in.Namespaces, ExportedVirtualServices: in.ExportedVirtualServices},
+		virtualservices.SingleHostChecker{Namespace: in.Namespace, Namespaces: in.Namespaces, VirtualServices: in.VirtualServices},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/virtual_service_checker_test.go
+++ b/business/checkers/virtual_service_checker_test.go
@@ -20,9 +20,9 @@ func prepareTestForVirtualService(vs *networking_v1alpha3.VirtualService) models
 	}
 
 	virtualServiceChecker := VirtualServiceChecker{
-		Namespace:                "bookinfo",
-		ExportedDestinationRules: destinationList,
-		VirtualServices:          vss,
+		Namespace:        "bookinfo",
+		DestinationRules: destinationList,
+		VirtualServices:  vss,
 	}
 
 	return virtualServiceChecker.Check()
@@ -87,9 +87,9 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 	}
 
 	virtualServiceChecker := VirtualServiceChecker{
-		Namespace:                "bookinfo",
-		ExportedDestinationRules: destinationList,
-		VirtualServices:          fakeVirtualServiceMultipleIstioObjects(),
+		Namespace:        "bookinfo",
+		DestinationRules: destinationList,
+		VirtualServices:  fakeVirtualServiceMultipleIstioObjects(),
 	}
 
 	validations := virtualServiceChecker.Check()

--- a/business/checkers/virtualservices/single_exported_host_checker_test.go
+++ b/business/checkers/virtualservices/single_exported_host_checker_test.go
@@ -20,8 +20,8 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "ratings"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -35,8 +35,8 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "ratings"),
 	}
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -50,8 +50,8 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 		*buildVirtualServiceWithGatewayNS("bookinfo2", "virtual-2", "ratings", "bookinfo-gateway"),
 	}
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -65,8 +65,8 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 		*buildVirtualServiceWithGatewayNS("bookinfo2", "virtual-2", "ratings", "bookinfo-gateway"),
 	}
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -81,8 +81,8 @@ func TestOneVirtualServicePerFQDNHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "ratings.bookinfo2.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -97,8 +97,8 @@ func TestOneVirtualServicePerFQDNWildcardHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "*.eshop.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -117,8 +117,8 @@ func TestRepeatingSimpleHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -148,8 +148,8 @@ func TestRepeatingSimpleHostWithGatewayExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	noObjectValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -162,8 +162,8 @@ func TestRepeatingSimpleHostWithGatewayExported(t *testing.T) {
 		*buildVirtualServiceWithGatewayNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local", "bookinfo2"),
 	}
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	noObjectValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -176,8 +176,8 @@ func TestRepeatingSimpleHostWithGatewayExported(t *testing.T) {
 		*buildVirtualServiceWithGatewayNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local", "bookinfo"),
 	}
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	refKey := models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo2", Name: "virtual-2"}
@@ -202,7 +202,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		ExportedVirtualServices: append(vss, evss...),
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -220,7 +220,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		ExportedVirtualServices: append(vss, evss...),
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -239,7 +239,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		ExportedVirtualServices: append(vss, evss...),
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -257,7 +257,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		ExportedVirtualServices: append(vss, evss...),
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -275,7 +275,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		ExportedVirtualServices: append(vss, evss...),
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	noObjectValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -295,7 +295,7 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
 		},
-		ExportedVirtualServices: append(vss, evss...),
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	noObjectValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -313,8 +313,8 @@ func TestRepeatingFQDNHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -345,8 +345,8 @@ func TestRepeatingFQDNWildcardHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "*.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -377,8 +377,8 @@ func TestIncludedIntoWildCardExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -408,8 +408,8 @@ func TestIncludedIntoWildCardExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -440,8 +440,8 @@ func TestShortHostNameIncludedIntoWildCardExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -472,8 +472,8 @@ func TestWildcardisMarkedInvalidExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -504,8 +504,8 @@ func TestMultipleHostsFailingExported(t *testing.T) {
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	presentValidationTestNS(t, vals, "virtual-1", "bookinfo")
@@ -530,8 +530,8 @@ func TestMultipleHostsPassingExported(t *testing.T) {
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: append(vss, evss...),
+		Namespace:       "bookinfo",
+		VirtualServices: append(vss, evss...),
 	}.Check()
 
 	emptyValidationTestNS(t, vals, "virtual-1", "bookinfo")

--- a/business/checkers/virtualservices/single_host_checker.go
+++ b/business/checkers/virtualservices/single_host_checker.go
@@ -9,16 +9,16 @@ import (
 )
 
 type SingleHostChecker struct {
-	Namespace               string
-	Namespaces              models.Namespaces
-	ExportedVirtualServices []networking_v1alpha3.VirtualService
+	Namespace       string
+	Namespaces      models.Namespaces
+	VirtualServices []networking_v1alpha3.VirtualService
 }
 
 func (s SingleHostChecker) Check() models.IstioValidations {
 	hostCounter := make(map[string]map[string]map[string]map[string][]*networking_v1alpha3.VirtualService)
 	validations := models.IstioValidations{}
 
-	for _, vs := range s.ExportedVirtualServices {
+	for _, vs := range s.VirtualServices {
 		for _, host := range s.getHosts(vs) {
 			storeHost(hostCounter, vs, host)
 		}

--- a/business/checkers/virtualservices/single_host_checker_test.go
+++ b/business/checkers/virtualservices/single_host_checker_test.go
@@ -17,8 +17,8 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "ratings"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -29,8 +29,8 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "ratings"),
 	}
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -42,8 +42,8 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 		*buildVirtualServiceWithGateway("virtual-2", "ratings", "bookinfo-gateway"),
 	}
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -56,8 +56,8 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 	}
 
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -70,8 +70,8 @@ func TestOneVirtualServicePerFQDNHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "ratings.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -83,8 +83,8 @@ func TestOneVirtualServicePerFQDNWildcardHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "*.eshop.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)
@@ -98,8 +98,8 @@ func TestRepeatingSimpleHost(t *testing.T) {
 	}
 
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -125,8 +125,8 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 	}
 
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	noObjectValidationTest(t, vals, "virtual-1")
@@ -138,8 +138,8 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 	}
 
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	noObjectValidationTest(t, vals, "virtual-1")
@@ -151,8 +151,8 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 	}
 
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	refKey := models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "bookinfo", Name: "virtual-2"}
@@ -174,7 +174,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		ExportedVirtualServices: vss,
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -189,7 +189,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		ExportedVirtualServices: vss,
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -205,7 +205,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		ExportedVirtualServices: vss,
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -220,7 +220,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		ExportedVirtualServices: vss,
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -235,7 +235,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		ExportedVirtualServices: vss,
+		VirtualServices: vss,
 	}.Check()
 
 	noObjectValidationTest(t, vals, "virtual-1")
@@ -251,7 +251,7 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
-		ExportedVirtualServices: vss,
+		VirtualServices: vss,
 	}.Check()
 
 	noObjectValidationTest(t, vals, "virtual-1")
@@ -266,8 +266,8 @@ func TestRepeatingFQDNHost(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -293,8 +293,8 @@ func TestRepeatingFQDNWildcardHost(t *testing.T) {
 		*buildVirtualService("virtual-3", "*.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -320,8 +320,8 @@ func TestIncludedIntoWildCard(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -346,8 +346,8 @@ func TestIncludedIntoWildCard(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals = SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -373,8 +373,8 @@ func TestShortHostNameIncludedIntoWildCard(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -400,8 +400,8 @@ func TestWildcardisMarkedInvalid(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews"),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -427,8 +427,8 @@ func TestMultipleHostsFailing(t *testing.T) {
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	presentValidationTest(t, vals, "virtual-1")
@@ -451,8 +451,8 @@ func TestMultipleHostsPassing(t *testing.T) {
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
 	vals := SingleHostChecker{
-		Namespace:               "bookinfo",
-		ExportedVirtualServices: vss,
+		Namespace:       "bookinfo",
+		VirtualServices: vss,
 	}.Check()
 
 	emptyValidationTest(t, vals)

--- a/business/checkers/virtualservices/subset_presence_checker.go
+++ b/business/checkers/virtualservices/subset_presence_checker.go
@@ -10,10 +10,10 @@ import (
 )
 
 type SubsetPresenceChecker struct {
-	Namespace                string
-	Namespaces               []string
-	ExportedDestinationRules []networking_v1alpha3.DestinationRule
-	VirtualService           networking_v1alpha3.VirtualService
+	Namespace        string
+	Namespaces       []string
+	DestinationRules []networking_v1alpha3.DestinationRule
+	VirtualService   networking_v1alpha3.VirtualService
 }
 
 func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
@@ -110,9 +110,9 @@ func (checker SubsetPresenceChecker) subsetPresent(host string, subset string) b
 }
 
 func (checker SubsetPresenceChecker) getDestinationRules(virtualServiceHost string) ([]networking_v1alpha3.DestinationRule, bool) {
-	drs := make([]networking_v1alpha3.DestinationRule, 0, len(checker.ExportedDestinationRules))
+	drs := make([]networking_v1alpha3.DestinationRule, 0, len(checker.DestinationRules))
 
-	for _, destinationRule := range checker.ExportedDestinationRules {
+	for _, destinationRule := range checker.DestinationRules {
 		host := destinationRule.Spec.Host
 
 		drHost := kubernetes.GetHost(host, destinationRule.Namespace, destinationRule.ClusterName, checker.Namespaces)

--- a/business/checkers/virtualservices/subset_presence_checker_test.go
+++ b/business/checkers/virtualservices/subset_presence_checker_test.go
@@ -81,10 +81,10 @@ func subsetPresenceCheckerPrep(scenario string, t *testing.T) ([]*models.IstioCh
 	err := loader.Load()
 
 	vals, valid := SubsetPresenceChecker{
-		Namespace:                "bookinfo",
-		Namespaces:               namespaceNames(loader.GetNamespaces()),
-		ExportedDestinationRules: append(loader.FindDestinationRuleIn("bookinfo"), loader.FindDestinationRuleNotIn("bookinfo")...),
-		VirtualService:           loader.GetResources().VirtualServices[0],
+		Namespace:        "bookinfo",
+		Namespaces:       namespaceNames(loader.GetNamespaces()),
+		DestinationRules: append(loader.FindDestinationRuleIn("bookinfo"), loader.FindDestinationRuleNotIn("bookinfo")...),
+		VirtualService:   loader.GetResources().VirtualServices[0],
 	}.Check()
 
 	if err != nil {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -100,8 +100,8 @@ func (in *IstioValidationsService) GetValidations(namespace, service string) (mo
 func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioConfigList models.IstioConfigList, exportedResources kubernetes.ExportedResources, services models.ServiceList, workloadsPerNamespace map[string]models.WorkloadList, workloads models.WorkloadList, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace, registryServices []*kubernetes.RegistryService) []ObjectChecker {
 	return []ObjectChecker{
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioConfigList: istioConfigList, ExportedResources: &exportedResources, ServiceList: services, WorkloadList: workloads, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices},
-		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices},
-		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: exportedResources.ServiceEntries},
+		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: exportedResources.VirtualServices, DestinationRules: exportedResources.DestinationRules},
+		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: exportedResources.ServiceEntries},
 		checkers.GatewayChecker{Gateways: exportedResources.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: exportedResources.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
@@ -159,10 +159,10 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 			checkers.GatewayChecker{Gateways: exportedResources.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		}
 	case kubernetes.VirtualServices:
-		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, ExportedDestinationRules: exportedResources.DestinationRules, ExportedVirtualServices: exportedResources.VirtualServices}
+		virtualServiceChecker := checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: exportedResources.VirtualServices, DestinationRules: exportedResources.DestinationRules}
 		objectCheckers = []ObjectChecker{noServiceChecker, virtualServiceChecker}
 	case kubernetes.DestinationRules:
-		destinationRulesChecker := checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, ExportedDestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: exportedResources.ServiceEntries}
+		destinationRulesChecker := checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: exportedResources.ServiceEntries}
 		objectCheckers = []ObjectChecker{noServiceChecker, destinationRulesChecker}
 	case kubernetes.ServiceEntries:
 		serviceEntryChecker := checkers.ServiceEntryChecker{ServiceEntries: exportedResources.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -105,7 +105,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioC
 		checkers.GatewayChecker{Gateways: exportedResources.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: exportedResources.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
-		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices},
+		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: exportedResources.VirtualServices, RegistryServices: registryServices},
 		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloads, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadList: workloads},
 	}
@@ -174,7 +174,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
 			Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries,
-			WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices}
+			WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: exportedResources.VirtualServices, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{authPoliciesChecker}
 	case kubernetes.PeerAuthentications:
 		// Validations on PeerAuthentications


### PR DESCRIPTION
Replaced ExportedDestinationRules variable with DestinationRules param is coming from Registry and includes local and exported ones.
Update: Did the same for ExportedVirtualServices.

RFE https://github.com/kiali/kiali/issues/4528

For QE:
Full manual regression testing for all Destination Rules and Virtual Services validations from https://kiali.io/docs/features/validations/
Automation regression testing.