### PR TITLE
Metrics tab: Ability to show both reporters

### DIFF
--- a/business/metrics.go
+++ b/business/metrics.go
@@ -28,7 +28,9 @@ func (in *MetricsService) GetMetrics(q models.IstioMetricsQuery, scaler func(n s
 
 func createMetricsLabelsBuilder(q *models.IstioMetricsQuery) *MetricsLabelsBuilder {
 	lb := NewMetricsLabelsBuilder(q.Direction)
-	lb.Reporter(q.Reporter)
+	if q.Reporter != "both" {
+		lb.Reporter(q.Reporter)
+	}
 
 	namespaceSet := false
 

--- a/frontend/src/components/Charts/KChart.tsx
+++ b/frontend/src/components/Charts/KChart.tsx
@@ -156,7 +156,13 @@ class KChart<T extends LineInfo> extends React.Component<KChartProps<T>, State> 
 
   private determineChartType() {
     if (this.props.chart.chartType === undefined) {
-      return this.props.chart.xAxis === 'series' ? barInfo : lineInfo;
+      if (this.props.chart.xAxis === 'series') {
+        return barInfo;
+      } else if (this.props.chart.metrics.some(m => m.datapoints.some(dp => dp[2]))) {
+        return areaInfo;
+      } else {
+        return lineInfo;
+      }
     }
     const chartType = this.props.chart.chartType;
     switch (chartType) {

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -149,17 +149,22 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
   private fetchMetrics = () => {
     // Time range needs to be reevaluated everytime fetching
     MetricsHelper.timeRangeToOptions(this.props.timeRange, this.options);
+    let opts = { ...this.options };
+    if (opts.reporter === 'both') {
+      opts.byLabels = (opts.byLabels ?? []).concat('reporter');
+    }
+
     let promise: Promise<API.Response<DashboardModel>>;
     switch (this.props.objectType) {
       case MetricsObjectTypes.WORKLOAD:
-        promise = API.getWorkloadDashboard(this.props.namespace, this.props.object, this.options);
+        promise = API.getWorkloadDashboard(this.props.namespace, this.props.object, opts);
         break;
       case MetricsObjectTypes.APP:
-        promise = API.getAppDashboard(this.props.namespace, this.props.object, this.options);
+        promise = API.getAppDashboard(this.props.namespace, this.props.object, opts);
         break;
       case MetricsObjectTypes.SERVICE:
       default:
-        promise = API.getServiceDashboard(this.props.namespace, this.props.object, this.options);
+        promise = API.getServiceDashboard(this.props.namespace, this.props.object, opts);
         break;
     }
     return promise

--- a/frontend/src/components/MetricsOptions/MetricsReporter.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsReporter.tsx
@@ -21,7 +21,8 @@ const infoStyle = style({
 export default class MetricsReporter extends React.Component<Props> {
   static ReporterOptions: { [key: string]: string } = {
     destination: 'Destination',
-    source: 'Source'
+    source: 'Source',
+    both: 'Both'
   };
 
   static initialReporter = (direction: Direction): Reporter => {

--- a/frontend/src/types/Metrics.ts
+++ b/frontend/src/types/Metrics.ts
@@ -1,5 +1,5 @@
-// First is timestamp, second is value
-export type Datapoint = [number, number];
+// First is timestamp, second is value, third is y0
+export type Datapoint = [number, number, number?];
 
 export interface Metric {
   labels: Labels;

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -28,7 +28,7 @@ export interface IstioMetricsOptions extends MetricsQuery {
   reporter: Reporter;
 }
 
-export type Reporter = 'source' | 'destination';
+export type Reporter = 'source' | 'destination' | 'both';
 export type Direction = 'inbound' | 'outbound';
 
 export interface Target {

--- a/frontend/src/types/VictoryChartInfo.ts
+++ b/frontend/src/types/VictoryChartInfo.ts
@@ -11,6 +11,7 @@ export type VCDataPoint = {
   name: string;
   x: number | Date | string;
   y: number;
+  y0?: number;
   style?: Style;
 };
 

--- a/frontend/src/utils/TimeSeriesUtils.ts
+++ b/frontend/src/utils/TimeSeriesUtils.ts
@@ -49,7 +49,9 @@ const renameMetrics = (metrics: Metric[], labelPrettifier?: KVMapper): Metric[] 
   return metrics.map(m => {
     const name = m.name;
     const stat = mapStatForDisplay(m.stat);
-    const otherLabels = Object.entries(m.labels)
+    let labelsNoReporter = { ...m.labels };
+    delete labelsNoReporter.reporter;
+    const otherLabels = Object.entries(labelsNoReporter)
       .filter(e => multipleValuesLabels.has(e[0]))
       .map(e => (labelPrettifier ? labelPrettifier(e[0], e[1]) : e[1]));
     const labels = (stat ? [stat] : []).concat(otherLabels).join(',');

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -208,8 +208,8 @@ func extractIstioMetricsQueryParams(r *http.Request, q *models.IstioMetricsQuery
 	}
 	reporter := queryParams.Get("reporter")
 	if reporter != "" {
-		if reporter != "source" && reporter != "destination" {
-			return errors.New("bad request, query parameter 'reporter' must be either 'source' or 'destination'")
+		if reporter != "source" && reporter != "destination" && reporter != "both" {
+			return errors.New("bad request, query parameter 'reporter' must be either 'source', 'destination' or 'both'")
 		}
 		q.Reporter = reporter
 	}

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -25,7 +25,7 @@ type IstioMetricsQuery struct {
 	Service         string
 	Direction       string // outbound | inbound
 	RequestProtocol string // e.g. http | grpc
-	Reporter        string // source | destination, defaults to source if not provided
+	Reporter        string // source | destination | both, defaults to source if not provided
 	Aggregate       string
 	AggregateValue  string
 }


### PR DESCRIPTION
In the metrics tabs, in the _Reporter_ drop-down a third _"Both"_ option is added. This allows to see data from both reporters in the charts. This is how it will look:

![image](https://user-images.githubusercontent.com/23639005/177210550-350693c2-6f2f-4725-b7f3-d3d290260ec3.png)

It can be appreciated that when both reporters are requested, the generated charts will be _area charts_. The solid lines still represent the actual data coming from the reporters and series are now arranged in pairs: lines that belong to the same serie where only the reporter varies, are associated with a filled area and are given the same color. This should make easier to see data differences between reporters which may tell, for example network latency or could be understood as triggering points for circuit breakers.

Fixes #2887 
