### PR TITLE
Single loading of multiple istiod registry services and configs

### DIFF
--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -193,7 +193,12 @@ func parseProxyStatus(statuses map[string][]byte) ([]*ProxyStatus, error) {
 
 func ParseRegistryServices(registries map[string][]byte) ([]*RegistryService, error) {
 	var fullRegistryServices []*RegistryService
+	isRegistryLoaded := false
 	for pilot, registry := range registries {
+		// skip reading registry configs multiple times in a case of multiple istiod pods
+		if isRegistryLoaded {
+			break
+		}
 		var rr []*RegistryService
 		err := json.Unmarshal(registry, &rr)
 		if err != nil {
@@ -204,6 +209,9 @@ func ParseRegistryServices(registries map[string][]byte) ([]*RegistryService, er
 			r.pilot = pilot
 		}
 		fullRegistryServices = append(fullRegistryServices, rr...)
+		if len(rr) > 0 {
+			isRegistryLoaded = true
+		}
 	}
 	return fullRegistryServices, nil
 }
@@ -227,7 +235,12 @@ func ParseRegistryEndpoints(endpoints map[string][]byte) ([]*RegistryEndpoint, e
 
 func ParseRegistryConfig(config map[string][]byte) (*RegistryConfiguration, error) {
 	registry := RegistryConfiguration{}
+	isRegistryLoaded := false
 	for istiod, bRegistry := range config {
+		// skip reading registry configs multiple times in a case of multiple istiod pods
+		if isRegistryLoaded {
+			break
+		}
 		r := bytes.NewReader(bRegistry)
 		dec := json.NewDecoder(r)
 		var jRegistry interface{}
@@ -334,6 +347,7 @@ func ParseRegistryConfig(config map[string][]byte) (*RegistryConfiguration, erro
 				}
 			}
 		}
+		isRegistryLoaded = true
 	}
 	return &registry, nil
 }

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -218,7 +218,12 @@ func ParseRegistryServices(registries map[string][]byte) ([]*RegistryService, er
 
 func ParseRegistryEndpoints(endpoints map[string][]byte) ([]*RegistryEndpoint, error) {
 	var fullRegistryEndpoints []*RegistryEndpoint
+	isRegistryLoaded := false
 	for pilot, endpoint := range endpoints {
+		// skip reading registry endpoints multiple times in a case of multiple istiod pods
+		if isRegistryLoaded {
+			break
+		}
 		var eps []*RegistryEndpoint
 		err := json.Unmarshal(endpoint, &eps)
 		if err != nil {
@@ -229,6 +234,9 @@ func ParseRegistryEndpoints(endpoints map[string][]byte) ([]*RegistryEndpoint, e
 			ep.pilot = pilot
 		}
 		fullRegistryEndpoints = append(fullRegistryEndpoints, eps...)
+		if len(eps) > 0 {
+			isRegistryLoaded = true
+		}
 	}
 	return fullRegistryEndpoints, nil
 }


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4711

When there are multiple istiod pods, Registry Services and Configs were loading multiple times, so causing duplicates and odd errors in validations.
Now Registry Configs and Services are loaded only for the first istiod pod.

For QE:
Increase istiod pods count.
List istio configs for bookinfo.
Before: all configs were having warnings and references to themselves.
Now: no additional warnings and duplicate references in configs.