### PR TITLE
Attempt to ensure colors are always defined in advance of use in the graph

### DIFF
--- a/frontend/src/app/StartupInitializer.tsx
+++ b/frontend/src/app/StartupInitializer.tsx
@@ -6,7 +6,6 @@ import { LoginSession } from '../store/Store';
 import { KialiDispatch } from '../types/Redux';
 import InitializingScreen from './InitializingScreen';
 import authenticationConfig from '../config/AuthenticationConfig';
-import { setPFColorVals } from 'components/Pf/PfColors';
 
 interface InitializerComponentProps {
   setInitialAuthentication: (session: LoginSession) => void;
@@ -26,7 +25,6 @@ class InitializerComponent extends React.Component<InitializerComponentProps, In
 
   componentDidMount() {
     this.fetchAuthenticationConfig();
-    setPFColorVals(document.documentElement);
   }
 
   render() {

--- a/frontend/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/frontend/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -10,6 +10,7 @@ import KialiGridLayout from './Layout/KialiGridLayout';
 import KialiDagreLayout from './Layout/KialiDagreLayout';
 import KialiConcentricLayout from './Layout/KialiConcentricLayout';
 import KialiBreadFirstLayout from './Layout/KialiBreadthFirstLayout';
+import { setPFColorVals } from 'components/Pf/PfColors';
 const nodeHtmlLabel = require('cy-node-html-label');
 
 cytoscape.use(canvas);
@@ -81,6 +82,10 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
     if (this.cy) {
       this.destroy();
     }
+
+    // ensure required colors are set
+    setPFColorVals(this.divParentRef.current!);
+
     const opts = {
       container: this.divParentRef.current,
       boxSelectionEnabled: false,


### PR DESCRIPTION
@lucasponce I can't reproduce the issue but perhaps this will fix https://github.com/kiali/openshift-servicemesh-plugin/issues/22.  Maybe give it a try.