### PR TITLE
Add lock icon if mTLS is enabled in traffic tab table

### DIFF
--- a/frontend/src/components/TrafficList/TrafficDetails.tsx
+++ b/frontend/src/components/TrafficList/TrafficDetails.tsx
@@ -60,6 +60,7 @@ export interface TrafficItem {
   node: TrafficNode;
   proxy?: TrafficItem;
   traffic: ProtocolTraffic;
+  mTLS?: number;
 }
 
 type TrafficDetailsProps = {
@@ -160,6 +161,7 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
         );
         params.includeHealth = false;
         params.injectServiceNodes = false;
+        params.showSecurity = true;
         this.graphDataSource.fetchGraphData(params);
         break;
       }
@@ -229,14 +231,16 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
         const trafficItem: TrafficItem = {
           direction: 'outbound',
           node: this.buildTrafficNode('out', targetNode),
-          traffic: edge.data.traffic!
+          traffic: edge.data.traffic!,
+          mTLS: edge.data.isMTLS
         };
         traffic.push(trafficItem);
       } else if (myNode.id === edge.data.target) {
         const trafficItem: TrafficItem = {
           direction: 'inbound',
           node: this.buildTrafficNode('in', sourceNode),
-          traffic: edge.data.traffic!
+          traffic: edge.data.traffic!,
+          mTLS: edge.data.isMTLS
         };
         traffic.push(trafficItem);
       }

--- a/frontend/src/components/TrafficList/TrafficListComponent.tsx
+++ b/frontend/src/components/TrafficList/TrafficListComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import {Title, TitleSizes, Tooltip, TooltipPosition} from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { IRow, sortable, SortByDirection, Table, TableBody, TableHeader, cellWidth } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
@@ -13,7 +13,7 @@ import { createIcon } from 'components/Health/Helper';
 import { sortFields } from './FiltersAndSorts';
 import { SortField } from 'types/SortFilters';
 import { PFBadgeType, PFBadge, PFBadges } from 'components/Pf/PfBadges';
-import { createTooltipIcon } from 'config/KialiIcon';
+import { createTooltipIcon, KialiIcon } from 'config/KialiIcon';
 
 export interface TrafficListItem {
   direction: TrafficDirection;
@@ -21,6 +21,7 @@ export interface TrafficListItem {
   badge: PFBadgeType;
   node: TrafficNode;
   protocol: string;
+  mTLS?: number;
   trafficRate: string;
   trafficPercentSuccess: string;
 }
@@ -57,8 +58,21 @@ const columns = [
   }
 ];
 
+function LockIcon(props) {
+
+  return (
+    <Tooltip
+      position={TooltipPosition.top}
+      content={<>{props.mTLS} % of mTLS traffic </>}
+    >
+      <KialiIcon.MtlsLock className={lockIconStyle}/>
+    </Tooltip>
+  );
+};
+
 // Style constants
 const containerPadding = style({ padding: '20px' });
+const lockIconStyle = style({ marginLeft: '5px' });
 
 class TrafficListComponent extends FilterComponent.Component<
   TrafficListComponentProps,
@@ -168,6 +182,7 @@ class TrafficListComponent extends FilterComponent.Component<
         badge: badge,
         node: ti.node,
         protocol: (ti.traffic.protocol || 'N/A').toUpperCase(),
+        mTLS: ti.mTLS,
         healthStatus: this.getHealthStatus(ti),
         ...this.getTraffic(ti.traffic)
       };
@@ -243,7 +258,7 @@ class TrafficListComponent extends FilterComponent.Component<
             </>,
             <>{item.trafficRate}</>,
             <>{item.trafficPercentSuccess}</>,
-            <>{item.protocol}</>,
+            <>{item.mTLS ? <>{item.protocol}<LockIcon mTLS={item.mTLS}></LockIcon></> : item.protocol }</>,
             <>
               {!!links.metrics && (
                 <Link key={`link_m_${item.badge}_${name}`} to={links.metrics} className={'virtualitem_definition_link'}>


### PR DESCRIPTION
Added mTLS information in the Traffic tab:

- Added lock icon if mTLS is enabled. This is less intrusive than use another column. 
- Added percentage of mTLS traffic in a tooltip


![Screenshot from 2022-07-01 13-36-42](https://user-images.githubusercontent.com/49480155/176896454-530095e0-ef36-4e7d-8c3a-3f31b0cc4ecc.png)

Fixes https://github.com/kiali/kiali/issues/5275