### PR TITLE
Include duration in test url

### DIFF
--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -23,7 +23,7 @@ Before(() => {
 
 Given('user opens the overview page', () => {
     // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
-    cy.visit(url + '/overview?refresh=0');
+    cy.visit(url + '/overview?refresh=0&duration=60');
 });
 
 When('user clicks in the {string} view', (view) => {


### PR DESCRIPTION
My working theory for why the tests are flaking in CI is that a re-render happens when the url changes. The URL gets updated with options from the overview toolbar: refresh & duration. We set `refresh` explicitly but we should also set `duration` so kiali doesn't try to update the URL with the default duration. If a re-render happens between the `cy.get('button[aria-labelledby^="overview-type"]')` and the `.click()` then this causes the reference to `cy.get(button...)` to be `undefined`.