### PR TITLE
fix: remove extra path in console local dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMMIT_HASH ?= $(shell git rev-parse HEAD)
 # have been built before trying to create a kiali server container
 # image. The UI project is configured to place its build
 # output in the $UI_SRC_ROOT/build/ subdirectory.
-CONSOLE_LOCAL_DIR ?= ${ROOTDIR}/../../../../../kiali-ui
+CONSOLE_LOCAL_DIR ?= ${ROOTDIR}/../kiali-ui
 
 # Version label is used in the OpenShift/K8S resources to identify
 # their specific instances. Kiali resources will have labels of

--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,7 @@ Once you have the required developer tools, you can get and build the code with 
 # Checkout the source code
 mkdir kiali_sources
 cd kiali_sources
-export KIALI_SOURCES=$(realpath .)
+export KIALI_SOURCES=$(pwd)
 
 git clone https://github.com/kiali/kiali.git
 git clone https://github.com/kiali/kiali-ui.git

--- a/deploy/get-console.sh
+++ b/deploy/get-console.sh
@@ -8,7 +8,7 @@
 # See the main Makefile for more info.
 
 DIR=$(dirname $0)/..
-CONSOLE_DIR=${CONSOLE_LOCAL_DIR:-$DIR/../../../../../kiali-ui}
+CONSOLE_DIR=${CONSOLE_LOCAL_DIR:-$DIR/../kiali-ui}
 
 mkdir -p $DIR/_output/docker
 

--- a/hack/ci-openshift-molecule-tests.sh
+++ b/hack/ci-openshift-molecule-tests.sh
@@ -390,7 +390,7 @@ infomsg "Log into the cluster [${OPENSHIFT_API}] as kubeadmin user named [${KUBE
 $OC login -u ${KUBEADMIN_USER} -p ${KUBEADMIN_PW} ${OPENSHIFT_API}
 
 if [ "${USE_DEV_IMAGES}" == "true" ]; then
-  GOPATH="${SRC}/kiali/src/github.com/kiali/kiali"
+  GOPATH="${GOPATH:-/tmp}"
   infomsg "Dev images are to be tested. Will prepare them now using GOPATH=${GOPATH}"
 
   infomsg "Building server..."


### PR DESCRIPTION
Signed-off-by: Xunzhuo <mixdeers@gmail.com>

**Describe the change**

Minor fix to the console path

Follow these commands in README:

``` bash
# Checkout the source code
mkdir kiali_sources
cd kiali_sources
export KIALI_SOURCES=$(realpath .)

git clone https://github.com/kiali/kiali.git
git clone https://github.com/kiali/kiali-ui.git
git clone https://github.com/kiali/kiali-operator.git
git clone https://github.com/kiali/helm-charts.git

ln -s $KIALI_SOURCES/kiali-operator kiali/operator

# Build the back-end and run the tests
cd $KIALI_SOURCES/kiali
make build test

# Build the front-end and run the tests
cd $KIALI_SOURCES/kiali-ui
yarn && yarn build && yarn test
```

When we run `make container-build` :

```
❯ make container-build
CONSOLE_DIR is /root/github.com/kiali_sources/kiali/../../../../../kiali-ui
Apparently, this CONSOLE_DIR does not contain the kiali-ui
make: *** [make/Makefile.container.mk:7: .prepare-kiali-image-files] Error 1
```
The default path should be:

```
CONSOLE_LOCAL_DIR ?= ${ROOTDIR}/../kiali-ui
```
