### PR TITLE
Remove Service list usage by RegistryServices in validations

### DIFF
--- a/business/checkers/authorization/mtls_enabled_checker.go
+++ b/business/checkers/authorization/mtls_enabled_checker.go
@@ -20,7 +20,6 @@ type MtlsEnabledChecker struct {
 	Namespace             string
 	AuthorizationPolicies []security_v1beta.AuthorizationPolicy
 	MtlsDetails           kubernetes.MTLSDetails
-	ServiceList           models.ServiceList
 	ServiceEntries        []networking_v1alpha3.ServiceEntry
 	RegistryServices      []*kubernetes.RegistryService
 }
@@ -135,7 +134,6 @@ func (c MtlsEnabledChecker) IsMtlsEnabledFor(labels labels.Set) bool {
 		MatchingLabels:      labels,
 		Namespace:           c.Namespace,
 		PeerAuthentications: c.MtlsDetails.PeerAuthentications,
-		ServiceList:         c.ServiceList,
 		RegistryServices:    c.RegistryServices,
 	}.WorkloadMtlsStatus()
 

--- a/business/checkers/authorization/mtls_enabled_checker_test.go
+++ b/business/checkers/authorization/mtls_enabled_checker_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
 	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
@@ -243,7 +244,7 @@ func mtlsCheckerTestPrep(scenario string, autoMtls bool, t *testing.T) models.Is
 	validations := MtlsEnabledChecker{
 		Namespace:             "bookinfo",
 		AuthorizationPolicies: loader.GetResources().AuthorizationPolicies,
-		ServiceList:           fakeServices([]string{"ratings"}),
+		RegistryServices:      data.CreateFakeRegistryServicesLabels("ratings", "bookinfo"),
 		MtlsDetails: kubernetes.MTLSDetails{
 			DestinationRules:        loader.GetResources().DestinationRules,
 			MeshPeerAuthentications: loader.FindPeerAuthenticationIn("istio-system"),

--- a/business/checkers/authorization/no_host_checker.go
+++ b/business/checkers/authorization/no_host_checker.go
@@ -7,7 +7,6 @@ import (
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
 
-	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -50,9 +49,6 @@ func (n NoHostChecker) validateHost(ruleIdx int, to []*api_security_v1beta.Rule_
 		return nil, true
 	}
 	namespace, clusterName := n.AuthorizationPolicy.Namespace, n.AuthorizationPolicy.ClusterName
-	if clusterName == "" {
-		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
-	}
 	checks, valid := make([]*models.IstioCheck, 0, len(to)), true
 	for toIdx, t := range to {
 		if t == nil {

--- a/business/checkers/authorization/no_host_checker_test.go
+++ b/business/checkers/authorization/no_host_checker_test.go
@@ -347,25 +347,6 @@ func authPolicyWithHost(hostList []string) *security_v1beta.AuthorizationPolicy 
 	return data.CreateAuthorizationPolicy(nss, methods, hostList, selector)
 }
 
-func fakeServices(serviceNames []string) models.ServiceList {
-	serviceList := models.ServiceList{
-		Services: []models.ServiceOverview{},
-	}
-	for _, sName := range serviceNames {
-		service := models.ServiceOverview{
-			Name:      sName,
-			Namespace: "bookinfo",
-			Labels: map[string]string{
-				"app":     sName,
-				"version": "v1",
-			},
-			Selector: map[string]string{"app": sName},
-		}
-		serviceList.Services = append(serviceList.Services, service)
-	}
-	return serviceList
-}
-
 func TestValidServiceRegistry(t *testing.T) {
 	assert := assert.New(t)
 

--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -17,7 +17,6 @@ type AuthorizationPolicyChecker struct {
 	Namespace             string
 	Namespaces            models.Namespaces
 	ServiceEntries        []networking_v1alpha3.ServiceEntry
-	ServiceList           models.ServiceList
 	WorkloadList          models.WorkloadList
 	MtlsDetails           kubernetes.MTLSDetails
 	VirtualServices       []networking_v1alpha3.VirtualService
@@ -37,7 +36,6 @@ func (a AuthorizationPolicyChecker) Check() models.IstioValidations {
 		Namespace:             a.Namespace,
 		AuthorizationPolicies: a.AuthorizationPolicies,
 		MtlsDetails:           a.MtlsDetails,
-		ServiceList:           a.ServiceList,
 		RegistryServices:      a.RegistryServices,
 	}.Check())
 

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -2,12 +2,12 @@ package destinationrules
 
 import (
 	"strconv"
-	"strings"
 
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -27,9 +27,14 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 	valid := true
 	validations := make([]*models.IstioCheck, 0)
 
-	fqdn := kubernetes.GetHost(n.DestinationRule.Spec.Host, n.DestinationRule.Namespace, n.DestinationRule.ClusterName, n.Namespaces.GetNames())
+	namespace, clusterName := n.DestinationRule.Namespace, n.DestinationRule.ClusterName
+	if clusterName == "" {
+		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
+	}
+
+	fqdn := kubernetes.GetHost(n.DestinationRule.Spec.Host, namespace, clusterName, n.Namespaces.GetNames())
 	// Testing Kubernetes Services + Istio ServiceEntries + Istio Runtime Registry (cross namespace)
-	if !n.hasMatchingService(fqdn, n.DestinationRule.Namespace) {
+	if !n.hasMatchingService(fqdn, namespace) {
 		validation := models.Build("destinationrules.nodest.matchingregistry", "spec/host")
 		valid = false
 		validations = append(validations, &validation)
@@ -37,7 +42,7 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 		// Check that each subset has a matching workload somewhere..
 		for i, subset := range n.DestinationRule.Spec.Subsets {
 			if len(subset.Labels) > 0 {
-				if !n.hasMatchingWorkload(fqdn.Service, subset.Labels) {
+				if !n.hasMatchingWorkload(fqdn, subset.Labels) {
 					validation := models.Build("destinationrules.nodest.subsetlabels",
 						"spec/subsets["+strconv.Itoa(i)+"]")
 					if n.isSubsetReferenced(n.DestinationRule.Spec.Host, subset.Name) {
@@ -58,25 +63,22 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 	return validations, valid
 }
 
-func (n NoDestinationChecker) hasMatchingWorkload(service string, subsetLabels map[string]string) bool {
+func (n NoDestinationChecker) hasMatchingWorkload(host kubernetes.Host, subsetLabels map[string]string) bool {
 	// Check wildcard hosts - needs to match "*" and "*.suffix" also..
-	if strings.HasPrefix(service, "*") {
+	if host.IsWildcard() {
 		return true
 	}
 
 	// Covering 'servicename.namespace' host format scenario
-	svc := service
-	svcParts := strings.Split(service, ".")
-	if len(svcParts) > 1 {
-		svc = svcParts[0]
-	}
+	localSvc, localNs := kubernetes.ParseTwoPartHost(host)
 
 	var selectors map[string]string
 
 	// Find the correct service
 	for _, s := range n.RegistryServices {
-		if s.Attributes.Name == svc {
+		if s.Attributes.Name == localSvc && s.Attributes.Namespace == localNs {
 			selectors = s.Attributes.LabelSelectors
+			break
 		}
 	}
 

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -7,7 +7,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -28,9 +27,6 @@ func (n NoDestinationChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
 	namespace, clusterName := n.DestinationRule.Namespace, n.DestinationRule.ClusterName
-	if clusterName == "" {
-		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
-	}
 
 	fqdn := kubernetes.GetHost(n.DestinationRule.Spec.Host, namespace, clusterName, n.Namespaces.GetNames())
 	// Testing Kubernetes Services + Istio ServiceEntries + Istio Runtime Registry (cross namespace)

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -19,7 +19,6 @@ type NoDestinationChecker struct {
 	DestinationRule  networking_v1alpha3.DestinationRule
 	VirtualServices  []networking_v1alpha3.VirtualService
 	ServiceEntries   map[string][]string
-	ServiceList      models.ServiceList
 	RegistryServices []*kubernetes.RegistryService
 }
 
@@ -75,9 +74,9 @@ func (n NoDestinationChecker) hasMatchingWorkload(service string, subsetLabels m
 	var selectors map[string]string
 
 	// Find the correct service
-	for _, s := range n.ServiceList.Services {
-		if s.Name == svc {
-			selectors = s.Selector
+	for _, s := range n.RegistryServices {
+		if s.Attributes.Name == svc {
+			selectors = s.Attributes.LabelSelectors
 		}
 	}
 
@@ -114,11 +113,6 @@ func (n NoDestinationChecker) hasMatchingService(host kubernetes.Host, itemNames
 	if localNs == itemNamespace {
 		// Check Workloads
 		if matches := kubernetes.HasMatchingWorkloads(localSvc, n.WorkloadList.GetLabels()); matches {
-			return matches
-		}
-
-		// Check ServiceNames
-		if matches := n.ServiceList.HasMatchingServices(localSvc); matches {
 			return matches
 		}
 	}

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -31,7 +31,7 @@ func TestValidHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 
@@ -48,7 +48,7 @@ func TestValidWildcardHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule: *data.CreateTestDestinationRule("test-namespace",
 			"name", "*.test-namespace.svc.cluster.local"),
 	}.Check()
@@ -69,7 +69,7 @@ func TestValidMeshWideHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "*.local"),
 	}.Check()
 
@@ -89,7 +89,7 @@ func TestValidServiceNamespace(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews.test-namespace"),
 	}.Check()
 
@@ -113,7 +113,7 @@ func TestValidServiceNamespaceInvalid(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews.not-a-namespace"),
 	}.Check()
 
@@ -142,7 +142,7 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 		),
 		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews.outside-ns.svc.cluster.local"),
 		// Note that a cross-namespace service should be visible in the registry, otherwise won't be visible
-		RegistryServices: append(fakeServicesReview("outside-ns"), fakeServicesReview("test-namespace")...),
+		RegistryServices: append(data.CreateFakeRegistryServicesLabels("reviews", "outside-ns"), data.CreateFakeRegistryServicesLabels("reviews", "test-namespace")...),
 	}.Check()
 
 	assert.True(valid)
@@ -185,7 +185,7 @@ func TestNoMatchingSubset(t *testing.T) {
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 		VirtualServices: []networking_v1alpha3.VirtualService{*data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v1", 55),
 			data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v2", 45),
@@ -229,7 +229,7 @@ func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *dr,
 		VirtualServices: []networking_v1alpha3.VirtualService{*data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "reviewsv1", 55),
 			data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "reviewsv2", 100),
@@ -263,7 +263,7 @@ func TestSubsetNotReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *dr,
 		VirtualServices:  []networking_v1alpha3.VirtualService{},
 	}.Check()
@@ -295,7 +295,7 @@ func TestSubsetReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *dr,
 		VirtualServices:  []networking_v1alpha3.VirtualService{*vs},
 	}.Check()
@@ -331,7 +331,7 @@ func TestSubsetPresentMatchingNotReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("bookinfo"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "bookinfo"),
 		DestinationRule:  *dr,
 		VirtualServices:  []networking_v1alpha3.VirtualService{*vs},
 	}.Check()
@@ -360,7 +360,7 @@ func TestWronglyReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *dr,
 		VirtualServices:  []networking_v1alpha3.VirtualService{*vs},
 	}.Check()
@@ -370,22 +370,6 @@ func TestWronglyReferenced(t *testing.T) {
 	assert.Equal(models.Unknown, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.nodest.subsetlabels", vals[0]))
 	assert.Equal("spec/subsets[0]", vals[0].Path)
-}
-
-func fakeServicesReview(namespace string) []*kubernetes.RegistryService {
-	registryService := kubernetes.RegistryService{}
-	registryService.Hostname = "reviews." + namespace + ".svc.cluster.local"
-	registryService.IstioService.Attributes.Name = "reviews"
-	registryService.IstioService.Attributes.Namespace = namespace
-	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
-	registryService.IstioService.Attributes.ExportTo["*"] = true
-	registryService.IstioService.Attributes.Labels = make(map[string]string)
-	registryService.IstioService.Attributes.Labels["app"] = "reviews"
-	registryService.IstioService.Attributes.Labels["version"] = "v1"
-	registryService.IstioService.Attributes.LabelSelectors = make(map[string]string)
-	registryService.IstioService.Attributes.LabelSelectors["app"] = "reviews"
-
-	return []*kubernetes.RegistryService{&registryService}
 }
 
 func TestFailCrossNamespaceHost(t *testing.T) {
@@ -401,7 +385,7 @@ func TestFailCrossNamespaceHost(t *testing.T) {
 		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews.different-ns.svc.cluster.local"),
 		// Note that a cross-namespace service should be visible in the registry, otherwise won't be visible
 		RegistryServices: append(data.CreateFakeRegistryServices("reviews.test-namespace.svc.cluster.local", "test-namespace", "test-namespace"),
-			fakeServicesReview("different-ns")...),
+			data.CreateFakeRegistryServicesLabels("reviews", "different-ns")...),
 	}.Check()
 
 	assert.True(valid)
@@ -617,7 +601,7 @@ func TestNoLabelsInSubset(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview("test-namespace"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  *data.CreateNoLabelsDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -31,8 +31,8 @@ func TestValidHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 
 	assert.True(valid)
@@ -48,7 +48,7 @@ func TestValidWildcardHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList: fakeServicesReview(),
+		RegistryServices: fakeServicesReview(),
 		DestinationRule: *data.CreateTestDestinationRule("test-namespace",
 			"name", "*.test-namespace.svc.cluster.local"),
 	}.Check()
@@ -69,8 +69,8 @@ func TestValidMeshWideHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "*.local"),
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "*.local"),
 	}.Check()
 
 	assert.True(valid)
@@ -89,8 +89,8 @@ func TestValidServiceNamespace(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews.test-namespace"),
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews.test-namespace"),
 	}.Check()
 
 	assert.True(valid)
@@ -113,8 +113,8 @@ func TestValidServiceNamespaceInvalid(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews.not-a-namespace"),
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews.not-a-namespace"),
 	}.Check()
 
 	assert.False(valid)
@@ -140,10 +140,10 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
 		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews.outside-ns.svc.cluster.local"),
 		// Note that a cross-namespace service should be visible in the registry, otherwise won't be visible
-		RegistryServices: data.CreateFakeRegistryServices("reviews.outside-ns.svc.cluster.local", "test-namespace", "."),
+		RegistryServices: append(data.CreateFakeRegistryServices("reviews.outside-ns.svc.cluster.local", "test-namespace", "."),
+			fakeServicesReview()...),
 	}.Check()
 
 	assert.True(valid)
@@ -163,8 +163,8 @@ func TestNoValidHost(t *testing.T) {
 			data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
 			data.CreateWorkloadListItem("otherv1", appVersionLabel("other", "v1")),
 		),
-		ServiceList:     models.ServiceList{},
-		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
+		RegistryServices: []*kubernetes.RegistryService{&kubernetes.RegistryService{}},
+		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 
 	assert.False(valid)
@@ -186,8 +186,8 @@ func TestNoMatchingSubset(t *testing.T) {
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 		VirtualServices: []networking_v1alpha3.VirtualService{*data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v1", 55),
 			data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v2", 45),
 				data.CreateEmptyVirtualService("reviews", "test-namespace", []string{"reviews"}),
@@ -230,8 +230,8 @@ func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *dr,
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *dr,
 		VirtualServices: []networking_v1alpha3.VirtualService{*data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "reviewsv1", 55),
 			data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "reviewsv2", 100),
 				data.CreateEmptyVirtualService("reviews", "test-namespace", []string{"reviews"}),
@@ -264,9 +264,9 @@ func TestSubsetNotReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *dr,
-		VirtualServices: []networking_v1alpha3.VirtualService{},
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *dr,
+		VirtualServices:  []networking_v1alpha3.VirtualService{},
 	}.Check()
 
 	assert.True(valid)
@@ -296,9 +296,9 @@ func TestSubsetReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *dr,
-		VirtualServices: []networking_v1alpha3.VirtualService{*vs},
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *dr,
+		VirtualServices:  []networking_v1alpha3.VirtualService{*vs},
 	}.Check()
 
 	assert.False(valid)
@@ -332,9 +332,9 @@ func TestSubsetPresentMatchingNotReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *dr,
-		VirtualServices: []networking_v1alpha3.VirtualService{*vs},
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *dr,
+		VirtualServices:  []networking_v1alpha3.VirtualService{*vs},
 	}.Check()
 
 	assert.True(valid)
@@ -361,9 +361,9 @@ func TestWronglyReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *dr,
-		VirtualServices: []networking_v1alpha3.VirtualService{*vs},
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *dr,
+		VirtualServices:  []networking_v1alpha3.VirtualService{*vs},
 	}.Check()
 
 	assert.True(valid)
@@ -373,20 +373,19 @@ func TestWronglyReferenced(t *testing.T) {
 	assert.Equal("spec/subsets[0]", vals[0].Path)
 }
 
-func fakeServicesReview() models.ServiceList {
-	serviceList := models.ServiceList{
-		Services: []models.ServiceOverview{
-			{
-				Name:      "reviews",
-				Namespace: "test-namespace",
-				Labels: map[string]string{
-					"app":     "reviews",
-					"version": "v1"},
-				Selector: map[string]string{"app": "reviews"},
-			},
-		},
-	}
-	return serviceList
+func fakeServicesReview() []*kubernetes.RegistryService {
+	registryService := kubernetes.RegistryService{}
+	registryService.Hostname = "reviews.test-namespace.svc.cluster.com"
+	registryService.IstioService.Attributes.Namespace = "test-namespace"
+	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
+	registryService.IstioService.Attributes.ExportTo["*"] = true
+	registryService.IstioService.Attributes.Labels = make(map[string]string)
+	registryService.IstioService.Attributes.Labels["app"] = "reviews"
+	registryService.IstioService.Attributes.Labels["version"] = "v1"
+	registryService.IstioService.Attributes.LabelSelectors = make(map[string]string)
+	registryService.IstioService.Attributes.LabelSelectors["app"] = "reviews"
+
+	return []*kubernetes.RegistryService{&registryService}
 }
 
 func TestFailCrossNamespaceHost(t *testing.T) {
@@ -398,11 +397,11 @@ func TestFailCrossNamespaceHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList: fakeServicesReview(),
 		// Intentionally using the same serviceName, but different NS. This shouldn't fail to match the above workloads
 		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews.different-ns.svc.cluster.local"),
 		// Note that a cross-namespace service should be visible in the registry, otherwise won't be visible
-		RegistryServices: data.CreateFakeRegistryServices("reviews.different-ns.svc.cluster.local", "test-namespace", "test-namespace"),
+		RegistryServices: append(data.CreateFakeRegistryServices("reviews.different-ns.svc.cluster.local", "test-namespace", "test-namespace"),
+			fakeServicesReview()...),
 	}.Check()
 
 	assert.True(valid)
@@ -618,8 +617,8 @@ func TestNoLabelsInSubset(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		ServiceList:     fakeServicesReview(),
-		DestinationRule: *data.CreateNoLabelsDestinationRule("test-namespace", "name", "reviews"),
+		RegistryServices: fakeServicesReview(),
+		DestinationRule:  *data.CreateNoLabelsDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 
 	assert.True(valid)

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -31,7 +31,7 @@ func TestValidHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 
@@ -48,7 +48,7 @@ func TestValidWildcardHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule: *data.CreateTestDestinationRule("test-namespace",
 			"name", "*.test-namespace.svc.cluster.local"),
 	}.Check()
@@ -69,7 +69,7 @@ func TestValidMeshWideHost(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "*.local"),
 	}.Check()
 
@@ -89,7 +89,7 @@ func TestValidServiceNamespace(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews.test-namespace"),
 	}.Check()
 
@@ -113,7 +113,7 @@ func TestValidServiceNamespaceInvalid(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews.not-a-namespace"),
 	}.Check()
 
@@ -142,8 +142,7 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 		),
 		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews.outside-ns.svc.cluster.local"),
 		// Note that a cross-namespace service should be visible in the registry, otherwise won't be visible
-		RegistryServices: append(data.CreateFakeRegistryServices("reviews.outside-ns.svc.cluster.local", "test-namespace", "."),
-			fakeServicesReview()...),
+		RegistryServices: append(fakeServicesReview("outside-ns"), fakeServicesReview("test-namespace")...),
 	}.Check()
 
 	assert.True(valid)
@@ -186,7 +185,7 @@ func TestNoMatchingSubset(t *testing.T) {
 		WorkloadList: data.CreateWorkloadList("test-namespace",
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
 		VirtualServices: []networking_v1alpha3.VirtualService{*data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v1", 55),
 			data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v2", 45),
@@ -230,7 +229,7 @@ func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *dr,
 		VirtualServices: []networking_v1alpha3.VirtualService{*data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "reviewsv1", 55),
 			data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "reviewsv2", 100),
@@ -264,7 +263,7 @@ func TestSubsetNotReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *dr,
 		VirtualServices:  []networking_v1alpha3.VirtualService{},
 	}.Check()
@@ -296,7 +295,7 @@ func TestSubsetReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *dr,
 		VirtualServices:  []networking_v1alpha3.VirtualService{*vs},
 	}.Check()
@@ -332,7 +331,7 @@ func TestSubsetPresentMatchingNotReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("bookinfo"),
 		DestinationRule:  *dr,
 		VirtualServices:  []networking_v1alpha3.VirtualService{*vs},
 	}.Check()
@@ -361,7 +360,7 @@ func TestWronglyReferenced(t *testing.T) {
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *dr,
 		VirtualServices:  []networking_v1alpha3.VirtualService{*vs},
 	}.Check()
@@ -373,10 +372,11 @@ func TestWronglyReferenced(t *testing.T) {
 	assert.Equal("spec/subsets[0]", vals[0].Path)
 }
 
-func fakeServicesReview() []*kubernetes.RegistryService {
+func fakeServicesReview(namespace string) []*kubernetes.RegistryService {
 	registryService := kubernetes.RegistryService{}
-	registryService.Hostname = "reviews.test-namespace.svc.cluster.com"
-	registryService.IstioService.Attributes.Namespace = "test-namespace"
+	registryService.Hostname = "reviews." + namespace + ".svc.cluster.local"
+	registryService.IstioService.Attributes.Name = "reviews"
+	registryService.IstioService.Attributes.Namespace = namespace
 	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
 	registryService.IstioService.Attributes.ExportTo["*"] = true
 	registryService.IstioService.Attributes.Labels = make(map[string]string)
@@ -400,8 +400,8 @@ func TestFailCrossNamespaceHost(t *testing.T) {
 		// Intentionally using the same serviceName, but different NS. This shouldn't fail to match the above workloads
 		DestinationRule: *data.CreateTestDestinationRule("test-namespace", "name", "reviews.different-ns.svc.cluster.local"),
 		// Note that a cross-namespace service should be visible in the registry, otherwise won't be visible
-		RegistryServices: append(data.CreateFakeRegistryServices("reviews.different-ns.svc.cluster.local", "test-namespace", "test-namespace"),
-			fakeServicesReview()...),
+		RegistryServices: append(data.CreateFakeRegistryServices("reviews.test-namespace.svc.cluster.local", "test-namespace", "test-namespace"),
+			fakeServicesReview("different-ns")...),
 	}.Check()
 
 	assert.True(valid)
@@ -617,7 +617,7 @@ func TestNoLabelsInSubset(t *testing.T) {
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
 		),
-		RegistryServices: fakeServicesReview(),
+		RegistryServices: fakeServicesReview("test-namespace"),
 		DestinationRule:  *data.CreateNoLabelsDestinationRule("test-namespace", "name", "reviews"),
 	}.Check()
 

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -14,9 +14,7 @@ const ServiceRoleCheckerType = "servicerole"
 type NoServiceChecker struct {
 	Namespace            string
 	Namespaces           models.Namespaces
-	IstioConfigList      models.IstioConfigList
 	ExportedResources    *kubernetes.ExportedResources
-	ServiceList          models.ServiceList
 	WorkloadList         models.WorkloadList
 	AuthorizationDetails *kubernetes.RBACDetails
 	RegistryServices     []*kubernetes.RegistryService
@@ -25,25 +23,25 @@ type NoServiceChecker struct {
 func (in NoServiceChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
-	if len(in.ServiceList.Services) == 0 {
+	if len(in.RegistryServices) == 0 {
 		return validations
 	}
 
-	serviceHosts := kubernetes.ServiceEntryHostnames(append(in.IstioConfigList.ServiceEntries, in.ExportedResources.ServiceEntries...))
+	serviceHosts := kubernetes.ServiceEntryHostnames(in.ExportedResources.ServiceEntries)
 	gatewayNames := kubernetes.GatewayNames(in.ExportedResources.Gateways)
 
-	for _, virtualService := range in.IstioConfigList.VirtualServices {
-		validations.MergeValidations(runVirtualServiceCheck(virtualService, in.Namespace, in.ServiceList, serviceHosts, in.Namespaces, in.RegistryServices))
+	for _, virtualService := range in.ExportedResources.VirtualServices {
+		validations.MergeValidations(runVirtualServiceCheck(virtualService, in.Namespace, serviceHosts, in.Namespaces, in.RegistryServices))
 
 		validations.MergeValidations(runGatewayCheck(virtualService, gatewayNames))
 	}
-	for _, destinationRule := range in.IstioConfigList.DestinationRules {
-		validations.MergeValidations(runDestinationRuleCheck(destinationRule, in.Namespace, in.WorkloadList, in.ServiceList, serviceHosts, in.Namespaces, in.RegistryServices, in.IstioConfigList.VirtualServices))
+	for _, destinationRule := range in.ExportedResources.DestinationRules {
+		validations.MergeValidations(runDestinationRuleCheck(destinationRule, in.Namespace, in.WorkloadList, serviceHosts, in.Namespaces, in.RegistryServices, in.ExportedResources.VirtualServices))
 	}
 	return validations
 }
 
-func runVirtualServiceCheck(virtualService networking_v1alpha3.VirtualService, namespace string, services models.ServiceList, serviceHosts map[string][]string, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryService) models.IstioValidations {
+func runVirtualServiceCheck(virtualService networking_v1alpha3.VirtualService, namespace string, serviceHosts map[string][]string, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryService) models.IstioValidations {
 	key, validations := EmptyValidValidation(virtualService.Name, virtualService.Namespace, VirtualCheckerType)
 
 	result, valid := virtualservices.NoHostChecker{
@@ -75,7 +73,7 @@ func runGatewayCheck(virtualService networking_v1alpha3.VirtualService, gatewayN
 }
 
 func runDestinationRuleCheck(destinationRule networking_v1alpha3.DestinationRule, namespace string, workloads models.WorkloadList,
-	services models.ServiceList, serviceHosts map[string][]string, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryService, virtualServices []networking_v1alpha3.VirtualService) models.IstioValidations {
+	serviceHosts map[string][]string, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryService, virtualServices []networking_v1alpha3.VirtualService) models.IstioValidations {
 	key, validations := EmptyValidValidation(destinationRule.Name, destinationRule.Namespace, DestinationRuleCheckerType)
 
 	result, valid := destinationrules.NoDestinationChecker{
@@ -84,7 +82,6 @@ func runDestinationRuleCheck(destinationRule networking_v1alpha3.DestinationRule
 		WorkloadList:     workloads,
 		DestinationRule:  destinationRule,
 		VirtualServices:  virtualServices,
-		ServiceList:      services,
 		ServiceEntries:   serviceHosts,
 		RegistryServices: registryStatus,
 	}.Check()

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -19,7 +19,7 @@ func TestNoCrashOnEmpty(t *testing.T) {
 	typeValidations := NoServiceChecker{
 		Namespace:         "test",
 		ExportedResources: emptyExportedResources(),
-		RegistryServices:  emptyRegistryServices(),
+		RegistryServices:  data.CreateEmptyRegistryServices(),
 	}.Check()
 
 	assert.Empty(typeValidations)
@@ -171,10 +171,6 @@ func TestObjectWithoutGateway(t *testing.T) {
 	assert.False(productVs.Valid)
 	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[0]))
 	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[1]))
-}
-
-func emptyRegistryServices() []*kubernetes.RegistryService {
-	return []*kubernetes.RegistryService{&kubernetes.RegistryService{}}
 }
 
 func emptyExportedResources() *kubernetes.ExportedResources {

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -13,14 +13,13 @@ import (
 	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
-func TestNoCrashOnNil(t *testing.T) {
+func TestNoCrashOnEmpty(t *testing.T) {
 	assert := assert.New(t)
 
 	typeValidations := NoServiceChecker{
 		Namespace:         "test",
-		IstioConfigList:   models.IstioConfigList{},
-		ExportedResources: nil,
-		ServiceList:       models.ServiceList{},
+		ExportedResources: emptyExportedResources(),
+		RegistryServices:  emptyRegistryServices(),
 	}.Check()
 
 	assert.Empty(typeValidations)
@@ -44,11 +43,10 @@ func TestAllIstioObjectWithServices(t *testing.T) {
 			data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
 			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
 		),
-		IstioConfigList:      *fakeIstioConfigList(),
-		ExportedResources:    emptyExportedResources(),
-		ServiceList:          fakeServiceList([]string{"reviews", "details", "product", "customer"}),
+		ExportedResources:    fakeExportedResources(),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
-		RegistryServices:     data.CreateFakeRegistryServices("product.test.svc.cluster.local", "test", "test"),
+		RegistryServices: append(data.CreateFakeRegistryServices("product.test.svc.cluster.local", "test", "test"),
+			data.CreateFakeMultiRegistryServices([]string{"reviews.test.svc.cluster.local", "details.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", "*")...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -66,8 +64,7 @@ func TestDetectObjectWithoutService(t *testing.T) {
 
 	vals := NoServiceChecker{
 		Namespace:         "test",
-		IstioConfigList:   *fakeIstioConfigList(),
-		ExportedResources: emptyExportedResources(),
+		ExportedResources: fakeExportedResources(),
 		WorkloadList: data.CreateWorkloadList("test",
 			data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
 			data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
@@ -76,9 +73,9 @@ func TestDetectObjectWithoutService(t *testing.T) {
 			data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
 			data.CreateWorkloadListItem("productv2", appVersionLabel("product", "v2")),
 		),
-		ServiceList:          fakeServiceList([]string{"reviews", "details", "product"}),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
-		RegistryServices:     data.CreateFakeRegistryServices("product.test.svc.cluster.local", "test", "."),
+		RegistryServices: append(data.CreateFakeRegistryServices("product.test.svc.cluster.local", "test", "."),
+			data.CreateFakeMultiRegistryServices([]string{"reviews.test.svc.cluster.local", "details.test.svc.cluster.local"}, "test", "*")...),
 	}.Check()
 
 	assert.NotEmpty(vals)
@@ -99,9 +96,8 @@ func TestDetectObjectWithoutService(t *testing.T) {
 			data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
 			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
 		),
-		IstioConfigList:      *fakeIstioConfigList(),
-		ExportedResources:    emptyExportedResources(),
-		ServiceList:          fakeServiceList([]string{"reviews", "details", "customer"}),
+		ExportedResources:    fakeExportedResources(),
+		RegistryServices:     data.CreateFakeMultiRegistryServices([]string{"reviews.test.svc.cluster.local", "details.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", "*"),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 	}.Check()
 
@@ -125,9 +121,8 @@ func TestDetectObjectWithoutService(t *testing.T) {
 			data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
 			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
 		),
-		IstioConfigList:      *fakeIstioConfigList(),
-		ExportedResources:    emptyExportedResources(),
-		ServiceList:          fakeServiceList([]string{"reviews", "product", "customer"}),
+		ExportedResources:    fakeExportedResources(),
+		RegistryServices:     data.CreateFakeMultiRegistryServices([]string{"reviews.test.svc.cluster.local", "product.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", "*"),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 	}.Check()
 
@@ -144,9 +139,8 @@ func TestDetectObjectWithoutService(t *testing.T) {
 			data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
 			data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2")),
 		),
-		IstioConfigList:      *fakeIstioConfigList(),
-		ExportedResources:    emptyExportedResources(),
-		ServiceList:          fakeServiceList([]string{"details", "product", "customer"}),
+		ExportedResources:    fakeExportedResources(),
+		RegistryServices:     data.CreateFakeMultiRegistryServices([]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", "*"),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 	}.Check()
 
@@ -159,16 +153,15 @@ func TestObjectWithoutGateway(t *testing.T) {
 	config.Set(conf)
 	assert := assert.New(t)
 
-	istioDetails := fakeIstioConfigList()
+	istioDetails := fakeExportedResources()
 	gateways := make([]string, 1)
 	gateways = append(gateways, "non-existant-gateway")
 
 	istioDetails.VirtualServices[0].Spec.Gateways = gateways
 	vals := NoServiceChecker{
 		Namespace:            "test",
-		IstioConfigList:      *istioDetails,
-		ExportedResources:    emptyExportedResources(),
-		ServiceList:          fakeServiceList([]string{"reviews", "product", "customer"}),
+		ExportedResources:    istioDetails,
+		RegistryServices:     data.CreateFakeMultiRegistryServices([]string{"reviews.test.svc.cluster.local", "product.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", "*"),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 	}.Check()
 
@@ -176,38 +169,32 @@ func TestObjectWithoutGateway(t *testing.T) {
 
 	productVs := vals[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}]
 	assert.False(productVs.Valid)
-	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[2]))
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[0]))
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nogateway", productVs.Checks[1]))
 }
 
-func fakeIstioConfigList() *models.IstioConfigList {
-	istioConfigList := models.IstioConfigList{}
-
-	istioConfigList.VirtualServices = []networking_v1alpha3.VirtualService{
-		*data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("product", "v1", -1),
-			data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("product", "v1", -1),
-				data.CreateEmptyVirtualService("product-vs", "test", []string{"product"}),
-			),
-		)}
-
-	istioConfigList.DestinationRules = []networking_v1alpha3.DestinationRule{
-		*data.CreateEmptyDestinationRule("test", "customer-dr", "customer"),
-	}
-
-	return &istioConfigList
+func emptyRegistryServices() []*kubernetes.RegistryService {
+	return []*kubernetes.RegistryService{&kubernetes.RegistryService{}}
 }
 
 func emptyExportedResources() *kubernetes.ExportedResources {
 	return &kubernetes.ExportedResources{}
 }
 
-func fakeServiceList(services []string) models.ServiceList {
-	serviceList := models.ServiceList{
-		Services: []models.ServiceOverview{},
+func fakeExportedResources() *kubernetes.ExportedResources {
+	result := kubernetes.ExportedResources{}
+
+	result.VirtualServices = []networking_v1alpha3.VirtualService{
+		*data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("product", "v1", -1),
+			data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("product", "v1", -1),
+				data.CreateEmptyVirtualService("product-vs", "test", []string{"product"}),
+			),
+		)}
+
+	result.DestinationRules = []networking_v1alpha3.DestinationRule{
+		*data.CreateEmptyDestinationRule("test", "customer-dr", "customer"),
 	}
-	for _, service := range services {
-		serviceList.Services = append(serviceList.Services, models.ServiceOverview{Name: service})
-	}
-	return serviceList
+	return &result
 }
 
 func appVersionLabel(app, version string) map[string]string {

--- a/business/checkers/sidecars/egress_listener_checker_test.go
+++ b/business/checkers/sidecars/egress_listener_checker_test.go
@@ -16,11 +16,8 @@ import (
 func TestEgressHostFormatCorrect(t *testing.T) {
 	assert := assert.New(t)
 
-	registryService1 := data.CreateFakeRegistryServices("details.bookinfo.svc.cluster.local", "bookinfo", "*")
-	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
-
 	vals, valid := EgressHostChecker{
-		RegistryServices: append(registryService1, registryService2...),
+		RegistryServices: data.CreateFakeMultiRegistryServices([]string{"details.bookinfo.svc.cluster.local", "reviews.bookinfo.svc.cluster.local"}, "bookinfo", "*"),
 		ServiceEntries:   kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{data.CreateExternalServiceEntry()}),
 		Sidecar: *sidecarWithHosts([]string{
 			"*/*",
@@ -44,7 +41,7 @@ func TestEgressHostNotFoundService(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := EgressHostChecker{
-		RegistryServices: data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*"),
+		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "bookinfo"),
 		ServiceEntries:   kubernetes.ServiceEntryHostnames([]networking_v1alpha3.ServiceEntry{data.CreateExternalServiceEntry()}),
 		Sidecar: *sidecarWithHosts([]string{
 			"bookinfo2/reviews.bookinfo2.svc.cluster.local",

--- a/business/checkers/virtualservices/no_gateway_checker.go
+++ b/business/checkers/virtualservices/no_gateway_checker.go
@@ -6,7 +6,6 @@ import (
 
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
-	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -30,9 +29,7 @@ func (s NoGatewayChecker) ValidateVirtualServiceGateways(validations *[]*models.
 	namespace := s.VirtualService.Namespace
 	clusterName := s.VirtualService.ClusterName
 	valid := true
-	if clusterName == "" {
-		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
-	}
+
 	if len(s.VirtualService.Spec.Gateways) > 0 {
 		valid = s.checkGateways(s.VirtualService.Spec.Gateways, namespace, clusterName, validations, "spec")
 	}

--- a/business/checkers/virtualservices/no_host_checker.go
+++ b/business/checkers/virtualservices/no_host_checker.go
@@ -6,7 +6,6 @@ import (
 
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
-	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -23,9 +22,6 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 	valid := true
 	namespace, clusterName := n.VirtualService.Namespace, n.VirtualService.ClusterName
-	if clusterName == "" {
-		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
-	}
 
 	for k, httpRoute := range n.VirtualService.Spec.Http {
 		if httpRoute != nil {

--- a/business/checkers/virtualservices/single_host_checker.go
+++ b/business/checkers/virtualservices/single_host_checker.go
@@ -2,8 +2,7 @@ package virtualservices
 
 import (
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
-
-	"github.com/kiali/kiali/config"
+	
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -141,9 +140,6 @@ func storeHost(hostCounter map[string]map[string]map[string]map[string][]*networ
 
 func (s SingleHostChecker) getHosts(virtualService networking_v1alpha3.VirtualService) []kubernetes.Host {
 	namespace, clusterName := virtualService.Namespace, virtualService.ClusterName
-	if clusterName == "" {
-		clusterName = config.Get().ExternalServices.Istio.IstioIdentityDomain
-	}
 
 	if len(virtualService.Spec.Hosts) == 0 {
 		return []kubernetes.Host{}

--- a/business/checkers/virtualservices/single_host_checker.go
+++ b/business/checkers/virtualservices/single_host_checker.go
@@ -2,7 +2,7 @@ package virtualservices
 
 import (
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
-	
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -91,7 +91,7 @@ func (in *IstioValidationsService) GetValidations(ctx context.Context, namespace
 		}
 	}
 
-	objectCheckers := in.getAllObjectCheckers(namespace, istioConfigList, exportedResources, services, workloadsPerNamespace, workloadsPerNamespace[namespace], mtlsDetails, rbacDetails, namespaces, registryServices)
+	objectCheckers := in.getAllObjectCheckers(namespace, istioConfigList, exportedResources, workloadsPerNamespace, workloadsPerNamespace[namespace], mtlsDetails, rbacDetails, namespaces, registryServices)
 
 	// Get group validations for same kind istio objects
 	validations := runObjectCheckers(objectCheckers)
@@ -106,7 +106,7 @@ func (in *IstioValidationsService) GetValidations(ctx context.Context, namespace
 	return validations, nil
 }
 
-func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioConfigList models.IstioConfigList, exportedResources kubernetes.ExportedResources, services models.ServiceList, workloadsPerNamespace map[string]models.WorkloadList, workloads models.WorkloadList, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace, registryServices []*kubernetes.RegistryService) []ObjectChecker {
+func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioConfigList models.IstioConfigList, exportedResources kubernetes.ExportedResources, workloadsPerNamespace map[string]models.WorkloadList, workloads models.WorkloadList, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace, registryServices []*kubernetes.RegistryService) []ObjectChecker {
 	return []ObjectChecker{
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, ExportedResources: &exportedResources, WorkloadList: workloads, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices},
 		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: exportedResources.VirtualServices, DestinationRules: exportedResources.DestinationRules},

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -108,7 +108,7 @@ func (in *IstioValidationsService) GetValidations(ctx context.Context, namespace
 
 func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioConfigList models.IstioConfigList, exportedResources kubernetes.ExportedResources, services models.ServiceList, workloadsPerNamespace map[string]models.WorkloadList, workloads models.WorkloadList, mtlsDetails kubernetes.MTLSDetails, rbacDetails kubernetes.RBACDetails, namespaces []models.Namespace, registryServices []*kubernetes.RegistryService) []ObjectChecker {
 	return []ObjectChecker{
-		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioConfigList: istioConfigList, ExportedResources: &exportedResources, ServiceList: services, WorkloadList: workloads, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices},
+		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, ExportedResources: &exportedResources, WorkloadList: workloads, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices},
 		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: exportedResources.VirtualServices, DestinationRules: exportedResources.DestinationRules},
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: exportedResources.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: exportedResources.ServiceEntries},
 		checkers.GatewayChecker{Gateways: exportedResources.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
@@ -169,7 +169,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 	go in.fetchRegistryServices(&registryServices, errChan, &wg)
 	wg.Wait()
 
-	noServiceChecker := checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioConfigList: istioConfigList, ExportedResources: &exportedResources, ServiceList: services, WorkloadList: workloads, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices}
+	noServiceChecker := checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, ExportedResources: &exportedResources, WorkloadList: workloads, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices}
 
 	switch objectType {
 	case kubernetes.Gateways:

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -114,7 +114,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioC
 		checkers.GatewayChecker{Gateways: exportedResources.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloads},
 		checkers.ServiceEntryChecker{ServiceEntries: exportedResources.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
-		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: exportedResources.VirtualServices, RegistryServices: registryServices},
+		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceEntries: exportedResources.ServiceEntries, WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: exportedResources.VirtualServices, RegistryServices: registryServices},
 		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloads, ServiceEntries: exportedResources.ServiceEntries, RegistryServices: registryServices},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadList: workloads},
 	}
@@ -191,7 +191,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 		objectCheckers = []ObjectChecker{sidecarsChecker}
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
-			Namespace: namespace, Namespaces: namespaces, ServiceList: services, ServiceEntries: exportedResources.ServiceEntries,
+			Namespace: namespace, Namespaces: namespaces, ServiceEntries: exportedResources.ServiceEntries,
 			WorkloadList: workloads, MtlsDetails: mtlsDetails, VirtualServices: exportedResources.VirtualServices, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{authPoliciesChecker}
 	case kubernetes.PeerAuthentications:

--- a/kubernetes/cache/registry_test_helper.go
+++ b/kubernetes/cache/registry_test_helper.go
@@ -29,9 +29,13 @@ func FakeGatewaysKialiCache(gws []networking_v1alpha3.Gateway) KialiCache {
 	return &kialiCacheImpl
 }
 
-// Fake KialiCache used for RegistryServices Scenarios
+// Fake KialiCache used for RegistryServices and ExportedResources Scenarios
 // It populates the Namespaces, Informers and Registry information needed
-func FakeServicesKialiCache(rss []*kubernetes.RegistryService) KialiCache {
+func FakeServicesKialiCache(rss []*kubernetes.RegistryService,
+	gws []networking_v1alpha3.Gateway,
+	vss []networking_v1alpha3.VirtualService,
+	drs []networking_v1alpha3.DestinationRule,
+	ses []networking_v1alpha3.ServiceEntry) KialiCache {
 	kialiCacheImpl := kialiCacheImpl{
 		tokenNamespaces: make(map[string]namespaceCache),
 		// ~ long duration for unit testing
@@ -41,6 +45,12 @@ func FakeServicesKialiCache(rss []*kubernetes.RegistryService) KialiCache {
 	// Populate all DestinationRules using the Registry
 	registryStatus := kubernetes.RegistryStatus{
 		Services: rss,
+		Configuration: &kubernetes.RegistryConfiguration{
+			Gateways:         gws,
+			DestinationRules: drs,
+			VirtualServices:  vss,
+			ServiceEntries:   ses,
+		},
 	}
 
 	kialiCacheImpl.SetRegistryStatus(&registryStatus)

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -231,6 +231,10 @@ func HostWithinWildcardHost(subdomain, wildcardDomain string) bool {
 }
 
 func ParseGatewayAsHost(gateway, currentNamespace, currentCluster string) Host {
+	if currentCluster == "" {
+		currentCluster = config.Get().ExternalServices.Istio.IstioIdentityDomain
+	}
+
 	host := Host{
 		Service:       gateway,
 		Namespace:     currentNamespace,

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -61,6 +61,10 @@ func ParseHost(hostName, namespace, cluster string) Host {
 // GetHost parses hostName and returns a Host struct. It considers Namespaces in the cluster to be more accurate
 // when deciding if the hostName is a ServiceEntry or a service.namespace host definition.
 func GetHost(hostName, namespace, cluster string, clusterNamespaces []string) Host {
+	if cluster == "" {
+		cluster = config.Get().ExternalServices.Istio.IstioIdentityDomain
+	}
+
 	hParts := strings.Split(hostName, ".")
 	// It might be a service entry or a 2-format host specification
 	if len(hParts) == 2 {

--- a/tests/data/service_data.go
+++ b/tests/data/service_data.go
@@ -4,25 +4,26 @@ import (
 	"strings"
 
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/models"
 )
 
-func CreateFakeServiceList(serviceNames []string, namespace string) models.ServiceList {
-	serviceList := models.ServiceList{
-		Services: []models.ServiceOverview{},
-	}
-	for _, sName := range serviceNames {
-		serviceList.Services = append(serviceList.Services, models.ServiceOverview{
-			Name:      sName,
-			Namespace: namespace,
-			AppLabel:  true,
-			Labels: map[string]string{
-				"app":     sName,
-				"version": "v1"},
-			Selector: map[string]string{"app": sName},
-		})
-	}
-	return serviceList
+func CreateEmptyRegistryServices() []*kubernetes.RegistryService {
+	return []*kubernetes.RegistryService{&kubernetes.RegistryService{}}
+}
+
+func CreateFakeRegistryServicesLabels(service string, namespace string) []*kubernetes.RegistryService {
+	registryService := kubernetes.RegistryService{}
+	registryService.Hostname = service + "." + namespace + ".svc.cluster.local"
+	registryService.IstioService.Attributes.Name = service
+	registryService.IstioService.Attributes.Namespace = namespace
+	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
+	registryService.IstioService.Attributes.ExportTo["*"] = true
+	registryService.IstioService.Attributes.Labels = make(map[string]string)
+	registryService.IstioService.Attributes.Labels["app"] = service
+	registryService.IstioService.Attributes.Labels["version"] = "v1"
+	registryService.IstioService.Attributes.LabelSelectors = make(map[string]string)
+	registryService.IstioService.Attributes.LabelSelectors["app"] = service
+
+	return []*kubernetes.RegistryService{&registryService}
 }
 
 func CreateFakeRegistryServices(host string, namespace string, exportToNamespace string) []*kubernetes.RegistryService {

--- a/tests/data/service_data.go
+++ b/tests/data/service_data.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"strings"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -27,6 +29,7 @@ func CreateFakeRegistryServices(host string, namespace string, exportToNamespace
 	registryService := kubernetes.RegistryService{}
 	registryService.Hostname = host
 	registryService.IstioService.Attributes.Namespace = namespace
+	registryService.IstioService.Attributes.Name = strings.Split(host, ".")[0]
 	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
 	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = true
 

--- a/tests/testutils/validations/fixture_loader.go
+++ b/tests/testutils/validations/fixture_loader.go
@@ -141,6 +141,7 @@ func (l YamlFixtureLoader) FindAuthorizationPolicy(name, namespace string) *secu
 func (l YamlFixtureLoader) FindDestinationRule(name, namespace string) *networking_v1alpha3.DestinationRule {
 	for _, d := range l.istioConfigList.DestinationRules {
 		if d.Name == name && d.Namespace == namespace {
+			d.ClusterName = "svc.cluster.local"
 			return &d
 		}
 	}
@@ -150,6 +151,7 @@ func (l YamlFixtureLoader) FindDestinationRule(name, namespace string) *networki
 func (l YamlFixtureLoader) FindVirtualService(name, namespace string) *networking_v1alpha3.VirtualService {
 	for _, v := range l.istioConfigList.VirtualServices {
 		if v.Name == name && v.Namespace == namespace {
+			v.ClusterName = "svc.cluster.local"
 			return &v
 		}
 	}

--- a/util/mtls/status.go
+++ b/util/mtls/status.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/models"
 )
 
 const (
@@ -21,7 +20,6 @@ type MtlsStatus struct {
 	PeerAuthentications []security_v1beta.PeerAuthentication
 	DestinationRules    []networking_v1alpha3.DestinationRule
 	MatchingLabels      labels.Labels
-	ServiceList         models.ServiceList
 	AutoMtlsEnabled     bool
 	AllowPermissive     bool
 	RegistryServices    []*kubernetes.RegistryService
@@ -85,12 +83,8 @@ func (m MtlsStatus) WorkloadMtlsStatus() string {
 				// Filter DR that applies to the Services matching with the selector
 				// Fetch hosts from DRs and its mtls mode [details, ISTIO_STATUS]
 				// Filter Svc and extract its workloads selectors
-				filteredSvcs := m.ServiceList.FilterServicesForSelector(selector)
 				filteredRSvcs := kubernetes.FilterRegistryServicesBySelector(selector, m.Namespace, m.RegistryServices)
 				nameNamespaces := []NameNamespace{}
-				for _, svc := range filteredSvcs {
-					nameNamespaces = append(nameNamespaces, NameNamespace{svc.Name, svc.Namespace})
-				}
 				for _, rSvc := range filteredRSvcs {
 					nameNamespaces = append(nameNamespaces, NameNamespace{rSvc.IstioService.Attributes.Name, rSvc.IstioService.Attributes.Namespace})
 				}


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4528

Replaced ServiceList by RegistryServices in all remaining validations.

For QE:
Full regression testing of validations. https://kiali.io/docs/features/validations/
UI and e2e  automations run.