### PR TITLE
Added support of showing OutBoundTrafficPolicy

### DIFF
--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -143,6 +143,7 @@ const conf = {
       namespaceTls: (namespace: string) => `api/namespaces/${namespace}/tls`,
       namespaceValidations: (namespace: string) => `api/namespaces/${namespace}/validations`,
       meshTls: () => 'api/mesh/tls',
+      outboundTrafficPolicyMode: () => 'api/mesh/outbound_traffic_policy/mode',
       istioStatus: () => 'api/istio/status',
       istioCertsInfo: () => 'api/istio/certs',
       pod: (namespace: string, pod: string) => `api/namespaces/${namespace}/pods/${pod}`,

--- a/frontend/src/pages/Overview/NamespaceInfo.ts
+++ b/frontend/src/pages/Overview/NamespaceInfo.ts
@@ -5,6 +5,7 @@ import { IstioConfigList } from '../../types/IstioConfigList';
 
 export type NamespaceInfo = {
   name: string;
+  suffix?: string;
   status?: NamespaceStatus;
   tlsStatus?: TLSStatus;
   istioConfig?: IstioConfigList;

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -242,6 +242,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           () => {
             this.fetchHealth(isAscending, sortField, type);
             this.fetchTLS(isAscending, sortField);
+            this.fetchOutboundTrafficPolicyMode();
             this.fetchValidations(isAscending, sortField);
             if (displayMode !== OverviewDisplayMode.COMPACT) {
               this.fetchMetrics(direction);
@@ -459,6 +460,20 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       })
       .catch(err => this.handleAxiosError('Could not fetch validations status', err));
   }
+
+  fetchOutboundTrafficPolicyMode() {
+    API.getOutboundTrafficPolicyMode()
+      .then(response => {
+        this.state.namespaces.forEach(nsInfo => {
+          if (serverConfig.istioNamespace === nsInfo.name && response.data !== '') {
+            nsInfo.suffix = ' (' + response.data + ')'
+          }
+        })
+      })
+      .catch(error => {
+        AlertUtils.addError('Error fetching Mesh OutboundTrafficPolicy.Mode.', error, 'default', MessageType.ERROR);
+      });
+  };
 
   handleAxiosError(message: string, error: AxiosError) {
     FilterHelper.handleError(`${message}: ${API.getErrorString(error)}`);
@@ -791,7 +806,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
                                 className={isLongNs ? cardNamespaceNameLongStyle : cardNamespaceNameNormalStyle}
                                 title={ns.name}
                               >
-                                {ns.name}
+                                {ns.name}{ns.suffix ? ns.suffix : ''}
                               </span>
                             </Title>
                           </CardHeaderMain>

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -133,7 +133,7 @@ export const getMeshTls = () => {
 };
 
 export const getOutboundTrafficPolicyMode = () => {
-  return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.outboundTrafficPolicyMode(), {}, {});
+  return newRequest<string>(HTTP_VERBS.GET, urls.outboundTrafficPolicyMode(), {}, {});
 };
 
 export const getIstioStatus = () => {

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -132,6 +132,10 @@ export const getMeshTls = () => {
   return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.meshTls(), {}, {});
 };
 
+export const getOutboundTrafficPolicyMode = () => {
+  return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.outboundTrafficPolicyMode(), {}, {});
+};
+
 export const getIstioStatus = () => {
   return newRequest<ComponentStatus[]>(HTTP_VERBS.GET, urls.istioStatus(), {}, {});
 };

--- a/handlers/mesh.go
+++ b/handlers/mesh.go
@@ -21,3 +21,14 @@ func GetClusters(w http.ResponseWriter, r *http.Request) {
 
 	RespondWithJSON(w, http.StatusOK, meshClusters)
 }
+
+func OutboundTrafficPolicyMode(w http.ResponseWriter, r *http.Request) {
+	business, err := getBusiness(r)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	otp, _ := business.Mesh.OutboundTrafficPolicy()
+	RespondWithJSON(w, http.StatusOK, otp)
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1362,9 +1362,9 @@ func NewRoutes() (r *Routes) {
 			handlers.GetClusters,
 			true,
 		},
-		// swagger:route GET /api/clusters
+		// GET /api/mesh/outbound_traffic_policy/mode
 		// ---
-		// Endpoint to get the list of the clusters that are hosting the service mesh.
+		// Endpoint to get the OutboundTrafficPolicy Mode configured in the service mesh.
 		//              Produces:
 		//              - application/json
 		//

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1362,6 +1362,24 @@ func NewRoutes() (r *Routes) {
 			handlers.GetClusters,
 			true,
 		},
+		// swagger:route GET /api/clusters
+		// ---
+		// Endpoint to get the list of the clusters that are hosting the service mesh.
+		//              Produces:
+		//              - application/json
+		//
+		//              Schemes: http, https
+		//
+		// responses:
+		//              500: internalError
+		//              200: clustersResponse
+		{
+			"OutboundTrafficPolicyMode",
+			"GET",
+			"/api/mesh/outbound_traffic_policy/mode",
+			handlers.OutboundTrafficPolicyMode,
+			true,
+		},
 	}
 
 	return


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4896

Adding support of showing mesh config OutBoundTrafficPolicy mode on Overview page, as a suffix on "istio-system" namespace.

![Screenshot from 2022-06-24 12-29-04](https://user-images.githubusercontent.com/604313/175520236-751cd2e6-c869-4fe5-838e-e3cf9fcc320e.png)
