### PR TITLE
PF-React, style updates

### DIFF
--- a/frontend/src/components/Filters/StatefulFilters.tsx
+++ b/frontend/src/components/Filters/StatefulFilters.tsx
@@ -34,7 +34,7 @@ import { KialiIcon } from 'config/KialiIcon';
 
 var classNames = require('classnames');
 
-const filterSelectStyle = style({
+const noPaddingStyle = style({
   padding: 0
 });
 
@@ -87,7 +87,6 @@ export class FilterSelected {
   };
 }
 
-// const filterWithChildrenStyle = style({ paddingRight: '10px', display: 'inherit' });
 const dividerStyle = style({ borderRight: '1px solid #d1d1d1;', padding: '10px', display: 'inherit' });
 const paddingStyle = style({ padding: '10px' });
 
@@ -360,12 +359,12 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
     return (
       <Toolbar
         id="filter-selection"
-        className={`pf-m-toggle-group-container ${filterSelectStyle}`}
+        className={`pf-m-toggle-group-container ${noPaddingStyle}`}
         collapseListedFiltersBreakpoint="xl"
         clearAllFilters={this.clearFilters}
       >
         {this.props.childrenFirst && this.renderChildren()}
-        <ToolbarContent>
+        <ToolbarContent className={noPaddingStyle}>
           <ToolbarToggleGroup toggleIcon={<KialiIcon.Filter />} breakpoint="md">
             <ToolbarGroup variant="filter-group">
               {this.state.filterTypes.map((ft, i) => {

--- a/frontend/src/components/TrafficList/TrafficListComponent.tsx
+++ b/frontend/src/components/TrafficList/TrafficListComponent.tsx
@@ -34,7 +34,7 @@ type TrafficListComponentState = FilterComponent.State<TrafficListItem>;
 const columns = [
   {
     title: 'Status',
-    transforms: [sortable, cellWidth(10)]
+    transforms: [sortable, cellWidth(15)]
   },
   {
     title: 'Name',
@@ -46,11 +46,11 @@ const columns = [
   },
   {
     title: 'Percent Success',
-    transforms: [sortable, cellWidth(10)]
+    transforms: [sortable, cellWidth(20)]
   },
   {
     title: 'Protocol',
-    transforms: [sortable, cellWidth(10)]
+    transforms: [sortable, cellWidth(15)]
   },
   {
     title: 'Actions'

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -81,7 +81,7 @@ const item: ResourceType<TResource> = {
   name: 'Item',
   param: 'wn',
   column: 'Name',
-  transforms: [sortable],
+  transforms: [sortable, cellWidth(30)],
   renderer: Renderers.item
 };
 
@@ -89,7 +89,7 @@ const serviceItem: ResourceType<ServiceListItem> = {
   name: 'Item',
   param: 'sn',
   column: 'Name',
-  transforms: [sortable],
+  transforms: [sortable, cellWidth(30)],
   renderer: Renderers.item
 };
 
@@ -105,7 +105,7 @@ const namespace: ResourceType<TResource> = {
   name: 'Namespace',
   param: 'ns',
   column: 'Namespace',
-  transforms: [sortable],
+  transforms: [sortable, cellWidth(20)],
   renderer: Renderers.namespace
 };
 
@@ -121,7 +121,7 @@ const health: ResourceType<TResource> = {
   name: 'Health',
   param: 'he',
   column: 'Health',
-  transforms: [sortable, cellWidth(10)],
+  transforms: [sortable, cellWidth(15)],
   renderer: Renderers.health
 };
 
@@ -129,7 +129,7 @@ const details: ResourceType<AppListItem | WorkloadListItem | ServiceListItem> = 
   name: 'Details',
   param: 'is',
   column: 'Details',
-  transforms: [sortable, cellWidth(10)],
+  transforms: [sortable, cellWidth(15)],
   renderer: Renderers.details
 };
 
@@ -137,7 +137,7 @@ const serviceConfiguration: ResourceType<ServiceListItem> = {
   name: 'Configuration',
   param: 'cv',
   column: 'Configuration',
-  transforms: [sortable, cellWidth(10)],
+  transforms: [sortable, cellWidth(20)],
   renderer: Renderers.serviceConfiguration
 };
 
@@ -145,7 +145,7 @@ const istioObjectConfiguration: ResourceType<IstioConfigItem> = {
   name: 'Configuration',
   param: 'cv',
   column: 'Configuration',
-  transforms: [sortable, cellWidth(10)],
+  transforms: [sortable, cellWidth(20)],
   renderer: Renderers.istioConfiguration
 };
 


### PR DESCRIPTION
Epic #4260 

- ensure column header names appear in full for list pages and traffic tab
- remove excess left and right padding for StatefulFilters

[skip-ci]
