### PR TITLE
Move the ignored validation message to trace level instead of debug

### DIFF
--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -486,7 +486,7 @@ func (iv *IstioValidations) StripIgnoredChecks() {
 				for _, cti := range codesToIgnore {
 					if cti == curCheck.Code {
 						ignoreCheck = true
-						log.Debugf("Ignoring validation failure [%+v] for object [%s:%s] in namespace [%s]", curCheck, curValidationKey.ObjectType, curValidationKey.Name, curValidationKey.Namespace)
+						log.Tracef("Ignoring validation failure [%+v] for object [%s:%s] in namespace [%s]", curCheck, curValidationKey.ObjectType, curValidationKey.Name, curValidationKey.Namespace)
 						break
 					}
 				}


### PR DESCRIPTION
Move the ignored validations message to "Trace" level instead of "Debug".
There is a validation disabled by default ("AuthorizationPolicies" on workloads) that populates the log pretty easily while trying to debug other things.

In the Kiali startup, there is an "Info" message that tells the user about this issue, so I think is reasonable to move the level.