### PR TITLE
Add Finalizers to the graph generation architecture

### DIFF
--- a/graph/finalizer.go
+++ b/graph/finalizer.go
@@ -1,0 +1,29 @@
+package graph
+
+import (
+	"github.com/kiali/kiali/business"
+)
+
+// FinalizerInfo caches information relevant to a single graph. It allows
+// a finalizer to populate the cache and then it, or another finalizer
+// can re-use the information.  A new instance is generated for graph and
+// is initially empty.
+type FinalizerInfo struct {
+	Business    *business.Layer
+	HomeCluster string
+}
+
+func NewFinalizerInfo() *FinalizerInfo {
+	return &FinalizerInfo{}
+}
+
+// Finalizer is implemented by any code designed to add-to or alter the final TrafficMap.
+// On error the finalizer should panic and it will be handled as an error response.
+type Finalizer interface {
+	// FinalizeGraph performs the finalizer work on the provided traffic map. The map
+	// may be initially empty. A finalizer is allowed to add or remove map entries.
+	FinalizeGraph(trafficMap TrafficMap, finalizerInfo *FinalizerInfo, o TelemetryOptions)
+
+	// Name returns a unique finalizer name used to identify the finalizer (e.g in 'finalizers' query param)
+	Name() string
+}

--- a/graph/telemetry/istio/finalizer/finalizer.go
+++ b/graph/telemetry/istio/finalizer/finalizer.go
@@ -1,0 +1,34 @@
+package finalizer
+
+import (
+	"github.com/kiali/kiali/graph"
+)
+
+// ParseFinalizers determines which finalizers should run for this graphing request
+func ParseFinalizers(o graph.TelemetryOptions) []graph.Finalizer {
+
+	/* Uncomment and add cases when we have queryParam finalizers
+	 *
+	requestedFinalizers := make(map[string]bool)
+	if !o.Finalizers.All {
+		for _, finalizerName := range o.Finalizers.FinalizerNames {
+			switch finalizerName {
+			case "":
+				// skip
+			default:
+				graph.BadRequest(fmt.Sprintf("Invalid finalizer [%s]", finalizerName))
+			}
+		}
+	}
+	*/
+
+	// The finalizer order is important, run the standard finalizers at the end
+	var finalizers []graph.Finalizer
+
+	// always run the outsider finalizer
+	finalizers = append(finalizers, &OutsiderFinalizer{})
+	// always run the traffic generator finalizer
+	finalizers = append(finalizers, &TrafficGeneratorFinalizer{})
+
+	return finalizers
+}

--- a/graph/telemetry/istio/finalizer/outsider.go
+++ b/graph/telemetry/istio/finalizer/outsider.go
@@ -1,0 +1,79 @@
+package finalizer
+
+import (
+	"time"
+
+	"github.com/kiali/kiali/graph"
+)
+
+const OutsiderFinalizerName = "outsider"
+
+// OutsiderFinalizer is responsible for marking the outsiders (i.e. nodes not in the requested namespaces) and inaccessible nodes
+// Name: outsider
+type OutsiderFinalizer struct{}
+
+// Name implements Finalizer
+func (f *OutsiderFinalizer) Name() string {
+	return OutsiderFinalizerName
+}
+
+// FinalizeGraph implements Appender
+func (f *OutsiderFinalizer) FinalizeGraph(trafficMap graph.TrafficMap, finalizerInfo *graph.FinalizerInfo, o graph.TelemetryOptions) {
+	if len(trafficMap) == 0 {
+		return
+	}
+
+	markOutsideOrInaccessible(trafficMap, o)
+}
+
+// MarkOutsideOrInaccessible sets metadata for outsider and inaccessible nodes.  It should be called
+// after all appender work is completed.
+func markOutsideOrInaccessible(trafficMap graph.TrafficMap, o graph.TelemetryOptions) {
+	for _, n := range trafficMap {
+		switch n.NodeType {
+		case graph.NodeTypeUnknown:
+			n.Metadata[graph.IsInaccessible] = true
+		case graph.NodeTypeService:
+			if n.Namespace == graph.Unknown {
+				n.Metadata[graph.IsInaccessible] = true
+			} else if n.Metadata[graph.IsEgressCluster] == true {
+				n.Metadata[graph.IsInaccessible] = true
+			} else {
+				if isOutside(n, o.Namespaces) {
+					n.Metadata[graph.IsOutside] = true
+				}
+			}
+		default:
+			if isOutside(n, o.Namespaces) {
+				n.Metadata[graph.IsOutside] = true
+			}
+		}
+		if isOutsider, ok := n.Metadata[graph.IsOutside]; ok && isOutsider.(bool) {
+			if _, ok2 := n.Metadata[graph.IsInaccessible]; !ok2 {
+				if isInaccessible(n, o.AccessibleNamespaces) {
+					n.Metadata[graph.IsInaccessible] = true
+				}
+			}
+		}
+	}
+}
+
+func isOutside(n *graph.Node, namespaces map[string]graph.NamespaceInfo) bool {
+	if n.Namespace == graph.Unknown {
+		return false
+	}
+	for _, ns := range namespaces {
+		if n.Namespace == ns.Name {
+			return false
+		}
+	}
+	return true
+}
+
+func isInaccessible(n *graph.Node, accessibleNamespaces map[string]time.Time) bool {
+	if _, found := accessibleNamespaces[n.Namespace]; !found {
+		return true
+	} else {
+		return false
+	}
+}

--- a/graph/telemetry/istio/finalizer/traffic_generator.go
+++ b/graph/telemetry/istio/finalizer/traffic_generator.go
@@ -1,0 +1,43 @@
+package finalizer
+
+import (
+	"github.com/kiali/kiali/graph"
+)
+
+const TrafficGeneratorFinalizerName = "trafficGenerator"
+
+// TrafficGeneratorFinalizer is responsible for marking the insider traffic generator nodes (i.e. inside the namespace and only having outgoing edges)
+// Name: trafficGenerator
+type TrafficGeneratorFinalizer struct{}
+
+// Name implements Finalizer
+func (f *TrafficGeneratorFinalizer) Name() string {
+	return OutsiderFinalizerName
+}
+
+// FinalizeGraph implements Appender
+func (f *TrafficGeneratorFinalizer) FinalizeGraph(trafficMap graph.TrafficMap, finalizerInfo *graph.FinalizerInfo, o graph.TelemetryOptions) {
+	if len(trafficMap) == 0 {
+		return
+	}
+
+	markTrafficGenerators(trafficMap)
+}
+
+// MarkTrafficGenerators set IsRoot metadata. It is called after appender work is complete.
+func markTrafficGenerators(trafficMap graph.TrafficMap) {
+	destMap := make(map[string]*graph.Node)
+	for _, n := range trafficMap {
+		for _, e := range n.Edges {
+			destMap[e.Dest.ID] = e.Dest
+		}
+	}
+	for _, n := range trafficMap {
+		if len(n.Edges) == 0 {
+			continue
+		}
+		if _, isDest := destMap[n.ID]; !isDest {
+			n.Metadata[graph.IsRoot] = true
+		}
+	}
+}

--- a/graph/telemetry/istio/finalizer/traffic_generator.go
+++ b/graph/telemetry/istio/finalizer/traffic_generator.go
@@ -15,7 +15,7 @@ func (f *TrafficGeneratorFinalizer) Name() string {
 	return OutsiderFinalizerName
 }
 
-// FinalizeGraph implements Appender
+// FinalizeGraph implements Finalizer
 func (f *TrafficGeneratorFinalizer) FinalizeGraph(trafficMap graph.TrafficMap, finalizerInfo *graph.FinalizerInfo, o graph.TelemetryOptions) {
 	if len(trafficMap) == 0 {
 		return


### PR DESCRIPTION
This is pure code organization at the moment.  But I think it may be useful for some of the
projected features.  I am tying this to a current epic, which likely
will want to add k8s label info to graph nodes. This could be done in
an appender, but may lend itself better to being done one time, at the end.
Even if we don't add more finalizers, it's still not a bad thing.  There
isn't really a perf hit and I think it adds some structure.

relates to https://github.com/kiali/kiali/issues/4605
