### PR TITLE
Alignment of Display Dropdown in Graph options

### DIFF
--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -187,7 +187,7 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
           onHandleRefresh={this.handleRefresh}
         />
         <Toolbar style={{ width: '100%' }}>
-          <ToolbarGroup aria-label="graph settings" style={{ margin: 0 }}>
+          <ToolbarGroup aria-label="graph settings" style={{ margin: 0, alignItems: "flex-start"}}>
             {this.props.node && (
               <ToolbarItem style={{ margin: 0 }}>
                 <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content={'Back to full graph'}>


### PR DESCRIPTION
The "Display" drop down in the the Graph page is misaligned when an invalid operand is typed (Find...)
As the container is display as a flex, the issue can be fixed with a align-items property.

Fixes #5302 