### PR TITLE
[hack] do not allow using 'oc' if not logged in or not talking to OpenShift.

### DIFF
--- a/hack/purge-kiali-from-cluster.sh
+++ b/hack/purge-kiali-from-cluster.sh
@@ -50,6 +50,13 @@ else
   exit 1
 fi
 
+if [[ "$CLIENT_EXE" = *"oc" ]]; then
+  if ! ${CLIENT_EXE} whoami &> /dev/null; then
+    echo "ERROR: Using 'oc' but you are not logged in. Log in or pass in '-c kubectl' if using a non-OpenShift cluster."
+    exit 1
+  fi
+fi
+
 msg() {
   if [ "${DRY_RUN}" == "false" ]; then echo "$1"; else echo "DRY RUN: $1"; fi
 }


### PR DESCRIPTION
This fixes the problem where the cluster resources aren't purged when on non-OpenShift but -c kubectl is not specified.
You now are told that -c kubectl is needed.
