### PR TITLE
Use pool of workers to do health requests in Health Appender

### DIFF
--- a/graph/telemetry/istio/appender/health.go
+++ b/graph/telemetry/istio/appender/health.go
@@ -1,9 +1,12 @@
 package appender
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"time"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
@@ -19,20 +22,22 @@ type HealthAppender struct {
 	Namespaces        graph.NamespaceInfoMap
 	QueryTime         int64 // unix time in seconds
 	RequestedDuration time.Duration
+
+	mu sync.Mutex
 }
 
 // Name implements Appender
-func (a HealthAppender) Name() string {
+func (a *HealthAppender) Name() string {
 	return HealthAppenderName
 }
 
 // IsFinalizer implements Appender
-func (a HealthAppender) IsFinalizer() bool {
+func (a *HealthAppender) IsFinalizer() bool {
 	return true
 }
 
 // AppendGraph implements Appender
-func (a HealthAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, _ *graph.AppenderNamespaceInfo) {
+func (a *HealthAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, _ *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
@@ -63,6 +68,14 @@ func (a *HealthAppender) attachHealthConfig(trafficMap graph.TrafficMap, globalI
 			continue
 		}
 	}
+}
+
+type result struct {
+	namespace      string
+	appHealth      *models.NamespaceAppHealth
+	serviceHealth  *models.NamespaceServiceHealth
+	workloadHealth *models.NamespaceWorkloadHealth
+	err            error
 }
 
 func (a *HealthAppender) attachHealth(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo) {
@@ -106,86 +119,38 @@ func (a *HealthAppender) attachHealth(trafficMap graph.TrafficMap, globalInfo *g
 	// Execute health fetches and attach retrieved health data to nodes
 	bs := globalInfo.Business
 	ctx := globalInfo.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	// Gather all the health data we'll need ahead of time key'd by namespace.
 	appHealth := make(map[string]models.NamespaceAppHealth)
 	serviceHealth := make(map[string]models.NamespaceServiceHealth)
 	workloadHealth := make(map[string]models.NamespaceWorkloadHealth)
-	type result struct {
-		namespace      string
-		appHealth      *models.NamespaceAppHealth
-		serviceHealth  *models.NamespaceServiceHealth
-		workloadHealth *models.NamespaceWorkloadHealth
-		err            error
-	}
-	healthCh := make(chan result)
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, time.Second*30) // If all the node health reqs take > 30s, there is a problem.
+	defer cancel()
+	resultsCh := a.getGraphNodeHealth(ctx, bs, healthReqs)
+
+	// Need to loop over resultsCh until closed, otherwise any go routines
+	// sending to this chan will remain blocked forever. Ideally as soon
+	// as we get an error we'd propagate cancellation to all the running
+	// goroutines.
 	var errors []error
-
-	// Start accumulating results before fetching health info
-	doneAccumulating := make(chan struct{})
-	go func() {
-		// Need to loop over healthCh until closed, otherwise any go routines
-		// sending to this chan will remain blocked forever. Ideally as soon
-		// as we get an error we'd propagate cancellation to all the running
-		// goroutines.
-		for res := range healthCh {
-			if res.err != nil {
-				errors = append(errors, res.err)
-			}
-			if res.appHealth != nil {
-				appHealth[res.namespace] = *res.appHealth
-			} else if res.serviceHealth != nil {
-				serviceHealth[res.namespace] = *res.serviceHealth
-			} else if res.workloadHealth != nil {
-				workloadHealth[res.namespace] = *res.workloadHealth
-			}
+	for res := range resultsCh {
+		if res.err != nil {
+			errors = append(errors, res.err)
 		}
-		doneAccumulating <- struct{}{}
-	}()
-
-	wg := sync.WaitGroup{}
-	for namespace, kinds := range healthReqs {
-		// use RequestedDuration as a default (for outsider nodes), otherwise use the safe duration for the requested namespace
-		duration := a.RequestedDuration
-		if ns, ok := a.Namespaces[namespace]; ok {
-			duration = ns.Duration
-		}
-
-		for kind := range kinds {
-			wg.Add(1)
-			go func(namespace, kind string) {
-				defer wg.Done()
-				switch kind {
-				case graph.NodeTypeApp:
-					health, err := bs.Health.GetNamespaceAppHealth(ctx, namespace, duration.String(), time.Unix(a.QueryTime, 0))
-					healthCh <- result{
-						namespace: namespace,
-						appHealth: &health,
-						err:       err,
-					}
-				case graph.NodeTypeService:
-					health, err := bs.Health.GetNamespaceServiceHealth(ctx, namespace, duration.String(), time.Unix(a.QueryTime, 0))
-					healthCh <- result{
-						namespace:     namespace,
-						serviceHealth: &health,
-						err:           err,
-					}
-				case graph.NodeTypeWorkload:
-					health, err := bs.Health.GetNamespaceWorkloadHealth(ctx, namespace, duration.String(), time.Unix(a.QueryTime, 0))
-					healthCh <- result{
-						namespace:      namespace,
-						workloadHealth: &health,
-						err:            err,
-					}
-				}
-			}(namespace, kind)
+		if res.appHealth != nil {
+			appHealth[res.namespace] = *res.appHealth
+		} else if res.serviceHealth != nil {
+			serviceHealth[res.namespace] = *res.serviceHealth
+		} else if res.workloadHealth != nil {
+			workloadHealth[res.namespace] = *res.workloadHealth
 		}
 	}
 
-	// Wait until all results have been sent on the chan until closing
-	wg.Wait()
-	close(healthCh)
-	<-doneAccumulating
 	if len(errors) > 0 {
 		// Check for error needs to happen in the main routine or else panic won't get propagated up
 		graph.CheckError(errors[0])
@@ -232,4 +197,87 @@ func (a *HealthAppender) attachHealth(trafficMap graph.TrafficMap, globalInfo *g
 			}
 		}
 	}
+}
+
+// getNamespaceDuration gets the duration for a given namespace. Safe for concurrent use.
+func (a *HealthAppender) getNamespaceDuration(namespace string) time.Duration {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	duration := a.RequestedDuration
+	if ns, ok := a.Namespaces[namespace]; ok {
+		duration = ns.Duration
+	}
+
+	return duration
+}
+
+// getGraphNodeHealth fetches the health for each node in the graph and sends the results
+// to the returned chan. The result chan will be closed after all results have been sent.
+// Callers should not close the results chan.
+func (a *HealthAppender) getGraphNodeHealth(ctx context.Context, bs *business.Layer, healthReqs map[string]map[string][]*graph.Node) <-chan result {
+	type work struct {
+		namespace string
+		kind      string
+		duration  time.Duration
+	}
+
+	resultsCh := make(chan result)
+
+	go func() {
+		workCh := make(chan work)
+		const numberOfGetters = 20
+
+		// We need to close the resultsCh after all the workers are finished. We track when the
+		// last worker exits with the waitgroup.
+		wg := sync.WaitGroup{}
+		wg.Add(numberOfGetters)
+
+		for i := 0; i < numberOfGetters; i++ {
+			// Start the workers in separate goroutines. Each one of these will read from
+			// the workCh until the workCh is closed and then exit.
+			go func(ctx context.Context) {
+				defer wg.Done()
+
+				for w := range workCh {
+					var res result
+					switch w.kind {
+					case graph.NodeTypeApp:
+						health, err := bs.Health.GetNamespaceAppHealth(ctx, w.namespace, w.duration.String(), time.Unix(a.QueryTime, 0))
+						res.appHealth = &health
+						res.err = err
+					case graph.NodeTypeService:
+						health, err := bs.Health.GetNamespaceServiceHealth(ctx, w.namespace, w.duration.String(), time.Unix(a.QueryTime, 0))
+						res.serviceHealth = &health
+						res.err = err
+					case graph.NodeTypeWorkload:
+						health, err := bs.Health.GetNamespaceWorkloadHealth(ctx, w.namespace, w.duration.String(), time.Unix(a.QueryTime, 0))
+						res.workloadHealth = &health
+						res.err = err
+					default:
+						res.err = fmt.Errorf("unrecognized node type: %s. HealthAppender only works for '%s', '%s', and '%s' node types", w.kind, graph.NodeTypeApp, graph.NodeTypeBox, graph.NodeTypeWorkload)
+					}
+
+					resultsCh <- res
+				}
+			}(ctx)
+		}
+
+		// Put work items into the workCh that the worker goroutines will then read from.
+		for namespace, kinds := range healthReqs {
+			duration := a.getNamespaceDuration(namespace)
+
+			for kind := range kinds {
+				workCh <- work{kind: kind, duration: duration, namespace: namespace}
+			}
+		}
+		// At this point we've sent all the work items to the workers.
+		// Closing the workCh will cause the workers goroutines to exit.
+		close(workCh)
+		// Wait until all the workers have returned/exited then close the resultsCh.
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	return resultsCh
 }


### PR DESCRIPTION
Followup to #4816. Creates a fixed amount of goroutines so that no more than 20 requests to the health service are made in parallel.