### PR TITLE
Kiali UI and Kiali Server can point to a single commit

### DIFF
--- a/deploy/get-console.sh
+++ b/deploy/get-console.sh
@@ -30,10 +30,3 @@ fi
 echo "Copying local console files from $CONSOLE_DIR"
 rm -rf $DIR/_output/docker/console && mkdir $DIR/_output/docker/console
 cp -r $CONSOLE_DIR/build/* $DIR/_output/docker/console
-
-# If there is a version.txt file, use it (required for continuous delivery)
-if [ ! -f "$DIR/_output/docker/console/version.txt" ]; then
-  echo "$(sed -n 's/.*"version":.*"\(.*\)".*/\1/p' $CONSOLE_DIR/package.json)-local-$(cd $CONSOLE_DIR; git rev-parse HEAD)" > $DIR/_output/docker/console/version.txt
-fi
-
-echo "Console version being packaged: $(cat $DIR/_output/docker/console/version.txt)"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@kiali/kiali-ui",
-  "version": "1.49.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
   "keywords": [
     "istio service mesh",

--- a/frontend/src/components/About/AboutUIModal.tsx
+++ b/frontend/src/components/About/AboutUIModal.tsx
@@ -33,10 +33,6 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
   };
 
   render() {
-    const uiVersion =
-      process.env.REACT_APP_GIT_HASH === '' || process.env.REACT_APP_GIT_HASH === 'unknown'
-        ? process.env.REACT_APP_VERSION
-        : `${process.env.REACT_APP_VERSION} (${process.env.REACT_APP_GIT_HASH})`;
     const coreVersion =
       this.props.status[StatusKey.KIALI_CORE_COMMIT_HASH] === '' ||
       this.props.status[StatusKey.KIALI_CORE_COMMIT_HASH] === 'unknown'
@@ -54,14 +50,8 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
       >
         <TextContent>
           <TextList component="dl">
-            <TextListItem key={'kiali-ui-name'} component="dt">
-              Kiali UI
-            </TextListItem>
-            <TextListItem key={'kiali-ui-version'} component="dd">
-              {uiVersion!}
-            </TextListItem>
             <TextListItem key={'kiali-name'} component="dt">
-              Kiali Server
+              Kiali
             </TextListItem>
             <TextListItem key={'kiali-version'} component="dd">
               {coreVersion!}

--- a/frontend/src/types/StatusState.ts
+++ b/frontend/src/types/StatusState.ts
@@ -1,7 +1,7 @@
 export enum StatusKey {
   DISABLED_FEATURES = 'Disabled features',
-  KIALI_CORE_COMMIT_HASH = 'Kiali core commit hash',
-  KIALI_CORE_VERSION = 'Kiali core version',
+  KIALI_CORE_COMMIT_HASH = 'Kiali commit hash',
+  KIALI_CORE_VERSION = 'Kiali version',
   KIALI_CONTAINER_VERSION = 'Kiali container version',
   KIALI_STATE = 'Kiali state'
 }

--- a/frontend/src/types/StatusState.ts
+++ b/frontend/src/types/StatusState.ts
@@ -2,7 +2,6 @@ export enum StatusKey {
   DISABLED_FEATURES = 'Disabled features',
   KIALI_CORE_COMMIT_HASH = 'Kiali core commit hash',
   KIALI_CORE_VERSION = 'Kiali core version',
-  KIALI_CONSOLE_VERSION = 'Kiali console version',
   KIALI_CONTAINER_VERSION = 'Kiali container version',
   KIALI_STATE = 'Kiali state'
 }

--- a/hack/run-kiali.sh
+++ b/hack/run-kiali.sh
@@ -470,11 +470,6 @@ if [ -z "${UI_CONSOLE_DIR:-}" ]; then
   fi
 fi
 
-# Kiali will log the version of the UI based on version.txt - create a dummy one to avoid a warning message at startup
-if [ ! -f "${UI_CONSOLE_DIR}/version.txt" ]; then
-  echo "Local-Build" > "${UI_CONSOLE_DIR}/version.txt"
-fi
-
 infomsg "===== SETTINGS ====="
 echo "API_PROXY_HOST=$API_PROXY_HOST"
 echo "API_PROXY_PORT=$API_PROXY_PORT"

--- a/kiali.go
+++ b/kiali.go
@@ -18,7 +18,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"regexp"
@@ -84,10 +83,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	consoleVersion := determineConsoleVersion()
-	log.Infof("Kiali: Console version: %v", consoleVersion)
-
-	status.Put(status.ConsoleVersion, consoleVersion)
 	status.Put(status.CoreVersion, version)
 	status.Put(status.CoreCommitHash, commitHash)
 	status.Put(status.ContainerVersion, determineContainerVersion(version))
@@ -201,21 +196,6 @@ func validateFlags() {
 			}
 		}
 	}
-}
-
-// determineConsoleVersion will return the version of the UI console the server will serve to clients.
-// Note this method requires the configuration to be loaded and available via config.Get()
-func determineConsoleVersion() string {
-	consoleVersion := "unknown"
-	filename := config.Get().Server.StaticContentRootDirectory + "/version.txt"
-	fileContent, err := ioutil.ReadFile(filename)
-	if err == nil {
-		consoleVersion = string(fileContent)
-		consoleVersion = strings.TrimSpace(consoleVersion) // also seems to kill off EOF
-	} else {
-		log.Errorf("Failed to determine console version from file [%v]. error=%v", filename, err)
-	}
-	return consoleVersion
 }
 
 // determineContainerVersion will return the version of the image container.

--- a/status/status.go
+++ b/status/status.go
@@ -11,11 +11,10 @@ import (
 const (
 	name             = "Kiali"
 	ContainerVersion = name + " container version"
-	ConsoleVersion   = name + " console version"
-	CoreVersion      = name + " core version"
+	CoreVersion      = name + " version"
 	MeshName         = "Mesh name"
 	MeshVersion      = "Mesh version"
-	CoreCommitHash   = name + " core commit hash"
+	CoreCommitHash   = name + " commit hash"
 	State            = name + " state"
 	ClusterMTLS      = "Istio mTLS"
 	StateRunning     = "running"


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/4895

![Screenshot from 2022-04-05 09-24-45](https://user-images.githubusercontent.com/3019213/161700766-7b0dcaca-3700-44f4-ba94-49d4a2020cc7.png)

# Changes in /api/status

- Removed **Kiali console version**
- Rename ~~**Kiali core version**~~ to **Kiali version**
- Rename ~~**Kiali core commit hash**~~ to **Kiali commit hash**

# Before /api/status

```json
{
  "status": {
    "Kiali console version": "unknown",
    "Kiali container version": "v1.49.0-SNAPSHOT",
    "Kiali core commit hash": "4f71e03c078592c10aee8a8deb48c4c066feea1a",
    "Kiali core version": "v1.49.0-SNAPSHOT",
    "Kiali state": "running"
  },
  "externalServices": [
    {
      "name": "Kubernetes",
      "version": "v1.21.2"
    },
    {
      "name": "Grafana"
    },
    {
      "name": "Jaeger"
    }
  ],
  "warningMessages": [
    "failed to get mesh version, please check if url_service_version is configured correctly."
  ],
  "istioEnvironment": {
    "isMaistra": false
  }
}
```

# Now  /api/status

```json
{
  "status": {
    "Kiali commit hash": "4f71e03c078592c10aee8a8deb48c4c066feea1a",
    "Kiali container version": "v1.49.0-SNAPSHOT",
    "Kiali state": "running",
    "Kiali version": "v1.49.0-SNAPSHOT"
  },
  "externalServices": [
    {
      "name": "Kubernetes",
      "version": "v1.21.2"
    },
    {
      "name": "Grafana"
    },
    {
      "name": "Jaeger"
    }
  ],
  "warningMessages": [
    "failed to get mesh version, please check if url_service_version is configured correctly."
  ],
  "istioEnvironment": {
    "isMaistra": false
  }
}
```