### PR TITLE
Refactor OpenShift auth to stop using the dgrijalva/jwt library

### DIFF
--- a/business/authentication/auth_controller.go
+++ b/business/authentication/auth_controller.go
@@ -6,11 +6,18 @@ import (
 	"github.com/kiali/kiali/config"
 )
 
+// TerminateSessionError is a helper type implementing the error interface.
+// Its main goal is to pass the right HTTP status code that should be sent
+// to the client if a session Logout operation fails.
 type TerminateSessionError struct {
-	Message    string
+	// A description of the error.
+	Message string
+
+	// The HTTP Status code that should be sent to the client.
 	HttpStatus int
 }
 
+// Error returns the string representation of an instance of TerminateSessionError.
 func (e TerminateSessionError) Error() string {
 	return e.Message
 }

--- a/business/authentication/auth_controller.go
+++ b/business/authentication/auth_controller.go
@@ -6,6 +6,15 @@ import (
 	"github.com/kiali/kiali/config"
 )
 
+type TerminateSessionError struct {
+	Message    string
+	HttpStatus int
+}
+
+func (e TerminateSessionError) Error() string {
+	return e.Message
+}
+
 // AuthController is the interface that all Kiali authentication strategies should implement.
 // An authentication controller is initialized during Kiali startup.
 type AuthController interface {
@@ -24,7 +33,7 @@ type AuthController interface {
 
 	// TerminateSession performs the needed procedures to terminate an existing session. If there is no
 	// active session, nothing is performed. If there is some invalid session, it is cleared.
-	TerminateSession(r *http.Request, w http.ResponseWriter)
+	TerminateSession(r *http.Request, w http.ResponseWriter) error
 }
 
 var authController AuthController

--- a/business/authentication/auth_controller.go
+++ b/business/authentication/auth_controller.go
@@ -54,5 +54,7 @@ func InitializeAuthenticationController(strategy string) {
 		authController = NewTokenAuthController(persistor, nil)
 	} else if strategy == config.AuthStrategyOpenId {
 		authController = NewOpenIdAuthController(persistor, nil)
+	} else if strategy == config.AuthStrategyOpenshift {
+		authController = NewOpenshiftAuthController(persistor, nil)
 	}
 }

--- a/business/authentication/openid_auth_controller.go
+++ b/business/authentication/openid_auth_controller.go
@@ -293,8 +293,9 @@ func (c OpenIdAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 }
 
 // TerminateSession unconditionally terminates any existing session without any validation.
-func (c OpenIdAuthController) TerminateSession(r *http.Request, w http.ResponseWriter) {
+func (c OpenIdAuthController) TerminateSession(r *http.Request, w http.ResponseWriter) error {
 	c.SessionStore.TerminateSession(r, w)
+	return nil
 }
 
 // authenticateWithAuthorizationCodeFlow is the entry point to handle OpenId authentication using the authorization

--- a/business/authentication/openshift_auth_controller.go
+++ b/business/authentication/openshift_auth_controller.go
@@ -27,6 +27,20 @@ type OpenshiftAuthController struct {
 	SessionStore SessionPersistor
 }
 
+// NewOpenshiftAuthController initializes a new controller for handling OpenShift authentication, with the
+// given persistor and the given businessInstantiator. The businessInstantiator can be nil and
+// the initialized contoller will use the business.Get function.
+func NewOpenshiftAuthController(persistor SessionPersistor, businessInstantiator func(authInfo *api.AuthInfo) (*business.Layer, error)) *OpenshiftAuthController {
+	if businessInstantiator == nil {
+		businessInstantiator = business.Get
+	}
+
+	return &OpenshiftAuthController{
+		businessInstantiator: businessInstantiator,
+		SessionStore:         persistor,
+	}
+}
+
 func (o OpenshiftAuthController) Authenticate(r *http.Request, w http.ResponseWriter) (*UserSessionData, error) {
 	err := r.ParseForm()
 

--- a/business/authentication/openshift_auth_controller.go
+++ b/business/authentication/openshift_auth_controller.go
@@ -3,14 +3,15 @@ package authentication
 import (
 	"errors"
 	"fmt"
-	"github.com/kiali/kiali/business"
-	"github.com/kiali/kiali/log"
-	"k8s.io/client-go/tools/clientcmd/api"
 	"net/http"
 	"strconv"
 	"time"
 
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
 )
 
 type openshiftSessionPayload struct {

--- a/business/authentication/openshift_auth_controller.go
+++ b/business/authentication/openshift_auth_controller.go
@@ -1,0 +1,156 @@
+package authentication
+
+import (
+	"errors"
+	"fmt"
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/log"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/kiali/kiali/config"
+)
+
+type openshiftSessionPayload struct {
+	Token string `json:"token,omitempty"`
+}
+
+type OpenshiftAuthController struct {
+	// businessInstantiator is a function that returns an already initialized
+	// business layer. Normally, it should be set to the business.Get function.
+	// For tests, it can be set to something else that returns a compatible API.
+	businessInstantiator func(authInfo *api.AuthInfo) (*business.Layer, error)
+
+	// SessionStore persists the session between HTTP requests.
+	SessionStore SessionPersistor
+}
+
+func (o OpenshiftAuthController) Authenticate(r *http.Request, w http.ResponseWriter) (*UserSessionData, error) {
+	err := r.ParseForm()
+
+	if err != nil {
+		return nil, fmt.Errorf("error parsing form info: %w", err)
+	}
+
+	token := r.Form.Get("access_token")
+	expiresIn := r.Form.Get("expires_in")
+	if token == "" || expiresIn == "" {
+		return nil, errors.New("token is empty or invalid")
+	}
+
+	expiresInNumber, err := strconv.Atoi(expiresIn)
+	if err != nil {
+		return nil, fmt.Errorf("token is empty or invalid: %w", err)
+	}
+
+	expiresOn := time.Now().Add(time.Second * time.Duration(expiresInNumber))
+	bs, err := o.businessInstantiator(&api.AuthInfo{Token: ""})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving the OAuth package (getting business layer): %w", err)
+	}
+
+	user, err := bs.OpenshiftOAuth.GetUserInfo(token)
+	if err != nil {
+		o.SessionStore.TerminateSession(r, w)
+		return nil, &AuthenticationFailureError{
+			Reason:     "Token is not valid or is expired.",
+			Detail:     err,
+			HttpStatus: http.StatusUnauthorized,
+		}
+	}
+
+	err = o.SessionStore.CreateSession(r, w, config.AuthStrategyOpenshift, expiresOn, openshiftSessionPayload{Token: token})
+	if err != nil {
+		return nil, err
+	}
+
+	return &UserSessionData{
+		ExpiresOn: expiresOn,
+		Username:  user.Metadata.Name,
+		Token:     token,
+	}, nil
+}
+
+func (o OpenshiftAuthController) ValidateSession(r *http.Request, w http.ResponseWriter) (*UserSessionData, error) {
+	sPayload := openshiftSessionPayload{}
+	sData, err := o.SessionStore.ReadSession(r, w, &sPayload)
+	if err != nil {
+		log.Warningf("Could not read the openshift session: %v", err)
+		return nil, nil
+	}
+	if sData == nil {
+		return nil, nil
+	}
+
+	// The Openshift token must be present
+	if len(sPayload.Token) == 0 {
+		log.Warning("Session is invalid: the Openshift token is absent")
+		return nil, nil
+	}
+
+	bs, err := o.businessInstantiator(&api.AuthInfo{Token: sPayload.Token})
+	if err != nil {
+		log.Warningf("Could not get the business layer!: %v", err)
+		return nil, fmt.Errorf("could not get the business layer: %w", err)
+	}
+
+	user, err := bs.OpenshiftOAuth.GetUserInfo(sPayload.Token)
+	if err == nil {
+		// Internal header used to propagate the subject of the request for audit purposes
+		r.Header.Add("Kiali-User", user.Metadata.Name)
+		return &UserSessionData{
+			ExpiresOn: sData.ExpiresOn,
+			Username:  user.Metadata.Name,
+			Token:     sPayload.Token,
+		}, nil
+	}
+
+	log.Warningf("Token error: %v", err)
+	return nil, nil
+}
+
+func (o OpenshiftAuthController) TerminateSession(r *http.Request, w http.ResponseWriter) error {
+	sPayload := openshiftSessionPayload{}
+	sData, err := o.SessionStore.ReadSession(r, w, &sPayload)
+	if err != nil {
+		return TerminateSessionError{
+			Message:    fmt.Sprintf("Apparently, there is no active openshift session: %v", err),
+			HttpStatus: http.StatusUnauthorized,
+		}
+	}
+	if sData == nil {
+		return TerminateSessionError{
+			Message:    "logout problem: no session exists.",
+			HttpStatus: http.StatusInternalServerError,
+		}
+	}
+
+	// The Openshift token must be present
+	if len(sPayload.Token) == 0 {
+		return TerminateSessionError{
+			Message:    "Cannot logout: the Openshift token is absent from the session",
+			HttpStatus: http.StatusInternalServerError,
+		}
+	}
+
+	bs, err := o.businessInstantiator(&api.AuthInfo{Token: sPayload.Token})
+	if err != nil {
+		return TerminateSessionError{
+			Message:    fmt.Sprintf("Could not get the business layer: %v", err),
+			HttpStatus: http.StatusInternalServerError,
+		}
+	}
+
+	err = bs.OpenshiftOAuth.Logout(sPayload.Token)
+	if err != nil {
+		return TerminateSessionError{
+			Message:    fmt.Sprintf("Could not log out of OpenShift: %v", err),
+			HttpStatus: http.StatusInternalServerError,
+		}
+	}
+
+	o.SessionStore.TerminateSession(r, w)
+	return nil
+}

--- a/business/authentication/openshift_auth_controller.go
+++ b/business/authentication/openshift_auth_controller.go
@@ -151,7 +151,7 @@ func (o openshiftAuthController) TerminateSession(r *http.Request, w http.Respon
 	sData, err := o.SessionStore.ReadSession(r, w, &sPayload)
 	if err != nil {
 		return TerminateSessionError{
-			Message:    fmt.Sprintf("Apparently, there is no active openshift session: %v", err),
+			Message:    fmt.Sprintf("There is no active openshift session: %v", err),
 			HttpStatus: http.StatusUnauthorized,
 		}
 	}

--- a/business/authentication/token_auth_controller.go
+++ b/business/authentication/token_auth_controller.go
@@ -191,8 +191,9 @@ func (c tokenAuthController) ValidateSession(r *http.Request, w http.ResponseWri
 }
 
 // TerminateSession unconditionally terminates any existing session without any validation.
-func (c tokenAuthController) TerminateSession(r *http.Request, w http.ResponseWriter) {
+func (c tokenAuthController) TerminateSession(r *http.Request, w http.ResponseWriter) error {
 	c.SessionStore.TerminateSession(r, w)
+	return nil
 }
 
 // extractSubjectFromK8sToken returns the string stored in the "sub" claim of a JWT.

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -314,7 +314,7 @@ func AuthenticationInfo(w http.ResponseWriter, r *http.Request) {
 			httputil.GuessKialiURL(r))
 	}
 
-	if conf.Auth.Strategy != config.AuthStrategyToken && conf.Auth.Strategy != config.AuthStrategyOpenId {
+	if conf.Auth.Strategy == config.AuthStrategyAnonymous || conf.Auth.Strategy == config.AuthStrategyHeader {
 		token := getTokenStringFromRequest(r)
 		claims, _ := config.GetTokenClaimsIfValid(token)
 


### PR DESCRIPTION
Refactor the OpenShift strategy to use the "auth controller" form. This moves it away from the dgrijalva/jwt library

Related to #4542 