### PR TITLE
Login programatically for cypress tests

### DIFF
--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -11,11 +11,12 @@ Installed all dev dependencies from frontend folder. Ensure the `baseUrl` field 
 Before you start using Cypress suite, you might need export some environment variables - depending on environment where tests are executed. If your authentication method defaults to `anonymous` **(i.e. dev env), no actions are needed.**
 
 ```bash
-export CYPRESS_BASE_URL=<value>        # defaults to http://localhost:3000
-export CYPRESS_USERNAME=<value>        # defaults to jenkins, opt. kubeadmin
-export CYPRESS_PASSWD=<value>          # no defaults 
-export CYPRESS_AUTH_PROVIDER=<value>   # defaults to my_htpasswd_provider, 
-                                       # or optionally openshift for AWS
+export CYPRESS_BASE_URL=<value>           # defaults to http://localhost:3000
+export CYPRESS_USERNAME=<value>           # defaults to jenkins, opt. kubeadmin
+export CYPRESS_PASSWD=<value>             # no defaults
+export CYPRESS_AUTH_PROVIDER=<value>      # defaults to my_htpasswd_provider,
+export CYPRESS_AUTH_PROVIDER_NAME=<value> # defaults to my_htpasswd_provider. Can pass a custom name for the htp provider.
+                                          # or optionally openshift for AWS
 ```
 
 Tests can be run with the cypress browser:
@@ -93,6 +94,14 @@ You can adjust some inputs of the performance tests by changing the [fixture fil
 ### Results:
 
 Results are logged here: `logs/performance.txt`
+
+### Running on IBM Cloud:
+
+You can use the [perf hack script](../../hack/perf-ibmcloud-openshift.sh) to spin up an openshift cluster on IBMCloud with Kiali + Istio + Kiali demos installed. To run the perf tests against the cluster, you must generate an IBM Cloud API Key and pass that in as the `CYPRESS_PASSWD`.
+
+```
+make -e CYPRESS_BASE_URL="https://<kiali-openshift-route>" -e CYPRESS_PASSWD="<IBMCloud API Key>" -e CYPRESS_USERNAME="IAM#<SSO-EMAIL>" -e CYPRESS_AUTH_PROVIDER="ibmcloud" perf-tests-gui
+```
 
 ## Testing Strategies
 

--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -11,12 +11,11 @@ Installed all dev dependencies from frontend folder. Ensure the `baseUrl` field 
 Before you start using Cypress suite, you might need export some environment variables - depending on environment where tests are executed. If your authentication method defaults to `anonymous` **(i.e. dev env), no actions are needed.**
 
 ```bash
-export CYPRESS_BASE_URL=<value>           # defaults to http://localhost:3000
-export CYPRESS_USERNAME=<value>           # defaults to jenkins, opt. kubeadmin
-export CYPRESS_PASSWD=<value>             # no defaults
-export CYPRESS_AUTH_PROVIDER=<value>      # defaults to my_htpasswd_provider,
-export CYPRESS_AUTH_PROVIDER_NAME=<value> # defaults to my_htpasswd_provider. Can pass a custom name for the htp provider.
-                                          # or optionally openshift for AWS
+export CYPRESS_BASE_URL=<value>               # defaults to http://localhost:3000
+export CYPRESS_USERNAME=<value>               # defaults to jenkins, opt. kubeadmin
+export CYPRESS_PASSWD=<value>                 # no defaults
+export CYPRESS_AUTH_PROVIDER=<value>          # defaults to my_htpasswd_provider
+export CYPRESS_AUTH_HTP_PROVIDER_NAME=<value> # defaults to my_htpasswd_provider. Can pass a custom name for the htp provider.
 ```
 
 Tests can be run with the cypress browser:

--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -15,7 +15,6 @@ export CYPRESS_BASE_URL=<value>               # defaults to http://localhost:300
 export CYPRESS_USERNAME=<value>               # defaults to jenkins, opt. kubeadmin
 export CYPRESS_PASSWD=<value>                 # no defaults
 export CYPRESS_AUTH_PROVIDER=<value>          # defaults to my_htpasswd_provider
-export CYPRESS_AUTH_HTP_PROVIDER_NAME=<value> # defaults to my_htpasswd_provider. Can pass a custom name for the htp provider.
 ```
 
 Tests can be run with the cypress browser:

--- a/frontend/cypress/fixtures/perf/graphParams.json
+++ b/frontend/cypress/fixtures/perf/graphParams.json
@@ -1,8 +1,8 @@
 {
   "traffic": "grpc,grpcRequest,http,httpRequest,tcp,tcpSent",
   "graphType": "versionedApp",
-  "namespaces": "bookinfo,cert-manager",
-  "duration": "60",
+  "namespaces": "bookinfo,alpha,beta,sleep",
+  "duration": "300",
   "refresh": "15000",
   "layout": "kiali-dagre",
   "namespaceLayout": "kiali-dagre"

--- a/frontend/cypress/integration/common/kiali_cookie.ts
+++ b/frontend/cypress/integration/common/kiali_cookie.ts
@@ -3,13 +3,12 @@ import { And, Given } from "cypress-cucumber-preprocessor/steps";
 const USERNAME = Cypress.env('USERNAME') || 'jenkins';
 const PASSWD = Cypress.env('PASSWD')
 const AUTH_PROVIDER = Cypress.env('AUTH_PROVIDER') || 'my_htpasswd_provider';
-const AUTH_STRATEGY = Cypress.env('auth_strategy')
 
 Given('user is at administrator perspective', () => {
     Cypress.Cookies.defaults({
         preserve: 'kiali-token-aes',
     })
-    cy.login(AUTH_PROVIDER, USERNAME, PASSWD, AUTH_STRATEGY)
+    cy.login(AUTH_PROVIDER, USERNAME, PASSWD)
 })
 
 And('user visits base url', () => {

--- a/frontend/cypress/integration/common/kiali_cookie.ts
+++ b/frontend/cypress/integration/common/kiali_cookie.ts
@@ -2,13 +2,12 @@ import { And, Given } from "cypress-cucumber-preprocessor/steps";
 
 const USERNAME = Cypress.env('USERNAME') || 'jenkins';
 const PASSWD = Cypress.env('PASSWD')
-const AUTH_PROVIDER = Cypress.env('AUTH_PROVIDER') || 'my_htpasswd_provider';
 
 Given('user is at administrator perspective', () => {
     Cypress.Cookies.defaults({
         preserve: 'kiali-token-aes',
     })
-    cy.login(AUTH_PROVIDER, USERNAME, PASSWD)
+    cy.login(USERNAME, PASSWD)
 })
 
 And('user visits base url', () => {

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -1,4 +1,4 @@
-import { Given, When, And, Then } from "cypress-cucumber-preprocessor/steps";
+import { Given, And, Then } from "cypress-cucumber-preprocessor/steps";
 
 const USERNAME = Cypress.env('USERNAME') || 'jenkins'; // CYPRESS_USERNAME to the user
 const PASSWD = Cypress.env('PASSWD'); // CYPRESS_PASSWD to the user
@@ -40,7 +40,7 @@ And('user clicks my_htpasswd_provider', () => {
 And('user fill in username and password', () => {
     if (auth_strategy === 'openshift') {
         cy.log('Log in as user: ' + USERNAME)
-        cy.get('#inputUsername').type('' || USERNAME);
+        cy.get('#inputUsername').clear().type('' || USERNAME);
         cy.get('#inputPassword').type('' || PASSWD);
         cy.get('button[type="submit"]').click()
     }

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -2,7 +2,7 @@ import { Given, And, Then } from "cypress-cucumber-preprocessor/steps";
 
 const USERNAME = Cypress.env('USERNAME') || 'jenkins'; // CYPRESS_USERNAME to the user
 const PASSWD = Cypress.env('PASSWD'); // CYPRESS_PASSWD to the user
-const KUBEADMIN_IDP = Cypress.env('AUTH_PROVIDER') || 'my_htpasswd_provider'; // CYPRESS_AUTH_PROVIDER to the user
+const KUBEADMIN_IDP = Cypress.env('AUTH_PROVIDER') // CYPRESS_AUTH_PROVIDER to the user
 const auth_strategy = Cypress.env('AUTH_STRATEGY');
 
 Given('user opens base url', () => {

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -3,7 +3,7 @@ import { Given, And, Then } from "cypress-cucumber-preprocessor/steps";
 const USERNAME = Cypress.env('USERNAME') || 'jenkins'; // CYPRESS_USERNAME to the user
 const PASSWD = Cypress.env('PASSWD'); // CYPRESS_PASSWD to the user
 const KUBEADMIN_IDP = Cypress.env('AUTH_PROVIDER') || 'my_htpasswd_provider'; // CYPRESS_AUTH_PROVIDER to the user
-const auth_strategy = Cypress.env('auth_strategy');
+const auth_strategy = Cypress.env('AUTH_STRATEGY');
 
 Given('user opens base url', () => {
     cy.visit('/');

--- a/frontend/cypress/perf/Graphload.spec.ts
+++ b/frontend/cypress/perf/Graphload.spec.ts
@@ -14,6 +14,12 @@ describe('graphload', () => {
                     +"&namespaceLayout="+data.namespaceLayout);
             })
             .as('data');
+
+        cy.login("ibmcloud", Cypress.env('USERNAME'), Cypress.env('PASSWD'));
+    })
+
+    beforeEach(() => {
+        Cypress.Cookies.preserveOnce('kiali-token-aes');
     })
 
     it('Visit Main Page', () => {

--- a/frontend/cypress/perf/Graphload.spec.ts
+++ b/frontend/cypress/perf/Graphload.spec.ts
@@ -15,7 +15,7 @@ describe('graphload', () => {
             })
             .as('data');
 
-        cy.login("ibmcloud", Cypress.env('USERNAME'), Cypress.env('PASSWD'));
+        cy.login(Cypress.env('USERNAME'), Cypress.env('PASSWD'));
     })
 
     beforeEach(() => {

--- a/frontend/cypress/plugins/bdd.ts
+++ b/frontend/cypress/plugins/bdd.ts
@@ -1,10 +1,10 @@
 const browserify = require('@cypress/browserify-preprocessor');
 const cucumber = require('cypress-cucumber-preprocessor').default;
 const path = require('path');
-const axios = require('axios');
+const plugin = require('./index');
 
 module.exports = (on, config) => {
-  config.env.cookie = false
+  config = plugin(on, config);
   const options = {
     ...browserify.defaultOptions,
     typescript: path.join(path.resolve('..'), 'frontend/node_modules/typescript')
@@ -12,20 +12,5 @@ module.exports = (on, config) => {
 
   on('file:preprocessor', cucumber(options));
 
-  async function exportConfig() {
-    const getAuthStrategy = async (url: string) => {
-      try {
-        const resp = await axios.get(url + '/api/auth/info');
-        return resp.data.strategy;
-      } catch (err) {
-        console.error(`ERROR: Kiali API is not reachable at ${JSON.stringify(err.config.url)}`);
-        throw new Error(`Kiali API is not reachable at ${JSON.stringify(err.config.url)}`);
-      }
-    };
-
-    config.env.auth_strategy = await getAuthStrategy(config.baseUrl);
-    return await config;
-  }
-
-  return exportConfig();
+  return config
 };

--- a/frontend/cypress/plugins/index.ts
+++ b/frontend/cypress/plugins/index.ts
@@ -19,6 +19,9 @@ const axios = require('axios');
 // eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
   config.env.cookie = false;
+  // This name is non-standard and might change based on your environment hence the separate
+  // env variable.
+  config.env.AUTH_HTTP_PROVIDER_NAME = config.env.AUTH_HTTP_PROVIDER_NAME || 'my_htpasswd_provider';
   config.env.AUTH_PROVIDER = config.env.AUTH_PROVIDER || 'my_htpasswd_provider';
 
   async function exportConfig() {

--- a/frontend/cypress/plugins/index.ts
+++ b/frontend/cypress/plugins/index.ts
@@ -21,7 +21,6 @@ module.exports = (on, config) => {
   config.env.cookie = false;
   // This name is non-standard and might change based on your environment hence the separate
   // env variable.
-  config.env.AUTH_HTP_PROVIDER_NAME = config.env.AUTH_HTP_PROVIDER_NAME || 'my_htpasswd_provider';
   config.env.AUTH_PROVIDER = config.env.AUTH_PROVIDER || 'my_htpasswd_provider';
 
   async function exportConfig() {

--- a/frontend/cypress/plugins/index.ts
+++ b/frontend/cypress/plugins/index.ts
@@ -21,7 +21,7 @@ module.exports = (on, config) => {
   config.env.cookie = false;
   // This name is non-standard and might change based on your environment hence the separate
   // env variable.
-  config.env.AUTH_HTTP_PROVIDER_NAME = config.env.AUTH_HTTP_PROVIDER_NAME || 'my_htpasswd_provider';
+  config.env.AUTH_HTP_PROVIDER_NAME = config.env.AUTH_HTP_PROVIDER_NAME || 'my_htpasswd_provider';
   config.env.AUTH_PROVIDER = config.env.AUTH_PROVIDER || 'my_htpasswd_provider';
 
   async function exportConfig() {

--- a/frontend/cypress/plugins/index.ts
+++ b/frontend/cypress/plugins/index.ts
@@ -19,6 +19,8 @@ const axios = require('axios');
 // eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
   config.env.cookie = false;
+  config.env.AUTH_PROVIDER = config.env.AUTH_PROVIDER || 'my_htpasswd_provider';
+
   async function exportConfig() {
     const getAuthStrategy = async (url: string) => {
       try {

--- a/frontend/cypress/plugins/index.ts
+++ b/frontend/cypress/plugins/index.ts
@@ -11,12 +11,28 @@
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
+const axios = require('axios');
 
 /**
  * @type {Cypress.PluginConfig}
  */
 // eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
-}
+  config.env.cookie = false;
+  async function exportConfig() {
+    const getAuthStrategy = async (url: string) => {
+      try {
+        const resp = await axios.get(url + '/api/auth/info');
+        return resp.data.strategy;
+      } catch (err) {
+        console.error(`ERROR: Kiali API is not reachable at ${JSON.stringify(err.config.url)}`);
+        throw new Error(`Kiali API is not reachable at ${JSON.stringify(err.config.url)}`);
+      }
+    };
+
+    config.env.AUTH_STRATEGY = await getAuthStrategy(config.baseUrl);
+    return await config;
+  }
+
+  return exportConfig();
+};

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -73,7 +73,7 @@ Cypress.Commands.add('login', (username: string, password: string) => {
       );
 
       if (auth_strategy === 'openshift') {
-        if (provider === Cypress.env('AUTH_HTTP_PROVIDER_NAME')) {
+        if (provider === Cypress.env('AUTH_HTP_PROVIDER_NAME')) {
           // This flow is ripped from the kiali-operator molecule tests:
           // https://github.com/kiali/kiali-operator/blob/master/molecule/openshift-auth-test/converge.yml#L59
           cy.request('api/auth/info').then(({ body }) => {

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -32,7 +32,16 @@ declare namespace Cypress {
      */
     getBySel(selector: string, ...args: any): Chainable<Subject>;
 
-    login(provider: string, username: string, password: string): Chainable<Subject>;
+    /**
+     * Login to Kiali with the given username and password.
+     * Sets the 'kiali-token-aes' cookie for later use.
+     *
+     * Provider will be determined by the environment variable AUTH_PROVIDER
+     * and auth strategy is fetched from the Kiali API.
+     * @param username
+     * @param password
+     */
+    login(username: string, password: string): Chainable<Subject>;
 
     logout(): Chainable<Subject>;
   }
@@ -40,10 +49,11 @@ declare namespace Cypress {
 
 let haveCookie = Cypress.env('cookie');
 
-Cypress.Commands.add('login', (provider: string, username: string, password: string) => {
+Cypress.Commands.add('login', (username: string, password: string) => {
   cy.log(`auth cookie is: ${haveCookie}`);
 
   const auth_strategy = Cypress.env('AUTH_STRATEGY');
+  const provider = Cypress.env('AUTH_PROVIDER');
 
   cy.window().then((win: any) => {
     if (auth_strategy !== 'openshift') {
@@ -63,7 +73,7 @@ Cypress.Commands.add('login', (provider: string, username: string, password: str
       );
 
       if (auth_strategy === 'openshift') {
-        if (provider === 'my_htpasswd_provider') {
+        if (provider === Cypress.env('AUTH_HTTP_PROVIDER_NAME')) {
           // This flow is ripped from the kiali-operator molecule tests:
           // https://github.com/kiali/kiali-operator/blob/master/molecule/openshift-auth-test/converge.yml#L59
           cy.request('api/auth/info').then(({ body }) => {


### PR DESCRIPTION
This replaces the manual flow that required cypress to actually navigate to the login page and type fields into boxes. Not only is this faster, but it eliminates the need for all the hacks around the login page. It is also the only way to login to the perf clusters. Note that the manual login flow is still being tested by the `kiali_login` feature.