### PR TITLE
feat: support config custom labels when scraping metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -145,6 +145,8 @@ type PrometheusConfig struct {
 	IsCore          bool              `yaml:"is_core,omitempty"`
 	ThanosProxy     ThanosProxy       `yaml:"thanos_proxy,omitempty"`
 	URL             string            `yaml:"url,omitempty"`
+	// Custom Additional Labels to scrape metrics from Prometheus
+	CustomLabels map[string]string `yaml:"custom_labels,omitempty"`
 }
 
 // CustomDashboardsConfig describes configuration specific to Custom Dashboards
@@ -599,6 +601,7 @@ func NewConfig() (c *Config) {
 				// Prom Cache expires and it forces to repopulate cache
 				CacheExpiration: 300,
 				CustomHeaders:   map[string]string{},
+				CustomLabels:    map[string]string{},
 				URL:             "http://prometheus.istio-system:9090",
 			},
 			Tracing: TracingConfig{

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -26,6 +26,7 @@ import (
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/graph/telemetry"
 	"github.com/kiali/kiali/graph/telemetry/istio/appender"
@@ -87,6 +88,8 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 	if o.IncludeIdleEdges {
 		idleCondition = ""
 	}
+	// build custom labels from config
+	customlabels := buildCustomLabelsFromConfig()
 
 	// HTTP/GRPC request traffic
 	if o.Rates.Http == graph.RateRequests || o.Rates.Grpc == graph.RateRequests {
@@ -94,10 +97,11 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 		groupBy := "source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags"
 
 		// 0) Incoming: query source telemetry to capture unserviced namespace services' incoming traffic
-		query := fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
+		query := fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"%s} [%vs])) by (%s) %s`,
 			metric,
 			namespace,
 			namespace,
+			customlabels,
 			int(duration.Seconds()), // range duration for the query
 			groupBy,
 			idleCondition)
@@ -105,9 +109,10 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 		populateTrafficMap(trafficMap, &incomingVector, metric, o)
 
 		// 1) Incoming: query destination telemetry to capture namespace services' incoming traffic
-		query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_workload_namespace="%s"} [%vs])) by (%s) %s`,
+		query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_workload_namespace="%s"%s} [%vs])) by (%s) %s`,
 			metric,
 			namespace,
+			customlabels,
 			int(duration.Seconds()), // range duration for the query
 			groupBy,
 			idleCondition)
@@ -115,9 +120,10 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 		populateTrafficMap(trafficMap, &incomingVector, metric, o)
 
 		// 2) Outgoing: query source telemetry to capture namespace workloads' outgoing traffic
-		query = fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace="%s"} [%vs])) by (%s) %s`,
+		query = fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace="%s"%s} [%vs])) by (%s) %s`,
 			metric,
 			namespace,
+			customlabels,
 			int(duration.Seconds()), // range duration for the query
 			groupBy,
 			idleCondition)
@@ -143,10 +149,11 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 
 		for _, metric := range metrics {
 			// 0) Incoming: query source telemetry to capture unserviced namespace services' incoming traffic
-			query := fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
+			query := fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"%s} [%vs])) by (%s) %s`,
 				metric,
 				namespace,
 				namespace,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
@@ -154,9 +161,10 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 			populateTrafficMap(trafficMap, &incomingVector, metric, o)
 
 			// 1) Incoming: query destination telemetry to capture namespace services' incoming traffic	query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_service_namespace="%s"} [%vs])) by (%s) %s`,
-			query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_workload_namespace="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_workload_namespace="%s"%s} [%vs])) by (%s) %s`,
 				metric,
 				namespace,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
@@ -164,9 +172,10 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 			populateTrafficMap(trafficMap, &incomingVector, metric, o)
 
 			// 2) Outgoing: query source telemetry to capture namespace workloads' outgoing traffic
-			query = fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace="%s"%s} [%vs])) by (%s) %s`,
 				metric,
 				namespace,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
@@ -193,10 +202,11 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 
 		for _, metric := range metrics {
 			// 0) Incoming: query source telemetry to capture unserviced namespace services' incoming traffic
-			query := fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
+			query := fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"%s} [%vs])) by (%s) %s`,
 				metric,
 				namespace,
 				namespace,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
@@ -204,9 +214,10 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 			populateTrafficMap(trafficMap, &incomingVector, metric, o)
 
 			// 1) Incoming: query destination telemetry to capture namespace services' incoming traffic	query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_service_namespace="%s"} [%vs])) by (%s) %s`,
-			query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_workload_namespace="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_workload_namespace="%s"%s} [%vs])) by (%s) %s`,
 				metric,
 				namespace,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
@@ -214,9 +225,10 @@ func buildNamespaceTrafficMap(namespace string, o graph.TelemetryOptions, client
 			populateTrafficMap(trafficMap, &incomingVector, metric, o)
 
 			// 2) Outgoing: query source telemetry to capture namespace workloads' outgoing traffic
-			query = fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace="%s"%s} [%vs])) by (%s) %s`,
 				metric,
 				namespace,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
@@ -461,6 +473,8 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 	if o.IncludeIdleEdges {
 		idleCondition = ""
 	}
+	// build custom labels from config
+	customlabels := buildCustomLabelsFromConfig()
 
 	// only narrow by cluster if it is set on the target node
 	var sourceCluster, destCluster string
@@ -479,31 +493,34 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 		var query string
 		switch n.NodeType {
 		case graph.NodeTypeWorkload:
-			query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_workload_namespace="%s",destination_workload="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_workload_namespace="%s",destination_workload="%s"%s} [%vs])) by (%s) %s`,
 				metric,
 				destCluster,
 				namespace,
 				n.Workload,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
 		case graph.NodeTypeApp:
 			if graph.IsOK(n.Version) {
-				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"%s} [%vs])) by (%s) %s`,
 					metric,
 					destCluster,
 					namespace,
 					n.App,
 					n.Version,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
 			} else {
-				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s"%s} [%vs])) by (%s) %s`,
 					metric,
 					destCluster,
 					namespace,
 					n.App,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
@@ -511,11 +528,12 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 		case graph.NodeTypeService:
 			// Service nodes require two queries for incoming
 			// 1.a) query source telemetry for requests to the service that could not be serviced
-			query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,destination_workload="unknown",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,destination_workload="unknown",destination_service=~"^%s\\.%s\\..*$"%s} [%vs])) by (%s) %s`,
 				metric,
 				destCluster,
 				n.Service,
 				namespace,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
@@ -523,12 +541,13 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 			populateTrafficMap(trafficMap, &vector, metric, o)
 
 			// 1.b) query dest telemetry for requests to the service, serviced by service workloads
-			query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"%s} [%vs])) by (%s) %s`,
 				metric,
 				destCluster,
 				namespace,
 				n.Service,
 				namespace,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
@@ -541,31 +560,34 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 		// 2) query for outbound traffic
 		switch n.NodeType {
 		case graph.NodeTypeWorkload:
-			query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_workload="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_workload="%s"%s} [%vs])) by (%s) %s`,
 				metric,
 				sourceCluster,
 				namespace,
 				n.Workload,
+				customlabels,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
 				idleCondition)
 		case graph.NodeTypeApp:
 			if graph.IsOK(n.Version) {
-				query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"%s} [%vs])) by (%s) %s`,
 					metric,
 					sourceCluster,
 					namespace,
 					n.App,
 					n.Version,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
 			} else {
-				query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s"%s} [%vs])) by (%s) %s`,
 					metric,
 					sourceCluster,
 					namespace,
 					n.App,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
@@ -600,43 +622,47 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 
 			switch n.NodeType {
 			case graph.NodeTypeWorkload:
-				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_workload_namespace="%s",destination_workload="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_workload_namespace="%s",destination_workload="%s"%s} [%vs])) by (%s) %s`,
 					metric,
 					destCluster,
 					namespace,
 					n.Workload,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
 			case graph.NodeTypeApp:
 				if graph.IsOK(n.Version) {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"%s} [%vs])) by (%s) %s`,
 						metric,
 						destCluster,
 						namespace,
 						n.App,
 						n.Version,
+						customlabels,
 						int(duration.Seconds()), // range duration for the query
 						groupBy,
 						idleCondition)
 				} else {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s"%s} [%vs])) by (%s) %s`,
 						metric,
 						destCluster,
 						namespace,
 						n.App,
+						customlabels,
 						int(duration.Seconds()), // range duration for the query
 						groupBy,
 						idleCondition)
 				}
 			case graph.NodeTypeService:
 				// TODO: Do we need to handle requests from unknown in a special way (like in HTTP above)? Not sure how gRPC-messages is reported from unknown.
-				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"%s} [%vs])) by (%s) %s`,
 					metric,
 					destCluster,
 					namespace,
 					n.Service,
 					namespace,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
@@ -649,31 +675,34 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 			// 2) query for outbound traffic
 			switch n.NodeType {
 			case graph.NodeTypeWorkload:
-				query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_workload="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_workload="%s"%s} [%vs])) by (%s) %s`,
 					metric,
 					sourceCluster,
 					namespace,
 					n.Workload,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
 			case graph.NodeTypeApp:
 				if graph.IsOK(n.Version) {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"%s} [%vs])) by (%s) %s`,
 						metric,
 						sourceCluster,
 						namespace,
 						n.App,
 						n.Version,
+						customlabels,
 						int(duration.Seconds()), // range duration for the query
 						groupBy,
 						idleCondition)
 				} else {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s"%s} [%vs])) by (%s) %s`,
 						metric,
 						sourceCluster,
 						namespace,
 						n.App,
+						customlabels,
 						int(duration.Seconds()), // range duration for the query
 						groupBy,
 						idleCondition)
@@ -709,43 +738,47 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 
 			switch n.NodeType {
 			case graph.NodeTypeWorkload:
-				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_workload_namespace="%s",destination_workload="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_workload_namespace="%s",destination_workload="%s"%s} [%vs])) by (%s) %s`,
 					metric,
 					destCluster,
 					namespace,
 					n.Workload,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
 			case graph.NodeTypeApp:
 				if graph.IsOK(n.Version) {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"%s} [%vs])) by (%s) %s`,
 						metric,
 						destCluster,
 						namespace,
 						n.App,
 						n.Version,
+						customlabels,
 						int(duration.Seconds()), // range duration for the query
 						groupBy,
 						idleCondition)
 				} else {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_canonical_service="%s"%s} [%vs])) by (%s) %s`,
 						metric,
 						destCluster,
 						namespace,
 						n.App,
+						customlabels,
 						int(duration.Seconds()), // range duration for the query
 						groupBy,
 						idleCondition)
 				}
 			case graph.NodeTypeService:
 				// TODO: Do we need to handle requests from unknown in a special way (like in HTTP above)? Not sure how tcp is reported from unknown.
-				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="destination"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"%s} [%vs])) by (%s) %s`,
 					metric,
 					destCluster,
 					namespace,
 					n.Service,
 					namespace,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
@@ -758,31 +791,34 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 			// 2) query for outbound traffic
 			switch n.NodeType {
 			case graph.NodeTypeWorkload:
-				query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_workload="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_workload="%s"%s} [%vs])) by (%s) %s`,
 					metric,
 					sourceCluster,
 					namespace,
 					n.Workload,
+					customlabels,
 					int(duration.Seconds()), // range duration for the query
 					groupBy,
 					idleCondition)
 			case graph.NodeTypeApp:
 				if graph.IsOK(n.Version) {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"%s} [%vs])) by (%s) %s`,
 						metric,
 						sourceCluster,
 						namespace,
 						n.App,
 						n.Version,
+						customlabels,
 						int(duration.Seconds()), // range duration for the query
 						groupBy,
 						idleCondition)
 				} else {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{reporter="source"%s,source_workload_namespace="%s",source_canonical_service="%s"%s} [%vs])) by (%s) %s`,
 						metric,
 						sourceCluster,
 						namespace,
 						n.App,
+						customlabels,
 						int(duration.Seconds()), // range duration for the query
 						groupBy,
 						idleCondition)
@@ -798,6 +834,27 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 	}
 
 	return trafficMap
+}
+
+// buildCustomLabelsFromConfig build custom addtional labels for prometheus from config
+func buildCustomLabelsFromConfig() string {
+	customLabels := config.Get().ExternalServices.Prometheus.CustomLabels
+	if len(customLabels) == 0 {
+		customLabels = config.Get().ExternalServices.CustomDashboards.Prometheus.CustomLabels
+		if len(customLabels) == 0 {
+			return ""
+		}
+	}
+	return buildCustomLabels(customLabels)
+}
+
+// buildCustomLabels build custom addtional labels for prometheus
+func buildCustomLabels(customLabels map[string]string) string {
+	labels := ""
+	for labelName, labelValue := range customLabels {
+		labels += fmt.Sprintf(",%s=\"%s\"", labelName, labelValue)
+	}
+	return labels
 }
 
 func handleAggregateNodeTrafficMap(o graph.TelemetryOptions, client *prometheus.Client, globalInfo *graph.AppenderGlobalInfo) graph.TrafficMap {

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -840,10 +840,7 @@ func buildNodeTrafficMap(cluster, namespace string, n graph.Node, o graph.Teleme
 func buildCustomLabelsFromConfig() string {
 	customLabels := config.Get().ExternalServices.Prometheus.CustomLabels
 	if len(customLabels) == 0 {
-		customLabels = config.Get().ExternalServices.CustomDashboards.Prometheus.CustomLabels
-		if len(customLabels) == 0 {
-			return ""
-		}
+		return ""
 	}
 	return buildCustomLabels(customLabels)
 }


### PR DESCRIPTION
Signed-off-by: Xunzhuo <mixdeers@gmail.com>

**Describe the change**

support config custom labels when scraping metrics in multi-cluster scenario.

prevent mixed topology when prometheus recieves more than one meshes metrics.

config like below:

``` yaml
  prometheus:
    url: "http://127.0.0.1:9090"
    custom_labels:
      mesh: "meshID"
      cluster: "clusterID"
      ...
```

config key and values of custom labels.

**Issue reference**

https://github.com/kiali/kiali/issues/4664

**Backwards incompatible?**

No

**Documentation**

* Does your contribution contain user-visible changes like e.g. new or changed configuration settings?

Yes, need some changes in CR reference.

**Before:**
**Namespace graph:**
<img width="892" alt="image" src="https://user-images.githubusercontent.com/48784001/153991993-14465896-0675-485e-ada8-ac83bb474966.png">

**Node graph:**
<img width="830" alt="image" src="https://user-images.githubusercontent.com/48784001/153991960-7d29d3f0-d5ef-40bd-9702-5d484af8494a.png">


**After:**
**Namespace graph:**
<img width="781" alt="image" src="https://user-images.githubusercontent.com/48784001/153991822-42e02375-cbb0-46d9-b6db-2564a4d9980b.png">
**Node graph:**
<img width="846" alt="image" src="https://user-images.githubusercontent.com/48784001/153991846-e2865b67-9c5a-4c74-b6ca-438e7d9fcd5b.png">
