### PR TITLE
Add Kiali validations on the Istio Config Detail sidepanel

### DIFF
--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -115,7 +115,7 @@ class IstioConfigOverview extends React.Component<IstioConfigOverviewProps> {
                 <KialiIcon.Info className={infoStyle} />
               </Tooltip>
               {this.props.istioValidations && (!this.props.statusMessages || this.props.statusMessages.length === 0)
-                && (!this.props.istioValidations.checks || this.props.istioValidations.checks.length == 0)
+                && (!this.props.istioValidations.checks || this.props.istioValidations.checks.length === 0)
                 && (
                 <span className={healthIconStyle}>
                   <ValidationObjectSummary

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -114,7 +114,9 @@ class IstioConfigOverview extends React.Component<IstioConfigOverviewProps> {
               >
                 <KialiIcon.Info className={infoStyle} />
               </Tooltip>
-              {this.props.istioValidations && (!this.props.statusMessages || this.props.statusMessages.length === 0) && (
+              {this.props.istioValidations && (!this.props.statusMessages || this.props.statusMessages.length === 0)
+                && (!this.props.istioValidations.checks || this.props.istioValidations.checks.length == 0)
+                && (
                 <span className={healthIconStyle}>
                   <ValidationObjectSummary
                     id={'config-validation'}

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -133,7 +133,8 @@ class IstioConfigOverview extends React.Component<IstioConfigOverviewProps> {
           </StackItem>
         )}
 
-        {this.props.statusMessages && this.props.statusMessages.length > 0 && (
+        {((this.props.statusMessages && this.props.statusMessages.length > 0 ) ||
+          (this.props.istioValidations && this.props.istioValidations.checks && this.props.istioValidations.checks.length > 0 ) ) && (
           <StackItem>
             <IstioStatusMessageList messages={this.props.statusMessages} checks={this.props.istioValidations?.checks} />
           </StackItem>

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -4,7 +4,7 @@ import { Flex, FlexItem, Stack, StackItem, Title, TitleSizes, Tooltip } from '@p
 import Validation from '../../../components/Validations/Validation';
 
 interface Props {
-  messages: ValidationMessage[];
+  messages?: ValidationMessage[];
   checks?: ObjectCheck[];
 }
 
@@ -18,7 +18,7 @@ class IstioStatusMessageList extends React.Component<Props> {
               Configuration Analysis
             </Title>
           </StackItem>
-          {this.props.messages.map((msg: ValidationMessage, i: number) => {
+          {(this.props.messages || []).map((msg: ValidationMessage, i: number) => {
             const severity: ValidationTypes = IstioLevelToSeverity[msg.level || 'UNKNOWN'];
             return (
               <StackItem id={'msg-' + i} className={'validation-message'}>

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {IstioLevelToSeverity, ObjectCheck, ValidationMessage, ValidationTypes} from '../../../types/IstioObjects';
-import { Flex, FlexItem, Stack, StackItem, Title, TitleSizes, Tooltip } from '@patternfly/react-core';
+import {Flex, FlexItem, Stack, StackItem, Title, TitleSizes, Tooltip, TooltipPosition} from '@patternfly/react-core';
 import Validation from '../../../components/Validations/Validation';
 import {KialiIcon} from "../../../config/KialiIcon";
 import {style} from "typestyle";
@@ -11,8 +11,7 @@ interface Props {
 }
 
 const infoStyle = style({
-  margin: '0px 0px 2px 10px',
-  verticalAlign: '-5px !important'
+  verticalAlign: '-0.125em !important'
 });
 
 class IstioStatusMessageList extends React.Component<Props> {
@@ -54,8 +53,10 @@ class IstioStatusMessageList extends React.Component<Props> {
                     <FlexItem>
                       {check.code}
                     </FlexItem>
-                    <Tooltip content={check.message} >
+                    <Tooltip content={check.message} position={TooltipPosition.right}>
+                      <div className="iconInfo">
                       <KialiIcon.Info className={infoStyle} />
+                      </div>
                     </Tooltip>
                   </Flex>
 

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -2,11 +2,18 @@ import * as React from 'react';
 import {IstioLevelToSeverity, ObjectCheck, ValidationMessage, ValidationTypes} from '../../../types/IstioObjects';
 import { Flex, FlexItem, Stack, StackItem, Title, TitleSizes, Tooltip } from '@patternfly/react-core';
 import Validation from '../../../components/Validations/Validation';
+import {KialiIcon} from "../../../config/KialiIcon";
+import {style} from "typestyle";
 
 interface Props {
   messages?: ValidationMessage[];
   checks?: ObjectCheck[];
 }
+
+const infoStyle = style({
+  margin: '0px 0px 2px 10px',
+  verticalAlign: '-5px !important'
+});
 
 class IstioStatusMessageList extends React.Component<Props> {
   render() {
@@ -40,16 +47,18 @@ class IstioStatusMessageList extends React.Component<Props> {
             {(this.props.checks || []).map((check, index) => {
               return (
                 <StackItem id={'valid_msg-' + index} className={'validation-message'}>
-                  <Tooltip content={check.message}>
-                    <Flex>
-                      <FlexItem>
-                        <Validation severity={check.severity} />
-                      </FlexItem>
-                      <FlexItem>
-                        {check.code}
-                      </FlexItem>
-                    </Flex>
-                  </Tooltip>
+                  <Flex>
+                    <FlexItem>
+                      <Validation severity={check.severity} />
+                    </FlexItem>
+                    <FlexItem>
+                      {check.code}
+                    </FlexItem>
+                    <Tooltip content={check.message} >
+                      <KialiIcon.Info className={infoStyle} />
+                    </Tooltip>
+                  </Flex>
+
                 </StackItem>
               );
             })}


### PR DESCRIPTION
Starting Istio with values.global.istiod.enableAnalysis=true
![Screenshot from 2022-06-15 14-29-26](https://user-images.githubusercontent.com/49480155/173843430-57c062fd-c3d8-4d47-bccc-9e17c6b54723.png)

Starting Istio with values.global.istiod.enableAnalysis=false
![Screenshot from 2022-06-15 14-38-16](https://user-images.githubusercontent.com/49480155/173843515-096e98eb-028a-4d47-a560-68a63d770dce.png)

No errors:
![Screenshot from 2022-06-15 14-47-56](https://user-images.githubusercontent.com/49480155/173843582-b8f6cc16-b96e-4dc1-a82b-744a1b9fb66f.png)

* I've seen the kiali validations don't have a link to the docs (https://kiali.io/docs/features/validations/), but Itsio validations have. An improvement could be, adding these links into kiali validations also. 

Sending as a draft to get feedback

Fixes https://github.com/kiali/kiali/issues/5204 

