### PR TITLE
Fix package.json version and release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
         sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
 
         # UI version
-        jq -r '.version |= "$(RELEASE_VERSION)"' frontend/package.json > frontend/package.json.tmp
+        jq -r '.version |= "${RELEASE_VERSION:1}"' frontend/package.json > frontend/package.json.tmp
         mv frontend/package.json.tmp frontend/package.json
 
 
@@ -293,7 +293,7 @@ jobs:
       run: |
         sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $NEXT_VERSION-SNAPSHOT/" Makefile
 
-        jq -r ".version |= \"$NEXT_VERSION\"" frontend/package.json > frontend/package.json.tmp
+        jq -r ".version |= \"${NEXT_VERSION:1}\"" frontend/package.json > frontend/package.json.tmp
         mv frontend/package.json.tmp frontend/package.json
 
         git add Makefile frontend/package.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiali/kiali-ui",
-  "version": "v1.52.0",
+  "version": "1.52.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
   "keywords": [
     "istio service mesh",


### PR DESCRIPTION
In the last release, the package.json version did not match the requirements of the version checker, it has an extra "v" prefixed. 

This PR fix the version and also the pipeline that modifies that.

Next time the version checker should pass.