### PR TITLE
Added authentication for remote Openshift clusters.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -308,6 +308,9 @@ type AuthConfig struct {
 // OpenShiftConfig contains specific configuration for authentication when on OpenShift
 type OpenShiftConfig struct {
 	ClientIdPrefix string `yaml:"client_id_prefix,omitempty"`
+	ServerPrefix   string `yaml:"server_prefix,omitempty"`
+	UseSystemCA    bool   `yaml:"use_system_ca,omitempty"`
+	RedirectURL    string `yaml:"redirect_url,omitempty"`
 }
 
 // OpenIdConfig contains specific configuration for authentication using an OpenID provider
@@ -526,6 +529,7 @@ func NewConfig() (c *Config) {
 			},
 			OpenShift: OpenShiftConfig{
 				ClientIdPrefix: "kiali",
+				ServerPrefix:   "https://kubernetes.default.svc/",
 			},
 		},
 		CustomDashboards: dashboards.GetBuiltInMonitoringDashboards(),

--- a/config/config.go
+++ b/config/config.go
@@ -311,6 +311,7 @@ type OpenShiftConfig struct {
 	ServerPrefix   string `yaml:"server_prefix,omitempty"`
 	UseSystemCA    bool   `yaml:"use_system_ca,omitempty"`
 	RedirectURL    string `yaml:"redirect_url,omitempty"`
+	CustomCA       string `yaml:"custom_ca,omitempty"`
 }
 
 // OpenIdConfig contains specific configuration for authentication using an OpenID provider

--- a/config/config.go
+++ b/config/config.go
@@ -308,6 +308,7 @@ type AuthConfig struct {
 // OpenShiftConfig contains specific configuration for authentication when on OpenShift
 type OpenShiftConfig struct {
 	ClientIdPrefix string `yaml:"client_id_prefix,omitempty"`
+	ClientId       string `yaml:"client_id,omitempty"`
 	ServerPrefix   string `yaml:"server_prefix,omitempty"`
 	UseSystemCA    bool   `yaml:"use_system_ca,omitempty"`
 	CustomCA       string `yaml:"custom_ca,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -310,7 +310,6 @@ type OpenShiftConfig struct {
 	ClientIdPrefix string `yaml:"client_id_prefix,omitempty"`
 	ServerPrefix   string `yaml:"server_prefix,omitempty"`
 	UseSystemCA    bool   `yaml:"use_system_ca,omitempty"`
-	RedirectURL    string `yaml:"redirect_url,omitempty"`
 	CustomCA       string `yaml:"custom_ca,omitempty"`
 }
 

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -137,7 +137,7 @@ func AuthenticationInfo(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		metadata, err := business.OpenshiftOAuth.Metadata()
+		metadata, err := business.OpenshiftOAuth.Metadata(r)
 		if err != nil {
 			RespondWithDetailedError(w, http.StatusInternalServerError, "Error trying to get OAuth metadata", err.Error())
 			return


### PR DESCRIPTION
** Describe the change **

Openshift authentication strategy is perfect when kiali is running inside the mesh cluster. If kiali is running outside the cluster, but the cluster APIs are hosted also outside of the cluster (common in case of managed Openshift clusters in pubic clouds), the same logic is applicable without the assumption of the in-cluster network settings.

This change makes the openshift authentication details configurable, with fallback to the original behavior.

** Issue reference **
https://github.com/kiali/kiali/issues/4359

* If this is a fix for a GH-issue, please link it here