### PR TITLE
use the config var - don't Get() again

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -155,7 +155,7 @@ func serveEnvJsFile(w http.ResponseWriter) {
 		body += fmt.Sprintf("window.HISTORY_MODE='%s';", conf.Server.WebHistoryMode)
 	}
 
-	if webRoot := strings.TrimSuffix(config.Get().Server.WebRoot, "/"); len(webRoot) > 0 {
+	if webRoot := strings.TrimSuffix(conf.Server.WebRoot, "/"); len(webRoot) > 0 {
 		body += fmt.Sprintf("window.WEB_ROOT='%s';", webRoot)
 	}
 


### PR DESCRIPTION
I found this by accident when I happened to read this code. We should fix this - no sense getting the config again when we already have it.
