### PR TITLE
Update MetricsSettingsDropdown styles

### DIFF
--- a/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -11,6 +11,10 @@ import {
   combineLabelsSettings,
   retrieveMetricsSettings
 } from 'components/Metrics/Helper';
+import {
+  menuStyle,
+  titleStyle
+} from 'styles/DropdownStyles';
 import { PFColors } from '../Pf/PfColors';
 import { PromLabel } from 'types/Metrics';
 
@@ -27,10 +31,11 @@ type State = MetricsSettings & {
   allSelected: boolean;
 };
 
-const checkboxSelectAllStyle = style({ marginLeft: 10, fontWeight: 700 });
-const checkboxStyle = style({ marginLeft: 10 });
+const checkboxSelectAllStyle = style({ marginLeft: 10 });
+const checkboxStyle = style({ marginLeft: 10, fontWeight: 400 });
 const secondLevelStyle = style({ marginLeft: 18 });
 const spacerStyle = style({ height: '1em' });
+const titlePaddingStyle = style({ paddingLeft: 0 });
 
 export class MetricsSettingsDropdown extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -191,7 +196,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
       >
         {/* TODO: Remove the class="pf-c-dropdown__menu-item" attribute which is fixing a sizing issue in PF.
          * https://github.com/patternfly/patternfly-react/issues/3156 */}
-        <div style={{ paddingLeft: '10px', backgroundColor: PFColors.White }} className="pf-c-dropdown__menu-item">
+        <div style={{ paddingLeft: '10px', backgroundColor: PFColors.White }} className={`pf-c-dropdown__menu-item ${menuStyle}`}>
           {hasLabels && this.renderBulkSelector()}
           {hasLabels && this.renderLabelOptions()}
           {hasHistograms && this.renderHistogramOptions()}
@@ -267,7 +272,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
     });
     return (
       <>
-        <label>Show metrics by:</label>
+        <label className={`${titlePaddingStyle} ${titleStyle}`}>Show metrics by:</label>
         {displayGroupingLabels}
         <div className={spacerStyle} />
       </>
@@ -307,7 +312,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
     );
     return (
       <>
-        <label>Histograms:</label>
+        <label className={`${titlePaddingStyle} ${titleStyle}`}>Histograms:</label>
         {displayHistogramOptions}
         <div className={spacerStyle} />
       </>

--- a/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -195,7 +195,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
       >
         {/* TODO: Remove the class="pf-c-dropdown__menu-item" attribute which is fixing a sizing issue in PF.
          * https://github.com/patternfly/patternfly-react/issues/3156 */}
-        <div style={{ paddingLeft: '10px', backgroundColor: PFColors.White }} className={"pf-c-dropdown__menu-item"}>
+        <div style={{ paddingLeft: '10px', backgroundColor: PFColors.White }} className="pf-c-dropdown__menu-item">
           {hasLabels && this.renderBulkSelector()}
           {hasLabels && this.renderLabelOptions()}
           {hasHistograms && this.renderHistogramOptions()}

--- a/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -12,7 +12,6 @@ import {
   retrieveMetricsSettings
 } from 'components/Metrics/Helper';
 import {
-  menuStyle,
   titleStyle
 } from 'styles/DropdownStyles';
 import { PFColors } from '../Pf/PfColors';
@@ -35,7 +34,7 @@ const checkboxSelectAllStyle = style({ marginLeft: 10 });
 const checkboxStyle = style({ marginLeft: 10, fontWeight: 400 });
 const secondLevelStyle = style({ marginLeft: 18 });
 const spacerStyle = style({ height: '1em' });
-const titlePaddingStyle = style({ paddingLeft: 0 });
+const titlePaddingStyle = style({ paddingLeft: 0, fontSize: "small" });
 
 export class MetricsSettingsDropdown extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -196,7 +195,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
       >
         {/* TODO: Remove the class="pf-c-dropdown__menu-item" attribute which is fixing a sizing issue in PF.
          * https://github.com/patternfly/patternfly-react/issues/3156 */}
-        <div style={{ paddingLeft: '10px', backgroundColor: PFColors.White }} className={`pf-c-dropdown__menu-item ${menuStyle}`}>
+        <div style={{ paddingLeft: '10px', backgroundColor: PFColors.White }} className={"pf-c-dropdown__menu-item"}>
           {hasLabels && this.renderBulkSelector()}
           {hasLabels && this.renderLabelOptions()}
           {hasHistograms && this.renderHistogramOptions()}


### PR DESCRIPTION
Adjust font style in metrics charts options. Was displayed in bold, and with different style in the titles. 

Fixes https://github.com/kiali/kiali/issues/5168