### PR TITLE
CI - Install frontend deps only once

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -19,13 +19,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.build_branch }}
-          
+
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: "14"
           cache: yarn
-          cache-dependency-path: frontend/yarn.lock
+          cache-dependency-path: |
+            frontend/yarn.lock
+            ~/.cache/Cypress
 
       - name: Build
         run: make clean-all build-ui

--- a/.github/workflows/integration-tests-frontend.yml
+++ b/.github/workflows/integration-tests-frontend.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           node-version: "14"
           cache: yarn
-          cache-dependency-path: frontend/yarn.lock
+          cache-dependency-path: |
+            frontend/yarn.lock
+            ~/.cache/Cypress
 
       - name: Download go binary
         uses: actions/download-artifact@v3

--- a/.github/workflows/integration-tests-frontend.yml
+++ b/.github/workflows/integration-tests-frontend.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           working-directory: frontend
           command: yarn run cypress:run
+          # All deps should already be installed.
+          install: false
         env:
           CYPRESS_BASE_URL: ${{ steps.set-kiali-url.outputs.kiali_url }}
           CYPRESS_NUM_TESTS_KEPT_IN_MEMORY: 0


### PR DESCRIPTION
Cypress plugin does its own install of deps. This is already done in a previous step and unnecessary.