### PR TITLE
Fix "xxx is not found as xxx" issue

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -746,7 +746,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 	for _, pod := range pods {
 		if len(pod.OwnerReferences) != 0 {
 			for _, ref := range pod.OwnerReferences {
-				if ref.Controller != nil && *ref.Controller {
+				if ref.Controller != nil && *ref.Controller && !isWorkloadIncluded(ref.Kind) {
 					if _, exist := controllers[ref.Name]; !exist {
 						controllers[ref.Name] = ref.Kind
 					} else {
@@ -1355,7 +1355,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, namespace string, workload
 	for _, pod := range pods {
 		if len(pod.OwnerReferences) != 0 {
 			for _, ref := range pod.OwnerReferences {
-				if ref.Controller != nil && *ref.Controller {
+				if ref.Controller != nil && *ref.Controller && !isWorkloadIncluded(ref.Kind) {
 					if _, exist := controllers[ref.Name]; !exist {
 						controllers[ref.Name] = ref.Kind
 					} else {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -746,7 +746,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 	for _, pod := range pods {
 		if len(pod.OwnerReferences) != 0 {
 			for _, ref := range pod.OwnerReferences {
-				if ref.Controller != nil && *ref.Controller && !isWorkloadIncluded(ref.Kind) {
+				if ref.Controller != nil && *ref.Controller && isWorkloadIncluded(ref.Kind) {
 					if _, exist := controllers[ref.Name]; !exist {
 						controllers[ref.Name] = ref.Kind
 					} else {
@@ -1355,7 +1355,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, namespace string, workload
 	for _, pod := range pods {
 		if len(pod.OwnerReferences) != 0 {
 			for _, ref := range pod.OwnerReferences {
-				if ref.Controller != nil && *ref.Controller && !isWorkloadIncluded(ref.Kind) {
+				if ref.Controller != nil && *ref.Controller && isWorkloadIncluded(ref.Kind) {
 					if _, exist := controllers[ref.Name]; !exist {
 						controllers[ref.Name] = ref.Kind
 					} else {


### PR DESCRIPTION
The excluded type(s) adding to controllers seems to cause "xxx is not found as xxx" issue.  
Let's take job type as an example. As it is excluded, the job array remains empty:
``` go
// business/workloads.go

	var jbs []batch_v1.Job  // line 593

	go func() {  // line 709
		defer wg.Done()
		var err error
		if isWorkloadIncluded(kubernetes.JobType) { // job type is excluded, condition is not met
			jbs, err = layer.k8s.GetJobs(namespace)
			if err != nil {
				log.Errorf("Error fetching Jobs per namespace %s: %s", namespace, err)
				errChan <- err
			}
		}
	}()
```

And the "is found" validation will always return false, which cause the  "xxx is not found as xxx" issue:
``` go
// business/workloads.go

		case kubernetes.JobType:  // line 1048
			found := false
			iFound := -1
			for i, jb := range jbs {
				if jb.Name == cname {
					found = true
					iFound = i
					break
				}
			}
			if found {
				selector := labels.Set(jbs[iFound].Spec.Template.Labels).AsSelector()
				w.SetPods(kubernetes.FilterPodsBySelector(selector, pods))
				w.ParseJob(&jbs[iFound])
			} else {  // always meet this condition
				log.Errorf("Workload %s is not found as Job", cname)
				cnFound = false
			}
```

I try to make controllers to not contain the excluded type(s) to fix the "xxx is not found as xxx" issue.

Looking forward to your review or better solution. 

Thanks! 