### PR TITLE
Display multiple condition values as comma-separated string

### DIFF
--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -103,10 +103,10 @@ class RuleList extends React.Component<Props> {
                         <b>key</b>: [{whenItem.key}]
                       </span>
                       <span style={{ marginLeft: 5 }}>
-                        <b>values:</b> [{whenItem.values}]
+                        <b>values:</b> [{whenItem.values ? whenItem.values.join(',') : ''}]
                       </span>
                       <span style={{ marginLeft: 5 }}>
-                        <b>notValues:</b> [{whenItem.notValues}]
+                        <b>notValues:</b> [{whenItem.notValues ? whenItem.notValues.join(',') : ''}]
                       </span>
                     </div>
                   );

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
@@ -38,12 +38,12 @@ class ConditionList extends React.Component<Props> {
             <b>key: </b> [{condition.key}]<br />
             {condition.values && (
               <>
-                <b>values: </b> [{condition.values.toString()}]<br />
+                <b>values: </b> [{condition.values.join(',')}]<br />
               </>
             )}
             {condition.notValues && (
               <>
-                <b>notValues: </b> [{condition.notValues.toString()}]<br />
+                <b>notValues: </b> [{condition.notValues.join(',')}]<br />
               </>
             )}
           </>,

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
@@ -38,12 +38,12 @@ class ConditionList extends React.Component<Props> {
             <b>key: </b> [{condition.key}]<br />
             {condition.values && (
               <>
-                <b>values: </b> [{condition.values}]<br />
+                <b>values: </b> [{condition.values.toString()}]<br />
               </>
             )}
             {condition.notValues && (
               <>
-                <b>notValues: </b> [{condition.notValues}]<br />
+                <b>notValues: </b> [{condition.notValues.toString()}]<br />
               </>
             )}
           </>,


### PR DESCRIPTION
** Describe the change **

- Use `.join(',')` to display condition values and notValues as comma-separated string
- Update this in ConditionList and RuleList

** Issue reference **

- Fixes #5111 