### PR TITLE
[cypress] Graph toolbar tests

### DIFF
--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -87,6 +87,11 @@ When('user {string} {string} option', (action, option: string) => {
   }
 });
 
+When('user resets to factory default', () => {
+  cy.get('button#graph-factory-reset').click()
+  cy.get('#loading_kiali_spinner').should('not.exist');
+});
+
 ///////////////////
 
 Then(`user sees no namespace selected`, () => {
@@ -131,27 +136,25 @@ Then('the graph reflects default settings', () => {
     .then(state => {
       // no nonDefault edge label info
       let numEdges = state.cy.edges(`[?responseTime],[?throughput]`).length;
-      assert.isTrue(numEdges === 0);
+      assert.equal(numEdges, 0);
 
       // no idle edges, mtls
       numEdges = state.cy.edges(`[^hasTraffic],[isMTLS > 0]`).length;
-      assert.isTrue(numEdges === 0);
+      assert.equal(numEdges, 0);
 
       // boxes
       let numNodes = state.cy.nodes(`[isBox = "app"]`).length;
-      assert.isTrue(numNodes > 0);
+      assert.isAbove(numNodes, 0);
       numNodes = state.cy.nodes(`[isBox = "namespace"]`).length;
-      assert.isTrue(numNodes > 0);
+      assert.isAbove(numNodes, 0);
 
       // service nodes
       numNodes = state.cy.nodes(`[nodeType = "service"]`).length;
-      assert.isTrue(numNodes > 0);
+      assert.isAbove(numNodes, 0);
 
       // a variety of not-found tests
-      numNodes = state.cy.nodes(
-        `[isBox = "cluster"],[?isIdle],[?rank],[nodeType = "operation"]`
-      ).length;
-      assert.isTrue(numNodes === 0);
+      numNodes = state.cy.nodes(`[isBox = "cluster"],[?isIdle],[?rank],[nodeType = "operation"]`).length;
+      assert.equal(numNodes, 0);
     });
 });
 
@@ -176,7 +179,7 @@ Then('user sees {string} edge labels', el => {
     .getCurrentState()
     .then(state => {
       const numEdges = state.cy.edges(`[${rate}" > 0]`).length;
-      assert.isTrue(numEdges > 0);
+      assert.isAbove(numEdges, 0);
     });
 });
 
@@ -193,7 +196,7 @@ Then('user does not see {string} boxing', (boxByType: string) => {
     .getCurrentState()
     .then(state => {
       const numBoxes = state.cy.nodes(`[isBox = "${boxByType.toLowerCase()}"]`).length;
-      assert.isTrue(numBoxes === 0);
+      assert.equal(numBoxes, 0);
     });
 });
 
@@ -207,9 +210,9 @@ Then('idle edges {string} in the graph', action => {
     .then(state => {
       const numEdges = state.cy.edges(`[^hasTraffic]`).length;
       if (action === 'appear') {
-        assert.isTrue(numEdges > 0);
+        assert.isAbove(numEdges, 0);
       } else {
-        assert.isTrue(numEdges === 0);
+        assert.equal(numEdges, 0);
       }
     });
 });
@@ -224,9 +227,9 @@ Then('idle nodes {string} in the graph', action => {
     .then(state => {
       const numNodes = state.cy.nodes(`[?isIdle]`).length;
       if (action === 'appear') {
-        assert.isTrue(numNodes > 0);
+        assert.isAbove(numNodes, 0);
       } else {
-        assert.isTrue(numNodes === 0);
+        assert.equal(numNodes, 0);
       }
     });
 });
@@ -241,9 +244,9 @@ Then('ranks {string} in the graph', action => {
     .then(state => {
       const numNodes = state.cy.nodes(`[rank > 0]`).length;
       if (action === 'appear') {
-        assert.isTrue(numNodes > 0);
+        assert.isAbove(numNodes, 0);
       } else {
-        assert.isTrue(numNodes === 0);
+        assert.equal(numNodes, 0);
       }
     });
 });
@@ -257,7 +260,7 @@ Then('user does not see service nodes', () => {
     .getCurrentState()
     .then(state => {
       const numBoxes = state.cy.nodes(`[nodeType = "service"][^isOutside]`).length;
-      assert.isTrue(numBoxes === 0);
+      assert.equal(numBoxes, 0);
     });
 });
 
@@ -271,9 +274,9 @@ Then('security {string} in the graph', action => {
     .then(state => {
       const numEdges = state.cy.edges(`[isMTLS > 0]`).length;
       if (action === 'appears') {
-        assert.isTrue(numEdges > 0);
+        assert.isAbove(numEdges, 0);
       } else {
-        assert.isTrue(numEdges === 0);
+        assert.equal(numEdges, 0);
       }
     });
 });

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -79,9 +79,6 @@ When('user selects {string} graph type', graphType => {
     .click();
   cy.get('#loading_kiali_spinner').should('not.exist');
 });
-
-///////////////////
-
 Then('user {string} graph tour', action => {
   if (action === 'sees') {
     cy.get('div[role="dialog"]').find('span').contains('Shortcuts').should('exist');

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -1,0 +1,190 @@
+import { Before, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { CytoscapeGlobalScratchData, CytoscapeGlobalScratchNamespace } from '../../../src/types/Graph';
+
+const url = '/console';
+
+Before(() => {
+  // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.
+  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
+  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
+  cy.on('uncaught:exception', (err, runnable, promise) => {
+    // when the exception originated from an unhandled promise
+    // rejection, the promise is provided as a third argument
+    // you can turn off failing the test in this case
+    if (promise) {
+      return false;
+    }
+    // we still want to ensure there are no other unexpected
+    // errors, so we let them fail the test
+  });
+});
+
+When('user graphs {string} namespaces with refresh {string} and duration {string}', (namespaces, refresh, duration) => {
+  cy.visit(url + `/graph/namespaces?refresh=${refresh}&duration=${duration}&namespaces=${namespaces}`);
+});
+
+When('user clicks graph tour', () => {
+  cy.get('button#graph-tour').click();
+});
+
+When('user closes graph tour', () => {
+  cy.get('div[role="dialog"]').find('button[aria-label="Close"]').click();
+});
+
+When('user clicks graph traffic menu', () => {
+  cy.get('button#graph-traffic-dropdown').click();
+});
+
+When('user disables all traffic', () => {
+  cy.get('div#graph-traffic-menu').within(() => {
+    cy.get('input#grpc').should('exist').uncheck();
+    cy.get('#loading_kiali_spinner').should('not.exist');
+    cy.get('input#http').should('exist').uncheck();
+    cy.get('#loading_kiali_spinner').should('not.exist');
+    cy.get('input#tcp').should('exist').uncheck();
+    cy.get('#loading_kiali_spinner').should('not.exist');
+  });
+});
+
+When('user enables {string} traffic', protocol => {
+  cy.get('div#graph-traffic-menu').find(`input#${protocol}`).should('exist').check();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+});
+
+When('user clicks graph duration menu', () => {
+  cy.get('button[aria-labelledby^="time_range_duration"]').click();
+});
+
+When(`user selects graph duration {string}`, duration => {
+  cy.get('button[aria-labelledby^="time_range_duration"]').click();
+  cy.get(`li#${duration}`).children('button').click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+});
+
+When('user clicks graph refresh menu', () => {
+  cy.get('button[aria-labelledby^="time_range_refresh"]').click();
+});
+
+When(`user selects graph refresh {string}`, refresh => {
+  cy.get('button[aria-labelledby^="time_range_refresh"]').click();
+  cy.get(`li[id="${refresh}"]`).children('button').click().get('#loading_kiali_spinner').should('not.exist');
+});
+
+When('user selects {string} graph type', graphType => {
+  cy.get('button#graph_type_dropdown-toggle')
+    .click()
+    .parent()
+    .find('ul#graph_type_dropdown')
+    .find(`li#${graphType}`)
+    .click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+});
+
+///////////////////
+
+Then('user {string} graph tour', action => {
+  if (action === 'sees') {
+    cy.get('div[role="dialog"]').find('span').contains('Shortcuts').should('exist');
+  } else {
+    cy.get('div[role="dialog"]').should('not.exist');
+  }
+});
+
+Then('user sees default graph traffic menu', () => {
+  cy.get('button#graph-traffic-dropdown').invoke('attr', 'aria-expanded').should('eq', 'true');
+  cy.get('div#graph-traffic-menu').within(() => {
+    cy.get('input').should('have.length', 11);
+    cy.get('input#grpc').should('exist').should('be.checked');
+    cy.get('input#grpcReceived').should('exist').should('not.be.checked');
+    cy.get('input#grpcRequest').should('exist').should('be.checked');
+    cy.get('input#grpcSent').should('exist').should('not.be.checked');
+    cy.get('input#grpcTotal').should('exist').should('not.be.checked');
+    cy.get('input#http').should('exist').should('be.enabled');
+    cy.get('input#httpRequest').should('exist').should('be.checked');
+    cy.get('input#tcp').should('exist').should('be.enabled');
+    cy.get('input#tcpReceived').should('exist').should('not.be.checked');
+    cy.get('input#tcpSent').should('exist').should('be.checked');
+    cy.get('input#tcpTotal').should('exist').should('not.be.checked');
+  });
+});
+
+Then('user does not see graph traffic menu', () => {
+  cy.get('button#graph-traffic-dropdown').invoke('attr', 'aria-expanded').should('eq', 'false');
+});
+
+Then('user {string} {string} traffic', (action, protocol) => {
+  cy.waitForReact();
+  cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
+    .getCurrentState()
+    .then(state => {
+      const numEdges = state.cy.edges(`[protocol = "${protocol}"]`).length;
+      if (action === 'sees') {
+        assert.isAbove(numEdges, 0);
+      } else {
+        assert.equal(numEdges, 0);
+      }
+    });
+});
+
+Then(`user does not see any traffic`, () => {
+  cy.get('div#empty-graph').should('be.visible');
+});
+
+Then('user sees graph duration menu', () => {
+  cy.get('button#time_range_duration-toggle').invoke('attr', 'aria-expanded').should('eq', 'true');
+  cy.get('ul#time_range_duration').within(() => {
+    cy.get('li').should('have.length', 10);
+    cy.get('li#60').should('exist');
+    cy.get('li#300').should('exist');
+    cy.get('li#600').should('exist');
+    cy.get('li#1800').should('exist');
+    cy.get('li#3600').should('exist');
+    cy.get('li#10800').should('exist');
+    cy.get('li#21600').should('exist');
+    cy.get('li#43200').should('exist');
+    cy.get('li#86400').should('exist');
+    cy.get('li#604800').should('exist');
+  });
+});
+
+Then('user does not see graph duration menu', () => {
+  cy.get('button#time_range_duration-toggle').invoke('attr', 'aria-expanded').should('eq', 'false');
+});
+
+Then('user sees selected graph duration {string}', duration => {
+  cy.get('button[aria-labelledby^="time_range_duration"]').find('span').contains(duration).should('exist');
+});
+
+Then('user sees graph refresh menu', refresh => {
+  cy.get('button#time_range_refresh-toggle').invoke('attr', 'aria-expanded').should('eq', 'true');
+  cy.get('ul#time_range_refresh').within(() => {
+    cy.get('li').should('have.length', 7);
+    cy.get('li#0').should('exist');
+    cy.get('li#10000').should('exist');
+    cy.get('li#15000').should('exist');
+    cy.get('li#30000').should('exist');
+    cy.get('li#60000').should('exist');
+    cy.get('li#300000').should('exist');
+    cy.get('li#900000').should('exist');
+  });
+});
+
+Then('user does not see graph refresh menu', () => {
+  cy.get('button#time_range_refresh-toggle').invoke('attr', 'aria-expanded').should('eq', 'false');
+});
+
+Then('user sees selected graph refresh {string}', refresh => {
+  cy.get('button[aria-labelledby^="time_range_refresh"]').find('span').contains(refresh).should('exist');
+});
+
+Then('user sees a {string} graph', graphType => {
+  cy.waitForReact();
+  cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
+    .getCurrentState()
+    .then(state => {
+      const globalScratch: CytoscapeGlobalScratchData = state.cy.scratch(CytoscapeGlobalScratchNamespace);
+      assert.equal(globalScratch.graphType, graphType);
+    });
+});

--- a/frontend/cypress/integration/featureFiles/graph_display.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display.feature
@@ -181,3 +181,10 @@ Scenario: User enables animation
 Scenario: User disables animation
   When user "disables" "traffic animation" option
   Then "traffic animation" option "does not appear" in the graph
+
+@graph-page-display
+Scenario: User resets to factory default
+  When user resets to factory default
+  And user opens display menu
+  Then the display menu opens
+  And the display menu has default settings

--- a/frontend/cypress/integration/featureFiles/graph_toolbar.feature
+++ b/frontend/cypress/integration/featureFiles/graph_toolbar.feature
@@ -1,0 +1,107 @@
+Feature: Kiali Graph page - Toolbar (various)
+
+  User opens the Graph page and manipulates the "error-rates" demo via Toolbar.
+
+  Background:
+    Given user is at administrator perspective
+
+# NOTE: Graph Display menu has its own test script
+#       - tests empty graph as well
+# NOTE: Graph Find/Hide has its own test script
+# NOTE: Graph Replay has its own test script
+
+@graph-page-toolbar
+Scenario: Graph alpha namespace with query params
+  When user graphs "alpha" namespaces with refresh "900000" and duration "300"
+  Then user sees the "alpha" namespace
+  And user sees selected graph duration "Last 5m"
+  And user sees selected graph refresh "Every 15m"
+
+@graph-page-toolbar
+Scenario: Open graph Tour
+  When user clicks graph tour
+  Then user "sees" graph tour
+
+@graph-page-toolbar
+Scenario: Close graph Tour
+  When user closes graph tour
+  Then user "does not see" graph tour
+
+@graph-page-toolbar
+Scenario: Open traffic dropdown
+  When user clicks graph traffic menu
+  Then user sees default graph traffic menu
+
+@graph-page-toolbar
+Scenario: Disable all traffic
+  When user disables all traffic
+  Then user does not see any traffic
+
+# todo: would be a better test if demos has tcp and/or grpc traffic
+@graph-page-toolbar
+Scenario: Enable http traffic
+  When user enables "http" traffic
+  Then user "sees" "http" traffic
+  And user "does not see" "tcp" traffic
+  And user "does not see" "grpc" traffic
+
+@graph-page-toolbar
+Scenario: Close traffic dropdown
+  When user clicks graph traffic menu
+  Then user does not see graph traffic menu
+
+@graph-page-display
+Scenario: User resets to factory default
+  When user resets to factory default
+  And user clicks graph traffic menu
+  Then user sees default graph traffic menu
+
+@graph-page-toolbar
+Scenario: Open duration dropdown
+  When user clicks graph duration menu
+  Then user sees graph duration menu
+
+@graph-page-toolbar
+Scenario: Close duration dropdown
+  When user clicks graph duration menu
+  Then user does not see graph duration menu
+
+@graph-page-toolbar
+Scenario: Set duration dropdown
+  When user selects graph duration "600"
+  Then user sees selected graph duration "Last 10m"
+
+@graph-page-toolbar
+Scenario: Open refresh dropdown
+  When user clicks graph refresh menu
+  Then user sees graph refresh menu
+
+@graph-page-toolbar
+Scenario: Close refresh dropdown
+  When user clicks graph refresh menu
+  Then user does not see graph refresh menu
+
+@graph-page-toolbar
+Scenario: Set refresh dropdown
+  When user selects graph refresh "0"  
+  Then user sees selected graph refresh "Pause"
+
+@graph-page-toolbar
+Scenario: graph type app
+  When user selects "APP" graph type
+  Then user sees a "app" graph
+
+@graph-page-toolbar
+Scenario: graph type service
+  When user selects "SERVICE" graph type
+  Then user sees a "service" graph
+
+@graph-page-toolbar
+Scenario: graph type versioned app
+  When user selects "VERSIONED_APP" graph type
+  Then user sees a "versionedApp" graph
+
+@graph-page-toolbar
+Scenario: graph type service
+  When user selects "WORKLOAD" graph type
+  Then user sees a "workload" graph

--- a/frontend/src/components/DurationDropdown/DurationDropdown.tsx
+++ b/frontend/src/components/DurationDropdown/DurationDropdown.tsx
@@ -11,6 +11,7 @@ import { UserSettingsActions } from '../../actions/UserSettingsActions';
 import { connect } from 'react-redux';
 import { HistoryManager, URLParam } from '../../app/History';
 import history from '../../app/History';
+import { TooltipPosition } from '@patternfly/react-core';
 
 type ReduxProps = {
   duration: DurationInSeconds;
@@ -21,7 +22,7 @@ type DurationDropdownProps = ReduxProps & {
   id: string;
   disabled?: boolean;
   tooltip?: string;
-  tooltipBottom?: boolean;
+  tooltipPosition?: TooltipPosition;
   nameDropdown?: string;
   suffix?: string;
   prefix?: string;
@@ -40,7 +41,7 @@ export class DurationDropdown extends React.Component<DurationDropdownProps> {
         label={durations[this.props.duration]}
         options={durations}
         tooltip={this.props.tooltip}
-        tooltipBottom={this.props.tooltipBottom}
+        tooltipPosition={this.props.tooltipPosition}
         nameDropdown={this.props.nameDropdown}
       />
     );

--- a/frontend/src/components/Refresh/Refresh.tsx
+++ b/frontend/src/components/Refresh/Refresh.tsx
@@ -11,6 +11,7 @@ import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import RefreshButtonContainer from './RefreshButton';
 import { GlobalActions } from '../../actions/GlobalActions';
 import { HistoryManager, URLParam } from 'app/History';
+import { TooltipPosition } from '@patternfly/react-core';
 
 type ReduxProps = {
   refreshInterval: IntervalInMilliseconds;
@@ -89,7 +90,7 @@ class Refresh extends React.PureComponent<Props, State> {
             label={REFRESH_INTERVALS[this.props.refreshInterval]}
             options={REFRESH_INTERVALS}
             tooltip={'Refresh interval'}
-            tooltipBottom={true}
+            tooltipPosition={TooltipPosition.left}
           />
           <RefreshButtonContainer handleRefresh={this.handleRefresh} disabled={this.props.disabled} />
         </>

--- a/frontend/src/components/Time/TimeDurationComponent.tsx
+++ b/frontend/src/components/Time/TimeDurationComponent.tsx
@@ -47,7 +47,7 @@ export class TimeDurationComponent extends React.PureComponent<TimeControlsProps
           prefix={prefix}
           suffix={suffix}
           tooltip={durationTooltip}
-          tooltipBottom={true}
+          tooltipPosition={TooltipPosition.left}
         />
         {!(this.props.supportsReplay && this.props.replayActive) && (
           <RefreshContainer

--- a/frontend/src/components/ToolbarDropdown/ToolbarDropdown.tsx
+++ b/frontend/src/components/ToolbarDropdown/ToolbarDropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Select, SelectOption, Tooltip } from '@patternfly/react-core';
+import { Select, SelectOption, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { style } from 'typestyle';
 
 const widthAuto = style({
@@ -22,7 +22,7 @@ type ToolbarDropdownProps = {
   nameDropdown?: string;
   options: object;
   tooltip?: string;
-  tooltipBottom?: boolean;
+  tooltipPosition?: TooltipPosition;
   value?: number | string;
   useName?: boolean;
   classNameSelect?: string;
@@ -101,7 +101,7 @@ export class ToolbarDropdown extends React.Component<ToolbarDropdownProps, Toolb
           <Tooltip
             key={'ot-' + this.props.id}
             entryDelay={1000}
-            position={this.props.tooltipBottom ? 'bottom' : 'top'}
+            position={this.props.tooltipPosition ? this.props.tooltipPosition : TooltipPosition.auto}
             content={<>{this.props.tooltip}</>}
           >
             {dropdownButton}

--- a/frontend/src/pages/Graph/GraphToolbar/GraphReset.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphReset.tsx
@@ -25,6 +25,7 @@ class GraphReset extends React.Component<GraphResetProps, GraphResetState> {
     return (
       <Tooltip key="factory_reset_settings" position="bottom" content="Reset to factory settings">
         <Button
+          id="graph-factory-reset"
           style={{ paddingLeft: '10px', paddingRight: '0px' }}
           variant={ButtonVariant.link}
           onClick={() => this.onReset()}

--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -212,6 +212,7 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
               <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content="Shortcuts and tips...">
                 <TourStopContainer info={GraphTourStops.Shortcuts}>
                   <Button
+                    id="graph-tour"
                     variant="link"
                     style={{ paddingLeft: '6px', paddingRight: '0px' }}
                     onClick={this.props.onToggleHelp}

--- a/make/Makefile.ui.mk
+++ b/make/Makefile.ui.mk
@@ -19,7 +19,7 @@ yarn-start:
 
 ## cypress-run: Runs all the cypress frontend integration tests locally without the GUI (i.e. headless).
 cypress-run:
-	@cd ${ROOTDIR}/frontend && yarn cypress:run --headless --env CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0 --env CYPRESS_VIDEO=false
+	@cd ${ROOTDIR}/frontend && yarn cypress:run --headless --env CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0 --config video=false
 
 ## cypress-gui: Opens the cypress GUI letting you pick which frontend integration tests to run locally.
 cypress-gui:

--- a/make/Makefile.ui.mk
+++ b/make/Makefile.ui.mk
@@ -19,7 +19,7 @@ yarn-start:
 
 ## cypress-run: Runs all the cypress frontend integration tests locally without the GUI (i.e. headless).
 cypress-run:
-	@cd ${ROOTDIR}/frontend && yarn cypress:run --headless --env CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0 --config video=false
+	@cd ${ROOTDIR}/frontend && yarn cypress:run --headless --config numTestsKeptInMemory=0,video=false
 
 ## cypress-gui: Opens the cypress GUI letting you pick which frontend integration tests to run locally.
 cypress-gui:


### PR DESCRIPTION
Toolbar tests not covered by other dedicated features.

Epic #4854 
Closes #4960 

- duration selection
- refresh selection
- graph type selection
- traffic selection
- graph factory-reset for traffic
- graph tour

Also:
- change tooltip positions for duration and refresh, it should not cover the
  menu (both for ux and also because it can break tests)
  - improve tooltip position option for affected dropdown components
- improve assertions in graph_display feature
- added graph factory reset test in graph_display feature
- fix cypress-run to not generate video
