### PR TITLE
Help messages for some key fields in Istio config details method

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -720,22 +720,6 @@ func NewConfig() (c *Config) {
 	return
 }
 
-func (conf *Config) AddHelpDefault() {
-	istioConfigHelpMessages := map[string][]IstioConfigHelp{
-		"virtualservices": {
-			{ObjectField: "spec.hosts", Message: "The destination hosts to which traffic is being sent. Could be a DNS name with wildcard prefix or an IP address. Depending on the platform, short-names can also be used instead of a FQDN (i.e. has no dots in the name)."},
-			{ObjectField: "spec.gateways", Message: "The names of gateways and sidecars that should apply these routes. Gateways in other namespaces may be referred to by <gateway namespace>/<gateway name>; specifying a gateway with no namespace qualifier is the same as specifying the VirtualService’s namespace. To apply the rules to both gateways and sidecars, specify mesh as one of the gateway names."},
-			{ObjectField: "spec.http", Message: "An ordered list of route rules for HTTP traffic."},
-			{ObjectField: "spec.exportTo", Message: "A list of namespaces to which this virtual service is exported. Exporting a virtual service allows it to be used by sidecars and gateways defined in other namespaces."},
-			{ObjectField: "spec.http.match", Message: "Match conditions to be satisfied for the rule to be activated."},
-			{ObjectField: "spec.http.route", Message: "A HTTP rule can either redirect or forward (default) traffic. The forwarding target can be one of several versions of a service. Weights associated with the service version determine the proportion of traffic it receives."},
-			{ObjectField: "spec.http.route.destination.host", Message: "The name of a service from the service registry. Service names are looked up from the platform’s service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by ServiceEntry."},
-			{ObjectField: "spec.http.route.destination.subset", Message: "The name of a subset within the service. Applicable only to services within the mesh. The subset must be defined in a corresponding DestinationRule."},
-		},
-	}
-	conf.IstioConfigHelpMessages = istioConfigHelpMessages
-}
-
 // AddHealthDefault Configuration
 func (conf *Config) AddHealthDefault() {
 	// Health default configuration

--- a/config/config.go
+++ b/config/config.go
@@ -244,12 +244,6 @@ type IstioLabels struct {
 	VersionLabelName   string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
-// IstioConfigHelp represents a help message for a given Istio object type and field
-type IstioConfigHelp struct {
-	ObjectField string `yaml:"object_field" json:"objectField"`
-	Message     string `yaml:"message" json:"message"`
-}
-
 // AdditionalDisplayItem holds some display-related configuration, like which annotations are to be displayed
 type AdditionalDisplayItem struct {
 	Annotation     string `yaml:"annotation"`
@@ -475,7 +469,6 @@ type Config struct {
 	Identity                 security.Identity                   `yaml:",omitempty"`
 	InCluster                bool                                `yaml:"in_cluster,omitempty"`
 	InstallationTag          string                              `yaml:"installation_tag,omitempty"`
-	IstioConfigHelpMessages  map[string][]IstioConfigHelp        `yaml:"istio_config_help_messages,omitempty" json:"help,omitempty"`
 	IstioLabels              IstioLabels                         `yaml:"istio_labels,omitempty"`
 	IstioNamespace           string                              `yaml:"istio_namespace,omitempty"` // default component namespace
 	KialiFeatureFlags        KialiFeatureFlags                   `yaml:"kiali_feature_flags,omitempty"`
@@ -774,7 +767,6 @@ func Set(conf *Config) {
 	rwMutex.Lock()
 	defer rwMutex.Unlock()
 	conf.AddHealthDefault()
-	conf.AddHelpDefault()
 	configuration = *conf
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -244,6 +244,12 @@ type IstioLabels struct {
 	VersionLabelName   string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
+// IstioConfigHelp represents a help message for a given Istio object type and field
+type IstioConfigHelp struct {
+	ObjectField string `yaml:"object_field" json:"objectField"`
+	Message     string `yaml:"message" json:"message"`
+}
+
 // AdditionalDisplayItem holds some display-related configuration, like which annotations are to be displayed
 type AdditionalDisplayItem struct {
 	Annotation     string `yaml:"annotation"`
@@ -469,6 +475,7 @@ type Config struct {
 	Identity                 security.Identity                   `yaml:",omitempty"`
 	InCluster                bool                                `yaml:"in_cluster,omitempty"`
 	InstallationTag          string                              `yaml:"installation_tag,omitempty"`
+	IstioConfigHelpMessages  map[string][]IstioConfigHelp        `yaml:"istio_config_help_messages,omitempty" json:"help,omitempty"`
 	IstioLabels              IstioLabels                         `yaml:"istio_labels,omitempty"`
 	IstioNamespace           string                              `yaml:"istio_namespace,omitempty"` // default component namespace
 	KialiFeatureFlags        KialiFeatureFlags                   `yaml:"kiali_feature_flags,omitempty"`
@@ -713,6 +720,22 @@ func NewConfig() (c *Config) {
 	return
 }
 
+func (conf *Config) AddHelpDefault() {
+	istioConfigHelpMessages := map[string][]IstioConfigHelp{
+		"virtualservices": {
+			{ObjectField: "spec.hosts", Message: "The destination hosts to which traffic is being sent. Could be a DNS name with wildcard prefix or an IP address. Depending on the platform, short-names can also be used instead of a FQDN (i.e. has no dots in the name)."},
+			{ObjectField: "spec.gateways", Message: "The names of gateways and sidecars that should apply these routes. Gateways in other namespaces may be referred to by <gateway namespace>/<gateway name>; specifying a gateway with no namespace qualifier is the same as specifying the VirtualService’s namespace. To apply the rules to both gateways and sidecars, specify mesh as one of the gateway names."},
+			{ObjectField: "spec.http", Message: "An ordered list of route rules for HTTP traffic."},
+			{ObjectField: "spec.exportTo", Message: "A list of namespaces to which this virtual service is exported. Exporting a virtual service allows it to be used by sidecars and gateways defined in other namespaces."},
+			{ObjectField: "spec.http.match", Message: "Match conditions to be satisfied for the rule to be activated."},
+			{ObjectField: "spec.http.route", Message: "A HTTP rule can either redirect or forward (default) traffic. The forwarding target can be one of several versions of a service. Weights associated with the service version determine the proportion of traffic it receives."},
+			{ObjectField: "spec.http.route.destination.host", Message: "The name of a service from the service registry. Service names are looked up from the platform’s service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by ServiceEntry."},
+			{ObjectField: "spec.http.route.destination.subset", Message: "The name of a subset within the service. Applicable only to services within the mesh. The subset must be defined in a corresponding DestinationRule."},
+		},
+	}
+	conf.IstioConfigHelpMessages = istioConfigHelpMessages
+}
+
 // AddHealthDefault Configuration
 func (conf *Config) AddHealthDefault() {
 	// Health default configuration
@@ -767,6 +790,7 @@ func Set(conf *Config) {
 	rwMutex.Lock()
 	defer rwMutex.Unlock()
 	conf.AddHealthDefault()
+	conf.AddHelpDefault()
 	configuration = *conf
 }
 

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -137,7 +137,7 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 	istioConfigDetails, err := business.IstioConfig.GetIstioConfigDetails(context.TODO(), namespace, objectType, object)
 
 	if includeHelp {
-		istioConfigDetails.IstioConfigHelpFields = config.Get().IstioConfigHelpMessages[objectType]
+		istioConfigDetails.IstioConfigHelpFields = models.IstioConfigHelpMessages[objectType]
 	}
 
 	if includeValidations && err == nil {

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -99,6 +99,11 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 		includeValidations = true
 	}
 
+	includeHelp := false
+	if _, found := query["help"]; found {
+		includeHelp = true
+	}
+
 	if !checkObjectType(objectType) {
 		RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+objectType)
 		return
@@ -130,6 +135,10 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	istioConfigDetails, err := business.IstioConfig.GetIstioConfigDetails(context.TODO(), namespace, objectType, object)
+
+	if includeHelp {
+		istioConfigDetails.IstioConfigHelpFields = config.Get().IstioConfigHelpMessages[objectType]
+	}
 
 	if includeValidations && err == nil {
 		wg.Wait()

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -7499,6 +7499,7 @@ Can be True, False, Unknown. |  |
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
+| IstioConfigHelpFields | [][IstioConfigHelp](#istio-config-help)| `[]*IstioConfigHelp` |  | |  |  |
 | ObjectType | string| `string` |  | |  |  |
 | authorizationPolicy | [AuthorizationPolicy](#authorization-policy)| `AuthorizationPolicy` |  | |  |  |
 | destinationRule | [DestinationRule](#destination-rule)| `DestinationRule` |  | |  |  |
@@ -7515,6 +7516,25 @@ Can be True, False, Unknown. |  |
 | virtualService | [VirtualService](#virtual-service)| `VirtualService` |  | |  |  |
 | workloadEntry | [WorkloadEntry](#workload-entry)| `WorkloadEntry` |  | |  |  |
 | workloadGroup | [WorkloadGroup](#workload-group)| `WorkloadGroup` |  | |  |  |
+
+
+
+### <span id="istio-config-help"></span> IstioConfigHelp
+
+
+> IstioConfigHelp represents a help message for a given Istio object type and field
+  
+
+
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| Message | string| `string` |  | |  |  |
+| ObjectField | string| `string` |  | |  |  |
 
 
 

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -3,8 +3,6 @@ package models
 import (
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
-
-	"github.com/kiali/kiali/config"
 )
 
 // IstioConfigList istioConfigList
@@ -50,10 +48,42 @@ type IstioConfigDetails struct {
 	PeerAuthentication    *security_v1beta.PeerAuthentication    `json:"peerAuthentication"`
 	RequestAuthentication *security_v1beta.RequestAuthentication `json:"requestAuthentication"`
 
-	Permissions           ResourcePermissions      `json:"permissions"`
-	IstioValidation       *IstioValidation         `json:"validation"`
-	IstioReferences       *IstioReferences         `json:"references"`
-	IstioConfigHelpFields []config.IstioConfigHelp `json:"help"`
+	Permissions           ResourcePermissions `json:"permissions"`
+	IstioValidation       *IstioValidation    `json:"validation"`
+	IstioReferences       *IstioReferences    `json:"references"`
+	IstioConfigHelpFields []IstioConfigHelp   `json:"help"`
+}
+
+// IstioConfigHelp represents a help message for a given Istio object type and field
+type IstioConfigHelp struct {
+	ObjectField string `json:"objectField"`
+	Message     string `json:"message"`
+}
+
+var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
+	"virtualservices": {
+		{ObjectField: "spec.hosts", Message: "The destination hosts to which traffic is being sent. Could be a DNS name with wildcard prefix or an IP address. Depending on the platform, short-names can also be used instead of a FQDN (i.e. has no dots in the name)."},
+		{ObjectField: "spec.gateways", Message: "The names of gateways and sidecars that should apply these routes. Gateways in other namespaces may be referred to by <gateway namespace>/<gateway name>; specifying a gateway with no namespace qualifier is the same as specifying the VirtualService’s namespace. To apply the rules to both gateways and sidecars, specify mesh as one of the gateway names."},
+		{ObjectField: "spec.http", Message: "An ordered list of route rules for HTTP traffic."},
+		{ObjectField: "spec.exportTo", Message: "A list of namespaces to which this virtual service is exported. Exporting a virtual service allows it to be used by sidecars and gateways defined in other namespaces."},
+		{ObjectField: "spec.http.match", Message: "Match conditions to be satisfied for the rule to be activated."},
+		{ObjectField: "spec.http.route", Message: "A HTTP rule can either redirect or forward (default) traffic. The forwarding target can be one of several versions of a service. Weights associated with the service version determine the proportion of traffic it receives."},
+		{ObjectField: "spec.http.route.destination.host", Message: "The name of a service from the service registry. Service names are looked up from the platform’s service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by ServiceEntry."},
+		{ObjectField: "spec.http.route.destination.subset", Message: "The name of a subset within the service. Applicable only to services within the mesh. The subset must be defined in a corresponding DestinationRule."},
+	},
+	"destinationrules": {
+		{ObjectField: "spec.host", Message: "The name of a service from the service registry. Rules defined for services that do not exist in the service registry will be ignored."},
+		{ObjectField: "spec.trafficPolicy", Message: "Traffic policies to apply (load balancing policy, connection pool sizes, outlier detection)."},
+		{ObjectField: "spec.subsets", Message: "One or more named sets that represent individual versions of a service. Traffic policies can be overridden at subset level."},
+		{ObjectField: "spec.exportTo", Message: "A list of namespaces to which this destination rule is exported. The resolution of a destination rule to apply to a service occurs in the context of a hierarchy of namespaces. This feature provides a mechanism for service owners and mesh administrators to control the visibility of destination rules across namespace boundaries. If no namespaces are specified then the destination rule is exported to all namespaces by default."},
+	},
+	"gateways": {
+		{ObjectField: "spec.servers", Message: "A list of server specifications."},
+		{ObjectField: "spec.selector", Message: "One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. By default workloads are searched across all namespaces based on label selectors."},
+		{ObjectField: "spec.servers.port", Message: "The port on which the proxy should listen for incoming connections."},
+		{ObjectField: "spec.servers.hosts", Message: "One or more hosts exposed by this gateway. While typically applicable to HTTP services, it can also be used for TCP services using TLS with SNI."},
+		{ObjectField: "spec.servers.tls", Message: "Set of TLS related options that govern the server’s behavior. Use these options to control if all http requests should be redirected to https, and the TLS modes to use."},
+	},
 }
 
 // ResourcePermissions holds permission flags for an object type

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -60,6 +60,7 @@ type IstioConfigHelp struct {
 	Message     string `json:"message"`
 }
 
+// IstioConfigHelpMessages represents the help messages for a given Istio object type
 var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 	"virtualservices": {
 		{ObjectField: "spec.hosts", Message: "The destination hosts to which traffic is being sent. Could be a DNS name with wildcard prefix or an IP address. Depending on the platform, short-names can also be used instead of a FQDN (i.e. has no dots in the name)."},
@@ -83,6 +84,54 @@ var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 		{ObjectField: "spec.servers.port", Message: "The port on which the proxy should listen for incoming connections."},
 		{ObjectField: "spec.servers.hosts", Message: "One or more hosts exposed by this gateway. While typically applicable to HTTP services, it can also be used for TCP services using TLS with SNI."},
 		{ObjectField: "spec.servers.tls", Message: "Set of TLS related options that govern the server’s behavior. Use these options to control if all http requests should be redirected to https, and the TLS modes to use."},
+	},
+	"authorizationpolicies": {
+		{ObjectField: "spec.selector", Message: "Optional. The selector decides where to apply the authorization policy. The selector will match with workloads in the same namespace as the authorization policy. If the authorization policy is in the root namespace, the selector will additionally match with workloads in all namespaces."},
+		{ObjectField: "spec.selector.matchLabels", Message: "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied."},
+		{ObjectField: "spec.rules", Message: "Optional. A list of rules to match the request. A match occurs when at least one rule matches the request."},
+		{ObjectField: "spec.rules.from", Message: "Optional. from specifies the source of a request. If not set, any source is allowed."},
+		{ObjectField: "spec.rules.to", Message: "Optional. to specifies the operation of a request. If not set, any operation is allowed."},
+		{ObjectField: "spec.rules.when", Message: "Optional. when specifies a list of additional conditions of a request. If not set, any condition is allowed."},
+		{ObjectField: "spec.action", Message: "Optional. The action to take if the request is matched with the rules. Default is ALLOW if not specified."},
+	},
+	"sidecars": {
+		{ObjectField: "spec.workloadSelector", Message: "Criteria used to select the specific set of pods/VMs on which this Sidecar configuration should be applied. If omitted, the Sidecar configuration will be applied to all workload instances in the same namespace."},
+		{ObjectField: "spec.ingress", Message: "Ingress specifies the configuration of the sidecar for processing inbound traffic to the attached workload instance."},
+		{ObjectField: "spec.egress", Message: "Egress specifies the configuration of the sidecar for processing outbound traffic from the attached workload instance to other services in the mesh"},
+	},
+	"peerauthentications": {
+		{ObjectField: "spec.selector", Message: "The selector determines the workloads to apply the ChannelAuthentication on. If not set, the policy will be applied to all workloads in the same namespace as the policy."},
+		{ObjectField: "spec.selector.matchLabels", Message: "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied."},
+		{ObjectField: "spec.mtls", Message: "Mutual TLS settings for workload. If not defined, inherit from parent."},
+	},
+	"requestauthentications": {
+		{ObjectField: "spec.selector", Message: "Optional. The selector decides where to apply the request authentication policy. The selector will match with workloads in the same namespace as the request authentication policy. If the request authentication policy is in the root namespace, the selector will additionally match with workloads in all namespaces."},
+		{ObjectField: "spec.selector.matchLabels", Message: "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied."},
+		{ObjectField: "spec.jwtRules", Message: "Define the list of JWTs that can be validated at the selected workloads’ proxy. A valid token will be used to extract the authenticated identity."},
+	},
+	"serviceentries": {
+		{ObjectField: "spec.hosts", Message: "The hosts associated with the ServiceEntry. Could be a DNS name with wildcard prefix."},
+		{ObjectField: "spec.addresses", Message: "The virtual IP addresses associated with the service. Could be CIDR prefix."},
+		{ObjectField: "spec.ports", Message: "The ports associated with the external service. If the Endpoints are Unix domain socket addresses, there must be exactly one port."},
+		{ObjectField: "spec.location", Message: "Specify whether the service should be considered external to the mesh or part of the mesh."},
+		{ObjectField: "spec.resolution", Message: "Service discovery mode for the hosts."},
+		{ObjectField: "spec.endpoints", Message: "One or more endpoints associated with the service. Only one of endpoints or workloadSelector can be specified."},
+		{ObjectField: "spec.workloadSelector", Message: "Applicable only for MESH_INTERNAL services. Only one of endpoints or workloadSelector can be specified."},
+		{ObjectField: "spec.exportTo", Message: "A list of namespaces to which this service is exported. Exporting a service allows it to be used by sidecars, gateways and virtual services defined in other namespaces. This feature provides a mechanism for service owners and mesh administrators to control the visibility of services across namespace boundaries."},
+	},
+	"workloadentries": {
+		{ObjectField: "spec.address", Message: "Address associated with the network endpoint without the port."},
+		{ObjectField: "spec.ports", Message: "Set of ports associated with the endpoint."},
+		{ObjectField: "spec.labels", Message: "One or more labels associated with the endpoint."},
+		{ObjectField: "spec.network", Message: "Network enables Istio to group endpoints resident in the same L3 domain/network. All endpoints in the same network are assumed to be directly reachable from one another."},
+		{ObjectField: "spec.locality", Message: "The locality associated with the endpoint. A locality corresponds to a failure domain (e.g., country/region/zone). Arbitrary failure domain hierarchies can be represented by separating each encapsulating failure domain by /."},
+		{ObjectField: "spec.weight", Message: "The load balancing weight associated with the endpoint. Endpoints with higher weights will receive proportionally higher traffic."},
+		{ObjectField: "spec.serviceAccount", Message: "The service account associated with the workload if a sidecar is present in the workload."},
+	},
+	"workloadgroups": {
+		{ObjectField: "spec.metadata", Message: "Metadata that will be used for all corresponding WorkloadEntries. User labels for a workload group should be set here in metadata rather than in template."},
+		{ObjectField: "spec.template", Message: "Template to be used for the generation of WorkloadEntry resources that belong to this WorkloadGroup."},
+		{ObjectField: "spec.probe", Message: "ReadinessProbe describes the configuration the user must provide for healthchecking on their workload."},
 	},
 }
 

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -3,6 +3,8 @@ package models
 import (
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
+
+	"github.com/kiali/kiali/config"
 )
 
 // IstioConfigList istioConfigList
@@ -28,8 +30,7 @@ type IstioConfigList struct {
 	AuthorizationPolicies  []security_v1beta.AuthorizationPolicy   `json:"authorizationPolicies"`
 	PeerAuthentications    []security_v1beta.PeerAuthentication    `json:"peerAuthentications"`
 	RequestAuthentications []security_v1beta.RequestAuthentication `json:"requestAuthentications"`
-
-	IstioValidations IstioValidations `json:"validations"`
+	IstioValidations       IstioValidations                        `json:"validations"`
 }
 
 type IstioConfigDetails struct {
@@ -49,9 +50,10 @@ type IstioConfigDetails struct {
 	PeerAuthentication    *security_v1beta.PeerAuthentication    `json:"peerAuthentication"`
 	RequestAuthentication *security_v1beta.RequestAuthentication `json:"requestAuthentication"`
 
-	Permissions     ResourcePermissions `json:"permissions"`
-	IstioValidation *IstioValidation    `json:"validation"`
-	IstioReferences *IstioReferences    `json:"references"`
+	Permissions           ResourcePermissions      `json:"permissions"`
+	IstioValidation       *IstioValidation         `json:"validation"`
+	IstioReferences       *IstioReferences         `json:"references"`
+	IstioConfigHelpFields []config.IstioConfigHelp `json:"help"`
 }
 
 // ResourcePermissions holds permission flags for an object type

--- a/swagger.json
+++ b/swagger.json
@@ -5315,6 +5315,13 @@
         "gateway": {
           "$ref": "#/definitions/Gateway"
         },
+        "help": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IstioConfigHelp"
+          },
+          "x-go-name": "IstioConfigHelpFields"
+        },
         "namespace": {
           "$ref": "#/definitions/namespace"
         },
@@ -5354,6 +5361,21 @@
         }
       },
       "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "IstioConfigHelp": {
+      "description": "IstioConfigHelp represents a help message for a given Istio object type and field",
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "objectField": {
+          "type": "string",
+          "x-go-name": "ObjectField"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/config"
     },
     "IstioConfigList": {
       "description": "This type is used for returning a response of IstioConfigList",

--- a/swagger.json
+++ b/swagger.json
@@ -5375,7 +5375,7 @@
           "x-go-name": "ObjectField"
         }
       },
-      "x-go-package": "github.com/kiali/kiali/config"
+      "x-go-package": "github.com/kiali/kiali/models"
     },
     "IstioConfigList": {
       "description": "This type is used for returning a response of IstioConfigList",


### PR DESCRIPTION
Work in progress.

Required by [#2299](https://github.com/kiali/kiali-ui/pull/2299).

When fetching the Istio config details for some config object, a new parameter can be configured to get help for some key object fields:

`http://localhost:20001/api/namespaces/bookinfo/istio/virtualservices/bookinfo?validate=true&help=true`

Then, this information can be displayed alongside the YAML to help the users to understand some important fields.