### PR TITLE
Added new option for namespace's mTLS enabled extended from Mesh-wide

### DIFF
--- a/frontend/src/components/MTls/NamespaceMTLSStatus.tsx
+++ b/frontend/src/components/MTls/NamespaceMTLSStatus.tsx
@@ -19,6 +19,14 @@ const statusDescriptors = new Map<string, StatusDescriptor>([
     }
   ],
   [
+    MTLSStatuses.ENABLED_EXTENDED,
+    {
+      message: 'mTLS is enabled for this namespace, extended from Mesh-wide config',
+      icon: MTLSIconTypes.LOCK_FULL_DARK,
+      showStatus: true
+    }
+  ],
+  [
     MTLSStatuses.PARTIALLY,
     {
       message: 'mTLS is partially enabled for this namespace',

--- a/frontend/src/types/TLSStatus.ts
+++ b/frontend/src/types/TLSStatus.ts
@@ -1,5 +1,6 @@
 export enum MTLSStatuses {
   ENABLED = 'MTLS_ENABLED',
+  ENABLED_EXTENDED = 'MTLS_ENABLED_EXTENDED',
   PARTIALLY = 'MTLS_PARTIALLY_ENABLED',
   NOT_ENABLED = 'MTLS_NOT_ENABLED',
   DISABLED = 'MTLS_DISABLED'
@@ -15,7 +16,7 @@ export const nsWideMTLSStatus = (nsStatus: string, meshStatus: string): string =
   // When mTLS is enabled meshwide but not disabled at ns level
   // Then the ns has mtls enabled
   if (meshStatus === MTLSStatuses.ENABLED && nsStatus === MTLSStatuses.NOT_ENABLED) {
-    finalStatus = MTLSStatuses.ENABLED;
+    finalStatus = MTLSStatuses.ENABLED_EXTENDED;
   }
 
   return finalStatus;


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5263

In Overview page, while showing mTLS lock icon on namespaces, where mTLS is enabled not for namespace but for Mesh-wide, it will show now a message in lock's tooltip that mTLS status is extended from Mesh-wide.

![Screenshot from 2022-07-08 17-00-22](https://user-images.githubusercontent.com/604313/178030963-c5dfdd9f-89be-4b39-8a2b-659c7d051da9.png)
