### PR TITLE
Update development setup documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ Please, complement the content of this readme document with the link:https://git
 Make sure you have the following tools:
 
 * The link:http://golang.org/doc/install[Go Programming Language]
-** Currently, Kiali releases are built using Go 1.16. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.16.2 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
+** Currently, Kiali releases are built using Go 1.17. Although Kiali may build correctly using other versions of Go, it's suggested to use version 1.17.7 for development to ensure replicatable builds. Makefiles will require this minimum version of Go.
 * link:http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[git]
 * link:https://docs.docker.com/installation/[Docker] or link:https://podman.io[Podman]
 ** If you are using `podman` declare the environment variable `DORP=podman`.

--- a/README.adoc
+++ b/README.adoc
@@ -53,6 +53,7 @@ Make sure you have the following tools:
 * link:https://docs.docker.com/installation/[Docker] or link:https://podman.io[Podman]
 ** If you are using `podman` declare the environment variable `DORP=podman`.
 * link:https://nodejs.org[NodeJS] (Node.js >= 12.22.0 && <16 with the NPM command)
+* link:https://classic.yarnpkg.com/[Yarn]
 * The _GNU make_ utility or any of it's alternatives
 
 Once you have the required developer tools, you can get and build the code with the following script:


### PR DESCRIPTION
** Describe the change **

Update the docs development setup to bump the go version which currently uses 1.17.7 in ci pipeline.

Add Yarn dependency to development setup docs.


** Issue reference **
#4851 

** Backwards compatible? **

[x] Is your change introducing backwards incompatible changes?

Updates docs

** Screenshot **

No UI changes

** Documentation **

Does your contribution contain user-visible changes like e.g. new or changed configuration settings?
If so, provide an update to documentation if appropriate [README.adoc](README.adoc)
For configuration options, consider sending a PR to https://github.com/kiali/kiali/blob/master/README.adoc