### PR TITLE
Align namespace label in custom dashboards

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -37,7 +37,7 @@ func NewDashboardsService(namespace *models.Namespace, workload *models.Workload
 	}
 	nsLabel := cfg.ExternalServices.CustomDashboards.NamespaceLabel
 	if nsLabel == "" {
-		nsLabel = "kubernetes_namespace"
+		nsLabel = "namespace"
 	}
 
 	// Overwrite Custom dashboards defined at Namespace level

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -31,7 +31,7 @@ func TestGetDashboard(t *testing.T) {
 	// Setup mocks
 	service, prom := setupService("my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1")})
 
-	expectedLabels := "{kubernetes_namespace=\"my-namespace\",APP=\"my-app\"}"
+	expectedLabels := "{namespace=\"my-namespace\",APP=\"my-app\"}"
 	namespace := models.Namespace{
 		Name: "my-namespace",
 	}
@@ -73,7 +73,7 @@ func TestGetDashboardFromKialiNamespace(t *testing.T) {
 	// Setup mocks
 	service, prom := setupService("my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1")})
 
-	expectedLabels := "{kubernetes_namespace=\"my-namespace\",APP=\"my-app\"}"
+	expectedLabels := "{namespace=\"my-namespace\",APP=\"my-app\"}"
 	namespace := models.Namespace{
 		Name: "my-namespace",
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -537,7 +537,7 @@ func NewConfig() (c *Config) {
 				DiscoveryAutoThreshold: 10,
 				Enabled:                true,
 				IsCore:                 false,
-				NamespaceLabel:         "kubernetes_namespace",
+				NamespaceLabel:         "namespace",
 				Prometheus: PrometheusConfig{
 					ThanosProxy: ThanosProxy{
 						Enabled: false,


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4769

Istio 1.13.x ships Prometheus v2.31.1 (chart 1.15) (vs Istio 1.12/Prometheus v2.26.0 - chart 1.14 -).

Prometheus v2.31.1 has introduced an alignment in the labels of the "kubernetes_pod" job, that affects the "namespace" label used in the CustomDashboards (also used by the Envoy subtab) [1].

[1] https://github.com/prometheus/prometheus/pull/9832

By default, CustomDashboards have the "kubernetes_namespace" label that needs to change to "namespace" in custom queries.

With this change, the custom dashboards work as expected.

This PR is not yet finished, it's just a draft to give visibility, it needs to apply the change into the tests and other places.

I think that the defaults should point to the default version this targets (Istio 1.13.x, also backported to the Kiali 1.47.x), and users can/should adjust this to the proper Prometheus they use.

This work has a pending UI fix to not crash on this case:
https://github.com/kiali/kiali-ui/pull/2317

Also, this will need a proper FAQ entry.

As commented, when this fix is ready, as Kiali 1.47.x targets Istio 1.13.x it would require a backport (I think, this issue looks bad).

How to test:
- Build Kiali backend and frontend PRs and use them in Istio 1.12.x cluster.
- Deploy "runtimes" demo: https://github.com/kiali/demos/tree/master/runtimes-demo
- Navigate to "vertx" App details: 
a) validate that custom dashboards don't show:
![image](https://user-images.githubusercontent.com/1662329/156544956-669d423d-d293-44f7-89cb-dea3f01da53e.png)
- Navigate to "vertx-v1" Workload details, validate that there are no custom dashboards:
a) validate that custom dashboard don't show:
![image](https://user-images.githubusercontent.com/1662329/156545359-514a24db-6347-4446-94df-851af945503a.png)
b) validate that Envoy tab doesn't show "Metrics" subtab:
![image](https://user-images.githubusercontent.com/1662329/156545433-9beb0c20-15f9-4e5b-a0b5-3f9269c53175.png)

- Build a Kiali backend and frontend PRs and use them in Istio 1.13.x cluster. 
- Deploy "runtimes" demo: https://github.com/kiali/demos/tree/master/runtimes-demo
- Navigate to "vertx" App details: 
a) validate that JVM custom dashboards show:
![image](https://user-images.githubusercontent.com/1662329/156546859-010d21db-5746-4ab8-ae1d-b3d5065cf073.png)
![image](https://user-images.githubusercontent.com/1662329/156546923-b97cea73-b5cf-40a1-b208-66fc52aaf49d.png)
- Navigate to "vertx-v1" Workload details, validate that there are JVM custom dashboards:
![image](https://user-images.githubusercontent.com/1662329/156547084-3163e874-a6e1-43e0-acac-7bdc9f06a7fc.png)
b) validate that Envoy tab show "Metrics" subtab and it works as expected:
![image](https://user-images.githubusercontent.com/1662329/156547136-76a0dbce-938e-4cd5-9362-f295da22e9c1.png)


Two pending topics:
- The PRs from backend/frontend should be backported to 1.47.x for community as 1.47.x is used with Istio 1.13.x and this bug looks bad, IMHO.
- This requires a pending FAQ in the kiali.io.
- This parameter should be updated in the defaults of the operator in 1.48.x if some distribution would use a different version of Prometheus different than the shipped in the Istio add-ons.


Note, these are the Prometheus versions used from the image and the charts:

- Istio 1.12.1:
```
    chart: prometheus-14.6.1
    image: "prom/prometheus:v2.26.0"
``` 
- Istio 1.13.1:
```
    chart: prometheus-15.0.1
    image: "prom/prometheus:v2.31.1"
```
