### PR TITLE
Toolbar help and bell icons misaligned

### DIFF
--- a/frontend/src/components/MessageCenter/MessageCenterTrigger.tsx
+++ b/frontend/src/components/MessageCenter/MessageCenterTrigger.tsx
@@ -50,11 +50,12 @@ export class MessageCenterTrigger extends React.PureComponent<PropsType, {}> {
     const bell = style({
       position: 'relative',
       right: '5px',
-      top: '3px'
+      top: '2px'
     });
     const count = style({
       position: 'relative',
-      top: '3px'
+      top: '2px',
+      verticalAlign: "0.125em"
     });
 
     return (

--- a/frontend/src/components/MessageCenter/MessageCenterTrigger.tsx
+++ b/frontend/src/components/MessageCenter/MessageCenterTrigger.tsx
@@ -17,6 +17,11 @@ type PropsType = {
   toggleSystemErrorsCenter: () => void;
 };
 
+const systemErrorCountStyle = style ({
+  marginRight: "0.3em",
+  paddingTop: "0.1em"
+});
+
 export class MessageCenterTrigger extends React.PureComponent<PropsType, {}> {
   render() {
     return (
@@ -39,7 +44,7 @@ export class MessageCenterTrigger extends React.PureComponent<PropsType, {}> {
         onClick={this.props.toggleSystemErrorsCenter}
         variant={ButtonVariant.plain}
       >
-        <KialiIcon.Warning />
+        <KialiIcon.Warning className={systemErrorCountStyle} />
         {this.props.systemErrorsCount}
         {this.props.systemErrorsCount === 1 ? ' Open Issue' : ' Open Issues'}
       </Button>

--- a/frontend/src/components/Nav/Masthead/HelpDropdown.tsx
+++ b/frontend/src/components/Nav/Masthead/HelpDropdown.tsx
@@ -79,7 +79,7 @@ class HelpDropdownContainer extends React.Component<HelpDropdownProps, HelpDropd
         toggleIndicator={null}
         onToggle={this.onDropdownToggle}
         aria-label="Help"
-        style={{ marginTop: 3 }}
+        style={{ marginTop: 3, verticalAlign: "-0.1em" }}
       >
         <QuestionCircleIcon />
       </DropdownToggle>


### PR DESCRIPTION
Align toolbar icons Bell and Help from Helpdropdown and MessageCenter.

Fixes #5148 

cc @jshaughn 