### PR TITLE
[v1.36] Bump go version to 1.17.10

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.2
+          go-version: 1.17.10
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.17.2
+GO_VERSION_KIALI = 1.17.10
 
 SWAGGER_VERSION ?= 0.27.0
 


### PR DESCRIPTION
Upgrade version to 1.17.10 for builds