### PR TITLE
Run backend integration tests in CI

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -55,7 +55,13 @@ jobs:
         run: make swagger-ci
 
       - name: Build
-        run: make clean-all build
+        run: make -e GO_BUILD_FLAGS=${{ env.GO_BUILD_FLAGS }} -e CGO_ENABLED=${{ env.CGO_ENABLED }} clean-all build
+        env:
+          # Build with -race flag if this is a PR, otherwise it is a release and
+          # we don't want to build with race detection because of the perf penalty.
+          GO_BUILD_FLAGS: ${{ github.base_ref && '-race' }}
+          # The -race flag requires CGO_ENABLED
+          CGO_ENABLED: ${{ github.base_ref && '1' }}
 
       - name: Test backend
         run: make test-race
@@ -153,3 +159,51 @@ jobs:
         with:
           name: cypress-videos
           path: frontend/cypress/videos
+
+  integration_tests_backend:
+    name: Backend API integration tests
+    needs: [build_backend, build_frontend]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.7
+
+      - name: Download go binary
+        uses: actions/download-artifact@v3
+        with:
+          name: kiali
+          path: ~/go/bin/
+
+      - name: Ensure kiali binary is executable
+        run: chmod +x ~/go/bin/kiali
+
+      - name: Download frontend build
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: frontend/build
+
+      - name: Setup kind
+        run: hack/setup-kind-in-ci.sh
+
+      - name: Set kiali URL
+        run: |
+          KIALI_URL="http://$(kubectl get svc kiali -n istio-system -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'):20001/kiali"
+          echo "::set-output name=kiali_url::$KIALI_URL"
+        id: set-kiali-url
+
+      - name: Run backend integration tests
+        run: go test -v
+        id: integration_tests
+        env:
+          URL: ${{ steps.set-kiali-url.outputs.kiali_url }}
+        working-directory: tests/integration/tests
+
+      - name: Get kiali pod logs when tests fail
+        if: ${{ steps.integration_tests.outcome == 'failure' }}
+        run: kubectl logs deployments/kiali -n istio-system

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ GO_BUILD_ENVVARS = \
 	CGO_ENABLED=$(CGO_ENABLED)
 
 # Extra build flags passed to the go compiler.
-GO_BUILD_FLAGS = 
+GO_BUILD_FLAGS ?= 
 
 # Determine which Dockerfile is used to build the server container
 KIALI_DOCKER_FILE ?= Dockerfile-ubi8-minimal

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,14 @@ GOPATH ?= ${HOME}/go
 # Environment variables set when running the Go compiler.
 GOOS ?= $(shell ${GO} env GOOS)
 GOARCH ?= $(shell ${GO} env GOARCH)
+CGO_ENABLED ?= 0
 GO_BUILD_ENVVARS = \
 	GOOS=$(GOOS) \
 	GOARCH=$(GOARCH) \
-	CGO_ENABLED=0 \
+	CGO_ENABLED=$(CGO_ENABLED)
+
+# Extra build flags passed to the go compiler.
+GO_BUILD_FLAGS = 
 
 # Determine which Dockerfile is used to build the server container
 KIALI_DOCKER_FILE ?= Dockerfile-ubi8-minimal

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -29,7 +29,7 @@ go-check:
 build: go-check
 	@echo Building...
 	${GO_BUILD_ENVVARS} ${GO} build \
-		-o ${GOPATH}/bin/kiali -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
+		-o ${GOPATH}/bin/kiali -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}" ${GO_BUILD_FLAGS}
 
 ## build-ui: Runs the yarn commands to build the frontend UI
 build-ui:
@@ -44,7 +44,7 @@ build-linux-multi-arch:
 	@for arch in ${TARGET_ARCHS}; do \
 		echo "Building for architecture [$${arch}]"; \
 		${GO_BUILD_ENVVARS} GOOS=linux GOARCH=$${arch} ${GO} build \
-			-o ${GOPATH}/bin/kiali-$${arch} -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"; \
+			-o ${GOPATH}/bin/kiali-$${arch} -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}" ${GO_BUILD_FLAGS}; \
 	done
 
 ## install: Install missing dependencies. Runs `go install` internally


### PR DESCRIPTION
Run backend integration tests as part of upstream CI. Runs as a separate job with a separate e2e env in parallel with the frontend integration tests. Builds PR go binaries with the `-race` flag for race detection while running tests. Releases won't be built with this flag since there is a perf penalty associated with it.

Fixes #4874 