### PR TITLE
Release pipeline for Kiali server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ on:
         - auto
         - minor
         - snapshot.0
-        - snpashot.1
+        - snapshot.1
+        - snapshot.2
+        - snapshot.3
         - edge
       repository:
         description: Repository (in owner/repo format)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
       BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
       NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
       RELEASE_BRANCH: ${{ github.event.inputs.release_branch }}
-      QUAY_TAG: ${{ github.event.inputs.quay_repository }}:${{ needs.initialize.outputs.release_version }}      
+      QUAY_TAG: ${{ github.event.inputs.quay_repository }}:${{ needs.initialize.outputs.release_version }} ${{ github.event.inputs.quay_repository }}:${{ needs.initialize.outputs.branch_version }}      
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,14 +112,15 @@ jobs:
         BRANCH_VERSION: ${{ steps.branch_version.outputs.branch_version }}
       id: quay_tag
       run: |
-        QUAY_TAG=${{ github.event.inputs.quay_repository }}:$RELEASE_VERSION
+        QUAY_TAG="${{ github.event.inputs.quay_repository }}:$RELEASE_VERSION"
         
         if [[ $RELEASE_TYPE == "minor" ]] || [ $RELEASE_TYPE == "patch" ]]
         then
-          QUAY_TAG=$QUAY_TAG ${{ github.event.inputs.quay_repository }}:$BRANCH_VERSION
+          QUAY_TAG="$QUAY_TAG ${{ github.event.inputs.quay_repository }}:$BRANCH_VERSION"
         fi
 
         echo "::set-output name=quay_tag::$QUAY_TAG"
+    
     - name: Log information
       run: |
         echo "Release type: ${{ steps.release_type.outputs.release_type }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       run: |          
         if [[ $RELEASE_TYPE == "patch" ]]
         then
-            NEXT_VERSION=$(./.github/workflows/util/bump $RELEASE_TYPE $RELEASE_VERSION)
+            NEXT_VERSION=$(./.github/workflows/util/bump.py $RELEASE_TYPE $RELEASE_VERSION)
         elif [[ $RELEASE_TYPE == "minor" ]]
         then 
             NEXT_VERSION=$(./.github/workflows/util/bump.py $RELEASE_TYPE $RELEASE_VERSION)          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,13 @@ on:
         type: choice
         options:
         - auto
+        - edge
         - minor
+        - patch
         - snapshot.0
         - snapshot.1
         - snapshot.2
         - snapshot.3
-        - edge
       release_branch:
         description: Branch to release
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
       release_version: ${{ steps.release_version.outputs.release_version }}
       branch_version: ${{ steps.branch_version.outputs.branch_version }}
       next_version: ${{ steps.next_version.outputs.next_version }}
+      quay_tag: ${{ steps.quay_tag.outputs.quay_tag }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -104,6 +105,21 @@ jobs:
       if: ${{ steps.release_type.outputs.release_type != 'edge' && !contains(steps.release_type.outputs.release_type, 'snapshot') }}
       run: echo "::set-output name=branch_version::$(echo $RELEASE_VERSION | sed 's/\.[0-9]*\+$//')"
 
+    - name: Determine Quay tag
+      env:
+        RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+        RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
+        BRANCH_VERSION: ${{ steps.branch_version.outputs.branch_version }}
+      id: quay_tag
+      run: |
+        QUAY_TAG=${{ github.event.inputs.quay_repository }}:$RELEASE_VERSION
+        
+        if [[ $RELEASE_TYPE == "minor" ]] || [ $RELEASE_TYPE == "patch" ]]
+        then
+          QUAY_TAG=$QUAY_TAG ${{ github.event.inputs.quay_repository }}:$BRANCH_VERSION
+        fi
+
+        echo "::set-output name=quay_tag::$QUAY_TAG"
     - name: Log information
       run: |
         echo "Release type: ${{ steps.release_type.outputs.release_type }}"
@@ -113,6 +129,8 @@ jobs:
         echo "Next version: ${{ steps.next_version.outputs.next_version }}"
 
         echo "Branch version: ${{ steps.branch_version.outputs.branch_version }}"
+
+        echo "Quay tag": ${{ steps.quay_tag.outputs.quay_tag }}
 
   build_backend:
     name: Build backend
@@ -151,7 +169,7 @@ jobs:
       BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
       NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
       RELEASE_BRANCH: ${{ github.event.inputs.release_branch }}
-      QUAY_TAG: ${{ github.event.inputs.quay_repository }}:${{ needs.initialize.outputs.release_version }} ${{ github.event.inputs.quay_repository }}:${{ needs.initialize.outputs.branch_version }}      
+      QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,9 +156,7 @@ jobs:
       BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
       NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
       RELEASE_BRANCH: ${{ github.event.inputs.release_branch }}
-      QUAY_TAG: ${{ github.event.inputs.quay_repository }}:${{ needs.initialize.outputs.release_version }}
-      GH_PULL_URI: https://api.github.com/repos/${{ github.event.inputs.repository }}/pulls
-      GH_RELEASE_URI: https://api.github.com/repos/${{ github.event.inputs.repository }}/releases
+      QUAY_TAG: ${{ github.event.inputs.quay_repository }}:${{ needs.initialize.outputs.release_version }}      
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,239 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Release type"
+        required: true
+        default: "auto"
+        type: choice
+        options:
+          - auto
+          - minor
+          - snapshot.0
+          - snpashot.1
+          - edge
+      repository:
+        description: Repository (in owner/repo format)
+        required: true
+        default: kiali/kiali
+        type: string
+      release_branch:
+        description: Branch to release
+        required: true
+        default: master
+        type: string
+      quay_repository:
+        description: Quay repository
+        type: string
+        default: quay.io/kiali/kiali
+        required: true
+
+jobs:
+  initialize:
+    name: Initialize
+    runs-on: ubuntu-20.04
+    outputs:
+      target_branch: ${{ github.base_ref || github.ref_name }}
+      release_type: ${{ steps.release_type.outputs.release_type }}
+      release_version: ${{ steps.release_version.outputs.release_version }}
+      branch_version: ${{ steps.branch_version.outputs.branch_version }}
+      next_version: ${{ steps.next_version.outputs.next_version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.release_branch }}
+
+      - name: Determine release type
+        id: release_type
+        run: |
+          if [[ ${{ github.event.inputs.release_type }} == 'auto' ]];
+          then
+            echo "::set-output name=release_type::$(./.github/workflows/util/release_type.sh)"
+          else
+            echo "::set-output name=release_type::${{ github.event.inputs.release_type }}"
+          fi
+
+      - name: Determine release version
+        env:
+          RELEASE_TYPE: ${{ steps.release_type.outputs.release_type }}
+        id: release_version
+        run: |
+          RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
+
+          # Remove any pre release identifier (ie: "-SNAPSHOT")
+          RELEASE_VERSION=${RAW_VERSION%-*}
+
+          if [[ $RELEASE_TYPE == "patch" ]]
+          then
+            RELEASE_VERSION=$(./.github/workflows/util/bump.py $RELEASE_TYPE $RELEASE_VERSION)
+          elif [[ $RELEASE_TYPE == *"snapshot"* ]]
+          then
+            RELEASE_VERSION="$RELEASE_VERSION-$RELEASE_TYPE"
+          elif [[ $RELEASE_TYPE == "minor" ]]
+          then
+            RELEASE_VERSION=$RELEASE_VERSION
+          elif [[ $RELEASE_TYPE == "edge" ]]
+          then
+            RELEASE_VERSION=latest
+          fi
+
+          echo "::set-output name=release_version::$RELEASE_VERSION"
+
+      - name: Determine next version
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+          RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
+        id: next_version
+        if: ${{ steps.release_type.outputs.release_type == 'patch' || steps.release_type.outputs.release_type == 'minor' }}
+        run: |          
+          if [[ $RELEASE_TYPE == "patch" ]]
+          then
+              NEXT_VERSION=$(./.github/workflows/util/bump $RELEASE_TYPE $RELEASE_VERSION)
+          elif [[ $RELEASE_TYPE == "minor" ]]
+          then 
+              NEXT_VERSION=$(./.github/workflows/util/bump.py $RELEASE_TYPE $RELEASE_VERSION)          
+          fi
+
+          echo "::set-output name=next_version::$NEXT_VERSION"
+
+      - name: Determine branch version
+        env:
+          RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
+        id: branch_version
+        if: ${{ steps.release_type.outputs.release_type != 'edge' && !contains(steps.release_type.outputs.release_type, 'snapshot') }}
+        run: echo "::set-output name=branch_version::$(echo $RELEASE_VERSION | sed 's/\.[0-9]*\+$//')"
+
+      - name: Log information
+        run: |
+
+          echo "Release type: ${{ steps.release_type.outputs.release_type }}"
+
+          echo "Release version: ${{ steps.release_version.outputs.release_version }}"
+                   
+          echo "Next version: ${{ steps.next_version.outputs.next_version }}"
+
+          echo "Branch version: ${{ steps.branch_version.outputs.branch_version }}"
+
+  build_backend:
+    name: Build backend
+    uses: ./.github/workflows/build-backend.yml
+    needs: [initialize]
+
+  build_frontend:
+    name: Build frontend
+    uses: ./.github/workflows/build-frontend.yml
+    needs: [initialize]
+    with:
+      target_branch: ${{needs.initialize.outputs.target_branch}}
+
+  # integration_tests_backend:
+  #   name: Run backend integration tests
+  #   uses: ./.github/workflows/integration-tests-backend.yml
+  #   needs: [initialize, build_backend, build_frontend]
+  #   with:
+  #     target_branch: ${{needs.initialize.outputs.target_branch}}
+
+  # integration_tests_frontend:
+  #   name: Run frontend integration tests
+  #   uses: ./.github/workflows/integration-tests-frontend.yml
+  #   needs: [initialize, build_backend, build_frontend]
+  #   with:
+  #     target_branch: ${{needs.initialize.outputs.target_branch}}
+
+  release:
+    name: Release
+    runs-on: ubuntu-20.04
+    #needs: [initialize, build_backend, build_frontend, integration_tests_backend, integration_tests_frontend]
+    needs: [initialize, build_backend, build_frontend]
+    env:
+      RELEASE_TYPE: ${{ needs.initialize.outputs.release_type }}
+      RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
+      BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
+      NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
+      RELEASE_BRANCH: ${{ github.event.inputs.release_branch }}
+      QUAY_TAG: ${{ github.event.inputs.quay_repository }}:${{ needs.initialize.outputs.release_version }}
+      GH_PULL_URI: https://api.github.com/repos/${{ github.event.inputs.repository }}/pulls
+      GH_RELEASE_URI: https://api.github.com/repos/${{ github.event.inputs.repository }}/releases
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.release_branch }}
+
+      - name: Set version to release
+        run: sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.7
+
+      - name: Cache Go deps
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download frontend build
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: frontend/build
+      
+      - name: Build and push image
+        run: |
+          docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+
+          make -e DOCKER_CLI_EXPERIMENTAL=enabled build-linux-multi-arch container-multi-arch-push-kiali-quay
+
+      - name: Configure git
+        run: |
+          git config user.email 'kiali-dev@googlegroups.com'
+
+          git config user.name 'kiali-bot'
+
+      - name: Create tag
+        if: ${{ needs.initialize.outputs.release_type != 'edge' }}
+        run: |
+          git add Makefile
+
+          git commit -m "Release $RELEASE_VERSION"
+
+          git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ $RELEASE_TYPE == *"snapshot"* ]]; then export PRERELEASE="-p"; fi
+
+          gh release create $RELEASE_VERSION $PRERELEASE -t "Kiali Operator $RELEASE_VERSION"
+
+      - name: Create or update version branch
+        if: ${{ needs.initialize.outputs.release_type != 'edge' && !contains(needs.initialize.outputs.release_type, 'snapshot') }}
+        run: git push origin $(git rev-parse HEAD):refs/heads/$BRANCH_VERSION
+
+      - name: Create a PR to prepare for next version
+        env:
+          BUILD_TAG: kiali-release-${{ github.run_number }}-main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ needs.initialize.outputs.release_type == 'minor' }}
+        run: |
+          sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $NEXT_VERSION-SNAPSHOT/" Makefile
+
+          git add Makefile
+
+          git commit -m "Prepare for next version"
+
+          git push origin $(git rev-parse HEAD):refs/heads/$BUILD_TAG
+
+          gh pr create -t "Prepare for next version" -b "Please, merge to update version numbers and prepare for release $NEXT_VERSION." -H $BUILD_TAG -B $RELEASE_BRANCH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,6 @@ on:
         - snapshot.2
         - snapshot.3
         - edge
-      repository:
-        description: Repository (in owner/repo format)
-        required: true
-        default: kiali/kiali
-        type: string
       release_branch:
         description: Branch to release
         required: true
@@ -46,7 +41,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.release_branch }}
 
     - name: Determine release type
@@ -161,7 +155,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.release_branch }}
 
     - name: Set version to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ on:
         default: "auto"
         type: choice
         options:
-          - auto
-          - minor
-          - snapshot.0
-          - snpashot.1
-          - edge
+        - auto
+        - minor
+        - snapshot.0
+        - snpashot.1
+        - edge
       repository:
         description: Repository (in owner/repo format)
         required: true
@@ -41,82 +41,81 @@ jobs:
       branch_version: ${{ steps.branch_version.outputs.branch_version }}
       next_version: ${{ steps.next_version.outputs.next_version }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ github.event.inputs.repository }}
-          ref: ${{ github.event.inputs.release_branch }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.inputs.repository }}
+        ref: ${{ github.event.inputs.release_branch }}
 
-      - name: Determine release type
-        id: release_type
-        run: |
-          if [[ ${{ github.event.inputs.release_type }} == 'auto' ]];
-          then
-            echo "::set-output name=release_type::$(./.github/workflows/util/release_type.sh)"
-          else
-            echo "::set-output name=release_type::${{ github.event.inputs.release_type }}"
-          fi
+    - name: Determine release type
+      id: release_type
+      run: |
+        if [[ ${{ github.event.inputs.release_type }} == "auto" ]];
+        then
+          echo "::set-output name=release_type::$(./.github/workflows/util/release_type.sh)"
+        else
+          echo "::set-output name=release_type::${{ github.event.inputs.release_type }}"
+        fi
 
-      - name: Determine release version
-        env:
-          RELEASE_TYPE: ${{ steps.release_type.outputs.release_type }}
-        id: release_version
-        run: |
-          RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
+    - name: Determine release version
+      env:
+        RELEASE_TYPE: ${{ steps.release_type.outputs.release_type }}
+      id: release_version
+      run: |
+        RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-          # Remove any pre release identifier (ie: "-SNAPSHOT")
-          RELEASE_VERSION=${RAW_VERSION%-*}
+        # Remove any pre release identifier (ie: "-SNAPSHOT")
+        RELEASE_VERSION=${RAW_VERSION%-*}
 
-          if [[ $RELEASE_TYPE == "patch" ]]
-          then
-            RELEASE_VERSION=$(./.github/workflows/util/bump.py $RELEASE_TYPE $RELEASE_VERSION)
-          elif [[ $RELEASE_TYPE == *"snapshot"* ]]
-          then
-            RELEASE_VERSION="$RELEASE_VERSION-$RELEASE_TYPE"
-          elif [[ $RELEASE_TYPE == "minor" ]]
-          then
-            RELEASE_VERSION=$RELEASE_VERSION
-          elif [[ $RELEASE_TYPE == "edge" ]]
-          then
-            RELEASE_VERSION=latest
-          fi
+        if [[ $RELEASE_TYPE == "patch" ]]
+        then
+          RELEASE_VERSION=$(./.github/workflows/util/bump.py $RELEASE_TYPE $RELEASE_VERSION)
+        elif [[ $RELEASE_TYPE == *"snapshot"* ]]
+        then
+          RELEASE_VERSION="$RELEASE_VERSION-$RELEASE_TYPE"
+        elif [[ $RELEASE_TYPE == "minor" ]]
+        then
+          RELEASE_VERSION=$RELEASE_VERSION
+        elif [[ $RELEASE_TYPE == "edge" ]]
+        then
+          RELEASE_VERSION=latest
+        fi
 
-          echo "::set-output name=release_version::$RELEASE_VERSION"
+        echo "::set-output name=release_version::$RELEASE_VERSION"
 
-      - name: Determine next version
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release_type }}
-          RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
-        id: next_version
-        if: ${{ steps.release_type.outputs.release_type == 'patch' || steps.release_type.outputs.release_type == 'minor' }}
-        run: |          
-          if [[ $RELEASE_TYPE == "patch" ]]
-          then
-              NEXT_VERSION=$(./.github/workflows/util/bump $RELEASE_TYPE $RELEASE_VERSION)
-          elif [[ $RELEASE_TYPE == "minor" ]]
-          then 
-              NEXT_VERSION=$(./.github/workflows/util/bump.py $RELEASE_TYPE $RELEASE_VERSION)          
-          fi
+    - name: Determine next version
+      env:
+        RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+        RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
+      id: next_version
+      if: ${{ steps.release_type.outputs.release_type == 'patch' || steps.release_type.outputs.release_type == 'minor' }}
+      run: |          
+        if [[ $RELEASE_TYPE == "patch" ]]
+        then
+            NEXT_VERSION=$(./.github/workflows/util/bump $RELEASE_TYPE $RELEASE_VERSION)
+        elif [[ $RELEASE_TYPE == "minor" ]]
+        then 
+            NEXT_VERSION=$(./.github/workflows/util/bump.py $RELEASE_TYPE $RELEASE_VERSION)          
+        fi
 
-          echo "::set-output name=next_version::$NEXT_VERSION"
+        echo "::set-output name=next_version::$NEXT_VERSION"
 
-      - name: Determine branch version
-        env:
-          RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
-        id: branch_version
-        if: ${{ steps.release_type.outputs.release_type != 'edge' && !contains(steps.release_type.outputs.release_type, 'snapshot') }}
-        run: echo "::set-output name=branch_version::$(echo $RELEASE_VERSION | sed 's/\.[0-9]*\+$//')"
+    - name: Determine branch version
+      env:
+        RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
+      id: branch_version
+      if: ${{ steps.release_type.outputs.release_type != 'edge' && !contains(steps.release_type.outputs.release_type, 'snapshot') }}
+      run: echo "::set-output name=branch_version::$(echo $RELEASE_VERSION | sed 's/\.[0-9]*\+$//')"
 
-      - name: Log information
-        run: |
+    - name: Log information
+      run: |
+        echo "Release type: ${{ steps.release_type.outputs.release_type }}"
 
-          echo "Release type: ${{ steps.release_type.outputs.release_type }}"
+        echo "Release version: ${{ steps.release_version.outputs.release_version }}"
+                  
+        echo "Next version: ${{ steps.next_version.outputs.next_version }}"
 
-          echo "Release version: ${{ steps.release_version.outputs.release_version }}"
-                   
-          echo "Next version: ${{ steps.next_version.outputs.next_version }}"
-
-          echo "Branch version: ${{ steps.branch_version.outputs.branch_version }}"
+        echo "Branch version: ${{ steps.branch_version.outputs.branch_version }}"
 
   build_backend:
     name: Build backend
@@ -159,81 +158,81 @@ jobs:
       GH_PULL_URI: https://api.github.com/repos/${{ github.event.inputs.repository }}/pulls
       GH_RELEASE_URI: https://api.github.com/repos/${{ github.event.inputs.repository }}/releases
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ github.event.inputs.repository }}
-          ref: ${{ github.event.inputs.release_branch }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.inputs.repository }}
+        ref: ${{ github.event.inputs.release_branch }}
 
-      - name: Set version to release
-        run: sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
+    - name: Set version to release
+      run: sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
 
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17.7
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.7
 
-      - name: Cache Go deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+    - name: Cache Go deps
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
-      - name: Download frontend build
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: frontend/build
-      
-      - name: Build and push image
-        run: |
-          docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+    - name: Download frontend build
+      uses: actions/download-artifact@v3
+      with:
+        name: build
+        path: frontend/build
+    
+    - name: Build and push image
+      run: |
+        docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
 
-          make -e DOCKER_CLI_EXPERIMENTAL=enabled build-linux-multi-arch container-multi-arch-push-kiali-quay
+        make -e DOCKER_CLI_EXPERIMENTAL=enabled build-linux-multi-arch container-multi-arch-push-kiali-quay
 
-      - name: Configure git
-        run: |
-          git config user.email 'kiali-dev@googlegroups.com'
+    - name: Configure git
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
 
-          git config user.name 'kiali-bot'
+        git config user.name 'kiali-bot'
 
-      - name: Create tag
-        if: ${{ needs.initialize.outputs.release_type != 'edge' }}
-        run: |
-          git add Makefile
+    - name: Create tag
+      if: ${{ needs.initialize.outputs.release_type != 'edge' }}
+      run: |
+        git add Makefile
 
-          git commit -m "Release $RELEASE_VERSION"
+        git commit -m "Release $RELEASE_VERSION"
 
-          git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
 
-      - name: Create release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [[ $RELEASE_TYPE == *"snapshot"* ]]; then export PRERELEASE="-p"; fi
+    - name: Create release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [[ $RELEASE_TYPE == *"snapshot"* ]]; then export PRERELEASE="-p"; fi
 
-          gh release create $RELEASE_VERSION $PRERELEASE -t "Kiali Operator $RELEASE_VERSION"
+        gh release create $RELEASE_VERSION $PRERELEASE -t "Kiali $RELEASE_VERSION"
 
-      - name: Create or update version branch
-        if: ${{ needs.initialize.outputs.release_type != 'edge' && !contains(needs.initialize.outputs.release_type, 'snapshot') }}
-        run: git push origin $(git rev-parse HEAD):refs/heads/$BRANCH_VERSION
+    - name: Create or update version branch
+      if: ${{ needs.initialize.outputs.release_type != 'edge' && !contains(needs.initialize.outputs.release_type, 'snapshot') }}
+      run: git push origin $(git rev-parse HEAD):refs/heads/$BRANCH_VERSION
 
-      - name: Create a PR to prepare for next version
-        env:
-          BUILD_TAG: kiali-release-${{ github.run_number }}-main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ needs.initialize.outputs.release_type == 'minor' }}
-        run: |
-          sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $NEXT_VERSION-SNAPSHOT/" Makefile
+    - name: Create a PR to prepare for next version
+      env:
+        BUILD_TAG: kiali-release-${{ github.run_number }}-main
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ needs.initialize.outputs.release_type == 'minor' }}
+      run: |
+        sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $NEXT_VERSION-SNAPSHOT/" Makefile
 
-          git add Makefile
+        git add Makefile
 
-          git commit -m "Prepare for next version"
+        git commit -m "Prepare for next version"
 
-          git push origin $(git rev-parse HEAD):refs/heads/$BUILD_TAG
+        git push origin $(git rev-parse HEAD):refs/heads/$BUILD_TAG
 
-          gh pr create -t "Prepare for next version" -b "Please, merge to update version numbers and prepare for release $NEXT_VERSION." -H $BUILD_TAG -B $RELEASE_BRANCH
+        gh pr create -t "Prepare for next version" -b "Please, merge to update version numbers and prepare for release $NEXT_VERSION." -H $BUILD_TAG -B $RELEASE_BRANCH

--- a/.github/workflows/util/bump.py
+++ b/.github/workflows/util/bump.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import sys
+
+release_type = sys.argv[1]
+version = sys.argv[2]
+
+parts = version.split('.')
+
+major = int(parts[0][1:])
+minor = int(parts[1])
+patch = int(parts[2])
+
+if release_type == 'major':
+    major = major + 1
+    minor = 0
+    patch = 0
+elif release_type == 'minor':
+    minor = minor + 1 
+    patch = 0
+elif release_type == 'patch':
+    patch = patch + 1
+
+print('.'.join(["v" + str(major), str(minor), str(patch)]))

--- a/.github/workflows/util/release_type.sh
+++ b/.github/workflows/util/release_type.sh
@@ -1,0 +1,34 @@
+BASE_DATE=${BASE_DATE:-$(date -d '2021-12-03' '+%s')} # Use last day of Sprint #66 as the base date for calcs
+NOW_DATE=${NOW_DATE:-$(date -d 'now' '+%s')}
+
+# Transitional calculations
+DATE_DIFF=$(( $NOW_DATE - $BASE_DATE ))
+DAYS_ELAPSED=$(( $DATE_DIFF / (24*60*60) ))
+WEEKS_ELAPSED=$(( $DAYS_ELAPSED / 7))
+
+# This value will be used to determine the type of the release
+WEEKS_MOD3=$(( $WEEKS_ELAPSED % 3 ))
+
+# Between Dec 23th 2021 and Jan 14th 2022, use Mod6 (six-week sprint)
+if [ $NOW_DATE -ge $(date -d '2021-12-23' '+%s') ] && [ $NOW_DATE -lt $(date -d '2022-01-14' '+%s') ];
+then
+  WEEKS_MOD3=$(( $WEEKS_ELAPSED % 6 ))
+fi
+
+case $WEEKS_MOD3 in
+  0)
+    RELEASE_TYPE='minor' ;;
+  1)
+    RELEASE_TYPE='snapshot.0' ;;
+  2)
+    RELEASE_TYPE='snapshot.1' ;;
+  3)
+    RELEASE_TYPE='snapshot.2' ;;
+  4)
+    RELEASE_TYPE='snapshot.3' ;;
+  5)
+    RELEASE_TYPE='snapshot.4' ;;
+esac
+
+# Print the determined type
+echo $RELEASE_TYPE


### PR DESCRIPTION
This is the migrated pipeline for the Kiali server.

Notes:

- I tested this as is me was the kiali bot, but in this PR there are mentions to kiali-bot, but never tried with it, we will need to create a GitHub Actions secret call GH_TOKEN
- I'm not using a fork and the reasons for that are 1) simplicity (not seeing any issue, if there is one, let me know :D) 2) that when CPaaS try to grab the tag, in the past, the commit usually doesn't belong to the repo (I guess it belongs to the fork, and the tag is created before this) and it fails, this was something we discuss with @aljesusg.
- The pipeline for now can be started manually (with workflow_dispatch option, that only works when master, so for that reason I was working on my master's branch in my fork)

Resolves https://github.com/kiali/kiali/issues/4850
Resolves https://github.com/kiali/kiali/issues/4869

Epic: https://github.com/kiali/kiali/issues/4827