### PR TITLE
For Istio Config validations result JSON, make the key 'name.namespace' instead of 'name' only to support multiple namepaces

### DIFF
--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -469,7 +469,7 @@ func (iv IstioValidations) MarshalJSON() ([]byte, error) {
 		if !ok {
 			out[k.ObjectType] = make(map[string]*IstioValidation)
 		}
-		out[k.ObjectType][k.Name] = v
+		out[k.ObjectType][k.Name+"."+k.Namespace] = v
 	}
 	return json.Marshal(out)
 }

--- a/models/istio_validation_test.go
+++ b/models/istio_validation_test.go
@@ -13,12 +13,12 @@ func TestIstioValidationsMarshal(t *testing.T) {
 	assert := assert.New(t)
 
 	validations := IstioValidations{
-		IstioValidationKey{ObjectType: "virtualservice", Name: "foo"}: &IstioValidation{
+		IstioValidationKey{ObjectType: "virtualservice", Name: "foo", Namespace: "test"}: &IstioValidation{
 			Name:       "foo",
 			ObjectType: "virtualservice",
 			Valid:      true,
 		},
-		IstioValidationKey{ObjectType: "virtualservice", Name: "bar"}: &IstioValidation{
+		IstioValidationKey{ObjectType: "virtualservice", Name: "bar", Namespace: "test2"}: &IstioValidation{
 			Name:       "bar",
 			ObjectType: "virtualservice",
 			Valid:      false,
@@ -26,7 +26,7 @@ func TestIstioValidationsMarshal(t *testing.T) {
 	}
 	b, err := json.Marshal(validations)
 	assert.NoError(err)
-	assert.Equal(string(b), `{"virtualservice":{"bar":{"name":"bar","objectType":"virtualservice","valid":false,"checks":null,"references":null},"foo":{"name":"foo","objectType":"virtualservice","valid":true,"checks":null,"references":null}}}`)
+	assert.Equal(string(b), `{"virtualservice":{"bar.test2":{"name":"bar","objectType":"virtualservice","valid":false,"checks":null,"references":null},"foo.test":{"name":"foo","objectType":"virtualservice","valid":true,"checks":null,"references":null}}}`)
 }
 
 func TestIstioValidationKeyMarshal(t *testing.T) {


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4766

UI changes are required: https://github.com/kiali/kiali-ui/pull/2315

Before, it was generating validation result JSON with config  'type' and 'name' in a key. So for multiple namespaces having similar config names were causing overriding the key in map, thus confusion is UI.

Now, it uses config's 'name.namespace' as a key, to make sure multiple namespaces are supported.

For QE:
Create 'bookinfo', 'bookinfo2' and 'bookinfo3' namespaces.
Make sure that several configs in 'bookinfo' only is broken, so contains warnings and errors.
List all istio configs for all namespaces.
Refresh the content several times.
Verify that all configs configuration statuses are consistent within all refreshes.