### PR TITLE
Set url for grafana and jaeger in CI environment

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -152,6 +152,9 @@ helm install \
   --set deployment.image_name=kiali/kiali \
   --set deployment.image_version=dev \
   --set deployment.image_pull_policy="Never" \
+  # These need to be set for backend e2e tests but they don't need to be accessible outside the cluster.
+  --set deployment.external_services.grafana.url="http://grafana.istio-system:3000" \
+  --set deployment.external_services.tracing.url="http://tracing.istio-system:16685/jaeger" \
   kiali-server \
   helm-charts/_output/charts/kiali-server-*-SNAPSHOT.tgz
 

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -145,6 +145,8 @@ git clone --single-branch --branch "${TARGET_BRANCH}" https://github.com/kiali/h
 make -C helm-charts build-helm-charts
 
 infomsg "Installing kiali server via Helm"
+# The grafana and tracing urls need to be set for backend e2e tests
+# but they don't need to be accessible outside the cluster.
 helm install \
   --namespace istio-system \
   --set auth.strategy="anonymous" \
@@ -152,7 +154,6 @@ helm install \
   --set deployment.image_name=kiali/kiali \
   --set deployment.image_version=dev \
   --set deployment.image_pull_policy="Never" \
-  # These need to be set for backend e2e tests but they don't need to be accessible outside the cluster.
   --set deployment.external_services.grafana.url="http://grafana.istio-system:3000" \
   --set deployment.external_services.tracing.url="http://tracing.istio-system:16685/jaeger" \
   kiali-server \


### PR DESCRIPTION
Sets the url field for grafana and jaeger in CI environment. Needed for #5018 