### PR TITLE
Bring back the black background for login page

### DIFF
--- a/frontend/src/styles/_overrides.scss
+++ b/frontend/src/styles/_overrides.scss
@@ -43,13 +43,11 @@ $color-grey-background-border: #ccc;
 }
 */
 
-/*
 .pf-c-login,
 .login-pf {
   background-image: none;
   background-color: #030303;
 }
-*/
 
 // Menu thin and remove margin in top
 /*


### PR DESCRIPTION
Epic #4260 

@lucasponce This just brings back the black background for the login page.  I think I will also create a new issue to update the login page to use more current PF components and styling, but it was too risky at this time.  Let;s just merge this for the 1.51 build.