### PR TITLE
Added support of considering ServiceEntry endpoint labels in DestinationRule subset labels validation

### DIFF
--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -36,7 +36,7 @@ func (in NoServiceChecker) Check() models.IstioValidations {
 		validations.MergeValidations(runGatewayCheck(virtualService, gatewayNames))
 	}
 	for _, destinationRule := range in.IstioConfigList.DestinationRules {
-		validations.MergeValidations(runDestinationRuleCheck(destinationRule, in.Namespace, in.WorkloadsPerNamespace, serviceHosts, in.Namespaces, in.RegistryServices, in.IstioConfigList.VirtualServices))
+		validations.MergeValidations(runDestinationRuleCheck(destinationRule, in.Namespace, in.WorkloadsPerNamespace, in.IstioConfigList.ServiceEntries, in.Namespaces, in.RegistryServices, in.IstioConfigList.VirtualServices))
 	}
 	return validations
 }
@@ -73,7 +73,7 @@ func runGatewayCheck(virtualService networking_v1beta1.VirtualService, gatewayNa
 }
 
 func runDestinationRuleCheck(destinationRule networking_v1beta1.DestinationRule, namespace string, workloads map[string]models.WorkloadList,
-	serviceHosts map[string][]string, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryService, virtualServices []networking_v1beta1.VirtualService) models.IstioValidations {
+	serviceEntries []networking_v1beta1.ServiceEntry, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryService, virtualServices []networking_v1beta1.VirtualService) models.IstioValidations {
 	key, validations := EmptyValidValidation(destinationRule.Name, destinationRule.Namespace, DestinationRuleCheckerType)
 
 	result, valid := destinationrules.NoDestinationChecker{
@@ -82,7 +82,7 @@ func runDestinationRuleCheck(destinationRule networking_v1beta1.DestinationRule,
 		WorkloadsPerNamespace: workloads,
 		DestinationRule:       destinationRule,
 		VirtualServices:       virtualServices,
-		ServiceEntries:        serviceHosts,
+		ServiceEntries:        serviceEntries,
 		RegistryServices:      registryStatus,
 	}.Check()
 

--- a/tests/data/destination_rules_data.go
+++ b/tests/data/destination_rules_data.go
@@ -14,6 +14,11 @@ func CreateEmptyDestinationRule(namespace string, name string, host string) *net
 	return &dr
 }
 
+func CreateDestinationRuleWithLabel(namespace string, name string, host string, labelKey, labelValue string) *networking_v1beta1.DestinationRule {
+	destinationRule := AddSubsetToDestinationRule(CreateCustomLabelSubset("v1", labelKey, labelValue), CreateEmptyDestinationRule(namespace, name, host))
+	return destinationRule
+}
+
 func CreateTestDestinationRule(namespace string, name string, host string) *networking_v1beta1.DestinationRule {
 	destinationRule := AddSubsetToDestinationRule(CreateSubset("v1", "v1"),
 		AddSubsetToDestinationRule(CreateSubset("v2", "v2"), CreateEmptyDestinationRule(namespace, name, host)))
@@ -31,6 +36,16 @@ func CreateSubset(name string, versionLabel string) *api_networking_v1beta1.Subs
 		Name: name,
 		Labels: map[string]string{
 			"version": versionLabel,
+		},
+	}
+	return &s
+}
+
+func CreateCustomLabelSubset(name string, labelKey, labelValue string) *api_networking_v1beta1.Subset {
+	s := api_networking_v1beta1.Subset{
+		Name: name,
+		Labels: map[string]string{
+			labelKey: labelValue,
 		},
 	}
 	return &s

--- a/tests/data/service_entry_data.go
+++ b/tests/data/service_entry_data.go
@@ -21,6 +21,18 @@ func CreateExternalServiceEntry() networking_v1beta1.ServiceEntry {
 	return se
 }
 
+func AddEndpointToServiceEntry(address, labelKey, labelValue string, se *networking_v1beta1.ServiceEntry) *networking_v1beta1.ServiceEntry {
+	se.Spec.Endpoints = []*api_networking_v1beta1.WorkloadEntry{
+		{
+			Address: address,
+			Labels: map[string]string{
+				labelKey: labelValue,
+			},
+		},
+	}
+	return se
+}
+
 func CreateEmptyMeshExternalServiceEntry(name, namespace string, hosts []string) *networking_v1beta1.ServiceEntry {
 	se := networking_v1beta1.ServiceEntry{}
 	se.Name = name

--- a/tests/integration/assets/bookinfo-service-entry-labels.yaml
+++ b/tests/integration/assets/bookinfo-service-entry-labels.yaml
@@ -1,0 +1,81 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: service-entry-labels
+  namespace: bookinfo
+spec:
+  endpoints:
+    - address: XXX.us-east-1.elb.amazonaws.com
+      labels:
+        cluster: cluster-1a
+      ports:
+        data: 443
+  hosts:
+    - app-rpc.bookinfo.svc.cluster-1a.global
+  location: MESH_INTERNAL
+  ports:
+    - name: data
+      number: 8765
+      protocol: TCP
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: dest-rule-labels
+  namespace: bookinfo
+spec:
+  host: app-rpc.bookinfo.svc.cluster-1a.global
+  subsets:
+    - labels:
+        cluster: cluster-1a
+      name: cluster-1a
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      sni: app-rpc.bookinfo
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: app-rpc-icc
+  namespace: bookinfo
+spec:
+  hosts:
+    - app-rpc
+    - app-rpc.bookinfo
+  gateways:
+    - bookinfo/ingress-app
+    - mesh
+  http:
+    - route:
+        - destination:
+            host: app-rpc.bookinfo.svc.cluster-1b.global
+            subset: cluster-1b
+          weight: 0
+        - destination:
+            host: app-rpc.bookinfo.svc.cluster-1a.global
+            subset: cluster-1a
+          weight: 0
+        - destination:
+            host: app-rpc.bookinfo.svc.cluster.local
+          weight: 100
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: ingress-app
+  namespace: bookinfo
+spec:
+  selector:
+    app: istio-ingressgateway
+  servers:
+    - hosts:
+        - bookinfo/app-rpc.bookinfo
+      port:
+        name: grpc
+        number: 443
+        protocol: HTTPS
+      tls:
+        credentialName: istio-icc-app
+        mode: SIMPLE

--- a/tests/integration/assets/bookinfo-service-entry-wrong-labels.yaml
+++ b/tests/integration/assets/bookinfo-service-entry-wrong-labels.yaml
@@ -1,0 +1,81 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: service-entry-labels
+  namespace: bookinfo
+spec:
+  endpoints:
+    - address: XXX.us-east-1.elb.amazonaws.com
+      labels:
+        cluster: cluster-1a
+      ports:
+        data: 443
+  hosts:
+    - app-rpc.bookinfo.svc.cluster-1a.global
+  location: MESH_INTERNAL
+  ports:
+    - name: data
+      number: 8765
+      protocol: TCP
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: dest-rule-labels-wrong
+  namespace: bookinfo
+spec:
+  host: app-rpc.bookinfo.svc.cluster-1a.global
+  subsets:
+    - labels:
+        cluster: wrong
+      name: cluster-1a
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      sni: app-rpc.bookinfo
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: app-rpc-icc
+  namespace: bookinfo
+spec:
+  hosts:
+    - app-rpc
+    - app-rpc.bookinfo
+  gateways:
+    - bookinfo/ingress-app
+    - mesh
+  http:
+    - route:
+        - destination:
+            host: app-rpc.bookinfo.svc.cluster-1b.global
+            subset: cluster-1b
+          weight: 0
+        - destination:
+            host: app-rpc.bookinfo.svc.cluster-1a.global
+            subset: cluster-1a
+          weight: 0
+        - destination:
+            host: app-rpc.bookinfo.svc.cluster.local
+          weight: 100
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: ingress-app
+  namespace: bookinfo
+spec:
+  selector:
+    app: istio-ingressgateway
+  servers:
+    - hosts:
+        - bookinfo/app-rpc.bookinfo
+      port:
+        name: grpc
+        number: 443
+        protocol: HTTPS
+      tls:
+        credentialName: istio-icc-app
+        mode: SIMPLE


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5131

DestinationRule subset labels has been checked to match workload labels.
In case when no Workload/Service exists, the ServiceEntry could be created which points to external resource and match the DestinationRule subset labels.
With this PR, the validation of DR subset labels is extended to consider ServiceEntry endpoint labels when no Workload is found with labels.

![Screenshot from 2022-05-31 15-15-22](https://user-images.githubusercontent.com/604313/171182122-d0c9c5c1-c272-42e7-9671-f7ab073a9b8f.png)
