### PR TITLE
Sidecar EgressChecker now supports Services from Registry.

### DIFF
--- a/business/checkers/sidecars/egress_listener_checker.go
+++ b/business/checkers/sidecars/egress_listener_checker.go
@@ -13,7 +13,6 @@ import (
 type EgressHostChecker struct {
 	Sidecar          networking_v1alpha3.Sidecar
 	ServiceEntries   map[string][]string
-	ServiceList      models.ServiceList
 	RegistryServices []*kubernetes.RegistryService
 }
 
@@ -90,9 +89,6 @@ func (elc EgressHostChecker) validateHost(host string, egrIdx, hostIdx int) ([]*
 func (elc EgressHostChecker) HasMatchingService(host kubernetes.Host, itemNamespace string) bool {
 	// Check wildcard hosts - needs to match "*" and "*.suffix" also.
 	if host.IsWildcard() && host.Namespace == itemNamespace {
-		return true
-	}
-	if host.Namespace == itemNamespace && elc.ServiceList.HasMatchingServices(host.Service) {
 		return true
 	}
 	if kubernetes.HasMatchingServiceEntries(host.String(), elc.ServiceEntries) {

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -14,7 +14,6 @@ const SidecarCheckerType = "sidecar"
 type SidecarChecker struct {
 	Sidecars         []networking_v1alpha3.Sidecar
 	ServiceEntries   []networking_v1alpha3.ServiceEntry
-	ServiceList      models.ServiceList
 	Namespaces       models.Namespaces
 	WorkloadList     models.WorkloadList
 	RegistryServices []*kubernetes.RegistryService
@@ -64,7 +63,7 @@ func (s SidecarChecker) runChecks(sidecar networking_v1alpha3.Sidecar) models.Is
 
 	enabledCheckers := []Checker{
 		common.WorkloadSelectorNoWorkloadFoundChecker(SidecarCheckerType, selectorLabels, s.WorkloadList),
-		sidecars.EgressHostChecker{Sidecar: sidecar, ServiceList: s.ServiceList, ServiceEntries: serviceHosts, RegistryServices: s.RegistryServices},
+		sidecars.EgressHostChecker{Sidecar: sidecar, ServiceEntries: serviceHosts, RegistryServices: s.RegistryServices},
 		sidecars.GlobalChecker{Sidecar: sidecar},
 	}
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -106,7 +106,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioC
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: exportedResources.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: exportedResources.VirtualServices, RegistryServices: registryServices},
-		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloads, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices},
+		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloads, ServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadList: workloads},
 	}
 }
@@ -169,7 +169,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(namespace string, o
 		objectCheckers = []ObjectChecker{serviceEntryChecker}
 	case kubernetes.Sidecars:
 		sidecarsChecker := checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces,
-			WorkloadList: workloads, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices}
+			WorkloadList: workloads, ServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{sidecarsChecker}
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4528

Modified the EgressHostChecker to use Services from Registry instead of only local namespace ones.
So now it supports exported Services as well.

The affected validation message is:
"KIA1004 This host has no matching entry in the service registry"

For QE:
Test the https://kiali.io/docs/features/validations/#kia1004---this-host-has-no-matching-entry-in-the-service-registry
Sidecar in "bookinfo", but using host from different namespace, for instance "bookinfo2/reviews.bookinfo2.svc.cluster.local".
Then "reviews/bookinfo2" service export to "bookinfo3" (Service annotation "networking.istio.io/exportTo") and verify that Sidecar host shows warning. 