### PR TITLE
Fix install-error-rates-demo hack

### DIFF
--- a/hack/istio/install-error-rates-demo.sh
+++ b/hack/istio/install-error-rates-demo.sh
@@ -150,6 +150,12 @@ kind: NetworkAttachmentDefinition
 metadata:
   name: istio-cni
 NAD
+    cat <<NAD | $CLIENT_EXE -n ${NAMESPACE_BETA} create -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+NAD
   fi
   cat <<SCC | $CLIENT_EXE apply -f -
 apiVersion: security.openshift.io/v1


### PR DESCRIPTION
The hack for the error-rates demo missed the "NetworkAttachmentDefinition" for OpenShift environments.