### PR TITLE
Add a comment for the minikube setup in the bookinfo demo

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -297,6 +297,11 @@ if [ "${TRAFFIC_GENERATOR_ENABLED}" == "true" ]; then
     INGRESS_ROUTE=$(${CLIENT_EXE} get route istio-ingressgateway -o jsonpath='{.spec.host}{"\n"}' -n ${ISTIO_NAMESPACE})
     echo "Traffic Generator will use the OpenShift ingress route of: ${INGRESS_ROUTE}"
   else
+    # Important note for minikube users
+    # Ingress and Egress configuration depend on the platform
+    # Check your "minikube tunnel" and/or Istio mesh config i.e. meshConfig.outboundTrafficPolicy.mode=REGISTRY_ONLY
+    # if you experiment some weird behaviour compared with the CI results
+
     # for now, we only support minikube k8s environments and maybe a good guess otherwise (e.g. for kind clusters)
     if minikube -p ${MINIKUBE_PROFILE} status > /dev/null 2>&1 ; then
       INGRESS_HOST=$(minikube -p ${MINIKUBE_PROFILE} ip)


### PR DESCRIPTION
Added a note/comment in the install-bookinfo-demo.sh script.
There are some considerations that are platform/mesh dependent and I hope it would save time for others.

I revert the change, as some tests expect the traffic coming from out of the cluster.

