### PR TITLE
Add an AppCriteria to GetAppList for consistency

### DIFF
--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -49,7 +49,8 @@ func TestGetAppListFromDeployments(t *testing.T) {
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return([]core_v1.Service{}, nil)
 	svc := setupAppService(k8s)
 
-	appList, _ := svc.GetAppList(context.TODO(), "Namespace", false)
+	criteria := AppCriteria{Namespace: "Namespace", IncludeIstioResources: false}
+	appList, _ := svc.GetAppList(context.TODO(), criteria)
 
 	assert.Equal("Namespace", appList.Namespace.Name)
 
@@ -114,7 +115,8 @@ func TestGetAppListFromReplicaSets(t *testing.T) {
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return([]core_v1.Service{}, nil)
 	svc := setupAppService(k8s)
 
-	appList, _ := svc.GetAppList(context.TODO(), "Namespace", false)
+	criteria := AppCriteria{Namespace: "Namespace", IncludeIstioResources: false}
+	appList, _ := svc.GetAppList(context.TODO(), criteria)
 
 	assert.Equal("Namespace", appList.Namespace.Name)
 

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -4,11 +4,16 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+
+	"github.com/kiali/kiali/business"
 )
 
 // AppList is the API handler to fetch all the apps to be displayed, related to a single namespace
 func AppList(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
+	namespace := params["namespace"]
+
+	criteria := business.AppCriteria{Namespace: namespace, IncludeIstioResources: true}
 
 	// Get business layer
 	business, err := getBusiness(r)
@@ -16,10 +21,9 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusInternalServerError, "Apps initialization error: "+err.Error())
 		return
 	}
-	namespace := params["namespace"]
 
 	// Fetch and build apps
-	appList, err := business.App.GetAppList(r.Context(), namespace, true)
+	appList, err := business.App.GetAppList(r.Context(), criteria)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return


### PR DESCRIPTION
Related to https://github.com/kiali/kiali/pull/4755#discussion_r818643828 discussion.

GetServiceList, GetWorkloadList, GetIstioConfigList were moved to use a "criteria" parameter to define what elements are needed.

GetAppList was missing, but in the context of the graph appender can be used like this:
https://github.com/kiali/kiali/blob/master/graph/telemetry/istio/appender/appender.go#L239
https://github.com/kiali/kiali/blob/master/graph/telemetry/istio/appender/appender.go#L279

