### PR TITLE
Add padding to charts equal to largest data size

### DIFF
--- a/frontend/src/components/Charts/ChartWithLegend.tsx
+++ b/frontend/src/components/Charts/ChartWithLegend.tsx
@@ -144,18 +144,10 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
     const overlayIdx = this.props.data.length;
     const showOverlay = (this.props.overlay && this.props.showSpans) || false;
     const overlayRightPadding = showOverlay ? 15 : 0;
-    let largestSize = 0;
-    this.props.data.forEach(dataSet => {
-      dataSet.datapoints.forEach(dp => {
-        if (dp.size !== undefined) {
-          largestSize = Math.max(largestSize, dp.size);
-        }
-      });
-    });
     const padding: Padding = {
-      top: largestSize,
+      top: 0,
       bottom: chartHeight > MIN_HEIGHT_YAXIS ? LEGEND_HEIGHT : 0,
-      left: largestSize,
+      left: 0,
       right: 10 + overlayRightPadding
     };
 
@@ -226,8 +218,11 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
             () => this.mouseOnLegend
           )}
           scale={{ x: this.props.xAxis === 'series' ? 'linear' : 'time' }}
-          // Hack: 1 pxl on Y domain padding to prevent harsh clipping (https://github.com/kiali/kiali/issues/2069)
-          domainPadding={{ y: 1, x: this.props.xAxis === 'series' ? 50 : undefined }}
+          // Hack: Need at least 1 pxl on Y domain padding to prevent harsh clipping (https://github.com/kiali/kiali/issues/2069)
+          // Hack: Chart points on the very edges are not clickable due to extra padding and the chart
+          // not resizing correctly for some reason. The additional domain padding squeezes the elements
+          // into the chart so that they are no longer on the edges (https://github.com/kiali/kiali/issues/5222).
+          domainPadding={{ y: 10, x: this.props.xAxis === 'series' ? 50 : 15 }}
           {...this.props.moreChartProps}
         >
           {

--- a/frontend/src/components/Charts/ChartWithLegend.tsx
+++ b/frontend/src/components/Charts/ChartWithLegend.tsx
@@ -144,10 +144,18 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
     const overlayIdx = this.props.data.length;
     const showOverlay = (this.props.overlay && this.props.showSpans) || false;
     const overlayRightPadding = showOverlay ? 15 : 0;
+    let largestSize = 0;
+    this.props.data.forEach(dataSet => {
+      dataSet.datapoints.forEach(dp => {
+        if (dp.size !== undefined) {
+          largestSize = Math.max(largestSize, dp.size);
+        }
+      });
+    });
     const padding: Padding = {
-      top: 0,
+      top: largestSize,
       bottom: chartHeight > MIN_HEIGHT_YAXIS ? LEGEND_HEIGHT : 0,
-      left: 0,
+      left: largestSize,
       right: 10 + overlayRightPadding
     };
 
@@ -241,11 +249,7 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
                 }}
               />
             ) : (
-              <ChartAxis
-                tickCount={scaleInfo.count}
-                style={AxisStyle}
-                domain={this.props.timeWindow}
-              />
+              <ChartAxis tickCount={scaleInfo.count} style={AxisStyle} domain={this.props.timeWindow} />
             )
           }
           <ChartAxis
@@ -507,7 +511,7 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
               fill: this.props.fill ? color : undefined,
               stroke: this.props.stroke ? color : undefined,
               strokeDasharray: strokeDasharray === true ? '3 5' : undefined,
-              cursor: this.props.pointer ? 'pointer' : 'default',
+              cursor: this.props.pointer ? 'pointer' : 'default'
             }
           }
         };


### PR DESCRIPTION
This ensures that the clickable area of the chart encompasses the largest point. Otherwise the points on the edge of the graph can't be clicked.

fixes #5222 