### PR TITLE
Keep tab envoy after refresh

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -44,8 +44,8 @@ type ReduxProps = {
 
 type WorkloadDetailsPageProps = ReduxProps & RouteComponentProps<WorkloadId>;
 
-const tabName = 'tab';
-const defaultTab = 'info';
+export const tabName = 'tab';
+export const defaultTab = 'info';
 
 const paramToTab: { [key: string]: number } = {
   info: 0,


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/5250

Envoy Tab change after refresh to default one ("clusters").
Now we keep the tab selected