### PR TITLE
revert dependabot config change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,8 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/frontend"
-    # temporary - run scans against the pf update branch, as opposed to master
-    target-branch: "kiali#4836"
     schedule:
-      # temporary: should go back to "weekly"
-      interval: "daily"
+      interval: "weekly"
     # Disable version updates for npm dependencies
     # We expect that any security alert will be listed in the security area but no automatic PR generation
     open-pull-requests-limit: 0


### PR DESCRIPTION
it was a failed experiment, the issue is having a '#' in the `target-branch` branch name.  Fixing that issue should allow me to do this dependabot checking in my fork.