### PR TITLE
[cypress] wait for redirect to overview page after logging in

### DIFF
--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -79,6 +79,7 @@ Cypress.Commands.add('login', (provider: string, username: string, password: str
             });
           // Wait for the redirect to the overview page after a successful login.
           // Otherwise the redirect can mess with page loading on subsequent tests.
+          cy.contains('loading', {matchCase: false}).should('not.exist')
           cy.url().should('include', '/overview');
         }
       } else {

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -68,8 +68,8 @@ Cypress.Commands.add('login', (provider: string, username: string, password: str
         }
 
         if (auth_strategy === 'openshift') {
-          cy.get('#inputUsername').type(username);
-          cy.get('#inputPassword').type(password);
+          cy.get('#inputUsername').clear().type(username);
+          cy.get('#inputPassword').clear().type(password);
           cy.get('button[type="submit"]').click();
           cy.wait('@authorized').its('response.statusCode').should('eq', 200);
           cy.getCookie('kiali-token-aes', { timeout: 15000 })
@@ -77,6 +77,9 @@ Cypress.Commands.add('login', (provider: string, username: string, password: str
             .then(() => {
               haveCookie = true;
             });
+          // Wait for the redirect to the overview page after a successful login.
+          // Otherwise the redirect can mess with page loading on subsequent tests.
+          cy.url().should('include', '/overview');
         }
       } else {
         cy.log('got an auth cookie, skipping login');


### PR DESCRIPTION
When running tests on openshift, after login the browser is redirected to the overview page. If the tests also navigate to a page, the redirect to the overview page can happen _after_ the tests try to navigate to a particular page causing a test failure on the first test in the test suite.

This change waits for the redirect to the overview page to happen after logging in. Also clears the username/pw fields in the login form in case there is any placeholder text there.