### PR TITLE
Fix flaky frontend test

### DIFF
--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -61,8 +61,8 @@ When(`user selects Health for {string}`, (type) => {
             break;
     }
     cy.get('button[aria-labelledby^="overview-type"]')
-        .click()
-        .get('button[id^="' + innerId + '"]')
+        .click();
+    cy.get('button[id^="' + innerId + '"]')
         .click();
 });
 
@@ -79,8 +79,8 @@ When(`user selects {string} time range`, (interval) => {
             break;
     }
     cy.get('button[aria-labelledby^="time_range_duration"]')
-        .click()
-        .get('button[id^="' + innerId + '"]')
+        .click();
+    cy.get('button[id^="' + innerId + '"]')
         .click();
 });
 


### PR DESCRIPTION
Hopefully fixes flaky CI test. This is hard to reproduce locally but failures are frequent in CI since the tests run slower there. Some different examples:
- https://github.com/kiali/kiali/runs/5980401734?check_suite_focus=true
- https://github.com/kiali/kiali/runs/5980025014?check_suite_focus=true

This change makes separate calls to `cy.get(...)` between clicks so cypress will wait for the inner element to exist before trying to click it.