### PR TITLE
[cypress] Tests for services list and helper cmd

### DIFF
--- a/.github/workflows/integration-tests-frontend.yml
+++ b/.github/workflows/integration-tests-frontend.yml
@@ -60,8 +60,8 @@ jobs:
         env:
           CYPRESS_BASE_URL: ${{ steps.set-kiali-url.outputs.kiali_url }}
           CYPRESS_NUM_TESTS_KEPT_IN_MEMORY: 0
+          # Recorded video is unusable due to low resources in CI: https://github.com/cypress-io/cypress/issues/4722
           CYPRESS_VIDEO: false
-          CYPRESS_SCREENSHOT_ON_RUN_FAILURE: false
 
       - name: Get debug info when integration tests fail
         if: failure()
@@ -69,3 +69,10 @@ jobs:
           kubectl logs -l app.kubernetes.io/name=kiali -n istio-system
           kubectl describe nodes
           kubectl get pods -l app.kubernetes.io/name=kiali -n istio-system -o yaml
+
+      - name: Upload cypress screenshots when tests fail
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: frontend/cypress/screenshots

--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -12,5 +12,5 @@
   "responseTimeout": 15000,
   "supportFile": "cypress/support/index.ts",
   "pluginsFile": "cypress/plugins/bdd.ts",
-  "fixturesFolder": "fixtures"
+  "fixturesFolder": "cypress/fixtures"
 }

--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -50,16 +50,17 @@ cypress/
     * One feature file should contain only one **specific** feature or concrete example of tested **feature / story**
     * Try to reuse already existing steps, like: `Given user is at administrator perspective` or `And I see {string} in the title` from other .feature files. The BDD framework doesn't mind interchanging keywords, like `Then I see {string} in the title`
     * If you are covering more complex flow (smoke, happy path, critical path) composed of multiple feature files, you need to decorate them with the `@` symbol (`@smoke`, `@happypath`, `@etc`)
-1) Execute cypress - with feature file you just created
+2) Execute cypress - with feature file you just created
     * If you have undefined execution steps in the feature file, cypress will let you know. 
     * You only need to implement step definitions you are missing *(see 1a)* in cypress/integration/common folder 
-1) Write new step definitions. 
+3) Write new step definitions. 
     * The rule of the thumb is you create `.ts` file with same name as a `.feature` file like:
     * cypress/integration/featureFiles/**testcase.feature** -> cypress/integration/common/**testcase.ts**
-1) Failed tests could mean that:
+    * Generic step definitions that can be used in multiple feature files should be grouped by **functionality** e.g. generic "table" definitions should go in the `table.ts` file but definitions specific to a single page should go in the page file.
+4) Failed tests could mean that:
     * Reuse of step definitions is not suitable or gets broken by different testcase or your modifications
     * We want to refactor broken code and if its heavily used, move it into a custom command file (cypress/support/commands.ts) - i.e. `cy.login()`, `cy.kiali_apply_config()` lives there
-1) Test case execution should be all green, you are ready to commit your test case. You might want verify whole regression run locally - so you did not introduce any braking changes in your PR
+5) Test case execution should be all green, you are ready to commit your test case. You might want verify whole regression run locally - so you did not introduce any braking changes in your PR
 
 
 ## Testing Strategies
@@ -79,3 +80,7 @@ Try setting the `numTestsKeptInMemory` setting to a lower value.
 ```
 make -e CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0 cypress
 ```
+
+### Tests are flaking 
+
+Try waiting for kiali to finish loading all the in-flight data before proceeding on to the next action or command. [Waiting for the loading spinner](https://github.com/kiali/kiali/blob/1766f20035e67a072dd68167869e0ce2009b9bc6/frontend/cypress/integration/common/overview.ts#L45-L46) to disappear is a good enough measure for this.

--- a/frontend/cypress/global.d.ts
+++ b/frontend/cypress/global.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="cypress" />
-
-declare namespace Cypress {
-  interface Chainable {
-    selectAllNamespaces(): Chainable<any>;
-  }
-}

--- a/frontend/cypress/integration/common/namespace.ts
+++ b/frontend/cypress/integration/common/namespace.ts
@@ -1,0 +1,7 @@
+import { And } from 'cypress-cucumber-preprocessor/steps';
+
+And('user selects the {string} namespace in the NamespaceSelector', (namespace: string) => {
+  cy.getBySel('namespace-dropdown').click();
+  cy.get(`input[type="checkbox"][value="${namespace}"]`).click();
+  cy.getBySel('namespace-dropdown').click();
+});

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -1,0 +1,6 @@
+import { Given } from 'cypress-cucumber-preprocessor/steps';
+
+Given('user opens the {string} page', (page: string) => {
+  // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
+  cy.visit(Cypress.config('baseUrl') + `/console/${page}?refresh=0`);
+});

--- a/frontend/cypress/integration/common/services.ts
+++ b/frontend/cypress/integration/common/services.ts
@@ -5,8 +5,8 @@ And('the {string} row is visible', (row: string) => {
   cy.get('table').contains('td', row);
 });
 
-And('the health column on the productpage row has a health icon', () => {
-  getColWithRowText('productpage', 'Health').find(
+And('the health column on the {string} row has a health icon', (row: string) => {
+  getColWithRowText(row, 'Health').find(
     'svg[class=icon-healthy], svg[class=icon-unhealthy], svg[class=icon-degraded], svg[class=icon-na]'
   );
 });

--- a/frontend/cypress/integration/common/services.ts
+++ b/frontend/cypress/integration/common/services.ts
@@ -1,0 +1,36 @@
+import { And, When } from 'cypress-cucumber-preprocessor/steps';
+import { getColWithRowText } from './table';
+
+And('the {string} row is visible', (row: string) => {
+  cy.get('table').contains('td', row);
+});
+
+And('the health column on the productpage row has a health icon', () => {
+  getColWithRowText('productpage', 'Health').find(
+    'svg[class=icon-healthy], svg[class=icon-unhealthy], svg[class=icon-degraded], svg[class=icon-na]'
+  );
+});
+
+And('user filters for service type {string}', (serviceType: string) => {
+  cy.get('button[aria-label="Options menu"]').click();
+  cy.contains('button', serviceType).click();
+});
+
+And('user filters for sidecar {string}', (sidecarState: string) => {
+  cy.get('select[aria-label="filter_select_value"]').select(sidecarState);
+});
+
+And('user filters for health {string}', (health: string) => {
+  cy.get('select[aria-label="filter_select_value"]').select(health);
+});
+
+And('user should only see healthy services in the table', () => {
+  cy.get('tbody').within(() => {
+    cy.get('svg[class=icon-healthy]').should('be.visible');
+    cy.get('svg[class=icon-unhealthy], svg[class=icon-degraded], svg[class=icon-na]').should('not.exist');
+  });
+});
+
+When('user filters for label {string}', (label: string) => {
+  cy.get('input[aria-label="filter_input_label_key"]').type(`${label}{enter}`);
+});

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -71,13 +71,14 @@ export function getColWithRowText(rowSearchText: string, colName: string) {
   return cy.get(`th[data-label="${colName}"]`).then($th => {
     // Get the col number
     const colNum = $th.attr('data-key');
+    expect(colNum).to.not.be.empty;
 
-    expect(colName).to.not.be.empty;
+    cy.log(`Looking in column named: ${colName} at index: ${colNum}`)
 
     return cy
       .get('tbody')
       .contains('tr', rowSearchText)
       .find('td')
-      .then($col => $col[colNum]);
+      .then($cols => $cols[colNum]);
   });
 }

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -1,0 +1,83 @@
+import { And, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { TableDefinition } from 'cypress-cucumber-preprocessor';
+
+Then(`user sees a table with headings`, (tableHeadings: TableDefinition) => {
+  const headings = tableHeadings.raw()[0];
+  cy.get('table');
+  headings.forEach(heading => {
+    cy.get(`th[data-label="${heading}"]`);
+  });
+});
+
+And(
+  'the {string} column on the {string} row has a link matching {string}',
+  (column: string, rowText: string, link: string) => {
+    getColWithRowText(rowText, column).within(() => {
+      cy.get(`a[href="${link}"]`).should('be.visible');
+    });
+  }
+);
+
+And(
+  'the {string} column on the {string} row has the text {string}',
+  (column: string, rowText: string, text: string) => {
+    getColWithRowText(rowText, column).contains(text);
+  }
+);
+
+Then('user sees {string} in the table', (service: string) => {
+  cy.get('tbody').within(() => {
+    if (service === 'nothing') {
+      cy.contains('No services found');
+    } else if (service === 'something') {
+      cy.contains('No services found').should('not.exist');
+    } else {
+      cy.contains('td', service);
+    }
+  });
+});
+
+And('table length should be {int}', (numRows: number) => {
+  cy.get('tbody').within(() => {
+    cy.get('tr').should('have.length', numRows);
+  });
+});
+
+When('user selects filter {string}', (filter: string) => {
+  cy.get('select[aria-label="filter_select_type"]').select(filter);
+});
+
+And('user filters for name {string}', (name: string) => {
+  cy.get('input[aria-label="filter_input_value"]').type(`${name}{enter}`);
+});
+
+When('user filters by {string} istio type', (istioType: string) => {
+  cy.get('select[aria-label="filter_select_type"]').select('istiotype');
+});
+
+And('user filters for istio type {string}', (istioType: string) => {
+  cy.get('input[placeholder="Filter by Istio Type"]').type(`${istioType}{enter}`);
+});
+
+// getColWithRowText will find the column matching the unique row text and column header name.
+// This func makes a couple assumptions:
+//
+// 1. The text to search for is unique in the row.
+// 2. There is only 1 table on the screen.
+//
+// Be aware of these assumptions when using this func.
+export function getColWithRowText(rowSearchText: string, colName: string) {
+  // Get all the table headers and find the index of their col.
+  return cy.get(`th[data-label="${colName}"]`).then($th => {
+    // Get the col number
+    const colNum = $th.attr('data-key');
+
+    expect(colName).to.not.be.empty;
+
+    return cy
+      .get('tbody')
+      .contains('tr', rowSearchText)
+      .find('td')
+      .then($col => $col[colNum]);
+  });
+}

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -13,6 +13,9 @@ And(
   'the {string} column on the {string} row has a link matching {string}',
   (column: string, rowText: string, link: string) => {
     getColWithRowText(rowText, column).within(() => {
+      // TODO: Remove 2 of these. Testing statements.
+      cy.get('a');
+      cy.get(`a[href="${link}"]`);
       cy.get(`a[href="${link}"]`).should('be.visible');
     });
   }
@@ -73,7 +76,7 @@ export function getColWithRowText(rowSearchText: string, colName: string) {
     const colNum = $th.attr('data-key');
     expect(colNum).to.not.be.empty;
 
-    cy.log(`Looking in column named: ${colName} at index: ${colNum}`)
+    cy.log(`Looking in column named: ${colName} at index: ${colNum}`);
 
     return cy
       .get('tbody')

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -10,13 +10,11 @@ Then(`user sees a table with headings`, (tableHeadings: TableDefinition) => {
 });
 
 And(
-  'the {string} column on the {string} row has a link matching {string}',
+  'the {string} column on the {string} row has a link ending in {string}',
   (column: string, rowText: string, link: string) => {
     getColWithRowText(rowText, column).within(() => {
-      // TODO: Remove 2 of these. Testing statements.
-      cy.get('a');
-      cy.get(`a[href="${link}"]`);
-      cy.get(`a[href="${link}"]`).should('be.visible');
+      // $= is endswith since console link can change depending on the deployment.
+      cy.get(`a[href$="${link}"]`).should('be.visible');
     });
   }
 );

--- a/frontend/cypress/integration/common/transition.ts
+++ b/frontend/cypress/integration/common/transition.ts
@@ -1,0 +1,5 @@
+import { And } from 'cypress-cucumber-preprocessor/steps';
+
+And('Kiali is done loading', () => {
+  cy.get('#loading_kiali_spinner').should('not.exist');
+});

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -13,7 +13,7 @@ Feature: Kiali Services page
     Then user sees a table with headings
       | Health | Name | Namespace | Labels | Configuration | Details |
     And the "productpage" row is visible
-    And the health column on the productpage row has a health icon
+    And the health column on the "productpage" row has a health icon
     And the "Name" column on the "productpage" row has a link ending in "/namespaces/bookinfo/services/productpage"
     And the "Namespace" column on the "productpage" row has the text "bookinfo"
     And the "Labels" column on the "productpage" row has the text "app: productpage"

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -14,13 +14,13 @@ Feature: Kiali Services page
       | Health | Name | Namespace | Labels | Configuration | Details |
     And the "productpage" row is visible
     And the health column on the productpage row has a health icon
-    And the "Name" column on the "productpage" row has a link matching "/console/namespaces/bookinfo/services/productpage"
+    And the "Name" column on the "productpage" row has a link ending in "/namespaces/bookinfo/services/productpage"
     And the "Namespace" column on the "productpage" row has the text "bookinfo"
     And the "Labels" column on the "productpage" row has the text "app: productpage"
     And the "Labels" column on the "productpage" row has the text "service: productpage"
-    And the "Configuration" column on the "productpage" row has a link matching "/console/namespaces/bookinfo/services/productpage"
-    And the "Details" column on the "productpage" row has a link matching "/console/namespaces/bookinfo/istio/virtualservices/bookinfo"
-    And the "Details" column on the "productpage" row has a link matching "/console/namespaces/bookinfo/istio/gateways/bookinfo-gateway"
+    And the "Configuration" column on the "productpage" row has a link ending in "/namespaces/bookinfo/services/productpage"
+    And the "Details" column on the "productpage" row has a link ending in "/namespaces/bookinfo/istio/virtualservices/bookinfo"
+    And the "Details" column on the "productpage" row has a link ending in "/namespaces/bookinfo/istio/gateways/bookinfo-gateway"
 
   @services-page
   Scenario: Filter services table by Service Name 

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -1,0 +1,63 @@
+Feature: Kiali Services page
+
+  User opens the Services page and sees the bookinfo namespaces
+
+  Background:
+    Given user is at administrator perspective
+    And user opens the "services" page
+    And user selects the "bookinfo" namespace in the NamespaceSelector
+    And Kiali is done loading
+
+  @services-page
+  Scenario: See a table with correct info
+    Then user sees a table with headings
+      | Health | Name | Namespace | Labels | Configuration | Details |
+    And the "productpage" row is visible
+    And the health column on the productpage row has a health icon
+    And the "Name" column on the "productpage" row has a link matching "/console/namespaces/bookinfo/services/productpage"
+    And the "Namespace" column on the "productpage" row has the text "bookinfo"
+    And the "Labels" column on the "productpage" row has the text "app: productpage"
+    And the "Labels" column on the "productpage" row has the text "service: productpage"
+    And the "Configuration" column on the "productpage" row has a link matching "/console/namespaces/bookinfo/services/productpage"
+    And the "Details" column on the "productpage" row has a link matching "/console/namespaces/bookinfo/istio/virtualservices/bookinfo"
+    And the "Details" column on the "productpage" row has a link matching "/console/namespaces/bookinfo/istio/gateways/bookinfo-gateway"
+
+  @services-page
+  Scenario: Filter services table by Service Name 
+    When user selects filter "Service Name"
+    And user filters for name "productpage"
+    Then user sees "productpage" in the table
+    And table length should be 1
+  
+  @services-page
+  Scenario: Filter services table by Service Type
+    When user selects filter "Service Type"
+    And user filters for service type "External"
+    Then user sees "nothing" in the table
+  
+  @services-page
+  Scenario: Filter services table by sidecar
+    When user selects filter "Istio Sidecar"
+    And user filters for sidecar "Present"
+    Then user sees "something" in the table
+
+  @services-page
+  Scenario: Filter services table by Istio Type
+    When user selects filter "Istio Type"
+    And user filters for istio type "VirtualService"
+    Then user sees "productpage" in the table
+    And table length should be 1
+  
+  @services-page
+  Scenario: Filter services table by health
+    When user selects filter "Health"
+    And user filters for health "Healthy"
+    Then user sees "something" in the table
+    And user should only see healthy services in the table
+
+  @services-page
+  Scenario: Filter services table by label
+    When user selects filter "Label"
+    And user filters for label "app:productpage"
+    Then user sees "productpage" in the table
+    And table length should be 1

--- a/frontend/cypress/support/index.ts
+++ b/frontend/cypress/support/index.ts
@@ -14,7 +14,4 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
+import './commands';

--- a/frontend/cypress/tsconfig.json
+++ b/frontend/cypress/tsconfig.json
@@ -1,16 +1,8 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "es2019",
-      "dom"
-    ],
-    "types": [
-      "cypress"
-    ]
+    "lib": ["es2019", "dom"],
+    "types": ["cypress"]
   },
-  "include": [
-    "**/*.ts",
-    "plugins/bdd.ts"
-  ]
+  "include": ["**/*.ts"]
 }

--- a/frontend/src/components/NamespaceDropdown.tsx
+++ b/frontend/src/components/NamespaceDropdown.tsx
@@ -223,7 +223,12 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
       <TourStopContainer info={GraphTourStops.Namespaces}>
         <Dropdown
           toggle={
-            <DropdownToggle id={'namespace-selector'} onToggle={this.onToggle} isDisabled={this.props.disabled}>
+            <DropdownToggle
+              data-test="namespace-dropdown"
+              id={'namespace-selector'}
+              onToggle={this.onToggle}
+              isDisabled={this.props.disabled}
+            >
               {this.namespaceButtonText()}
             </DropdownToggle>
           }

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -94,7 +94,7 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
         {item.istioReferences &&
           item.istioReferences.length > 0 &&
           item.istioReferences.map(ir => (
-            <li>
+            <li key={ir.namespace ? `${ir.name}_${ir.namespace}` : ir.name}>
               <PFBadge badge={PFBadges[ir.objectType]} position={TooltipPosition.top} />
               <IstioObjectLink name={ir.name} namespace={ir.namespace || ''} type={ir.objectType.toLowerCase()}>
                 {ir.name}

--- a/hack/istio/install-error-rates-demo.sh
+++ b/hack/istio/install-error-rates-demo.sh
@@ -173,4 +173,3 @@ users:
 - "system:serviceaccount:${NAMESPACE_BETA}:default"
 SCC
 fi
-

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -43,16 +43,32 @@ fi
 echo "CLIENT_EXE=${CLIENT_EXE}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
 
+# Waits for workloads in the specified namespace to be ready
+wait_for_workloads () {
+  local namespace=$1
+  local workloads=$(${CLIENT_EXE} get deployments -n $namespace -o jsonpath='{.items[*].metadata.name}')
+  for workload in ${workloads}
+  do
+    echo "Waiting for workload: '${workload}' to be ready"
+    ${CLIENT_EXE} rollout status deployment "${workload}" -n "${namespace}"
+  done
+}
+
 # Installed demos should be the exact same for both environments.
 # Only the args passed to the scripts differ from each other.
 if [[ "${IS_OPENSHIFT}" = "true" ]]; then
   echo "Deploying bookinfo demo..."
   "${SCRIPT_DIR}/install-bookinfo-demo.sh" -tg
   echo "Deploying error rates demo..."
-  "${SCRIPT_DIR}/install-error-rates-demo.sh"
+  "${SCRIPT_DIR}/install-error-rates-demo.sh" 
 else 
   echo "Deploying bookinfo demo..."
   "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -tg
   echo "Deploying error rates demo..."
   "${SCRIPT_DIR}/install-error-rates-demo.sh" -c kubectl
 fi
+
+for namespace in bookinfo alpha beta
+do
+  wait_for_workloads "${namespace}"
+done


### PR DESCRIPTION
Adds cypress tests for the services list page. Adds a `getBySel` custom command to select an element based on the `data-test` attribute. Adds back screenshots for failed CI tests to help debug flakes. Updates hack script to deploy demos to wait for demos to be ready before running tests.

Fixes #4955 