### PR TITLE
Fix .svc short host name

### DIFF
--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -80,6 +80,16 @@ func GetHost(hostName, namespace, cluster string, clusterNamespaces []string) Ho
 		}
 	}
 
+	// Case where it's a short name with the format <service>.<namespace>.svc
+	if len(hParts) == 3 && hParts[2] == "svc" {
+		return Host{
+			Service:       hParts[0],
+			Namespace:     hParts[1],
+			Cluster:       cluster,
+			CompleteInput: true,
+		}
+	}
+
 	return ParseHost(hostName, namespace, cluster)
 }
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4975

Add support to the ".svc" host format, used for validations:

```
	// Valid cases:
	// tracing.istio-system
	// tracing.istio-system.svc
	// tracing.istio-system.svc.cluster.local

	// Not valid:
	// tracing.istio-system.svc.cluster
``` 