### PR TITLE
[v1.48] [molecule] add more fields to the junit xml results file

### DIFF
--- a/hack/run-molecule-tests.sh
+++ b/hack/run-molecule-tests.sh
@@ -322,13 +322,13 @@ output_junit_xml_results() {
 
   if [ ! -f "${JUNIT_XML_FILE}" ] && touch "${JUNIT_XML_FILE}"; then
     cat <<EOM >> "${JUNIT_XML_FILE}"
-<testsuites  id="kiali molecule tests" name="kiali molecule tests" tests="${junit_total_tests}" failures="${junit_total_failures}" time="${junit_total_time}">
-  <testsuite id="kiali molecule tests" name="kiali molecule tests" tests="${junit_total_tests}" failures="${junit_total_failures}" time="${junit_total_time}">
+<testsuites  id="0" name="kiali molecule tests" tests="${junit_total_tests}" failures="${junit_total_failures}" time="${junit_total_time}">
+  <testsuite id="0" name="kiali molecule tests" tests="${junit_total_tests}" failures="${junit_total_failures}" time="${junit_total_time}">
 EOM
 
     for i in ${!junit_name[@]};
     do
-      echo -n "    <testcase id=\"${junit_name[$i]}\" name=\"${junit_name[$i]}\" time=\"${junit_duration[$i]}\">" >> "${JUNIT_XML_FILE}"
+      echo -n "    <testcase id=\"${junit_name[$i]}\" name=\"${junit_name[$i]}\" classname=\"${junit_name[$i]}\" time=\"${junit_duration[$i]}\">" >> "${JUNIT_XML_FILE}"
       if [ "${junit_failure[$i]}" != "0" ]; then
         printf "\n      <failure type=\"error\" message=\"For details, see ${TEST_LOGS_DIR}/${junit_name[$i]}.log\"/>\n    " >> "${JUNIT_XML_FILE}"
       fi


### PR DESCRIPTION
following schema documented here: https://llg.cubic.org/docs/junit/

(cherry picked from commit 2bd41759523cae8c2aa8094675d86e40dbf2dead)

see https://github.com/kiali/kiali/pull/5062

backporting this so we can produce a junit xml file that polarion can (hopefully) accept now

This is only changing a hack script used to run molecule tests - nothing in the server code is changing.