### PR TITLE
Added istio port-forward to run-kiali script

### DIFF
--- a/hack/run-kiali-config-template.yaml
+++ b/hack/run-kiali-config-template.yaml
@@ -30,6 +30,9 @@ external_services:
     in_cluster_url: "${GRAFANA_URL}"
     url: "${GRAFANA_URL}"
 
+  istio:
+    url_service_version: "${ISTIOD_URL}"
+
   prometheus:
     url: "${PROMETHEUS_URL}"
 

--- a/hack/run-kiali.sh
+++ b/hack/run-kiali.sh
@@ -75,7 +75,7 @@ DEFAULT_API_PROXY_PORT="8001"
 DEFAULT_CLIENT_EXE="kubectl"
 DEFAULT_ENABLE_SERVER="true"
 DEFAULT_ISTIO_NAMESPACE="istio-system"
-DEFAULT_ISTIO_URL="http://127.0.0.1:15014/version"
+DEFAULT_ISTIOD_URL="http://127.0.0.1:15014/version"
 DEFAULT_KIALI_CONFIG_TEMPLATE_FILE="${SCRIPT_DIR}/run-kiali-config-template.yaml"
 DEFAULT_KIALI_EXE="${GOPATH:-.}/bin/kiali"
 DEFAULT_KUBE_CONTEXT="kiali-developer"
@@ -155,7 +155,7 @@ Valid options:
       Default: ${DEFAULT_ISTIO_NAMESPACE}
   -iu|--istiod-url
       The URL of the istiod endpoint.
-      Default: ${DEFAULT_ISTIO_URL}
+      Default: ${DEFAULT_ISTIOD_URL}
   -kah|--kubernetes-api-host
       The hostname of the Kubernetes API Endpoint.
       Default: <will be auto-discovered>
@@ -288,9 +288,7 @@ fi
 # Port forward data for Istiod, used for the Istiod URL
 PORT_FORWARD_SERVICE_ISTIOD="service/istiod"
 LOCAL_REMOTE_PORTS_ISTIOD="15014:15014"
-if [ -z "${ISTIOD_URL:-}" ]; then
-  ISTIOD_URL= "${DEFAULT_ISTIO_URL}"
-fi
+ISTIOD_URL="${ISTIOD_URL:-${DEFAULT_ISTIOD_URL}}"
 
 
 # If the user didn't tell us what the Prometheus URL is, try to auto-discover it
@@ -490,6 +488,7 @@ echo "CLIENT_EXE=$CLIENT_EXE"
 echo "ENABLE_SERVER=$ENABLE_SERVER"
 echo "GRAFANA_URL=$GRAFANA_URL"
 echo "ISTIO_NAMESPACE=$ISTIO_NAMESPACE"
+echo "ISTIOD_URL=$ISTIOD_URL"
 echo "KIALI_CONFIG_TEMPLATE_FILE=$KIALI_CONFIG_TEMPLATE_FILE"
 echo "KIALI_EXE=$KIALI_EXE"
 echo "KUBE_CONTEXT=$KUBE_CONTEXT"

--- a/hack/run-kiali.sh
+++ b/hack/run-kiali.sh
@@ -75,6 +75,7 @@ DEFAULT_API_PROXY_PORT="8001"
 DEFAULT_CLIENT_EXE="kubectl"
 DEFAULT_ENABLE_SERVER="true"
 DEFAULT_ISTIO_NAMESPACE="istio-system"
+DEFAULT_ISTIO_URL="http://127.0.0.1:15014/version"
 DEFAULT_KIALI_CONFIG_TEMPLATE_FILE="${SCRIPT_DIR}/run-kiali-config-template.yaml"
 DEFAULT_KIALI_EXE="${GOPATH:-.}/bin/kiali"
 DEFAULT_KUBE_CONTEXT="kiali-developer"
@@ -96,8 +97,8 @@ while [[ $# -gt 0 ]]; do
     -ce|--client-exe)            CLIENT_EXE="$2";                    shift;shift ;;
     -es|--enable-server)         ENABLE_SERVER="$2";                 shift;shift ;;
     -gu|--grafana-url)           GRAFANA_URL="$2";                   shift;shift ;;
-    -iu|--istiod-url)            ISTIOD_URL="$2";                    shift;shift ;;
     -in|--istio-namespace)       ISTIO_NAMESPACE="$2";               shift;shift ;;
+    -iu|--istiod-url)            ISTIOD_URL="$2";                    shift;shift ;;
     -kah|--kubernetes-api-host)  KUBERNETES_API_HOST="$2";           shift;shift ;;
     -kap|--kubernetes-api-port)  KUBERNETES_API_PORT="$2";           shift;shift ;;
     -kc|--kube-context)          KUBE_CONTEXT="$2";                  shift;shift ;;
@@ -152,6 +153,9 @@ Valid options:
   -in|--istio-namespace
       The name of the control plane namespace - this is where Istio components are installed.
       Default: ${DEFAULT_ISTIO_NAMESPACE}
+  -iu|--istiod-url
+      The URL of the istiod endpoint.
+      Default: ${DEFAULT_ISTIO_URL}
   -kah|--kubernetes-api-host
       The hostname of the Kubernetes API Endpoint.
       Default: <will be auto-discovered>
@@ -285,7 +289,7 @@ fi
 PORT_FORWARD_SERVICE_ISTIOD="service/istiod"
 LOCAL_REMOTE_PORTS_ISTIOD="15014:15014"
 if [ -z "${ISTIOD_URL:-}" ]; then
-  ISTIOD_URL="http://127.0.0.1:15014/version"
+  ISTIOD_URL= "${DEFAULT_ISTIO_URL}"
 fi
 
 

--- a/hack/run-kiali.sh
+++ b/hack/run-kiali.sh
@@ -96,6 +96,7 @@ while [[ $# -gt 0 ]]; do
     -ce|--client-exe)            CLIENT_EXE="$2";                    shift;shift ;;
     -es|--enable-server)         ENABLE_SERVER="$2";                 shift;shift ;;
     -gu|--grafana-url)           GRAFANA_URL="$2";                   shift;shift ;;
+    -iu|--istiod-url)            ISTIOD_URL="$2";                    shift;shift ;;
     -in|--istio-namespace)       ISTIO_NAMESPACE="$2";               shift;shift ;;
     -kah|--kubernetes-api-host)  KUBERNETES_API_HOST="$2";           shift;shift ;;
     -kap|--kubernetes-api-port)  KUBERNETES_API_PORT="$2";           shift;shift ;;
@@ -279,6 +280,14 @@ else
   IS_OPENSHIFT="false"
   infomsg "You are connecting to a (non-OpenShift) Kubernetes cluster"
 fi
+
+# Port forward data for Istiod, used for the Istiod URL
+PORT_FORWARD_SERVICE_ISTIOD="service/istiod"
+LOCAL_REMOTE_PORTS_ISTIOD="15014:15014"
+if [ -z "${ISTIOD_URL:-}" ]; then
+  ISTIOD_URL="http://127.0.0.1:15014/version"
+fi
+
 
 # If the user didn't tell us what the Prometheus URL is, try to auto-discover it
 
@@ -512,6 +521,7 @@ if ! echo "${LOG_LEVEL}" | grep -qiE "^(trace|debug|info|warn|error|fatal)$"; th
 KIALI_CONFIG_FILE="${TMP_DIR}/run-kiali-config.yaml"
 cat ${KIALI_CONFIG_TEMPLATE_FILE} | \
   ISTIO_NAMESPACE=${ISTIO_NAMESPACE} \
+  ISTIOD_URL=${ISTIOD_URL} \
   PROMETHEUS_URL=${PROMETHEUS_URL} \
   GRAFANA_URL=${GRAFANA_URL} \
   TRACING_URL=${TRACING_URL} \
@@ -634,6 +644,14 @@ kill_port_forward_component() {
   fi
 }
 
+start_port_forward_istiod() {
+  start_port_forward_component 'Istiod' 'PORT_FORWARD_JOB_ISTIOD' "${PORT_FORWARD_SERVICE_ISTIOD}" "${LOCAL_REMOTE_PORTS_ISTIOD}" "${ISTIOD_URL}" '--istiod-url'
+}
+
+kill_port_forward_istiod() {
+  kill_port_forward_component 'Istiod' 'PORT_FORWARD_JOB_ISTIOD'
+}
+
 start_port_forward_prometheus() {
   start_port_forward_component 'Prometheus' 'PORT_FORWARD_JOB_PROMETHEUS' "${PORT_FORWARD_DEPLOYMENT_PROMETHEUS}" "${LOCAL_REMOTE_PORTS_PROMETHEUS}"  "${PROMETHEUS_URL}" '--prometheus-url'
 }
@@ -722,6 +740,7 @@ ask_to_restart_or_exit() {
 cleanup_and_exit() {
   kill_server
   kill_proxy
+  kill_port_forward_istiod
   kill_port_forward_prometheus
   kill_port_forward_grafana
   kill_port_forward_tracing
@@ -749,6 +768,7 @@ else
   infomsg "The server is not rebootable. You can kill this script via either [kill $$] or [kill -USR1 $$]"
 fi
 
+start_port_forward_istiod
 start_port_forward_prometheus
 start_port_forward_grafana
 start_port_forward_tracing


### PR DESCRIPTION
Added istio port forward to run kiali script when istio_url is passed as a parameter. 

Changes from https://github.com/kiali/kiali/pull/5061/files#diff-4835d54dd5ef3a768c44727c31447cdc82e8fe4cb7be22858493b38ca2d239c4

For more details, see https://github.com/kiali/kiali.io/pull/537#issuecomment-1142047243 

cc @jmazzitelli 