### PR TITLE
Added principals checkers for AuthPolicy

### DIFF
--- a/business/checkers/authorization/principals_checker.go
+++ b/business/checkers/authorization/principals_checker.go
@@ -1,0 +1,73 @@
+package authorization
+
+import (
+	"fmt"
+
+	api_security_v1beta "istio.io/api/security/v1beta1"
+	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
+
+	"github.com/kiali/kiali/models"
+)
+
+type PrincipalsChecker struct {
+	AuthorizationPolicy security_v1beta.AuthorizationPolicy
+	ServiceAccounts     []string
+}
+
+func (pc PrincipalsChecker) Check() ([]*models.IstioCheck, bool) {
+	checks, valid := make([]*models.IstioCheck, 0), true
+
+	for ruleIdx, rule := range pc.AuthorizationPolicy.Spec.Rules {
+		if rule == nil {
+			continue
+		}
+		if len(rule.From) > 0 {
+			toChecks, toValid := pc.validateFromField(ruleIdx, rule.From)
+			checks = append(checks, toChecks...)
+			valid = valid && toValid
+		}
+	}
+	return checks, valid
+}
+
+func (pc PrincipalsChecker) validateFromField(ruleIdx int, from []*api_security_v1beta.Rule_From) ([]*models.IstioCheck, bool) {
+	if len(from) == 0 {
+		return nil, true
+	}
+
+	checks, valid := make([]*models.IstioCheck, 0, len(from)), true
+	for fromIdx, f := range from {
+		if f == nil {
+			continue
+		}
+
+		if f.Source == nil {
+			continue
+		}
+
+		if len(f.Source.Principals) == 0 {
+			continue
+		}
+
+		for i, p := range f.Source.Principals {
+			if !pc.hasMatchingServiceAccount(p) {
+				valid = false
+				path := fmt.Sprintf("spec/rules[%d]/from[%d]/source/principals[%d]", ruleIdx, fromIdx, i)
+				validation := models.Build("authorizationpolicy.source.principalnotfound", path)
+				checks = append(checks, &validation)
+			}
+		}
+	}
+
+	return checks, valid
+}
+
+func (pc PrincipalsChecker) hasMatchingServiceAccount(principal string) bool {
+	for _, sa := range pc.ServiceAccounts {
+		if sa == principal {
+			return true
+		}
+	}
+
+	return false
+}

--- a/business/checkers/authorization/principals_checker_test.go
+++ b/business/checkers/authorization/principals_checker_test.go
@@ -1,0 +1,49 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
+
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+func TestPresentServiceAccount(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := PrincipalsChecker{
+		AuthorizationPolicy: *authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}),
+		ServiceAccounts:     []string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"},
+	}.Check()
+
+	// Well configured object
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestNotPresentServiceAccount(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: *authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/wrong", "test"}),
+		ServiceAccounts:     []string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"},
+	}.Check()
+
+	// Wrong host is not present
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 2)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.Error(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.principalnotfound", vals[0]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[0]", vals[0].Path)
+	assert.Equal(models.ErrorSeverity, vals[1].Severity)
+	assert.Error(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.principalnotfound", vals[1]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[1]", vals[1].Path)
+}
+
+func authPolicyWithPrincipals(principalsList []string) *security_v1beta.AuthorizationPolicy {
+	return data.CreateAuthorizationPolicyWithPrincipals("auth-policy", "bookinfo", principalsList)
+}

--- a/business/checkers/authorization/principals_checker_test.go
+++ b/business/checkers/authorization/principals_checker_test.go
@@ -24,6 +24,19 @@ func TestPresentServiceAccount(t *testing.T) {
 	assert.Empty(validations)
 }
 
+func TestEmptyPrincipals(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := PrincipalsChecker{
+		AuthorizationPolicy: *authPolicyWithPrincipals([]string{}),
+		ServiceAccounts:     []string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"},
+	}.Check()
+
+	// Well configured object
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
 func TestNotPresentServiceAccount(t *testing.T) {
 	assert := assert.New(t)
 
@@ -42,6 +55,23 @@ func TestNotPresentServiceAccount(t *testing.T) {
 	assert.Equal(models.ErrorSeverity, vals[1].Severity)
 	assert.Error(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.principalnotfound", vals[1]))
 	assert.Equal("spec/rules[0]/from[0]/source/principals[1]", vals[1].Path)
+}
+
+func TestEmptyServiceAccount(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: *authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/wrong"}),
+		ServiceAccounts:     []string{},
+	}.Check()
+
+	// Wrong host is not present
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.Error(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.principalnotfound", vals[0]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[0]", vals[0].Path)
 }
 
 func authPolicyWithPrincipals(principalsList []string) *security_v1beta.AuthorizationPolicy {

--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -56,6 +56,7 @@ func (a AuthorizationPolicyChecker) runChecks(authPolicy security_v1beta.Authori
 		authorization.NamespaceMethodChecker{AuthorizationPolicy: authPolicy, Namespaces: a.Namespaces.GetNames()},
 		authorization.NoHostChecker{AuthorizationPolicy: authPolicy, Namespace: a.Namespace, Namespaces: a.Namespaces,
 			ServiceEntries: serviceHosts, VirtualServices: a.VirtualServices, RegistryServices: a.RegistryServices},
+		authorization.PrincipalsChecker{AuthorizationPolicy: authPolicy, ServiceAccounts: kubernetes.ServiceAccountNames(a.RegistryServices)},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -1,11 +1,15 @@
 package checkers
 
 import (
+	"fmt"
+	"strings"
+
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
 
 	"github.com/kiali/kiali/business/checkers/authorization"
 	"github.com/kiali/kiali/business/checkers/common"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -17,7 +21,7 @@ type AuthorizationPolicyChecker struct {
 	Namespace             string
 	Namespaces            models.Namespaces
 	ServiceEntries        []networking_v1beta1.ServiceEntry
-	WorkloadList          models.WorkloadList
+	WorkloadsPerNamespace map[string]models.WorkloadList
 	MtlsDetails           kubernetes.MTLSDetails
 	VirtualServices       []networking_v1beta1.VirtualService
 	RegistryServices      []*kubernetes.RegistryService
@@ -52,11 +56,11 @@ func (a AuthorizationPolicyChecker) runChecks(authPolicy security_v1beta.Authori
 		matchLabels = authPolicy.Spec.Selector.MatchLabels
 	}
 	enabledCheckers := []Checker{
-		common.SelectorNoWorkloadFoundChecker(AuthorizationPolicyCheckerType, matchLabels, a.WorkloadList),
+		common.SelectorNoWorkloadFoundChecker(AuthorizationPolicyCheckerType, matchLabels, a.WorkloadsPerNamespace[a.Namespace]),
 		authorization.NamespaceMethodChecker{AuthorizationPolicy: authPolicy, Namespaces: a.Namespaces.GetNames()},
 		authorization.NoHostChecker{AuthorizationPolicy: authPolicy, Namespace: a.Namespace, Namespaces: a.Namespaces,
 			ServiceEntries: serviceHosts, VirtualServices: a.VirtualServices, RegistryServices: a.RegistryServices},
-		authorization.PrincipalsChecker{AuthorizationPolicy: authPolicy, ServiceAccounts: kubernetes.ServiceAccountNames(a.RegistryServices)},
+		authorization.PrincipalsChecker{AuthorizationPolicy: authPolicy, ServiceAccounts: a.ServiceAccountNames(strings.Replace(config.Get().ExternalServices.Istio.IstioIdentityDomain, "svc.", "", 1))},
 	}
 
 	for _, checker := range enabledCheckers {
@@ -66,4 +70,28 @@ func (a AuthorizationPolicyChecker) runChecks(authPolicy security_v1beta.Authori
 	}
 
 	return models.IstioValidations{key: rrValidation}
+}
+
+// ServiceAccountNames returns a list of names of the ServiceAccounts retrieved from Registry Services.
+func (a AuthorizationPolicyChecker) ServiceAccountNames(clusterName string) []string {
+	names := make([]string, 0)
+
+	for _, wpn := range a.WorkloadsPerNamespace {
+		for _, wl := range wpn.Workloads {
+			for _, sAccountName := range wl.ServiceAccountNames {
+				saFullName := fmt.Sprintf("%s/ns/%s/sa/%s", clusterName, wpn.Namespace.Name, sAccountName)
+				found := false
+				for _, name := range names {
+					if name == saFullName {
+						found = true
+						break
+					}
+				}
+				if !found {
+					names = append(names, saFullName)
+				}
+			}
+		}
+	}
+	return names
 }

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -125,7 +125,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(namespace string, istioC
 		checkers.GatewayChecker{Gateways: istioConfigList.Gateways, Namespace: namespace, WorkloadsPerNamespace: workloadsPerNamespace, IsGatewayToNamespace: in.isGatewayToNamespace()},
 		checkers.PeerAuthenticationChecker{PeerAuthentications: mtlsDetails.PeerAuthentications, MTLSDetails: mtlsDetails, WorkloadList: workloadsPerNamespace[namespace]},
 		checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries},
-		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceEntries: istioConfigList.ServiceEntries, WorkloadList: workloadsPerNamespace[namespace], MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices},
+		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, ServiceEntries: istioConfigList.ServiceEntries, WorkloadsPerNamespace: workloadsPerNamespace, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices},
 		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadList: workloadsPerNamespace[namespace], ServiceEntries: istioConfigList.ServiceEntries, RegistryServices: registryServices},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadList: workloadsPerNamespace[namespace]},
 		checkers.WorkloadChecker{Namespace: namespace, AuthorizationPolicies: rbacDetails.AuthorizationPolicies, WorkloadList: workloadsPerNamespace[namespace]},
@@ -203,7 +203,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
 			Namespace: namespace, Namespaces: namespaces, ServiceEntries: istioConfigList.ServiceEntries,
-			WorkloadList: workloadsPerNamespace[namespace], MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices}
+			WorkloadsPerNamespace: workloadsPerNamespace, MtlsDetails: mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{authPoliciesChecker}
 		referenceChecker = references.AuthorizationPolicyReferences{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespace: namespace, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, ServiceEntries: istioConfigList.ServiceEntries, RegistryServices: registryServices, WorkloadsPerNamespace: workloadsPerNamespace}
 	case kubernetes.PeerAuthentications:

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -561,6 +561,16 @@ func GatewayNames(gateways []networking_v1beta1.Gateway) map[string]struct{} {
 	return names
 }
 
+// ServiceAccountNames returns a list of names of the ServiceAccounts retrieved from Segistry Services.
+func ServiceAccountNames(registryServices []*RegistryService) []string {
+	names := make([]string, 0)
+
+	for _, rs := range registryServices {
+		names = append(names, rs.ServiceAccounts...)
+	}
+	return names
+}
+
 func PeerAuthnHasStrictMTLS(peerAuthn security_v1beta1.PeerAuthentication) bool {
 	_, mode := PeerAuthnHasMTLSEnabled(peerAuthn)
 	return mode == "STRICT"

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -561,16 +561,6 @@ func GatewayNames(gateways []networking_v1beta1.Gateway) map[string]struct{} {
 	return names
 }
 
-// ServiceAccountNames returns a list of names of the ServiceAccounts retrieved from Segistry Services.
-func ServiceAccountNames(registryServices []*RegistryService) []string {
-	names := make([]string, 0)
-
-	for _, rs := range registryServices {
-		names = append(names, rs.ServiceAccounts...)
-	}
-	return names
-}
-
 func PeerAuthnHasStrictMTLS(peerAuthn security_v1beta1.PeerAuthentication) bool {
 	_, mode := PeerAuthnHasMTLSEnabled(peerAuthn)
 	return mode == "STRICT"

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -67,6 +67,7 @@ var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 		{ObjectField: "spec.selector.matchLabels", Message: "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied."},
 		{ObjectField: "spec.rules", Message: "Optional. A list of rules to match the request. A match occurs when at least one rule matches the request."},
 		{ObjectField: "spec.rules.from", Message: "Optional. from specifies the source of a request. If not set, any source is allowed."},
+		{ObjectField: "spec.rules.from.source.principals", Message: "Optional. A list of peer identities derived from the peer certificate. If not set, any principal is allowed."},
 		{ObjectField: "spec.rules.to", Message: "Optional. to specifies the operation of a request. If not set, any operation is allowed."},
 		{ObjectField: "spec.rules.when", Message: "Optional. when specifies a list of additional conditions of a request. If not set, any condition is allowed."},
 		{ObjectField: "spec.action", Message: "Optional. The action to take if the request is matched with the rules. Default is ALLOW if not specified."},

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -117,6 +117,11 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "Namespace not found for this rule",
 		Severity: WarningSeverity,
 	},
+	"authorizationpolicy.source.principalnotfound": {
+		Code:     "KIA0106",
+		Message:  "Service Account not found for this principal",
+		Severity: ErrorSeverity,
+	},
 	"authorizationpolicy.to.wrongmethod": {
 		Code:     "KIA0102",
 		Message:  "Only HTTP methods and fully-qualified gRPC names are allowed",

--- a/tests/data/authorization_policy_data.go
+++ b/tests/data/authorization_policy_data.go
@@ -63,3 +63,21 @@ func CreateAuthorizationPolicyWithMetaAndSelector(name, namespace string, select
 	}
 	return &ap
 }
+
+func CreateAuthorizationPolicyWithPrincipals(name, namespace string, principalsList []string) *security_v1beta1.AuthorizationPolicy {
+	ap := security_v1beta1.AuthorizationPolicy{}
+	ap.Name = name
+	ap.Namespace = namespace
+	ap.Spec.Rules = []*api_security_v1beta1.Rule{
+		{
+			From: []*api_security_v1beta1.Rule_From{
+				{
+					Source: &api_security_v1beta1.Source{
+						Principals: principalsList,
+					},
+				},
+			},
+		},
+	}
+	return &ap
+}

--- a/tests/integration/assets/bookinfo-auth-policy-principals.yaml
+++ b/tests/integration/assets/bookinfo-auth-policy-principals.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: ratings-policy
+  namespace: bookinfo
+spec:
+  action: DENY
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/default/sa/bookinfo-wrong
+              - cluster.local/ns/bookinfo/sa/bookinfo-details
+  selector:
+    matchLabels:
+      app: ratings

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -1,0 +1,41 @@
+package tests
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/integration/utils"
+	"github.com/kiali/kiali/tools/cmd"
+)
+
+func TestAuthPolicyPrincipalsError(t *testing.T) {
+	name := "ratings-policy"
+	assert := assert.New(t)
+	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-auth-policy-principals.yaml")
+	defer utils.DeleteFile(filePath, utils.BOOKINFO)
+	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+
+	config, _, err := utils.IstioConfigDetails(utils.BOOKINFO, name, kubernetes.AuthorizationPolicies)
+
+	assert.Nil(err)
+	assert.NotNil(config)
+	assert.Equal(kubernetes.AuthorizationPolicies, config.ObjectType)
+	assert.Equal(utils.BOOKINFO, config.Namespace.Name)
+	assert.NotNil(config.AuthorizationPolicy)
+	assert.Equal(name, config.AuthorizationPolicy.Name)
+	assert.Equal(utils.BOOKINFO, config.AuthorizationPolicy.Namespace)
+	assert.NotNil(config.IstioReferences)
+	assert.NotNil(config.IstioValidation)
+	assert.Equal(name, config.IstioValidation.Name)
+	assert.Equal("authorizationpolicy", config.IstioValidation.ObjectType)
+	assert.False(config.IstioValidation.Valid)
+	assert.Empty(config.IstioValidation.References)
+	assert.NotEmpty(config.IstioValidation.Checks)
+	assert.Len(config.IstioValidation.Checks, 1)
+	assert.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
+	assert.Equal("Service Account not found for this principal", config.IstioValidation.Checks[0].Message)
+}


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4424
Istio documentation https://istio.io/latest/docs/reference/config/security/authorization-policy/#Source

Authorization Policy Source has a "principals" field, which contains a list of ServiceAccounts names in "<TRUST_DOMAIN>/ns/<NAMESPACE>/sa/<SERVICE_ACCOUNT>" format.

This PR adds a validation on an existence of those ServiceAccounts, based on searching among Workloads SAs.
Error message is displayed on a principal, which does not refer to existing SA which is labeled to any Workload.

![Screenshot from 2022-05-13 09-14-21](https://user-images.githubusercontent.com/604313/168231666-a71e42d0-1511-4e84-bd4f-a829e659a868.png)
