### PR TITLE
Improve Duration/Refresh handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -687,7 +687,7 @@ func NewConfig() (c *Config) {
 				MetricsOutbound:   MetricsDefaults{},
 				MetricsPerRefresh: "1m",
 				Namespaces:        make([]string, 0),
-				RefreshInterval:   "15s",
+				RefreshInterval:   "60s",
 			},
 			Validations: Validations{
 				Ignore: make([]string, 0),

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -131,8 +131,9 @@ Then(`user does not see any traffic`, () => {
 Then('user sees graph duration menu', () => {
   cy.get('button#time_range_duration-toggle').invoke('attr', 'aria-expanded').should('eq', 'true');
   cy.get('ul#time_range_duration').within(() => {
-    cy.get('li').should('have.length', 10);
+    cy.get('li').should('have.length', 11);
     cy.get('li#60').should('exist');
+    cy.get('li#120').should('exist');
     cy.get('li#300').should('exist');
     cy.get('li#600').should('exist');
     cy.get('li#1800').should('exist');

--- a/frontend/src/components/ToolbarDropdown/__tests__/__snapshots__/ToolbarDropdown.test.tsx.snap
+++ b/frontend/src/components/ToolbarDropdown/__tests__/__snapshots__/ToolbarDropdown.test.tsx.snap
@@ -84,6 +84,30 @@ exports[`ToolbarDropdown Render correctly all dropdowns 1`] = `
     <SelectOption
       className=""
       component="button"
+      id="120"
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLastOptionBeforeFooter={[Function]}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="120"
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      setViewMoreNextIndex={[Function]}
+      value="120"
+    >
+      2m
+    </SelectOption>
+    <SelectOption
+      className=""
+      component="button"
       id="300"
       index={0}
       inputId=""
@@ -274,10 +298,10 @@ exports[`ToolbarDropdown Render correctly all dropdowns 2`] = `
     onToggle={[Function]}
     onTypeaheadInputChanged={null}
     ouiaSafe={true}
-    placeholderText="Every 15s"
+    placeholderText="Every 1m"
     position="left"
     removeSelectionAriaLabel="Remove"
-    selections={15000}
+    selections={60000}
     toggleAriaLabel="Options menu"
     toggleIcon={null}
     toggleId="metrics_filter_poll_interval-toggle"
@@ -348,7 +372,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 2`] = `
       isLoading={false}
       isNoResultsOption={false}
       isPlaceholder={false}
-      isSelected={true}
+      isSelected={false}
       key="15000"
       keyHandler={[Function]}
       onClick={[Function]}
@@ -396,7 +420,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 2`] = `
       isLoading={false}
       isNoResultsOption={false}
       isPlaceholder={false}
-      isSelected={false}
+      isSelected={true}
       key="60000"
       keyHandler={[Function]}
       onClick={[Function]}
@@ -675,6 +699,30 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
     <SelectOption
       className=""
       component="button"
+      id="120"
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLastOptionBeforeFooter={[Function]}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="120"
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      setViewMoreNextIndex={[Function]}
+      value="120"
+    >
+      2m
+    </SelectOption>
+    <SelectOption
+      className=""
+      component="button"
       id="300"
       index={0}
       inputId=""
@@ -865,10 +913,10 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
     onToggle={[Function]}
     onTypeaheadInputChanged={null}
     ouiaSafe={true}
-    placeholderText="Every 15s"
+    placeholderText="Every 1m"
     position="left"
     removeSelectionAriaLabel="Remove"
-    selections={15000}
+    selections={60000}
     toggleAriaLabel="Options menu"
     toggleIcon={null}
     toggleId="metrics_filter_poll_interval-toggle"
@@ -939,7 +987,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
       isLoading={false}
       isNoResultsOption={false}
       isPlaceholder={false}
-      isSelected={true}
+      isSelected={false}
       key="15000"
       keyHandler={[Function]}
       onClick={[Function]}
@@ -987,7 +1035,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
       isLoading={false}
       isNoResultsOption={false}
       isPlaceholder={false}
-      isSelected={false}
+      isSelected={true}
       key="60000"
       keyHandler={[Function]}
       onClick={[Function]}

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -12,11 +12,11 @@ const conf = {
   },
   /** Toolbar Configuration */
   toolbar: {
-    /** Duration default in 1 minute */
+    /** Duration default is 1 minute */
     defaultDuration: 1 * UNIT_TIME.MINUTE,
-    /** By default refresh is 15 seconds */
-    defaultRefreshInterval: 15 * MILLISECONDS,
-    /** Time Range default in 10 minutes **/
+    /** By default refresh is 1 minute */
+    defaultRefreshInterval: 60 * MILLISECONDS,
+    /** Time Range default is 10 minutes **/
     defaultTimeRange: {
       rangeDuration: 10 * UNIT_TIME.MINUTE
     },

--- a/frontend/src/reducers/__tests__/UserSettingsState.test.ts
+++ b/frontend/src/reducers/__tests__/UserSettingsState.test.ts
@@ -23,7 +23,7 @@ describe('UserSettingsState reducer', () => {
     expect(UserSettingsState(undefined, GlobalActions.unknown())).toEqual({
       duration: 60,
       interface: { navCollapse: false },
-      refreshInterval: 15000,
+      refreshInterval: 60000,
       replayActive: false,
       replayQueryTime: 0,
       timeRange: { rangeDuration: 600 }


### PR DESCRIPTION
- remove invalid durations based on globalScrapeInterval (duration < 2 x scrape)
- add 2m duration to choices.  This is good when 1m is invalid, and may
  be useful even when 1m is available.
- fix bug in toValidDuration util
- change default refreshInterval from 15s to 1m, 15s is too frequent, especially
  in non-trivial installs.  1m may also be too small, but it's better.

Part-of https://github.com/kiali/kiali/issues/5269