### PR TITLE
Improve 'Sort by name' test in the overview page

### DIFF
--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -45,7 +45,8 @@ Feature: Kiali Overview page
 
   @overview-page
   Scenario: Sort by name
-    When user filters "Failure" health
+    When user filters "alpha" namespace
+    And user filters "beta" namespace
     And user sorts by name desc
     Then user sees the "beta,alpha" namespace list
 


### PR DESCRIPTION
The "Sort by name" test in the overview page is designed over the "alpha,beta" namespaces.

To select them, it used the "Failure" filter, BUT after adding the Traffic Generator in the "bookinfo" namespace, the cluster can be unstable, and that namespace throws more errors.

It's a separate discussion if we could improve the "generators" as the kind cluster is very short in terms of resources, but in any case, the UI test was showing that something was not 100% well designed.

Also, general note, at some point, we need to investigate these errors at the PR level, in theory, there shouldn't be more "flaky" tests. 

Tests could be slow but we need to design the suite to support those conditions as well, or to have clear messages when it's a platform issue rather than a test.

Once these tests are more consolidated we investigate the errors before the merge.

