### PR TITLE
Hack scripts to install demos in OpenShift 

### DIFF
--- a/hack/istio/install-electronic-shop-demo.sh
+++ b/hack/istio/install-electronic-shop-demo.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+##############################################################################
+# install-electronic-shop-demo.sh
+#
+# Installs electronic-shop kiali demo application
+# https://github.com/kiali/demos/tree/master/electronic-shop
+# Works on both openshift and non-openshift environments.
+##############################################################################
+
+: ${CLIENT_EXE:=oc}
+: ${DELETE_DEMOS:=false}
+: ${ESHOP:=electronic-shop}
+: ${BASE_URL:=https://raw.githubusercontent.com/kiali/demos/master}
+HACK_SCRIPT_DIR="$(pwd)"
+OUTPUT_DIR="${OUTPUT_DIR:-${HACK_SCRIPT_DIR}/../istio}"
+
+apply_network_attachment() {
+  NAME=$1
+cat <<NAD | $CLIENT_EXE -n ${NAME} apply -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+NAD
+    cat <<SCC | $CLIENT_EXE apply -f -
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: ${NAME}-scc
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- "system:serviceaccount:${NAME}:default"
+- "system:serviceaccount:${NAME}:${NAME}"
+SCC
+}
+
+install_eshop_app() {
+  APP="electronic-shop"
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} get project ${APP} || ${CLIENT_EXE} new-project ${APP}
+  else
+    ${CLIENT_EXE} get ns ${APP} || ${CLIENT_EXE} create ns ${APP}
+  fi
+
+  ${CLIENT_EXE} label namespace ${APP} istio-injection=enabled --overwrite=true
+
+  ${CLIENT_EXE} apply -n ${APP} -f <(curl -L ${BASE_URL}/${APP}/${APP}.yaml)
+
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+      apply_network_attachment ${APP}
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  key="$1"
+  case $key in
+    -c|--client)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -d|-delete)
+      DELETE_DEMOS="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -c|--client: either 'oc' or 'kubectl'
+  -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed.
+  -h|--help: this text
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+IS_OPENSHIFT="false"
+if [[ "${CLIENT_EXE}" = *"oc" ]]; then
+  IS_OPENSHIFT="true"
+fi
+
+echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
+
+if [ "${DELETE_DEMOS}" != "true" ]; then
+    echo "Installing the 'electronic-shop' app in the 'electronic-shop' namespace..."
+    install_eshop_app
+else
+
+    echo "Deleting the '${ESHOP}' app in the '${ESHOP}' namespace..."
+    ${CLIENT_EXE} delete -n ${ESHOP} -f <(curl -L ${BASE_RUL}/${ESHOP}/${ESHOP}.yaml)
+    ${CLIENT_EXE} delete ns ${ESHOP} --ignore-not-found=true
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+      ${CLIENT_EXE} delete project ${ESHOP}
+      ${CLIENT_EXE} delete SecurityContextConstraints ${ESHOP}-scc
+    fi
+
+fi
+
+

--- a/hack/istio/install-electronic-shop-demo.sh
+++ b/hack/istio/install-electronic-shop-demo.sh
@@ -98,7 +98,7 @@ if [ "${DELETE_DEMOS}" != "true" ]; then
 else
 
     echo "Deleting the '${ESHOP}' app in the '${ESHOP}' namespace..."
-    ${CLIENT_EXE} delete -n ${ESHOP} -f <(curl -L ${BASE_RUL}/${ESHOP}/${ESHOP}.yaml)
+    ${CLIENT_EXE} delete -n ${ESHOP} -f <(curl -L ${BASE_URL}/${ESHOP}/${ESHOP}.yaml)
     ${CLIENT_EXE} delete ns ${ESHOP} --ignore-not-found=true
     if [ "${IS_OPENSHIFT}" == "true" ]; then
       ${CLIENT_EXE} delete project ${ESHOP}

--- a/hack/istio/install-electronic-shop-demo.sh
+++ b/hack/istio/install-electronic-shop-demo.sh
@@ -53,7 +53,7 @@ install_eshop_app() {
   ${CLIENT_EXE} apply -n ${APP} -f <(curl -L ${BASE_URL}/${APP}/${APP}.yaml)
 
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-      apply_network_attachment ${APP}
+    apply_network_attachment ${APP}
   fi
 }
 
@@ -93,18 +93,16 @@ echo "CLIENT_EXE=${CLIENT_EXE}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
 
 if [ "${DELETE_DEMOS}" != "true" ]; then
-    echo "Installing the 'electronic-shop' app in the 'electronic-shop' namespace..."
-    install_eshop_app
+  echo "Installing the 'electronic-shop' app in the 'electronic-shop' namespace..."
+  install_eshop_app
 else
-
-    echo "Deleting the '${ESHOP}' app in the '${ESHOP}' namespace..."
-    ${CLIENT_EXE} delete -n ${ESHOP} -f <(curl -L ${BASE_URL}/${ESHOP}/${ESHOP}.yaml)
-    ${CLIENT_EXE} delete ns ${ESHOP} --ignore-not-found=true
-    if [ "${IS_OPENSHIFT}" == "true" ]; then
-      ${CLIENT_EXE} delete project ${ESHOP}
-      ${CLIENT_EXE} delete SecurityContextConstraints ${ESHOP}-scc
-    fi
-
+  echo "Deleting the '${ESHOP}' app in the '${ESHOP}' namespace..."
+  ${CLIENT_EXE} delete -n ${ESHOP} -f <(curl -L ${BASE_URL}/${ESHOP}/${ESHOP}.yaml)
+  ${CLIENT_EXE} delete ns ${ESHOP} --ignore-not-found=true
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} delete project ${ESHOP}
+    ${CLIENT_EXE} delete SecurityContextConstraints ${ESHOP}-scc
+  fi
 fi
 
 

--- a/hack/istio/install-federated-travels-demo.sh
+++ b/hack/istio/install-federated-travels-demo.sh
@@ -46,7 +46,7 @@ install_ftravels_app() {
   for i in "${arr[@]}"
   do
     if [ "${IS_OPENSHIFT}" == "true" ]; then
-        ${CLIENT_EXE} new-project ${i}
+      ${CLIENT_EXE} new-project ${i}
     else
       ${CLIENT_EXE} create namespace ${i}
     fi
@@ -112,34 +112,30 @@ echo "CLIENT_EXE=${CLIENT_EXE}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
 
 if [ "${DELETE_DEMOS}" != "true" ]; then
-    echo "Installing the ${FTRAVELS} app in the ${FTRAVELS} namespace..."
-    install_ftravels_app
+  echo "Installing the ${FTRAVELS} app in the ${FTRAVELS} namespace..."
+  install_ftravels_app
 else
+  echo "Deleting the '${FTRAVELS}' app in the '${FTRAVELS}' namespace..."
+  ${CLIENT_EXE} delete -n east-mesh-system -f ${BASE_URL}/${FTRAVELS}/east/east-ossm.yaml
+  ${CLIENT_EXE} delete -n west-mesh-system -f ${BASE_URL}/${FTRAVELS}/west/west-ossm.yaml
+  ${CLIENT_EXE} delete configmap east-ca-root-cert --from-file=root-cert.pem=east-cert.pem -n west-mesh-system
+  ${CLIENT_EXE} delete configmap west-ca-root-cert --from-file=root-cert.pem=west-cert.pem -n east-mesh-system
+  ${CLIENT_EXE} delete -n east-mesh-system -f ${BASE_URL}/${FTRAVELS}/east/east-federation.yaml
+  ${CLIENT_EXE} delete -n west-mesh-system -f ${BASE_URL}/${FTRAVELS}/west/west-federation.yaml
 
-    echo "Deleting the '${FTRAVELS}' app in the '${FTRAVELS}' namespace..."
-    ${CLIENT_EXE} delete -n east-mesh-system -f ${BASE_URL}/${FTRAVELS}/east/east-ossm.yaml
-    ${CLIENT_EXE} delete -n west-mesh-system -f ${BASE_URL}/${FTRAVELS}/west/west-ossm.yaml
-    ${CLIENT_EXE} delete configmap east-ca-root-cert --from-file=root-cert.pem=east-cert.pem -n west-mesh-system
-    ${CLIENT_EXE} delete configmap west-ca-root-cert --from-file=root-cert.pem=west-cert.pem -n east-mesh-system
-    ${CLIENT_EXE} delete -n east-mesh-system -f ${BASE_URL}/${FTRAVELS}/east/east-federation.yaml
-    ${CLIENT_EXE} delete -n west-mesh-system -f ${BASE_URL}/${FTRAVELS}/west/west-federation.yaml
+  ${CLIENT_EXE} delete -n east-travel-agency -f ${BASE_URL}/${FTRAVELS}/east/east-travel-agency.yaml
+  ${CLIENT_EXE} delete -n east-travel-portal -f ${BASE_URL}/${FTRAVELS}/east/east-travel-portal.yaml
+  ${CLIENT_EXE} delete -n east-travel-control -f ${BASE_URL}/${FTRAVELS}/east/east-travel-control.yaml
+  ${CLIENT_EXE} delete -n west-travel-agency -f ${BASE_URL}/${FTRAVELS}/west/west-travel-agency.yaml
 
-    ${CLIENT_EXE} delete -n east-travel-agency -f ${BASE_URL}/${FTRAVELS}/east/east-travel-agency.yaml
-    ${CLIENT_EXE} delete -n east-travel-portal -f ${BASE_URL}/${FTRAVELS}/east/east-travel-portal.yaml
-    ${CLIENT_EXE} delete -n east-travel-control -f ${BASE_URL}/${FTRAVELS}/east/east-travel-control.yaml
-    ${CLIENT_EXE} delete -n west-travel-agency -f ${BASE_URL}/${FTRAVELS}/west/west-travel-agency.yaml
+  declare -a arr=("east-mesh-system" "west-mesh-system" "east-travel-agency" "east-travel-portal" "east-travel-control" "west-travel-agency")
 
-    declare -a arr=("east-mesh-system" "west-mesh-system" "east-travel-agency" "east-travel-portal" "east-travel-control" "west-travel-agency")
-
-    for i in "${arr[@]}"
-      do
-        if [ "${IS_OPENSHIFT}" == "true" ]; then
-          ${CLIENT_EXE} delete project ${i}
-         else
-          ${CLIENT_EXE} delete ns ${i} --ignore-not-found=true
-        fi
-    done
-
+  for i in "${arr[@]}"
+  do
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+      ${CLIENT_EXE} delete project ${i}
+    else
+      ${CLIENT_EXE} delete ns ${i} --ignore-not-found=true
+    fi
+  done
 fi
-
-

--- a/hack/istio/install-federated-travels-demo.sh
+++ b/hack/istio/install-federated-travels-demo.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+##############################################################################
+# install-federated-travels-demo.sh
+#
+# Installs federated travels kiali demo application
+# https://github.com/kiali/demos/tree/master/federated-travels
+# Works on both openshift and non-openshift environments.
+##############################################################################
+
+: ${CLIENT_EXE:=oc}
+: ${DELETE_DEMOS:=false}
+: ${FTRAVELS:=federated-travels}
+: ${MSTORE:=music-store}
+: ${BASE_URL:=https://raw.githubusercontent.com/kiali/demos/master}
+
+apply_network_attachment() {
+  NAME=$1
+cat <<NAD | $CLIENT_EXE -n ${NAME} apply -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+NAD
+    cat <<SCC | $CLIENT_EXE apply -f -
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: ${NAME}-scc
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- "system:serviceaccount:${NAME}:default"
+- "system:serviceaccount:${NAME}:${NAME}"
+SCC
+}
+
+install_ftravels_app() {
+  APP="federated-travels"
+  declare -a arr=("east-mesh-system" "west-mesh-system" "east-travel-agency" "east-travel-portal" "east-travel-control" "west-travel-agency")
+
+  for i in "${arr[@]}"
+  do
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+      ${CLIENT_EXE} new-project ${i}
+    else
+      ${CLIENT_EXE} create namespace ${i}
+    fi
+  done
+
+  ${CLIENT_EXE} apply -f ${BASE_URL}/${APP}/ossm-subs.yaml
+
+  ${CLIENT_EXE} apply -n east-mesh-system -f ${BASE_URL}/${APP}/east/east-ossm.yaml
+  ${CLIENT_EXE} apply -n west-mesh-system -f ${BASE_URL}/${APP}/west/west-ossm.yaml
+  ${CLIENT_EXE} wait --for condition=Ready -n east-mesh-system smmr/default --timeout 300s
+  ${CLIENT_EXE} wait --for condition=Ready -n west-mesh-system smmr/default --timeout 300s
+  ${CLIENT_EXE} get configmap istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' -n east-mesh-system > east-cert.pem
+  ${CLIENT_EXE} create configmap east-ca-root-cert --from-file=root-cert.pem=east-cert.pem -n west-mesh-system
+
+  ${CLIENT_EXE} get configmap istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' -n west-mesh-system > west-cert.pem
+  ${CLIENT_EXE} create configmap west-ca-root-cert --from-file=root-cert.pem=west-cert.pem -n east-mesh-system
+  ${CLIENT_EXE} apply -n east-mesh-system -f ${BASE_URL}/${APP}/east/east-federation.yaml
+  ${CLIENT_EXE} apply -n west-mesh-system -f ${BASE_URL}/${APP}/west/west-federation.yaml
+
+  ${CLIENT_EXE} apply -n east-travel-agency -f ${BASE_URL}/${APP}/east/east-travel-agency.yaml
+  ${CLIENT_EXE} apply -n east-travel-portal -f ${BASE_URL}/${APP}/east/east-travel-portal.yaml
+  ${CLIENT_EXE} apply -n east-travel-control -f ${BASE_URL}/${APP}/east/east-travel-control.yaml
+  ${CLIENT_EXE} apply -n west-travel-agency -f ${BASE_URL}/${APP}/west/west-travel-agency.yaml
+}
+
+while [ $# -gt 0 ]; do
+  key="$1"
+  case $key in
+    -c|--client)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -d|-delete)
+      DELETE_DEMOS="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -c|--client: either 'oc' or 'kubectl'
+  -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed.
+  -h|--help: this text
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+IS_OPENSHIFT="false"
+if [[ "${CLIENT_EXE}" = *"oc" ]]; then
+  IS_OPENSHIFT="true"
+fi
+
+echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
+
+if [ "${DELETE_DEMOS}" != "true" ]; then
+    echo "Installing the ${FTRAVELS} app in the ${FTRAVELS} namespace..."
+    install_ftravels_app
+else
+
+    echo "Deleting the '${FTRAVELS}' app in the '${FTRAVELS}' namespace..."
+    ${CLIENT_EXE} delete -n east-mesh-system -f ${BASE_URL}/${FTRAVELS}/east/east-ossm.yaml
+    ${CLIENT_EXE} delete -n west-mesh-system -f ${BASE_URL}/${FTRAVELS}/west/west-ossm.yaml
+    ${CLIENT_EXE} delete configmap east-ca-root-cert --from-file=root-cert.pem=east-cert.pem -n west-mesh-system
+    ${CLIENT_EXE} delete configmap west-ca-root-cert --from-file=root-cert.pem=west-cert.pem -n east-mesh-system
+    ${CLIENT_EXE} delete -n east-mesh-system -f ${BASE_URL}/${FTRAVELS}/east/east-federation.yaml
+    ${CLIENT_EXE} delete -n west-mesh-system -f ${BASE_URL}/${FTRAVELS}/west/west-federation.yaml
+
+    ${CLIENT_EXE} delete -n east-travel-agency -f ${BASE_URL}/${FTRAVELS}/east/east-travel-agency.yaml
+    ${CLIENT_EXE} delete -n east-travel-portal -f ${BASE_URL}/${FTRAVELS}/east/east-travel-portal.yaml
+    ${CLIENT_EXE} delete -n east-travel-control -f ${BASE_URL}/${FTRAVELS}/east/east-travel-control.yaml
+    ${CLIENT_EXE} delete -n west-travel-agency -f ${BASE_URL}/${FTRAVELS}/west/west-travel-agency.yaml
+
+    declare -a arr=("east-mesh-system" "west-mesh-system" "east-travel-agency" "east-travel-portal" "east-travel-control" "west-travel-agency")
+
+    for i in "${arr[@]}"
+    do
+        if [ "${IS_OPENSHIFT}" == "true" ]; then
+          ${CLIENT_EXE} delete project ${i}
+        else
+          ${CLIENT_EXE} delete ns ${i} --ignore-not-found=true
+        fi
+    done
+
+fi
+
+

--- a/hack/istio/install-music-store-demo.sh
+++ b/hack/istio/install-music-store-demo.sh
@@ -12,8 +12,8 @@
 : ${DELETE_DEMOS:=false}
 : ${MSTORE:=music-store}
 : ${BASE_URL:=https://raw.githubusercontent.com/kiali/demos/master}
-: ${MINIKUBE_PROFILE=minikube}
-: ${ISTIO_NAMESPACE=istio-system}
+: ${MINIKUBE_PROFILE:=minikube}
+: ${ISTIO_NAMESPACE:=istio-system}
 
 apply_network_attachment() {
   NAME=$1

--- a/hack/istio/install-music-store-demo.sh
+++ b/hack/istio/install-music-store-demo.sh
@@ -50,8 +50,8 @@ install_mstore_app() {
   ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/ui.yaml -n ${MSTORE}
   ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/backend.yaml -n ${MSTORE}
 
-  #${CLIENT_EXE} wait --timeout 60s --for condition=available deployment/music-store-backend-v1 -n music-store
-  #${CLIENT_EXE} wait --timeout 60s --for condition=available deployment/music-store-ui-v1 -n music-store
+  ${CLIENT_EXE} wait --timeout 60s --for condition=available deployment/music-store-backend-v1 -n music-store
+  ${CLIENT_EXE} wait --timeout 60s --for condition=available deployment/music-store-ui-v1 -n music-store
 
   export INGRESS_PORT=$(${CLIENT_EXE} -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
   if [ "${IS_OPENSHIFT}" == "true" ]; then
@@ -63,9 +63,6 @@ install_mstore_app() {
   export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
   export MUSIC_STORE_UI=http://$GATEWAY_URL/
   export MUSIC_STORE_BACKEND=http://$GATEWAY_URL/api
-
-  echo "API url: ${MUSIC_STORE_BACKEND} "
-  echo "UI url: ${MUSIC_STORE_UI} "
 
   cat <<EOF | $CLIENT_EXE apply -f -
 apiVersion: networking.istio.io/v1alpha3
@@ -158,7 +155,8 @@ if [ "${DELETE_DEMOS}" != "true" ]; then
 
     echo "Installing the ${MSTORE} app in the ${MSTORE} namespace..."
     install_mstore_app
-
+    echo "You should be able to access the API with the url: ${MUSIC_STORE_BACKEND} "
+    echo "You should be able to access the UI with the url: ${MUSIC_STORE_UI} "
 else
 
     echo "Deleting the '${MSTORE}' app in the '${MSTORE}' namespace..."

--- a/hack/istio/install-music-store-demo.sh
+++ b/hack/istio/install-music-store-demo.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+##############################################################################
+# install-music-store-demo.sh
+#
+# Installs the kiali music store demo application
+# https://github.com/kiali/demos/tree/master/music-store
+# Works on both openshift and non-openshift environments.
+##############################################################################
+
+: ${CLIENT_EXE:=oc}
+: ${DELETE_DEMOS:=false}
+: ${MSTORE:=music-store}
+: ${BASE_URL:=https://raw.githubusercontent.com/kiali/demos/master}
+
+apply_network_attachment() {
+  NAME=$1
+cat <<NAD | $CLIENT_EXE -n ${NAME} apply -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+NAD
+    cat <<SCC | $CLIENT_EXE apply -f -
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: ${NAME}-scc
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- "system:serviceaccount:${NAME}:default"
+- "system:serviceaccount:${NAME}:${NAME}"
+SCC
+}
+
+install_mstore_app() {
+
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} get project ${MSTORE} || ${CLIENT_EXE} new-project ${MSTORE}
+  else
+    ${CLIENT_EXE} get ns ${MSTORE} || ${CLIENT_EXE} create ns ${MSTORE}
+  fi
+
+  ${CLIENT_EXE} label namespace ${MSTORE} istio-injection=enabled --overwrite=true
+  ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/ui.yaml -n ${MSTORE}
+  ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/backend.yaml -n ${MSTORE}
+
+  #${CLIENT_EXE} wait --timeout 60s --for condition=available deployment/music-store-backend-v1 -n music-store
+  #${CLIENT_EXE} wait --timeout 60s --for condition=available deployment/music-store-ui-v1 -n music-store
+
+  export INGRESS_PORT=$(${CLIENT_EXE} -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+       export INGRESS_HOST=$(crc ip)
+    else
+       export INGRESS_HOST=$(minikube ip)
+  fi
+
+  export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
+  export MUSIC_STORE_UI=http://$GATEWAY_URL/
+  export MUSIC_STORE_BACKEND=http://$GATEWAY_URL/api
+
+  echo "API url: ${MUSIC_STORE_BACKEND} "
+  echo "UI url: ${MUSIC_STORE_UI} "
+
+  cat <<EOF | $CLIENT_EXE apply -f -
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: music-store
+  namespace: music-store
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: music-store-ui
+  namespace: music-store
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - music-store
+  http:
+    - match:
+        - uri:
+            exact: /
+      route:
+        - destination:
+            host: music-store-ui
+            port:
+              number: 8080
+    - match:
+        - uri:
+            prefix: /api
+      route:
+        - destination:
+            host: music-store-backend
+            port:
+              number: 8080
+EOF
+
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+      apply_network_attachment ${MSTORE}
+  fi
+
+}
+
+while [ $# -gt 0 ]; do
+  key="$1"
+  case $key in
+    -c|--client)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -d|-delete)
+      DELETE_DEMOS="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -c|--client: either 'oc' or 'kubectl'
+  -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
+  -h|--help: this text
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+IS_OPENSHIFT="false"
+if [[ "${CLIENT_EXE}" = *"oc" ]]; then
+  IS_OPENSHIFT="true"
+fi
+
+echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
+
+if [ "${DELETE_DEMOS}" != "true" ]; then
+
+    echo "Installing the ${MSTORE} app in the ${MSTORE} namespace..."
+    install_mstore_app
+
+else
+
+    echo "Deleting the '${MSTORE}' app in the '${MSTORE}' namespace..."
+    ${CLIENT_EXE} delete -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/ui.yaml -n ${MSTORE}
+    ${CLIENT_EXE} delete -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/backend.yaml -n ${MSTORE}
+
+    ${CLIENT_EXE} delete ns ${MSTORE} --ignore-not-found=true
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+      ${CLIENT_EXE} delete project ${MSTORE}
+      ${CLIENT_EXE} delete SecurityContextConstraints ${MSTORE}-scc
+    fi
+fi
+
+

--- a/hack/istio/install-music-store-demo.sh
+++ b/hack/istio/install-music-store-demo.sh
@@ -55,9 +55,9 @@ install_mstore_app() {
 
   export INGRESS_PORT=$(${CLIENT_EXE} -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-       export INGRESS_HOST=$(crc ip)
-    else
-       export INGRESS_HOST=$(minikube ip)
+    export INGRESS_HOST=$(crc ip)
+  else
+    export INGRESS_HOST=$(minikube ip)
   fi
 
   export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT

--- a/hack/istio/install-music-store-demo.sh
+++ b/hack/istio/install-music-store-demo.sh
@@ -111,7 +111,7 @@ spec:
 EOF
 
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-      apply_network_attachment ${MSTORE}
+    apply_network_attachment ${MSTORE}
   fi
 
 }
@@ -152,22 +152,20 @@ echo "CLIENT_EXE=${CLIENT_EXE}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
 
 if [ "${DELETE_DEMOS}" != "true" ]; then
-
-    echo "Installing the ${MSTORE} app in the ${MSTORE} namespace..."
-    install_mstore_app
-    echo "You should be able to access the API with the url: ${MUSIC_STORE_BACKEND} "
-    echo "You should be able to access the UI with the url: ${MUSIC_STORE_UI} "
+  echo "Installing the ${MSTORE} app in the ${MSTORE} namespace..."
+  install_mstore_app
+  echo "You should be able to access the API with the url: ${MUSIC_STORE_BACKEND} "
+  echo "You should be able to access the UI with the url: ${MUSIC_STORE_UI} "
 else
+  echo "Deleting the '${MSTORE}' app in the '${MSTORE}' namespace..."
+  ${CLIENT_EXE} delete -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/ui.yaml -n ${MSTORE}
+  ${CLIENT_EXE} delete -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/backend.yaml -n ${MSTORE}
 
-    echo "Deleting the '${MSTORE}' app in the '${MSTORE}' namespace..."
-    ${CLIENT_EXE} delete -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/ui.yaml -n ${MSTORE}
-    ${CLIENT_EXE} delete -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/backend.yaml -n ${MSTORE}
-
-    ${CLIENT_EXE} delete ns ${MSTORE} --ignore-not-found=true
-    if [ "${IS_OPENSHIFT}" == "true" ]; then
-      ${CLIENT_EXE} delete project ${MSTORE}
-      ${CLIENT_EXE} delete SecurityContextConstraints ${MSTORE}-scc
-    fi
+  ${CLIENT_EXE} delete ns ${MSTORE} --ignore-not-found=true
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} delete project ${MSTORE}
+    ${CLIENT_EXE} delete SecurityContextConstraints ${MSTORE}-scc
+  fi
 fi
 
 

--- a/hack/istio/install-runtimes-demo.sh
+++ b/hack/istio/install-runtimes-demo.sh
@@ -40,16 +40,16 @@ SCC
 
 install_runtimes_demo() {
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-      ${CLIENT_EXE} get project ${RUNTIMES} || ${CLIENT_EXE} new-project ${RUNTIMES}
-    else
-      ${CLIENT_EXE} get ns ${RUNTIMES} || ${CLIENT_EXE} create ns ${RUNTIMES}
+    ${CLIENT_EXE} get project ${RUNTIMES} || ${CLIENT_EXE} new-project ${RUNTIMES}
+  else
+    ${CLIENT_EXE} get ns ${RUNTIMES} || ${CLIENT_EXE} create ns ${RUNTIMES}
   fi
 
   ${CLIENT_EXE} label namespace ${RUNTIMES} istio-injection=enabled --overwrite=true
   ${CLIENT_EXE} apply -f ${BASE_URL}/runtimes-demo/quickstart.yml -n ${RUNTIMES}
 
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-      apply_network_attachment ${RUNTIMES}
+    apply_network_attachment ${RUNTIMES}
   fi
 }
 
@@ -89,20 +89,15 @@ echo "CLIENT_EXE=${CLIENT_EXE}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
 
 if [ "${DELETE_DEMOS}" != "true" ]; then
-
-    echo "Installing the ${RUNTIMES} app in the ${RUNTIMES} namespace..."
-    install_runtimes_demo
-
+  echo "Installing the ${RUNTIMES} app in the ${RUNTIMES} namespace..."
+  install_runtimes_demo
 else
+  echo "Deleting the '${RUNTIMES}' app in the '${RUNTIMES}' namespace..."
+  ${CLIENT_EXE} delete -f ${BASE_URL}/runtimes-demo/quickstart.yml -n ${RUNTIMES}
 
-    echo "Deleting the '${RUNTIMES}' app in the '${RUNTIMES}' namespace..."
-    ${CLIENT_EXE} delete -f ${BASE_URL}/runtimes-demo/quickstart.yml -n ${RUNTIMES}
-
-    ${CLIENT_EXE} delete ns ${RUNTIMES} --ignore-not-found=true
-    if [ "${IS_OPENSHIFT}" == "true" ]; then
-      ${CLIENT_EXE} delete project ${RUNTIMES}
-      ${CLIENT_EXE} delete SecurityContextConstraints ${RUNTIMES}-scc
-    fi
+  ${CLIENT_EXE} delete ns ${RUNTIMES} --ignore-not-found=true
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} delete project ${RUNTIMES}
+    ${CLIENT_EXE} delete SecurityContextConstraints ${RUNTIMES}-scc
+  fi
 fi
-
-

--- a/hack/istio/install-runtimes-demo.sh
+++ b/hack/istio/install-runtimes-demo.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+##############################################################################
+# install-runtimes-demo.sh
+#
+# Installs the kiali runtimes demo application
+# https://github.com/kiali/demos/tree/master/runtimes-demo
+# Works on both openshift and non-openshift environments.
+##############################################################################
+
+: ${CLIENT_EXE:=oc}
+: ${DELETE_DEMOS:=false}
+: ${RUNTIMES:=runtimes}
+: ${BASE_URL:=https://raw.githubusercontent.com/kiali/demos/master}
+
+apply_network_attachment() {
+  NAME=$1
+cat <<NAD | $CLIENT_EXE -n ${NAME} apply -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+NAD
+    cat <<SCC | $CLIENT_EXE apply -f -
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: ${NAME}-scc
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- "system:serviceaccount:${NAME}:default"
+- "system:serviceaccount:${NAME}:${NAME}"
+SCC
+}
+
+install_runtimes_demo() {
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+      ${CLIENT_EXE} get project ${RUNTIMES} || ${CLIENT_EXE} new-project ${RUNTIMES}
+    else
+      ${CLIENT_EXE} get ns ${RUNTIMES} || ${CLIENT_EXE} create ns ${RUNTIMES}
+  fi
+
+  ${CLIENT_EXE} label namespace ${RUNTIMES} istio-injection=enabled --overwrite=true
+  ${CLIENT_EXE} apply -f ${BASE_URL}/runtimes-demo/quickstart.yml -n ${RUNTIMES}
+
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+      apply_network_attachment ${RUNTIMES}
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  key="$1"
+  case $key in
+    -c|--client)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -d|-delete)
+      DELETE_DEMOS="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -c|--client: either 'oc' or 'kubectl'
+  -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
+  -h|--help: this text
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+IS_OPENSHIFT="false"
+if [[ "${CLIENT_EXE}" = *"oc" ]]; then
+  IS_OPENSHIFT="true"
+fi
+
+echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
+
+if [ "${DELETE_DEMOS}" != "true" ]; then
+
+    echo "Installing the ${RUNTIMES} app in the ${RUNTIMES} namespace..."
+    install_runtimes_demo
+
+else
+
+    echo "Deleting the '${RUNTIMES}' app in the '${RUNTIMES}' namespace..."
+    ${CLIENT_EXE} delete -f ${BASE_URL}/runtimes-demo/quickstart.yml -n ${RUNTIMES}
+
+    ${CLIENT_EXE} delete ns ${RUNTIMES} --ignore-not-found=true
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+      ${CLIENT_EXE} delete project ${RUNTIMES}
+      ${CLIENT_EXE} delete SecurityContextConstraints ${RUNTIMES}-scc
+    fi
+fi
+
+

--- a/hack/istio/install-scale-mesh-demo.sh
+++ b/hack/istio/install-scale-mesh-demo.sh
@@ -44,9 +44,9 @@ install_scale_mesh_demo() {
   while [ $x -lt ${NUM_NS} ]
   do
     if [ "${IS_OPENSHIFT}" == "true" ]; then
-        ${CLIENT_EXE} new-project depth-${x}
-      else
-        ${CLIENT_EXE} create ns depth-${x}
+      ${CLIENT_EXE} new-project depth-${x}
+    else
+      ${CLIENT_EXE} create ns depth-${x}
     fi
     ${CLIENT_EXE} label namespace  depth-${x} istio-injection=enabled --overwrite=true
     apply_network_attachment depth-${x}
@@ -97,28 +97,23 @@ echo "CLIENT_EXE=${CLIENT_EXE}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
 
 if [ "${DELETE_DEMOS}" != "true" ]; then
-
-    echo "Installing the ${SMESH} app in the ${SMESH} namespace..."
-    install_scale_mesh_demo
-
+  echo "Installing the ${SMESH} app in the ${SMESH} namespace..."
+  install_scale_mesh_demo
 else
+  echo "Deleting the '${SMESH}' app in the '${SMESH}' namespace..."
 
-    echo "Deleting the '${SMESH}' app in the '${SMESH}' namespace..."
+  bash <(curl -L ${BASE_URL}/scale-mesh/scale-mesh.sh) uninstall --mesh-type depth --versions 3
 
-    bash <(curl -L ${BASE_URL}/scale-mesh/scale-mesh.sh) uninstall --mesh-type depth --versions 3
+  x=0
+  while [ $x -lt ${NUM_NS} ]
+  do
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+      ${CLIENT_EXE} delete project depth-${x}
+      ${CLIENT_EXE} delete SecurityContextConstraints depth-${x}-scc
+    else
+      ${CLIENT_EXE} delete ns depth-${x} --ignore-not-found=true
+    fi
 
-    x=0
-    while [ $x -lt ${NUM_NS} ]
-    do
-        if [ "${IS_OPENSHIFT}" == "true" ]; then
-            ${CLIENT_EXE} delete project depth-${x}
-            ${CLIENT_EXE} delete SecurityContextConstraints depth-${x}-scc
-          else
-            ${CLIENT_EXE} delete ns depth-${x} --ignore-not-found=true
-        fi
-
-        x=$(( $x + 1 ))
-    done
+    x=$(( $x + 1 ))
+  done
 fi
-
-

--- a/hack/istio/install-scale-mesh-demo.sh
+++ b/hack/istio/install-scale-mesh-demo.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+##############################################################################
+# install-scale-mesh-demo.sh
+#
+# Installs the kiali music store demo application
+# https://github.com/kiali/demos/tree/master/scale-mesh
+# Works on both openshift and non-openshift environments.
+##############################################################################
+
+: ${CLIENT_EXE:=oc}
+: ${DELETE_DEMOS:=false}
+: ${SMESH:=scale-mesh}
+: ${BASE_URL:=https://raw.githubusercontent.com/kiali/demos/master}
+: ${NUM_NS:=1}
+
+apply_network_attachment() {
+  NAME=$1
+cat <<NAD | $CLIENT_EXE -n ${NAME} apply -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+NAD
+    cat <<SCC | $CLIENT_EXE apply -f -
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: ${NAME}-scc
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- "system:serviceaccount:${NAME}:default"
+- "system:serviceaccount:${NAME}:${NAME}"
+SCC
+}
+
+install_scale_mesh_demo() {
+  x=0
+  while [ $x -lt ${NUM_NS} ]
+  do
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+        ${CLIENT_EXE} new-project depth-${x}
+      else
+        ${CLIENT_EXE} create ns depth-${x}
+    fi
+    ${CLIENT_EXE} label namespace  depth-${x} istio-injection=enabled --overwrite=true
+    apply_network_attachment depth-${x}
+    x=$(( $x + 1 ))
+  done
+
+  bash <(curl -L ${BASE_URL}/scale-mesh/scale-mesh.sh) install --mesh-type depth --versions 3
+}
+
+while [ $# -gt 0 ]; do
+  key="$1"
+  case $key in
+    -c|--client)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -n|-namespaces)
+      NUM_NS="$2"
+      shift;shift
+      ;;
+    -d|-delete)
+      DELETE_DEMOS="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -c|--client: either 'oc' or 'kubectl'
+  -n|--namespaces: Number of namespaces. Default: 1
+  -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
+  -h|--help: this text
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+IS_OPENSHIFT="false"
+if [[ "${CLIENT_EXE}" = *"oc" ]]; then
+  IS_OPENSHIFT="true"
+fi
+
+echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
+
+if [ "${DELETE_DEMOS}" != "true" ]; then
+
+    echo "Installing the ${SMESH} app in the ${SMESH} namespace..."
+    install_scale_mesh_demo
+
+else
+
+    echo "Deleting the '${SMESH}' app in the '${SMESH}' namespace..."
+
+    bash <(curl -L ${BASE_URL}/scale-mesh/scale-mesh.sh) uninstall --mesh-type depth --versions 3
+
+    x=0
+    while [ $x -lt ${NUM_NS} ]
+    do
+        if [ "${IS_OPENSHIFT}" == "true" ]; then
+            ${CLIENT_EXE} delete project depth-${x}
+            ${CLIENT_EXE} delete SecurityContextConstraints depth-${x}-scc
+          else
+            ${CLIENT_EXE} delete ns depth-${x} --ignore-not-found=true
+        fi
+
+        x=$(( $x + 1 ))
+    done
+fi
+
+

--- a/hack/istio/install-service-spawner-demo.sh
+++ b/hack/istio/install-service-spawner-demo.sh
@@ -58,9 +58,10 @@ install_service_spawner_demo() {
     curl -L ${BASE_URL}/service-spawner/deployment-tpl.yaml -o deployment-tpl.yaml
     cat deployment-tpl.yaml \
           | sed -e "s:this-service:service-$c:g" \
-          | sed -e "s:target-service:service-$next:g" \
+          | sed -e "s:80:8080:g" \
+          | sed -e "s:target-service:service-$next\:8080:g" \
           | sed -e "s:this-namespace:$SSPAWNER:g" \
-          | sed -e "s:wget:sleep 60;wget:g" \
+          | sed -e "s:quay.io/jotak/nginx-hello:nginxdemos/nginx-hello:g" \
           > tmp-$c.yaml
     ${CLIENT_EXE} apply -f tmp-${c}.yaml -n ${SSPAWNER}
   done

--- a/hack/istio/install-service-spawner-demo.sh
+++ b/hack/istio/install-service-spawner-demo.sh
@@ -42,31 +42,31 @@ SCC
 install_service_spawner_demo() {
 
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-        ${CLIENT_EXE} new-project ${SSPAWNER}
-      else
-        ${CLIENT_EXE} create ns ${SSPAWNER}
+    ${CLIENT_EXE} new-project ${SSPAWNER}
+  else
+    ${CLIENT_EXE} create ns ${SSPAWNER}
   fi
   ${CLIENT_EXE} label namespace ${SSPAWNER} istio-injection=enabled --overwrite=true
   apply_network_attachment ${SSPAWNER}
 
   for (( c=0; c<$NUM_SPAWNS; c++ ))
   do
-      next=$(($c+1))
-      if [[ $next -eq NUM_SPAWNS ]]; then
-          next=0
-      fi
-      curl -L ${BASE_URL}/service-spawner/deployment-tpl.yaml -o deployment-tpl.yaml
-      cat deployment-tpl.yaml \
-                                     | sed -e "s:this-service:service-$c:g" \
-                                     | sed -e "s:target-service:service-$next:g" \
-                                     | sed -e "s:this-namespace:$SSPAWNER:g" \
-                                     | sed -e "s:wget:sleep 60;wget:g" \
-                                     > tmp-$c.yaml
-      ${CLIENT_EXE} apply -f tmp-${c}.yaml -n ${SSPAWNER}
+    next=$(($c+1))
+    if [[ $next -eq NUM_SPAWNS ]]; then
+      next=0
+    fi
+    curl -L ${BASE_URL}/service-spawner/deployment-tpl.yaml -o deployment-tpl.yaml
+    cat deployment-tpl.yaml \
+          | sed -e "s:this-service:service-$c:g" \
+          | sed -e "s:target-service:service-$next:g" \
+          | sed -e "s:this-namespace:$SSPAWNER:g" \
+          | sed -e "s:wget:sleep 60;wget:g" \
+          > tmp-$c.yaml
+    ${CLIENT_EXE} apply -f tmp-${c}.yaml -n ${SSPAWNER}
   done
   rm deployment-tpl.yaml
   for (( c=0; c<$NUM_SPAWNS; c++ ))
-    do
+  do
       rm tmp-${c}.yaml
   done
 }
@@ -112,20 +112,17 @@ echo "CLIENT_EXE=${CLIENT_EXE}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
 
 if [ "${DELETE_DEMOS}" != "true" ]; then
-
-    echo "Installing the ${SSPAWNER} app in the ${SSPAWNER} namespace..."
-    install_service_spawner_demo
-
+  echo "Installing the ${SSPAWNER} app in the ${SSPAWNER} namespace..."
+  install_service_spawner_demo
 else
+  echo "Deleting the '${SSPAWNER}' app in the '${SSPAWNER}' namespace..."
 
-    echo "Deleting the '${SSPAWNER}' app in the '${SSPAWNER}' namespace..."
+  ${CLIENT_EXE} delete all -l project=service-spawner
 
-    ${CLIENT_EXE} delete all -l project=service-spawner
-
-    if [ "${IS_OPENSHIFT}" == "true" ]; then
-          ${CLIENT_EXE} delete project ${SSPAWNER}
-          ${CLIENT_EXE} delete SecurityContextConstraints ${SSPAWNER}-scc
-    else
-          ${CLIENT_EXE} delete ns ${SSPAWNER} --ignore-not-found=true
-    fi
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} delete project ${SSPAWNER}
+    ${CLIENT_EXE} delete SecurityContextConstraints ${SSPAWNER}-scc
+  else
+    ${CLIENT_EXE} delete ns ${SSPAWNER} --ignore-not-found=true
+  fi
 fi

--- a/hack/istio/install-service-spawner-demo.sh
+++ b/hack/istio/install-service-spawner-demo.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+##############################################################################
+# install-service-spawner-demo.sh
+#
+# Installs the kiali service spawner demo application
+# https://github.com/kiali/demos/tree/master/service-spawner
+# Works on both openshift and non-openshift environments.
+##############################################################################
+
+: ${CLIENT_EXE:=oc}
+: ${DELETE_DEMOS:=false}
+: ${SSPAWNER:=service-spawner}
+: ${BASE_URL:=https://raw.githubusercontent.com/kiali/demos/master}
+: ${NUM_SPAWNS:=10}
+
+apply_network_attachment() {
+  NAME=$1
+cat <<NAD | $CLIENT_EXE -n ${NAME} apply -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+NAD
+    cat <<SCC | $CLIENT_EXE apply -f -
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: ${NAME}-scc
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- "system:serviceaccount:${NAME}:default"
+- "system:serviceaccount:${NAME}:${NAME}"
+SCC
+}
+
+install_service_spawner_demo() {
+
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+        ${CLIENT_EXE} new-project ${SSPAWNER}
+      else
+        ${CLIENT_EXE} create ns ${SSPAWNER}
+  fi
+  ${CLIENT_EXE} label namespace ${SSPAWNER} istio-injection=enabled --overwrite=true
+  apply_network_attachment ${SSPAWNER}
+
+  for (( c=0; c<$NUM_SPAWNS; c++ ))
+  do
+      next=$(($c+1))
+      if [[ $next -eq NUM_SPAWNS ]]; then
+          next=0
+      fi
+      curl -L ${BASE_URL}/service-spawner/deployment-tpl.yaml -o deployment-tpl.yaml
+      cat deployment-tpl.yaml \
+                                     | sed -e "s:this-service:service-$c:g" \
+                                     | sed -e "s:target-service:service-$next:g" \
+                                     | sed -e "s:this-namespace:$SSPAWNER:g" \
+                                     > tmp-$c.yaml
+      ${CLIENT_EXE} apply -f tmp-${c}.yaml -n ${SSPAWNER}
+  done
+  rm deployment-tpl.yaml
+  for (( c=0; c<$NUM_SPAWNS; c++ ))
+    do
+      rm tmp-${c}.yaml
+  done
+  #rm tmp.yaml
+}
+
+while [ $# -gt 0 ]; do
+  key="$1"
+  case $key in
+    -c|--client)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -n|-spawns)
+      NUM_SPAWNS="$2"
+      shift;shift
+      ;;
+    -d|-delete)
+      DELETE_DEMOS="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -c|--client: either 'oc' or 'kubectl'
+  -n|--spawns: Number of spawns. Default: 10
+  -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
+  -h|--help: this text
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+IS_OPENSHIFT="false"
+if [[ "${CLIENT_EXE}" = *"oc" ]]; then
+  IS_OPENSHIFT="true"
+fi
+
+echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
+
+if [ "${DELETE_DEMOS}" != "true" ]; then
+
+    echo "Installing the ${SSPAWNER} app in the ${SSPAWNER} namespace..."
+    install_service_spawner_demo
+
+else
+
+    echo "Deleting the '${SSPAWNER}' app in the '${SSPAWNER}' namespace..."
+
+    ${CLIENT_EXE} delete all -l project=service-spawner
+
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+          ${CLIENT_EXE} delete project ${SSPAWNER}
+          ${CLIENT_EXE} delete SecurityContextConstraints ${SSPAWNER}-scc
+    else
+          ${CLIENT_EXE} delete ns ${SSPAWNER} --ignore-not-found=true
+    fi
+fi

--- a/hack/istio/install-service-spawner-demo.sh
+++ b/hack/istio/install-service-spawner-demo.sh
@@ -60,6 +60,7 @@ install_service_spawner_demo() {
                                      | sed -e "s:this-service:service-$c:g" \
                                      | sed -e "s:target-service:service-$next:g" \
                                      | sed -e "s:this-namespace:$SSPAWNER:g" \
+                                     | sed -e "s:wget:sleep 60;wget:g" \
                                      > tmp-$c.yaml
       ${CLIENT_EXE} apply -f tmp-${c}.yaml -n ${SSPAWNER}
   done
@@ -68,7 +69,6 @@ install_service_spawner_demo() {
     do
       rm tmp-${c}.yaml
   done
-  #rm tmp.yaml
 }
 
 while [ $# -gt 0 ]; do

--- a/hack/istio/install-topology-generator-demo.sh
+++ b/hack/istio/install-topology-generator-demo.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+##############################################################################
+# install-scale-mesh-demo.sh
+#
+# Installs the kiali topology-generator demo application
+# https://github.com/kiali/demos/tree/master/topology-generator
+# Works on both openshift and non-openshift environments.
+##############################################################################
+
+: ${CLIENT_EXE:=oc}
+: ${DELETE_DEMOS:=false}
+: ${TOPO:=topology-generator}
+: ${BASE_URL:=https://raw.githubusercontent.com/kiali/demos/master}
+
+apply_network_attachment() {
+  NAME=$1
+cat <<NAD | $CLIENT_EXE -n ${NAME} apply -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+NAD
+    cat <<SCC | $CLIENT_EXE apply -f -
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: ${NAME}-scc
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- "system:serviceaccount:${NAME}:default"
+- "system:serviceaccount:${NAME}:${NAME}"
+SCC
+}
+
+install_topology_generator_demo() {
+
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+        ${CLIENT_EXE} new-project ${TOPO}
+      else
+        ${CLIENT_EXE} create ns ${TOPO}
+    fi
+    ${CLIENT_EXE} label namespace  ${TOPO} istio-injection=enabled --overwrite=true
+    apply_network_attachment ${TOPO}
+
+    ${CLIENT_EXE} apply -n ${TOPO}  -f ${BASE_URL}/topology-generator/deploy/generator.yaml
+}
+
+while [ $# -gt 0 ]; do
+  key="$1"
+  case $key in
+    -c|--client)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -d|-delete)
+      DELETE_DEMOS="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -c|--client: either 'oc' or 'kubectl'
+  -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
+  -h|--help: this text
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+IS_OPENSHIFT="false"
+if [[ "${CLIENT_EXE}" = *"oc" ]]; then
+  IS_OPENSHIFT="true"
+fi
+
+echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
+
+if [ "${DELETE_DEMOS}" != "true" ]; then
+
+    echo "Installing the ${TOPO} app in the ${TOPO} namespace..."
+    install_topology_generator_demo
+
+else
+
+    echo "Deleting the '${TOPO}' app in the '${TOPO}' namespace..."
+
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+            ${CLIENT_EXE} delete project ${TOPO}
+            ${CLIENT_EXE} delete SecurityContextConstraints ${TOPO}
+            ${CLIENT_EXE} delete ns --selector=generated-by=mimik
+            ${CLIENT_EXE} delete ns ${TOPO}
+    fi
+
+fi
+
+

--- a/hack/istio/install-topology-generator-demo.sh
+++ b/hack/istio/install-topology-generator-demo.sh
@@ -94,7 +94,7 @@ Valid command line arguments:
   -c|--client: either 'oc' or 'kubectl'
   -n|--namespaces: number of namespaces to be generate in the generator to apply the network policies
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
-  -g|--generate_config: Generate configuration of the topology based in the number of namespaces (-n)
+  -g|--generate-config: Generate configuration of the topology based in the number of namespaces (-n)
   -h|--help: this text
 
 Usage:

--- a/hack/istio/install-topology-generator-demo.sh
+++ b/hack/istio/install-topology-generator-demo.sh
@@ -50,7 +50,10 @@ install_topology_generator_demo() {
         ${CLIENT_EXE} create ns ${TOPO}
     fi
     ${CLIENT_EXE} label namespace  ${TOPO} istio-injection=enabled --overwrite=true
-    apply_network_attachment ${TOPO}
+
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+      apply_network_attachment ${TOPO}
+    fi
 
     ${CLIENT_EXE} apply -n ${TOPO}  -f ${BASE_URL}/topology-generator/deploy/generator.yaml
 }
@@ -133,12 +136,11 @@ else
     echo "Deleting the '${TOPO}' app in the '${TOPO}' namespace..."
 
     if [ "${IS_OPENSHIFT}" == "true" ]; then
-            ${CLIENT_EXE} delete project ${TOPO}
-            ${CLIENT_EXE} delete SecurityContextConstraints ${TOPO}
-            ${CLIENT_EXE} delete ns --selector=generated-by=mimik
-            ${CLIENT_EXE} delete ns ${TOPO}
+        ${CLIENT_EXE} delete project ${TOPO}
+        ${CLIENT_EXE} delete SecurityContextConstraints ${TOPO}
     fi
-
+    ${CLIENT_EXE} delete ns --selector=generated-by=mimik
+    ${CLIENT_EXE} delete ns ${TOPO}
   fi
 fi
 

--- a/hack/istio/install-topology-generator-demo.sh
+++ b/hack/istio/install-topology-generator-demo.sh
@@ -43,28 +43,25 @@ SCC
 }
 
 install_topology_generator_demo() {
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} new-project ${TOPO}
+  else
+    ${CLIENT_EXE} create ns ${TOPO}
+  fi
+  ${CLIENT_EXE} label namespace  ${TOPO} istio-injection=enabled --overwrite=true
 
-    if [ "${IS_OPENSHIFT}" == "true" ]; then
-        ${CLIENT_EXE} new-project ${TOPO}
-      else
-        ${CLIENT_EXE} create ns ${TOPO}
-    fi
-    ${CLIENT_EXE} label namespace  ${TOPO} istio-injection=enabled --overwrite=true
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    apply_network_attachment ${TOPO}
+  fi
 
-    if [ "${IS_OPENSHIFT}" == "true" ]; then
-      apply_network_attachment ${TOPO}
-    fi
-
-    ${CLIENT_EXE} apply -n ${TOPO}  -f ${BASE_URL}/topology-generator/deploy/generator.yaml
+  ${CLIENT_EXE} apply -n ${TOPO}  -f ${BASE_URL}/topology-generator/deploy/generator.yaml
 }
 
 generate_config() {
-
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     for (( i=1; i<=$NUM_NS; i++ ))
-        do
-
-            apply_network_attachment n${i}
+    do
+      apply_network_attachment n${i}
     done
   fi
 }

--- a/hack/istio/install-topology-generator-demo.sh
+++ b/hack/istio/install-topology-generator-demo.sh
@@ -80,7 +80,7 @@ while [ $# -gt 0 ]; do
       NUM_NS="$2"
       shift;shift
       ;;
-    -g|--generate_config)
+    -g|--generate-config)
       GENERATE_CONFIG="$2"
       shift;shift
       ;;

--- a/hack/istio/install-topology-generator-demo.sh
+++ b/hack/istio/install-topology-generator-demo.sh
@@ -92,7 +92,7 @@ while [ $# -gt 0 ]; do
       cat <<HELPMSG
 Valid command line arguments:
   -c|--client: either 'oc' or 'kubectl'
-  -n|--num_ns: number of namespaces to be generate in the generator to apply the network policies
+  -n|--namespaces: number of namespaces to be generate in the generator to apply the network policies
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
   -g|--generate_config: Generate configuration of the topology based in the number of namespaces (-n)
   -h|--help: this text

--- a/hack/istio/install-topology-generator-demo.sh
+++ b/hack/istio/install-topology-generator-demo.sh
@@ -92,7 +92,7 @@ while [ $# -gt 0 ]; do
       cat <<HELPMSG
 Valid command line arguments:
   -c|--client: either 'oc' or 'kubectl'
-  -n|--namespaces: number of namespaces to be generate in the generator to apply the network policies
+  -n|--namespaces: number of namespaces to be created in the generator to apply the network policies
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
   -g|--generate-config: Generate configuration of the topology based in the number of namespaces (-n)
   -h|--help: this text
@@ -101,7 +101,7 @@ Usage:
   1) Run with no args - or -c - to install the topology generator
   2) Run the proxy: CLIENT port-forward svc/topology-generator 8080:8080 -n topology-generator
   3) Go to the app and generate the topology
-  4) Run -g to run the openshift configuration and -n with the number of namespaces created
+  4) Run -g to configure the demo to work on OpenShift along with -n argument. You only need to run this if you are on OpenShift and using upstream Istio (not OSSM).
 HELPMSG
       exit 1
       ;;


### PR DESCRIPTION
Adding some hack scripts to install demos in OpenShift.

The idea is they work the same - Having each one their own particularities: 

- h for help 
- d for uninstall 
- c for client (oc by default, tested also for kubectl)

demos added: 

- electronic shop
- federated travels: When installing this one in open shift, for some reason, it doesn't look to be injecting pro pertly the Istio injections, but it looks to be installed in the mesh. To be reviewed. 
- music store
- runtimes
- scale mesh
- service spawner: For some reason I'm not able to install the example. There is a crashLoopBackOff error trying to deploy the image quay.io/jotak/nginx-hello:0.2 - I should look into this, or probably remove the script in the meantime. 
- topology generator

Fixes https://github.com/kiali/kiali/issues/5268 