### PR TITLE
[cypress] add health indicator checks for workloads and services lists

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -1,5 +1,5 @@
 import { And, Then, When } from 'cypress-cucumber-preprocessor/steps';
-import { getColWithRowText, ensureObjectsInTable } from './table';
+import { getColWithRowText, ensureObjectsInTable, checkHealthIndicatorInTable, checkHealthStatusInTable } from './table';
 
 // Choosing a random bookinfo app to test with.
 const APP = 'details';
@@ -58,13 +58,9 @@ Then('user only sees healthy apps', () => {
 });
 
 Then('the application should be listed as {string}', function (healthStatus: string) {
-  cy.get(`[data-test=VirtualItem_Ns${this.targetNamespace}_${this.targetApp}] svg[class=icon-${healthStatus}]`)
-      .should('exist');
+  checkHealthIndicatorInTable(this.targetNamespace, this.targetApp, healthStatus);
 });
 
 Then('the health status of the application should be {string}', function (healthStatus: string) {
-  cy.get(`[data-test=VirtualItem_Ns${this.targetNamespace}_${this.targetApp}] td:first-child span`)
-      .trigger('mouseenter');
-  cy.get(`[aria-label='Health indicator'] strong`)
-      .should('contain.text', healthStatus);
+  checkHealthStatusInTable(this.targetNamespace, this.targetApp, healthStatus);
 });

--- a/frontend/cypress/integration/common/services.ts
+++ b/frontend/cypress/integration/common/services.ts
@@ -31,10 +31,6 @@ And('the health column on the {string} row has a health icon', (row: string) => 
   );
 });
 
-When('I fetch the list of services', function () {
-  cy.visit('/console/services?refresh=0');
-});
-
 And('user filters for service type {string}', (serviceType: string) => {
   cy.get('select[aria-label="filter_select_type"]').parent().within(() => {
     cy.get('button').click();

--- a/frontend/cypress/integration/common/services.ts
+++ b/frontend/cypress/integration/common/services.ts
@@ -1,5 +1,25 @@
-import { And, When } from 'cypress-cucumber-preprocessor/steps';
-import { getColWithRowText } from './table';
+import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { checkHealthIndicatorInTable, checkHealthStatusInTable, getColWithRowText } from './table';
+
+Given('a service in the cluster with a healthy amount of traffic', function () {
+  this.targetNamespace = 'bookinfo';
+  this.targetService = 'productpage';
+});
+
+Given('a service in the cluster with no traffic', function () {
+  this.targetNamespace = 'default';
+  this.targetService = 'sleep';
+});
+
+Given('a service in the mesh with a failing amount of traffic', function () {
+  this.targetNamespace = 'alpha';
+  this.targetService = 'w-server';
+});
+
+Given('a service in the mesh with a degraded amount of traffic', function () {
+  this.targetNamespace = 'alpha';
+  this.targetService = 'y-server';
+});
 
 And('the {string} row is visible', (row: string) => {
   cy.get('table').contains('td', row);
@@ -9,6 +29,10 @@ And('the health column on the {string} row has a health icon', (row: string) => 
   getColWithRowText(row, 'Health').find(
     'svg[class=icon-healthy], svg[class=icon-unhealthy], svg[class=icon-degraded], svg[class=icon-na]'
   );
+});
+
+When('I fetch the list of services', function () {
+  cy.visit('/console/services?refresh=0');
 });
 
 And('user filters for service type {string}', (serviceType: string) => {
@@ -35,4 +59,12 @@ And('user should only see healthy services in the table', () => {
 
 When('user filters for label {string}', (label: string) => {
   cy.get('input[aria-label="filter_input_label_key"]').type(`${label}{enter}`);
+});
+
+Then('the service should be listed as {string}', function (healthStatus: string) {
+  checkHealthIndicatorInTable(this.targetNamespace, this.targetService, healthStatus);
+});
+
+Then('the health status of the service should be {string}', function (healthStatus: string) {
+  checkHealthStatusInTable(this.targetNamespace, this.targetService, healthStatus);
 });

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -136,3 +136,15 @@ export function ensureObjectsInTable(...names: string[]) {
     });
   });
 }
+
+export function checkHealthIndicatorInTable(targetNamespace: string, targetRowItemName: string, healthStatus: string) {
+  cy.get(`[data-test=VirtualItem_Ns${targetNamespace}_${targetRowItemName}] svg[class=icon-${healthStatus}]`)
+      .should('exist');
+}
+
+export function checkHealthStatusInTable(targetNamespace: string, targetRowItemName: string, healthStatus: string) {
+  cy.get(`[data-test=VirtualItem_Ns${targetNamespace}_${targetRowItemName}] td:first-child span`)
+      .trigger('mouseenter');
+  cy.get(`[aria-label='Health indicator'] strong`)
+      .should('contain.text', healthStatus);
+}

--- a/frontend/cypress/integration/common/workloads.ts
+++ b/frontend/cypress/integration/common/workloads.ts
@@ -1,4 +1,4 @@
-import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { And, Given, Then } from 'cypress-cucumber-preprocessor/steps';
 import { checkHealthIndicatorInTable, checkHealthStatusInTable } from "./table";
 
 Given('a healthy workload in the cluster', function () {
@@ -29,10 +29,6 @@ And('user filters for workload type {string}', (workloadType: string) => {
       cy.get(`button[label="${workloadType}"]`).click();
     });
   });
-
-When('I fetch the list of workloads', function () {
-    cy.visit('/console/workloads?refresh=0');
-});
 
 Then('user sees {string} in workloads table', (workload: string) => {
   cy.get('tbody').within(() => {

--- a/frontend/cypress/integration/common/workloads.ts
+++ b/frontend/cypress/integration/common/workloads.ts
@@ -1,4 +1,27 @@
-import { And, Then } from 'cypress-cucumber-preprocessor/steps';
+import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { checkHealthIndicatorInTable, checkHealthStatusInTable } from "./table";
+
+Given('a healthy workload in the cluster', function () {
+    this.targetNamespace = 'bookinfo';
+    this.targetWorkload = 'productpage-v1';
+});
+
+Given('an idle workload in the cluster', function () {
+    this.targetNamespace = 'default';
+    this.targetWorkload = 'sleep';
+
+    cy.exec('kubectl scale -n default --replicas=0 deployment/sleep');
+});
+
+Given('a failing workload in the mesh', function () {
+    this.targetNamespace = 'alpha';
+    this.targetWorkload = 'v-server';
+});
+
+Given('a degraded workload in the mesh', function () {
+    this.targetNamespace = 'alpha';
+    this.targetWorkload = 'b-client';
+});
 
 And('user filters for workload type {string}', (workloadType: string) => {
     cy.get('select[aria-label="filter_select_type"]').parent().within(() => {
@@ -6,6 +29,10 @@ And('user filters for workload type {string}', (workloadType: string) => {
       cy.get(`button[label="${workloadType}"]`).click();
     });
   });
+
+When('I fetch the list of workloads', function () {
+    cy.visit('/console/workloads?refresh=0');
+});
 
 Then('user sees {string} in workloads table', (workload: string) => {
   cy.get('tbody').within(() => {
@@ -25,3 +52,11 @@ And('user should only see healthy workloads in workloads table', () => {
       cy.get('svg[class=icon-unhealthy], svg[class=icon-degraded], svg[class=icon-na]').should('not.exist');
     });
   });
+
+Then('the workload should be listed as {string}', function (healthStatus: string) {
+    checkHealthIndicatorInTable(this.targetNamespace, this.targetWorkload, healthStatus);
+});
+
+Then('the health status of the workload should be {string}', function (healthStatus: string) {
+    checkHealthStatusInTable(this.targetNamespace, this.targetWorkload, healthStatus);
+});

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -60,3 +60,34 @@ Feature: Kiali Services page
     And user filters for label "app=productpage"
     Then user sees "productpage" in the table
     And table length should be 1
+
+  @services-page
+  Scenario: The healthy status of a service is reported in the list of services
+    Given a service in the cluster with a healthy amount of traffic
+    When I fetch the list of services
+    And user selects the "bookinfo" namespace
+    Then the service should be listed as "healthy"
+
+  @services-page
+  Scenario: The idle status of a service is reported in the list of services
+    Given a service in the cluster with no traffic
+    When I fetch the list of services
+    And user selects the "default" namespace
+    Then the service should be listed as "na"
+    And the health status of the service should be "No health information"
+
+  @services-page
+  Scenario: The failing status of a service is reported in the list of services
+    Given a service in the mesh with a failing amount of traffic
+    When I fetch the list of services
+    And user selects the "alpha" namespace
+    Then the service should be listed as "failure"
+    And the health status of the service should be "Failure"
+
+  @services-page
+  Scenario: The degraded status of a service is reported in the list of services
+    Given a service in the mesh with a degraded amount of traffic
+    When I fetch the list of services
+    And user selects the "alpha" namespace
+    Then the service should be listed as "degraded"
+    And the health status of the service should be "Degraded"

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -5,10 +5,10 @@ Feature: Kiali Services page
   Background:
     Given user is at administrator perspective
     And user is at the "services" page
-    And user selects the "bookinfo" namespace
 
   @services-page
   Scenario: See a table with correct info
+    When user selects the "bookinfo" namespace
     Then user sees a table with headings
       | Health | Name | Namespace | Labels | Configuration | Details |
     And the "productpage" row is visible
@@ -22,41 +22,47 @@ Feature: Kiali Services page
     And the "Details" column on the "productpage" row has a link ending in "/namespaces/bookinfo/istio/gateways/bookinfo-gateway"
 
   @services-page
-  Scenario: Filter services table by Service Name 
-    When user selects filter "Service Name"
+  Scenario: Filter services table by Service Name
+    When user selects the "bookinfo" namespace
+    And user selects filter "Service Name"
     And user filters for name "productpage"
     Then user sees "productpage" in the table
     And table length should be 1
   
   @services-page
   Scenario: Filter services table by Service Type
-    When user selects filter "Service Type"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Service Type"
     And user filters for service type "External"
     Then user sees "nothing" in the table
   
   @services-page
   Scenario: Filter services table by sidecar
-    When user selects filter "Istio Sidecar"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Istio Sidecar"
     And user filters for sidecar "Present"
     Then user sees "something" in the table
 
   @services-page
   Scenario: Filter services table by Istio Type
-    When user selects filter "Istio Type"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Istio Type"
     And user filters for istio type "VirtualService"
     Then user sees "productpage" in the table
     And table length should be 1
   
   @services-page
   Scenario: Filter services table by health
-    When user selects filter "Health"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Health"
     And user filters for health "Healthy"
     Then user sees "something" in the table
     And user should only see healthy services in the table
 
   @services-page
   Scenario: Filter services table by label
-    When user selects filter "Label"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Label"
     And user filters for label "app=productpage"
     Then user sees "productpage" in the table
     And table length should be 1
@@ -64,30 +70,26 @@ Feature: Kiali Services page
   @services-page
   Scenario: The healthy status of a service is reported in the list of services
     Given a service in the cluster with a healthy amount of traffic
-    When I fetch the list of services
-    And user selects the "bookinfo" namespace
+    When user selects the "bookinfo" namespace
     Then the service should be listed as "healthy"
 
   @services-page
   Scenario: The idle status of a service is reported in the list of services
     Given a service in the cluster with no traffic
-    When I fetch the list of services
-    And user selects the "default" namespace
+    When user selects the "default" namespace
     Then the service should be listed as "na"
     And the health status of the service should be "No health information"
 
   @services-page
   Scenario: The failing status of a service is reported in the list of services
     Given a service in the mesh with a failing amount of traffic
-    When I fetch the list of services
-    And user selects the "alpha" namespace
+    When user selects the "alpha" namespace
     Then the service should be listed as "failure"
     And the health status of the service should be "Failure"
 
   @services-page
   Scenario: The degraded status of a service is reported in the list of services
     Given a service in the mesh with a degraded amount of traffic
-    When I fetch the list of services
-    And user selects the "alpha" namespace
+    When user selects the "alpha" namespace
     Then the service should be listed as "degraded"
     And the health status of the service should be "Degraded"

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -5,10 +5,10 @@ Feature: Kiali Workloads page
   Background:
     Given user is at administrator perspective
     And user is at the "workloads" page
-    And user selects the "bookinfo" namespace
 
   @workloads-page
   Scenario: See a table with correct info
+    When user selects the "bookinfo" namespace
     Then user sees a table with headings
       | Health | Name | Namespace | Type | Labels | Details |
     And the "details-v1" row is visible
@@ -21,40 +21,46 @@ Feature: Kiali Workloads page
     And the "Details" column on the "details-v1" row is empty
 
   @workloads-page
-  Scenario: Filter workloads table by Workloads Name 
-    When user selects filter "Workload Name"
+  Scenario: Filter workloads table by Workloads Name
+    When user selects the "bookinfo" namespace
+    And user selects filter "Workload Name"
     And user filters for name "details-v1"
     Then user sees "details-v1" in the table
     And table length should be 1
 
   @workloads-page
   Scenario: Filter workloads table by Workloads Type
-    When user selects filter "Workload Type"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Workload Type"
     And user filters for workload type "StatefulSet"
     Then user sees "no workloads" in workloads table    
 
   @workloads-page
   Scenario: Filter workloads table by sidecar
-    When user selects filter "Istio Sidecar"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Istio Sidecar"
     And user filters for sidecar "Present"
     Then user sees "workloads" in workloads table
 
  @workloads-page
   Scenario: Filter workloads table by Istio Type
-    When user selects filter "Istio Type"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Istio Type"
     And user filters for istio type "VirtualService"    
     Then user sees "no workloads" in workloads table
   
   @workloads-page
   Scenario: Filter workloads table by health
-    When user selects filter "Health"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Health"
     And user filters for health "Healthy"
     Then user sees "workloads" in workloads table
     And user should only see healthy workloads in workloads table
 
   @workloads-page
   Scenario: Filter workloads table by label
-    When user selects filter "Label"
+    When user selects the "bookinfo" namespace
+    And user selects filter "Label"
     And user filters for label "app=details"
     Then user sees "details-v1" in the table
     And table length should be 1
@@ -62,30 +68,26 @@ Feature: Kiali Workloads page
   @workloads-page
   Scenario: The healthy status of a workload is reported in the list of workloads
     Given a healthy workload in the cluster
-    When I fetch the list of workloads
-    And user selects the "bookinfo" namespace
+    When user selects the "bookinfo" namespace
     Then the workload should be listed as "healthy"
 
   @workloads-page
   Scenario: The idle status of a workload is reported in the list of workloads
     Given an idle workload in the cluster
-    When I fetch the list of workloads
-    And user selects the "default" namespace
+    When user selects the "default" namespace
     Then the workload should be listed as "idle"
     And the health status of the workload should be "Not Ready"
 
   @workloads-page
   Scenario: The failing status of a workload is reported in the list of workloads
     Given a failing workload in the mesh
-    When I fetch the list of workloads
-    And user selects the "alpha" namespace
+    When user selects the "alpha" namespace
     Then the workload should be listed as "failure"
     And the health status of the workload should be "Failure"
 
   @workloads-page
   Scenario: The degraded status of a workload is reported in the list of workloads
     Given a degraded workload in the mesh
-    When I fetch the list of workloads
-    And user selects the "alpha" namespace
+    When user selects the "alpha" namespace
     Then the workload should be listed as "degraded"
     And the health status of the workload should be "Degraded"

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -58,3 +58,34 @@ Feature: Kiali Workloads page
     And user filters for label "app=details"
     Then user sees "details-v1" in the table
     And table length should be 1
+
+  @workloads-page
+  Scenario: The healthy status of a workload is reported in the list of workloads
+    Given a healthy workload in the cluster
+    When I fetch the list of workloads
+    And user selects the "bookinfo" namespace
+    Then the workload should be listed as "healthy"
+
+  @workloads-page
+  Scenario: The idle status of a workload is reported in the list of workloads
+    Given an idle workload in the cluster
+    When I fetch the list of workloads
+    And user selects the "default" namespace
+    Then the workload should be listed as "idle"
+    And the health status of the workload should be "Not Ready"
+
+  @workloads-page
+  Scenario: The failing status of a workload is reported in the list of workloads
+    Given a failing workload in the mesh
+    When I fetch the list of workloads
+    And user selects the "alpha" namespace
+    Then the workload should be listed as "failure"
+    And the health status of the workload should be "Failure"
+
+  @workloads-page
+  Scenario: The degraded status of a workload is reported in the list of workloads
+    Given a degraded workload in the mesh
+    When I fetch the list of workloads
+    And user selects the "alpha" namespace
+    Then the workload should be listed as "degraded"
+    And the health status of the workload should be "Degraded"


### PR DESCRIPTION
Add cypress tests for health indicators in workloads and services list pages.

Looks like tests in the overview page does not apply, since the health indicator on overview is focused only on apps.