### PR TITLE
Outbound traffic in Overview cards. Added dropdown.

### DIFF
--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -125,9 +125,9 @@ When(`user selects {string} time range`, (interval) => {
         .should('not.exist');
 });
 
-When(`user selects {string} traffic duration`, (duration) => {
+When(`user selects {string} traffic direction`, (direction) => {
     let innerId = '';
-    switch (duration) {
+    switch (direction) {
         case 'Outbound':
             innerId = 'outbound';
             break;

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -125,6 +125,26 @@ When(`user selects {string} time range`, (interval) => {
         .should('not.exist');
 });
 
+When(`user selects {string} traffic duration`, (duration) => {
+    let innerId = '';
+    switch (duration) {
+        case 'Outbound':
+            innerId = 'outbound';
+            break;
+        case 'Inbound':
+            innerId = 'inbound';
+            break;
+    }
+    cy.get('button[aria-labelledby^="direction-type"]')
+        .click()
+        .get('#loading_kiali_spinner')
+        .should('not.exist');
+    cy.get(`li[id="${innerId}"]`).children('button')
+        .click()
+        .get('#loading_kiali_spinner')
+        .should('not.exist');
+});
+
 When('I fetch the overview of the cluster', function () {
     cy.visit('/console/overview?refresh=0');
 });
@@ -170,8 +190,8 @@ Then(`user sees the {string} namespace list`, (nslist) => {
         });
 });
 
-Then(`user sees the {string} namespace with Inbound traffic {string}`, (ns, duration) => {
-    cy.get('article[data-test^="' + ns + '"]').find('span[data-test="sparkline-duration-' + duration + '"]');
+Then(`user sees the {string} namespace with {string} traffic {string}`, (ns, direction, duration) => {
+    cy.get('article[data-test^="' + ns + '"]').find('span[data-test="sparkline-' + direction + '-duration-' + duration + '"]');
 });
 
 Then('there should be a {string} application indicator in the namespace', function (healthStatus: string) {

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -80,7 +80,7 @@ Feature: Kiali Overview page
   @overview-page
   Scenario: Last 10 minutes Outbound traffic
     When user selects "Last 10m" time range
-    And user selects "Outbound" traffic duration
+    And user selects "Outbound" traffic direction
     Then user sees the "alpha" namespace with "outbound" traffic "10m"
 
   @overview-page

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -75,7 +75,13 @@ Feature: Kiali Overview page
   @overview-page
   Scenario: Last 10 minutes
     When user selects "Last 10m" time range
-    Then user sees the "alpha" namespace with Inbound traffic "10m"
+    Then user sees the "alpha" namespace with "inbound" traffic "10m"
+
+  @overview-page
+  Scenario: Last 10 minutes Outbound traffic
+    When user selects "Last 10m" time range
+    And user selects "Outbound" traffic duration
+    Then user sees the "alpha" namespace with "outbound" traffic "10m"
 
   @overview-page
   Scenario: The healthy status of a logical mesh application is reported in the overview of a namespace

--- a/frontend/src/app/History.ts
+++ b/frontend/src/app/History.ts
@@ -53,6 +53,7 @@ export enum URLParam {
   JAEGER_SPAN_ID = 'spanId',
   NAMESPACES = 'namespaces',
   OVERVIEW_TYPE = 'otype',
+  DIRECTION_TYPE = 'drtype',
   QUANTILES = 'quantiles',
   RANGE_DURATION = 'rangeDuration',
   REFRESH_INTERVAL = 'refresh',

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -154,6 +154,7 @@ export const status: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
           duration={FilterHelper.currentDuration()}
           status={ns.status}
           type={OverviewToolbar.currentOverviewType()}
+          direction={OverviewToolbar.currentDirectionType()}
           metrics={ns.metrics}
           errorMetrics={ns.errorMetrics}
         />

--- a/frontend/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/frontend/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -27,7 +27,8 @@ class OverviewCardContentExpanded extends React.Component<Props> {
         <div
           style={{
             width: '100%',
-            height: 90,
+            height: 100,
+            paddingTop: 10,
             verticalAlign: 'top'
           }}
         >

--- a/frontend/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/frontend/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DEGRADED, FAILURE, HEALTHY, NOT_READY } from '../../types/Health';
 import OverviewStatus from './OverviewStatus';
-import { OverviewType } from './OverviewToolbar';
+import { OverviewType, DirectionType } from './OverviewToolbar';
 import { NamespaceStatus } from './NamespaceInfo';
 import { switchType } from './OverviewHelper';
 import { Paths } from '../../config';
@@ -14,6 +14,7 @@ type Props = {
   type: OverviewType;
   duration: DurationInSeconds;
   status: NamespaceStatus;
+  direction: DirectionType
   metrics?: Metric[];
   errorMetrics?: Metric[];
 };
@@ -34,6 +35,7 @@ class OverviewCardContentExpanded extends React.Component<Props> {
             metrics={this.props.metrics}
             errorMetrics={this.props.errorMetrics}
             duration={this.props.duration}
+            direction={this.props.direction}
           />
         </div>
       </>

--- a/frontend/src/pages/Overview/OverviewCardSparkline.tsx
+++ b/frontend/src/pages/Overview/OverviewCardSparkline.tsx
@@ -47,10 +47,10 @@ class OverviewCardSparkline extends React.Component<Props, {}> {
           <span data-test={'sparkline-' + this.props.direction.toLowerCase() + '-duration-' + getName(this.props.duration).toLowerCase()}>{this.props.direction + ' traffic, ' + getName(this.props.duration).toLowerCase()}</span>
           <SparklineChart
             name={'traffic'}
-            height={60}
+            height={65}
             showLegend={false}
             showYAxis={true}
-            padding={{ top: 5, left: 30 }}
+            padding={{ top: 10, left: 30 }}
             tooltipFormat={dp => `${(dp.x as Date).toLocaleTimeString()}\n${dp.y} ${dp.name}`}
             series={series}
           />

--- a/frontend/src/pages/Overview/OverviewCardSparkline.tsx
+++ b/frontend/src/pages/Overview/OverviewCardSparkline.tsx
@@ -44,7 +44,7 @@ class OverviewCardSparkline extends React.Component<Props, {}> {
 
       return (
         <>
-          <span data-test={'sparkline-duration-' + getName(this.props.duration).toLowerCase()}>{this.props.direction + ' traffic, ' + getName(this.props.duration).toLowerCase()}</span>
+          <span data-test={'sparkline-' + this.props.direction.toLowerCase() + '-duration-' + getName(this.props.duration).toLowerCase()}>{this.props.direction + ' traffic, ' + getName(this.props.duration).toLowerCase()}</span>
           <SparklineChart
             name={'traffic'}
             height={60}

--- a/frontend/src/pages/Overview/OverviewCardSparkline.tsx
+++ b/frontend/src/pages/Overview/OverviewCardSparkline.tsx
@@ -9,11 +9,13 @@ import { toVCLine } from 'utils/VictoryChartsUtils';
 
 import 'components/Charts/Charts.css';
 import { RichDataPoint, VCLine } from 'types/VictoryChartInfo';
+import {DirectionType} from "./OverviewToolbar";
 
 type Props = {
   metrics?: Metric[];
   errorMetrics?: Metric[];
   duration: DurationInSeconds;
+  direction: DirectionType;
 };
 
 function showMetrics(metrics: Metric[] | undefined): boolean {
@@ -42,7 +44,7 @@ class OverviewCardSparkline extends React.Component<Props, {}> {
 
       return (
         <>
-          <span data-test={'sparkline-duration-' + getName(this.props.duration).toLowerCase()}>{'Inbound traffic, ' + getName(this.props.duration).toLowerCase()}</span>
+          <span data-test={'sparkline-duration-' + getName(this.props.duration).toLowerCase()}>{this.props.direction + ' traffic, ' + getName(this.props.duration).toLowerCase()}</span>
           <SparklineChart
             name={'traffic'}
             height={60}
@@ -55,7 +57,7 @@ class OverviewCardSparkline extends React.Component<Props, {}> {
         </>
       );
     }
-    return <div style={{ paddingTop: '40px' }}>No inbound traffic</div>;
+    return <div style={{ paddingTop: '40px' }}>No {this.props.direction.toLowerCase()} traffic</div>;
   }
 }
 

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -386,7 +386,6 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           nsInfo.errorMetrics = rs.data.request_error_count;
           return nsInfo;
         });
-        return nsInfo;
       })
     ).catch(err => this.handleAxiosError('Could not fetch metrics', err));
   }

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -33,7 +33,7 @@ import {
 } from '../../types/Health';
 import { SortField } from '../../types/SortFilters';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
-import OverviewToolbarContainer, { OverviewDisplayMode, OverviewToolbar, OverviewType } from './OverviewToolbar';
+import OverviewToolbarContainer, { OverviewDisplayMode, OverviewToolbar, OverviewType, DirectionType } from './OverviewToolbar';
 import NamespaceInfo, { NamespaceStatus } from './NamespaceInfo';
 import NamespaceMTLSStatusContainer from '../../components/MTls/NamespaceMTLSStatus';
 import { RenderComponentScroll } from '../../components/Nav/Page';
@@ -121,6 +121,7 @@ enum Show {
 type State = {
   namespaces: NamespaceInfo[];
   type: OverviewType;
+  direction: DirectionType;
   displayMode: OverviewDisplayMode;
   showTrafficPoliciesModal: boolean;
   kind: string;
@@ -150,6 +151,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     this.state = {
       namespaces: [],
       type: OverviewToolbar.currentOverviewType(),
+      direction: OverviewToolbar.currentDirectionType(),
       displayMode: display ? Number(display) : OverviewDisplayMode.EXPAND,
       showTrafficPoliciesModal: false,
       kind: '',
@@ -218,6 +220,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
         const isAscending = FilterHelper.isCurrentSortAscending();
         const sortField = FilterHelper.currentSortField(Sorts.sortFields);
         const type = OverviewToolbar.currentOverviewType();
+        const direction = OverviewToolbar.currentDirectionType();
         const displayMode = this.getStartDisplayMode(allNamespaces.length > 16);
 
         // Set state before actually fetching health
@@ -225,6 +228,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           prevState => {
             return {
               type: type,
+              direction: direction,
               namespaces: Sorts.sortFunc(allNamespaces, sortField, isAscending),
               displayMode: displayMode,
               showTrafficPoliciesModal: prevState.showTrafficPoliciesModal,
@@ -238,7 +242,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
             this.fetchTLS(isAscending, sortField);
             this.fetchValidations(isAscending, sortField);
             if (displayMode !== OverviewDisplayMode.COMPACT) {
-              this.fetchMetrics();
+              this.fetchMetrics(direction);
             }
           }
         );
@@ -350,12 +354,12 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       .catch(err => this.handleAxiosError('Could not fetch health', err));
   }
 
-  fetchMetrics() {
+  fetchMetrics(direction: DirectionType) {
     const duration = FilterHelper.currentDuration();
     // debounce async for back-pressure, ten by ten
     _.chunk(this.state.namespaces, 10).forEach(chunk => {
       this.promises
-        .registerChained('metricschunks', undefined, () => this.fetchMetricsChunk(chunk, duration))
+        .registerChained('metricschunks', undefined, () => this.fetchMetricsChunk(chunk, duration, direction))
         .then(() => {
           this.setState(prevState => {
             return { namespaces: prevState.namespaces.slice() };
@@ -364,23 +368,25 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     });
   }
 
-  fetchMetricsChunk(chunk: NamespaceInfo[], duration: number) {
+  fetchMetricsChunk(chunk: NamespaceInfo[], duration: number, direction: DirectionType) {
     const rateParams = computePrometheusRateParams(duration, 10);
-    const optionsIn: IstioMetricsOptions = {
+    const options: IstioMetricsOptions = {
       filters: ['request_count', 'request_error_count'],
       duration: duration,
       step: rateParams.step,
       rateInterval: rateParams.rateInterval,
-      direction: 'inbound',
-      reporter: 'destination'
+      direction: direction,
+      reporter: direction === 'inbound' ? 'destination' : 'source',
     };
+
     return Promise.all(
       chunk.map(nsInfo => {
-        return API.getNamespaceMetrics(nsInfo.name, optionsIn).then(rs => {
+        return API.getNamespaceMetrics(nsInfo.name, options).then(rs => {
           nsInfo.metrics = rs.data.request_count;
           nsInfo.errorMetrics = rs.data.request_error_count;
           return nsInfo;
         });
+        return nsInfo;
       })
     ).catch(err => this.handleAxiosError('Could not fetch metrics', err));
   }
@@ -467,7 +473,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     HistoryManager.setParam(URLParam.DISPLAY_MODE, String(mode));
     if (mode === OverviewDisplayMode.EXPAND) {
       // Load metrics
-      this.fetchMetrics();
+      this.fetchMetrics(this.state.direction);
     }
   };
 
@@ -860,6 +866,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           duration={FilterHelper.currentDuration()}
           status={ns.status}
           type={this.state.type}
+          direction={this.state.direction}
           metrics={ns.metrics}
           errorMetrics={ns.errorMetrics}
         />

--- a/frontend/src/pages/Overview/OverviewToolbar.tsx
+++ b/frontend/src/pages/Overview/OverviewToolbar.tsx
@@ -49,6 +49,11 @@ const overviewTypes = {
   service: 'Services'
 };
 
+const directionTypes = {
+  inbound: 'Inbound',
+  outbound: 'Outbound'
+};
+
 // TODO Use Object.fromEntries when available
 const sortTypes = (function () {
   let o = {};
@@ -87,11 +92,18 @@ const actionsToolbarStyle = style({
   paddingTop: '17px'
 });
 
+const typeSelectStyle = style({
+  paddingRight: '6px'
+});
+
 export type OverviewType = keyof typeof overviewTypes;
+
+export type DirectionType = keyof typeof directionTypes;
 
 type State = {
   isSortAscending: boolean;
   overviewType: OverviewType;
+  directionType: DirectionType;
   sortField: SortField<NamespaceInfo>;
 };
 
@@ -101,12 +113,18 @@ export class OverviewToolbar extends React.Component<Props, State> {
     return (otype as OverviewType) || 'app';
   }
 
+  static currentDirectionType(): DirectionType {
+    const drtype = HistoryManager.getParam(URLParam.DIRECTION_TYPE);
+    return (drtype as DirectionType) || 'inbound';
+  }
+
   constructor(props: Props) {
     super(props);
 
     this.state = {
       isSortAscending: FilterHelper.isCurrentSortAscending(),
       overviewType: OverviewToolbar.currentOverviewType(),
+      directionType: OverviewToolbar.currentDirectionType(),
       sortField: FilterHelper.currentSortField(Sorts.sortFields)
     };
   }
@@ -149,6 +167,19 @@ export class OverviewToolbar extends React.Component<Props, State> {
       this.props.onRefresh();
     } else {
       throw new Error('Overview type is not valid.');
+    }
+  };
+
+  updateDirectionType = (dtype: String) => {
+    const isDirectionType = (val: String): val is DirectionType =>
+      val === 'inbound' || val === 'outbound';
+
+    if (isDirectionType(dtype)) {
+      HistoryManager.setParam(URLParam.DIRECTION_TYPE, dtype);
+      this.setState({ directionType: dtype });
+      this.props.onRefresh();
+    } else {
+      throw new Error('Direction type is not valid.');
     }
   };
 
@@ -198,11 +229,21 @@ export class OverviewToolbar extends React.Component<Props, State> {
         <ToolbarDropdown
           id="overview-type"
           disabled={false}
+          classNameSelect={typeSelectStyle}
           handleSelect={this.updateOverviewType}
           nameDropdown="Health for"
           value={this.state.overviewType}
           label={overviewTypes[this.state.overviewType]}
           options={overviewTypes}
+        />
+        <ToolbarDropdown
+          id="direction-type"
+          disabled={false}
+          handleSelect={this.updateDirectionType}
+          nameDropdown="Traffic direction"
+          value={this.state.directionType}
+          label={directionTypes[this.state.directionType]}
+          options={directionTypes}
         />
         <Tooltip content={<>Expand view</>} position={TooltipPosition.top}>
           <Button

--- a/frontend/src/pages/Overview/OverviewToolbar.tsx
+++ b/frontend/src/pages/Overview/OverviewToolbar.tsx
@@ -240,7 +240,7 @@ export class OverviewToolbar extends React.Component<Props, State> {
           id="direction-type"
           disabled={false}
           handleSelect={this.updateDirectionType}
-          nameDropdown="Traffic direction"
+          nameDropdown="Traffic"
           value={this.state.directionType}
           label={directionTypes[this.state.directionType]}
           options={directionTypes}


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4896

Added Traffic Direction dropdown in Overview toolbar to select Outbound and Inbound traffic to show. Selection triggers reload of Overview items and the traffic with particular direction.

Added cypress tests.

![Screenshot from 2022-05-25 18-04-08](https://user-images.githubusercontent.com/604313/170324884-e877f278-d63a-432e-9330-043d68d19235.png)
