### PR TITLE
Add tooltips to graph side-panel traffic tabs

### DIFF
--- a/frontend/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tab } from '@patternfly/react-core';
+import { Tab, Tooltip } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { summaryFont, summaryHeader, summaryBodyTabs, summaryPanelWidth, getTitle } from './SummaryPanelCommon';
 import { CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
@@ -75,6 +75,10 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
     const tcpOut = getAccumulatedTrafficRateTcp(outboundEdges);
     const tcpTotal = getAccumulatedTrafficRateTcp(totalEdges);
 
+    const tooltipInboundRef = React.createRef();
+    const tooltipOutboundRef = React.createRef();
+    const tooltipTotalRef = React.createRef();
+
     return (
       <div className="panel panel-default" style={SummaryPanelClusterBox.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
@@ -84,7 +88,25 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
         </div>
         <div className={summaryBodyTabs}>
           <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-            <Tab style={summaryFont} title="Inbound" eventKey={0}>
+            <Tooltip
+              id="tooltip-inbound"
+              content="Traffic entering from another cluster."
+              entryDelay={1250}
+              reference={tooltipInboundRef}
+            />
+            <Tooltip
+              id="tooltip-outbound"
+              content="Traffic exiting to another cluster."
+              entryDelay={1250}
+              reference={tooltipOutboundRef}
+            />
+            <Tooltip
+              id="tooltip-total"
+              content="All inbound, outbound and internal cluster traffic."
+              entryDelay={1250}
+              reference={tooltipTotalRef}
+            />
+            <Tab style={summaryFont} title="Inbound" eventKey={0} ref={tooltipInboundRef}>
               <div style={summaryFont}>
                 {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
                   <>
@@ -116,7 +138,7 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
                 }
               </div>
             </Tab>
-            <Tab style={summaryFont} title="Outbound" eventKey={1}>
+            <Tab style={summaryFont} title="Outbound" eventKey={1} ref={tooltipOutboundRef}>
               <div style={summaryFont}>
                 {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
                   <>
@@ -148,7 +170,7 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
                 }
               </div>
             </Tab>
-            <Tab style={summaryFont} title="Total" eventKey={2}>
+            <Tab style={summaryFont} title="Total" eventKey={2} ref={tooltipTotalRef}>
               <div style={summaryFont}>
                 {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
                   <>

--- a/frontend/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelGraph.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tab } from '@patternfly/react-core';
+import { Tab, Tooltip } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import _ from 'lodash';
 import { RateTableGrpc, RateTableHttp, RateTableTcp } from '../../components/SummaryPanel/RateTable';
@@ -181,6 +181,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     const { grpcIn, grpcOut, grpcTotal, httpIn, httpOut, httpTotal, isGrpcRequests, tcpIn, tcpOut, tcpTotal } =
       this.graphTraffic || this.getGraphTraffic();
 
+    const tooltipInboundRef = React.createRef();
+    const tooltipOutboundRef = React.createRef();
+    const tooltipTotalRef = React.createRef();
+
     return (
       <div id="summary-panel-graph" className="panel panel-default" style={SummaryPanelGraph.panelStyle}>
         <div id="summary-panel-graph-heading" className="panel-heading" style={summaryHeader}>
@@ -191,7 +195,25 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
         </div>
         <div className={summaryBodyTabs}>
           <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-            <Tab style={summaryFont} title="Inbound" eventKey={0}>
+            <Tooltip
+              id="tooltip-inbound"
+              content="Traffic entering from traffic sources."
+              entryDelay={1250}
+              reference={tooltipInboundRef}
+            />
+            <Tooltip
+              id="tooltip-outbound"
+              content="Traffic exiting the requested namespaces."
+              entryDelay={1250}
+              reference={tooltipOutboundRef}
+            />
+            <Tooltip
+              id="tooltip-total"
+              content="All inbound, outbound and traffic within the requested namespaces."
+              entryDelay={1250}
+              reference={tooltipTotalRef}
+            />
+            <Tab style={summaryFont} title="Inbound" eventKey={0} ref={tooltipInboundRef}>
               <div style={summaryFont}>
                 {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
                   <>
@@ -223,7 +245,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
                 }
               </div>
             </Tab>
-            <Tab style={summaryFont} title="Outbound" eventKey={1}>
+            <Tab style={summaryFont} title="Outbound" eventKey={1} ref={tooltipOutboundRef}>
               <div style={summaryFont}>
                 {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
                   <>
@@ -255,7 +277,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
                 }
               </div>
             </Tab>
-            <Tab style={summaryFont} title="Total" eventKey={2}>
+            <Tab style={summaryFont} title="Total" eventKey={2} ref={tooltipTotalRef}>
               <div style={summaryFont}>
                 {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
                   <>

--- a/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tab } from '@patternfly/react-core';
+import { Tab, Tooltip } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { RateTableGrpc, RateTableHttp, RateTableTcp } from '../../components/SummaryPanel/RateTable';
 import { RequestChart, StreamChart } from '../../components/SummaryPanel/RpsChart';
@@ -174,6 +174,10 @@ export default class SummaryPanelNamespaceBox extends React.Component<
     const { grpcIn, grpcOut, grpcTotal, httpIn, httpOut, httpTotal, isGrpcRequests, tcpIn, tcpOut, tcpTotal } =
       this.boxTraffic || this.getBoxTraffic();
 
+    const tooltipInboundRef = React.createRef();
+    const tooltipOutboundRef = React.createRef();
+    const tooltipTotalRef = React.createRef();
+
     return (
       <div className="panel panel-default" style={SummaryPanelNamespaceBox.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
@@ -184,7 +188,25 @@ export default class SummaryPanelNamespaceBox extends React.Component<
         </div>
         <div className={summaryBodyTabs}>
           <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-            <Tab style={summaryFont} title="Inbound" eventKey={0}>
+            <Tooltip
+              id="tooltip-inbound"
+              content="Traffic entering from another namespace."
+              entryDelay={1250}
+              reference={tooltipInboundRef}
+            />
+            <Tooltip
+              id="tooltip-outbound"
+              content="Traffic exiting to another namespace."
+              entryDelay={1250}
+              reference={tooltipOutboundRef}
+            />
+            <Tooltip
+              id="tooltip-total"
+              content="All inbound, outbound and internal namespace traffic."
+              entryDelay={1250}
+              reference={tooltipTotalRef}
+            />
+            <Tab style={summaryFont} title="Inbound" eventKey={0} ref={tooltipInboundRef}>
               <div style={summaryFont}>
                 {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
                   <>
@@ -216,7 +238,7 @@ export default class SummaryPanelNamespaceBox extends React.Component<
                 }
               </div>
             </Tab>
-            <Tab style={summaryFont} title="Outbound" eventKey={1}>
+            <Tab style={summaryFont} title="Outbound" eventKey={1} ref={tooltipOutboundRef}>
               <div style={summaryFont}>
                 {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
                   <>
@@ -248,7 +270,7 @@ export default class SummaryPanelNamespaceBox extends React.Component<
                 }
               </div>
             </Tab>
-            <Tab style={summaryFont} title="Total" eventKey={2}>
+            <Tab style={summaryFont} title="Total" eventKey={2} ref={tooltipTotalRef}>
               <div style={summaryFont}>
                 {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
                   <>
@@ -422,7 +444,7 @@ export default class SummaryPanelNamespaceBox extends React.Component<
 
     // When there is any traffic for the protocol, show both inbound and outbound charts. It's a little
     // confusing because for the tabs inbound is limited to just traffic entering the namespace, and outbound
-    // is limited to just traffic exitingt the namespace.  But in the charts inbound ad outbound also
+    // is limited to just traffic exiting the namespace.  But in the charts inbound ad outbound also
     // includes traffic within the namespace.
     const { grpcTotal, httpTotal, isGrpcRequests, tcpTotal } = this.boxTraffic!;
 


### PR DESCRIPTION
Related to review comments for:
issue: https://github.com/kiali/kiali/issues/4896
pr: https://github.com/kiali/kiali/pull/5117

For graph side-panels with Inbound/Outbound/Total tabs, add tooltips that
explain the semantics for each, as each side-panel is different.
