### PR TITLE
Update font color on green red labels for trace details

### DIFF
--- a/frontend/src/components/JaegerIntegration/JaegerResults/TraceLabels.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/TraceLabels.tsx
@@ -36,9 +36,9 @@ export const TraceLabels = (p: Props) => {
       </Label>
       {!p.oneline && <br />}
       {errors === 0 ? (
-        <Label style={{ margin: 10, backgroundColor: PFColors.Success }}>0 Spans with error</Label>
+        <Label className="whiteColorLabelContent" style={{ margin: 10, backgroundColor: PFColors.Success }}>0 Spans with error</Label>
       ) : (
-        <Label style={{ margin: 10, backgroundColor: filteredErrors === 0 ? PFColors.Warning : PFColors.Danger }}>
+        <Label className="whiteColorLabelContent" style={{ margin: 10, backgroundColor: filteredErrors === 0 ? PFColors.Warning : PFColors.Danger }}>
           {p.filteredSpans && `${filteredErrors} / `}
           {pluralize(errors, 'Span')} with error
         </Label>

--- a/frontend/src/components/Label/_Label.scss
+++ b/frontend/src/components/Label/_Label.scss
@@ -1,0 +1,8 @@
+/*
+PF4 adds a wrapper for the label content
+And the label color is override by .pf-c-label__content
+And there are not styles with the color white
+*/
+.whiteColorLabelContent > .pf-c-label__content {
+  color: #FFF;
+}

--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -34,4 +34,5 @@ body {
 @import '../components/IstioWizards/Slider/_Slider';
 @import '../components/Time/_Time';
 @import '../components/Nav/_Menu';
+@import '../components/Label/_Label';
 @import '../pages/Graph/_Graph';


### PR DESCRIPTION
Update font color on green red labels for trace details

I've though in adding a custom Label style with a new class whiteColorLaberContent with nested css. Because PF4 adds a wrapper in the label content, and apply the style to the label, is not enough. 

Comment: Should we add this into warning? (I will revert if not)

![Screenshot from 2022-06-09 09-57-41](https://user-images.githubusercontent.com/49480155/172810877-2699b111-bc88-4475-a75e-b66cd0ee96e8.png)
![Screenshot from 2022-06-09 09-59-14](https://user-images.githubusercontent.com/49480155/172810879-5155b0c4-a8ac-4274-a541-9965fc465138.png)
![Screenshot from 2022-06-09 10-00-40](https://user-images.githubusercontent.com/49480155/172810880-127d7893-ad1c-4d3e-b917-d522c1d8c549.png)



Fixes https://github.com/kiali/kiali/issues/5092 