### PR TITLE
Istio Validations optimization for Overview page

### DIFF
--- a/business/checkers/authorization/mtls_enabled_checker_test.go
+++ b/business/checkers/authorization/mtls_enabled_checker_test.go
@@ -242,7 +242,6 @@ func mtlsCheckerTestPrep(scenario string, autoMtls bool, t *testing.T) models.Is
 	}
 
 	validations := MtlsEnabledChecker{
-		Namespace:             "bookinfo",
 		AuthorizationPolicies: loader.GetResources().AuthorizationPolicies,
 		RegistryServices:      data.CreateFakeRegistryServicesLabels("ratings", "bookinfo"),
 		MtlsDetails: kubernetes.MTLSDetails{

--- a/business/checkers/authorization/no_host_checker.go
+++ b/business/checkers/authorization/no_host_checker.go
@@ -13,7 +13,6 @@ import (
 
 type NoHostChecker struct {
 	AuthorizationPolicy security_v1beta.AuthorizationPolicy
-	Namespace           string
 	Namespaces          models.Namespaces
 	ServiceEntries      map[string][]string
 	VirtualServices     []networking_v1beta1.VirtualService

--- a/business/checkers/authorization/no_host_checker_test.go
+++ b/business/checkers/authorization/no_host_checker_test.go
@@ -21,7 +21,6 @@ func TestPresentService(t *testing.T) {
 
 	validations, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"details", "reviews"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
 		RegistryServices:    append(registryService1, registryService2...),
@@ -40,7 +39,6 @@ func TestNonExistingService(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"details", "wrong"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
 		RegistryServices:    append(registryService1, registryService2...),
@@ -63,7 +61,6 @@ func TestWildcardHost(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"*", "*.bookinfo", "*.bookinfo.svc.cluster.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
 		RegistryServices:    append(registryService1, registryService2...),
@@ -82,7 +79,6 @@ func TestWildcardHostOutsideNamespace(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"*.outside", "*.outside.svc.cluster.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
 		RegistryServices:    append(registryService1, registryService2...),
@@ -106,7 +102,6 @@ func TestServiceEntryPresent(t *testing.T) {
 
 	validations, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"wikipedia.org"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{serviceEntry}),
 	}.Check()
@@ -123,7 +118,6 @@ func TestExportedInternalServiceEntryPresent(t *testing.T) {
 
 	validations, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"details.bookinfo2.svc.cluster.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{*serviceEntry}),
 	}.Check()
@@ -140,7 +134,6 @@ func TestExportedExternalServiceEntryPresent(t *testing.T) {
 
 	validations, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"www.myhost.com"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{*serviceEntry}),
 	}.Check()
@@ -157,7 +150,6 @@ func TestExportedExternalServiceEntryFail(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"www.wrong.com"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{*serviceEntry}),
 	}.Check()
@@ -178,7 +170,6 @@ func TestWildcardExportedInternalServiceEntryPresent(t *testing.T) {
 
 	validations, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"details.bookinfo2.svc.cluster.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{*serviceEntry}),
 	}.Check()
@@ -195,7 +186,6 @@ func TestWildcardExportedInternalServiceEntryFail(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"details.bookinfo3.svc.cluster.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{*serviceEntry}),
 	}.Check()
@@ -216,7 +206,6 @@ func TestExportedNonFQDNInternalServiceEntryFail(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"details.bookinfo2.svc.cluster.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{*serviceEntry}),
 	}.Check()
@@ -236,7 +225,6 @@ func TestServiceEntryNotPresent(t *testing.T) {
 	serviceEntry := data.CreateExternalServiceEntry()
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"wrong.org"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{serviceEntry}),
 	}.Check()
@@ -256,7 +244,6 @@ func TestExportedInternalServiceEntryNotPresent(t *testing.T) {
 	serviceEntry := data.CreateEmptyMeshInternalServiceEntry("details-se", "bookinfo3", []string{"details.bookinfo2.svc.cluster.local"})
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"wrong.bookinfo2.svc.cluster.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{*serviceEntry}),
 	}.Check()
@@ -276,7 +263,6 @@ func TestVirtualServicePresent(t *testing.T) {
 	virtualService := *data.CreateEmptyVirtualService("foo-dev", "foo", []string{"foo-dev.example.com"})
 	validations, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"foo-dev.example.com"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
 		VirtualServices:     []networking_v1beta1.VirtualService{virtualService},
@@ -292,7 +278,6 @@ func TestVirtualServiceNotPresent(t *testing.T) {
 	virtualService := *data.CreateEmptyVirtualService("foo-dev", "foo", []string{"foo-dev.example.com"})
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"foo-bogus.example.com"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      map[string][]string{},
 		VirtualServices:     []networking_v1beta1.VirtualService{virtualService},
@@ -314,7 +299,6 @@ func TestWildcardServiceEntryHost(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"maps.google.com"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{serviceEntry}),
 	}.Check()
@@ -326,7 +310,6 @@ func TestWildcardServiceEntryHost(t *testing.T) {
 	// Not matching
 	vals, valid = NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"maps.apple.com"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{serviceEntry}),
 	}.Check()
@@ -352,7 +335,6 @@ func TestValidServiceRegistry(t *testing.T) {
 
 	validations, valid := NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"ratings.mesh2-bookinfo.svc.mesh1-imports.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 	}.Check()
 
@@ -363,7 +345,6 @@ func TestValidServiceRegistry(t *testing.T) {
 
 	validations, valid = NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"ratings.mesh2-bookinfo.svc.mesh1-imports.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		RegistryServices:    registryService,
 	}.Check()
@@ -375,7 +356,6 @@ func TestValidServiceRegistry(t *testing.T) {
 
 	validations, valid = NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"ratings.mesh2-bookinfo.svc.mesh1-imports.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		RegistryServices:    registryService,
 	}.Check()
@@ -387,7 +367,6 @@ func TestValidServiceRegistry(t *testing.T) {
 
 	validations, valid = NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"ratings.bookinfo.svc.cluster.local"}),
-		Namespace:           "bookinfo",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		RegistryServices:    registryService,
 	}.Check()
@@ -399,7 +378,6 @@ func TestValidServiceRegistry(t *testing.T) {
 
 	validations, valid = NoHostChecker{
 		AuthorizationPolicy: *authPolicyWithHost([]string{"ratings2.bookinfo.svc.cluster.local"}),
-		Namespace:           "test",
 		Namespaces:          models.Namespaces{models.Namespace{Name: "outside"}, models.Namespace{Name: "bookinfo"}},
 		RegistryServices:    registryService,
 	}.Check()

--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -18,7 +18,6 @@ const AuthorizationPolicyCheckerType = "authorizationpolicy"
 
 type AuthorizationPolicyChecker struct {
 	AuthorizationPolicies []security_v1beta.AuthorizationPolicy
-	Namespace             string
 	Namespaces            models.Namespaces
 	ServiceEntries        []networking_v1beta1.ServiceEntry
 	WorkloadsPerNamespace map[string]models.WorkloadList
@@ -37,7 +36,6 @@ func (a AuthorizationPolicyChecker) Check() models.IstioValidations {
 
 	// Group Validations
 	validations.MergeValidations(authorization.MtlsEnabledChecker{
-		Namespace:             a.Namespace,
 		AuthorizationPolicies: a.AuthorizationPolicies,
 		MtlsDetails:           a.MtlsDetails,
 		RegistryServices:      a.RegistryServices,
@@ -56,9 +54,9 @@ func (a AuthorizationPolicyChecker) runChecks(authPolicy security_v1beta.Authori
 		matchLabels = authPolicy.Spec.Selector.MatchLabels
 	}
 	enabledCheckers := []Checker{
-		common.SelectorNoWorkloadFoundChecker(AuthorizationPolicyCheckerType, matchLabels, a.WorkloadsPerNamespace[a.Namespace]),
+		common.SelectorNoWorkloadFoundChecker(AuthorizationPolicyCheckerType, matchLabels, a.WorkloadsPerNamespace),
 		authorization.NamespaceMethodChecker{AuthorizationPolicy: authPolicy, Namespaces: a.Namespaces.GetNames()},
-		authorization.NoHostChecker{AuthorizationPolicy: authPolicy, Namespace: a.Namespace, Namespaces: a.Namespaces,
+		authorization.NoHostChecker{AuthorizationPolicy: authPolicy, Namespaces: a.Namespaces,
 			ServiceEntries: serviceHosts, VirtualServices: a.VirtualServices, RegistryServices: a.RegistryServices},
 		authorization.PrincipalsChecker{AuthorizationPolicy: authPolicy, ServiceAccounts: a.ServiceAccountNames(strings.Replace(config.Get().ExternalServices.Istio.IstioIdentityDomain, "svc.", "", 1))},
 	}

--- a/business/checkers/common/multi_match_selector_checker_test.go
+++ b/business/checkers/common/multi_match_selector_checker_test.go
@@ -155,12 +155,12 @@ func assertMultimatchFailure(t *testing.T, code string, vals models.IstioValidat
 	}
 }
 
-func workloadList() models.WorkloadList {
+func workloadList() map[string]models.WorkloadList {
 	wli := []models.WorkloadListItem{
 		data.CreateWorkloadListItem("details-v1", map[string]string{"app": "details", "version": "v1"}),
 		data.CreateWorkloadListItem("details-v2", map[string]string{"app": "details", "version": "v2"}),
 		data.CreateWorkloadListItem("details-v3", map[string]string{"app": "details", "version": "v3"}),
 	}
 
-	return data.CreateWorkloadList("bookinfo", wli...)
+	return data.CreateWorkloadsPerNamespace("bookinfo", wli...)
 }

--- a/business/checkers/common/workload_selector_checker.go
+++ b/business/checkers/common/workload_selector_checker.go
@@ -7,27 +7,27 @@ import (
 )
 
 type GenericNoWorkloadFoundChecker struct {
-	SubjectType    string
-	SelectorLabels map[string]string
-	WorkloadList   models.WorkloadList
-	Path           string
+	SubjectType           string
+	SelectorLabels        map[string]string
+	WorkloadsPerNamespace map[string]models.WorkloadList
+	Path                  string
 }
 
-func SelectorNoWorkloadFoundChecker(subjectType string, selectorLabels map[string]string, workloadList models.WorkloadList) GenericNoWorkloadFoundChecker {
+func SelectorNoWorkloadFoundChecker(subjectType string, selectorLabels map[string]string, workloadsPerNamespace map[string]models.WorkloadList) GenericNoWorkloadFoundChecker {
 	return GenericNoWorkloadFoundChecker{
-		SubjectType:    subjectType,
-		SelectorLabels: selectorLabels,
-		WorkloadList:   workloadList,
-		Path:           "spec/selector/matchLabels",
+		SubjectType:           subjectType,
+		SelectorLabels:        selectorLabels,
+		WorkloadsPerNamespace: workloadsPerNamespace,
+		Path:                  "spec/selector/matchLabels",
 	}
 }
 
-func WorkloadSelectorNoWorkloadFoundChecker(subjectType string, selectorLabels map[string]string, workloadList models.WorkloadList) GenericNoWorkloadFoundChecker {
+func WorkloadSelectorNoWorkloadFoundChecker(subjectType string, selectorLabels map[string]string, workloadsPerNamespace map[string]models.WorkloadList) GenericNoWorkloadFoundChecker {
 	return GenericNoWorkloadFoundChecker{
-		SubjectType:    subjectType,
-		SelectorLabels: selectorLabels,
-		WorkloadList:   workloadList,
-		Path:           "spec/workloadSelector/labels",
+		SubjectType:           subjectType,
+		SelectorLabels:        selectorLabels,
+		WorkloadsPerNamespace: workloadsPerNamespace,
+		Path:                  "spec/workloadSelector/labels",
 	}
 }
 
@@ -46,10 +46,12 @@ func (wsc GenericNoWorkloadFoundChecker) Check() ([]*models.IstioCheck, bool) {
 func (wsc GenericNoWorkloadFoundChecker) hasMatchingWorkload(labelSelector map[string]string) bool {
 	selector := labels.SelectorFromSet(labelSelector)
 
-	for _, wl := range wsc.WorkloadList.Workloads {
-		wlLabelSet := labels.Set(wl.Labels)
-		if selector.Matches(wlLabelSet) {
-			return true
+	for _, wls := range wsc.WorkloadsPerNamespace {
+		for _, wl := range wls.Workloads {
+			wlLabelSet := labels.Set(wl.Labels)
+			if selector.Matches(wlLabelSet) {
+				return true
+			}
 		}
 	}
 	return false

--- a/business/checkers/common/workload_selector_checker_test.go
+++ b/business/checkers/common/workload_selector_checker_test.go
@@ -54,10 +54,10 @@ func testFailureWithWorkloadList(assert *assert.Assertions, selector map[string]
 }
 
 func testFailureWithEmptyWorkloadList(assert *assert.Assertions, selector map[string]string) {
-	testFailure(assert, selector, data.CreateWorkloadList("test", models.WorkloadListItem{}), "generic.selector.workloadnotfound")
+	testFailure(assert, selector, data.CreateWorkloadsPerNamespace("test", models.WorkloadListItem{}), "generic.selector.workloadnotfound")
 }
 
-func testFailure(assert *assert.Assertions, selector map[string]string, wl models.WorkloadList, code string) {
+func testFailure(assert *assert.Assertions, selector map[string]string, wl map[string]models.WorkloadList, code string) {
 	vals, valid := WorkloadSelectorNoWorkloadFoundChecker(
 		"sidecar",
 		selector,

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -11,7 +11,6 @@ import (
 )
 
 type NoDestinationChecker struct {
-	Namespace             string
 	Namespaces            models.Namespaces
 	WorkloadsPerNamespace map[string]models.WorkloadList
 	DestinationRule       networking_v1beta1.DestinationRule

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -26,7 +26,6 @@ func TestValidHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -44,7 +43,6 @@ func TestValidWildcardHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -66,7 +64,6 @@ func TestValidMeshWideHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -87,7 +84,6 @@ func TestValidShortSvcHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -108,7 +104,6 @@ func TestValidServiceNamespace(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -129,7 +124,6 @@ func TestValidServiceNamespaceInvalid(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test-namespace"},
 			models.Namespace{Name: "outside-ns"},
@@ -157,7 +151,6 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test-namespace"},
 			models.Namespace{Name: "outside-ns"},
@@ -185,7 +178,6 @@ func TestNoValidHost(t *testing.T) {
 
 	// reviews is not part of services
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
@@ -215,7 +207,6 @@ func TestNoValidShortSvcHost(t *testing.T) {
 	// Not valid:
 	// reviews.test-namespace.svc.cluster
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
@@ -240,7 +231,6 @@ func TestNoMatchingSubset(t *testing.T) {
 
 	// reviews does not have v2 in known services
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1"))),
@@ -284,7 +274,6 @@ func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
 		data.AddSubsetToDestinationRule(s2, data.CreateEmptyDestinationRule("test-namespace", "name", "reviews")))
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
@@ -318,7 +307,6 @@ func TestSubsetNotReferenced(t *testing.T) {
 	dr := loader.FindDestinationRule("testrule", "bookinfo")
 
 	vals, valid := NoDestinationChecker{
-		Namespace:  "bookinfo",
 		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo"}},
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"bookinfo": data.CreateWorkloadList("bookinfo",
@@ -351,7 +339,6 @@ func TestSubsetReferenced(t *testing.T) {
 	vs := loader.FindVirtualService("testvs", "bookinfo")
 
 	vals, valid := NoDestinationChecker{
-		Namespace:  "bookinfo",
 		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo"}},
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"bookinfo": data.CreateWorkloadList("bookinfo",
@@ -388,7 +375,6 @@ func TestSubsetPresentMatchingNotReferenced(t *testing.T) {
 	vs := loader.FindVirtualService("testvs", "bookinfo")
 
 	vals, valid := NoDestinationChecker{
-		Namespace:  "bookinfo",
 		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo"}},
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"bookinfo": data.CreateWorkloadList("bookinfo",
@@ -418,7 +404,6 @@ func TestWronglyReferenced(t *testing.T) {
 	vs := loader.FindVirtualService("testvs", "bookinfo")
 
 	vals, valid := NoDestinationChecker{
-		Namespace:  "bookinfo",
 		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo"}},
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"bookinfo": data.CreateWorkloadList("bookinfo",
@@ -441,7 +426,6 @@ func TestFailCrossNamespaceHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -477,7 +461,6 @@ func TestSNIProxyExample(t *testing.T) {
 		data.CreateEmptyMeshExternalServiceEntry("sni-proxy", "test", []string{"sni-proxy.local"}))
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "test",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -497,7 +480,6 @@ func TestWildcardServiceEntry(t *testing.T) {
 		data.CreateEmptyMeshExternalServiceEntry("sni-proxy", "test", []string{"*.local"}))
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "test",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -516,7 +498,6 @@ func TestExportedInternalServiceEntry(t *testing.T) {
 	se := data.CreateEmptyMeshInternalServiceEntry("details-se", "bookinfo3", []string{"details.bookinfo2.svc.cluster.local"})
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -535,7 +516,6 @@ func TestWildcardExportedInternalServiceEntry(t *testing.T) {
 	se := data.CreateEmptyMeshInternalServiceEntry("details-se", "bookinfo3", []string{"*.bookinfo2.svc.cluster.local"})
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -554,7 +534,6 @@ func TestExportedInternalServiceEntryFail(t *testing.T) {
 	se := data.CreateEmptyMeshInternalServiceEntry("details-se", "bookinfo3", []string{"details.bookinfo3.svc.cluster.local"})
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -576,7 +555,6 @@ func TestWildcardExportedInternalServiceEntryFail(t *testing.T) {
 	se := data.CreateEmptyMeshInternalServiceEntry("details-se", "bookinfo3", []string{"*.bookinfo3.svc.cluster.local"})
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -598,7 +576,6 @@ func TestExportedNonFQDNInternalServiceEntryFail(t *testing.T) {
 	se := data.CreateEmptyMeshInternalServiceEntry("details-se", "bookinfo3", []string{"details"})
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -612,7 +589,6 @@ func TestExportedNonFQDNInternalServiceEntryFail(t *testing.T) {
 	dr = data.CreateEmptyDestinationRule("bookinfo", "details", "details")
 
 	vals, valid = NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -634,7 +610,6 @@ func TestExportedExternalServiceEntry(t *testing.T) {
 	se := data.CreateEmptyMeshExternalServiceEntry("details-se", "bookinfo3", []string{"www.myhost.com"})
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -653,7 +628,6 @@ func TestExportedExternalServiceEntryFail(t *testing.T) {
 	se := data.CreateEmptyMeshExternalServiceEntry("details-se", "bookinfo3", []string{"www.myhost.com"})
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -669,7 +643,6 @@ func TestNoLabelsInSubset(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		Namespace: "test-namespace",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test-namespace": data.CreateWorkloadList("test-namespace",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -696,7 +669,6 @@ func TestValidServiceRegistry(t *testing.T) {
 	dr := data.CreateEmptyDestinationRule("test", "test-exported", "ratings.mesh2-bookinfo.svc.mesh1-imports.local")
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "test",
 		DestinationRule: *dr,
 	}.Check()
 
@@ -704,7 +676,6 @@ func TestValidServiceRegistry(t *testing.T) {
 	assert.NotEmpty(vals)
 
 	vals, valid = NoDestinationChecker{
-		Namespace:        "test",
 		DestinationRule:  *dr,
 		RegistryServices: data.CreateFakeRegistryServices("ratings.mesh2-bookinfo.svc.mesh1-imports.local", "test", "*"),
 	}.Check()
@@ -713,7 +684,6 @@ func TestValidServiceRegistry(t *testing.T) {
 	assert.Empty(vals)
 
 	vals, valid = NoDestinationChecker{
-		Namespace:        "test",
 		DestinationRule:  *dr,
 		RegistryServices: data.CreateFakeRegistryServices("ratings2.mesh2-bookinfo.svc.mesh1-imports.local", "test", "."),
 	}.Check()
@@ -724,7 +694,6 @@ func TestValidServiceRegistry(t *testing.T) {
 	dr = data.CreateEmptyDestinationRule("test", "test-exported", "ratings.bookinfo.svc.cluster.local")
 
 	vals, valid = NoDestinationChecker{
-		Namespace:        "test",
 		DestinationRule:  *dr,
 		RegistryServices: data.CreateFakeRegistryServices("ratings.bookinfo.svc.cluster.local", "test", "test"),
 	}.Check()
@@ -733,7 +702,6 @@ func TestValidServiceRegistry(t *testing.T) {
 	assert.Empty(vals)
 
 	vals, valid = NoDestinationChecker{
-		Namespace:        "test",
 		DestinationRule:  *dr,
 		RegistryServices: data.CreateFakeRegistryServices("ratings2.bookinfo.svc.cluster.local", "test", "test"),
 	}.Check()
@@ -752,7 +720,6 @@ func TestServiceEntryLabelsMatchSubsets(t *testing.T) {
 	se := data.AddEndpointToServiceEntry("details.bookinfo.svc.cluster.local", "cluster", "global", data.CreateEmptyMeshInternalServiceEntry("details-se", "bookinfo", []string{"details.bookinfo.svc.cluster.local"}))
 
 	vals, valid := NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()
@@ -771,7 +738,6 @@ func TestServiceEntryLabelsNoMatchingSubsets(t *testing.T) {
 	se := data.AddEndpointToServiceEntry("details.bookinfo.svc.cluster.local", "cluster", "wrong", data.CreateEmptyMeshInternalServiceEntry("details-se", "bookinfo", []string{"details.bookinfo.svc.cluster.local"}))
 
 	vals, _ := NoDestinationChecker{
-		Namespace:       "bookinfo",
 		ServiceEntries:  []networking_v1beta1.ServiceEntry{*se},
 		DestinationRule: *dr,
 	}.Check()

--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -11,7 +11,6 @@ const GatewayCheckerType = "gateway"
 
 type GatewayChecker struct {
 	Gateways              []networking_v1beta1.Gateway
-	Namespace             string
 	WorkloadsPerNamespace map[string]models.WorkloadList
 	IsGatewayToNamespace  bool
 }
@@ -24,9 +23,7 @@ func (g GatewayChecker) Check() models.IstioValidations {
 	}.Check()
 
 	for _, gw := range g.Gateways {
-		if gw.Namespace == g.Namespace {
-			validations.MergeValidations(g.runSingleChecks(gw))
-		}
+		validations.MergeValidations(g.runSingleChecks(gw))
 	}
 
 	return validations

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -17,7 +17,6 @@ func TestNoCrashOnEmpty(t *testing.T) {
 	assert := assert.New(t)
 
 	typeValidations := NoServiceChecker{
-		Namespace:        "test",
 		IstioConfigList:  emptyIstioConfigList(),
 		RegistryServices: data.CreateEmptyRegistryServices(),
 	}.Check()
@@ -32,7 +31,6 @@ func TestAllIstioObjectWithServices(t *testing.T) {
 	assert := assert.New(t)
 
 	vals := NoServiceChecker{
-		Namespace: "test",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": data.CreateWorkloadList("test",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -64,7 +62,6 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert := assert.New(t)
 
 	vals := NoServiceChecker{
-		Namespace:       "test",
 		IstioConfigList: fakeIstioConfigList(),
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": data.CreateWorkloadList("test",
@@ -89,7 +86,6 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", customerDr.Checks[0]))
 
 	vals = NoServiceChecker{
-		Namespace: "test",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": data.CreateWorkloadList("test",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -115,7 +111,6 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", productVs.Checks[1]))
 
 	vals = NoServiceChecker{
-		Namespace: "test",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": data.CreateWorkloadList("test",
 				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
@@ -134,7 +129,6 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.True(vals[models.IstioValidationKey{ObjectType: "destinationrule", Namespace: "test", Name: "customer-dr"}].Valid)
 
 	vals = NoServiceChecker{
-		Namespace: "test",
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"test": data.CreateWorkloadList("test",
 				data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
@@ -164,7 +158,6 @@ func TestObjectWithoutGateway(t *testing.T) {
 
 	istioDetails.VirtualServices[0].Spec.Gateways = gateways
 	vals := NoServiceChecker{
-		Namespace:            "test",
 		IstioConfigList:      istioDetails,
 		RegistryServices:     data.CreateFakeMultiRegistryServices([]string{"reviews.test.svc.cluster.local", "product.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", "*"),
 		AuthorizationDetails: &kubernetes.RBACDetails{},

--- a/business/checkers/peer_authentication_checker.go
+++ b/business/checkers/peer_authentication_checker.go
@@ -13,15 +13,15 @@ import (
 const PeerAuthenticationCheckerType = "peerauthentication"
 
 type PeerAuthenticationChecker struct {
-	PeerAuthentications []security_v1beta.PeerAuthentication
-	MTLSDetails         kubernetes.MTLSDetails
-	WorkloadList        models.WorkloadList
+	PeerAuthentications   []security_v1beta.PeerAuthentication
+	MTLSDetails           kubernetes.MTLSDetails
+	WorkloadsPerNamespace map[string]models.WorkloadList
 }
 
 func (m PeerAuthenticationChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
-	validations.MergeValidations(common.PeerAuthenticationMultiMatchChecker(PeerAuthenticationCheckerType, m.PeerAuthentications, m.WorkloadList).Check())
+	validations.MergeValidations(common.PeerAuthenticationMultiMatchChecker(PeerAuthenticationCheckerType, m.PeerAuthentications, m.WorkloadsPerNamespace).Check())
 
 	for _, peerAuthn := range m.PeerAuthentications {
 		validations.MergeValidations(m.runChecks(peerAuthn))
@@ -41,7 +41,7 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn security_v1beta.PeerAuthe
 	if peerAuthn.Spec.Selector != nil {
 		matchLabels = peerAuthn.Spec.Selector.MatchLabels
 	}
-	enabledCheckers = append(enabledCheckers, common.SelectorNoWorkloadFoundChecker(PeerAuthenticationCheckerType, matchLabels, m.WorkloadList))
+	enabledCheckers = append(enabledCheckers, common.SelectorNoWorkloadFoundChecker(PeerAuthenticationCheckerType, matchLabels, m.WorkloadsPerNamespace))
 	if config.IsRootNamespace(peerAuthn.Namespace) {
 		enabledCheckers = append(enabledCheckers, peerauthentications.DisabledMeshWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})
 	} else {

--- a/business/checkers/request_authentication_checker.go
+++ b/business/checkers/request_authentication_checker.go
@@ -11,13 +11,13 @@ const RequestAuthenticationCheckerType = "requestauthentication"
 
 type RequestAuthenticationChecker struct {
 	RequestAuthentications []security_v1beta.RequestAuthentication
-	WorkloadList           models.WorkloadList
+	WorkloadsPerNamespace  map[string]models.WorkloadList
 }
 
 func (m RequestAuthenticationChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
-	validations.MergeValidations(common.RequestAuthenticationMultiMatchChecker(RequestAuthenticationCheckerType, m.RequestAuthentications, m.WorkloadList).Check())
+	validations.MergeValidations(common.RequestAuthenticationMultiMatchChecker(RequestAuthenticationCheckerType, m.RequestAuthentications, m.WorkloadsPerNamespace).Check())
 
 	for _, peerAuthn := range m.RequestAuthentications {
 		validations.MergeValidations(m.runChecks(peerAuthn))
@@ -35,7 +35,7 @@ func (m RequestAuthenticationChecker) runChecks(requestAuthn security_v1beta.Req
 		matchLabels = requestAuthn.Spec.Selector.MatchLabels
 	}
 	enabledCheckers := []Checker{
-		common.SelectorNoWorkloadFoundChecker(RequestAuthenticationCheckerType, matchLabels, m.WorkloadList),
+		common.SelectorNoWorkloadFoundChecker(RequestAuthenticationCheckerType, matchLabels, m.WorkloadsPerNamespace),
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -12,11 +12,11 @@ import (
 const SidecarCheckerType = "sidecar"
 
 type SidecarChecker struct {
-	Sidecars         []networking_v1beta1.Sidecar
-	ServiceEntries   []networking_v1beta1.ServiceEntry
-	Namespaces       models.Namespaces
-	WorkloadList     models.WorkloadList
-	RegistryServices []*kubernetes.RegistryService
+	Sidecars              []networking_v1beta1.Sidecar
+	ServiceEntries        []networking_v1beta1.ServiceEntry
+	Namespaces            models.Namespaces
+	WorkloadsPerNamespace map[string]models.WorkloadList
+	RegistryServices      []*kubernetes.RegistryService
 }
 
 func (s SidecarChecker) Check() models.IstioValidations {
@@ -32,7 +32,7 @@ func (s SidecarChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	enabledDRCheckers := []GroupChecker{
-		common.SidecarSelectorMultiMatchChecker(SidecarCheckerType, s.Sidecars, s.WorkloadList),
+		common.SidecarSelectorMultiMatchChecker(SidecarCheckerType, s.Sidecars, s.WorkloadsPerNamespace),
 	}
 
 	for _, checker := range enabledDRCheckers {
@@ -62,7 +62,7 @@ func (s SidecarChecker) runChecks(sidecar networking_v1beta1.Sidecar) models.Ist
 	}
 
 	enabledCheckers := []Checker{
-		common.WorkloadSelectorNoWorkloadFoundChecker(SidecarCheckerType, selectorLabels, s.WorkloadList),
+		common.WorkloadSelectorNoWorkloadFoundChecker(SidecarCheckerType, selectorLabels, s.WorkloadsPerNamespace),
 		sidecars.EgressHostChecker{Sidecar: sidecar, ServiceEntries: serviceHosts, RegistryServices: s.RegistryServices},
 		sidecars.GlobalChecker{Sidecar: sidecar},
 	}

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -11,7 +11,6 @@ import (
 const VirtualCheckerType = "virtualservice"
 
 type VirtualServiceChecker struct {
-	Namespace        string
 	Namespaces       models.Namespaces
 	VirtualServices  []networking_v1beta1.VirtualService
 	DestinationRules []networking_v1beta1.DestinationRule
@@ -46,7 +45,7 @@ func (in VirtualServiceChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	enabledCheckers := []GroupChecker{
-		virtualservices.SingleHostChecker{Namespace: in.Namespace, Namespaces: in.Namespaces, VirtualServices: in.VirtualServices},
+		virtualservices.SingleHostChecker{Namespaces: in.Namespaces, VirtualServices: in.VirtualServices},
 	}
 
 	for _, checker := range enabledCheckers {
@@ -62,8 +61,8 @@ func (in VirtualServiceChecker) runChecks(virtualService networking_v1beta1.Virt
 	key, rrValidation := EmptyValidValidation(virtualServiceName, virtualService.Namespace, VirtualCheckerType)
 
 	enabledCheckers := []Checker{
-		virtualservices.RouteChecker{VirtualService: virtualService, Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames()},
-		virtualservices.SubsetPresenceChecker{Namespace: in.Namespace, Namespaces: in.Namespaces.GetNames(), VirtualService: virtualService, DestinationRules: in.DestinationRules},
+		virtualservices.RouteChecker{VirtualService: virtualService, Namespaces: in.Namespaces.GetNames()},
+		virtualservices.SubsetPresenceChecker{Namespaces: in.Namespaces.GetNames(), VirtualService: virtualService, DestinationRules: in.DestinationRules},
 		common.ExportToNamespaceChecker{ExportTo: virtualService.Spec.ExportTo, Namespaces: in.Namespaces},
 	}
 

--- a/business/checkers/virtual_service_checker_test.go
+++ b/business/checkers/virtual_service_checker_test.go
@@ -20,7 +20,6 @@ func prepareTestForVirtualService(vs *networking_v1beta1.VirtualService) models.
 	}
 
 	virtualServiceChecker := VirtualServiceChecker{
-		Namespace:        "bookinfo",
 		DestinationRules: destinationList,
 		VirtualServices:  vss,
 	}
@@ -87,7 +86,6 @@ func TestVirtualServiceMultipleIstioObjects(t *testing.T) {
 	}
 
 	virtualServiceChecker := VirtualServiceChecker{
-		Namespace:        "bookinfo",
 		DestinationRules: destinationList,
 		VirtualServices:  fakeVirtualServiceMultipleIstioObjects(),
 	}

--- a/business/checkers/virtualservices/no_host_checker.go
+++ b/business/checkers/virtualservices/no_host_checker.go
@@ -11,7 +11,6 @@ import (
 )
 
 type NoHostChecker struct {
-	Namespace         string
 	Namespaces        models.Namespaces
 	VirtualService    networking_v1beta1.VirtualService
 	ServiceEntryHosts map[string][]string

--- a/business/checkers/virtualservices/no_host_checker_test.go
+++ b/business/checkers/virtualservices/no_host_checker_test.go
@@ -26,7 +26,6 @@ func TestValidHost(t *testing.T) {
 	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
 
 	vals, valid := NoHostChecker{
-		Namespace:        "bookinfo",
 		RegistryServices: append(registryService1, registryService2...),
 		VirtualService:   *virtualService,
 	}.Check()
@@ -47,7 +46,6 @@ func TestValidHostExported(t *testing.T) {
 	registryService := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
 
 	vals, valid := NoHostChecker{
-		Namespace:        "bookinfo",
 		VirtualService:   *virtualService,
 		RegistryServices: append(data.CreateFakeRegistryServices("ratings.bookinfo2.svc.cluster.local", "bookinfo2", "bookinfo2"), registryService...),
 	}.Check()
@@ -68,7 +66,6 @@ func TestNoValidHost(t *testing.T) {
 	virtualService := data.CreateVirtualService()
 
 	vals, valid := NoHostChecker{
-		Namespace:        "test-namespace",
 		RegistryServices: append(registryService1, registryService2...),
 		VirtualService:   *virtualService,
 	}.Check()
@@ -85,7 +82,6 @@ func TestNoValidHost(t *testing.T) {
 	virtualService.Spec.Http = nil
 
 	vals, valid = NoHostChecker{
-		Namespace:        "test-namespace",
 		RegistryServices: append(registryService1, registryService2...),
 		VirtualService:   *virtualService,
 	}.Check()
@@ -113,7 +109,6 @@ func TestNoValidExportedHost(t *testing.T) {
 	)
 
 	vals, valid := NoHostChecker{
-		Namespace:        "bookinfo",
 		VirtualService:   *virtualService,
 		RegistryServices: append(data.CreateFakeRegistryServices("ratings.bookinfo2.svc.cluster.local", "bookinfo2", "*"), append(registryService1, registryService2...)...),
 	}.Check()
@@ -130,7 +125,6 @@ func TestNoValidExportedHost(t *testing.T) {
 	virtualService.Spec.Http = nil
 
 	vals, valid = NoHostChecker{
-		Namespace:        "bookinfo",
 		VirtualService:   *virtualService,
 		RegistryServices: append(data.CreateFakeRegistryServices("ratings.bookinfo2.svc.cluster.local", "bookinfo2", "."), append(registryService1, registryService2...)...),
 	}.Check()
@@ -156,7 +150,6 @@ func TestInvalidServiceNamespaceFormatHost(t *testing.T) {
 	)
 
 	vals, valid := NoHostChecker{
-		Namespace: "test-namespace",
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "outside-namespace"},
@@ -186,7 +179,6 @@ func TestInvalidServiceNamespaceFormatExportedHost(t *testing.T) {
 	)
 
 	vals, valid := NoHostChecker{
-		Namespace: "test-namespace",
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "test"},
 			models.Namespace{Name: "outside-namespace"},
@@ -206,7 +198,6 @@ func TestInvalidServiceNamespaceFormatExportedHost(t *testing.T) {
 	)
 
 	vals, valid = NoHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			models.Namespace{Name: "bookinfo"},
 			models.Namespace{Name: "bookinfo2"},
@@ -233,7 +224,6 @@ func TestValidServiceEntryHost(t *testing.T) {
 	virtualService := data.CreateVirtualServiceWithServiceEntryTarget()
 
 	vals, valid := NoHostChecker{
-		Namespace:        "wikipedia",
 		VirtualService:   *virtualService,
 		RegistryServices: registryService1,
 	}.Check()
@@ -245,7 +235,6 @@ func TestValidServiceEntryHost(t *testing.T) {
 	serviceEntry := data.CreateExternalServiceEntry()
 
 	vals, valid = NoHostChecker{
-		Namespace:         "wikipedia",
 		VirtualService:    *virtualService,
 		ServiceEntryHosts: kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{serviceEntry}),
 		RegistryServices:  registryService1,
@@ -267,7 +256,6 @@ func TestValidWildcardServiceEntryHost(t *testing.T) {
 		data.CreateEmptyVirtualService("googleIt", "google", []string{"www.google.com"}))
 
 	vals, valid := NoHostChecker{
-		Namespace:        "google",
 		VirtualService:   *virtualService,
 		RegistryServices: registryService1,
 	}.Check()
@@ -279,7 +267,6 @@ func TestValidWildcardServiceEntryHost(t *testing.T) {
 	serviceEntry := data.CreateEmptyMeshExternalServiceEntry("googlecard", "google", []string{"*.google.com"})
 
 	vals, valid = NoHostChecker{
-		Namespace:         "google",
 		VirtualService:    *virtualService,
 		ServiceEntryHosts: kubernetes.ServiceEntryHostnames([]networking_v1beta1.ServiceEntry{*serviceEntry}),
 		RegistryServices:  registryService1,
@@ -300,7 +287,6 @@ func TestValidServiceRegistry(t *testing.T) {
 		data.CreateEmptyVirtualService("federation-vs", "bookinfo", []string{"*"}))
 
 	vals, valid := NoHostChecker{
-		Namespace:      "bookinfo",
 		VirtualService: *virtualService,
 	}.Check()
 
@@ -308,7 +294,6 @@ func TestValidServiceRegistry(t *testing.T) {
 	assert.NotEmpty(vals)
 
 	vals, valid = NoHostChecker{
-		Namespace:        "bookinfo",
 		VirtualService:   *virtualService,
 		RegistryServices: data.CreateFakeRegistryServices("ratings.mesh2-bookinfo.svc.mesh1-imports.local", "bookinfo", "bookinfo"),
 	}.Check()
@@ -317,7 +302,6 @@ func TestValidServiceRegistry(t *testing.T) {
 	assert.Empty(vals)
 
 	vals, valid = NoHostChecker{
-		Namespace:        "bookinfo",
 		VirtualService:   *virtualService,
 		RegistryServices: data.CreateFakeRegistryServices("ratings2.mesh2-bookinfo.svc.mesh1-imports.local", "bookinfo", "."),
 	}.Check()

--- a/business/checkers/virtualservices/route_checker.go
+++ b/business/checkers/virtualservices/route_checker.go
@@ -11,7 +11,6 @@ import (
 )
 
 type RouteChecker struct {
-	Namespace      string
 	Namespaces     []string
 	VirtualService networking_v1beta1.VirtualService
 }
@@ -144,7 +143,7 @@ func (route RouteChecker) trackHttpSubset(routeIdx int, kind string, destination
 		if destinationWeight.Destination == nil {
 			return
 		}
-		fqdn := kubernetes.GetHost(destinationWeight.Destination.Host, route.Namespace, route.VirtualService.ClusterName, route.Namespaces)
+		fqdn := kubernetes.GetHost(destinationWeight.Destination.Host, route.VirtualService.Namespace, route.VirtualService.ClusterName, route.Namespaces)
 		subset := destinationWeight.Destination.Subset
 		key := fmt.Sprintf("%s%s", fqdn.String(), subset)
 		collisions := subsetCollitions[key]
@@ -167,7 +166,7 @@ func (route RouteChecker) trackTcpTlsSubset(routeIdx int, kind string, destinati
 		if destinationWeight.Destination == nil {
 			return
 		}
-		fqdn := kubernetes.GetHost(destinationWeight.Destination.Host, route.Namespace, route.VirtualService.ClusterName, route.Namespaces)
+		fqdn := kubernetes.GetHost(destinationWeight.Destination.Host, route.VirtualService.Namespace, route.VirtualService.ClusterName, route.Namespaces)
 		subset := destinationWeight.Destination.Subset
 		key := fmt.Sprintf("%s%s", fqdn.String(), subset)
 		collisions := subsetCollitions[key]

--- a/business/checkers/virtualservices/route_checker_test.go
+++ b/business/checkers/virtualservices/route_checker_test.go
@@ -17,7 +17,6 @@ func TestServiceWellVirtualServiceValidation(t *testing.T) {
 
 	// Setup mocks
 	vals, valid := RouteChecker{
-		Namespace:      "test",
 		Namespaces:     []string{"test"},
 		VirtualService: *fakeValidVirtualService(),
 	}.Check()
@@ -32,7 +31,6 @@ func TestServiceMultipleChecks(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := RouteChecker{
-		Namespace:      "test",
 		Namespaces:     []string{"test"},
 		VirtualService: *fakeOneRouteUnder100(),
 	}.Check()
@@ -50,7 +48,6 @@ func TestVSWithRepeatingSubsets(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := RouteChecker{
-		Namespace:      "test",
 		Namespaces:     []string{"test"},
 		VirtualService: *fakeRepeatedSubset(),
 	}.Check()
@@ -69,7 +66,6 @@ func TestVSWithRepeatingHostsNoSubsets(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := RouteChecker{
-		Namespace:      "test",
 		Namespaces:     []string{"test"},
 		VirtualService: *fakeRepeatedHosts(),
 	}.Check()

--- a/business/checkers/virtualservices/single_exported_host_checker_test.go
+++ b/business/checkers/virtualservices/single_exported_host_checker_test.go
@@ -20,7 +20,6 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "ratings"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -35,7 +34,6 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "ratings"),
 	}
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -50,7 +48,6 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 		*buildVirtualServiceWithGatewayNS("bookinfo2", "virtual-2", "ratings", "bookinfo-gateway"),
 	}
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -65,7 +62,6 @@ func TestOneVirtualServicePerHostExported(t *testing.T) {
 		*buildVirtualServiceWithGatewayNS("bookinfo2", "virtual-2", "ratings", "bookinfo-gateway"),
 	}
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -81,7 +77,6 @@ func TestOneVirtualServicePerFQDNHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "ratings.bookinfo2.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -97,7 +92,6 @@ func TestOneVirtualServicePerFQDNWildcardHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "*.eshop.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -117,7 +111,6 @@ func TestRepeatingSimpleHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -148,7 +141,6 @@ func TestRepeatingSimpleHostWithGatewayExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -162,7 +154,6 @@ func TestRepeatingSimpleHostWithGatewayExported(t *testing.T) {
 		*buildVirtualServiceWithGatewayNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local", "bookinfo2"),
 	}
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -176,7 +167,6 @@ func TestRepeatingSimpleHostWithGatewayExported(t *testing.T) {
 		*buildVirtualServiceWithGatewayNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local", "bookinfo"),
 	}
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -197,7 +187,6 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
@@ -215,7 +204,6 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
@@ -234,7 +222,6 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
@@ -252,7 +239,6 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
@@ -270,7 +256,6 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "details.bookinfo.svc.cluster.local"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
@@ -290,7 +275,6 @@ func TestRepeatingSVCNSHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo2", "virtual-2", "details.bookinfo.svc.cluster.local"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 			{Name: "bookinfo2"},
@@ -313,7 +297,6 @@ func TestRepeatingFQDNHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -345,7 +328,6 @@ func TestRepeatingFQDNWildcardHostExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "*.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -377,7 +359,6 @@ func TestIncludedIntoWildCardExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -408,7 +389,6 @@ func TestIncludedIntoWildCardExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -440,7 +420,6 @@ func TestShortHostNameIncludedIntoWildCardExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -472,7 +451,6 @@ func TestWildcardisMarkedInvalidExported(t *testing.T) {
 		*buildVirtualServiceNS("bookinfo3", "virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -504,7 +482,6 @@ func TestMultipleHostsFailingExported(t *testing.T) {
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 
@@ -530,7 +507,6 @@ func TestMultipleHostsPassingExported(t *testing.T) {
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: append(vss, evss...),
 	}.Check()
 

--- a/business/checkers/virtualservices/single_host_checker.go
+++ b/business/checkers/virtualservices/single_host_checker.go
@@ -8,7 +8,6 @@ import (
 )
 
 type SingleHostChecker struct {
-	Namespace       string
 	Namespaces      models.Namespaces
 	VirtualServices []networking_v1beta1.VirtualService
 }

--- a/business/checkers/virtualservices/single_host_checker_test.go
+++ b/business/checkers/virtualservices/single_host_checker_test.go
@@ -17,7 +17,6 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "ratings"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -29,7 +28,6 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "ratings"),
 	}
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -42,7 +40,6 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 		*buildVirtualServiceWithGateway("virtual-2", "ratings", "bookinfo-gateway"),
 	}
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -56,7 +53,6 @@ func TestOneVirtualServicePerHost(t *testing.T) {
 	}
 
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -70,7 +66,6 @@ func TestOneVirtualServicePerFQDNHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "ratings.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -83,7 +78,6 @@ func TestOneVirtualServicePerFQDNWildcardHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "*.eshop.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -98,7 +92,6 @@ func TestRepeatingSimpleHost(t *testing.T) {
 	}
 
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -125,7 +118,6 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 	}
 
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -138,7 +130,6 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 	}
 
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -151,7 +142,6 @@ func TestRepeatingSimpleHostWithGateway(t *testing.T) {
 	}
 
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -170,7 +160,6 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "reviews.bookinfo"),
 	}
 	vals := SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
@@ -185,7 +174,6 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "reviews.bookinfo"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
@@ -201,7 +189,6 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		*buildVirtualServiceWithGateway("virtual-3", "reviews", "bookinfo-gateway-auto"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
@@ -216,7 +203,6 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "reviews.bookinfo"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
@@ -231,7 +217,6 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "details.bookinfo"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
@@ -247,7 +232,6 @@ func TestRepeatingSVCNSHost(t *testing.T) {
 		*buildVirtualService("virtual-2", "details.bookinfo"),
 	}
 	vals = SingleHostChecker{
-		Namespace: "bookinfo",
 		Namespaces: models.Namespaces{
 			{Name: "bookinfo"},
 		},
@@ -266,7 +250,6 @@ func TestRepeatingFQDNHost(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -293,7 +276,6 @@ func TestRepeatingFQDNWildcardHost(t *testing.T) {
 		*buildVirtualService("virtual-3", "*.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -320,7 +302,6 @@ func TestIncludedIntoWildCard(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -346,7 +327,6 @@ func TestIncludedIntoWildCard(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews.bookinfo.svc.cluster.local"),
 	}
 	vals = SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -373,7 +353,6 @@ func TestShortHostNameIncludedIntoWildCard(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -400,7 +379,6 @@ func TestWildcardisMarkedInvalid(t *testing.T) {
 		*buildVirtualService("virtual-3", "reviews"),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -427,7 +405,6 @@ func TestMultipleHostsFailing(t *testing.T) {
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 
@@ -451,7 +428,6 @@ func TestMultipleHostsPassing(t *testing.T) {
 			"mongo.backup.svc.cluster.local", "mongo.staging.svc.cluster.local"}),
 	}
 	vals := SingleHostChecker{
-		Namespace:       "bookinfo",
 		VirtualServices: vss,
 	}.Check()
 

--- a/business/checkers/virtualservices/subset_presence_checker.go
+++ b/business/checkers/virtualservices/subset_presence_checker.go
@@ -10,7 +10,6 @@ import (
 )
 
 type SubsetPresenceChecker struct {
-	Namespace        string
 	Namespaces       []string
 	DestinationRules []networking_v1beta1.DestinationRule
 	VirtualService   networking_v1beta1.VirtualService
@@ -116,7 +115,7 @@ func (checker SubsetPresenceChecker) getDestinationRules(virtualServiceHost stri
 		host := destinationRule.Spec.Host
 
 		drHost := kubernetes.GetHost(host, destinationRule.Namespace, destinationRule.ClusterName, checker.Namespaces)
-		vsHost := kubernetes.GetHost(virtualServiceHost, checker.Namespace, checker.VirtualService.ClusterName, checker.Namespaces)
+		vsHost := kubernetes.GetHost(virtualServiceHost, checker.VirtualService.Namespace, checker.VirtualService.ClusterName, checker.Namespaces)
 
 		// TODO Host could be in another namespace (FQDN)
 		if kubernetes.FilterByHost(vsHost.String(), vsHost.Namespace, drHost.Service, drHost.Namespace) {

--- a/business/checkers/virtualservices/subset_presence_checker_test.go
+++ b/business/checkers/virtualservices/subset_presence_checker_test.go
@@ -81,7 +81,6 @@ func subsetPresenceCheckerPrep(scenario string, t *testing.T) ([]*models.IstioCh
 	err := loader.Load()
 
 	vals, valid := SubsetPresenceChecker{
-		Namespace:        "bookinfo",
 		Namespaces:       namespaceNames(loader.GetNamespaces()),
 		DestinationRules: append(loader.FindDestinationRuleIn("bookinfo"), loader.FindDestinationRuleNotIn("bookinfo")...),
 		VirtualService:   loader.GetResources().VirtualServices[0],

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -412,7 +412,7 @@ func (in *IstioValidationsService) filterPeerAuths(namespace string, mtlsDetails
 
 func (in *IstioValidationsService) filterAuthPolicies(namespace string, rbacDetails *kubernetes.RBACDetails, authPolicies []security_v1beta.AuthorizationPolicy) {
 	for _, ap := range authPolicies {
-		if ap.Namespace == namespace || namespace == ""  {
+		if ap.Namespace == namespace || namespace == "" {
 			rbacDetails.AuthorizationPolicies = append(rbacDetails.AuthorizationPolicies, ap)
 		}
 	}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -404,7 +404,7 @@ func (in *IstioValidationsService) filterPeerAuths(namespace string, mtlsDetails
 		if pa.Namespace == rootNs {
 			mtlsDetails.MeshPeerAuthentications = append(mtlsDetails.MeshPeerAuthentications, pa)
 		}
-		if pa.Namespace == namespace {
+		if pa.Namespace == namespace || namespace == "" {
 			mtlsDetails.PeerAuthentications = append(mtlsDetails.PeerAuthentications, pa)
 		}
 	}
@@ -412,13 +412,16 @@ func (in *IstioValidationsService) filterPeerAuths(namespace string, mtlsDetails
 
 func (in *IstioValidationsService) filterAuthPolicies(namespace string, rbacDetails *kubernetes.RBACDetails, authPolicies []security_v1beta.AuthorizationPolicy) {
 	for _, ap := range authPolicies {
-		if ap.Namespace == namespace {
+		if ap.Namespace == namespace || namespace == ""  {
 			rbacDetails.AuthorizationPolicies = append(rbacDetails.AuthorizationPolicies, ap)
 		}
 	}
 }
 
 func (in *IstioValidationsService) filterVSExportToNamespaces(namespace string, vs []networking_v1beta1.VirtualService) []networking_v1beta1.VirtualService {
+	if namespace == "" {
+		return vs
+	}
 	var result []networking_v1beta1.VirtualService
 	for _, v := range vs {
 		if len(v.Spec.ExportTo) > 0 {
@@ -437,6 +440,9 @@ func (in *IstioValidationsService) filterVSExportToNamespaces(namespace string, 
 }
 
 func (in *IstioValidationsService) filterDRExportToNamespaces(namespace string, dr []networking_v1beta1.DestinationRule) []networking_v1beta1.DestinationRule {
+	if namespace == "" {
+		return dr
+	}
 	var result []networking_v1beta1.DestinationRule
 	for _, d := range dr {
 		if len(d.Spec.ExportTo) > 0 {
@@ -455,6 +461,9 @@ func (in *IstioValidationsService) filterDRExportToNamespaces(namespace string, 
 }
 
 func (in *IstioValidationsService) filterSEExportToNamespaces(namespace string, se []networking_v1beta1.ServiceEntry) []networking_v1beta1.ServiceEntry {
+	if namespace == "" {
+		return se
+	}
 	var result []networking_v1beta1.ServiceEntry
 	for _, s := range se {
 		if len(s.Spec.ExportTo) > 0 {

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -3,6 +3,7 @@ package business
 import (
 	"context"
 	"fmt"
+	"github.com/kiali/kiali/log"
 	"os"
 	"strconv"
 	"testing"
@@ -48,7 +49,7 @@ func TestGetValidationsPerf(t *testing.T) {
 
 	now := time.Now()
 	validations, _ := vs.GetValidations(context.TODO(), "test", "", "")
-	assert.WithinDuration(now, time.Now(), time.Millisecond)
+	log.Debugf("Validation Performance test took %f seconds for %d namespaces", time.Now().Sub(now).Seconds(), numNs)
 	assert.NotEmpty(validations)
 }
 

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -3,7 +3,6 @@ package business
 import (
 	"context"
 	"fmt"
-	"github.com/kiali/kiali/log"
 	"os"
 	"strconv"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 )
@@ -49,7 +49,7 @@ func TestGetValidationsPerf(t *testing.T) {
 
 	now := time.Now()
 	validations, _ := vs.GetValidations(context.TODO(), "test", "", "")
-	log.Debugf("Validation Performance test took %f seconds for %d namespaces", time.Now().Sub(now).Seconds(), numNs)
+	log.Debugf("Validation Performance test took %f seconds for %d namespaces", time.Since(now).Seconds(), numNs)
 	assert.NotEmpty(validations)
 }
 

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -1,0 +1,83 @@
+package business
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+func TestGetValidationsPerf(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	sNumNs := os.Getenv("NUMNS")
+	sNumDr := os.Getenv("NUMDR")
+	sNumVs := os.Getenv("NUMVS")
+	sNumGw := os.Getenv("NUMGW")
+	numNs := 10
+	numDr := 10
+	numVs := 10
+	numGw := 10
+	if sNumNs != "" {
+		if n, err := strconv.Atoi(sNumNs); err == nil {
+			numNs = n
+		}
+		if n, err := strconv.Atoi(sNumDr); err == nil {
+			numDr = n
+		}
+		if n, err := strconv.Atoi(sNumVs); err == nil {
+			numVs = n
+		}
+		if n, err := strconv.Atoi(sNumGw); err == nil {
+			numGw = n
+		}
+	}
+
+	vs := mockCombinedValidationService(fakeIstioConfigListPerf(numNs, numDr, numVs, numGw),
+		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", fakePods())
+
+	now := time.Now()
+	validations, _ := vs.GetValidations(context.TODO(), "test", "", "")
+	assert.WithinDuration(now, time.Now(), time.Millisecond)
+	assert.NotEmpty(validations)
+}
+
+func fakeIstioConfigListPerf(numNs, numDr, numVs, numGw int) *models.IstioConfigList {
+	istioConfigList := models.IstioConfigList{}
+
+	n := 0
+	for n < numNs {
+		d := 0
+		for d < numDr {
+			istioConfigList.DestinationRules = append(istioConfigList.DestinationRules,
+				*data.AddSubsetToDestinationRule(data.CreateSubset("v1", "v1"), data.CreateEmptyDestinationRule(fmt.Sprintf("test%d", n), fmt.Sprintf("product-dr%d", d), fmt.Sprintf("product%d", d))),
+				*data.CreateEmptyDestinationRule(fmt.Sprintf("test%d", n), fmt.Sprintf("customer-dr%d", d), fmt.Sprintf("customer%d", d)))
+			d++
+		}
+		v := 0
+		for v < numVs {
+			istioConfigList.VirtualServices = append(istioConfigList.VirtualServices,
+				*data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination(fmt.Sprintf("product-%d", v), "v1", -1),
+					data.AddTcpRoutesToVirtualService(data.CreateTcpRoute(fmt.Sprintf("product2-%d", v), "v1", -1),
+						data.CreateEmptyVirtualService(fmt.Sprintf("product-vs%d", v), fmt.Sprintf("test%d", n), []string{fmt.Sprintf("product%d", v)}))))
+			v++
+		}
+		g := 0
+		for g < numGw {
+			istioConfigList.Gateways = append(istioConfigList.Gateways, append(getGateway(fmt.Sprintf("first%d", g), fmt.Sprintf("test%d", n)), getGateway(fmt.Sprintf("second%d", g), fmt.Sprintf("test2%d", n))...)...)
+			g++
+		}
+		n++
+	}
+	return &istioConfigList
+}

--- a/business/tls.go
+++ b/business/tls.go
@@ -90,7 +90,6 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace str
 	drs := kubernetes.FilterDestinationRulesByNamespaces(nss, istioConfigList.DestinationRules)
 
 	mtlsStatus := mtls.MtlsStatus{
-		Namespace:           namespace,
 		PeerAuthentications: pas,
 		DestinationRules:    drs,
 		AutoMtlsEnabled:     in.hasAutoMTLSEnabled(),
@@ -98,7 +97,7 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace str
 	}
 
 	return models.MTLSStatus{
-		Status: mtlsStatus.NamespaceMtlsStatus().OverallStatus,
+		Status: mtlsStatus.NamespaceMtlsStatus(namespace).OverallStatus,
 	}, nil
 }
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -95,11 +95,10 @@ func isWorkloadIncluded(workload string) bool {
 	return !excludedWorkloads[workload]
 }
 
-func (in *WorkloadService) getWorkloadValidations(authpolicies []security_v1beta1.AuthorizationPolicy, workloads models.WorkloadList, namespace string) models.IstioValidations {
+func (in *WorkloadService) getWorkloadValidations(authpolicies []security_v1beta1.AuthorizationPolicy, workloadsPerNamespace map[string]models.WorkloadList) models.IstioValidations {
 	validations := checkers.WorkloadChecker{
-		Namespace:             namespace,
 		AuthorizationPolicies: authpolicies,
-		WorkloadList:          workloads,
+		WorkloadsPerNamespace: workloadsPerNamespace,
 	}.Check()
 
 	return validations
@@ -188,7 +187,9 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		workloadList.Workloads = append(workloadList.Workloads, *wItem)
 	}
 	authpolicies = istioConfigList.AuthorizationPolicies
-	validations := in.getWorkloadValidations(authpolicies, *workloadList, criteria.Namespace)
+	allWorkloads := map[string]models.WorkloadList{}
+	allWorkloads[criteria.Namespace] = *workloadList
+	validations := in.getWorkloadValidations(authpolicies, allWorkloads)
 	validations.StripIgnoredChecks()
 	workloadList.Validations = validations
 	return *workloadList, nil

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -122,7 +122,7 @@ const conf = {
         `api/namespaces/${namespace}/customdashboard/${template}`,
       grafana: 'api/grafana',
       istioConfig: (namespace: string) => `api/namespaces/${namespace}/istio`,
-      allIstioConfigs: `api/istio/config`,
+      allIstioConfigs: () => `api/istio/config`,
       istioConfigCreate: (namespace: string, objectType: string) => `api/namespaces/${namespace}/istio/${objectType}`,
       istioConfigDetail: (namespace: string, objectType: string, object: string) =>
         `api/namespaces/${namespace}/istio/${objectType}/${object}`,

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -142,6 +142,7 @@ const conf = {
       namespaceMetrics: (namespace: string) => `api/namespaces/${namespace}/metrics`,
       namespaceTls: (namespace: string) => `api/namespaces/${namespace}/tls`,
       namespaceValidations: (namespace: string) => `api/namespaces/${namespace}/validations`,
+      configValidations: () => `api/istio/validations`,
       meshTls: () => 'api/mesh/tls',
       outboundTrafficPolicyMode: () => 'api/mesh/outbound_traffic_policy/mode',
       istioStatus: () => 'api/istio/status',

--- a/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -27,7 +27,6 @@ import { KialiAppState } from '../../store/Store';
 import { activeNamespacesSelector } from '../../store/Selectors';
 import { connect } from 'react-redux';
 import DefaultSecondaryMasthead from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
-import _ from "lodash";
 
 interface IstioConfigListPageState extends FilterComponent.State<IstioConfigItem> {}
 interface IstioConfigListPageProps extends FilterComponent.Props<IstioConfigItem> {
@@ -140,44 +139,18 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
 
   // Fetch the Istio configs, apply filters and map them into flattened list items
   fetchIstioConfigs(namespaces: string[], typeFilters: string[], istioNameFilters: string[]) {
-    // return this.promises
-    //   .registerAll(
-    //     'configs',
-    //     // THIS should be one call, not per namespace , OR the next section
-    //     namespaces.map(_ => API.getAllIstioConfigs(namespaces, typeFilters, true, '', ''))
-    //   )
-    //   .then(responses => {
-    //     let istioItems: IstioConfigItem[] = [];
-    //     responses.forEach(response => {
-    //       namespaces.forEach(ns => {
-    //         istioItems = istioItems.concat(toIstioItems(filterByName(response.data[ns], istioNameFilters)));
-    //       })
-    //     });
-    //     return istioItems;
-    //     });
-    // OR PER Chunk
-    let istioItems: IstioConfigItem[] = [];
-    _.chunk(namespaces, 10).forEach(chunk => {
-      return this.promises
-        .registerChained('configs', undefined, () => this.fetchIstioConfigChunks(chunk, typeFilters, istioNameFilters, istioItems))
-        .then(() => {
-          return istioItems;
-        })
-    })
-  }
-
-  fetchIstioConfigChunks(chunk: string[], typeFilters: string[], istioNameFilters: string[], istioItems: IstioConfigItem[]) {
-    return Promise.all(
-      [
-        API.getAllIstioConfigs(chunk, typeFilters, true, '', '')
-      ]
-    )
-      .then( results => {
-          chunk.forEach(ns => {
-            istioItems = istioItems.concat(toIstioItems(filterByName(results[0].data[ns], istioNameFilters)));
-          })
-      })
-      .catch(err => this.handleAxiosError('Could not fetch Istio configs', err));
+    return this.promises
+      .registerAll(
+        'configs',
+        namespaces.map(ns => API.getIstioConfig(ns, typeFilters, true, '', ''))
+      )
+      .then(responses => {
+        let istioItems: IstioConfigItem[] = [];
+        responses.forEach(response => {
+          istioItems = istioItems.concat(toIstioItems(filterByName(response.data, istioNameFilters)));
+        });
+        return istioItems;
+      });
   }
 
   render() {

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -450,7 +450,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     return Promise.all(
       [
         API.getConfigValidations(nss),
-        API.getAllIstioConfigs(nss, [], false, '', '')
+        API.getAllIstioConfigs(nss, false, '', '')
       ]
     )
       .then(results => {

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -450,7 +450,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     return Promise.all(
       [
         API.getConfigValidations(nss),
-        API.getAllIstioConfigs(nss, false, '', '')
+        API.getAllIstioConfigs(nss, [], false, '', '')
       ]
     )
       .then(results => {

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -457,6 +457,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
         chunk.map(nsInfo => {
           nsInfo.validations = results[0].data[nsInfo.name]
           nsInfo.istioConfig = results[1].data[nsInfo.name]
+          return nsInfo
         });
       })
       .catch(err => this.handleAxiosError('Could not fetch validations status', err));

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -446,7 +446,8 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       chunk.map(nsInfo => {
         return Promise.all([
           API.getNamespaceValidations(nsInfo.name),
-          API.getIstioConfig(nsInfo.name, ['authorizationpolicies', 'sidecars'], false, '', '')
+          API.getIstioConfig(nsInfo.name, ['authorizationpolicies', 'sidecars'], false, '', ''),
+          API.getConfigValidations([nsInfo.name])
         ]).then(results => {
           return { validations: results[0].data, istioConfig: results[1].data, nsInfo: nsInfo };
         });

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -447,7 +447,6 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
         return Promise.all([
           API.getNamespaceValidations(nsInfo.name),
           API.getIstioConfig(nsInfo.name, ['authorizationpolicies', 'sidecars'], false, '', ''),
-          API.getConfigValidations([nsInfo.name])
         ]).then(results => {
           return { validations: results[0].data, istioConfig: results[1].data, nsInfo: nsInfo };
         });

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -454,10 +454,9 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       ]
     )
       .then(results => {
-        chunk.map(nsInfo => {
+        chunk.forEach(nsInfo => {
           nsInfo.validations = results[0].data[nsInfo.name]
           nsInfo.istioConfig = results[1].data[nsInfo.name]
-          return nsInfo
         });
       })
       .catch(err => this.handleAxiosError('Could not fetch validations status', err));

--- a/frontend/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/frontend/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -86,7 +86,7 @@ describe('Overview page', () => {
     // Ignore other calls
     mockAPIToPromise('getNamespaceMetrics', null, false);
     mockAPIToPromise('getNamespaceTls', null, false);
-    mockAPIToPromise('getNamespaceValidations', null, false);
+    mockAPIToPromise('getConfigValidations', null, false);
     mockAPIToPromise('getAllIstioConfigs', null, false);
     mockAPIToPromise('getIstioPermissions', {}, false);
   });

--- a/frontend/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/frontend/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -87,7 +87,7 @@ describe('Overview page', () => {
     mockAPIToPromise('getNamespaceMetrics', null, false);
     mockAPIToPromise('getNamespaceTls', null, false);
     mockAPIToPromise('getNamespaceValidations', null, false);
-    mockAPIToPromise('getIstioConfig', null, false);
+    mockAPIToPromise('getAllIstioConfigs', null, false);
     mockAPIToPromise('getIstioPermissions', {}, false);
   });
 

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -182,15 +182,11 @@ export const getIstioConfig = (
 
 export const getAllIstioConfigs = (
   namespaces: string[],
-  objects: string[],
   validate: boolean,
   labelSelector: string,
   workloadSelector: string
 ) => {
   const params: any = namespaces && namespaces.length > 0 ? { namespaces: namespaces.join(',') } : {};
-  if (objects && objects.length > 0) {
-    params.objects = objects.join(',');
-  }
   if (validate) {
     params.validate = validate;
   }

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -182,11 +182,15 @@ export const getIstioConfig = (
 
 export const getAllIstioConfigs = (
   namespaces: string[],
+  objects: string[],
   validate: boolean,
   labelSelector: string,
   workloadSelector: string
 ) => {
   const params: any = namespaces && namespaces.length > 0 ? { namespaces: namespaces.join(',') } : {};
+  if (objects && objects.length > 0) {
+    params.objects = objects.join(',');
+  }
   if (validate) {
     params.validate = validate;
   }

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -176,7 +176,7 @@ export const getIstioConfig = (
   if (namespace) {
     return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
   } else {
-    return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.allIstioConfigs, params, {});
+    return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.allIstioConfigs(), params, {});
   }
 };
 
@@ -196,7 +196,7 @@ export const getAllIstioConfigs = (
   if (workloadSelector) {
     params.workloadSelector = workloadSelector;
   }
-  return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.allIstioConfigs, params, {});
+  return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.allIstioConfigs(), params, {});
 };
 
 export const getIstioConfigDetail = (namespace: string, objectType: string, object: string, validate: boolean) => {

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -210,6 +210,10 @@ export const createIstioConfigDetail = (
   return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), {}, json);
 };
 
+export const getConfigValidations = (namespaces: string[]) => {
+  return newRequest<ValidationStatus>(HTTP_VERBS.GET, urls.configValidations(), { namespaces: namespaces.join(',') }, {});
+};
+
 export const getServices = (namespace: string, params: { [key: string]: string } = {}) => {
   return newRequest<ServiceList>(HTTP_VERBS.GET, urls.services(namespace), params, {});
 };

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -180,6 +180,25 @@ export const getIstioConfig = (
   }
 };
 
+export const getAllIstioConfigs = (
+  namespaces: string[],
+  validate: boolean,
+  labelSelector: string,
+  workloadSelector: string
+) => {
+  const params: any = namespaces && namespaces.length > 0 ? { namespaces: namespaces.join(',') } : {};
+  if (validate) {
+    params.validate = validate;
+  }
+  if (labelSelector) {
+    params.labelSelector = labelSelector;
+  }
+  if (workloadSelector) {
+    params.workloadSelector = workloadSelector;
+  }
+  return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.allIstioConfigs, params, {});
+};
+
 export const getIstioConfigDetail = (namespace: string, objectType: string, object: string, validate: boolean) => {
   return newRequest<IstioConfigDetails>(
     HTTP_VERBS.GET,

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -180,9 +180,13 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
     const entryName = typeNameProto.charAt(0).toLowerCase() + typeNameProto.slice(1);
 
     let entries = istioConfigList[field];
-    if (!(entries instanceof Array)) {
+    if (entries && !(entries instanceof Array)) {
       // VirtualServices, DestinationRules
       entries = entries.items;
+    }
+
+    if (!entries) {
+      return
     }
 
     entries.forEach(entry => {

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -180,13 +180,9 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
     const entryName = typeNameProto.charAt(0).toLowerCase() + typeNameProto.slice(1);
 
     let entries = istioConfigList[field];
-    if (entries && !(entries instanceof Array)) {
+    if (!(entries instanceof Array)) {
       // VirtualServices, DestinationRules
       entries = entries.items;
-    }
-
-    if (!entries) {
-      return
     }
 
     entries.forEach(entry => {

--- a/hack/validations/setup-validation-configs.sh
+++ b/hack/validations/setup-validation-configs.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+#
+# Refer to the --help output for a description of this script and its available options.
+#
+
+infomsg() {
+  echo "[INFO] ${1}"
+}
+
+helpmsg() {
+  cat <<HELP
+This script will run setup Validation prerequisites for Istio configs
+Options:
+-ec|--error-code
+    Error code used for finding examples in https://kiali.io/docs/features/validations
+HELP
+}
+
+# process command line arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -ec|--error-code)     ERRORCODE="$2";                  shift;shift; ;;
+    -h|--help)                    helpmsg;                    exit 1       ;;
+    *) echo "Unknown argument: [$key]. Aborting."; helpmsg; exit 1 ;;
+  esac
+done
+
+# abort on any error
+set -e
+
+infomsg "Make sure everything exists"
+which kubectl > /dev/null || (infomsg "kubectl executable is missing"; exit 1)
+
+if [ "${ERRORCODE}" == "KIA0101" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/801.yaml"
+elif [ "${ERRORCODE}" == "KIA0102" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/802.yaml"
+elif [ "${ERRORCODE}" == "KIA0104" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/804.yaml"
+elif [ "${ERRORCODE}" == "KIA0106" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/806.yaml"
+elif [ "${ERRORCODE}" == "KIA0201" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/001.yaml"
+elif [ "${ERRORCODE}" == "KIA0202" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/002.yaml"
+elif [ "${ERRORCODE}" == "KIA0203" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/003.yaml"
+elif [ "${ERRORCODE}" == "KIA0204" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/005.yaml"
+elif [ "${ERRORCODE}" == "KIA0205" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/004.yaml"
+elif [ "${ERRORCODE}" == "KIA0206" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/006.yaml"
+elif [ "${ERRORCODE}" == "KIA0207" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/007.yaml"
+elif [ "${ERRORCODE}" == "KIA0208" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/008.yaml"
+elif [ "${ERRORCODE}" == "KIA0301" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/201.yaml"
+elif [ "${ERRORCODE}" == "KIA0302" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/202.yaml"
+elif [ "${ERRORCODE}" == "KIA0401" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/401.yaml"
+elif [ "${ERRORCODE}" == "KIA0501" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/501.yaml"
+elif [ "${ERRORCODE}" == "KIA0505" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/305.yaml"
+elif [ "${ERRORCODE}" == "KIA0506" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/306.yaml"
+elif [ "${ERRORCODE}" == "KIA0601" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/701.yaml"
+elif [ "${ERRORCODE}" == "KIA0602" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/602.yaml"
+elif [ "${ERRORCODE}" == "KIA0701" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/702.yaml"
+elif [ "${ERRORCODE}" == "KIA0801" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/402.yaml"
+elif [ "${ERRORCODE}" == "KIA0901" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/501.yaml"
+elif [ "${ERRORCODE}" == "KIA0902" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/502.yaml"
+elif [ "${ERRORCODE}" == "KIA0903" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/601.yaml"
+elif [ "${ERRORCODE}" == "KIA1003" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/903.yaml"
+elif [ "${ERRORCODE}" == "KIA1004" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/904.yaml"
+elif [ "${ERRORCODE}" == "KIA1006" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/906.yaml"
+elif [ "${ERRORCODE}" == "KIA1101" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/101.yaml"
+elif [ "${ERRORCODE}" == "KIA1102" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/102.yaml"
+elif [ "${ERRORCODE}" == "KIA1103" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/103.yaml"
+elif [ "${ERRORCODE}" == "KIA1104" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/106.yaml"
+elif [ "${ERRORCODE}" == "KIA1105" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/111.yaml"
+elif [ "${ERRORCODE}" == "KIA1106" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/104.yaml"
+elif [ "${ERRORCODE}" == "KIA1107" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/105.yaml"
+elif [ "${ERRORCODE}" == "KIA1108" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/112.yaml"
+elif [ "${ERRORCODE}" == "KIA0002" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/302.yaml"
+elif [ "${ERRORCODE}" == "KIA0003" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/303.yaml"
+elif [ "${ERRORCODE}" == "KIA0004" ]; then
+  FILEPATH="https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/304.yaml"
+else
+  echo "Error code ${ERRORCODE} not found, or validation reproduction example yaml file does not exist for it in kiali.io."
+  exit 1
+fi
+
+infomsg "Create Validation configs $FILEPATH"
+
+kubectl delete -f $FILEPATH > /dev/null 2>&1
+
+kubectl apply -f $FILEPATH
+
+infomsg "Validations env is prepared."
+

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -27,6 +27,11 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 			parsedTypes = strings.Split(objects, ",")
 		}
 	}
+	namespaces := query.Get("namespaces") // csl of namespaces
+	nss := []string{}
+	if len(namespaces) > 0 {
+		nss = strings.Split(namespaces, ",")
+	}
 
 	allNamespaces := false
 	if namespace == "" {
@@ -89,7 +94,12 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	RespondWithJSON(w, http.StatusOK, istioConfig)
+	if len(nss) > 0 {
+		// From allNamespaces load only requested ones
+		RespondWithJSON(w, http.StatusOK, istioConfig.FilterIstioConfigs(nss))
+	} else {
+		RespondWithJSON(w, http.StatusOK, istioConfig)
+	}
 }
 
 func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -157,3 +157,83 @@ type ResourcesPermissions map[string]*ResourcePermissions
 
 // IstioConfigPermissions holds a map of ResourcesPermissions per namespace
 type IstioConfigPermissions map[string]*ResourcesPermissions
+
+// IstioConfigs holds a map of IstioConfigList per namespace
+type IstioConfigs map[string]*IstioConfigList
+
+// FilterIstioConfigs Filters all Istio configs from Istio registry by given namespaces and return a map config list per namespace
+func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs {
+	filtered := IstioConfigs{}
+
+	for _, ns := range nss {
+		if filtered[ns] == nil {
+			filtered[ns] = new(IstioConfigList)
+		}
+		for _, dr := range configList.DestinationRules {
+			if dr.Namespace == ns {
+				filtered[ns].DestinationRules = append(filtered[ns].DestinationRules, dr)
+			}
+		}
+
+		for _, ef := range configList.EnvoyFilters {
+			if ef.Namespace == ns {
+				filtered[ns].EnvoyFilters = append(filtered[ns].EnvoyFilters, ef)
+			}
+		}
+
+		for _, gw := range configList.Gateways {
+			if gw.Namespace == ns {
+				filtered[ns].Gateways = append(filtered[ns].Gateways, gw)
+			}
+		}
+
+		for _, se := range configList.ServiceEntries {
+			if se.Namespace == ns {
+				filtered[ns].ServiceEntries = append(filtered[ns].ServiceEntries, se)
+			}
+		}
+
+		for _, sc := range configList.Sidecars {
+			if sc.Namespace == ns {
+				filtered[ns].Sidecars = append(filtered[ns].Sidecars, sc)
+			}
+		}
+
+		for _, vs := range configList.VirtualServices {
+			if vs.Namespace == ns {
+				filtered[ns].VirtualServices = append(filtered[ns].VirtualServices, vs)
+			}
+		}
+
+		for _, we := range configList.WorkloadEntries {
+			if we.Namespace == ns {
+				filtered[ns].WorkloadEntries = append(filtered[ns].WorkloadEntries, we)
+			}
+		}
+
+		for _, wg := range configList.WorkloadGroups {
+			if wg.Namespace == ns {
+				filtered[ns].WorkloadGroups = append(filtered[ns].WorkloadGroups, wg)
+			}
+		}
+
+		for _, ap := range configList.AuthorizationPolicies {
+			if ap.Namespace == ns {
+				filtered[ns].AuthorizationPolicies = append(filtered[ns].AuthorizationPolicies, ap)
+			}
+		}
+
+		for _, pa := range configList.PeerAuthentications {
+			if pa.Namespace == ns {
+				filtered[ns].PeerAuthentications = append(filtered[ns].PeerAuthentications, pa)
+			}
+		}
+
+		for _, ra := range configList.RequestAuthentications {
+			if ra.Namespace == ns {
+				filtered[ns].RequestAuthentications = append(filtered[ns].RequestAuthentications, ra)
+			}
+		}
+	}
+	return &filtered
+}

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -168,6 +168,7 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 	for _, ns := range nss {
 		if filtered[ns] == nil {
 			filtered[ns] = new(IstioConfigList)
+			filtered[ns].Namespace = Namespace{Name: ns}
 		}
 		for _, dr := range configList.DestinationRules {
 			if dr.Namespace == ns {

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -168,7 +168,6 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 	for _, ns := range nss {
 		if filtered[ns] == nil {
 			filtered[ns] = new(IstioConfigList)
-			filtered[ns].Namespace = Namespace{Name: ns}
 		}
 		for _, dr := range configList.DestinationRules {
 			if dr.Namespace == ns {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -33,6 +33,9 @@ type IstioValidationSummary struct {
 	Warnings int `json:"warnings"`
 }
 
+// ValidationSummaries holds a map of IstioValidationSummary per namespace
+type ValidationSummaries map[string]*IstioValidationSummary
+
 // IstioValidations represents a set of IstioValidation grouped by IstioValidationKey.
 type IstioValidations map[IstioValidationKey]*IstioValidation
 
@@ -435,14 +438,14 @@ func (iv IstioValidations) MergeReferences(validations IstioValidations) IstioVa
 	return iv
 }
 
-func (iv IstioValidations) SummarizeValidation(ns string) IstioValidationSummary {
+func (iv IstioValidations) SummarizeValidation(ns string) *IstioValidationSummary {
 	ivs := IstioValidationSummary{}
 	for k, v := range iv {
 		if k.Namespace == ns {
 			ivs.mergeSummaries(v.Checks)
 		}
 	}
-	return ivs
+	return &ivs
 }
 
 func (summary *IstioValidationSummary) mergeSummaries(cs []*IstioCheck) {

--- a/prometheus/internalmetrics/internal_metrics.go
+++ b/prometheus/internalmetrics/internal_metrics.go
@@ -309,9 +309,14 @@ func GetValidationProcessingTimePrometheusTimer(namespace string, service string
 			labelNamespace: namespace,
 			labelService:   service,
 		}
-	} else {
+	} else if namespace != "" {
 		labels = prometheus.Labels{
 			labelNamespace: namespace,
+			labelService:   "_all_",
+		}
+	} else {
+		labels = prometheus.Labels{
+			labelNamespace: "_all_",
 			labelService:   "_all_",
 		}
 	}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -940,6 +940,27 @@ func NewRoutes() (r *Routes) {
 			handlers.NamespaceValidationSummary,
 			true,
 		},
+		// swagger:route GET /istio/validations namespaces namespacesValidations
+		// ---
+		// Get validation summary for all objects in the given namespaces
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      200: namespaceValidationSummaryResponse
+		//      400: badRequestError
+		//      500: internalError
+		//
+		{
+			"ConfigValidationSummary",
+			"GET",
+			"/api/istio/validations",
+			handlers.ConfigValidationSummary,
+			true,
+		},
 		// swagger:route GET /mesh/tls tls meshTls
 		// ---
 		// Get TLS status for the whole mesh

--- a/tests/data/workload_data.go
+++ b/tests/data/workload_data.go
@@ -2,6 +2,12 @@ package data
 
 import "github.com/kiali/kiali/models"
 
+func CreateWorkloadsPerNamespace(namespace string, items ...models.WorkloadListItem) map[string]models.WorkloadList {
+	allWorkloads := map[string]models.WorkloadList{}
+	allWorkloads[namespace] = CreateWorkloadList(namespace, items...)
+	return allWorkloads
+}
+
 func CreateWorkloadList(namespace string, items ...models.WorkloadListItem) models.WorkloadList {
 	return models.WorkloadList{
 		Namespace: models.Namespace{Name: namespace},


### PR DESCRIPTION
Research and optimization task: https://github.com/kiali/kiali/issues/5153

The main idea of this PR is to reduce the requests of Istio Config lists and validations from Overview page.
Originally there was one request per namespace, and requests were done in a batch of 10 namespaces.

With this PR, there is 1 request per 10 namespace, which reduces the load on backend.
The load of Istio resources are performed from Istio Registry, and filtered by requested namespaces.