### PR TITLE
Remove KIA1003 and KIA1103 checkers

### DIFF
--- a/business/checkers/sidecars/egress_listener_checker.go
+++ b/business/checkers/sidecars/egress_listener_checker.go
@@ -61,10 +61,7 @@ func (elc EgressHostChecker) validateHost(host string, egrIdx, hostIdx int) ([]*
 	checks := make([]*models.IstioCheck, 0)
 	sns := elc.Sidecar.Namespace
 
-	hostNs, dnsName, valid := getHostComponents(host)
-	if !valid {
-		return append(checks, buildCheck("sidecar.egress.invalidhostformat", egrIdx, hostIdx)), false
-	}
+	hostNs, dnsName := getHostComponents(host)
 
 	// Don't show any validation for common scenarios like */*, ~/* and ./*
 	if (hostNs == "*" || hostNs == "~" || hostNs == ".") && dnsName == "*" {
@@ -97,14 +94,9 @@ func (elc EgressHostChecker) HasMatchingService(host kubernetes.Host, itemNamesp
 	return kubernetes.HasMatchingRegistryService(itemNamespace, host.String(), elc.RegistryServices)
 }
 
-func getHostComponents(host string) (string, string, bool) {
+func getHostComponents(host string) (string, string) {
 	hParts := strings.Split(host, "/")
-
-	if len(hParts) != 2 {
-		return "", "", false
-	}
-
-	return hParts[0], hParts[1], true
+	return hParts[0], hParts[1]
 }
 
 func buildCheck(code string, egrIdx, hostIdx int) *models.IstioCheck {

--- a/business/checkers/sidecars/egress_listener_checker_test.go
+++ b/business/checkers/sidecars/egress_listener_checker_test.go
@@ -282,24 +282,6 @@ func TestEgressHostCrossNamespaceServiceNotFound(t *testing.T) {
 	}
 }
 
-func TestEgressInvalidHostFormat(t *testing.T) {
-	assert := assert.New(t)
-
-	vals, valid := EgressHostChecker{
-		Sidecar: *sidecarWithHosts([]string{
-			"no-dash-used",
-		}),
-	}.Check()
-
-	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
-	assert.False(valid)
-
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.Equal("spec/egress[0]/hosts[0]", vals[0].Path)
-	assert.NoError(validations.ConfirmIstioCheckMessage("sidecar.egress.invalidhostformat", vals[0]))
-}
-
 func TestEgressServiceNotFound(t *testing.T) {
 	assert := assert.New(t)
 

--- a/business/checkers/virtualservices/no_host_checker.go
+++ b/business/checkers/virtualservices/no_host_checker.go
@@ -83,11 +83,6 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 		}
 	}
 
-	if len(n.VirtualService.Spec.Http) == 0 && len(n.VirtualService.Spec.Tcp) == 0 && len(n.VirtualService.Spec.Tls) == 0 {
-		validation := models.Build("virtualservices.nohost.invalidprotocol", "")
-		validations = append(validations, &validation)
-		valid = false
-	}
 	return validations, valid
 }
 

--- a/business/checkers/virtualservices/no_host_checker_test.go
+++ b/business/checkers/virtualservices/no_host_checker_test.go
@@ -95,20 +95,6 @@ func TestNoValidHost(t *testing.T) {
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", vals[0]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", vals[0].Path)
-
-	virtualService.Spec.Tcp = nil
-
-	vals, valid = NoHostChecker{
-		Namespace:        "test-namespace",
-		RegistryServices: append(registryService1, registryService2...),
-		VirtualService:   *virtualService,
-	}.Check()
-
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.invalidprotocol", vals[0]))
-	assert.Equal("", vals[0].Path)
 }
 
 func TestNoValidExportedHost(t *testing.T) {
@@ -154,20 +140,6 @@ func TestNoValidExportedHost(t *testing.T) {
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", vals[0]))
 	assert.Equal("spec/tcp[0]/route[0]/destination/host", vals[0].Path)
-
-	virtualService.Spec.Tcp = nil
-
-	vals, valid = NoHostChecker{
-		Namespace:        "bookinfo",
-		VirtualService:   *virtualService,
-		RegistryServices: append(data.CreateFakeRegistryServices("ratings.bookinfo2.svc.cluster.local", "bookinfo2", "bookinfo2"), append(registryService1, registryService2...)...),
-	}.Check()
-
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.invalidprotocol", vals[0]))
-	assert.Equal("", vals[0].Path)
 }
 
 func TestInvalidServiceNamespaceFormatHost(t *testing.T) {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -267,11 +267,6 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "ServiceRole does not exists in this namespace",
 		Severity: ErrorSeverity,
 	},
-	"sidecar.egress.invalidhostformat": {
-		Code:     "KIA1003",
-		Message:  "Invalid host format. 'namespace/dnsName' format expected",
-		Severity: ErrorSeverity,
-	},
 	"sidecar.egress.servicenotfound": {
 		Code:     "KIA1004",
 		Message:  "This host has no matching entry in the service registry",
@@ -295,11 +290,6 @@ var checkDescriptors = map[string]IstioCheck{
 	"virtualservices.nogateway": {
 		Code:     "KIA1102",
 		Message:  "VirtualService is pointing to a non-existent gateway",
-		Severity: ErrorSeverity,
-	},
-	"virtualservices.nohost.invalidprotocol": {
-		Code:     "KIA1103",
-		Message:  "VirtualService doesn't define any valid route protocol",
 		Severity: ErrorSeverity,
 	},
 	"virtualservices.route.singleweight": {


### PR DESCRIPTION
These checkers are now obsolete, because Istio is actively ensuring that the offending configurations verified by KIA1003 and KIA1103 cannot make it into the cluster (i.e. the cluster will reject a resource with the offending configs). This means that KIA1003 and KIA1103 are now dead checkers and can be removed safely.

Found while working on #5085.