### PR TITLE
Wait for given namespace to be removed when uninstalling bookinfo app

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -200,6 +200,15 @@ if [ "${DELETE_BOOKINFO}" == "true" ]; then
   else
     $CLIENT_EXE delete namespace ${NAMESPACE}
   fi
+  # It takes some time to delete the namespace, let's wait for that
+  echo -n "Waiting for ${NAMESPACE} to be deleted..."
+  while $CLIENT_EXE get namespace ${NAMESPACE} &> /dev/null
+  do
+    echo -n '.'
+    sleep 10
+  done
+  echo ""
+
   echo "====== BOOKINFO UNINSTALLED ====="
   exit 0
 fi

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -197,18 +197,11 @@ if [ "${DELETE_BOOKINFO}" == "true" ]; then
     fi
     $CLIENT_EXE delete scc bookinfo-scc
     $CLIENT_EXE delete project ${NAMESPACE}
+    # oc delete project does not wait for a namespace to be removed, we need to also call 'oc delete namespace'
+    $CLIENT_EXE delete namespace ${NAMESPACE}
   else
     $CLIENT_EXE delete namespace ${NAMESPACE}
   fi
-  # It takes some time to delete the namespace, let's wait for that
-  echo -n "Waiting for ${NAMESPACE} to be deleted..."
-  while $CLIENT_EXE get namespace ${NAMESPACE} &> /dev/null
-  do
-    echo -n '.'
-    sleep 10
-  done
-  echo ""
-
   echo "====== BOOKINFO UNINSTALLED ====="
   exit 0
 fi


### PR DESCRIPTION
In cases when the CI is removing existing demo app and installing new one, it often fails because the removal operation is not blocking and the namespace is still being terminated when trying to install new app there.
This will wait for namespace to be removed.

There is no timeout defined but if it ever gets stuck on this operation, it will require manual interaction with the cluster anyway.

