### PR TITLE
Update confirmation button placement and styling

### DIFF
--- a/frontend/src/app/InitializingScreen.tsx
+++ b/frontend/src/app/InitializingScreen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, Button } from '@patternfly/react-core';
+import { Alert, Button, ButtonVariant } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { isKioskMode } from '../utils/SearchParamUtils';
 
@@ -68,7 +68,7 @@ const InitializingScreen: React.FC<initializingScreenProps> = (props: initializi
             <>
               <p>
                 <Button
-                  variant="link"
+                  variant={ButtonVariant.link}
                   onClick={e => {
                     e.preventDefault();
                     if (errorDiv.current) {

--- a/frontend/src/components/About/AboutUIModal.tsx
+++ b/frontend/src/components/About/AboutUIModal.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { AboutModal, TextContent, TextList, TextListItem, Title, Button, TitleSizes } from '@patternfly/react-core';
+import {
+  AboutModal,
+  TextContent,
+  TextList,
+  TextListItem,
+  Title,
+  Button,
+  TitleSizes,
+  ButtonVariant
+} from '@patternfly/react-core';
 import { ExternalServiceInfo, Status, StatusKey } from '../../types/StatusState';
 import { config, kialiLogo } from '../../config';
 import { style } from 'typestyle';

--- a/frontend/src/components/About/AboutUIModal.tsx
+++ b/frontend/src/components/About/AboutUIModal.tsx
@@ -110,7 +110,7 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
     if (config.about && config.about.website) {
       return (
         // @ts-ignore
-        <Button component="a" href={config.about.website.url} variant="link" target="_blank">
+        <Button component="a" href={config.about.website.url} variant={ButtonVariant.link} target="_blank">
           <KialiIcon.Website className={iconStyle} />
           {config.about.website.linkText}
         </Button>
@@ -124,7 +124,7 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
     if (config.about && config.about.project) {
       return (
         // @ts-ignore
-        <Button component="a" href={config.about.project.url} variant="link" target="_blank">
+        <Button component="a" href={config.about.project.url} variant={ButtonVariant.link} target="_blank">
           <KialiIcon.Repository className={iconStyle} />
           {config.about.project.linkText}
         </Button>

--- a/frontend/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/frontend/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Cy from 'cytoscape';
-import { Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Button, ButtonVariant, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import {
   LongArrowAltRightIcon,
   ExpandArrowsAltIcon,
@@ -113,7 +113,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
               isActive={this.state.allowGrab}
               onClick={() => this.toggleDrag()}
               style={buttonStyle}
-              variant="plain"
+              variant={ButtonVariant.plain}
             >
               <PficonDragdropIcon className={this.state.allowGrab ? activeButtonStyle : undefined} />
             </Button>
@@ -126,7 +126,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
               aria-label="Zoom to Fit"
               onClick={() => this.fit()}
               style={buttonStyle}
-              variant="plain"
+              variant={ButtonVariant.plain}
             >
               <ExpandArrowsAltIcon />
             </Button>
@@ -142,7 +142,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                 this.handleEdgeModeClick(EdgeMode.UNHEALTHY);
               }}
               style={buttonStyle}
-              variant="plain"
+              variant={ButtonVariant.plain}
             >
               <LongArrowAltRightIcon
                 className={this.props.edgeMode === EdgeMode.UNHEALTHY ? activeButtonStyle : undefined}
@@ -160,7 +160,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                 this.handleEdgeModeClick(EdgeMode.NONE);
               }}
               style={buttonStyle}
-              variant="plain"
+              variant={ButtonVariant.plain}
             >
               <LongArrowAltRightIcon
                 className={this.props.edgeMode === EdgeMode.NONE ? activeButtonStyle : undefined}
@@ -180,7 +180,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                 this.setLayout(KialiDagreGraph.getLayout());
               }}
               style={buttonStyle}
-              variant="plain"
+              variant={ButtonVariant.plain}
             >
               <TopologyIcon
                 className={this.props.layout.name === KialiDagreGraph.getLayout().name ? activeButtonStyle : undefined}
@@ -201,7 +201,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                   this.setLayout(KialiGridGraph.getLayout());
                 }}
                 style={buttonStyle}
-                variant="plain"
+                variant={ButtonVariant.plain}
               >
                 <TopologyIcon
                   className={this.props.layout.name === KialiGridGraph.getLayout().name ? activeButtonStyle : undefined}
@@ -222,7 +222,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                 this.setLayout(KialiConcentricGraph.getLayout());
               }}
               style={buttonStyle}
-              variant="plain"
+              variant={ButtonVariant.plain}
             >
               <TopologyIcon
                 className={
@@ -244,7 +244,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                 this.setLayout(KialiBreadthFirstGraph.getLayout());
               }}
               style={buttonStyle}
-              variant="plain"
+              variant={ButtonVariant.plain}
             >
               <TopologyIcon
                 className={
@@ -270,7 +270,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                   this.setNamespaceLayout(KialiDagreGraph.getLayout());
                 }}
                 style={buttonStyle}
-                variant="plain"
+                variant={ButtonVariant.plain}
               >
                 <TenantIcon
                   className={
@@ -297,7 +297,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                   this.setNamespaceLayout(KialiBreadthFirstGraph.getLayout());
                 }}
                 style={buttonStyle}
-                variant="plain"
+                variant={ButtonVariant.plain}
               >
                 <TenantIcon
                   className={
@@ -320,7 +320,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                 isActive={this.props.showLegend}
                 onClick={this.props.toggleLegend}
                 style={buttonStyle}
-                variant="plain"
+                variant={ButtonVariant.plain}
               >
                 <MapIcon className={this.props.showLegend ? activeButtonStyle : undefined} size="sm" />
               </Button>

--- a/frontend/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
+++ b/frontend/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   Button,
+  ButtonVariant,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -134,7 +135,10 @@ export default class EmptyGraphLayout extends React.Component<EmptyGraphLayoutPr
               <> You can enable 'Idle Nodes' to display service mesh nodes that have yet to see any request traffic.</>
             )}
           </EmptyStateBody>
-          <Button onClick={this.props.showIdleNodes ? this.props.action : this.props.toggleIdleNodes} variant="primary">
+          <Button
+            onClick={this.props.showIdleNodes ? this.props.action : this.props.toggleIdleNodes}
+            variant={ButtonVariant.primary}
+          >
             {(this.props.showIdleNodes && <>Refresh</>) || <>Display idle nodes</>}
           </Button>
         </EmptyState>

--- a/frontend/src/components/IstioActions/IstioActionsButtons.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsButtons.tsx
@@ -52,7 +52,7 @@ class IstioActionButtons extends React.Component<Props, State> {
             </Button>
           </span>
           <span style={{ paddingRight: '5px' }}>
-            <Button variant={ButtonVariant.link} isInline onClick={this.props.onCancel}>
+            <Button variant={ButtonVariant.secondary} onClick={this.props.onCancel}>
               {this.props.readOnly ? 'Close' : 'Cancel'}
             </Button>
           </span>

--- a/frontend/src/components/IstioActions/IstioActionsButtons.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsButtons.tsx
@@ -52,7 +52,7 @@ class IstioActionButtons extends React.Component<Props, State> {
             </Button>
           </span>
           <span style={{ paddingRight: '5px' }}>
-            <Button variant={ButtonVariant.secondary} onClick={this.props.onCancel}>
+            <Button variant={ButtonVariant.link} isInline onClick={this.props.onCancel}>
               {this.props.readOnly ? 'Close' : 'Cancel'}
             </Button>
           </span>

--- a/frontend/src/components/IstioActions/IstioActionsDropdown.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsDropdown.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   Button,
+  ButtonVariant,
   Dropdown,
   DropdownItem,
   DropdownPosition,
@@ -95,10 +96,10 @@ class IstioActionDropdown extends React.Component<Props, State> {
           isOpen={this.state.showConfirmModal}
           onClose={this.hideConfirmModal}
           actions={[
-            <Button key="confirm" variant="danger" onClick={this.onDelete}>
+            <Button key="confirm" variant={ButtonVariant.danger} onClick={this.onDelete}>
               Delete
             </Button>,
-            <Button key="cancel" variant="link" isInline onClick={this.hideConfirmModal}>
+            <Button key="cancel" variant={ButtonVariant.secondary} onClick={this.hideConfirmModal}>
               Cancel
             </Button>
           ]}

--- a/frontend/src/components/IstioActions/IstioActionsDropdown.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsDropdown.tsx
@@ -95,11 +95,11 @@ class IstioActionDropdown extends React.Component<Props, State> {
           isOpen={this.state.showConfirmModal}
           onClose={this.hideConfirmModal}
           actions={[
-            <Button key="cancel" variant="secondary" onClick={this.hideConfirmModal}>
-              Cancel
-            </Button>,
             <Button key="confirm" variant="danger" onClick={this.onDelete}>
               Delete
+            </Button>,
+            <Button key="cancel" variant="link" isInline onClick={this.hideConfirmModal}>
+              Cancel
             </Button>
           ]}
         >

--- a/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
+++ b/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
@@ -178,9 +178,6 @@ export class IstioConfigPreview extends React.Component<Props, State> {
           this.props.actions
             ? this.props.actions
             : [
-                <Button key="cancel" variant="secondary" onClick={this.props.onClose}>
-                  Cancel
-                </Button>,
                 <Button
                   key={this.props.opTarget}
                   variant={this.props.opTarget === 'delete' ? 'danger' : 'primary'}
@@ -189,6 +186,9 @@ export class IstioConfigPreview extends React.Component<Props, State> {
                   data-test={this.props.opTarget}
                 >
                   {this.props.opTarget && this.props.opTarget[0].toUpperCase() + this.props.opTarget.substr(1)}
+                </Button>,
+                <Button key="cancel" variant="link" isInline onClick={this.props.onClose}>
+                  Cancel
                 </Button>
               ]
         }

--- a/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
+++ b/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
@@ -187,7 +187,7 @@ export class IstioConfigPreview extends React.Component<Props, State> {
                 >
                   {this.props.opTarget && this.props.opTarget[0].toUpperCase() + this.props.opTarget.substr(1)}
                 </Button>,
-                <Button key="cancel" variant="link" isInline onClick={this.props.onClose}>
+                <Button key="cancel" variant={ButtonVariant.secondary} onClick={this.props.onClose}>
                   Cancel
                 </Button>
               ]

--- a/frontend/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
+++ b/frontend/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Button, Dropdown, DropdownToggle, DropdownItem, InputGroup, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  InputGroup,
+  TextInput,
+  ButtonVariant
+} from '@patternfly/react-core';
 
 type Props = {
   category: string;
@@ -71,7 +79,11 @@ class MatchBuilder extends React.Component<Props, State> {
     return (
       <InputGroup>
         <Dropdown
-          toggle={<DropdownToggle onToggle={this.onMathOptionsToggle} data-test={'requestmatching-header-toggle'}>{this.props.category}</DropdownToggle>}
+          toggle={
+            <DropdownToggle onToggle={this.onMathOptionsToggle} data-test={'requestmatching-header-toggle'}>
+              {this.props.category}
+            </DropdownToggle>
+          }
           isOpen={this.state.isMatchDropdown}
           dropdownItems={matchOptions.map((mode, index) => (
             <DropdownItem
@@ -97,7 +109,11 @@ class MatchBuilder extends React.Component<Props, State> {
           />
         )}
         <Dropdown
-          toggle={<DropdownToggle onToggle={this.onOperatorToggle} data-test={'requestmatching-match-toggle'}>{this.props.operator}</DropdownToggle>}
+          toggle={
+            <DropdownToggle onToggle={this.onOperatorToggle} data-test={'requestmatching-match-toggle'}>
+              {this.props.operator}
+            </DropdownToggle>
+          }
           isOpen={this.state.isOperatorDropdown}
           dropdownItems={renderOpOptions.map((op, index) => (
             <DropdownItem
@@ -122,7 +138,12 @@ class MatchBuilder extends React.Component<Props, State> {
             placeholder={placeholderText[this.props.category]}
           />
         )}
-        <Button variant="secondary" disabled={!this.props.isValid} onClick={this.props.onAddMatch} data-test="add-match">
+        <Button
+          variant={ButtonVariant.secondary}
+          disabled={!this.props.isValid}
+          onClick={this.props.onAddMatch}
+          data-test="add-match"
+        >
           Add Match
         </Button>
       </InputGroup>

--- a/frontend/src/components/IstioWizards/RequestRouting/RuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/RequestRouting/RuleBuilder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Tabs, Tab } from '@patternfly/react-core';
+import { Button, Tabs, Tab, ButtonVariant } from '@patternfly/react-core';
 import MatchBuilder from './MatchBuilder';
 import Matches from './Matches';
 import { style } from 'typestyle';
@@ -123,7 +123,12 @@ class RuleBuilder extends React.Component<Props, State> {
         <div className={addRuleStyle}>
           <span>
             {this.props.validationMsg.length > 0 && <div className={validationStyle}>{this.props.validationMsg}</div>}
-            <Button variant="secondary" isDisabled={!this.props.isValid} onClick={this.props.onAddRule} data-test="add-route">
+            <Button
+              variant={ButtonVariant.secondary}
+              isDisabled={!this.props.isValid}
+              onClick={this.props.onAddRule}
+              data-test="add-route"
+            >
               Add Route Rule
             </Button>
           </span>

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ExpandableSection, Modal, ModalVariant, Tab, Tabs } from '@patternfly/react-core';
+import { Button, ButtonVariant, ExpandableSection, Modal, ModalVariant, Tab, Tabs } from '@patternfly/react-core';
 import { WorkloadOverview } from '../../types/ServiceInfo';
 import * as API from '../../services/Api';
 import { Response } from '../../services/Api';
@@ -554,13 +554,13 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
           actions={[
             <Button
               key="confirm"
-              variant={'primary'}
+              variant={ButtonVariant.primary}
               onClick={this.onCreateUpdate}
               data-test={'confirm-' + (this.props.update ? 'update' : 'create')}
             >
               {this.props.update ? 'Update' : 'Create'}
             </Button>,
-            <Button key="cancel" variant="link" isInline onClick={() => this.onClose(false)}>
+            <Button key="cancel" variant={ButtonVariant.secondary} onClick={() => this.onClose(false)}>
               Cancel
             </Button>
           ]}
@@ -585,13 +585,13 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
             <Button
               isDisabled={!this.isValid(this.state)}
               key="confirm"
-              variant="primary"
+              variant={ButtonVariant.primary}
               onClick={this.onPreview}
               data-test="preview"
             >
               Preview
             </Button>,
-            <Button key="cancel" variant="link" isInline onClick={() => this.onClose(false)}>
+            <Button key="cancel" variant={ButtonVariant.secondary} onClick={() => this.onClose(false)}>
               Cancel
             </Button>
           ]}

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -538,11 +538,12 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
           ? 'Update ' + WIZARD_TITLES[this.props.type]
           : 'Create ' + WIZARD_TITLES[this.props.type]
         : '';
-    const titleModal = this.props.type.length > 0
-      ? this.props.update
-        ? 'Update ' + WIZARD_TITLES[this.props.type]
-        : 'Create ' + WIZARD_TITLES[this.props.type]
-      : '';
+    const titleModal =
+      this.props.type.length > 0
+        ? this.props.update
+          ? 'Update ' + WIZARD_TITLES[this.props.type]
+          : 'Create ' + WIZARD_TITLES[this.props.type]
+        : '';
     return (
       <>
         <Modal
@@ -551,11 +552,16 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
           isOpen={this.state.confirmationModal}
           onClose={() => this.onClose(false)}
           actions={[
-            <Button key="cancel" variant="secondary" onClick={() => this.onClose(false)}>
-              Cancel
-            </Button>,
-            <Button key="confirm" variant={'primary'} onClick={this.onCreateUpdate} data-test={'confirm-' + (this.props.update ? 'update' : 'create')}>
+            <Button
+              key="confirm"
+              variant={'primary'}
+              onClick={this.onCreateUpdate}
+              data-test={'confirm-' + (this.props.update ? 'update' : 'create')}
+            >
               {this.props.update ? 'Update' : 'Create'}
+            </Button>,
+            <Button key="cancel" variant="link" isInline onClick={() => this.onClose(false)}>
+              Cancel
             </Button>
           ]}
         >
@@ -576,11 +582,17 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
             }
           }}
           actions={[
-            <Button key="cancel" variant="secondary" onClick={() => this.onClose(false)}>
-              Cancel
-            </Button>,
-            <Button isDisabled={!this.isValid(this.state)} key="confirm" variant="primary" onClick={this.onPreview} data-test="preview">
+            <Button
+              isDisabled={!this.isValid(this.state)}
+              key="confirm"
+              variant="primary"
+              onClick={this.onPreview}
+              data-test="preview"
+            >
               Preview
+            </Button>,
+            <Button key="cancel" variant="link" isInline onClick={() => this.onClose(false)}>
+              Cancel
             </Button>
           ]}
         >

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -401,11 +401,11 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
           isOpen={this.state.showConfirmDelete}
           onClose={this.hideConfirmDelete}
           actions={[
-            <Button key="cancel" variant="secondary" onClick={this.hideConfirmDelete}>
-              Cancel
-            </Button>,
             <Button key="confirm" variant="danger" onClick={this.onDelete} data-test={'confirm-delete'}>
               Delete
+            </Button>,
+            <Button key="cancel" variant="link" isInline onClick={this.hideConfirmDelete}>
+              Cancel
             </Button>
           ]}
         >

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   Button,
+  ButtonVariant,
   Dropdown,
   DropdownGroup,
   DropdownItem,
@@ -401,10 +402,10 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
           isOpen={this.state.showConfirmDelete}
           onClose={this.hideConfirmDelete}
           actions={[
-            <Button key="confirm" variant="danger" onClick={this.onDelete} data-test={'confirm-delete'}>
+            <Button key="confirm" variant={ButtonVariant.danger} onClick={this.onDelete} data-test={'confirm-delete'}>
               Delete
             </Button>,
-            <Button key="cancel" variant="link" isInline onClick={this.hideConfirmDelete}>
+            <Button key="cancel" variant={ButtonVariant.secondary} isInline onClick={this.hideConfirmDelete}>
               Cancel
             </Button>
           ]}

--- a/frontend/src/components/IstioWizards/Slider/Slider.tsx
+++ b/frontend/src/components/IstioWizards/Slider/Slider.tsx
@@ -198,7 +198,7 @@ class Slider extends React.Component<Props, State> {
             <>
               <Button
                 className={leftButtonStyle}
-                variant="link"
+                variant={ButtonVariant.link}
                 isDisabled={this.props.locked}
                 onClick={() => this.onMinus()}
               >
@@ -215,7 +215,7 @@ class Slider extends React.Component<Props, State> {
               />
               <Button
                 className={rightButtonStyle}
-                variant="link"
+                variant={ButtonVariant.link}
                 isDisabled={this.props.locked}
                 onClick={() => this.onPlus()}
               >

--- a/frontend/src/components/IstioWizards/TrafficShifting.tsx
+++ b/frontend/src/components/IstioWizards/TrafficShifting.tsx
@@ -4,7 +4,7 @@ import Slider from './Slider/Slider';
 import { WorkloadOverview } from '../../types/ServiceInfo';
 import { style } from 'typestyle';
 import { PFColors } from '../Pf/PfColors';
-import { Badge, Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Badge, Button, ButtonVariant, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { EqualizerIcon } from '@patternfly/react-icons';
 import { getDefaultWeights } from './WizardActions';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
@@ -323,7 +323,7 @@ class TrafficShifting extends React.Component<Props, State> {
         )}
         {this.props.workloads.length > 1 && (
           <div className={evenlyButtonStyle}>
-            <Button variant="link" icon={<EqualizerIcon />} onClick={() => this.resetState()}>
+            <Button variant={ButtonVariant.link} icon={<EqualizerIcon />} onClick={() => this.resetState()}>
               Evenly distribute traffic
             </Button>{' '}
           </div>

--- a/frontend/src/components/IstioWizards/WorkloadWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadWizard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { WIZARD_TITLES, WorkloadWizardProps, WorkloadWizardState } from './WizardActions';
-import { Button, Modal } from '@patternfly/react-core';
+import { Button, ButtonVariant, Modal } from '@patternfly/react-core';
 
 // NOTE: This class is not used but I will keep it in the repo as skeleton as we'll add again WorkloadWizards for other
 class WorkloadWizard extends React.Component<WorkloadWizardProps, WorkloadWizardState> {
@@ -51,12 +51,12 @@ class WorkloadWizard extends React.Component<WorkloadWizardProps, WorkloadWizard
             <Button
               isDisabled={!this.isValid(this.state)}
               key="confirm"
-              variant="primary"
+              variant={ButtonVariant.primary}
               onClick={this.onCreateUpdate}
             >
               {'Create'}
             </Button>,
-            <Button key="cancel" variant="link" isInline onClick={() => this.onClose(false)}>
+            <Button key="cancel" variant={ButtonVariant.secondary} onClick={() => this.onClose(false)}>
               Cancel
             </Button>
           ]}

--- a/frontend/src/components/IstioWizards/WorkloadWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadWizard.tsx
@@ -48,9 +48,6 @@ class WorkloadWizard extends React.Component<WorkloadWizardProps, WorkloadWizard
           isOpen={this.state.showWizard}
           onClose={() => this.onClose(false)}
           actions={[
-            <Button key="cancel" variant="secondary" onClick={() => this.onClose(false)}>
-              Cancel
-            </Button>,
             <Button
               isDisabled={!this.isValid(this.state)}
               key="confirm"
@@ -58,6 +55,9 @@ class WorkloadWizard extends React.Component<WorkloadWizardProps, WorkloadWizard
               onClick={this.onCreateUpdate}
             >
               {'Create'}
+            </Button>,
+            <Button key="cancel" variant="link" isInline onClick={() => this.onClose(false)}>
+              Cancel
             </Button>
           ]}
         >

--- a/frontend/src/components/JaegerIntegration/JaegerResults/SpanTags.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/SpanTags.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { CopyIcon } from '@patternfly/react-icons';
 import { KeyValuePair } from '../../../types/JaegerInfo';
 import { PFColors } from '../../Pf/PfColors';
@@ -48,7 +48,7 @@ export class SpanTags extends React.Component<SpanDetailProps> {
               <td style={{ color: isNaN(tag.value) ? PFColors.Green500 : PFColors.Blue500 }}>{this.printValue(tag)}</td>
               <td>
                 <Tooltip content={<>Copy {`{key": "${tag.key}", "type": "string", "value": "${tag.value}"}`}</>}>
-                  <Button variant="plain" aria-label="Action" onClick={() => this.copiedText(tag)}>
+                  <Button variant={ButtonVariant.plain} aria-label="Action" onClick={() => this.copiedText(tag)}>
                     <CopyIcon />
                   </Button>
                 </Tooltip>

--- a/frontend/src/components/Label/Labels.tsx
+++ b/frontend/src/components/Label/Labels.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Label from './Label';
-import { Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Button, ButtonVariant, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { KialiIcon } from '../../config/KialiIcon';
 
@@ -64,7 +64,7 @@ class Labels extends React.Component<Props, State> {
         <Button
           data-test="label_more"
           key="label_more"
-          variant="link"
+          variant={ButtonVariant.link}
           className={linkStyle}
           onClick={this.expandLabels}
         >

--- a/frontend/src/components/MessageCenter/AlertDrawer.tsx
+++ b/frontend/src/components/MessageCenter/AlertDrawer.tsx
@@ -9,7 +9,8 @@ import {
   Accordion,
   AccordionToggle,
   AccordionItem,
-  AccordionContent
+  AccordionContent,
+  ButtonVariant
 } from '@patternfly/react-core';
 import { CloseIcon, InfoIcon } from '@patternfly/react-icons';
 import { connect } from 'react-redux';
@@ -93,15 +94,15 @@ export class AlertDrawer extends React.PureComponent<AlertDrawerProps> {
           <CardHeader className={AlertDrawer.head}>
             <CardActions>
               {this.props.isExpanded ? (
-                <Button id="alert_drawer_collapse" variant="plain" onClick={this.props.expandDrawer}>
+                <Button id="alert_drawer_collapse" variant={ButtonVariant.plain} onClick={this.props.expandDrawer}>
                   <KialiIcon.AngleDoubleRight />
                 </Button>
               ) : (
-                <Button id="alert_drawer_expand" variant="plain" onClick={this.props.expandDrawer}>
+                <Button id="alert_drawer_expand" variant={ButtonVariant.plain} onClick={this.props.expandDrawer}>
                   <KialiIcon.AngleDoubleLeft />
                 </Button>
               )}
-              <Button id="alert_drawer_close" variant="plain" onClick={this.props.hideDrawer}>
+              <Button id="alert_drawer_close" variant={ButtonVariant.plain} onClick={this.props.hideDrawer}>
                 <CloseIcon />
               </Button>
             </CardActions>

--- a/frontend/src/components/MessageCenter/AlertDrawerGroup.tsx
+++ b/frontend/src/components/MessageCenter/AlertDrawerGroup.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { KialiAppState } from 'store/Store';
-import { Card, Button, CardBody, CardFooter } from '@patternfly/react-core';
+import { Card, Button, CardBody, CardFooter, ButtonVariant } from '@patternfly/react-core';
 import { InfoIcon } from '@patternfly/react-icons';
 import { style } from 'typestyle';
 import { NotificationGroup } from '../../types/MessageCenter';
@@ -55,10 +55,18 @@ class AlertDrawerGroup extends React.PureComponent<AlertDrawerGroupProps> {
         </CardBody>
         {group.showActions && group.messages.length > 0 && (
           <CardFooter className={AlertDrawerGroup.footer}>
-            <Button className={AlertDrawerGroup.left} variant="link" onClick={() => this.props.markGroupAsRead(group)}>
+            <Button
+              className={AlertDrawerGroup.left}
+              variant={ButtonVariant.link}
+              onClick={() => this.props.markGroupAsRead(group)}
+            >
               Mark All Read
             </Button>
-            <Button className={AlertDrawerGroup.right} variant="link" onClick={() => this.props.clearGroup(group)}>
+            <Button
+              className={AlertDrawerGroup.right}
+              variant={ButtonVariant.link}
+              onClick={() => this.props.clearGroup(group)}
+            >
               Clear All
             </Button>
           </CardFooter>

--- a/frontend/src/components/Nav/Navigation.tsx
+++ b/frontend/src/components/Nav/Navigation.tsx
@@ -13,7 +13,8 @@ import {
   MastheadContent,
   PageSection,
   PageSidebar,
-  PageToggleButton
+  PageToggleButton,
+  ButtonVariant
 } from '@patternfly/react-core';
 import { BarsIcon } from '@patternfly/react-icons';
 import { style } from 'typestyle';
@@ -110,7 +111,7 @@ export class Navigation extends React.Component<PropsType, NavigationState> {
       <Masthead role="kiali_header" style={{ height: '76px' }}>
         <MastheadToggle>
           <PageToggleButton
-            variant="plain"
+            variant={ButtonVariant.plain}
             aria-label="Kiali navigation"
             isNavOpen={isNavOpen}
             onNavToggle={isMobileView ? this.onNavToggleMobile : this.onNavToggleDesktop}
@@ -136,7 +137,7 @@ export class Navigation extends React.Component<PropsType, NavigationState> {
     return (
       <Page header={masthead} sidebar={Sidebar} onPageResize={this.onPageResize}>
         <MessageCenterContainer drawerTitle="Message Center" />
-        <PageSection className={flexBoxColumnStyle} variant={'light'}>
+        <PageSection className={flexBoxColumnStyle} variant="light">
           <RenderPage isGraph={this.isGraph()} />
         </PageSection>
       </Page>

--- a/frontend/src/components/Refresh/RefreshButton.tsx
+++ b/frontend/src/components/Refresh/RefreshButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
 import { TimeInMilliseconds } from '../../types/Common';
 import { KialiAppAction } from '../../actions/KialiAppAction';
@@ -37,7 +37,7 @@ class RefreshButton extends React.Component<Props> {
           onClick={this.handleRefresh}
           isDisabled={this.getDisabled()}
           aria-label="Action"
-          variant="primary"
+          variant={ButtonVariant.primary}
         >
           <SyncAltIcon />
         </Button>

--- a/frontend/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/frontend/src/components/SessionTimeout/SessionTimeout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Modal, Button } from '@patternfly/react-core';
+import { Modal, Button, ButtonVariant } from '@patternfly/react-core';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 import { AuthStrategy } from '../../types/Auth';
 import { LoginSession } from '../../store/Store';
@@ -18,11 +18,11 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
   render() {
     const defaultAction = this.props.onDismiss;
     const buttons = [
-      <Button key="confirm" variant="link" onClick={this.props.onLogout}>
-        Log Out
-      </Button>,
-      <Button autoFocus={true} variant="primary" onClick={this.props.onDismiss}>
+      <Button autoFocus={true} variant={ButtonVariant.primary} onClick={this.props.onDismiss}>
         OK
+      </Button>,
+      <Button key="confirm" variant={ButtonVariant.secondary} onClick={this.props.onLogout}>
+        Log Out
       </Button>
     ];
     return (

--- a/frontend/src/components/Time/TimeDurationComponent.tsx
+++ b/frontend/src/components/Time/TimeDurationComponent.tsx
@@ -5,7 +5,7 @@ import RefreshContainer from 'components/Refresh/Refresh';
 import { KialiAppState } from 'store/Store';
 import { durationSelector, replayActiveSelector } from 'store/Selectors';
 import { DurationInSeconds } from 'types/Common';
-import { Tooltip, TooltipPosition, Button } from '@patternfly/react-core';
+import { Tooltip, TooltipPosition, Button, ButtonVariant } from '@patternfly/react-core';
 import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
 import { UserSettingsActions } from 'actions/UserSettingsActions';
 import { ThunkDispatch } from 'redux-thunk';
@@ -36,7 +36,12 @@ export class TimeDurationComponent extends React.PureComponent<TimeControlsProps
       <span>
         {this.props.supportsReplay && !this.props.replayActive && (
           <Tooltip key={'time_range_replay'} position={TooltipPosition.left} content="Replay...">
-            <Button data-test="graph-replay-button" variant="link" style={{ padding: '1px 6px 0 0' }} onClick={this.onToggleReplay}>
+            <Button
+              data-test="graph-replay-button"
+              variant={ButtonVariant.link}
+              style={{ padding: '1px 6px 0 0' }}
+              onClick={this.onToggleReplay}
+            >
               <KialiIcon.History className={defaultIconStyle} />
             </Button>
           </Tooltip>
@@ -59,7 +64,12 @@ export class TimeDurationComponent extends React.PureComponent<TimeControlsProps
           />
         )}
         {this.props.supportsReplay && this.props.replayActive && (
-          <Button data-test="graph-replay-close-button" variant="link" style={{ margin: '1px 0 0 5px' }} onClick={this.onToggleReplay}>
+          <Button
+            data-test="graph-replay-close-button"
+            variant={ButtonVariant.link}
+            style={{ margin: '1px 0 0 5px' }}
+            onClick={this.onToggleReplay}
+          >
             <span>
               <KialiIcon.Close className={defaultIconStyle} />
               {`  Close Replay`}

--- a/frontend/src/components/Tour/TourStop.tsx
+++ b/frontend/src/components/Tour/TourStop.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
+import { Button, ButtonVariant, Popover, PopoverPosition } from '@patternfly/react-core';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -91,7 +91,7 @@ class TourStop extends React.PureComponent<TourStopProps> {
   private backButton = () => {
     const stop = this.getStop('back');
     return (
-      <Button isDisabled={stop === undefined} variant="secondary" onClick={() => this.setStop(stop!)}>
+      <Button isDisabled={stop === undefined} variant={ButtonVariant.secondary} onClick={() => this.setStop(stop!)}>
         <KialiIcon.AngleLeft /> Back
       </Button>
     );
@@ -105,14 +105,14 @@ class TourStop extends React.PureComponent<TourStopProps> {
 
     if (stop === undefined) {
       return (
-        <Button className={right} variant="primary" onClick={this.props.endTour}>
+        <Button className={right} variant={ButtonVariant.primary} onClick={this.props.endTour}>
           Done
         </Button>
       );
     }
 
     return (
-      <Button className={right} variant="primary" onClick={() => this.setStop(stop!)}>
+      <Button className={right} variant={ButtonVariant.primary} onClick={() => this.setStop(stop!)}>
         Next <KialiIcon.AngleRight />
       </Button>
     );

--- a/frontend/src/pages/Graph/GraphLegend.tsx
+++ b/frontend/src/pages/Graph/GraphLegend.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { style } from 'typestyle';
 import legendData, { GraphLegendItem, GraphLegendItemRow } from './GraphLegendData';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import CloseIcon from '@patternfly/react-icons/dist/js/icons/close-icon';
 import { PFColors } from 'components/Pf/PfColors';
 import { summaryFont, summaryTitle } from './SummaryPanelCommon';
@@ -46,7 +46,7 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
           <span>Legend</span>
           <span className={closeBoxStyle}>
             <Tooltip content="Close Legend">
-              <Button id="legend_close" variant="plain" onClick={this.props.closeLegend}>
+              <Button id="legend_close" variant={ButtonVariant.plain} onClick={this.props.closeLegend}>
                 <CloseIcon />
               </Button>
             </Tooltip>

--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -213,7 +213,7 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
                 <TourStopContainer info={GraphTourStops.Shortcuts}>
                   <Button
                     id="graph-tour"
-                    variant="link"
+                    variant={ButtonVariant.link}
                     style={{ paddingLeft: '6px', paddingRight: '0px' }}
                     onClick={this.props.onToggleHelp}
                   >

--- a/frontend/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
-import { SimpleList, SimpleListItem, Button, Checkbox, Divider } from '@patternfly/react-core';
+import { SimpleList, SimpleListItem, Button, Checkbox, Divider, ButtonVariant } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
 import { style } from 'typestyle';
 
@@ -162,7 +162,7 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
             isDisabled={this.state.useGraphRefresh}
             onClick={() => this.loadTraces()}
             aria-label="Refresh"
-            variant="secondary"
+            variant={ButtonVariant.secondary}
             className={refreshButtonStyle}
           >
             <SyncAltIcon />

--- a/frontend/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -123,7 +123,7 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
           <span>Trace</span>
           <span className={closeBoxStyle}>
             <Tooltip content="Close and clear trace selection">
-              <Button id="close-trace" variant="plain" onClick={this.props.close}>
+              <Button id="close-trace" variant={ButtonVariant.plain} onClick={this.props.close}>
                 <CloseIcon />
               </Button>
             </Tooltip>

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
-import { Button, FormSelect, FormSelectOption, TextInputBase as TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  FormSelect,
+  FormSelectOption,
+  TextInputBase as TextInput
+} from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { isValidIp } from '../../../../utils/IstioConfigUtils';
 import { style } from 'typestyle';
@@ -195,7 +201,7 @@ class SourceBuilder extends React.Component<Props, State> {
             <>
               {this.state.sourceFields.length > 0 && (
                 <Button
-                  variant="link"
+                  variant={ButtonVariant.link}
                   icon={<PlusCircleIcon />}
                   onClick={this.onAddSource}
                   isDisabled={!isValidSource}
@@ -223,7 +229,7 @@ class SourceBuilder extends React.Component<Props, State> {
           <TableBody />
         </Table>
         <Button
-          variant="link"
+          variant={ButtonVariant.link}
           icon={<PlusCircleIcon />}
           isDisabled={Object.keys(this.state.source).length === 0}
           onClick={this.onAddSourceFromList}

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, FormGroup, Switch } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormGroup, Switch } from '@patternfly/react-core';
 import SourceBuilder from './From/SourceBuilder';
 import SourceList from './From/SourceList';
 import OperationBuilder from './To/OperationBuilder';
@@ -204,7 +204,7 @@ class RuleBuilder extends React.Component<Props, State> {
         )}
         <FormGroup fieldId="addRule">
           <Button
-            variant="link"
+            variant={ButtonVariant.link}
             icon={<PlusCircleIcon />}
             onClick={this.onAddRule}
             isDisabled={!this.canAddRule()}

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
-import { Button, FormSelect, FormSelectOption, TextInputBase as TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  FormSelect,
+  FormSelectOption,
+  TextInputBase as TextInput
+} from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 
 type Props = {
@@ -163,7 +169,7 @@ class OperationBuilder extends React.Component<Props, State> {
             </>,
             <>
               {this.state.operationFields.length > 0 && (
-                <Button variant="link" icon={<PlusCircleIcon />} onClick={this.onAddOperation} />
+                <Button variant={ButtonVariant.link} icon={<PlusCircleIcon />} onClick={this.onAddOperation} />
               )}
             </>
           ]
@@ -187,7 +193,7 @@ class OperationBuilder extends React.Component<Props, State> {
           <TableBody />
         </Table>
         <Button
-          variant="link"
+          variant={ButtonVariant.link}
           icon={<PlusCircleIcon />}
           isDisabled={Object.keys(this.state.operation).length === 0}
           onClick={this.onAddOperationToList}

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
-import { Button, TextInputBase as TextInput } from '@patternfly/react-core';
+import { Button, ButtonVariant, TextInputBase as TextInput } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { isValidRequestHeaderName, isValidRequestAuthClaimName } from '../../../../helpers/ValidationHelpers';
 import { style } from 'typestyle';
@@ -58,11 +58,7 @@ const conditionFixedKeys = [
   'connection.sni'
 ];
 
-const conditionIpAddressKeys = [
-  'source.ip',
-  'remote.ip',
-  'destination.ip'
-]
+const conditionIpAddressKeys = ['source.ip', 'remote.ip', 'destination.ip'];
 
 class ConditionBuilder extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -231,7 +227,7 @@ class ConditionBuilder extends React.Component<Props, State> {
           <TableBody />
         </Table>
         <Button
-          variant="link"
+          variant={ButtonVariant.link}
           icon={<PlusCircleIcon />}
           isDisabled={!validCondition}
           onClick={this.onAddConditionToList}

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { style } from 'typestyle';
@@ -336,7 +336,7 @@ class ServerBuilder extends React.Component<Props, State> {
         )}
         <FormGroup fieldId="addRule">
           <Button
-            variant="link"
+            variant={ButtonVariant.link}
             icon={<PlusCircleIcon />}
             onClick={this.onAddServer}
             isDisabled={!this.canAddServer()}

--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -411,7 +411,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
               <Button variant="primary" isDisabled={!isFormValid} onClick={() => this.showPreview()}>
                 Preview
               </Button>
-              <Button variant="secondary" onClick={() => this.backToList()}>
+              <Button variant="link" isInline onClick={() => this.backToList()}>
                 Cancel
               </Button>
               {!isNamespacesValid && (

--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -3,7 +3,7 @@ import { KialiAppState } from '../../store/Store';
 import { activeNamespacesSelector } from '../../store/Selectors';
 import { connect } from 'react-redux';
 import Namespace from '../../types/Namespace';
-import { ActionGroup, Button, Form, FormGroup, TextInput } from '@patternfly/react-core';
+import { ActionGroup, Button, ButtonVariant, Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { RenderContent } from '../../components/Nav/Page';
 import { style } from 'typestyle';
 import GatewayForm, { GATEWAY, GATEWAYS, GatewayState, initGateway, isGatewayStateValid } from './GatewayForm';
@@ -408,10 +408,10 @@ class IstioConfigNewPage extends React.Component<Props, State> {
               <SidecarForm sidecar={this.state.sidecar} onChange={this.onChangeSidecar} />
             )}
             <ActionGroup>
-              <Button variant="primary" isDisabled={!isFormValid} onClick={() => this.showPreview()}>
+              <Button variant={ButtonVariant.primary} isDisabled={!isFormValid} onClick={() => this.showPreview()}>
                 Preview
               </Button>
-              <Button variant="link" isInline onClick={() => this.backToList()}>
+              <Button variant={ButtonVariant.secondary} onClick={() => this.backToList()}>
                 Cancel
               </Button>
               {!isNamespacesValid && (

--- a/frontend/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, FormGroup, FormSelect, FormSelectOption, Switch } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormGroup, FormSelect, FormSelectOption, Switch } from '@patternfly/react-core';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { PeerAuthenticationMutualTLSMode } from '../../types/IstioObjects';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
@@ -280,7 +280,7 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
             <>
               <Button
                 id="addServerBtn"
-                variant="link"
+                variant={ButtonVariant.link}
                 icon={<PlusCircleIcon />}
                 isDisabled={
                   this.state.addNewPortMtls.port.length === 0 || isNaN(Number(this.state.addNewPortMtls.port))

--- a/frontend/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { JWTHeader, JWTRule } from '../../../types/IstioObjects';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { Button, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { style } from 'typestyle';
@@ -277,7 +277,7 @@ class JwtRuleBuilder extends React.Component<Props, State> {
             <>
               {this.state.jwtRuleFields.length > 0 && (
                 <Button
-                  variant="link"
+                  variant={ButtonVariant.link}
                   icon={<PlusCircleIcon />}
                   onClick={this.onUpdateJwtRule}
                   isDisabled={!isJwtFieldValid}
@@ -305,7 +305,7 @@ class JwtRuleBuilder extends React.Component<Props, State> {
           <TableBody />
         </Table>
         <Button
-          variant="link"
+          variant={ButtonVariant.link}
           icon={<PlusCircleIcon />}
           isDisabled={!this.isJwtRuleValid()}
           onClick={this.onAddJwtRuleToList}

--- a/frontend/src/pages/IstioConfigNew/ServiceEntryForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/ServiceEntryForm.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Port, ServiceEntrySpec } from '../../types/IstioObjects';
-import { Button, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { isGatewayHostValid } from '../../utils/IstioConfigUtils';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
@@ -246,7 +246,9 @@ class ServiceEntryForm extends React.Component<Props, ServiceEntryState> {
                 aria-describedby="add port number"
                 name="addPortNumber"
                 onChange={this.onAddPortNumber}
-                validated={isValid(this.state.addNewPortNumber.length > 0 && !isNaN(Number(this.state.addNewPortNumber)))}
+                validated={isValid(
+                  this.state.addNewPortNumber.length > 0 && !isNaN(Number(this.state.addNewPortNumber))
+                )}
               />
             </>,
             <>
@@ -280,14 +282,14 @@ class ServiceEntryForm extends React.Component<Props, ServiceEntryState> {
                 onChange={this.onAddTargetPort}
                 validated={isValid(
                   this.state.addNewTargetPort.length === 0 ||
-                  (this.state.addNewTargetPort.length > 0 && !isNaN(Number(this.state.addNewTargetPort))))
-                }
+                    (this.state.addNewTargetPort.length > 0 && !isNaN(Number(this.state.addNewTargetPort)))
+                )}
               />
             </>,
             <>
               <Button
                 id="addServerBtn"
-                variant="link"
+                variant={ButtonVariant.link}
                 icon={<PlusCircleIcon />}
                 isDisabled={!this.isValidPort()}
                 onClick={this.onAddNewPort}

--- a/frontend/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -3,7 +3,7 @@ import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/rea
 import { style } from 'typestyle';
 import { PFColors } from '../../components/Pf/PfColors';
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
-import { Button, FormGroup, Switch, TextInputBase as TextInput } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormGroup, Switch, TextInputBase as TextInput } from '@patternfly/react-core';
 import { isSidecarHostValid } from '../../utils/IstioConfigUtils';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { isValid } from 'utils/Common';
@@ -197,7 +197,7 @@ class SidecarForm extends React.Component<Props, SidecarState> {
             </>,
             <>
               <Button
-                variant="link"
+                variant={ButtonVariant.link}
                 icon={<PlusCircleIcon />}
                 isDisabled={!this.state.validEgressHost}
                 onClick={this.onAddEgressHost}

--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -4,6 +4,7 @@ import { ThunkDispatch } from 'redux-thunk';
 import {
   ActionGroup,
   Button,
+  ButtonVariant,
   Form,
   FormGroup,
   FormHelperText,
@@ -214,7 +215,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
               onClick={this.handleSubmit}
               isDisabled={isLoginButtonDisabled}
               style={{ width: '100%' }}
-              variant="primary"
+              variant={ButtonVariant.primary}
             >
               Log In
             </Button>
@@ -231,7 +232,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
             {messages}
           </FormHelperText>
           <ActionGroup>
-            <Button type="submit" onClick={this.handleSubmit} style={{ width: '100%' }} variant="primary">
+            <Button type="submit" onClick={this.handleSubmit} style={{ width: '100%' }} variant={ButtonVariant.primary}>
               {loginLabel}
             </Button>
           </ActionGroup>

--- a/frontend/src/pages/Overview/OverviewToolbar.tsx
+++ b/frontend/src/pages/Overview/OverviewToolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Button, ButtonVariant, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ListIcon, ThIcon, ThLargeIcon } from '@patternfly/react-icons';
 import { SortAlphaDownIcon, SortAlphaUpIcon } from '@patternfly/react-icons';
 import { connect } from 'react-redux';
@@ -176,7 +176,12 @@ export class OverviewToolbar extends React.Component<Props, State> {
               options={sortTypes}
               data-sort-field={this.state.sortField.id}
             />
-            <Button variant="plain" onClick={this.updateSortDirection} style={{ ...ThinStyle }} data-sort-asc={this.state.isSortAscending}>
+            <Button
+              variant={ButtonVariant.plain}
+              onClick={this.updateSortDirection}
+              style={{ ...ThinStyle }}
+              data-sort-asc={this.state.isSortAscending}
+            >
               {this.state.isSortAscending ? <SortAlphaDownIcon /> : <SortAlphaUpIcon />}
             </Button>
           </>
@@ -207,7 +212,7 @@ export class OverviewToolbar extends React.Component<Props, State> {
         <Tooltip content={<>Expand view</>} position={TooltipPosition.top}>
           <Button
             onClick={() => this.props.setDisplayMode(OverviewDisplayMode.EXPAND)}
-            variant="plain"
+            variant={ButtonVariant.plain}
             isActive={this.props.displayMode === OverviewDisplayMode.EXPAND}
             style={{ padding: '0 4px 0 16px' }}
             data-test={'overview-type-' + OverviewDisplayMode[OverviewDisplayMode.EXPAND]}
@@ -218,7 +223,7 @@ export class OverviewToolbar extends React.Component<Props, State> {
         <Tooltip content={<>Compact view</>} position={TooltipPosition.top}>
           <Button
             onClick={() => this.props.setDisplayMode(OverviewDisplayMode.COMPACT)}
-            variant="plain"
+            variant={ButtonVariant.plain}
             isActive={this.props.displayMode === OverviewDisplayMode.COMPACT}
             style={{ padding: '0 4px 0 4px' }}
             data-test={'overview-type-' + OverviewDisplayMode[OverviewDisplayMode.COMPACT]}
@@ -229,7 +234,7 @@ export class OverviewToolbar extends React.Component<Props, State> {
         <Tooltip content={<>List view</>} position={TooltipPosition.top}>
           <Button
             onClick={() => this.props.setDisplayMode(OverviewDisplayMode.LIST)}
-            variant="plain"
+            variant={ButtonVariant.plain}
             isActive={this.props.displayMode === OverviewDisplayMode.LIST}
             style={{ padding: '0 4px 0 4px' }}
             data-test={'overview-type-' + OverviewDisplayMode[OverviewDisplayMode.LIST]}

--- a/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
+++ b/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
@@ -37,8 +37,6 @@ type State = {
   loaded: boolean;
 };
 
-type colorButton = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'link' | 'plain' | 'control';
-
 export default class OverviewTrafficPolicies extends React.Component<OverviewTrafficPoliciesProps, State> {
   private promises = new PromisesRegistry();
   constructor(props: OverviewTrafficPoliciesProps) {

--- a/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
+++ b/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
@@ -301,9 +301,6 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
           isOpen={this.state.confirmationModal}
           onClose={this.onHideConfirmModal}
           actions={[
-            <Button key="cancel" variant="secondary" onClick={this.onHideConfirmModal}>
-              Cancel
-            </Button>,
             <Button
               data-test="confirm-traffic-policies"
               key="confirm"
@@ -312,6 +309,9 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
               onClick={this.onConfirm}
             >
               {modalAction}
+            </Button>,
+            <Button key="cancel" variant="link" isInline onClick={this.onHideConfirmModal}>
+              Cancel
             </Button>
           ]}
         >

--- a/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
+++ b/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
 import NamespaceInfo from './NamespaceInfo';
 import { AuthorizationPolicy, Sidecar } from 'types/IstioObjects';
 import { MessageType } from 'types/MessageCenter';
@@ -267,7 +267,9 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
       this.props.opTarget.length > 0
         ? this.props.opTarget.charAt(0).toLocaleUpperCase() + this.props.opTarget.slice(1)
         : '';
-    const colorAction = ['enable', 'disable', 'create'].includes(this.props.opTarget) ? 'primary' : 'danger';
+    const colorAction = ['enable', 'disable', 'create'].includes(this.props.opTarget)
+      ? ButtonVariant.primary
+      : ButtonVariant.danger;
     const title =
       'Confirm ' +
       modalAction +
@@ -305,12 +307,12 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
               data-test="confirm-traffic-policies"
               key="confirm"
               isDisabled={this.state.disableOp}
-              variant={colorAction as colorButton}
+              variant={colorAction}
               onClick={this.onConfirm}
             >
               {modalAction}
             </Button>,
-            <Button key="cancel" variant="link" isInline onClick={this.onHideConfirmModal}>
+            <Button key="cancel" variant={ButtonVariant.secondary} onClick={this.onHideConfirmModal}>
               Cancel
             </Button>
           ]}


### PR DESCRIPTION
Epic #4260 

The initial PF update left the confirmation box buttons in an intermediate
state.  PF styling moved the buttons from bottom-right to bottom-left,
and as such the button order needed to change such that "Cancel" is the
inner, not the leading, button.  Furthermore PF styling calls for the
"Cancel" button to be the "link" variant.

See https://www.patternfly.org/v4/components/modal/design-guidelines/#confirmation-dialogs

I think I found all of the instances for the change.  Here is one example:

Before:
![image](https://user-images.githubusercontent.com/2104052/170551123-5f132b29-f903-4c16-96a9-1a2b752e16ab.png)
After:
![image](https://user-images.githubusercontent.com/2104052/170551274-d124fb64-c412-4969-831e-4f375ef7a699.png)


