### PR TITLE
Skip KIA0701 Port missmatch validation check for Services in istio-system namespace.

### DIFF
--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -40,6 +41,10 @@ func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 		}
 	}
 
+	// Ignoring istio-system Services as some ports are used for debug purposes and not exposed in deployments
+	if config.IsIstioNamespace(p.Service.Namespace) {
+		return validations, len(validations) == 0
+	}
 	if deployment := p.findMatchingDeployment(p.Service.Spec.Selector); deployment != nil {
 		p.matchPorts(&p.Service, deployment, &validations)
 	}

--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 )
 
@@ -43,6 +44,7 @@ func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 
 	// Ignoring istio-system Services as some ports are used for debug purposes and not exposed in deployments
 	if config.IsIstioNamespace(p.Service.Namespace) {
+		log.Debugf("Skipping Port matching check for Service %s from Istio Namespace %s", p.Service.Name, p.Service.Namespace)
 		return validations, len(validations) == 0
 	}
 	if deployment := p.findMatchingDeployment(p.Service.Spec.Selector); deployment != nil {

--- a/business/checkers/services/port_mapping_checker_test.go
+++ b/business/checkers/services/port_mapping_checker_test.go
@@ -20,7 +20,7 @@ func TestPortMappingMatch(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http", nil),
+		Service:     getService(9080, "http", nil, "test-namespace"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -36,7 +36,7 @@ func TestTargetPortMappingMatch(t *testing.T) {
 
 	assert := assert.New(t)
 
-	service := getService(9080, "http", nil)
+	service := getService(9080, "http", nil, "test-namespace")
 	service.Spec.Ports[0].TargetPort = intstr.FromInt(8080)
 
 	/*
@@ -74,7 +74,7 @@ func TestPortMappingMismatch(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http", nil),
+		Service:     getService(9080, "http", nil, "test-namespace"),
 		Deployments: getDeployment(8080),
 		Pods:        getPods(true),
 	}
@@ -86,6 +86,24 @@ func TestPortMappingMismatch(t *testing.T) {
 	assert.Equal("spec/ports[0]", vals[0].Path)
 }
 
+func TestPortMappingNoMismatchIstio(t *testing.T) {
+	// As per KIALI-2454
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	pmc := PortMappingChecker{
+		Service:     getService(9080, "http", nil, "istio-system"),
+		Deployments: getDeployment(8080),
+		Pods:        getPods(true),
+	}
+
+	vals, valid := pmc.Check()
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
 func TestServicePortNaming(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -93,7 +111,26 @@ func TestServicePortNaming(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http2foo", nil),
+		Service:     getService(9080, "http2foo", nil, "test-namespace"),
+		Deployments: getDeployment(9080),
+		Pods:        getPods(true),
+	}
+
+	vals, valid := pmc.Check()
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.NoError(validations.ConfirmIstioCheckMessage("port.name.mismatch", vals[0]))
+	assert.Equal("spec/ports[0]", vals[0].Path)
+}
+
+func TestServicePortNamingIstioSystem(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	pmc := PortMappingChecker{
+		Service:     getService(9080, "http2foo", nil, "istio-system"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -113,7 +150,7 @@ func TestServicePortAppProtocol(t *testing.T) {
 
 	appProtocol := "mysql-wrong"
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "database", &appProtocol),
+		Service:     getService(9080, "database", &appProtocol, "test-namespace"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -126,7 +163,7 @@ func TestServicePortAppProtocol(t *testing.T) {
 
 	appProtocol = "mysql"
 	pmc = PortMappingChecker{
-		Service:     getService(9080, "database", &appProtocol),
+		Service:     getService(9080, "database", &appProtocol, "test-namespace"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -143,7 +180,7 @@ func TestServicePortNamingWithoutSidecar(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http2foo", nil),
+		Service:     getService(9080, "http2foo", nil, "test-namespace"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(false),
 	}
@@ -153,10 +190,11 @@ func TestServicePortNamingWithoutSidecar(t *testing.T) {
 	assert.Empty(vals)
 }
 
-func getService(servicePort int32, portName string, appProtocol *string) v1.Service {
+func getService(servicePort int32, portName string, appProtocol *string, namespace string) v1.Service {
 	return v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "service1",
+			Name:      "service1",
+			Namespace: namespace,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{


### PR DESCRIPTION
Fixing https://github.com/kiali/kiali/issues/4764.

For the Services in istio-system control plane namespace, skip "KIA0701 Deployment exposing same port as Service not found" validation.
But keep it for other namespaces.

For QE:
In "istiod", "tracing" and other Services from istio-system namespace, verify that validation warning "Deployment exposing same port as Service not found" is not shown.
Before:
![Screenshot from 2022-02-28 10-56-57](https://user-images.githubusercontent.com/604313/155979700-6c20a7c1-6a26-4bc9-9803-20aa84abc232.png)


After:
![Screenshot from 2022-02-28 12-57-41](https://user-images.githubusercontent.com/604313/155979674-2c70f7c2-fd1e-4f6d-8b20-aaac643847bd.png)

Regression test if Services from other nemaspaces continue getting validation warning: https://raw.githubusercontent.com/Kiali-QE/kiali-qe-python/master/data/resources/istio_objects/validation/ratings_java_svc.yaml
![Screenshot from 2022-02-28 12-58-28](https://user-images.githubusercontent.com/604313/155979770-4ca87567-517b-4a90-b1ae-7c5b50a7552d.png)

