### PR TITLE
Added a support of istiod's PILOT_SCOPE_GATEWAY_TO_NAMESPACE env variable

### DIFF
--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -13,6 +13,7 @@ type GatewayChecker struct {
 	Gateways              []networking_v1alpha3.Gateway
 	Namespace             string
 	WorkloadsPerNamespace map[string]models.WorkloadList
+	IsGatewayToNamespace  bool
 }
 
 // Check runs checks for the all namespaces actions as well as for the single namespace validations
@@ -38,6 +39,7 @@ func (g GatewayChecker) runSingleChecks(gw networking_v1alpha3.Gateway) models.I
 		gateways.SelectorChecker{
 			Gateway:               gw,
 			WorkloadsPerNamespace: g.WorkloadsPerNamespace,
+			IsGatewayToNamespace:  g.IsGatewayToNamespace,
 		},
 	}
 

--- a/business/checkers/gateways/selector_checker.go
+++ b/business/checkers/gateways/selector_checker.go
@@ -10,6 +10,7 @@ import (
 type SelectorChecker struct {
 	WorkloadsPerNamespace map[string]models.WorkloadList
 	Gateway               networking_v1alpha3.Gateway
+	IsGatewayToNamespace  bool
 }
 
 // Check verifies that the Gateway's selector's labels do match a known service inside the same namespace as recommended/required by the docs
@@ -26,6 +27,9 @@ func (s SelectorChecker) hasMatchingWorkload(labelSelector map[string]string) bo
 	selector := labels.SelectorFromSet(labelSelector)
 
 	for _, wls := range s.WorkloadsPerNamespace {
+		if s.IsGatewayToNamespace && wls.Namespace.Name != s.Gateway.Namespace {
+			continue
+		}
 		for _, wl := range wls.Workloads {
 			wlLabelSet := labels.Set(wl.Labels)
 			if selector.Matches(wlLabelSet) {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -122,7 +122,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioC
 		checkers.NoServiceChecker{Namespace: namespace, Namespaces: namespaces, IstioConfigList: &istioConfigList, WorkloadsPerNamespace: workloadsPerNamespace, AuthorizationDetails: &rbacDetails, RegistryServices: registryServices},
 		checkers.VirtualServiceChecker{Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, DestinationRules: istioConfigList.DestinationRules},
 		checkers.DestinationRulesChecker{Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, MTLSDetails: mtlsDetails, ServiceEntries: istioConfigList.ServiceEntries},
-		checkers.GatewayChecker{Gateways: istioConfigList.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace},
+		checkers.GatewayChecker{Gateways: istioConfigList.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace, IsGatewayToNamespace: in.isGatewayToNamespace()},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloadsPerNamespace[namespace]},
 		checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceEntries: istioConfigList.ServiceEntries, WorkloadList: workloadsPerNamespace[namespace], MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices},

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -53,6 +53,10 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 									Name:  "CLUSTER_ID",
 									Value: "KialiCluster",
 								},
+								{
+									Name:  "PILOT_SCOPE_GATEWAY_TO_NAMESPACE",
+									Value: "true",
+								},
 							},
 						},
 					},
@@ -109,6 +113,7 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 	check.Len(a, 1, "GetClusters didn't resolve the Kiali cluster")
 	check.Equal("KialiCluster", a[0].Name, "Unexpected cluster name")
 	check.True(a[0].IsKialiHome, "Kiali cluster not properly marked as such")
+	check.True(a[0].IsGatewayToNamespace, "Kiali GatewayToNamespace not properly marked as such")
 	check.Equal("http://127.0.0.2:9443", a[0].ApiEndpoint)
 	check.Len(a[0].SecretName, 0)
 	check.Equal("kialiNetwork", a[0].Network)
@@ -312,6 +317,10 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 									Name:  "CLUSTER_ID",
 									Value: "KialiCluster",
 								},
+								{
+									Name:  "PILOT_SCOPE_GATEWAY_TO_NAMESPACE",
+									Value: "false",
+								},
 							},
 						},
 					},
@@ -341,6 +350,7 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 	check.Nil(err, "ResolveKialiControlPlaneCluster failed: %s", err)
 	check.NotNil(result)
 	check.Equal("KialiCluster", result.Name) // Sanity check. Rest of values are tested in TestGetClustersResolvesTheKialiCluster
+	check.False(result.IsGatewayToNamespace, "Kiali GatewayToNamespace not properly marked as such")
 
 	// Create a new MeshService with an empty mock. If cached value is properly used, the
 	// empty mock should never be called and we still should get a value.


### PR DESCRIPTION
Solution for https://github.com/kiali/kiali/issues/3408.

When istiod deployment has env variable PILOT_SCOPE_GATEWAY_TO_NAMESPACE= true, then a gateway workload can only select gateway resources in the same namespace. Gateways with same selectors in different namespaces will not be applicable.

Before
![Screenshot from 2022-03-22 10-46-52](https://user-images.githubusercontent.com/604313/159457652-33c83395-b239-4392-a5db-10b4780704c7.png)

After
![Screenshot from 2022-03-22 10-45-11](https://user-images.githubusercontent.com/604313/159457679-6ae9343b-19d0-41d6-87f6-448a50fa8f49.png)
