### PR TITLE
Update customTooltip to place tooltip in the correct point in the graph

### DIFF
--- a/frontend/src/components/Charts/CustomTooltip.tsx
+++ b/frontend/src/components/Charts/CustomTooltip.tsx
@@ -17,6 +17,7 @@ const CustomLabel = (props: any & { head?: string; text: string[]; textWidth: nu
   const textsWithHead = props.head ? [props.head, ' '].concat(props.text) : props.text;
   const headSize = props.head ? 2 * dy : 0;
   const startY = yMargin + props.y - (textsWithHead.length * dy) / 2 + headSize;
+
   return (
     <>
       {props.activePoints &&
@@ -121,7 +122,6 @@ export class CustomTooltip extends React.Component<Props, State> {
         flyoutHeight={this.state.height}
         flyoutComponent={<ChartCursorFlyout style={{ stroke: 'none', fillOpacity: 0.6 }} />}
         labelComponent={<CustomLabel head={this.state.head} textWidth={this.state.textWidth} />}
-        constrainToVisibleArea={true}
       />
     );
   }

--- a/frontend/src/components/JaegerIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/JaegerIntegration/TraceTooltip.tsx
@@ -110,7 +110,6 @@ export class TraceTooltip extends React.Component<HookedTooltipProps<JaegerLineI
           flyoutHeight={flyoutHeight}
           flyoutComponent={<ChartCursorFlyout style={{ stroke: 'none', fillOpacity: 0.6 }} />}
           labelComponent={<TraceLabelContainer trace={trace} />}
-          constrainToVisibleArea={true}
         />
       );
     }


### PR DESCRIPTION
The property constraintToVisibleArea seems to collide somehow with the with and heigh modified by the tooltip. 

https://formidable.com/open-source/victory/docs/victory-tooltip/#constraintovisiblearea

But, maybe it is expected to render the tooltip just inside the graph?

Fixes https://github.com/kiali/kiali/issues/5160