### PR TITLE
[cypress] login cookie renamed, cy.login() polishing

### DIFF
--- a/frontend/cypress/integration/common/kiali_cookie.ts
+++ b/frontend/cypress/integration/common/kiali_cookie.ts
@@ -1,4 +1,4 @@
-import { Given } from "cypress-cucumber-preprocessor/steps";
+import { And, Given } from "cypress-cucumber-preprocessor/steps";
 
 const USERNAME = Cypress.env('USERNAME') || 'jenkins';
 const PASSWD = Cypress.env('PASSWD')
@@ -7,7 +7,11 @@ const AUTH_STRATEGY = Cypress.env('auth_strategy')
 
 Given('user is at administrator perspective', () => {
     Cypress.Cookies.defaults({
-        preserve: 'kiali-token',
+        preserve: 'kiali-token-aes',
     })
     cy.login(AUTH_PROVIDER, USERNAME, PASSWD, AUTH_STRATEGY)
+})
+
+And('user visits base url', () => {
+    cy.visit('/')
 })

--- a/frontend/cypress/integration/featureFiles/kiali_cookie.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_cookie.feature
@@ -7,11 +7,11 @@ Feature: Kiali login cookie
     Given user is at administrator perspective
   
   Scenario: Open Kaili home page
-    And user opens base url
+    And user visits base url
     Then user see console in URL
 
   Scenario: Open Kaili home page2
-    And user opens base url
+    And user visits base url
     Then user see console in URL
 
   

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -44,6 +44,9 @@ Cypress.Commands.add('login', (provider: string, username: string, password: str
 		} else {
 			if (haveCookie === false) {
 				cy.intercept('api/authenticate').as('authorized') //request setting kiali cookie
+				// Cypress.Cookies.debug(true) // now Cypress will log when it alters cookies
+				// cy.getCookies()
+
 				cy.log(
 					`provider: ${provider}, 
 					username: ${username},
@@ -63,9 +66,10 @@ Cypress.Commands.add('login', (provider: string, username: string, password: str
 					cy.get('#inputPassword').type(password);
 					cy.get('button[type="submit"]').click()
 					cy.wait('@authorized').its('response.statusCode').should('eq', 200)
-					cy.getCookie('kiali-token', { timeout: 5000 }).should('exist').then((c) => {
+					cy.getCookie('kiali-token-aes', { timeout: 15000 }).should('exist').then((c) => {
 						haveCookie = true
 					})
+
 				}
 			} else {
 				cy.log('got an auth cookie, skipping login')


### PR DESCRIPTION
In some recent change, kilai auth cookie was renamed. This PR is fixing `cy.login()` function with new kaili cookie name. There is also more isolation in smoke test itself.

Tested on stage, please test locally.