### PR TITLE
Reduce memory usage for the pod logs endpoint

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -445,7 +445,7 @@ func (in *WorkloadService) BuildLogOptionsCriteria(container, duration, isProxy,
 				opts.MaxLines = &numLines
 			}
 		} else {
-			return nil, fmt.Errorf("Invalid max-lines [%s]: %v", maxLines, err)
+			return nil, fmt.Errorf("Invalid maxLines [%s]: %v", maxLines, err)
 		}
 	}
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -54,7 +54,8 @@ type WorkloadCriteria struct {
 
 // PodLog reports log entries
 type PodLog struct {
-	Entries []LogEntry `json:"entries,omitempty"`
+	Entries           []LogEntry `json:"entries,omitempty"`
+	MaxLinesSurpassed bool       `json:"maxLinesSurpassed,omitempty"`
 }
 
 // AccessLogEntry provides parsed info from a single proxy access log entry

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -54,8 +54,8 @@ type WorkloadCriteria struct {
 
 // PodLog reports log entries
 type PodLog struct {
-	Entries           []LogEntry `json:"entries,omitempty"`
-	MaxLinesSurpassed bool       `json:"maxLinesSurpassed,omitempty"`
+	Entries        []LogEntry `json:"entries,omitempty"`
+	LinesTruncated bool       `json:"linesTruncated,omitempty"`
 }
 
 // AccessLogEntry provides parsed info from a single proxy access log entry
@@ -1919,8 +1919,8 @@ func (in *WorkloadService) streamParsedLogs(namespace, name string, opts *LogOpt
 	}
 
 	if readErr == nil && opts.MaxLines != nil && linesWritten >= *opts.MaxLines {
-		// End the JSON document, setting the max-lines surpassed flag
-		_, writeErr = w.Write([]byte("], \"maxLinesSurpassed\": true}"))
+		// End the JSON document, setting the max-lines truncated flag
+		_, writeErr = w.Write([]byte("], \"linesTruncated\": true}"))
 	} else {
 		// End the JSON document
 		_, writeErr = w.Write([]byte("]}"))

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -658,19 +658,6 @@ func (in *WorkloadService) streamParsedLogs(namespace, name string, opts *LogOpt
 	firstEntry := true
 	line, readErr := bufferedReader.ReadString('\n')
 	for ; readErr == nil || (readErr == io.EOF && len(line) > 0); line, readErr = bufferedReader.ReadString('\n') {
-		if firstEntry == true {
-			firstEntry = false
-		} else {
-			_, writeErr = w.Write([]byte{','})
-			if writeErr != nil {
-				// Remember that since the HTTP Response body is already being sent,
-				// it is not possible to change the response code. So, log the error
-				// and terminate early the response.
-				log.Errorf("Error when writing log entries separator: %s", writeErr.Error())
-				return nil
-			}
-		}
-
 		entry := LogEntry{
 			Message:       "",
 			Timestamp:     "",
@@ -770,6 +757,19 @@ func (in *WorkloadService) streamParsedLogs(namespace, name string, opts *LogOpt
 			// and terminate early the response.
 			log.Errorf("Error when marshalling JSON while streaming pod logs: %s", err.Error())
 			return nil
+		}
+
+		if firstEntry == true {
+			firstEntry = false
+		} else {
+			_, writeErr = w.Write([]byte{','})
+			if writeErr != nil {
+				// Remember that since the HTTP Response body is already being sent,
+				// it is not possible to change the response code. So, log the error
+				// and terminate early the response.
+				log.Errorf("Error when writing log entries separator: %s", writeErr.Error())
+				return nil
+			}
 		}
 
 		_, writeErr = w.Write(response)

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -449,7 +449,7 @@ func (in *WorkloadService) BuildLogOptionsCriteria(container, duration, isProxy,
 	return opts, nil
 }
 
-// getParsedLogs only works correctly when opts has Duration *and* TailLines set.
+// getParsedLogs covers the case when opts has Duration *and* TailLines set.
 func (in *WorkloadService) getParsedLogs(namespace, name string, opts *LogOptions) (*PodLog, error) {
 	k8sOpts := opts.PodLogOptions
 	// the k8s API does not support "endTime/beforeTime". So for bounded time ranges we need to
@@ -1871,7 +1871,7 @@ func (in *WorkloadService) GetWorkloadAppName(ctx context.Context, namespace, wo
 	return app, nil
 }
 
-// streamParsedLogs only works correctly when opts does not have Duration set || does not have TailLines set.
+// streamParsedLogs covers the case when opts does not have both Duration and TailLines set.
 func (in *WorkloadService) streamParsedLogs(namespace, name string, opts *LogOptions, w http.ResponseWriter) error {
 	k8sOpts := opts.PodLogOptions
 	// the k8s API does not support "endTime/beforeTime". So for bounded time ranges we need to
@@ -1912,10 +1912,10 @@ func (in *WorkloadService) streamParsedLogs(namespace, name string, opts *LogOpt
 	// the response body right now and any errors at the middle of the log
 	// processing can no longer be informed to the client. So, starting
 	// these lines, the best we can do if some error happens is to simply
-	// log the error and strop/truncate the response, which will have the
+	// log the error and stop/truncate the response, which will have the
 	// effect of sending an incomplete JSON document that the browser will fail
 	// to parse. Hopefully, the client/UI can catch the parsing error and
-	// properly show an error message about that there was a failure retrieving logs.
+	// properly show an error message about the failure retrieving logs.
 	w.Header().Set("Content-Type", "application/json")
 	_, writeErr := w.Write([]byte("{\"entries\":[")) // This starts the JSON document
 	if writeErr != nil {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -2026,7 +2026,7 @@ func (in *WorkloadService) streamParsedLogs(namespace, name string, opts *LogOpt
 			return nil
 		}
 
-		if firstEntry == true {
+		if firstEntry {
 			firstEntry = false
 		} else {
 			_, writeErr = w.Write([]byte{','})

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -604,194 +604,6 @@ func (in *WorkloadService) GetPodLogs(namespace, name string, opts *LogOptions) 
 	return in.getParsedLogs(namespace, name, opts)
 }
 
-// streamParsedLogs only works correctly when opts does not have Duration set || does not have TailLines set.
-func (in *WorkloadService) streamParsedLogs(namespace, name string, opts *LogOptions, w http.ResponseWriter) error {
-	k8sOpts := opts.PodLogOptions
-	// the k8s API does not support "endTime/beforeTime". So for bounded time ranges we need to
-	// discard the logs after sinceTime+duration
-	isBounded := opts.Duration != nil
-
-	logsReader, err := in.k8s.StreamPodLogs(namespace, name, &k8sOpts)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		e := logsReader.Close()
-		if e != nil {
-			log.Errorf("Error when closing the connection streaming logs of a pod: %s", e.Error())
-		}
-	}()
-
-	bufferedReader := bufio.NewReader(logsReader)
-
-	var startTime *time.Time
-	var endTime *time.Time
-	if k8sOpts.SinceTime != nil {
-		startTime = &k8sOpts.SinceTime.Time
-		if isBounded {
-			end := startTime.Add(*opts.Duration)
-			endTime = &end
-		}
-	}
-
-	engardeParser := parser.New(parser.IstioProxyAccessLogsPattern)
-
-	// To avoid high memory usage, the JSON will be written
-	// to the HTTP Response as it's received from the cluster API.
-	// That is, each log line is parsed, decorated with Kiali's metadata,
-	// marshalled to JSON and immediately written to the HTTP Response.
-	// This means that it is needed to push HTTP headers and start writing
-	// the response body right now and any errors at the middle of the log
-	// processing can no longer be informed to the client. So, starting
-	// these lines, the best we can do if some error happens is to simply
-	// log the error and strop/truncate the response, which will have the
-	// effect of sending an incomplete JSON document that the browser will fail
-	// to parse. Hopefully, the client/UI can catch the parsing error and
-	// properly show an error message about that there was a failure retrieving logs.
-	w.Header().Set("Content-Type", "application/json")
-	_, writeErr := w.Write([]byte("{\"entries\":[")) // This starts the JSON document
-	if writeErr != nil {
-		return writeErr
-	}
-
-	firstEntry := true
-	line, readErr := bufferedReader.ReadString('\n')
-	for ; readErr == nil || (readErr == io.EOF && len(line) > 0); line, readErr = bufferedReader.ReadString('\n') {
-		entry := LogEntry{
-			Message:       "",
-			Timestamp:     "",
-			TimestampUnix: 0,
-			Severity:      "INFO",
-		}
-		splitted := strings.SplitN(line, " ", 2)
-		if len(splitted) != 2 {
-			log.Debugf("Skipping unexpected log line [%s]", line)
-			continue
-		}
-
-		// k8s promises RFC3339 or RFC3339Nano timestamp, ensure RFC3339
-		splittedTimestamp := strings.Split(splitted[0], ".")
-		if len(splittedTimestamp) == 1 {
-			entry.Timestamp = splittedTimestamp[0]
-		} else {
-			entry.Timestamp = fmt.Sprintf("%sZ", splittedTimestamp[0])
-		}
-
-		entry.Message = strings.TrimSpace(splitted[1])
-		if entry.Message == "" {
-			log.Debugf("Skipping empty log line [%s]", line)
-			continue
-		}
-
-		// If we are past the requested time window then stop processing
-		parsedTimestamp, err := time.Parse(time.RFC3339, entry.Timestamp)
-		if err == nil {
-			if startTime == nil {
-				startTime = &parsedTimestamp
-			}
-
-			if isBounded {
-				if endTime == nil {
-					end := parsedTimestamp.Add(*opts.Duration)
-					endTime = &end
-				}
-
-				if parsedTimestamp.After(*endTime) {
-					break
-				}
-			}
-		} else {
-			log.Debugf("Failed to parse log timestamp (skipping) [%s], %s", entry.Timestamp, err.Error())
-			continue
-		}
-
-		severity := severityRegexp.FindString(line)
-		if severity != "" {
-			entry.Severity = strings.ToUpper(severity)
-		}
-
-		// If this is an istio access log, then parse it out. Prefer the access log time over the k8s time
-		// as it is the actual time as opposed to the k8s store time.
-		if opts.IsProxy {
-			al, err := engardeParser.Parse(entry.Message)
-			// engardeParser.Parse will not throw errors even if no fields
-			// were parsed out. Checking here that some fields were actually
-			// set before setting the AccessLog to an empty object. See issue #4346.
-			if err != nil || isAccessLogEmpty(al) {
-				if err != nil {
-					log.Debugf("AccessLog parse failure: %s", err.Error())
-				}
-				// try to parse out the time manually
-				tokens := strings.SplitN(entry.Message, " ", 2)
-				timestampToken := strings.Trim(tokens[0], "[]")
-				t, err := time.Parse(time.RFC3339, timestampToken)
-				if err == nil {
-					parsedTimestamp = t
-				}
-			} else {
-				entry.AccessLog = al
-				t, err := time.Parse(time.RFC3339, al.Timestamp)
-				if err == nil {
-					parsedTimestamp = t
-				}
-
-				// clear accessLog fields we don't need in the returned JSON
-				entry.AccessLog.MixerStatus = ""
-				entry.AccessLog.OriginalMessage = ""
-				entry.AccessLog.ParseError = ""
-			}
-		}
-
-		// override the timestamp with a simpler format
-		timestamp := fmt.Sprintf("%d-%02d-%02d %02d:%02d:%02d",
-			parsedTimestamp.Year(), parsedTimestamp.Month(), parsedTimestamp.Day(),
-			parsedTimestamp.Hour(), parsedTimestamp.Minute(), parsedTimestamp.Second())
-		entry.Timestamp = timestamp
-		entry.TimestampUnix = parsedTimestamp.Unix()
-
-		response, err := json.Marshal(entry)
-		if err != nil {
-			// Remember that since the HTTP Response body is already being sent,
-			// it is not possible to change the response code. So, log the error
-			// and terminate early the response.
-			log.Errorf("Error when marshalling JSON while streaming pod logs: %s", err.Error())
-			return nil
-		}
-
-		if firstEntry == true {
-			firstEntry = false
-		} else {
-			_, writeErr = w.Write([]byte{','})
-			if writeErr != nil {
-				// Remember that since the HTTP Response body is already being sent,
-				// it is not possible to change the response code. So, log the error
-				// and terminate early the response.
-				log.Errorf("Error when writing log entries separator: %s", writeErr.Error())
-				return nil
-			}
-		}
-
-		_, writeErr = w.Write(response)
-		if writeErr != nil {
-			log.Errorf("Error when writing a processed log entry while streaming pod logs: %s", writeErr.Error())
-			return nil
-		}
-	}
-
-	_, writeErr = w.Write([]byte("]}")) // This ends the JSON document
-	if writeErr != nil {
-		log.Errorf("Error when writing the outro of the JSON document while streaming pod logs: %s", err.Error())
-	}
-
-	return nil
-}
-
-// StreamPodLogs streams pod logs to an HTTP Response given the provided options
-func (in *WorkloadService) StreamPodLogs(namespace, name string, opts *LogOptions, w http.ResponseWriter) error {
-	return in.streamParsedLogs(namespace, name, opts, w)
-}
-
 func isAccessLogEmpty(al *parser.AccessLog) bool {
 	if al == nil {
 		return true
@@ -2057,4 +1869,192 @@ func (in *WorkloadService) GetWorkloadAppName(ctx context.Context, namespace, wo
 	appLabelName := config.Get().IstioLabels.AppLabelName
 	app := wkd.Labels[appLabelName]
 	return app, nil
+}
+
+// streamParsedLogs only works correctly when opts does not have Duration set || does not have TailLines set.
+func (in *WorkloadService) streamParsedLogs(namespace, name string, opts *LogOptions, w http.ResponseWriter) error {
+	k8sOpts := opts.PodLogOptions
+	// the k8s API does not support "endTime/beforeTime". So for bounded time ranges we need to
+	// discard the logs after sinceTime+duration
+	isBounded := opts.Duration != nil
+
+	logsReader, err := in.k8s.StreamPodLogs(namespace, name, &k8sOpts)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		e := logsReader.Close()
+		if e != nil {
+			log.Errorf("Error when closing the connection streaming logs of a pod: %s", e.Error())
+		}
+	}()
+
+	bufferedReader := bufio.NewReader(logsReader)
+
+	var startTime *time.Time
+	var endTime *time.Time
+	if k8sOpts.SinceTime != nil {
+		startTime = &k8sOpts.SinceTime.Time
+		if isBounded {
+			end := startTime.Add(*opts.Duration)
+			endTime = &end
+		}
+	}
+
+	engardeParser := parser.New(parser.IstioProxyAccessLogsPattern)
+
+	// To avoid high memory usage, the JSON will be written
+	// to the HTTP Response as it's received from the cluster API.
+	// That is, each log line is parsed, decorated with Kiali's metadata,
+	// marshalled to JSON and immediately written to the HTTP Response.
+	// This means that it is needed to push HTTP headers and start writing
+	// the response body right now and any errors at the middle of the log
+	// processing can no longer be informed to the client. So, starting
+	// these lines, the best we can do if some error happens is to simply
+	// log the error and strop/truncate the response, which will have the
+	// effect of sending an incomplete JSON document that the browser will fail
+	// to parse. Hopefully, the client/UI can catch the parsing error and
+	// properly show an error message about that there was a failure retrieving logs.
+	w.Header().Set("Content-Type", "application/json")
+	_, writeErr := w.Write([]byte("{\"entries\":[")) // This starts the JSON document
+	if writeErr != nil {
+		return writeErr
+	}
+
+	firstEntry := true
+	line, readErr := bufferedReader.ReadString('\n')
+	for ; readErr == nil || (readErr == io.EOF && len(line) > 0); line, readErr = bufferedReader.ReadString('\n') {
+		entry := LogEntry{
+			Message:       "",
+			Timestamp:     "",
+			TimestampUnix: 0,
+			Severity:      "INFO",
+		}
+		splitted := strings.SplitN(line, " ", 2)
+		if len(splitted) != 2 {
+			log.Debugf("Skipping unexpected log line [%s]", line)
+			continue
+		}
+
+		// k8s promises RFC3339 or RFC3339Nano timestamp, ensure RFC3339
+		splittedTimestamp := strings.Split(splitted[0], ".")
+		if len(splittedTimestamp) == 1 {
+			entry.Timestamp = splittedTimestamp[0]
+		} else {
+			entry.Timestamp = fmt.Sprintf("%sZ", splittedTimestamp[0])
+		}
+
+		entry.Message = strings.TrimSpace(splitted[1])
+		if entry.Message == "" {
+			log.Debugf("Skipping empty log line [%s]", line)
+			continue
+		}
+
+		// If we are past the requested time window then stop processing
+		parsedTimestamp, err := time.Parse(time.RFC3339, entry.Timestamp)
+		if err == nil {
+			if startTime == nil {
+				startTime = &parsedTimestamp
+			}
+
+			if isBounded {
+				if endTime == nil {
+					end := parsedTimestamp.Add(*opts.Duration)
+					endTime = &end
+				}
+
+				if parsedTimestamp.After(*endTime) {
+					break
+				}
+			}
+		} else {
+			log.Debugf("Failed to parse log timestamp (skipping) [%s], %s", entry.Timestamp, err.Error())
+			continue
+		}
+
+		severity := severityRegexp.FindString(line)
+		if severity != "" {
+			entry.Severity = strings.ToUpper(severity)
+		}
+
+		// If this is an istio access log, then parse it out. Prefer the access log time over the k8s time
+		// as it is the actual time as opposed to the k8s store time.
+		if opts.IsProxy {
+			al, err := engardeParser.Parse(entry.Message)
+			// engardeParser.Parse will not throw errors even if no fields
+			// were parsed out. Checking here that some fields were actually
+			// set before setting the AccessLog to an empty object. See issue #4346.
+			if err != nil || isAccessLogEmpty(al) {
+				if err != nil {
+					log.Debugf("AccessLog parse failure: %s", err.Error())
+				}
+				// try to parse out the time manually
+				tokens := strings.SplitN(entry.Message, " ", 2)
+				timestampToken := strings.Trim(tokens[0], "[]")
+				t, err := time.Parse(time.RFC3339, timestampToken)
+				if err == nil {
+					parsedTimestamp = t
+				}
+			} else {
+				entry.AccessLog = al
+				t, err := time.Parse(time.RFC3339, al.Timestamp)
+				if err == nil {
+					parsedTimestamp = t
+				}
+
+				// clear accessLog fields we don't need in the returned JSON
+				entry.AccessLog.MixerStatus = ""
+				entry.AccessLog.OriginalMessage = ""
+				entry.AccessLog.ParseError = ""
+			}
+		}
+
+		// override the timestamp with a simpler format
+		timestamp := fmt.Sprintf("%d-%02d-%02d %02d:%02d:%02d",
+			parsedTimestamp.Year(), parsedTimestamp.Month(), parsedTimestamp.Day(),
+			parsedTimestamp.Hour(), parsedTimestamp.Minute(), parsedTimestamp.Second())
+		entry.Timestamp = timestamp
+		entry.TimestampUnix = parsedTimestamp.Unix()
+
+		response, err := json.Marshal(entry)
+		if err != nil {
+			// Remember that since the HTTP Response body is already being sent,
+			// it is not possible to change the response code. So, log the error
+			// and terminate early the response.
+			log.Errorf("Error when marshalling JSON while streaming pod logs: %s", err.Error())
+			return nil
+		}
+
+		if firstEntry == true {
+			firstEntry = false
+		} else {
+			_, writeErr = w.Write([]byte{','})
+			if writeErr != nil {
+				// Remember that since the HTTP Response body is already being sent,
+				// it is not possible to change the response code. So, log the error
+				// and terminate early the response.
+				log.Errorf("Error when writing log entries separator: %s", writeErr.Error())
+				return nil
+			}
+		}
+
+		_, writeErr = w.Write(response)
+		if writeErr != nil {
+			log.Errorf("Error when writing a processed log entry while streaming pod logs: %s", writeErr.Error())
+			return nil
+		}
+	}
+
+	_, writeErr = w.Write([]byte("]}")) // This ends the JSON document
+	if writeErr != nil {
+		log.Errorf("Error when writing the outro of the JSON document while streaming pod logs: %s", err.Error())
+	}
+
+	return nil
+}
+
+// StreamPodLogs streams pod logs to an HTTP Response given the provided options
+func (in *WorkloadService) StreamPodLogs(namespace, name string, opts *LogOptions, w http.ResponseWriter) error {
+	return in.streamParsedLogs(namespace, name, opts, w)
 }

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -37,13 +37,13 @@ func setupWorkloadService(k8s *kubetest.K8SClientMock) WorkloadService {
 
 func callStreamPodLogs(svc WorkloadService, namespace, podName string, opts *LogOptions) PodLog {
 	w := httptest.NewRecorder()
-	svc.StreamPodLogs(namespace, podName, opts, w)
+	_ = svc.StreamPodLogs(namespace, podName, opts, w)
 
 	response := w.Result()
 	body, _ := io.ReadAll(response.Body)
 
 	var podLogs PodLog
-	json.Unmarshal(body, &podLogs)
+	_ = json.Unmarshal(body, &podLogs)
 
 	return podLogs
 }

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -678,7 +678,7 @@ func TestGetPodLogsMaxLinesAndDurations(t *testing.T) {
 	assert.Equal(2, len(podLogs.Entries))
 	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
 	assert.Equal("WARN #2 Log Message", podLogs.Entries[1].Message)
-	assert.True(podLogs.MaxLinesSurpassed)
+	assert.True(podLogs.LinesTruncated)
 
 	// Re-setup mocks
 	k8s = new(kubetest.K8SClientMock)
@@ -693,7 +693,7 @@ func TestGetPodLogsMaxLinesAndDurations(t *testing.T) {
 	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
 	assert.Equal("WARN #2 Log Message", podLogs.Entries[1].Message)
 	assert.Equal("#3 Log Message", podLogs.Entries[2].Message)
-	assert.False(podLogs.MaxLinesSurpassed)
+	assert.False(podLogs.LinesTruncated)
 }
 
 func TestGetPodLogsProxy(t *testing.T) {

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -595,7 +595,7 @@ func TestGetPodLogs(t *testing.T) {
 	assert.Equal("ERROR", podLogs.Entries[3].Severity)
 }
 
-func TestGetPodLogsTailLines(t *testing.T) {
+func TestGetPodLogsMaxLines(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -608,13 +608,13 @@ func TestGetPodLogsTailLines(t *testing.T) {
 
 	svc := setupWorkloadService(k8s)
 
-	tailLines := int64(2)
+	maxLines := 2
 	duration, _ := time.ParseDuration("6h") // still need a duration to force manual tailLines handling
-	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}, Duration: &duration})
+	podLogs := callStreamPodLogs(svc, "Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details"}, MaxLines: &maxLines, Duration: &duration})
 
 	assert.Equal(2, len(podLogs.Entries))
-	assert.Equal("#3 Log Message", podLogs.Entries[0].Message)
-	assert.Equal("#4 Log error Message", podLogs.Entries[1].Message)
+	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
+	assert.Equal("WARN #2 Log Message", podLogs.Entries[1].Message)
 }
 
 func TestGetPodLogsDuration(t *testing.T) {
@@ -660,7 +660,7 @@ func TestGetPodLogsDuration(t *testing.T) {
 	assert.Equal("#3 Log Message", podLogs.Entries[2].Message)
 }
 
-func TestGetPodLogsTailLinesAndDurations(t *testing.T) {
+func TestGetPodLogsMaxLinesAndDurations(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -672,12 +672,13 @@ func TestGetPodLogsTailLinesAndDurations(t *testing.T) {
 	k8s.On("IsOpenShift").Return(false)
 	svc := setupWorkloadService(k8s)
 
-	tailLines := int64(2)
+	maxLines := 2
 	duration, _ := time.ParseDuration("2h")
-	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}})
+	podLogs := callStreamPodLogs(svc, "Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, PodLogOptions: core_v1.PodLogOptions{Container: "details"}, MaxLines: &maxLines})
 	assert.Equal(2, len(podLogs.Entries))
-	assert.Equal("WARN #2 Log Message", podLogs.Entries[0].Message)
-	assert.Equal("#3 Log Message", podLogs.Entries[1].Message)
+	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
+	assert.Equal("WARN #2 Log Message", podLogs.Entries[1].Message)
+	assert.True(podLogs.MaxLinesSurpassed)
 
 	// Re-setup mocks
 	k8s = new(kubetest.K8SClientMock)
@@ -685,23 +686,14 @@ func TestGetPodLogsTailLinesAndDurations(t *testing.T) {
 	k8s.On("IsOpenShift").Return(false)
 	svc = setupWorkloadService(k8s)
 
-	tailLines = int64(1)
-	duration, _ = time.ParseDuration("2h")
-	podLogs, _ = svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}})
-	assert.Equal(1, len(podLogs.Entries))
-	assert.Equal("#3 Log Message", podLogs.Entries[0].Message)
-
-	// Re-setup mocks
-	k8s = new(kubetest.K8SClientMock)
-	k8s.On("StreamPodLogs", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.Anything).Return(io.NopCloser(strings.NewReader(fplswd.Logs)), nil)
-	k8s.On("IsOpenShift").Return(false)
-	svc = setupWorkloadService(k8s)
-
-	tailLines = int64(1)
+	maxLines = 3
 	duration, _ = time.ParseDuration("3h")
-	podLogs, _ = svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}})
-	assert.Equal(1, len(podLogs.Entries))
-	assert.Equal("#4 Log error Message", podLogs.Entries[0].Message)
+	podLogs = callStreamPodLogs(svc, "Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, PodLogOptions: core_v1.PodLogOptions{Container: "details"}, MaxLines: &maxLines})
+	assert.Equal(3, len(podLogs.Entries))
+	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
+	assert.Equal("WARN #2 Log Message", podLogs.Entries[1].Message)
+	assert.Equal("#3 Log Message", podLogs.Entries[2].Message)
+	assert.False(podLogs.MaxLinesSurpassed)
 }
 
 func TestGetPodLogsProxy(t *testing.T) {
@@ -717,9 +709,9 @@ func TestGetPodLogsProxy(t *testing.T) {
 
 	svc := setupWorkloadService(k8s)
 
-	tailLines := int64(2)
+	maxLines := 2
 	duration, _ := time.ParseDuration("2h")
-	podLogs, _ := svc.GetPodLogs("Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, IsProxy: true, PodLogOptions: core_v1.PodLogOptions{Container: "details", TailLines: &tailLines}})
+	podLogs := callStreamPodLogs(svc, "Namespace", "details-v1-3618568057-dnkjp", &LogOptions{Duration: &duration, IsProxy: true, PodLogOptions: core_v1.PodLogOptions{Container: "details"}, MaxLines: &maxLines})
 	assert.Equal(1, len(podLogs.Entries))
 	entry := podLogs.Entries[0]
 	assert.Equal(`[2021-02-01T21:34:35.533Z] "GET /hotels/Ljubljana HTTP/1.1" 200 - via_upstream - "-" 0 99 14 14 "-" "Go-http-client/1.1" "7e7e2dd0-0a96-4535-950b-e303805b7e27" "hotels.travel-agency:8000" "127.0.2021-02-01T21:34:38.761055140Z 0.1:8000" inbound|8000|| 127.0.0.1:33704 10.129.0.72:8000 10.128.0.79:39880 outbound_.8000_._.hotels.travel-agency.svc.cluster.local default`, entry.Message)

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -609,7 +609,7 @@ func TestGetPodLogsMaxLines(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	maxLines := 2
-	duration, _ := time.ParseDuration("6h") // still need a duration to force manual tailLines handling
+	duration, _ := time.ParseDuration("6h")
 	podLogs := callStreamPodLogs(svc, "Namespace", "details-v1-3618568057-dnkjp", &LogOptions{PodLogOptions: core_v1.PodLogOptions{Container: "details"}, MaxLines: &maxLines, Duration: &duration})
 
 	assert.Equal(2, len(podLogs.Entries))

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -20,9 +20,9 @@ When('I type {string} on the Hide text field', showText => {
   cy.get('#log_hide').type(showText + '{enter}');
 });
 
-When('I choose to show 10 lines of logs', () => {
-  cy.get('#wpl_tailLines-toggle').click();
-  cy.get('#10').click();
+When('I choose to show 100 lines of logs', () => {
+  cy.get('#wpl_maxLines-toggle').click();
+  cy.get('#100').click();
 });
 
 When('I select only the {string} container', containerName => {
@@ -70,7 +70,7 @@ Then('the log pane should only show log lines not containing {string}', filterTe
     });
 });
 
-Then('the log pane should show only {int} lines of logs of each selected container', numberOfLinesPerContainer => {
+Then('the log pane should show at most {int} lines of logs of each selected container', numberOfLinesPerContainer => {
   cy.get('[data-test=workload-logs-pod-containers]')
     .get('[type=checkbox]:checked')
     .its('length')
@@ -78,7 +78,7 @@ Then('the log pane should show only {int} lines of logs of each selected contain
       cy.get('#logsText')
         .get('p')
         .its('length')
-        .should('eq', numContainersEnabled * numberOfLinesPerContainer);
+        .should('be.lte', numContainersEnabled * numberOfLinesPerContainer);
     });
 });
 

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -28,8 +28,8 @@ Feature: Workload logs tab
 
   Scenario: The log pane of the logs tab should limit the number of log lines that are fetched
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace
-    When I choose to show 10 lines of logs
-    Then the log pane should show only 10 lines of logs of each selected container
+    When I choose to show 100 lines of logs
+    Then the log pane should show at most 100 lines of logs of each selected container
 
   Scenario: The log pane of the logs tab should only show logs for the selected container
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -118,14 +118,13 @@ const NoLogsFoundMessage = 'No container logs found for the time period.';
 const MaxLinesDefault = 3000;
 const MaxLinesOptions = {
   '-1': 'All lines',
-  '100': 'Max: 100 lines',
-  '500': 'Max: 500 lines',
-  '1000': 'Max: 1,000 lines',
-  '3000': 'Max: 3,000 lines',
-  '5000': 'Max: 5,000 lines',
-  '10000': 'Max: 10,000 lines',
-  '20000': 'Max: 20,000 lines',
-  '50000': 'Max: 50,000 lines',
+  '100': '100 lines',
+  '500': '500 lines',
+  '1000': '1000 lines',
+  '3000': '3000 lines',
+  '5000': '5000 lines',
+  '10000': '10000 lines',
+  '25000': '25000 lines'
 };
 
 const alInfoIcon = style({
@@ -930,7 +929,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
           responses.shift();
         }
 
-        let linesSurpassedContainers: string[] = [];
+        let linesTruncatedContainers: string[] = [];
         for (let i = 0; i < responses.length; i++) {
           const response = responses[i].data as PodLogs;
           const containerLogEntries = response.entries as LogEntry[];
@@ -943,8 +942,8 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
             entries.push({ timestamp: le.timestamp, timestampUnix: le.timestampUnix, logEntry: le } as Entry);
           });
 
-          if (response.maxLinesSurpassed) {
-            linesSurpassedContainers.push(new URL(responses[i].request.responseURL).searchParams.get('container')!);
+          if (response.linesTruncated) {
+            linesTruncatedContainers.push(new URL(responses[i].request.responseURL).searchParams.get('container')!);
           }
         }
 
@@ -953,8 +952,8 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
           return a.timestampUnix - b.timestampUnix;
         });
 
-        if (linesSurpassedContainers.length > 0) {
-          addWarning('Maximum lines surpassed for containers: ' + linesSurpassedContainers.join(', ') +
+        if (linesTruncatedContainers.length > 0) {
+          addWarning('Maximum lines surpassed for containers: ' + linesTruncatedContainers.join(', ') +
             '. Not all log lines for the requested time range are shown.', true);
         }
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -381,7 +381,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
                               value={this.state.maxLines}
                               label={MaxLinesOptions[this.state.maxLines]}
                               options={MaxLinesOptions}
-                              tooltip={'Show up to N head log lines'}
+                              tooltip={'Truncate after N log lines'}
                               classNameSelect={toolbarTail}
                             />
                           </ToolbarItem>

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -475,7 +475,7 @@ export const getPodLogs = (
   namespace: string,
   name: string,
   container?: string,
-  tailLines?: number,
+  maxLines?: number,
   sinceTime?: number,
   duration?: DurationInSeconds,
   isProxy?: boolean
@@ -487,8 +487,8 @@ export const getPodLogs = (
   if (sinceTime) {
     params.sinceTime = sinceTime;
   }
-  if (tailLines && tailLines > 0) {
-    params.tailLines = tailLines;
+  if (maxLines && maxLines > 0) {
+    params.maxLines = maxLines;
   }
   if (duration && duration > 0) {
     params.duration = `${duration}s`;

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -242,6 +242,7 @@ export type LogEntry = {
 
 export interface PodLogs {
   entries: LogEntry[];
+  maxLinesSurpassed?: boolean;
 }
 
 export interface EnvoyProxyDump {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -242,7 +242,7 @@ export type LogEntry = {
 
 export interface PodLogs {
   entries: LogEntry[];
-  maxLinesSurpassed?: boolean;
+  linesTruncated?: boolean;
 }
 
 export interface EnvoyProxyDump {

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -236,11 +236,9 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch pod logs
-	podLogs, err := business.Workload.GetPodLogs(namespace, pod, opts)
+	err = business.Workload.StreamPodLogs(namespace, pod, opts, w)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return
 	}
-
-	RespondWithJSON(w, http.StatusOK, podLogs)
 }

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -228,7 +228,7 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 		queryParams.Get("duration"),
 		queryParams.Get("isProxy"),
 		queryParams.Get("sinceTime"),
-		queryParams.Get("tailLines"))
+		queryParams.Get("maxLines"))
 
 	if err != nil {
 		handleErrorResponse(w, err)
@@ -236,19 +236,9 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch pod logs
-	if opts.Duration != nil && opts.TailLines != nil {
-		podLogs, err := business.Workload.GetPodLogs(namespace, pod, opts)
-		if err != nil {
-			handleErrorResponse(w, err)
-			return
-		}
-
-		RespondWithJSON(w, http.StatusOK, podLogs)
-	} else {
-		err = business.Workload.StreamPodLogs(namespace, pod, opts, w)
-		if err != nil {
-			handleErrorResponse(w, err)
-			return
-		}
+	err = business.Workload.StreamPodLogs(namespace, pod, opts, w)
+	if err != nil {
+		handleErrorResponse(w, err)
+		return
 	}
 }

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -236,9 +236,19 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch pod logs
-	err = business.Workload.StreamPodLogs(namespace, pod, opts, w)
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
+	if opts.Duration != nil && opts.TailLines != nil {
+		podLogs, err := business.Workload.GetPodLogs(namespace, pod, opts)
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		}
+
+		RespondWithJSON(w, http.StatusOK, podLogs)
+	} else {
+		err = business.Workload.StreamPodLogs(namespace, pod, opts, w)
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		}
 	}
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"io"
 	"time"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
@@ -50,7 +51,6 @@ type K8SClientInterface interface {
 	GetNamespace(namespace string) (*core_v1.Namespace, error)
 	GetNamespaces(labelSelector string) ([]core_v1.Namespace, error)
 	GetPod(namespace, name string) (*core_v1.Pod, error)
-	GetPodLogs(namespace, name string, opts *core_v1.PodLogOptions) (*PodLogs, error)
 	GetPods(namespace, labelSelector string) ([]core_v1.Pod, error)
 	GetPodPortForwarder(namespace, podName, portMap string) (*httputil.PortForwarder, error)
 	GetReplicationControllers(namespace string) ([]core_v1.ReplicationController, error)
@@ -64,6 +64,7 @@ type K8SClientInterface interface {
 	GetStatefulSet(namespace string, name string) (*apps_v1.StatefulSet, error)
 	GetStatefulSets(namespace string) ([]apps_v1.StatefulSet, error)
 	GetTokenSubject(authInfo *api.AuthInfo) (string, error)
+	StreamPodLogs(namespace, name string, opts *core_v1.PodLogOptions) (io.ReadCloser, error)
 	UpdateNamespace(namespace string, jsonPatch string) (*core_v1.Namespace, error)
 	UpdateService(namespace string, name string, jsonPatch string) error
 	UpdateWorkload(namespace string, name string, workloadType string, jsonPatch string) error
@@ -433,24 +434,11 @@ func (in *K8SClient) GetPod(namespace, name string) (*core_v1.Pod, error) {
 	}
 }
 
-// GetPod returns the pod definitions for a given pod name.
+// StreamPodLogs opens a connection to progressively fetch the logs of a pod. Callers must make sure to properly close the returned io.ReadCloser.
 // It returns an error on any problem.
-func (in *K8SClient) GetPodLogs(namespace, name string, opts *core_v1.PodLogOptions) (*PodLogs, error) {
+func (in *K8SClient) StreamPodLogs(namespace, name string, opts *core_v1.PodLogOptions) (io.ReadCloser, error) {
 	req := in.k8s.CoreV1().RESTClient().Get().Namespace(namespace).Name(name).Resource("pods").SubResource("log").VersionedParams(opts, scheme.ParameterCodec)
-
-	readCloser, err := req.Stream(in.ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	defer readCloser.Close()
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(readCloser)
-	if err != nil {
-		return nil, err
-	}
-
-	return &PodLogs{Logs: buf.String()}, nil
+	return req.Stream(in.ctx)
 }
 
 func (in *K8SClient) GetCronJobs(namespace string) ([]batch_v1beta1.CronJob, error) {

--- a/kubernetes/kubetest/mock_kubernetes.go
+++ b/kubernetes/kubetest/mock_kubernetes.go
@@ -2,6 +2,7 @@ package kubetest
 
 import (
 	"context"
+	"io"
 
 	apps_v1 "k8s.io/api/apps/v1"
 	auth_v1 "k8s.io/api/authorization/v1"
@@ -9,7 +10,6 @@ import (
 	batch_apps_v1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/util/httputil"
 )
 
@@ -88,11 +88,6 @@ func (o *K8SClientMock) GetPod(namespace, name string) (*core_v1.Pod, error) {
 	return args.Get(0).(*core_v1.Pod), args.Error(1)
 }
 
-func (o *K8SClientMock) GetPodLogs(namespace, name string, opts *core_v1.PodLogOptions) (*kubernetes.PodLogs, error) {
-	args := o.Called(namespace, name, opts)
-	return args.Get(0).(*kubernetes.PodLogs), args.Error(1)
-}
-
 func (o *K8SClientMock) GetPodPortForwarder(namespace, name, portMap string) (*httputil.PortForwarder, error) {
 	args := o.Called(namespace, name, portMap)
 	return args.Get(0).(*httputil.PortForwarder), args.Error(1)
@@ -146,6 +141,11 @@ func (o *K8SClientMock) GetStatefulSet(namespace string, name string) (*apps_v1.
 func (o *K8SClientMock) GetStatefulSets(namespace string) ([]apps_v1.StatefulSet, error) {
 	args := o.Called(namespace)
 	return args.Get(0).([]apps_v1.StatefulSet), args.Error(1)
+}
+
+func (o *K8SClientMock) StreamPodLogs(namespace, name string, opts *core_v1.PodLogOptions) (io.ReadCloser, error) {
+	args := o.Called(namespace, name, opts)
+	return args.Get(0).(io.ReadCloser), args.Error(1)
 }
 
 func (o *K8SClientMock) UpdateNamespace(namespace string, jsonPatch string) (*core_v1.Namespace, error) {

--- a/tests/integration/tests/pod_logs_test.go
+++ b/tests/integration/tests/pod_logs_test.go
@@ -17,7 +17,7 @@ func TestLogsContainerIstioProxy(t *testing.T) {
 	podName, err := utils.FirstPodName(workloadName, utils.BOOKINFO)
 	assert.Nil(err)
 	assert.NotEmpty(podName)
-	params := map[string]string{"container": "istio-proxy", "tailLines": fmt.Sprintf("%d", lines)}
+	params := map[string]string{"container": "istio-proxy", "maxLines": fmt.Sprintf("%d", lines)}
 	logs, err := utils.PodLogs(podName, utils.BOOKINFO, params)
 	assertLogs(logs, lines, err, assert)
 }
@@ -29,7 +29,7 @@ func TestLogsContainerDetails(t *testing.T) {
 	podName, err := utils.FirstPodName(workloadName, utils.BOOKINFO)
 	assert.Nil(err)
 	assert.NotEmpty(podName)
-	params := map[string]string{"container": "details", "tailLines": fmt.Sprintf("%d", lines)}
+	params := map[string]string{"container": "details", "maxLines": fmt.Sprintf("%d", lines)}
 	logs, err := utils.PodLogs(podName, utils.BOOKINFO, params)
 	assertLogs(logs, lines, err, assert)
 }
@@ -41,7 +41,7 @@ func TestLogsInvalidContainer(t *testing.T) {
 	podName, err := utils.FirstPodName(workloadName, utils.BOOKINFO)
 	assert.Nil(err)
 	assert.NotEmpty(podName)
-	params := map[string]string{"container": "invalid", "tailLines": fmt.Sprintf("%d", lines)}
+	params := map[string]string{"container": "invalid", "maxLines": fmt.Sprintf("%d", lines)}
 	logs, err := utils.PodLogs(podName, utils.BOOKINFO, params)
 	assertEmptyLogs(logs, err, assert)
 }
@@ -52,7 +52,7 @@ func TestLogsInvalidLineCount(t *testing.T) {
 	podName, err := utils.FirstPodName(workloadName, utils.BOOKINFO)
 	assert.Nil(err)
 	assert.NotEmpty(podName)
-	params := map[string]string{"container": "details", "tailLines": "*50"}
+	params := map[string]string{"container": "details", "maxLines": "*50"}
 	logs, err := utils.PodLogs(podName, utils.BOOKINFO, params)
 	assertEmptyLogs(logs, err, assert)
 }
@@ -66,7 +66,7 @@ func assertEmptyLogs(logs *business.PodLog, err error, assert *assert.Assertions
 func assertLogs(logs *business.PodLog, lines int, err error, assert *assert.Assertions) {
 	assert.Nil(err)
 	assert.NotNil(logs)
-	assert.True(len(logs.Entries) <= lines)
+	assert.LessOrEqual(len(logs.Entries), lines)
 	for _, entry := range logs.Entries {
 		assert.NotNil(entry.Message)
 		assert.NotNil(entry.Severity)

--- a/tests/integration/tests/workloads_test.go
+++ b/tests/integration/tests/workloads_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kiali/kiali/tests/integration/utils"
 	"github.com/kiali/kiali/tools/cmd"


### PR DESCRIPTION
The pod logs endpoint was loading to memory the whole results from the cluster API, then parsing/processing them (also on memory) and, finally sending the results to the browser/client. While this works OK for small data sets, this is leading to high memory usage for large logs.

This is changing the how the input from the cluster API is read and how the results are sent:
1. There is the specific case when the users chooses a time range specifying both a start and end date AND also chooses to show only the last _N_ lines. For this case, the original code is changed only slightly:
    * Instead of loading the whole response of the cluster API into memory to thereafter process it, the response from the cluster API is read as processing is possible. So, only one unprocessed/raw log line is loaded at memory.
    * Instead of loading into memory an undetermined amount of processed log lines to thereafter pick the requested tail, a circular list is used to discard the unneeded lines as soon as possible, keeping memory usage constrained to the amount needed for the requested tail lines.
2. For the other cases that the front-end allows, it is possible to read a line from the cluster API, process it, and immediately send the results to the client/browser, keeping memory usage to a minimum.

---
Results:

**Notice:** These are dumb tests. I simply changed parameters until I had large results. I wasn't counting how many lines are coming from the cluster, nor how many resulting lines are coming from Kiali.

At past state, after a few runs this is Kiali's memory usage:
![image](https://user-images.githubusercontent.com/23639005/172960250-12f94ce4-54ef-4e89-8b49-6fb0c883f4a9.png)

So, Kiali uses 438MiB (in the terminal) when the returned response from Kiali is about 44MiB (seen in browser's developer console, _Size_ column). Also, in the developer console can be seen that the browser spends most of its time "waiting" for a response rather than receiving data.

With these changes applied, this is for case (2):

![image](https://user-images.githubusercontent.com/23639005/172961107-0910c4d5-f924-4b69-a884-fc03f2fed5b6.png)

It can be seen that memory usage is down to 46MiB. In the browser console, it is possible to see that Kiali is _not_ faster nor slower, but it can be seen that the browser is now spending more time receiving data than waiting. This clearly shows that Kiali is now "streaming" data to the browser as is being processed.

For case (1) I don't have screenshots, but similarly memory usage remains at the ~50MiB mark even when using the maximum amount of "tail lines" allowed from the front-end (which is 5,000).

---

It is worth to note that, although the back-end is more optimized regarding memory usage reducing the chances of being killed by the cluster, the front-end cannot handle these big responses because it freezes on rendering. I didn't wait until the UI unfroze to know how much time it takes. I'll deal with the front-end on another PR.

---

There is also a bug-fix: When specifying both a start and end date, the shown logs did not belong to the chosen time window under some circumstances.

---
Related to #4701 