### PR TITLE
hack and make changes for the kiali-ui repo merge into kiali repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMMIT_HASH ?= $(shell git rev-parse HEAD)
 # have been built before trying to create a kiali server container
 # image. The UI project is configured to place its build
 # output in the $UI_SRC_ROOT/build/ subdirectory.
-CONSOLE_LOCAL_DIR ?= ${ROOTDIR}/../kiali-ui
+CONSOLE_LOCAL_DIR ?= ${ROOTDIR}/frontend
 
 # Version label is used in the OpenShift/K8S resources to identify
 # their specific instances. Kiali resources will have labels of

--- a/deploy/get-console.sh
+++ b/deploy/get-console.sh
@@ -8,23 +8,22 @@
 # See the main Makefile for more info.
 
 DIR=$(dirname $0)/..
-CONSOLE_DIR=${CONSOLE_LOCAL_DIR:-$DIR/../kiali-ui}
+CONSOLE_DIR=${CONSOLE_LOCAL_DIR:-$DIR/frontend}
 
 mkdir -p $DIR/_output/docker
 
 # Some sanity checks of CONSOLE_DIR. Some checks are naive.
 if [ -z "$CONSOLE_DIR" ]; then
-  echo "You must set the CONSOLE_LOCAL_DIR environment variable to the path where the kiali-ui source code is located."
-  echo "If you don't have the kiali-ui source code, download it from the kiali/kiali-ui GitHub repository."
+  echo "You must set the CONSOLE_LOCAL_DIR environment variable to the path where the UI source code is located."
   exit 1
 elif [ ! -f "$CONSOLE_DIR/package.json" ]; then
   echo "CONSOLE_DIR is $CONSOLE_DIR"
-  echo "Apparently, this CONSOLE_DIR does not contain the kiali-ui"
+  echo "Apparently, this CONSOLE_DIR does not contain the kiali UI"
   exit 1
 elif [ ! -d "$CONSOLE_DIR/build" ] || [ -z "$(ls -A $CONSOLE_DIR/build)" ]; then
   echo "CONSOLE_DIR is $CONSOLE_DIR"
-  echo "Apparently, the kiali-ui is not built."
-  echo "Build the front-end by running 'yarn && yarn build' inside the kiali-ui directory"
+  echo "Apparently, the kiali UI is not built."
+  echo "Build the front-end by running 'yarn && yarn build' inside the kiali UI directory"
   exit 1
 fi
 

--- a/hack/ci-openshift-molecule-tests.sh
+++ b/hack/ci-openshift-molecule-tests.sh
@@ -95,16 +95,6 @@ Options:
     A username that has kubeadmin permissions.
     Default: kubeadmin
 
--kuib|--kiali-ui-branch <branch name>
-    The kiali-ui branch to clone.
-    This is only needed if --use-dev-images is true and thus the UI needs to be built.
-    Default: master
-
--kuif|--kiali-ui-fork <name>
-    The kiali-ui fork/org to clone.
-    This is only needed if --use-dev-images is true and thus the UI needs to be built.
-    Default: kiali
-
 -lb|--logs-branch <branch name>
     The logs branch to clone.
     Default: openshift
@@ -192,8 +182,6 @@ while [[ $# -gt 0 ]]; do
     -kp|--kubeadmin-pw)           KUBEADMIN_PW="$2";          shift;shift; ;;
     -kpf|--kubeadmin-pw-file)     KUBEADMIN_PW_FILE="$2";     shift;shift; ;;
     -ku|--kubeadmin-user)         KUBEADMIN_USER="$2";        shift;shift; ;;
-    -kuib|--kiali-ui-branch)      UI_BRANCH="$2";             shift;shift; ;;
-    -kuif|--kiali-ui-fork)        UI_FORK="$2";               shift;shift; ;;
     -lb|--logs-branch)            LOGS_BRANCH="$2";           shift;shift; ;;
     -lf|--logs-fork)              LOGS_FORK="$2";             shift;shift; ;;
     -lpn|--logs-project-name)     LOGS_PROJECT_NAME="$2";     shift;shift; ;;
@@ -227,8 +215,6 @@ HELM_FORK="${HELM_FORK:-kiali}"
 HELM_BRANCH="${HELM_BRANCH:-master}"
 KIALI_FORK="${KIALI_FORK:-kiali}"
 KIALI_BRANCH="${KIALI_BRANCH:-master}"
-UI_FORK="${UI_FORK:-kiali}"
-UI_BRANCH="${UI_BRANCH:-master}"
 KIALI_OPERATOR_FORK="${KIALI_OPERATOR_FORK:-kiali}"
 KIALI_OPERATOR_BRANCH="${KIALI_OPERATOR_BRANCH:-master}"
 
@@ -253,8 +239,6 @@ HELM_GITHUB_GITCLONE_GIT="${GITHUB_PROTOCOL_GIT}${HELM_FORK}/helm-charts.git"
 HELM_GITHUB_GITCLONE_HTTPS="${GITHUB_PROTOCOL_HTTPS}${HELM_FORK}/helm-charts.git"
 KIALI_GITHUB_GITCLONE_GIT="${GITHUB_PROTOCOL_GIT}${KIALI_FORK}/kiali.git"
 KIALI_GITHUB_GITCLONE_HTTPS="${GITHUB_PROTOCOL_HTTPS}${KIALI_FORK}/kiali.git"
-UI_GITHUB_GITCLONE_GIT="${GITHUB_PROTOCOL_GIT}${UI_FORK}/kiali-ui.git"
-UI_GITHUB_GITCLONE_HTTPS="${GITHUB_PROTOCOL_HTTPS}${UI_FORK}/kiali-ui.git"
 KIALI_OPERATOR_GITHUB_GITCLONE_GIT="${GITHUB_PROTOCOL_GIT}${KIALI_OPERATOR_FORK}/kiali-operator.git"
 KIALI_OPERATOR_GITHUB_GITCLONE_HTTPS="${GITHUB_PROTOCOL_HTTPS}${KIALI_OPERATOR_FORK}/kiali-operator.git"
 LOGS_GITHUB_GITCLONE_GIT="${GITHUB_PROTOCOL_GIT}${LOGS_FORK}/${LOGS_PROJECT_NAME}.git"
@@ -290,8 +274,6 @@ INSTALL_ISTIO=$INSTALL_ISTIO
 IRC_ROOM=$IRC_ROOM
 KIALI_BRANCH=$KIALI_BRANCH
 KIALI_FORK=$KIALI_FORK
-UI_BRANCH=$UI_BRANCH
-UI_FORK=$UI_FORK
 KIALI_OPERATOR_BRANCH=$KIALI_OPERATOR_BRANCH
 KIALI_OPERATOR_FORK=$KIALI_OPERATOR_FORK
 KUBEADMIN_PW_FILE=$KUBEADMIN_PW_FILE
@@ -317,13 +299,11 @@ EOM
 if [ "${GIT_CLONE_PROTOCOL}" == "git" ]; then
   HELM_GITHUB_GITCLONE="${HELM_GITHUB_GITCLONE_GIT}"
   KIALI_GITHUB_GITCLONE="${KIALI_GITHUB_GITCLONE_GIT}"
-  UI_GITHUB_GITCLONE="${UI_GITHUB_GITCLONE_GIT}"
   KIALI_OPERATOR_GITHUB_GITCLONE="${KIALI_OPERATOR_GITHUB_GITCLONE_GIT}"
   LOGS_GITHUB_GITCLONE="${LOGS_GITHUB_GITCLONE_GIT}"
 elif [ "${GIT_CLONE_PROTOCOL}" == "https" ]; then
   HELM_GITHUB_GITCLONE="${HELM_GITHUB_GITCLONE_HTTPS}"
   KIALI_GITHUB_GITCLONE="${KIALI_GITHUB_GITCLONE_HTTPS}"
-  UI_GITHUB_GITCLONE="${UI_GITHUB_GITCLONE_HTTPS}"
   KIALI_OPERATOR_GITHUB_GITCLONE="${KIALI_OPERATOR_GITHUB_GITCLONE_HTTPS}"
   LOGS_GITHUB_GITCLONE="${LOGS_GITHUB_GITCLONE_HTTPS}"
   if [ "${UPLOAD_LOGS}" == "true" ]; then
@@ -346,7 +326,6 @@ if [ "${LOGS_PROJECT_NAME}" == "" ]; then
 fi
 test -d ${SRC}/helm-charts && rm -rf ${SRC}/helm-charts
 test -d ${SRC}/kiali-operator && rm -rf ${SRC}/kiali-operator
-test -d ${SRC}/kiali-ui && rm -rf ${SRC}/kiali-ui
 test -d ${SRC}/kiali && rm -rf ${SRC}/kiali
 test -d ${SRC}/${LOGS_PROJECT_NAME:-invalid} && [ "${SRC}/${LOGS_PROJECT_NAME}" != "/" ] && rm -rf ${SRC}/${LOGS_PROJECT_NAME:-invalid}
 mkdir -p ${SRC}
@@ -372,11 +351,6 @@ git clone --single-branch --branch ${LOGS_BRANCH} ${LOGS_GITHUB_GITCLONE}
 infomsg "Cloning helm-charts [${HELM_FORK}/helm-charts:${HELM_BRANCH}] from [${HELM_GITHUB_GITCLONE}]..."
 git clone --single-branch --branch ${HELM_BRANCH} ${HELM_GITHUB_GITCLONE}
 
-if [ "${USE_DEV_IMAGES}" == "true" ]; then
-  infomsg "Cloning kiali-ui [${UI_FORK}/kiali-ui:${UI_BRANCH}] from [${UI_GITHUB_GITCLONE}]..."
-  git clone --single-branch --branch ${UI_BRANCH} ${UI_GITHUB_GITCLONE}
-fi
-
 infomsg "Cloning kiali [${KIALI_FORK}/kiali:${KIALI_BRANCH}] from [${KIALI_GITHUB_GITCLONE}]..."
 git clone --single-branch --branch ${KIALI_BRANCH} ${KIALI_GITHUB_GITCLONE}
 
@@ -394,18 +368,16 @@ if [ "${USE_DEV_IMAGES}" == "true" ]; then
   infomsg "Dev images are to be tested. Will prepare them now using GOPATH=${GOPATH}"
 
   infomsg "Building server..."
-  make -e OC="${OC}" -e DORP="${DORP}" -e CONSOLE_LOCAL_DIR="${SRC}/kiali-ui" -e GOPATH="${GOPATH}" clean build test
+  make -e OC="${OC}" -e DORP="${DORP}" -e GOPATH="${GOPATH}" clean build test
 
   infomsg "Building UI..."
-  pushd ${SRC}/kiali-ui
   yarn && yarn run build
-  popd
 
   infomsg "Logging into the image registry..."
   eval $(make -e OC="${OC}" -e DORP="${DORP}" cluster-status | grep "Image Registry login:" | sed 's/Image Registry login: \(.*\)$/\1/')
 
   infomsg "Pushing the images into the cluster..."
-  make -e OC="${OC}" -e DORP="${DORP}" -e CONSOLE_LOCAL_DIR="${SRC}/kiali-ui" -e GOPATH="${GOPATH}" cluster-push
+  make -e OC="${OC}" -e DORP="${DORP}" -e GOPATH="${GOPATH}" cluster-push
 else
   infomsg "Will test the latest published images"
 fi

--- a/hack/run-kiali.sh
+++ b/hack/run-kiali.sh
@@ -214,11 +214,10 @@ Valid options:
   -ucd|--ui-console-dir
       A directory on the local machine containing the UI console code.
       If not specified, an attempt to find it on the local machine will be made. A search up the
-      directory tree is made, looking for any directory called "kiali-ui" that has a "build" directory under it.
-      The "build" directory of the kiali-ui is generated after you run "yarn build" to
-      generate the distributable package. So, make sure that you build the kiali-ui before
+      directory tree is made, looking for any directory called "kiali-ui" or "frontend" that has a "build" directory under it.
+      The "build" directory of the UI is generated after you run "yarn build" to
+      generate the distributable package. So, make sure that you build the UI before
       using this script and then set this option to the generated build directory.
-      For details, see: https://github.com/kiali/kiali-ui
       Default: <a local build that is auto-discovered>
 HELPMSG
       exit 1
@@ -444,11 +443,15 @@ fi
 if [ -z "${UI_CONSOLE_DIR:-}" ]; then
   infomsg "Attempting to find the UI Console directory..."
 
-  # See if the user has the typical dev environment. Go up the dir tree to find a 'kiali-ui' directory with a 'build' directory under it.
+  # See if the user has the typical dev environment. Go up the dir tree to find a 'frontend' or 'kiali-ui' directory with a 'build' directory under it.
   cur_path="${SCRIPT_DIR}"
   while [[ ${cur_path} != / ]];
   do
-    find_results="$(find "${cur_path}" -maxdepth 1 -mindepth 1 -name "kiali-ui" | head -n 1)"
+    find_results="$(find "${cur_path}" -maxdepth 1 -mindepth 1 -name "frontend" | head -n 1)"
+    if [ -z "${find_results}" ]; then
+      # do this in case you are running an older Kiali that had its kiali-ui split out into a separate repo
+      find_results="$(find "${cur_path}" -maxdepth 1 -mindepth 1 -name "kiali-ui" | head -n 1)"
+    fi
     if [ ! -z "${find_results}" ]; then
       if [ -d "${find_results}/build" ]; then
         UI_CONSOLE_DIR="${find_results}/build"


### PR DESCRIPTION
This PR contains the changes I think need to be made when the kiali-ui repo is merged into the kiali repo.

The only thing missing would be a make target "make ui". I suggest something simple like the following in `make/Makefile.build.mk`:

```make
build-ui:
  yarn install && yarn run build
```

If we don't do that, then we should just expect people to do a `yarn install && yarn run build` in the new `frontend` directory where the kiali-ui code will go.

cc @aljesusg you can either (1) manually put these changes in your own PR, or (2) you can merge this PR into yours. I just created this PR to document what changes will be needed.

NOTE! I did NOT make any changes to the Jenkins files - there will be changes necessary for that. I'll leave that for someone else who knows more about the Jenkins stuff than I.