### PR TITLE
Add graph find/hide cypress tests

### DIFF
--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -1,4 +1,5 @@
 import { Before, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { ensureKialiFinishedLoading } from './transition';
 
 const url = '/console';
 
@@ -20,7 +21,12 @@ Before(() => {
 
 When('user graphs {string} namespaces', namespaces => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
+  cy.intercept('/api/namespaces/graph*').as('graphNamespaces');
   cy.visit(url + `/graph/namespaces?refresh=0&namespaces=${namespaces}`);
+  if (namespaces !== '') {
+    cy.wait('@graphNamespaces');
+  }
+  ensureKialiFinishedLoading();
 });
 
 When('user opens display menu', () => {
@@ -88,7 +94,7 @@ When('user {string} {string} option', (action, option: string) => {
 });
 
 When('user resets to factory default', () => {
-  cy.get('button#graph-factory-reset').click()
+  cy.get('button#graph-factory-reset').click();
   cy.get('#loading_kiali_spinner').should('not.exist');
 });
 

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -21,7 +21,7 @@ Before(() => {
 
 When('user graphs {string} namespaces', namespaces => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
-  cy.intercept('/api/namespaces/graph*').as('graphNamespaces');
+  cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
   cy.visit(url + `/graph/namespaces?refresh=0&namespaces=${namespaces}`);
   if (namespaces !== '') {
     cy.wait('@graphNamespaces');

--- a/frontend/cypress/integration/common/graph_find_hide.ts
+++ b/frontend/cypress/integration/common/graph_find_hide.ts
@@ -1,0 +1,116 @@
+import { And, Then, When } from 'cypress-cucumber-preprocessor/steps';
+
+function clearFindAndHide() {
+  cy.get('#graph_hide').clear();
+  cy.get('#graph_find').clear();
+}
+
+Then('user finds unhealthy workloads', () => {
+  clearFindAndHide();
+  cy.get('#graph_find').type('!healthy{enter}');
+});
+
+Then('user sees unhealthy workloads highlighted on the graph', () => {
+  const expectedUnhealthyNodes = [
+    {
+      app: 'v-server',
+      version: 'v1',
+      namespace: 'alpha'
+    },
+    {
+      app: 'w-server',
+      version: 'v1',
+      namespace: 'alpha'
+    },
+    {
+      app: 'w-server',
+      version: undefined, // Service does not have version
+      namespace: 'alpha'
+    }
+  ];
+  cy.waitForReact();
+  cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
+    .getCurrentState()
+    .then(state => {
+      const unhealthyNodes = state.cy
+        .nodes()
+        .filter(node => node.classes().includes('find'))
+        .map(node => ({ app: node.data('app'), version: node.data('version'), namespace: node.data('namespace') }));
+      expect(unhealthyNodes).to.include.deep.members(expectedUnhealthyNodes);
+    });
+});
+
+Then('user sees nothing highlighted on the graph', () => {
+  cy.contains('Loading Graph').should('not.exist');
+
+  cy.waitForReact();
+  cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
+    .getCurrentState()
+    .then(state => {
+      expect(state.cy.nodes().filter(node => node.classes().includes('find')).length).to.equal(0);
+    });
+});
+
+When('user hides unhealthy workloads', () => {
+  clearFindAndHide();
+  cy.get('#graph_hide').type('!healthy{enter}');
+});
+
+Then('user sees no unhealthy workloads on the graph', () => {
+  cy.waitForReact();
+  cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
+    .getCurrentState()
+    .then(state => {
+      const noUnhealthy = state.cy
+        .nodes()
+        // Unhealthy boxes are fine.
+        .every(node => node.data('healthStatus') !== 'Failure' || node.data('nodeType') === 'box');
+      expect(noUnhealthy).to.be.true;
+    });
+});
+
+Then('user sees preset find options', () => {
+  cy.getBySel('find-options-dropdown').click();
+  cy.contains('Find: unhealthy nodes');
+});
+
+When('user selects the preset the find option {string}', (option: string) => {
+  cy.get('#graph-find-presets').contains(option).click();
+});
+
+Then('user sees preset hide options', () => {
+  cy.getBySel('hide-options-dropdown').click();
+  cy.contains('Hide: healthy nodes');
+});
+
+When('user selects the preset hide option {string}', (option: string) => {
+  cy.get('#graph-hide-presets').contains(option).click();
+});
+
+Then('user sees no healthy workloads on the graph', () => {
+  cy.waitForReact();
+  cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
+    .getCurrentState()
+    .then(state => {
+      const noHealthy = state.cy
+        .nodes()
+        .every(node => node.data('healthStatus') !== 'Healthy' || node.data('nodeType') === 'box');
+      expect(noHealthy).to.be.true;
+    });
+});
+
+When('user seeks help for find and hide', () => {
+  cy.getBySel('graph-find-hide-help-button').click();
+});
+
+Then('user sees the help menu', () => {
+  cy.getBySel('graph-find-hide-help').should('be.visible');
+});
+
+And('the help menu has info on {string}', (helpMenuItem: string) => {
+  cy.get('#graph_find_help_tabs').contains(helpMenuItem).should('be.visible').click();
+});

--- a/frontend/cypress/integration/featureFiles/graph_find_hide.feature
+++ b/frontend/cypress/integration/featureFiles/graph_find_hide.feature
@@ -1,0 +1,45 @@
+
+Feature: Kiali Graph page - Find/Hide 
+
+  User opens the Graph page and manipulates the "error-rates" demo.
+  The find/hide feature lets the user either highlight or hide nodes 
+  on the graph that match the query expression. Some preset queries
+  allow the user to easily get started using find/hide and a help
+  section describes in more detail how to use find/hide.
+
+  Background:
+    Given user is at administrator perspective
+    And user graphs "alpha,beta" namespaces
+
+  @graph-page-find-hide
+  Scenario: Find unhealthy workloads
+    Then user sees nothing highlighted on the graph
+    When user finds unhealthy workloads
+    Then user sees unhealthy workloads highlighted on the graph
+
+  @graph-page-find-hide
+  Scenario: Hide unhealthy workloads
+    When user hides unhealthy workloads
+    Then user sees no unhealthy workloads on the graph
+
+  @graph-page-find-hide
+  Scenario: Use preset find option to filter workloads
+    Then user sees preset find options
+    When user selects the preset the find option "Find: unhealthy nodes"
+    Then user sees unhealthy workloads highlighted on the graph
+  
+  @graph-page-find-hide
+  Scenario: Use preset hide option to filter workloads
+    Then user sees preset hide options
+    When user selects the preset hide option "Hide: healthy nodes"
+    Then user sees no healthy workloads on the graph
+
+  @graph-page-find-hide
+  Scenario: Show Graph Find/Hide help menu
+    When user seeks help for find and hide
+    Then user sees the help menu
+    And the help menu has info on "Examples"
+    And the help menu has info on "Nodes"
+    And the help menu has info on "Edges"
+    And the help menu has info on "Operators"
+    And the help menu has info on "Usage Notes"

--- a/frontend/src/pages/Graph/GraphHelpFind.tsx
+++ b/frontend/src/pages/Graph/GraphHelpFind.tsx
@@ -59,6 +59,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
           onResize={this.onResize}
         />
         <Popover
+          data-test="graph-find-hide-help"
           className={popoverStyle}
           position={PopoverPosition.auto}
           isVisible={true}

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -324,13 +324,23 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
             )}
             {this.props.showFindHelp ? (
               <GraphHelpFind onClose={this.toggleFindHelp}>
-                <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
+                <Button
+                  data-test="graph-find-hide-help-button"
+                  variant={ButtonVariant.link}
+                  style={{ paddingLeft: '6px' }}
+                  onClick={this.toggleFindHelp}
+                >
                   <KialiIcon.Info className={defaultIconStyle} />
                 </Button>
               </GraphHelpFind>
             ) : (
               <Tooltip key={'ot_graph_find_help'} position="top" content="Find/Hide Help...">
-                <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
+                <Button
+                  data-test="graph-find-hide-help-button"
+                  variant={ButtonVariant.link}
+                  style={{ paddingLeft: '6px' }}
+                  onClick={this.toggleFindHelp}
+                >
                   <KialiIcon.Info className={defaultIconStyle} />
                 </Button>
               </Tooltip>

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
@@ -37,9 +37,14 @@ export class GraphFindOptions extends React.PureComponent<GraphFindOptionsProps,
     return (
       <Dropdown
         key={`graph-${this.props.kind}-presets`}
-        id="graph-findhide-presets"
+        id={`graph-${this.props.kind}-presets`}
         toggle={
-          <DropdownToggle className={dropdown} toggleIndicator={null} onToggle={this.onToggle}>
+          <DropdownToggle
+            data-test={`${this.props.kind}-options-dropdown`}
+            className={dropdown}
+            toggleIndicator={null}
+            onToggle={this.onToggle}
+          >
             <KialiIcon.AngleDown />
           </DropdownToggle>
         }


### PR DESCRIPTION
Adds cypress tests for graph find/hide.

Tests:
- Finding unhealthy nodes
- Hiding unhealthy nodes
- Using find/hide presets
- Opening help menu

Fixes: #5073 