### PR TITLE
feat: add apiserver config when out of cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMMIT_HASH ?= $(shell git rev-parse HEAD)
 # have been built before trying to create a kiali server container
 # image. The UI project is configured to place its build
 # output in the $UI_SRC_ROOT/build/ subdirectory.
-CONSOLE_LOCAL_DIR ?= ${ROOTDIR}/../../../../../kiali-ui
+CONSOLE_LOCAL_DIR ?= ${ROOTDIR}/../kiali-ui
 
 # Version label is used in the OpenShift/K8S resources to identify
 # their specific instances. Kiali resources will have labels of
@@ -35,7 +35,7 @@ SWAGGER_VERSION ?= 0.27.0
 # Identifies the Kiali container image that will be built.
 IMAGE_ORG ?= kiali
 CONTAINER_NAME ?= ${IMAGE_ORG}/kiali
-CONTAINER_VERSION ?= dev
+CONTAINER_VERSION ?= 1.54
 
 # These two vars allow Jenkins to override values.
 QUAY_NAME ?= quay.io/${CONTAINER_NAME}

--- a/config/config.go
+++ b/config/config.go
@@ -281,6 +281,9 @@ type KubernetesConfig struct {
 	// can be skipped from Kiali workloads query if they are present in this list
 	ExcludeWorkloads []string `yaml:"excluded_workloads,omitempty"`
 	QPS              float32  `yaml:"qps,omitempty"`
+	// Configure APIServerServiceName and APIServerServicePort only work when out of cluster
+	APIServerServiceName string `yaml:"apiserver_service_name,omitempty"`
+	APIServerServicePort string `yaml:"apiserver_service_port,omitempty"`
 }
 
 // ApiConfig contains API specific configuration.

--- a/config/config.go
+++ b/config/config.go
@@ -284,6 +284,8 @@ type KubernetesConfig struct {
 	// Configure APIServerServiceName and APIServerServicePort only work when out of cluster
 	APIServerServiceName string `yaml:"apiserver_service_name,omitempty"`
 	APIServerServicePort string `yaml:"apiserver_service_port,omitempty"`
+	// SecretPath the path of secret
+	SecretPath string `yaml:"secret_path,omitempty"`
 }
 
 // ApiConfig contains API specific configuration.

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -55,6 +56,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.2.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/vjeantet/grok v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,7 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -119,16 +119,25 @@ func ConfigClient() (*rest.Config, error) {
 		}
 		incluster.QPS = kialiConfig.Get().KubernetesConfig.QPS
 		incluster.Burst = kialiConfig.Get().KubernetesConfig.Burst
+
 		return incluster, nil
 	}
-	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
-	if len(host) == 0 || len(port) == 0 {
+
+	// Read apiserver Host and Port from config
+	apiserverServiceHost := kialiConfig.Get().KubernetesConfig.APIServerServiceName
+	apiserverServicePort := kialiConfig.Get().KubernetesConfig.APIServerServicePort
+	// If apiserver Host or Port is empty, read them from env
+	if apiserverServiceHost == "" || apiserverServicePort == "" {
+		apiserverServiceHost, apiserverServicePort = os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	}
+
+	if len(apiserverServiceHost) == 0 || len(apiserverServicePort) == 0 {
 		return nil, fmt.Errorf("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
 	}
 
 	return &rest.Config{
 		// TODO: switch to using cluster DNS.
-		Host:  "http://" + net.JoinHostPort(host, port),
+		Host:  "http://" + net.JoinHostPort(apiserverServiceHost, apiserverServicePort),
 		QPS:   kialiConfig.Get().KubernetesConfig.QPS,
 		Burst: kialiConfig.Get().KubernetesConfig.Burst,
 	}, nil

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	kube "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	kialiConfig "github.com/kiali/kiali/config"
@@ -112,7 +113,11 @@ func ConfigClient() (*rest.Config, error) {
 		if remoteSecret, readErr := GetRemoteSecret(RemoteSecretData); readErr == nil {
 			incluster, err = UseRemoteCreds(remoteSecret)
 		} else {
-			incluster, err = rest.InClusterConfig()
+			if kialiConfig.Get().KubernetesConfig.SecretPath != "" {
+				incluster, err = clientcmd.BuildConfigFromFlags("", kialiConfig.Get().KubernetesConfig.SecretPath)
+			} else {
+				incluster, err = rest.InClusterConfig()
+			}
 		}
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: Xunzhuo <mixdeers@gmail.com>

**Describe the change**

Add apiserver config fields, kiali can talk to specfic apiserver.

This is only work outside of cluster.

**Backwards incompatible?**

No
