### PR TITLE
temporary change to get dependabot to run against our dep update branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -14,8 +15,11 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/frontend"
+    # temporary - run scans against the pf update branch, as opposed to master
+    target-branch: "kiali#4836"
     schedule:
-      interval: "weekly"
+      # temporary: should go back to "weekly"
+      interval: "daily"
     # Disable version updates for npm dependencies
     # We expect that any security alert will be listed in the security area but no automatic PR generation
     open-pull-requests-limit: 0


### PR DESCRIPTION
if this works it will help ensure the new branch covers all of the npm security alerts.

related to #4836 