### PR TITLE
Added new API endpoint to list all Istio Configs for All Namespaces

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -844,10 +844,9 @@ func checkType(types []string, name string) bool {
 	return false
 }
 
-func ParseIstioConfigCriteria(namespace, objects, labelSelector, workloadSelector string) IstioConfigCriteria {
+func ParseIstioConfigCriteria(namespace, objects, labelSelector, workloadSelector string, allNamespaces bool) IstioConfigCriteria {
 	defaultInclude := objects == ""
 	criteria := IstioConfigCriteria{}
-	criteria.Namespace = namespace
 	criteria.IncludeGateways = defaultInclude
 	criteria.IncludeVirtualServices = defaultInclude
 	criteria.IncludeDestinationRules = defaultInclude
@@ -861,6 +860,12 @@ func ParseIstioConfigCriteria(namespace, objects, labelSelector, workloadSelecto
 	criteria.IncludeEnvoyFilters = defaultInclude
 	criteria.LabelSelector = labelSelector
 	criteria.WorkloadSelector = workloadSelector
+
+	if allNamespaces {
+		criteria.AllNamespaces = true
+	} else {
+		criteria.Namespace = namespace
+	}
 
 	if defaultInclude {
 		return criteria

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -25,68 +25,84 @@ func TestParseListParams(t *testing.T) {
 	namespace := "bookinfo"
 	objects := ""
 	labelSelector := ""
-	criteria := ParseIstioConfigCriteria(namespace, objects, labelSelector, "")
+	criteria := ParseIstioConfigCriteria(namespace, objects, labelSelector, "", false)
 
 	assert.Equal(t, "bookinfo", criteria.Namespace)
 	assert.True(t, criteria.IncludeVirtualServices)
 	assert.True(t, criteria.IncludeDestinationRules)
 	assert.True(t, criteria.IncludeServiceEntries)
+	assert.False(t, criteria.AllNamespaces)
 
 	objects = "gateways"
-	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "")
+	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "", false)
 
 	assert.True(t, criteria.IncludeGateways)
 	assert.False(t, criteria.IncludeVirtualServices)
 	assert.False(t, criteria.IncludeDestinationRules)
 	assert.False(t, criteria.IncludeServiceEntries)
+	assert.False(t, criteria.AllNamespaces)
+
+	criteria = ParseIstioConfigCriteria("", objects, labelSelector, "", true)
+
+	assert.True(t, criteria.IncludeGateways)
+	assert.False(t, criteria.IncludeVirtualServices)
+	assert.False(t, criteria.IncludeDestinationRules)
+	assert.False(t, criteria.IncludeServiceEntries)
+	assert.True(t, criteria.AllNamespaces)
 
 	objects = "virtualservices"
-	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "")
+	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "", false)
 
 	assert.False(t, criteria.IncludeGateways)
 	assert.True(t, criteria.IncludeVirtualServices)
 	assert.False(t, criteria.IncludeDestinationRules)
 	assert.False(t, criteria.IncludeServiceEntries)
+	assert.False(t, criteria.AllNamespaces)
 
 	objects = "destinationrules"
-	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "")
+	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "", false)
 
 	assert.False(t, criteria.IncludeGateways)
 	assert.False(t, criteria.IncludeVirtualServices)
 	assert.True(t, criteria.IncludeDestinationRules)
 	assert.False(t, criteria.IncludeServiceEntries)
+	assert.False(t, criteria.AllNamespaces)
 
 	objects = "serviceentries"
-	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "")
+	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "", false)
 
 	assert.False(t, criteria.IncludeGateways)
 	assert.False(t, criteria.IncludeVirtualServices)
 	assert.False(t, criteria.IncludeDestinationRules)
 	assert.True(t, criteria.IncludeServiceEntries)
+	assert.False(t, criteria.AllNamespaces)
 
 	objects = "virtualservices"
-	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "")
+	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "", false)
 
 	assert.False(t, criteria.IncludeGateways)
 	assert.True(t, criteria.IncludeVirtualServices)
 	assert.False(t, criteria.IncludeDestinationRules)
 	assert.False(t, criteria.IncludeServiceEntries)
+	assert.False(t, criteria.AllNamespaces)
 
 	objects = "destinationrules,virtualservices"
-	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "")
+	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "", false)
 
 	assert.False(t, criteria.IncludeGateways)
 	assert.True(t, criteria.IncludeVirtualServices)
 	assert.True(t, criteria.IncludeDestinationRules)
 	assert.False(t, criteria.IncludeServiceEntries)
+	assert.False(t, criteria.AllNamespaces)
 
 	objects = "notsupported"
-	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "")
+	criteria = ParseIstioConfigCriteria(namespace, objects, labelSelector, "", false)
 
 	assert.False(t, criteria.IncludeGateways)
 	assert.False(t, criteria.IncludeVirtualServices)
 	assert.False(t, criteria.IncludeDestinationRules)
 	assert.False(t, criteria.IncludeServiceEntries)
+	assert.False(t, criteria.AllNamespaces)
 }
 
 func TestGetIstioConfigList(t *testing.T) {

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -28,6 +28,11 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	allNamespaces := false
+	if namespace == "" {
+		allNamespaces = true
+	}
+
 	includeValidations := false
 	if _, found := query["validate"]; found {
 		includeValidations = true
@@ -43,7 +48,7 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 		workloadSelector = query.Get("workloadSelector")
 	}
 
-	criteria := business.ParseIstioConfigCriteria(namespace, objects, labelSelector, workloadSelector)
+	criteria := business.ParseIstioConfigCriteria(namespace, objects, labelSelector, workloadSelector, allNamespaces)
 
 	// Get business layer
 	business, err := getBusiness(r)

--- a/kiali_api.md
+++ b/kiali_api.md
@@ -75,6 +75,7 @@ _
 | DELETE | /api/namespaces/{namespace}/istio/{object_type}/{object} | [istio config delete](#istio-config-delete) |  |
 | GET | /api/namespaces/{namespace}/istio/{object_type}/{object} | [istio config details](#istio-config-details) |  |
 | GET | /api/namespaces/{namespace}/istio | [istio config list](#istio-config-list) |  |
+| GET | /api/istio | [istio config list all](#istio-config-list-all) |  |
 | PATCH | /api/namespaces/{namespace}/istio/{object_type}/{object} | [istio config update](#istio-config-update) | Endpoint to update the Istio Config of an Istio object used for templates and adapters using Json Merge Patch strategy. |
   
 
@@ -2736,6 +2737,66 @@ Status: Internal Server Error
 ###### Inlined models
 
 **<span id="istio-config-list-internal-server-error-body"></span> IstioConfigListInternalServerErrorBody**
+
+
+  
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| Code | int32 (formatted integer)| `int32` |  | `500`| HTTP status code | `500` |
+| Message | string| `string` |  | |  |  |
+
+
+
+### <span id="istio-config-list-all"></span> istio config list all (*istioConfigListAll*)
+
+```
+GET /api/istio
+```
+
+Endpoint to get the list of Istio Config of all namespaces
+
+#### URI Schemes
+  * http
+  * https
+
+#### Produces
+  * application/json
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#istio-config-list-all-200) | OK | HTTP status code 200 and IstioConfigList model in data |  | [schema](#istio-config-list-all-200-schema) |
+| [500](#istio-config-list-all-500) | Internal Server Error | A Internal is the error message that means something has gone wrong |  | [schema](#istio-config-list-all-500-schema) |
+
+#### Responses
+
+
+##### <span id="istio-config-list-all-200"></span> 200 - HTTP status code 200 and IstioConfigList model in data
+Status: OK
+
+###### <span id="istio-config-list-all-200-schema"></span> Schema
+   
+  
+
+[IstioConfigList](#istio-config-list)
+
+##### <span id="istio-config-list-all-500"></span> 500 - A Internal is the error message that means something has gone wrong
+Status: Internal Server Error
+
+###### <span id="istio-config-list-all-500-schema"></span> Schema
+   
+  
+
+[IstioConfigListAllInternalServerErrorBody](#istio-config-list-all-internal-server-error-body)
+
+###### Inlined models
+
+**<span id="istio-config-list-all-internal-server-error-body"></span> IstioConfigListAllInternalServerErrorBody**
 
 
   

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -234,7 +234,7 @@ func NewRoutes() (r *Routes) {
 		{
 			"IstioConfigListAll",
 			"GET",
-			"/api/istio",
+			"/api/istio/config",
 			handlers.IstioConfigList,
 			true,
 		},

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -218,7 +218,7 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigList,
 			true,
 		},
-		// swagger:route GET /istio config istioConfigList
+		// swagger:route GET /istio config istioConfigListAll
 		// ---
 		// Endpoint to get the list of Istio Config of all namespaces
 		//
@@ -232,7 +232,7 @@ func NewRoutes() (r *Routes) {
 		//      200: istioConfigList
 		//
 		{
-			"IstioConfigList",
+			"IstioConfigListAll",
 			"GET",
 			"/api/istio",
 			handlers.IstioConfigList,

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -218,6 +218,26 @@ func NewRoutes() (r *Routes) {
 			handlers.IstioConfigList,
 			true,
 		},
+		// swagger:route GET /istio config istioConfigList
+		// ---
+		// Endpoint to get the list of Istio Config of all namespaces
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      500: internalError
+		//      200: istioConfigList
+		//
+		{
+			"IstioConfigList",
+			"GET",
+			"/api/istio",
+			handlers.IstioConfigList,
+			true,
+		},
 		// swagger:route GET /namespaces/{namespace}/istio/{object_type}/{object} config istioConfigDetails
 		// ---
 		// Endpoint to get the Istio Config of an Istio object

--- a/swagger.json
+++ b/swagger.json
@@ -224,6 +224,30 @@
         }
       }
     },
+    "/istio": {
+      "get": {
+        "description": "Endpoint to get the list of Istio Config of all namespaces",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "config"
+        ],
+        "operationId": "istioConfigListAll",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/istioConfigList"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
     "/istio/certs": {
       "get": {
         "description": "Get certificates (internal) information used by Istio",


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4692

It used to list Gateways per Namespace in Service Details page for Wizzard.

Now there is a new API "/api/istio" for listing Istio Configs for All Namespaces.

This PoC has a weakness:  Listing Gateways for All Namespaces means listing them from Registry, and it returns all Configs, not only Gateways.