### PR TITLE
Ignore return codes in wait polls.

### DIFF
--- a/tests/integration/tests/external_host_node_test.go
+++ b/tests/integration/tests/external_host_node_test.go
@@ -28,15 +28,16 @@ func assertExternalNode(params map[string]string, yaml, name string, assert *ass
 	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
-		return NodeMatch(params, name, assert), nil
+		return NodeMatch(params, name), nil
 	})
 	assert.Nil(pollErr, "Name %s should exist in node services names", name)
 }
 
-func NodeMatch(params map[string]string, nodeName string, assert *assert.Assertions) bool {
-	graph, statusCode, err := utils.Graph(params)
-	assert.Equal(200, statusCode)
-	assert.Nil(err)
+func NodeMatch(params map[string]string, nodeName string) bool {
+	graph, statusCode, _ := utils.Graph(params)
+	if statusCode != 200 {
+		return false
+	}
 	for _, node := range graph.Elements.Nodes {
 		name := node.Data.Service
 		if name == nodeName {

--- a/tests/integration/tests/graph_badges_test.go
+++ b/tests/integration/tests/graph_badges_test.go
@@ -155,7 +155,7 @@ func assertGraphBadges(params map[string]string, yaml, badge string, assert *ass
 	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
-		badgeCount := BadgeCount(params, badge, assert)
+		badgeCount := BadgeCount(params, badge)
 		if badgeCount > preBadgeCount {
 			return true, nil
 		}
@@ -164,11 +164,12 @@ func assertGraphBadges(params map[string]string, yaml, badge string, assert *ass
 	assert.Nil(pollErr, "Badge %s should exist", badge)
 }
 
-func BadgeCount(params map[string]string, badge string, assert *assert.Assertions) int {
+func BadgeCount(params map[string]string, badge string) int {
 	count := 0
-	graph, statusCode, err := utils.Graph(params)
-	assert.Equal(200, statusCode)
-	assert.Nil(err)
+	graph, statusCode, _ := utils.Graph(params)
+	if statusCode != 200 {
+		return 0
+	}
 	for _, node := range graph.Elements.Nodes {
 		switch badge {
 		case "hasCB":

--- a/tests/integration/tests/graph_nodes_test.go
+++ b/tests/integration/tests/graph_nodes_test.go
@@ -63,8 +63,9 @@ func TestWorkloadGraphEmpty(t *testing.T) {
 func assertGraphConfig(objectType, graphType, namespace, name string, assert *assert.Assertions) {
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		config, statusCode, err := utils.ObjectGraph(objectType, graphType, name, namespace)
-		assert.Equal(200, statusCode)
-		assert.Nil(err)
+		if statusCode != 200 {
+			return false, err
+		}
 		assert.Equal(config.GraphType, graphType)
 		assert.NotNil(config.Elements)
 		return len(config.Elements.Nodes) > 0 && len(config.Elements.Edges) > 0, nil

--- a/tests/integration/tests/graph_test.go
+++ b/tests/integration/tests/graph_test.go
@@ -239,8 +239,9 @@ func assertGraph(params map[string]string, assert *assert.Assertions) {
 	params["namespaces"] = utils.BOOKINFO
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		graph, statusCode, err := utils.Graph(params)
-		assert.Equal(200, statusCode)
-		assert.Nil(err)
+		if statusCode != 200 {
+			return false, err
+		}
 
 		for key, value := range params {
 			switch key {


### PR DESCRIPTION
Patch PR for fixing intermittent non stable backend integration tests.
Ignoring API call return codes in case of wait polls.