### PR TITLE
Move port-matching skip message to trace level

### DIFF
--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -44,7 +44,7 @@ func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 
 	// Ignoring istio-system Services as some ports are used for debug purposes and not exposed in deployments
 	if config.IsIstioNamespace(p.Service.Namespace) {
-		log.Debugf("Skipping Port matching check for Service %s from Istio Namespace %s", p.Service.Name, p.Service.Namespace)
+		log.Tracef("Skipping Port matching check for Service %s from Istio Namespace %s", p.Service.Name, p.Service.Namespace)
 		return validations, len(validations) == 0
 	}
 	if deployment := p.findMatchingDeployment(p.Service.Spec.Selector); deployment != nil {


### PR DESCRIPTION
Moving some well-known repetitive debug messages to trace level, as this would help to differentiate those debug/trace situations:
![image](https://user-images.githubusercontent.com/1662329/164439431-23b2c8ac-7189-4e63-b12b-401077b43d7b.png)

