### PR TITLE
Optimized Istio Config list loading

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -140,17 +140,39 @@ func (in *IstioConfigService) GetIstioConfigList(ctx context.Context, criteria I
 		}
 		// AllNamespaces will return an empty namespace
 		istioConfigList.Namespace.Name = ""
-		istioConfigList.DestinationRules = registryConfiguration.DestinationRules
-		istioConfigList.EnvoyFilters = registryConfiguration.EnvoyFilters
-		istioConfigList.Gateways = registryConfiguration.Gateways
-		istioConfigList.VirtualServices = registryConfiguration.VirtualServices
-		istioConfigList.ServiceEntries = registryConfiguration.ServiceEntries
-		istioConfigList.Sidecars = registryConfiguration.Sidecars
-		istioConfigList.WorkloadEntries = registryConfiguration.WorkloadEntries
-		istioConfigList.WorkloadGroups = registryConfiguration.WorkloadGroups
-		istioConfigList.AuthorizationPolicies = registryConfiguration.AuthorizationPolicies
-		istioConfigList.PeerAuthentications = registryConfiguration.PeerAuthentications
-		istioConfigList.RequestAuthentications = registryConfiguration.RequestAuthentications
+		if criteria.Include(kubernetes.DestinationRules) {
+			istioConfigList.DestinationRules = registryConfiguration.DestinationRules
+		}
+		if criteria.Include(kubernetes.EnvoyFilters) {
+			istioConfigList.EnvoyFilters = registryConfiguration.EnvoyFilters
+		}
+		if criteria.Include(kubernetes.Gateways) {
+			istioConfigList.Gateways = registryConfiguration.Gateways
+		}
+		if criteria.Include(kubernetes.VirtualServices) {
+			istioConfigList.VirtualServices = registryConfiguration.VirtualServices
+		}
+		if criteria.Include(kubernetes.ServiceEntries) {
+			istioConfigList.ServiceEntries = registryConfiguration.ServiceEntries
+		}
+		if criteria.Include(kubernetes.Sidecars) {
+			istioConfigList.Sidecars = registryConfiguration.Sidecars
+		}
+		if criteria.Include(kubernetes.WorkloadEntries) {
+			istioConfigList.WorkloadEntries = registryConfiguration.WorkloadEntries
+		}
+		if criteria.Include(kubernetes.WorkloadGroups) {
+			istioConfigList.WorkloadGroups = registryConfiguration.WorkloadGroups
+		}
+		if criteria.Include(kubernetes.AuthorizationPolicies) {
+			istioConfigList.AuthorizationPolicies = registryConfiguration.AuthorizationPolicies
+		}
+		if criteria.Include(kubernetes.PeerAuthentications) {
+			istioConfigList.PeerAuthentications = registryConfiguration.PeerAuthentications
+		}
+		if criteria.Include(kubernetes.RequestAuthentications) {
+			istioConfigList.RequestAuthentications = registryConfiguration.RequestAuthentications
+		}
 
 		return istioConfigList, nil
 	}

--- a/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -27,7 +27,6 @@ import { KialiAppState } from '../../store/Store';
 import { activeNamespacesSelector } from '../../store/Selectors';
 import { connect } from 'react-redux';
 import DefaultSecondaryMasthead from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
-import _ from "lodash";
 
 interface IstioConfigListPageState extends FilterComponent.State<IstioConfigItem> {}
 interface IstioConfigListPageProps extends FilterComponent.Props<IstioConfigItem> {
@@ -143,7 +142,7 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
     return this.promises
       .registerAll(
         'configs',
-        namespaces.slice(0,1).map(_ => API.getAllIstioConfigs(namespaces, typeFilters, true, '', ''))
+        [""].map(_ => API.getAllIstioConfigs(namespaces, typeFilters, true, '', ''))
       )
       .then(responses => {
         let istioItems: IstioConfigItem[] = [];

--- a/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -142,6 +142,7 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
     return this.promises
       .registerAll(
         'configs',
+        // hacky way to load all configs in one call
         [""].map(_ => API.getAllIstioConfigs([], typeFilters, true, '', ''))
       )
       .then(responses => {

--- a/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -140,30 +140,20 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
 
   // Fetch the Istio configs, apply filters and map them into flattened list items
   fetchIstioConfigs(namespaces: string[], typeFilters: string[], istioNameFilters: string[]) {
-    // return this.promises
-    //   .registerAll(
-    //     'configs',
-    //     // THIS should be one call, not per namespace , OR the next section
-    //     namespaces.map(_ => API.getAllIstioConfigs(namespaces, typeFilters, true, '', ''))
-    //   )
-    //   .then(responses => {
-    //     let istioItems: IstioConfigItem[] = [];
-    //     responses.forEach(response => {
-    //       namespaces.forEach(ns => {
-    //         istioItems = istioItems.concat(toIstioItems(filterByName(response.data[ns], istioNameFilters)));
-    //       })
-    //     });
-    //     return istioItems;
-    //     });
-    // OR PER Chunk
-    let istioItems: IstioConfigItem[] = [];
-    _.chunk(namespaces, 10).forEach(chunk => {
-      return this.promises
-        .registerChained('configs', undefined, () => this.fetchIstioConfigChunks(chunk, typeFilters, istioNameFilters, istioItems))
-        .then(() => {
-          return istioItems;
-        })
-    })
+    return this.promises
+      .registerAll(
+        'configs',
+        namespaces.slice(0,1).map(_ => API.getAllIstioConfigs(namespaces, typeFilters, true, '', ''))
+      )
+      .then(responses => {
+        let istioItems: IstioConfigItem[] = [];
+        responses.forEach(response => {
+          namespaces.forEach(ns => {
+            istioItems = istioItems.concat(toIstioItems(filterByName(response.data[ns], istioNameFilters)));
+          })
+        });
+        return istioItems;
+        });
   }
 
   fetchIstioConfigChunks(chunk: string[], typeFilters: string[], istioNameFilters: string[], istioItems: IstioConfigItem[]) {

--- a/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -142,7 +142,7 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
     return this.promises
       .registerAll(
         'configs',
-        [""].map(_ => API.getAllIstioConfigs(namespaces, typeFilters, true, '', ''))
+        [""].map(_ => API.getAllIstioConfigs([], typeFilters, true, '', ''))
       )
       .then(responses => {
         let istioItems: IstioConfigItem[] = [];
@@ -153,20 +153,6 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
         });
         return istioItems;
         });
-  }
-
-  fetchIstioConfigChunks(chunk: string[], typeFilters: string[], istioNameFilters: string[], istioItems: IstioConfigItem[]) {
-    return Promise.all(
-      [
-        API.getAllIstioConfigs(chunk, typeFilters, true, '', '')
-      ]
-    )
-      .then( results => {
-          chunk.forEach(ns => {
-            istioItems = istioItems.concat(toIstioItems(filterByName(results[0].data[ns], istioNameFilters)));
-          })
-      })
-      .catch(err => this.handleAxiosError('Could not fetch Istio configs', err));
   }
 
   render() {

--- a/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -139,21 +139,15 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
 
   // Fetch the Istio configs, apply filters and map them into flattened list items
   fetchIstioConfigs(namespaces: string[], typeFilters: string[], istioNameFilters: string[]) {
-    return this.promises
-      .registerAll(
-        'configs',
-        // hacky way to load all configs in one call
-        [""].map(_ => API.getAllIstioConfigs([], typeFilters, true, '', ''))
-      )
-      .then(responses => {
-        let istioItems: IstioConfigItem[] = [];
-        responses.forEach(response => {
-          namespaces.forEach(ns => {
-            istioItems = istioItems.concat(toIstioItems(filterByName(response.data[ns], istioNameFilters)));
-          })
-        });
-        return istioItems;
-        });
+    // Request all configs from all namespaces, as in backend all configs are always loaded from registry
+    return this.promises.register('configs', API.getAllIstioConfigs([], typeFilters, true, '', '')).then(response => {
+      let istioItems: IstioConfigItem[] = [];
+      // filter by selected namespaces
+      namespaces.forEach(ns => {
+        istioItems = istioItems.concat(toIstioItems(filterByName(response.data[ns], istioNameFilters)));
+      });
+      return istioItems;
+    });
   }
 
   render() {

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -450,7 +450,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     return Promise.all(
       [
         API.getConfigValidations(nss),
-        API.getAllIstioConfigs(nss, false, '', '')
+        API.getAllIstioConfigs(nss, [], false, '', '')
       ]
     )
       .then(results => {

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -86,9 +86,11 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
   private fetchService = () => {
     this.promises.cancelAll();
     this.promises
-      .register('gateways', API.getIstioConfig('', ['gateways'], false, '', ''))
+      .register('gateways', API.getAllIstioConfigs([], ['gateways'], false, '', ''))
       .then(response => {
-        this.setState({ gateways: response.data.gateways });
+        Object.values(response.data).forEach(item => {
+          this.setState({ gateways: this.state.gateways.concat(item.gateways) });
+        });
       })
       .catch(gwError => {
         AlertUtils.addError('Could not fetch Gateways list.', gwError);

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -162,7 +162,7 @@ export const getIstioConfig = (
   validate: boolean,
   labelSelector: string,
   workloadSelector: string
-) => {
+): Promise<Response<IstioConfigList>> => {
   const params: any = objects && objects.length > 0 ? { objects: objects.join(',') } : {};
   if (validate) {
     params.validate = validate;
@@ -173,11 +173,7 @@ export const getIstioConfig = (
   if (workloadSelector) {
     params.workloadSelector = workloadSelector;
   }
-  if (namespace) {
-    return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
-  } else {
-    return newRequest<IstioConfigsMap>(HTTP_VERBS.GET, urls.allIstioConfigs(), params, {});
-  }
+  return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
 };
 
 export const getAllIstioConfigs = (

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -182,11 +182,15 @@ export const getIstioConfig = (
 
 export const getAllIstioConfigs = (
   namespaces: string[],
+  objects: string[],
   validate: boolean,
   labelSelector: string,
   workloadSelector: string
 ) => {
   const params: any = namespaces && namespaces.length > 0 ? { namespaces: namespaces.join(',') } : {};
+  if (objects && objects.length > 0) {
+    params.objects = objects.join(',');
+  }
   if (validate) {
     params.validate = validate;
   }

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -186,7 +186,7 @@ export const getAllIstioConfigs = (
   validate: boolean,
   labelSelector: string,
   workloadSelector: string
-) => {
+): Promise<Response<IstioConfigList>> => {
   const params: any = namespaces && namespaces.length > 0 ? { namespaces: namespaces.join(',') } : {};
   if (objects && objects.length > 0) {
     params.objects = objects.join(',');

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -19,7 +19,7 @@ import {
   WorkloadHealth
 } from '../types/Health';
 import { IstioConfigDetails, IstioPermissions } from '../types/IstioConfigDetails';
-import { IstioConfigList } from '../types/IstioConfigList';
+import { IstioConfigList, IstioConfigsMap } from '../types/IstioConfigList';
 import { Pod, PodLogs, ValidationStatus, EnvoyProxyDump } from '../types/IstioObjects';
 import { ComponentStatus } from '../types/IstioStatus';
 import { JaegerInfo, JaegerResponse, JaegerSingleResponse } from '../types/JaegerInfo';
@@ -176,7 +176,7 @@ export const getIstioConfig = (
   if (namespace) {
     return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
   } else {
-    return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.allIstioConfigs(), params, {});
+    return newRequest<IstioConfigsMap>(HTTP_VERBS.GET, urls.allIstioConfigs(), params, {});
   }
 };
 
@@ -186,7 +186,7 @@ export const getAllIstioConfigs = (
   validate: boolean,
   labelSelector: string,
   workloadSelector: string
-): Promise<Response<IstioConfigList>> => {
+): Promise<Response<IstioConfigsMap>> => {
   const params: any = namespaces && namespaces.length > 0 ? { namespaces: namespaces.join(',') } : {};
   if (objects && objects.length > 0) {
     params.objects = objects.join(',');
@@ -200,7 +200,7 @@ export const getAllIstioConfigs = (
   if (workloadSelector) {
     params.workloadSelector = workloadSelector;
   }
-  return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.allIstioConfigs(), params, {});
+  return newRequest<IstioConfigsMap>(HTTP_VERBS.GET, urls.allIstioConfigs(), params, {});
 };
 
 export const getIstioConfigDetail = (namespace: string, objectType: string, object: string, validate: boolean) => {

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -180,9 +180,13 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
     const entryName = typeNameProto.charAt(0).toLowerCase() + typeNameProto.slice(1);
 
     let entries = istioConfigList[field];
-    if (!(entries instanceof Array)) {
+    if (entries && !(entries instanceof Array)) {
       // VirtualServices, DestinationRules
       entries = entries.items;
+    }
+
+    if (!entries) {
+      return
     }
 
     entries.forEach(entry => {

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -114,17 +114,17 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
   }
   return {
     namespace: unfiltered.namespace,
-    gateways: unfiltered.gateways.filter(gw => includeName(gw.metadata.name, names)),
-    virtualServices: unfiltered.virtualServices.filter(vs => includeName(vs.metadata.name, names)),
-    destinationRules: unfiltered.destinationRules.filter(dr => includeName(dr.metadata.name, names)),
-    serviceEntries: unfiltered.serviceEntries.filter(se => includeName(se.metadata.name, names)),
-    authorizationPolicies: unfiltered.authorizationPolicies.filter(rc => includeName(rc.metadata.name, names)),
-    sidecars: unfiltered.sidecars.filter(sc => includeName(sc.metadata.name, names)),
-    peerAuthentications: unfiltered.peerAuthentications.filter(pa => includeName(pa.metadata.name, names)),
-    requestAuthentications: unfiltered.requestAuthentications.filter(ra => includeName(ra.metadata.name, names)),
-    workloadEntries: unfiltered.workloadEntries.filter(we => includeName(we.metadata.name, names)),
-    workloadGroups: unfiltered.workloadGroups.filter(wg => includeName(wg.metadata.name, names)),
-    envoyFilters: unfiltered.envoyFilters.filter(ef => includeName(ef.metadata.name, names)),
+    gateways: unfiltered.gateways?.filter(gw => includeName(gw.metadata.name, names)),
+    virtualServices: unfiltered.virtualServices?.filter(vs => includeName(vs.metadata.name, names)),
+    destinationRules: unfiltered.destinationRules?.filter(dr => includeName(dr.metadata.name, names)),
+    serviceEntries: unfiltered.serviceEntries?.filter(se => includeName(se.metadata.name, names)),
+    authorizationPolicies: unfiltered.authorizationPolicies?.filter(rc => includeName(rc.metadata.name, names)),
+    sidecars: unfiltered.sidecars?.filter(sc => includeName(sc.metadata.name, names)),
+    peerAuthentications: unfiltered.peerAuthentications?.filter(pa => includeName(pa.metadata.name, names)),
+    requestAuthentications: unfiltered.requestAuthentications?.filter(ra => includeName(ra.metadata.name, names)),
+    workloadEntries: unfiltered.workloadEntries?.filter(we => includeName(we.metadata.name, names)),
+    workloadGroups: unfiltered.workloadGroups?.filter(wg => includeName(wg.metadata.name, names)),
+    envoyFilters: unfiltered.envoyFilters?.filter(ef => includeName(ef.metadata.name, names)),
     validations: unfiltered.validations,
     permissions: unfiltered.permissions
   };

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -36,6 +36,8 @@ export interface IstioConfigItem {
   validation?: ObjectValidation;
 }
 
+export declare type IstioConfigsMap = Map<string, IstioConfigList>;
+
 export interface IstioConfigList {
   namespace: Namespace;
   gateways: Gateway[];
@@ -114,17 +116,17 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
   }
   return {
     namespace: unfiltered.namespace,
-    gateways: unfiltered.gateways?.filter(gw => includeName(gw.metadata.name, names)),
-    virtualServices: unfiltered.virtualServices?.filter(vs => includeName(vs.metadata.name, names)),
-    destinationRules: unfiltered.destinationRules?.filter(dr => includeName(dr.metadata.name, names)),
-    serviceEntries: unfiltered.serviceEntries?.filter(se => includeName(se.metadata.name, names)),
-    authorizationPolicies: unfiltered.authorizationPolicies?.filter(rc => includeName(rc.metadata.name, names)),
-    sidecars: unfiltered.sidecars?.filter(sc => includeName(sc.metadata.name, names)),
-    peerAuthentications: unfiltered.peerAuthentications?.filter(pa => includeName(pa.metadata.name, names)),
-    requestAuthentications: unfiltered.requestAuthentications?.filter(ra => includeName(ra.metadata.name, names)),
-    workloadEntries: unfiltered.workloadEntries?.filter(we => includeName(we.metadata.name, names)),
-    workloadGroups: unfiltered.workloadGroups?.filter(wg => includeName(wg.metadata.name, names)),
-    envoyFilters: unfiltered.envoyFilters?.filter(ef => includeName(ef.metadata.name, names)),
+    gateways: unfiltered.gateways.filter(gw => includeName(gw.metadata.name, names)),
+    virtualServices: unfiltered.virtualServices.filter(vs => includeName(vs.metadata.name, names)),
+    destinationRules: unfiltered.destinationRules.filter(dr => includeName(dr.metadata.name, names)),
+    serviceEntries: unfiltered.serviceEntries.filter(se => includeName(se.metadata.name, names)),
+    authorizationPolicies: unfiltered.authorizationPolicies.filter(rc => includeName(rc.metadata.name, names)),
+    sidecars: unfiltered.sidecars.filter(sc => includeName(sc.metadata.name, names)),
+    peerAuthentications: unfiltered.peerAuthentications.filter(pa => includeName(pa.metadata.name, names)),
+    requestAuthentications: unfiltered.requestAuthentications.filter(ra => includeName(ra.metadata.name, names)),
+    workloadEntries: unfiltered.workloadEntries.filter(we => includeName(we.metadata.name, names)),
+    workloadGroups: unfiltered.workloadGroups.filter(wg => includeName(wg.metadata.name, names)),
+    envoyFilters: unfiltered.envoyFilters.filter(ef => includeName(ef.metadata.name, names)),
     validations: unfiltered.validations,
     permissions: unfiltered.permissions
   };

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -62,6 +62,13 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if allNamespaces && len(nss) == 0 {
+		allNamespaces, _ := business.Namespace.GetNamespaces(r.Context())
+		for _, ns := range allNamespaces {
+			nss = append(nss, ns.Name)
+		}
+	}
+
 	var istioConfigValidations models.IstioValidations
 
 	wg := sync.WaitGroup{}

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -168,6 +168,7 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 	for _, ns := range nss {
 		if filtered[ns] == nil {
 			filtered[ns] = new(IstioConfigList)
+			filtered[ns].Namespace = Namespace{Name: ns}
 		}
 		for _, dr := range configList.DestinationRules {
 			if dr.Namespace == ns {

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -170,6 +170,17 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 			filtered[ns] = new(IstioConfigList)
 			filtered[ns].IstioValidations = IstioValidations{}
 			filtered[ns].Namespace = Namespace{Name: ns}
+			filtered[ns].DestinationRules = []*networking_v1beta1.DestinationRule{}
+			filtered[ns].EnvoyFilters = []*networking_v1alpha3.EnvoyFilter{}
+			filtered[ns].Gateways = []*networking_v1beta1.Gateway{}
+			filtered[ns].VirtualServices = []*networking_v1beta1.VirtualService{}
+			filtered[ns].ServiceEntries = []*networking_v1beta1.ServiceEntry{}
+			filtered[ns].Sidecars = []*networking_v1beta1.Sidecar{}
+			filtered[ns].WorkloadEntries = []*networking_v1beta1.WorkloadEntry{}
+			filtered[ns].WorkloadGroups = []*networking_v1beta1.WorkloadGroup{}
+			filtered[ns].AuthorizationPolicies = []*security_v1beta.AuthorizationPolicy{}
+			filtered[ns].PeerAuthentications = []*security_v1beta.PeerAuthentication{}
+			filtered[ns].RequestAuthentications = []*security_v1beta.RequestAuthentication{}
 		}
 		for _, dr := range configList.DestinationRules {
 			if dr.Namespace == ns {

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -235,6 +235,7 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 				filtered[ns].RequestAuthentications = append(filtered[ns].RequestAuthentications, ra)
 			}
 		}
+		filtered[ns].IstioValidations = configList.IstioValidations
 	}
 	return &filtered
 }

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -168,6 +168,7 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 	for _, ns := range nss {
 		if filtered[ns] == nil {
 			filtered[ns] = new(IstioConfigList)
+			filtered[ns].IstioValidations = IstioValidations{}
 			filtered[ns].Namespace = Namespace{Name: ns}
 		}
 		for _, dr := range configList.DestinationRules {
@@ -235,7 +236,11 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 				filtered[ns].RequestAuthentications = append(filtered[ns].RequestAuthentications, ra)
 			}
 		}
-		filtered[ns].IstioValidations = configList.IstioValidations
+		for k, v := range configList.IstioValidations {
+			if k.Namespace == ns {
+				filtered[ns].IstioValidations.MergeValidations(IstioValidations{k: v})
+			}
+		}
 	}
 	return &filtered
 }


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5153

Before, while loading Istio Config list:
It was requesting configs per namespace.

Now: it does not provide namespace list into API call, and the handler loads all configs for all namespaces.
This approach is used,  as handler is now loading configs from Registry, where all configs are cached for all namespaces.


