### PR TITLE
Fix Prometheus TSDB retention config

### DIFF
--- a/handlers/config.go
+++ b/handlers/config.go
@@ -189,7 +189,7 @@ func getPrometheusConfig() PrometheusConfig {
 				retention, err := model.ParseDuration(retentionString)
 				if checkErr(err, fmt.Sprintf("Invalid storage.tsdb.retention.time [%s]", retentionString)) {
 					if retention == 0 {
-						log.Warningf("%s", "Prometheus storage.tsdb.retention.time configured to 0, ignoring...")
+						log.Warning("Prometheus storage.tsdb.retention.time configured to 0, ignoring...")
 					} else {
 						promConfig.StorageTsdbRetention = int64(time.Duration(retention).Seconds())
 					}


### PR DESCRIPTION
Prometheus deprecated "storage.tsdb.retention" many versions back, and
it is no longer valid.  Unfortunately it is still set, but to 0, invalidating
this information in serverConfig.  Switch to "storage.tsdb.retention.time",
the valid setting.  Also, add a check to ensure this setting is never 0.
Furthermore, ensure that if all fails we provide a valid default to
consumers of the config.

Fixes https://github.com/kiali/kiali/issues/4784
