### PR TITLE
add cypress-gui and cypress-run targets

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -264,9 +264,11 @@ make -e YARN_START_URL=http://<kiali-url> yarn-start
 # Start the cypress tests. The tests will run against the frontend development server by default.
 # Otherwise you can pass a custom url with env vars:
 #
-# make -e CYPRESS_BASE_URL=http://<kiali-url> cypress
-make cypress
+# make -e CYPRESS_BASE_URL=http://<kiali-url> cypress-gui
+make cypress-gui
 ----
+
+Note that `make cypress-gui` runs the Cypress GUI that allows you to pick which individual tests to run. To run the entire test suite in headless mode, use the make target `cypress-run` instead.
 
 ==== Debugging With VisualStudio Code
 

--- a/make/Makefile.ui.mk
+++ b/make/Makefile.ui.mk
@@ -3,8 +3,8 @@
 #
 
 ## yarn-start: Run the UI in a local process that is separate from the backend. Set YARN_START_URL to update package.json.
-## If the YARN_START_URL env var is passed, the 'proxy' field will either be created or replaced with the YARN_START_URL.
-## If the YARN_START_URL is empty but the 'proxy' field is set, the existing value will be used. Otherwise this cmd fails. 
+# If the YARN_START_URL env var is passed, the 'proxy' field will either be created or replaced with the YARN_START_URL.
+# If the YARN_START_URL is empty but the 'proxy' field is set, the existing value will be used. Otherwise this cmd fails.
 yarn-start:
 	@if [ -n "${YARN_START_URL}" ]; then \
 		sed -i -e "2 i \ \ \"proxy\": \"${YARN_START_URL}\"," -e "/\"proxy\":/d" ${ROOTDIR}/frontend/package.json; \
@@ -17,6 +17,10 @@ yarn-start:
 	@echo "'yarn start' will use this proxy setting: $$(grep proxy ${ROOTDIR}/frontend/package.json)"
 	@cd ${ROOTDIR}/frontend && yarn start
 
-## cypress: Runs the cypress frontend integration tests locally.
-cypress:
+## cypress-run: Runs all the cypress frontend integration tests locally without the GUI (i.e. headless).
+cypress-run:
+	@cd ${ROOTDIR}/frontend && yarn cypress:run --headless --env CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0
+
+## cypress-gui: Opens the cypress GUI letting you pick which frontend integration tests to run locally.
+cypress-gui:
 	@cd ${ROOTDIR}/frontend && yarn cypress


### PR DESCRIPTION
This is so it is easy to remember what they go.
cypress-gui runs the GUI so you can pick which individual tests to run.
cypress-run runs the full test suite headless.
Side note: also fixes the help text (make help).. the UI ones were getting indented too much.
