### PR TITLE
[make] provide a make target to allow for an easy way to "yarn start"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ include make/Makefile.cluster.mk
 include make/Makefile.helm.mk
 include make/Makefile.operator.mk
 include make/Makefile.molecule.mk
+include make/Makefile.ui.mk
 
 .PHONY: help
 help: Makefile
@@ -186,6 +187,9 @@ help: Makefile
 	@echo
 	@echo "Molecule test targets"
 	@sed -n 's/^##//p' make/Makefile.molecule.mk | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+	@echo "UI targets"
+	@sed -n 's/^##//p' make/Makefile.ui.mk | column -t -s ':' |  sed -e 's/^/ /'
 	@echo
 	@echo "Misc targets"
 	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'

--- a/README.adoc
+++ b/README.adoc
@@ -328,7 +328,7 @@ spec:
 
 === Running the UI outside the cluster
 
-When developing the http://github.com/kiali/kiali/frontend[Kiali UI] you will find it useful to run it outside of the cluster to make it easier to update the UI code and see the changes without having to re-deploy. The preferred approach for this is to use the _proxy_ feature of React. The process is described https://github.com/kiali/kiali/frontend#developing[here].
+When developing the http://github.com/kiali/kiali/frontend[Kiali UI] you will find it useful to run it outside of the cluster to make it easier to update the UI code and see the changes without having to re-deploy. The preferred approach for this is to use the _proxy_ feature of React. The process is described https://github.com/kiali/kiali/blob/master/frontend/README.adoc#developing[here]. Alternatively, you can use the `make -e YARN_START_URL=<url> yarn-start` command where `<url>` is to the Kiali backend.
 
 === Disabling SSL
 

--- a/make/Makefile.ui.mk
+++ b/make/Makefile.ui.mk
@@ -1,0 +1,16 @@
+#
+# Targets for working with the UI from source
+#
+
+## yarn-start: Run the UI in a local process that is separate from the backend. Set YARN_START_URL to update package.json.
+yarn-start:
+	@if ! (cat ${ROOTDIR}/frontend/package.json | grep -q "\"proxy\":"); then \
+	  if [ -z "${YARN_START_URL}" ]; then \
+	    echo "${ROOTDIR}/frontend/package.json does not have a 'proxy' setting and you did not set YARN_START_URL. Aborting."; \
+	    exit 1; \
+	  else \
+	    sed -i "2 i \ \ \"proxy\": \"${YARN_START_URL}\"," ${ROOTDIR}/frontend/package.json; \
+	  fi; \
+	fi
+	@echo "'yarn start' will use this proxy setting: $$(grep proxy ${ROOTDIR}/frontend/package.json)"
+	@cd ${ROOTDIR}/frontend && yarn start


### PR DESCRIPTION
This is for developers who are not familiar with (or who forget :) the proxy setting and where/how to set it in the package.json. You just have to provide your server URL via `-e YARN_START_URL` such as `make -e YARN_START_URL="http://localhost:20001" yarn-start`. Once that updates the package.json it will invoke `yarn start`. You won't have to set that env var thereafter unless you reset package.json. If the package.json already has a proxy setting, the env var is ignored. You can just run `make yarn-start` in that case.

Here is how to test. Get a cluster up with istio installed. Then run the "run-kiali.sh" hack script to start the server.  Then run this make target to start a ui via yarn start.  At this point, you have a development environment of both the backend (you can use a debugger to connect to it) and of the frontend (you can edit the frontend UI files and have them automatically recompiled/redployed in the browser). Steps are:

1. `./hack/run-kiali.sh -kc current`
2. `make -e YARN_START_URL="http://localhost:20001" yarn-start`

Tell yarn that you want to start it on another port (the backend run-kiali.sh script will have already started a proxy on port 3000 for grafana, so yarn needs to use another port). At this point, the browser can access the UI at `http://localhost:3001`.

NOTE: you don't have to use run-kiali.sh - I just show how you can use hack scripts and make to stand up a development version of both the server and UI without deploying anything Kiali-related to the cluster. If you already have kiali deployed somewhere, use its URL for the YARN_START_URL setting.