### PR TITLE
Default to podman in CI molecule tests

### DIFF
--- a/hack/ci-kind-molecule-tests.sh
+++ b/hack/ci-kind-molecule-tests.sh
@@ -360,7 +360,7 @@ EOF
   # ${CLIENT_EXE} create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
   ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
 
-  subnet=$(${DORP} network inspect kind --format '{{(index .IPAM.Config 0).Subnet}}')
+  subnet=$(sudo ${DORP} network inspect kind --format '{{(index .IPAM.Config 0).Subnet}}')
   subnet_trimmed=$(echo ${subnet} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+\..*/\1/')
   first_ip="${subnet_trimmed}.$(echo "${lb_addr_range}" | cut -d '-' -f 1)"
   last_ip="${subnet_trimmed}.$(echo "${lb_addr_range}" | cut -d '-' -f 2)"

--- a/hack/ci-kind-molecule-tests.sh
+++ b/hack/ci-kind-molecule-tests.sh
@@ -178,7 +178,7 @@ set -e
 # set up some of our defaults
 CLIENT_EXE=${CLIENT_EXE:-/usr/bin/kubectl}
 SRC="${SRC:-/tmp/KIALI-GIT}"
-DORP="${DORP:-docker}"
+DORP="${DORP:-podman}"
 GIT_CLONE_PROTOCOL="${GIT_CLONE_PROTOCOL:-git}"
 OLM_ENABLED="${OLM_ENABLED:-false}"
 

--- a/hack/run-molecule-tests.sh
+++ b/hack/run-molecule-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in
@@ -21,6 +23,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     -ct|--cluster-type)
       CLUSTER_TYPE="$2"
+      shift;shift
+      ;;
+    -dorp|--docker-or-podman)
+      echo "Docker is no longer supported by the molecule tests. This argument will largely be ignored and podman used instead."
+      DORP="$2"
       shift;shift
       ;;
     -d|--debug)
@@ -96,6 +103,7 @@ $0 [option...] command
 -ci                      Run in continuous-integration mode. Verbose logs will be printed to stdout. (default: false).
 -ct|--cluster-type       The type of cluster being tested. Must be one of: minikube, openshift. (default: openshift)
 -d|--debug               True if you want the molecule tests to output large amounts of debug messages. (default: true)
+-dorp|--docker-or-podman What should be used. NOTE: Docker is no longer supported. Molecule tests will only run with "podman". (default: podman)
 -hcr|--helm-charts-repo  Location of the helm charts git repo. (default: ../helm-charts)
 -jxf|--junit-xml-file    Location of the JUnit XML results file; set to "" to not output this file. (default: results.xml in the --test-logs-dir)
 -ksh|--kiali_src-home    Location of the Kiali source code, the makefiles, and operator/molecule tests. (default: ..)
@@ -213,6 +221,7 @@ if [ "${MOLECULE_USE_DEV_IMAGES}" == "true" -a "${MOLECULE_USE_DEFAULT_SERVER_IM
 fi
 
 echo "========== SETTINGS =========="
+echo DORP="$DORP"
 echo KIALI_SRC_HOME="$KIALI_SRC_HOME"
 echo ALL_TESTS="$ALL_TESTS"
 echo SKIP_TESTS="$SKIP_TESTS"
@@ -346,6 +355,21 @@ if [ ! -z "${TEST_CLIENT_EXE}" ]; then
   export OC="${TEST_CLIENT_EXE}"
 fi
 
+# we have to explicitly tell the makefile about the DORP value
+if [ -z "${DORP}" ]; then
+  if ! which podman > /dev/null 2>&1; then
+    if which docker > /dev/null 2>&1; then
+      DORP="docker"
+    else
+      echo "You do not have 'docker' or 'podman' in PATH - aborting."
+      exit 1
+    fi
+  else
+    DORP="podman"
+  fi
+fi
+export DORP
+
 # the user may have specified a specific minikube profile to use - export this so make knows about it
 export MINIKUBE_PROFILE
 
@@ -405,7 +429,7 @@ do
 
   export MOLECULE_SCENARIO="${t}"
   if [ "$CI" != "true" ]; then
-    make -e HELM_CHARTS_REPO=${HELM_CHARTS_REPO} molecule-test >> ${TEST_LOGS_DIR}/${t}.log 2>&1
+    make molecule-test >> ${TEST_LOGS_DIR}/${t}.log 2>&1
     exitcode="$?"
   else
     make molecule-test |& tee ${TEST_LOGS_DIR}/${t}.log
@@ -455,4 +479,3 @@ echo "Test logs can be found at: ${TEST_LOGS_DIR}"
 echo
 
 exit $EXIT_CODE
-

--- a/hack/run-molecule-tests.sh
+++ b/hack/run-molecule-tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in

--- a/make/Makefile.molecule.mk
+++ b/make/Makefile.molecule.mk
@@ -90,13 +90,9 @@ MOLECULE_KUBECONFIG ?= ${HOME}/.kube/config
 # Set up some additional things needed in order to run the molecule tests against a minikube installation
 ifeq ($(CLUSTER_TYPE),minikube)
 MOLECULE_MINIKUBE_DIR ?= ${HOME}/.minikube
-ifeq ($(DORP),podman)
 # Mounting each file under .minikube individually. podman 3 has more restrictive volume permissions and the :Z label is required
 # but there are two files which are owned by the qemu user and these cannot be labeled since the current user doesn't own them.
 MOLECULE_MINIKUBE_VOL_ARG ?= $(shell MYVAR=""; while read -r file ; do MYVAR="$${MYVAR} -v $${file}:$${file}:Z" ; done <<< $$(find ${MOLECULE_MINIKUBE_DIR} -type f | grep -v ".iso" | grep -v ".rawdisk") && echo $$MYVAR)
-else
-MOLECULE_MINIKUBE_VOL_ARG ?= -v ${MOLECULE_MINIKUBE_DIR}:${MOLECULE_MINIKUBE_DIR}
-endif
 MOLECULE_MINIKUBE_IP ?= $(shell ${MINIKUBE} ip -p ${MINIKUBE_PROFILE})
 MOLECULE_MINIKUBE_ENV_ARGS ?= --env MOLECULE_MINIKUBE_IP=$(shell echo -n ${MOLECULE_MINIKUBE_IP})
 # if there are no hosts the user wants, explicitly set this to empty string to avoid errors later
@@ -107,7 +103,7 @@ endif
 
 # Set up some additional things needed in order to run the molecule tests against a kind installation
 ifeq ($(CLUSTER_TYPE),kind)
-MOLECULE_KIND_IP ?= $(shell ${DORP} inspect ${KIND_NAME}-control-plane --format "{{ .NetworkSettings.Networks.kind.IPAddress }}")
+MOLECULE_KIND_IP ?= $(shell docker inspect ${KIND_NAME}-control-plane --format "{{ .NetworkSettings.Networks.kind.IPAddress }}")
 MOLECULE_KIND_ENV_ARGS ?= --env MOLECULE_KIND_IP=$(shell echo -n ${MOLECULE_KIND_IP})
 # if there are no hosts the user wants, explicitly set this to empty string to avoid errors later
 ifndef MOLECULE_ADD_HOST_ARGS
@@ -130,19 +126,11 @@ endif
 MOLECULE_WAIT_RETRIES_ARG ?= --env MOLECULE_WAIT_RETRIES=${MOLECULE_WAIT_RETRIES}
 
 .prepare-force-molecule-build:
-ifeq ($(DORP),docker)
-	@$(eval FORCE_MOLECULE_BUILD ?= $(shell docker inspect kiali-molecule:latest > /dev/null 2>&1 || echo "true"))
-else
 	@$(eval FORCE_MOLECULE_BUILD ?= $(shell podman inspect kiali-molecule:latest > /dev/null 2>&1 || echo "true"))
-endif
 
 ## molecule-build: Builds an image to run Molecule without requiring the host to have python/pip installed. If it already exists, and you want to build it again, set env var FORCE_MOLECULE_BUILD to "true".
 molecule-build: .ensure-operator-repo-exists .prepare-force-molecule-build
-ifeq ($(DORP),docker)
-	@if [ "${FORCE_MOLECULE_BUILD}" == "true" ]; then docker build --no-cache -t kiali-molecule:latest ${ROOTDIR}/operator/molecule/docker; else echo "Will not rebuild kiali-molecule image."; fi
-else
 	@if [ "${FORCE_MOLECULE_BUILD}" == "true" ]; then podman build --no-cache -t kiali-molecule:latest ${ROOTDIR}/operator/molecule/docker; else echo "Will not rebuild kiali-molecule image."; fi
-endif
 
 ifndef MOLECULE_ADD_HOST_ARGS
 .prepare-add-host-args: .prepare-cluster
@@ -155,18 +143,14 @@ else
 endif
 
 .prepare-molecule-data-volume:
-	$(DORP) volume create molecule-tests-volume
-	$(DORP) create -v molecule-tests-volume:/data --name molecule-volume-helper docker.io/busybox true
-	$(DORP) cp "${HELM_CHARTS_REPO}" molecule-volume-helper:/data/helm-charts-repo
-	$(DORP) cp "${ROOTDIR}/operator/" molecule-volume-helper:/data/operator
-	$(DORP) cp "${MOLECULE_KUBECONFIG}" molecule-volume-helper:/data/kubeconfig
-	$(DORP) rm molecule-volume-helper
+	podman volume create molecule-tests-volume
+	podman create -v molecule-tests-volume:/data --name molecule-volume-helper docker.io/busybox true
+	podman cp "${HELM_CHARTS_REPO}" molecule-volume-helper:/data/helm-charts-repo
+	podman cp "${ROOTDIR}/operator/" molecule-volume-helper:/data/operator
+	podman cp "${MOLECULE_KUBECONFIG}" molecule-volume-helper:/data/kubeconfig
+	podman rm molecule-volume-helper
 
 ## molecule-test: Runs Molecule tests using the Molecule docker image
 molecule-test: .ensure-operator-repo-exists .ensure-operator-helm-chart-exists .prepare-add-host-args molecule-build .prepare-molecule-data-volume .create-operator-pull-secret
-ifeq ($(DORP),docker)
-	for msn in ${MOLECULE_SCENARIO}; do docker run --rm ${MOLECULE_DOCKER_TERM_ARGS} --env KUBECONFIG="/tmp/molecule/kubeconfig" --env K8S_AUTH_KUBECONFIG="/tmp/molecule/kubeconfig" --env MOLECULE_CLUSTER_TYPE="${CLUSTER_TYPE}" --env MOLECULE_HELM_CHARTS_REPO=/tmp/molecule/helm-charts-repo -v molecule-tests-volume:/tmp/molecule -v /var/run/docker.sock:/var/run/docker.sock ${MOLECULE_MINIKUBE_VOL_ARG} ${MOLECULE_MINIKUBE_ENV_ARGS} ${MOLECULE_KIND_ENV_ARGS} -w /tmp/molecule/operator --network="host" ${MOLECULE_ADD_HOST_ARGS} --add-host="api.crc.testing:192.168.130.11" --add-host="kiali-istio-system.apps-crc.testing:192.168.130.11" --add-host="prometheus-istio-system.apps-crc.testing:192.168.130.11" --env DORP=${DORP} --env OPERATOR_IMAGE_PULL_SECRET_NAME=${OPERATOR_IMAGE_PULL_SECRET_NAME} --env MOLECULE_KIALI_CR_SPEC_VERSION=${MOLECULE_KIALI_CR_SPEC_VERSION} ${MOLECULE_IMAGE_ENV_ARGS} ${MOLECULE_OPERATOR_PROFILER_ENABLED_ENV_VAR} ${MOLECULE_OPERATOR_INSTALLER_ENV_VAR} ${MOLECULE_DUMP_LOGS_ON_ERROR_ENV_VAR} ${MOLECULE_IMAGE_PULL_POLICY_ENV_ARGS} ${MOLECULE_WAIT_RETRIES_ARG} kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name $${msn}; if [ "$$?" != "0" ]; then echo "Molecule test failed: $${msn}"; docker volume rm molecule-tests-volume; exit 1; fi; done
-else
-	for msn in ${MOLECULE_SCENARIO}; do podman run --rm ${MOLECULE_DOCKER_TERM_ARGS} --env KUBECONFIG="/tmp/molecule/kubeconfig" --env K8S_AUTH_KUBECONFIG="/tmp/molecule/kubeconfig" --env MOLECULE_CLUSTER_TYPE="${CLUSTER_TYPE}" --env MOLECULE_HELM_CHARTS_REPO=/tmp/molecule/helm-charts-repo -v molecule-tests-volume:/tmp/molecule ${MOLECULE_MINIKUBE_VOL_ARG} ${MOLECULE_MINIKUBE_ENV_ARGS} ${MOLECULE_KIND_ENV_ARGS} -w /tmp/molecule/operator --network="host" ${MOLECULE_ADD_HOST_ARGS} --add-host="api.crc.testing:192.168.130.11" --add-host="kiali-istio-system.apps-crc.testing:192.168.130.11" --add-host="prometheus-istio-system.apps-crc.testing:192.168.130.11" --env DORP=${DORP} --env OPERATOR_IMAGE_PULL_SECRET_NAME=${OPERATOR_IMAGE_PULL_SECRET_NAME} --env MOLECULE_KIALI_CR_SPEC_VERSION=${MOLECULE_KIALI_CR_SPEC_VERSION} ${MOLECULE_IMAGE_ENV_ARGS} ${MOLECULE_OPERATOR_PROFILER_ENABLED_ENV_VAR} ${MOLECULE_OPERATOR_INSTALLER_ENV_VAR} ${MOLECULE_DUMP_LOGS_ON_ERROR_ENV_VAR} ${MOLECULE_IMAGE_PULL_POLICY_ENV_ARGS} ${MOLECULE_WAIT_RETRIES_ARG} localhost/kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name $${msn}; if [ "$$?" != "0" ]; then echo "Molecule test failed: $${msn}"; podman volume rm molecule-tests-volume; exit 1; fi; done
-endif
-	$(DORP) volume rm molecule-tests-volume
+	for msn in ${MOLECULE_SCENARIO}; do podman run --rm ${MOLECULE_DOCKER_TERM_ARGS} --env KUBECONFIG="/tmp/molecule/kubeconfig" --env K8S_AUTH_KUBECONFIG="/tmp/molecule/kubeconfig" --env MOLECULE_CLUSTER_TYPE="${CLUSTER_TYPE}" --env MOLECULE_HELM_CHARTS_REPO=/tmp/molecule/helm-charts-repo -v molecule-tests-volume:/tmp/molecule ${MOLECULE_MINIKUBE_VOL_ARG} ${MOLECULE_MINIKUBE_ENV_ARGS} ${MOLECULE_KIND_ENV_ARGS} -w /tmp/molecule/operator --network="host" ${MOLECULE_ADD_HOST_ARGS} --add-host="api.crc.testing:192.168.130.11" --add-host="kiali-istio-system.apps-crc.testing:192.168.130.11" --add-host="prometheus-istio-system.apps-crc.testing:192.168.130.11" --env DORP=podman --env OPERATOR_IMAGE_PULL_SECRET_NAME=${OPERATOR_IMAGE_PULL_SECRET_NAME} --env MOLECULE_KIALI_CR_SPEC_VERSION=${MOLECULE_KIALI_CR_SPEC_VERSION} ${MOLECULE_IMAGE_ENV_ARGS} ${MOLECULE_OPERATOR_PROFILER_ENABLED_ENV_VAR} ${MOLECULE_OPERATOR_INSTALLER_ENV_VAR} ${MOLECULE_DUMP_LOGS_ON_ERROR_ENV_VAR} ${MOLECULE_IMAGE_PULL_POLICY_ENV_ARGS} ${MOLECULE_WAIT_RETRIES_ARG} localhost/kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name $${msn}; if [ "$$?" != "0" ]; then echo "Molecule test failed: $${msn}"; podman volume rm molecule-tests-volume; exit 1; fi; done
+	podman volume rm molecule-tests-volume

--- a/make/Makefile.molecule.mk
+++ b/make/Makefile.molecule.mk
@@ -90,9 +90,13 @@ MOLECULE_KUBECONFIG ?= ${HOME}/.kube/config
 # Set up some additional things needed in order to run the molecule tests against a minikube installation
 ifeq ($(CLUSTER_TYPE),minikube)
 MOLECULE_MINIKUBE_DIR ?= ${HOME}/.minikube
+ifeq ($(DORP),podman)
 # Mounting each file under .minikube individually. podman 3 has more restrictive volume permissions and the :Z label is required
 # but there are two files which are owned by the qemu user and these cannot be labeled since the current user doesn't own them.
 MOLECULE_MINIKUBE_VOL_ARG ?= $(shell MYVAR=""; while read -r file ; do MYVAR="$${MYVAR} -v $${file}:$${file}:Z" ; done <<< $$(find ${MOLECULE_MINIKUBE_DIR} -type f | grep -v ".iso" | grep -v ".rawdisk") && echo $$MYVAR)
+else
+MOLECULE_MINIKUBE_VOL_ARG ?= -v ${MOLECULE_MINIKUBE_DIR}:${MOLECULE_MINIKUBE_DIR}
+endif
 MOLECULE_MINIKUBE_IP ?= $(shell ${MINIKUBE} ip -p ${MINIKUBE_PROFILE})
 MOLECULE_MINIKUBE_ENV_ARGS ?= --env MOLECULE_MINIKUBE_IP=$(shell echo -n ${MOLECULE_MINIKUBE_IP})
 # if there are no hosts the user wants, explicitly set this to empty string to avoid errors later
@@ -103,7 +107,7 @@ endif
 
 # Set up some additional things needed in order to run the molecule tests against a kind installation
 ifeq ($(CLUSTER_TYPE),kind)
-MOLECULE_KIND_IP ?= $(shell docker inspect ${KIND_NAME}-control-plane --format "{{ .NetworkSettings.Networks.kind.IPAddress }}")
+MOLECULE_KIND_IP ?= $(shell ${DORP} inspect ${KIND_NAME}-control-plane --format "{{ .NetworkSettings.Networks.kind.IPAddress }}")
 MOLECULE_KIND_ENV_ARGS ?= --env MOLECULE_KIND_IP=$(shell echo -n ${MOLECULE_KIND_IP})
 # if there are no hosts the user wants, explicitly set this to empty string to avoid errors later
 ifndef MOLECULE_ADD_HOST_ARGS
@@ -126,11 +130,19 @@ endif
 MOLECULE_WAIT_RETRIES_ARG ?= --env MOLECULE_WAIT_RETRIES=${MOLECULE_WAIT_RETRIES}
 
 .prepare-force-molecule-build:
+ifeq ($(DORP),docker)
+	@$(eval FORCE_MOLECULE_BUILD ?= $(shell docker inspect kiali-molecule:latest > /dev/null 2>&1 || echo "true"))
+else
 	@$(eval FORCE_MOLECULE_BUILD ?= $(shell podman inspect kiali-molecule:latest > /dev/null 2>&1 || echo "true"))
+endif
 
 ## molecule-build: Builds an image to run Molecule without requiring the host to have python/pip installed. If it already exists, and you want to build it again, set env var FORCE_MOLECULE_BUILD to "true".
 molecule-build: .ensure-operator-repo-exists .prepare-force-molecule-build
+ifeq ($(DORP),docker)
+	@if [ "${FORCE_MOLECULE_BUILD}" == "true" ]; then docker build --no-cache -t kiali-molecule:latest ${ROOTDIR}/operator/molecule/docker; else echo "Will not rebuild kiali-molecule image."; fi
+else
 	@if [ "${FORCE_MOLECULE_BUILD}" == "true" ]; then podman build --no-cache -t kiali-molecule:latest ${ROOTDIR}/operator/molecule/docker; else echo "Will not rebuild kiali-molecule image."; fi
+endif
 
 ifndef MOLECULE_ADD_HOST_ARGS
 .prepare-add-host-args: .prepare-cluster
@@ -143,6 +155,10 @@ else
 endif
 
 .prepare-molecule-data-volume:
+ifeq ($(DORP),docker)
+	@echo "Docker is not supported for running the molecule tests. Ignoring 'dorp=docker' and using podman."
+endif
+
 	podman volume create molecule-tests-volume
 	podman create -v molecule-tests-volume:/data --name molecule-volume-helper docker.io/busybox true
 	podman cp "${HELM_CHARTS_REPO}" molecule-volume-helper:/data/helm-charts-repo
@@ -152,5 +168,9 @@ endif
 
 ## molecule-test: Runs Molecule tests using the Molecule docker image
 molecule-test: .ensure-operator-repo-exists .ensure-operator-helm-chart-exists .prepare-add-host-args molecule-build .prepare-molecule-data-volume .create-operator-pull-secret
+ifeq ($(DORP),docker)
+	@echo "Docker is not supported for running the molecule tests. Ignoring 'dorp=docker' and using podman."
+endif
+
 	for msn in ${MOLECULE_SCENARIO}; do podman run --rm ${MOLECULE_DOCKER_TERM_ARGS} --env KUBECONFIG="/tmp/molecule/kubeconfig" --env K8S_AUTH_KUBECONFIG="/tmp/molecule/kubeconfig" --env MOLECULE_CLUSTER_TYPE="${CLUSTER_TYPE}" --env MOLECULE_HELM_CHARTS_REPO=/tmp/molecule/helm-charts-repo -v molecule-tests-volume:/tmp/molecule ${MOLECULE_MINIKUBE_VOL_ARG} ${MOLECULE_MINIKUBE_ENV_ARGS} ${MOLECULE_KIND_ENV_ARGS} -w /tmp/molecule/operator --network="host" ${MOLECULE_ADD_HOST_ARGS} --add-host="api.crc.testing:192.168.130.11" --add-host="kiali-istio-system.apps-crc.testing:192.168.130.11" --add-host="prometheus-istio-system.apps-crc.testing:192.168.130.11" --env DORP=podman --env OPERATOR_IMAGE_PULL_SECRET_NAME=${OPERATOR_IMAGE_PULL_SECRET_NAME} --env MOLECULE_KIALI_CR_SPEC_VERSION=${MOLECULE_KIALI_CR_SPEC_VERSION} ${MOLECULE_IMAGE_ENV_ARGS} ${MOLECULE_OPERATOR_PROFILER_ENABLED_ENV_VAR} ${MOLECULE_OPERATOR_INSTALLER_ENV_VAR} ${MOLECULE_DUMP_LOGS_ON_ERROR_ENV_VAR} ${MOLECULE_IMAGE_PULL_POLICY_ENV_ARGS} ${MOLECULE_WAIT_RETRIES_ARG} localhost/kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name $${msn}; if [ "$$?" != "0" ]; then echo "Molecule test failed: $${msn}"; podman volume rm molecule-tests-volume; exit 1; fi; done
 	podman volume rm molecule-tests-volume


### PR DESCRIPTION
Molecule tests no longer support the docker driver.