### PR TITLE
Adjust mouse pointer in charts for traces

### DIFF
--- a/frontend/src/components/Charts/ChartWithLegend.tsx
+++ b/frontend/src/components/Charts/ChartWithLegend.tsx
@@ -45,6 +45,9 @@ type Props<T extends RichDataPoint, O extends LineInfo> = {
   unit: string;
   xAxis?: XAxisType;
   labelComponent?: React.ReactElement<ChartTooltipProps>;
+  // The JaegerScatter component needs a flag to indicate that the trace datapoint needs a mouse pointer
+  // It could be detected indirectly, but it's complicated and less clear, a new optional flag simplifies this logic
+  pointer?: boolean;
 };
 
 type State = {
@@ -492,7 +495,8 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
             data: {
               fill: this.props.fill ? color : undefined,
               stroke: this.props.stroke ? color : undefined,
-              strokeDasharray: strokeDasharray === true ? '3 5' : undefined
+              strokeDasharray: strokeDasharray === true ? '3 5' : undefined,
+              cursor: this.props.pointer ? 'pointer' : 'default',
             }
           }
         };

--- a/frontend/src/components/JaegerIntegration/JaegerScatter.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerScatter.tsx
@@ -130,6 +130,7 @@ class JaegerScatter extends React.Component<JaegerScatterProps> {
             seriesComponent={<ChartScatter />}
             onClick={dp => this.props.setTraceId(dp.trace.traceID)}
             labelComponent={<TraceTooltip />}
+            pointer={true}
           />
         </div>
       </div>

--- a/frontend/src/components/Metrics/SpanOverlay.ts
+++ b/frontend/src/components/Metrics/SpanOverlay.ts
@@ -78,7 +78,7 @@ export class SpanOverlay {
           symbol: 'circle',
           size: 10
         },
-        dataStyle: { fill: ({ datum }) => (datum.error ? PFColors.Danger : PFColors.Cyan300), fillOpacity: 0.6 },
+        dataStyle: { fill: ({ datum }) => (datum.error ? PFColors.Danger : PFColors.Cyan300), fillOpacity: 0.6, cursor: 'pointer' },
         buckets: this.spans.length > 1000 ? 15 : 0
       };
       const dps = this.spans.map(span => {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/5276

Follow-up work to change the mouse pointer when:
- "Show spans" is enabled in metrics.
- "Traces" main chart.