### PR TITLE
Fix cypress kiali_login.feature test

### DIFF
--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -1,6 +1,6 @@
 import { Given, When, And, Then } from "cypress-cucumber-preprocessor/steps";
 
-const USERNAME = Cypress.env('USERNAME'); // CYPRESS_USERNAME to the user
+const USERNAME = Cypress.env('USERNAME') || 'jenkins'; // CYPRESS_USERNAME to the user
 const PASSWD = Cypress.env('PASSWD'); // CYPRESS_PASSWD to the user
 const KUBEADMIN_IDP = Cypress.env('AUTH_PROVIDER'); // CYPRESS_AUTH_PROVIDER to the user
 const auth_strategy = Cypress.env('auth_strategy');

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -34,8 +34,6 @@ And('user clicks my_htpasswd_provider', () => {
                     .click();
             }
         });
-        // another way to press the button - this is the way other tests do it:
-        //cy.get('.pf-c-button').contains(KUBEADMIN_IDP, { matchCase: false }).click();
     }
 })
 

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -2,7 +2,7 @@ import { Given, When, And, Then } from "cypress-cucumber-preprocessor/steps";
 
 const USERNAME = Cypress.env('USERNAME') || 'jenkins'; // CYPRESS_USERNAME to the user
 const PASSWD = Cypress.env('PASSWD'); // CYPRESS_PASSWD to the user
-const KUBEADMIN_IDP = Cypress.env('AUTH_PROVIDER'); // CYPRESS_AUTH_PROVIDER to the user
+const KUBEADMIN_IDP = Cypress.env('AUTH_PROVIDER') || 'my_htpasswd_provider'; // CYPRESS_AUTH_PROVIDER to the user
 const auth_strategy = Cypress.env('auth_strategy');
 
 Given('user opens base url', () => {

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -26,8 +26,16 @@ And('user clicks Log In With OpenShift', () => {
 
 And('user clicks my_htpasswd_provider', () => {
     if (auth_strategy === 'openshift') {
-        cy.log('Log in using auth provider: ' + KUBEADMIN_IDP)
-        cy.get('.pf-c-button').contains(KUBEADMIN_IDP, { matchCase: false }).click();
+        cy.log('Log in using auth provider: ' + KUBEADMIN_IDP);
+        cy.get('body').then(($body) => {
+            if ($body.text().includes(KUBEADMIN_IDP)) {
+                cy.contains(KUBEADMIN_IDP)
+                    .should('be.visible')
+                    .click();
+            }
+        });
+        // another way to press the button - this is the way other tests do it:
+        //cy.get('.pf-c-button').contains(KUBEADMIN_IDP, { matchCase: false }).click();
     }
 })
 

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -1,8 +1,8 @@
 import { Given, When, And, Then } from "cypress-cucumber-preprocessor/steps";
 
-const USERNAME = Cypress.env('CYPRESS_USERNAME') || 'kiali';
-const PASSWD = Cypress.env('CYPRESS_PASSWD') || 'kiali';
-const KUBEADMIN_IDP = Cypress.env('CYPRESS_AUTH_PROVIDER') || 'htpasswd';
+const USERNAME = Cypress.env('USERNAME'); // CYPRESS_USERNAME to the user
+const PASSWD = Cypress.env('PASSWD'); // CYPRESS_PASSWD to the user
+const KUBEADMIN_IDP = Cypress.env('AUTH_PROVIDER'); // CYPRESS_AUTH_PROVIDER to the user
 const auth_strategy = Cypress.env('auth_strategy');
 
 Given('user opens base url', () => {

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -1,9 +1,9 @@
 import { Given, When, And, Then } from "cypress-cucumber-preprocessor/steps";
 
-const USERNAME = Cypress.env('USERNAME') || 'jenkins';
-const PASSWD = Cypress.env('PASSWD')
-const KUBEADMIN_IDP = 'my_htpasswd_provider';
-const auth_strategy = Cypress.env('auth_strategy')
+const USERNAME = Cypress.env('CYPRESS_USERNAME') || 'kiali';
+const PASSWD = Cypress.env('CYPRESS_PASSWD') || 'kiali';
+const KUBEADMIN_IDP = Cypress.env('CYPRESS_AUTH_PROVIDER') || 'htpasswd';
+const auth_strategy = Cypress.env('auth_strategy');
 
 Given('user opens base url', () => {
     cy.visit('/');
@@ -19,8 +19,6 @@ Given('user opens base url', () => {
 
 And('user clicks Log In With OpenShift', () => {
     if (auth_strategy === 'openshift') {
-        const idp = KUBEADMIN_IDP;
-        cy.log(`Logging in as ${USERNAME}`);
         cy.get('button[type="submit"]').should('be.visible');
         cy.get('button[type="submit"]').click();
     }
@@ -28,18 +26,14 @@ And('user clicks Log In With OpenShift', () => {
 
 And('user clicks my_htpasswd_provider', () => {
     if (auth_strategy === 'openshift') {
-        cy.get('body').then(($body) => {
-            if ($body.text().includes(KUBEADMIN_IDP)) {
-                cy.contains(KUBEADMIN_IDP)
-                    .should('be.visible')
-                    .click();
-            }
-        });
+        cy.log('Log in using auth provider: ' + KUBEADMIN_IDP)
+        cy.get('.pf-c-button').contains(KUBEADMIN_IDP, { matchCase: false }).click();
     }
 })
 
 And('user fill in username and password', () => {
     if (auth_strategy === 'openshift') {
+        cy.log('Log in as user: ' + USERNAME)
         cy.get('#inputUsername').type('' || USERNAME);
         cy.get('#inputPassword').type('' || PASSWD);
         cy.get('button[type="submit"]').click()

--- a/frontend/cypress/integration/featureFiles/kiali_about.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_about.feature
@@ -1,6 +1,6 @@
 Feature: Kiali help about verify
 
-  User wants to verfiy the  Kiali in help button
+  User wants to verify the Kiali in help button
   
   Background: 
     Given user is at administrator perspective
@@ -11,7 +11,3 @@ Feature: Kiali help about verify
     And user clicks on Help Button
     And user clicks on About Button
     Then user see Kiali brand
-
-
-
-    

--- a/frontend/cypress/integration/featureFiles/kiali_about.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_about.feature
@@ -1,6 +1,6 @@
 Feature: Kiali help about verify
 
-  User wants to verify the Kiali in help button
+  User wants to verify the Kiali help about information
   
   Background: 
     Given user is at administrator perspective

--- a/make/Makefile.ui.mk
+++ b/make/Makefile.ui.mk
@@ -23,9 +23,4 @@ cypress-run:
 
 ## cypress-gui: Opens the cypress GUI letting you pick which frontend integration tests to run locally.
 cypress-gui:
-	@cd ${ROOTDIR}/frontend && \
-	export CYPRESS_AUTH_PROVIDER="${CYPRESS_AUTH_PROVIDER}" ;\
-	export CYPRESS_PASSWD="${CYPRESS_PASSWD}" ;\
-	export CYPRESS_USERNAME="${CYPRESS_USERNAME}" ;\
-	export CYPRESS_BASE_URL="${CYPRESS_BASE_URL}" ;\
-	yarn cypress
+	@cd ${ROOTDIR}/frontend && yarn cypress

--- a/make/Makefile.ui.mk
+++ b/make/Makefile.ui.mk
@@ -23,4 +23,9 @@ cypress-run:
 
 ## cypress-gui: Opens the cypress GUI letting you pick which frontend integration tests to run locally.
 cypress-gui:
-	@cd ${ROOTDIR}/frontend && yarn cypress
+	@cd ${ROOTDIR}/frontend && \
+	export CYPRESS_AUTH_PROVIDER="${CYPRESS_AUTH_PROVIDER}" ;\
+	export CYPRESS_PASSWD="${CYPRESS_PASSWD}" ;\
+	export CYPRESS_USERNAME="${CYPRESS_USERNAME}" ;\
+	export CYPRESS_BASE_URL="${CYPRESS_BASE_URL}" ;\
+	yarn cypress


### PR DESCRIPTION
This fixes the login test.

To test, this assumes you have a kiali user created in the htpasswd provider in your cluster. You can create this via `make cluster-add-users`.

Once you do that, run (note: set your base url correctly):

```bash
make -e CYPRESS_AUTH_PROVIDER=htpasswd \
   -e CYPRESS_PASSWD=kiali \
   -e CYPRESS_USERNAME=kiali \
   -e CYPRESS_BASE_URL=https://your.kiali.route.url.here \
   cypress-gui
```

Then select the `kiali_login.feature` test to run. It should now pass.