### PR TITLE
security: update go-jwt and make it backlog compatible

### DIFF
--- a/STYLE_GUIDE.adoc
+++ b/STYLE_GUIDE.adoc
@@ -33,7 +33,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go/v4"
 
 	"github.com/kiali/kiali/log"
 )

--- a/config/token.go
+++ b/config/token.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go/v4"
 
 	"github.com/kiali/kiali/util"
 )
@@ -61,9 +61,11 @@ func GenerateToken(username string) (TokenGenerated, error) {
 	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(Get().LoginToken.ExpirationSeconds))
 	claim := IanaClaims{
 		StandardClaims: jwt.StandardClaims{
-			Subject:   username,
-			ExpiresAt: timeExpire.Unix(),
-			Issuer:    AuthStrategyTokenIssuer,
+			Subject: username,
+			ExpiresAt: &jwt.Time{
+				Time: timeExpire,
+			},
+			Issuer: AuthStrategyTokenIssuer,
 		},
 	}
 
@@ -105,7 +107,7 @@ func GetTokenClaimsIfValid(tokenString string) (*IanaClaims, error) {
 		}
 
 		// A token with no expiration claim is invalid for Kiali
-		if claims.ExpiresAt == 0 {
+		if claims.ExpiresAt.Unix() == 0 {
 			return nil, errors.New("token is invalid because expiration claim is missing")
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go/v4"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -155,9 +155,11 @@ func performOpenshiftAuthentication(w http.ResponseWriter, r *http.Request) bool
 	tokenClaims := config.IanaClaims{
 		SessionId: token,
 		StandardClaims: jwt.StandardClaims{
-			Subject:   user.Metadata.Name,
-			ExpiresAt: expiresOn.Unix(),
-			Issuer:    config.AuthStrategyOpenshiftIssuer,
+			Subject: user.Metadata.Name,
+			ExpiresAt: &jwt.Time{
+				Time: expiresOn,
+			},
+			Issuer: config.AuthStrategyOpenshiftIssuer,
 		},
 	}
 	tokenString, err := config.GetSignedTokenString(tokenClaims)
@@ -226,9 +228,11 @@ func performHeaderAuthentication(w http.ResponseWriter, r *http.Request) bool {
 	tokenClaims := config.IanaClaims{
 		SessionId: string(uuid.NewUUID()),
 		StandardClaims: jwt.StandardClaims{
-			Subject:   tokenSubject,
-			ExpiresAt: timeExpire.Unix(),
-			Issuer:    config.AuthStrategyHeaderIssuer,
+			Subject: tokenSubject,
+			ExpiresAt: &jwt.Time{
+				Time: timeExpire,
+			},
+			Issuer: config.AuthStrategyHeaderIssuer,
 		},
 	}
 	tokenString, err := config.GetSignedTokenString(tokenClaims)
@@ -446,7 +450,7 @@ func AuthenticationInfo(w http.ResponseWriter, r *http.Request) {
 
 		if claims != nil {
 			response.SessionInfo = sessionInfo{
-				ExpiresOn: time.Unix(claims.ExpiresAt, 0).Format(time.RFC1123Z),
+				ExpiresOn: time.Unix(claims.ExpiresAt.Unix(), 0).Format(time.RFC1123Z),
 				Username:  claims.Subject,
 			}
 		}

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go/v4"
 	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -1,7 +1,7 @@
 package kubetest
 
 import (
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go/v4"
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	"github.com/stretchr/testify/mock"
 	istio_fake "istio.io/client-go/pkg/clientset/versioned/fake"


### PR DESCRIPTION
Signed-off-by: Xunzhuo <mixdeers@gmail.com>

**Describe the change**

update jwt-go and make it compatible with new version

> jwt-go before 4.0.0-preview1 allows attackers to bypass intended access restrictions in situations with []string{} for m["aud"] (which is allowed by the specification). Because the type assertion fails, "" is the value of aud. This is a security problem if the JWT token is presented to a service that lacks its own audience check.

**Issue reference**

https://github.com/kiali/kiali/issues/4862