### PR TITLE
Try fixing the cypress failure

### DIFF
--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -213,9 +213,12 @@ Given('a workload with override configuration for automatic sidecar injection', 
     });
 });
 
-When('I override the default automatic sidecar injection policy in the namespace to enabled', function () {
+When('I visit the overview page', function () {
     cy.visit('/console/overview?refresh=0');
     cy.contains('Inbound traffic', {matchCase: false}); // Make sure data finished loading, so avoid broken tests because of a re-render
+});
+
+When('I override the default automatic sidecar injection policy in the namespace to enabled', function () {
     cy.get('[data-test=overview-type-LIST]').click();
     cy.get(`[data-test=VirtualItem_${this.targetNamespace}] button`).click();
     cy.get(`[data-test=enable-${this.targetNamespace}-namespace-sidecar-injection]`).click();
@@ -224,8 +227,6 @@ When('I override the default automatic sidecar injection policy in the namespace
 });
 
 When('I change the override configuration for automatic sidecar injection policy in the namespace to {string} it', function (enabledOrDisabled) {
-    cy.visit('/console/overview?refresh=0');
-    cy.contains('Inbound traffic', {matchCase: false}); // Make sure data finished loading, so avoid broken tests because of a re-render
     cy.get('[data-test=overview-type-LIST]').click();
     cy.get(`[data-test=VirtualItem_${this.targetNamespace}] button`).click();
     cy.get(`[data-test=${enabledOrDisabled}-${this.targetNamespace}-namespace-sidecar-injection]`).click();
@@ -234,8 +235,6 @@ When('I change the override configuration for automatic sidecar injection policy
 });
 
 When('I remove override configuration for sidecar injection in the namespace', function () {
-    cy.visit('/console/overview?refresh=0');
-    cy.contains('Inbound traffic', {matchCase: false}); // Make sure data finished loading, so avoid broken tests because of a re-render
     cy.get('[data-test=overview-type-LIST]').click();
     cy.get(`[data-test=VirtualItem_${this.targetNamespace}] button`).click();
     cy.get(`[data-test=remove-${this.targetNamespace}-namespace-sidecar-injection]`).click();

--- a/frontend/cypress/integration/featureFiles/sidecar_injection.feature
+++ b/frontend/cypress/integration/featureFiles/sidecar_injection.feature
@@ -11,24 +11,32 @@ Feature: Controlling sidecar injection
 
     Scenario: Override the default policy for automatic sidecar injection by enabling it in a namespace
         Given a namespace without override configuration for automatic sidecar injection
-        When I override the default automatic sidecar injection policy in the namespace to enabled
+        When I visit the overview page
+        And user filters "default" namespace
+        And I override the default automatic sidecar injection policy in the namespace to enabled
         Then I should see the override annotation for sidecar injection in the namespace as "enabled"
 
     Scenario: Switch the override configuration for automatic sidecar injection in a namespace to disabled
         Given a namespace which has override configuration for automatic sidecar injection
         And the override configuration for sidecar injection is "enabled"
-        When I change the override configuration for automatic sidecar injection policy in the namespace to "disable" it
+        When I visit the overview page
+        And user filters "default" namespace
+        And I change the override configuration for automatic sidecar injection policy in the namespace to "disable" it
         Then I should see the override annotation for sidecar injection in the namespace as "disabled"
 
     Scenario: Switch the override configuration for automatic sidecar injection in a namespace to enabled
         Given a namespace which has override configuration for automatic sidecar injection
         And the override configuration for sidecar injection is "disabled"
-        When I change the override configuration for automatic sidecar injection policy in the namespace to "enable" it
+        When I visit the overview page
+        And user filters "default" namespace
+        And I change the override configuration for automatic sidecar injection policy in the namespace to "enable" it
         Then I should see the override annotation for sidecar injection in the namespace as "enabled"
 
     Scenario: Switch to using the default policy for automatic sidecar injection in a namespace
         Given a namespace which has override configuration for automatic sidecar injection
-        When I remove override configuration for sidecar injection in the namespace
+        When I visit the overview page
+        And user filters "default" namespace
+        And I remove override configuration for sidecar injection in the namespace
         Then I should see no override annotation for sidecar injection in the namespace
 
     Scenario: Override the default policy for automatic sidecar injection by enabling it in a workload


### PR DESCRIPTION
Try fixing the cypress failure by filtering the overview list to a single entry, on the assumption that maybe the kebab menu item is sometimes getting clipped and not in the dom, if the row happens to be too close
to the bottom.

Fixes #5198 