### PR TITLE
Sidecar's workload selector should take workload from own namespace.

### DIFF
--- a/business/checkers/common/multi_match_selector_checker.go
+++ b/business/checkers/common/multi_match_selector_checker.go
@@ -72,7 +72,12 @@ func RequestAuthenticationMultiMatchChecker(subjectType string, ra []security_v1
 func SidecarSelectorMultiMatchChecker(subjectType string, sc []networking_v1alpha3.Sidecar, workloadList models.WorkloadList) GenericMultiMatchChecker {
 	keys := []models.IstioValidationKey{}
 	selectors := make(map[int]map[string]string, len(sc))
-	for i, s := range sc {
+	i := 0
+	for _, s := range sc {
+		if s.Namespace != workloadList.Namespace.Name {
+			// Workloads from Sidecar's own Namespaces only are considered in Selector
+			continue
+		}
 		key := models.IstioValidationKey{
 			ObjectType: subjectType,
 			Name:       s.Name,
@@ -83,6 +88,7 @@ func SidecarSelectorMultiMatchChecker(subjectType string, sc []networking_v1alph
 		if s.Spec.WorkloadSelector != nil {
 			selectors[i] = s.Spec.WorkloadSelector.Labels
 		}
+		i++
 	}
 	return GenericMultiMatchChecker{
 		SubjectType:  subjectType,


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4758

Sidecar's Workload Selector now checks workloads and other Sidecars only from local namespace.

Before:
![](https://user-images.githubusercontent.com/604313/155531777-5a401734-5c3e-42e1-abcc-ab2d9e3e1c30.png)

After:
![Screenshot from 2022-03-15 17-46-12](https://user-images.githubusercontent.com/604313/158428932-3cbfce1c-12c4-4bd6-974a-3beb392fc713.png)
