### PR TITLE
Init Kiali Cache on Server startup

### DIFF
--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -33,6 +33,9 @@ type (
 		// Stop all caches
 		Stop()
 
+		// Kubernetes Client used for cache
+		GetClient() *kubernetes.K8SClient
+
 		KubernetesCache
 		IstioCache
 		NamespacesCache
@@ -245,4 +248,8 @@ func (c *kialiCacheImpl) Stop() {
 	for ns := range c.nsCache {
 		delete(c.nsCache, ns)
 	}
+}
+
+func (c *kialiCacheImpl) GetClient() *kubernetes.K8SClient {
+	return &c.istioClient
 }

--- a/server/server.go
+++ b/server/server.go
@@ -106,6 +106,9 @@ func (s *Server) Start() {
 	if conf.Server.Observability.Metrics.Enabled {
 		StartMetricsServer()
 	}
+
+	// Start the business to initialize cache dependencies
+	business.Start()
 }
 
 // Stop the HTTP server


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4502

Suggested test plan (QE @skondkar):
- This PR shouldn't change the current behavior from the user's perspective, it can be tested validating that when the Kiali server starts (with NO access from the UI, just deployment), the log should show that the Kiali has been populated.
- A basic access to the Overview page should be enough to validate regressions.