### PR TITLE
[e2e] Added a support of new env variable OC_COMMAND

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -10,7 +10,7 @@
 ## Environment Setup
 
 * System dependencies that will need to be available
-    *  `oc`
+    *  `oc` or `kubectl`
     *  `go`
     *  `make`
     *  `npm`
@@ -70,7 +70,7 @@ $ git clone https://github.com/kiali/kiali.git
 $ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app.kubernetes.io/name=kiali -o name) 20001:20001
 
 # Run all tests using the Kiali port-forward proxy and authenticated as the Kiali service account
-$ make test-integration -e URL="http://localhost:20001/kiali" -e TOKEN="$(kubectl get -n istio-system $(kubectl get secret -n istio-system -o name | grep 'kiali.*-token' | head -n 1) -o jsonpath={.data.token} | base64 -d)"
+$ make test-integration -e OC_COMMAND="kubectl" -e URL="http://localhost:20001/kiali" -e TOKEN="$(kubectl get -n istio-system $(kubectl get secret -n istio-system -o name | grep 'kiali.*-token' | head -n 1) -o jsonpath={.data.token} | base64 -d)"
 
 # test results are stored in the "tests/integration/junit-rest-report.xml" file
 ```

--- a/tests/integration/utils/exec_client.go
+++ b/tests/integration/utils/exec_client.go
@@ -1,14 +1,26 @@
 package utils
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/kiali/kiali/log"
 )
 
+var ocCommand = NewExecCommand()
+
+func NewExecCommand() string {
+	command := os.Getenv("OC_COMMAND")
+	if command != "" {
+		return command
+	} else {
+		return "oc"
+	}
+}
+
 func ApplyFile(yamlFile, namespace string) bool {
-	cmd := exec.Command("oc", "apply", "-n="+namespace, "-f="+yamlFile)
+	cmd := exec.Command(ocCommand, "apply", "-n="+namespace, "-f="+yamlFile)
 	stdout, err := cmd.Output()
 
 	if err != nil {
@@ -20,7 +32,7 @@ func ApplyFile(yamlFile, namespace string) bool {
 }
 
 func DeleteFile(yamlFile, namespace string) bool {
-	cmd := exec.Command("oc", "delete", "-n="+namespace, "-f="+yamlFile)
+	cmd := exec.Command(ocCommand, "delete", "-n="+namespace, "-f="+yamlFile)
 	stdout, err := cmd.Output()
 
 	if err != nil {


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4826

Added support of providing oc or kubectl command name to execute.

So now, for executing e2e integration tests on environment where `oc` command is not available, but `kubectl` is there, the `-e OC_COMMAND="kubectl"` env variable should be provided.