### PR TITLE
Add make cmd for cypress and reduce mem usage in CI

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -140,25 +140,13 @@ jobs:
           echo "::set-output name=kiali_url::$KIALI_URL"
         id: set-kiali-url
 
-      - name: Run cypress integration tests
-        uses: cypress-io/github-action@v2
-        with:
-          working-directory: frontend
-          command: yarn run cypress:run --config baseUrl=${{ steps.set-kiali-url.outputs.kiali_url }}
-
-      - name: Upload cypress screenshots when tests fail
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: frontend/cypress/screenshots
-
-      - name: Upload cypress videos when tests fail
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-videos
-          path: frontend/cypress/videos
+        run: kubectl logs deployments/kiali -n istio-system
+          command: yarn run cypress:run
+        env:
+          CYPRESS_BASE_URL: ${{ steps.set-kiali-url.outputs.kiali_url }}
+          CYPRESS_NUM_TESTS_KEPT_IN_MEMORY: 0
+          CYPRESS_VIDEO: false
+          CYPRESS_SCREENSHOT_ON_RUN_FAILURE: false
 
   integration_tests_backend:
     name: Backend API integration tests
@@ -199,11 +187,10 @@ jobs:
 
       - name: Run backend integration tests
         run: go test -v
-        id: integration_tests
+        id: integration-tests
         env:
           URL: ${{ steps.set-kiali-url.outputs.kiali_url }}
         working-directory: tests/integration/tests
 
       - name: Get kiali pod logs when tests fail
-        if: ${{ steps.integration_tests.outcome == 'failure' }}
-        run: kubectl logs deployments/kiali -n istio-system
+        if: ${{ steps.integration-tests.outcome == 'failure' }}

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -140,7 +140,10 @@ jobs:
           echo "::set-output name=kiali_url::$KIALI_URL"
         id: set-kiali-url
 
-        run: kubectl logs deployments/kiali -n istio-system
+      - name: Run cypress integration tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: frontend
           command: yarn run cypress:run
         env:
           CYPRESS_BASE_URL: ${{ steps.set-kiali-url.outputs.kiali_url }}

--- a/README.adoc
+++ b/README.adoc
@@ -258,6 +258,20 @@ cd $KIALI_SOURCES/kiali/hack
 ./run-kiali.sh
 ----
 
+=== Running Cypress tests
+
+[source,shell]
+----
+# If you are doing frontend development, start the frontend development server, where `<kiali-url>` is the URL to the base Kiali UI location such as `http://localhost:20001/kiali`:
+make -e YARN_START_URL=http://<kiali-url> yarn-start
+
+# Start the cypress tests. The tests will run against the frontend development server by default.
+# Otherwise you can pass a custom url with env vars:
+#
+# make -e CYPRESS_BASE_URL=http://<kiali-url> cypress
+make cypress
+----
+
 ==== Debugging With VisualStudio Code
 
 If you are using VisualStudio Code, you can install the following `launcher.json` that is then used to launch the Kiali Server in the debugger. Run the `hack/run-kiali.sh` script first to ensure the proper services are up (such as the Prometheus port-forward proxy).

--- a/make/Makefile.ui.mk
+++ b/make/Makefile.ui.mk
@@ -14,3 +14,7 @@ yarn-start:
 	fi
 	@echo "'yarn start' will use this proxy setting: $$(grep proxy ${ROOTDIR}/frontend/package.json)"
 	@cd ${ROOTDIR}/frontend && yarn start
+
+## cypress: Runs the cypress frontend integration tests locally.
+cypress:
+	@cd ${ROOTDIR}/frontend && yarn cypress


### PR DESCRIPTION
Adds a make command for cypress and tweaks some cypress settings in CI to reduce memory consumption (and hopefully speed up tests).

Config reference: https://docs.cypress.io/guides/references/configuration#Global
> The number of tests for which snapshots and command data are kept in memory. Reduce this number if you are experiencing high memory consumption in your browser during a test run.

Removes screenshots/videos from CI to save on GH resource consumption.