### PR TITLE
Use a tagged version of metallb

### DIFF
--- a/hack/ci-kind-molecule-tests.sh
+++ b/hack/ci-kind-molecule-tests.sh
@@ -375,9 +375,9 @@ EOF
   infomsg "Create Kind LoadBalancer via MetalLB"
   lb_addr_range="255.70-255.84"
 
-  ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/metallb/metallb/master/manifests/namespace.yaml
-  ${CLIENT_EXE} create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
-  ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/metallb/metallb/master/manifests/metallb.yaml
+  ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
+  # ${CLIENT_EXE} create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+  ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
 
   subnet=$(${DORP} network inspect kind --format '{{(index .IPAM.Config 0).Subnet}}')
   subnet_trimmed=$(echo ${subnet} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+\..*/\1/')


### PR DESCRIPTION
Hopefully, this will fix the failing molecules in GHActions.

---

Prefer a tagged version instead of master.

This is also removing the creation of a secret, which is no longer
needed (it is created automatically).
