### PR TITLE
fix cypress graph display  feature in CI

### DIFF
--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -12,5 +12,10 @@
   "responseTimeout": 15000,
   "supportFile": "cypress/support/index.ts",
   "pluginsFile": "cypress/plugins/bdd.ts",
-  "fixturesFolder": "cypress/fixtures"
+  "fixturesFolder": "cypress/fixtures",
+  "env": {
+    "cypress-react-selector": {
+      "root": "#root"
+    }
+  }
 }

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -124,8 +124,9 @@ Then('the display menu has default settings', () => {
 });
 
 Then('the graph reflects default settings', () => {
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
   cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
     .getCurrentState()
     .then(state => {
       // no nonDefault edge label info
@@ -148,7 +149,7 @@ Then('the graph reflects default settings', () => {
 
       // a variety of not-found tests
       numNodes = state.cy.nodes(
-        `[isBox = "cluster"],[?isIdle],[?rank],[?hasMissingSC],[?hasVS],[nodeType = "operation"]`
+        `[isBox = "cluster"],[?isIdle],[?rank],[nodeType = "operation"]`
       ).length;
       assert.isTrue(numNodes === 0);
     });
@@ -169,8 +170,9 @@ Then('user sees {string} edge labels', el => {
       rate = el;
   }
 
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
   cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
     .getCurrentState()
     .then(state => {
       const numEdges = state.cy.edges(`[${rate}" > 0]`).length;
@@ -185,8 +187,9 @@ Then('user sees {string} edge label option is closed', edgeLabel => {
 Then('user does not see {string} boxing', (boxByType: string) => {
   validateInput(`boxBy${boxByType}`, 'does not appear');
 
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
   cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
     .getCurrentState()
     .then(state => {
       const numBoxes = state.cy.nodes(`[isBox = "${boxByType.toLowerCase()}"]`).length;
@@ -197,8 +200,9 @@ Then('user does not see {string} boxing', (boxByType: string) => {
 Then('idle edges {string} in the graph', action => {
   validateInput('filterIdleEdges', action);
 
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
   cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
     .getCurrentState()
     .then(state => {
       const numEdges = state.cy.edges(`[^hasTraffic]`).length;
@@ -213,8 +217,9 @@ Then('idle edges {string} in the graph', action => {
 Then('idle nodes {string} in the graph', action => {
   validateInput('filterIdleNodes', action);
 
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
   cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
     .getCurrentState()
     .then(state => {
       const numNodes = state.cy.nodes(`[?isIdle]`).length;
@@ -229,8 +234,9 @@ Then('idle nodes {string} in the graph', action => {
 Then('ranks {string} in the graph', action => {
   validateInput('rank', action);
 
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
   cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
     .getCurrentState()
     .then(state => {
       const numNodes = state.cy.nodes(`[rank > 0]`).length;
@@ -245,8 +251,9 @@ Then('ranks {string} in the graph', action => {
 Then('user does not see service nodes', () => {
   validateInput('filterServiceNodes', 'do not appear');
 
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
   cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
     .getCurrentState()
     .then(state => {
       const numBoxes = state.cy.nodes(`[nodeType = "service"][^isOutside]`).length;
@@ -257,8 +264,9 @@ Then('user does not see service nodes', () => {
 Then('security {string} in the graph', action => {
   validateInput('filterSecurity', action);
 
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
   cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
     .getCurrentState()
     .then(state => {
       const numEdges = state.cy.edges(`[isMTLS > 0]`).length;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "build": "if [ \"${KIALI_ENV}\" = \"production\" ]; then npm run build:prod; else npm run build:dev; fi",
     "build-css": "node-sass src/ --output-style compressed --include-path $npm_package_sassIncludes_src -o src/",
     "build:dev": "sh -ac '. ./.env.upstream; npm run lint && npm run build:kiali'",
-    "build:kiali": "npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) GENERATE_SOURCEMAP=false EXTEND_ESLINT=true react-scripts build",
+    "build:kiali": "npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) GENERATE_SOURCEMAP=false EXTEND_ESLINT=true react-scripts build --profile",
     "build:prod": "sh -ac '. ./.env.downstream; npm run build:kiali'",
     "cypress": "cypress open",
     "cypress:run": "cypress run",

--- a/make/Makefile.ui.mk
+++ b/make/Makefile.ui.mk
@@ -19,7 +19,7 @@ yarn-start:
 
 ## cypress-run: Runs all the cypress frontend integration tests locally without the GUI (i.e. headless).
 cypress-run:
-	@cd ${ROOTDIR}/frontend && yarn cypress:run --headless --env CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0
+	@cd ${ROOTDIR}/frontend && yarn cypress:run --headless --env CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0 --env CYPRESS_VIDEO=false
 
 ## cypress-gui: Opens the cypress GUI letting you pick which frontend integration tests to run locally.
 cypress-gui:


### PR DESCRIPTION
Epic #4260 

- add "--profile" to the build. This option adds a little bit of overhead but has the advantage of not munging names that can be important for understanding profiler information, but in this case, also for searching on react component names in tests.

also:
- move #root into config, as suggested in crs doco
- turn off video when running headless via make
- update one test that was failing due to the slightly different demo app setup in CI, as compared to what I had locally.

