### PR TITLE
fix: add dev to istioDevVersionExpr

### DIFF
--- a/status/versions.go
+++ b/status/versions.go
@@ -34,10 +34,11 @@ var (
 	//   1.7.0-alpha.1-cd46a166947eac363380c3aa3523b26a8c391f98-dirty-Modified
 	// Example Istio dev version is:
 	//   1.5-alpha.dbd2aca8887fb42c2bb358417621a78de372f906-dbd2aca8887fb42c2bb358417621a78de372f906-Clean
+	//   1.10-dev-65a124dc2ab69f91331298fbf6d9b4335abcf0fd-Clean
 	maistraProductVersionExpr = regexp.MustCompile(`maistra-([0-9]+\.[0-9]+\.[0-9]+)`)
 	ossmVersionExpr           = regexp.MustCompile(`(?:OSSM_|openshift-service-mesh-)([0-9]+\.[0-9]+\.[0-9]+)`)
 	maistraProjectVersionExpr = regexp.MustCompile(`(?:Maistra_|openshift-istio.*-)([0-9]+\.[0-9]+\.[0-9]+)`)
-	istioDevVersionExpr       = regexp.MustCompile(`(\d+\.\d+)-alpha\.([[:alnum:]]+)-.*`)
+	istioDevVersionExpr       = regexp.MustCompile(`((\d+\.\d+)-alpha\.([[:alnum:]]+)-.*)|(\d+\.\d+)-(?:dev)`)
 	istioRCVersionExpr        = regexp.MustCompile(`(\d+\.\d+.\d+)-((?:alpha|beta|rc|RC)\.\d+)`)
 	istioSnapshotVersionExpr  = regexp.MustCompile(`istio-release-([0-9]+\.[0-9]+)(-[0-9]{8})`)
 	istioVersionExpr          = regexp.MustCompile(`([0-9]+\.[0-9]+\.[0-9]+)`)

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -141,6 +141,12 @@ func TestParseIstioRawVersion(t *testing.T) {
 			supported:  true,
 		},
 		{
+			rawVersion: "1.10-dev-65a124dc2ab69f91331298fbf6d9b4335abcf0fd-Clean",
+			name:       "Istio Dev",
+			version:    "1.10 (dev 65a124dc2ab69f91331298fbf6d9b4335abcf0fd)",
+			supported:  true,
+		},
+		{
 			rawVersion: "root@f72e3d3ef3c2-docker.io/1.6.0-beta.0",
 			name:       "Istio RC",
 			version:    "1.6.0 (beta.0)",


### PR DESCRIPTION
Signed-off-by: Xunzhuo <mixdeers@gmail.com>

**Describe the change**
_Please describe what the code change is about._

istio dev version has dev prefix like this:
`1.10-dev-65a124dc2ab69f91331298fbf6d9b4335abcf0fd-Clean`


**Issue reference**

_Please, provide the link to the GitHub issue here._

**Backwards incompatible?**

- Is your change introducing backwards incompatible changes?

_describe the changes if appropriate._

**Documentation**

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
If so, please also update [README.adoc](README.adoc)
