### PR TITLE
Perf tests for overview page and varying namespaces

### DIFF
--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -75,6 +75,8 @@ cli
 make -e CYPRESS_BASE_URL=http://mybaseurl perf-tests-run
 ```
 
+**Note**: The performance tests are typically long running tests that perform many actions. The Cypress GUI generally does not handle this well so it's recommended to use the CLI instead.
+
 gui
 ```
 make perf-tests-gui
@@ -85,13 +87,20 @@ yarn from current dir
 yarn cypress --config-file cypress-perf.json
 ```
 
-### Update url parameters:
+### Parameterizing tests:
 
-You can adjust some inputs of the performance tests by changing the [fixture file](fixtures/perf/graphParams.json).
+You can adjust some inputs of the performance tests by changing the [fixture files](fixtures/perf/).
 
 ### Results:
 
 Results are logged here: `logs/performance.txt`
+
+### Cleanup
+
+If the test runner fails for any reason, this can leave some resources lingering around after the tests have run. You can clean these up by running:
+```
+kubectl delete --ignore-not-found=true -l kiali.io=perf-testing ns
+```
 
 ### Running on IBM Cloud:
 

--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -101,6 +101,22 @@ You can use the [perf hack script](../../hack/perf-ibmcloud-openshift.sh) to spi
 make -e CYPRESS_BASE_URL="https://<kiali-openshift-route>" -e CYPRESS_PASSWD="<IBMCloud API Key>" -e CYPRESS_USERNAME="IAM#<SSO-EMAIL>" -e CYPRESS_AUTH_PROVIDER="ibmcloud" perf-tests-gui
 ```
 
+#### Logging into your cluster on IBM Cloud:
+
+For `kubectl` or `oc` access to your cluster, use:
+
+```
+ibmcloud oc cluster config --cluster <cluster-name> --admin
+```
+
+#### Teardown cluster
+
+The cluster can be cleaned up with the `ibmcloud-openshift.sh` script. You must provide the cluster name without the trailing `-cluster` e.g. if your cluster is named `my-perf-cluster` you should pass `my-perf` as the name prefix (np).
+
+```
+./hack/ibmcloud-openshift.sh -np <cluster-name-without-trailing-cluster> delete
+```
+
 ## Testing Strategies
 
 

--- a/frontend/cypress/fixtures/perf/overviewPage.json
+++ b/frontend/cypress/fixtures/perf/overviewPage.json
@@ -1,0 +1,11 @@
+[
+  {
+    "namespaces": 10
+  },
+  {
+    "namespaces": 50
+  },
+  {
+    "namespaces": 300
+  }
+]

--- a/frontend/cypress/perf/Graphload.spec.ts
+++ b/frontend/cypress/perf/Graphload.spec.ts
@@ -16,7 +16,8 @@ metadata:
 
 function deleteNamespaces() {
   cy.log('Deleting namespaces...');
-  cy.exec('kubectl delete --ignore-not-found=true -l kiali.io=perf-testing ns');
+  // This can take awhile to delete. Waiting for 10 mins max.
+  cy.exec('kubectl delete --ignore-not-found=true -l kiali.io=perf-testing ns', {timeout: 600000});
 }
 
 type OverviewCase = {

--- a/frontend/cypress/perf/Graphload.spec.ts
+++ b/frontend/cypress/perf/Graphload.spec.ts
@@ -1,71 +1,163 @@
-describe('graphload', () => {
+function namespaceName(index: number) {
+  return `perf-testing-${index}`;
+}
 
+function createNamespaces(count: number) {
+  cy.log(`Creating ${count} namespaces...`);
+  for (let i = 1; i <= count; i++) {
+    createNamespace(namespaceName(i));
+  }
+}
+
+function createNamespace(name: string) {
+  cy.exec(`kubectl get ns ${name} || kubectl create ns ${name}`);
+}
+
+function deleteNamespaces(count: number) {
+  cy.log(`Deleting ${count} namespaces...`);
+  // Fire off async delete requests then wait for them to complete.
+  for (let i = 1; i <= count; i++) {
+    deleteNamespace(namespaceName(i));
+  }
+
+  cy.log('Waiting for namespaces to be deleted...');
+  for (let i = 1; i <= count; i++) {
+    cy.exec(`kubectl wait --for=delete --timeout=5m namespace/${namespaceName(i)}`);
+  }
+}
+
+function deleteNamespace(name: string) {
+  cy.exec(`kubectl delete --ignore-not-found=true --wait=false ns ${name}`);
+}
+
+describe('Performance tests', () => {
+  const reportFilePath = 'logs/performance.txt';
+
+  before(() => {
+    // Setup the perf report.
+    cy.writeFile(reportFilePath, 'PERFORMANCE REPORT\n\n');
+
+    cy.login(Cypress.env('USERNAME'), Cypress.env('PASSWD'));
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('kiali-token-aes');
+  });
+
+  // Testing empty namespaces to understand the impact of adding namespaces alone.
+  describe('Overview page with empty namespaces', () => {
+    const overviewCases = [
+      {
+        namespaces: 10
+      },
+      {
+        namespaces: 50
+      },
+      {
+        namespaces: 300
+      }
+    ];
+
+    before(() => {
+      cy.writeFile(reportFilePath, '[Empty Namespaces]\n\n', { flag: 'a+' });
+    });
+
+    overviewCases.forEach(function (testCase) {
+      describe(`Test with ${testCase.namespaces} empty namespaces`, () => {
+        before(() => {
+          createNamespaces(testCase.namespaces);
+        });
+
+        after(() => {
+          deleteNamespaces(testCase.namespaces);
+        });
+
+        it('loads the overview page', () => {
+          // Disabling refresh so that we can see how long it takes to load the page without additional requests
+          // being made due to the refresh.
+          cy.visit('/console/overview?refresh=0', {
+            onBeforeLoad(win) {
+              win.performance.mark('start');
+            }
+          })
+            .its('performance')
+            .then(performance => {
+              cy.get('.pf-l-grid').should('be.visible');
+              cy.get('#loading_kiali_spinner', { timeout: 300000 })
+                .should('not.exist')
+                .then(() => {
+                  performance.mark('end');
+                  performance.measure('initPageLoad', 'start', 'end');
+                  const measure = performance.getEntriesByName('initPageLoad')[0];
+                  const duration = measure.duration;
+                  assert.isAtMost(duration, Cypress.env('threshold'));
+
+                  const contents = `Namespaces: ${testCase.namespaces}
+  Init page load time: ${(duration / 1000).toPrecision(5)} seconds
+
+`;
+                  cy.writeFile(reportFilePath, contents, { flag: 'a+' });
+                });
+            });
+        });
+      });
+    });
+  });
+
+  describe('Graph page with workloads', () => {
     var graphUrl;
 
     before(() => {
-        cy.fixture('graphParams')
-            .then(function (data) {
-                graphUrl = encodeURI("/console/graph/namespaces?traffic="+data.traffic
-                    +"&graphType="+data.graphType
-                    +"&namespaces="+data.namespaces
-                    +"&duration="+data.duration
-                    +"&refresh="+data.refresh
-                    +"&layout="+data.layout
-                    +"&namespaceLayout="+data.namespaceLayout);
-            })
-            .as('data');
-
-        cy.login(Cypress.env('USERNAME'), Cypress.env('PASSWD'));
-    })
-
-    beforeEach(() => {
-        Cypress.Cookies.preserveOnce('kiali-token-aes');
-    })
-
-    it('Visit Main Page', () => {
-        cy.visit("/", {
-            onBeforeLoad(win) {
-                win.performance.mark("start");
-            }
+      cy.fixture('graphParams')
+        .then(function (data) {
+          graphUrl = encodeURI(
+            '/console/graph/namespaces?traffic=' +
+              data.traffic +
+              '&graphType=' +
+              data.graphType +
+              '&namespaces=' +
+              data.namespaces +
+              '&duration=' +
+              data.duration +
+              '&refresh=' +
+              data.refresh +
+              '&layout=' +
+              data.layout +
+              '&namespaceLayout=' +
+              data.namespaceLayout
+          );
         })
-        .its("performance").then((performance) => {
+        .as('data');
 
-            cy.get(".pf-l-grid").should('be.visible')
-                .then(() => {
-                    performance.mark("end")
-                    performance.measure("initPageLoad", "start", "end");
-                    const measure = performance.getEntriesByName("initPageLoad")[0];
-                    const duration = measure.duration;
-                    assert.isAtMost(duration, Cypress.env('threshold'));
+      cy.writeFile(reportFilePath, '[Graph page With workloads]\n\n', { flag: 'a+' });
+    });
 
-                    cy.writeFile('logs/performance.txt', `[PERFORMANCE] Init page load time: \n ${duration / 1000} seconds\n`)
-                })
-        })
-    })
+    it('Measures Graph load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
+      cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
+      cy.visit(graphUrl, {
+        onBeforeLoad(win) {
+          win.performance.mark('start');
+        }
+      })
+        .its('performance')
+        .then(performance => {
+          cy.wait('@graphNamespaces');
 
-    it('Measure Graph load time', {
-            defaultCommandTimeout: Cypress.env('timeout')
-    }, () => {
-        cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
-        cy.visit(graphUrl, {
-            onBeforeLoad(win) {
-                win.performance.mark("start");
-            }
-        })
-        .its("performance").then((performance) => {
-            cy.wait('@graphNamespaces')
+          cy.get('#cy', { timeout: 10000 })
+            .should('be.visible')
+            .then(() => {
+              performance.mark('end');
+              performance.measure('pageLoad', 'start', 'end');
+              const measure = performance.getEntriesByName('pageLoad')[0];
+              const duration = measure.duration;
+              assert.isAtMost(duration, Cypress.env('threshold'));
 
-            cy.get("#cy", { timeout: 10000 }).should('be.visible')
-                .then(() => {
-                    performance.mark("end")
-                    performance.measure("pageLoad", "start", "end");
-                    const measure = performance.getEntriesByName("pageLoad")[0];
-                    const duration = measure.duration;
-                    assert.isAtMost(duration, Cypress.env('threshold'));
+              const contents = `Graph load time for ${graphUrl}: ${(duration / 1000).toPrecision(5)} seconds
 
-                    cy.writeFile('logs/performance.txt', `[PERFORMANCE] Graph load time for ${graphUrl}: \n ${duration / 1000} seconds\n`, { flag: 'a+' })
-                })
-
-        })
-    })
-})
+  `;
+              cy.writeFile(reportFilePath, contents, { flag: 'a+' });
+            });
+        });
+    });
+  });
+});

--- a/frontend/cypress/plugins/bdd.ts
+++ b/frontend/cypress/plugins/bdd.ts
@@ -12,5 +12,5 @@ module.exports = (on, config) => {
 
   on('file:preprocessor', cucumber(options));
 
-  return config
+  return config;
 };

--- a/frontend/cypress/tsconfig.json
+++ b/frontend/cypress/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "target": "es5",
     "lib": ["es2019", "dom"],
-    "types": [
-      "cypress",
-      "cypress-react-selector",
-      "node"
-    ]
+    "resolveJsonModule": true,
+    "types": ["cypress", "cypress-react-selector", "node"]
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
Adds performance tests for the overview page when varying amounts of namespaces are present to understand the impact of merely having a larger number of namespaces.

Related to #5144 