### PR TITLE
Consider objects from own namespace only in workload selector/less checkers.

### DIFF
--- a/business/checkers/common/multi_match_selector_checker_test.go
+++ b/business/checkers/common/multi_match_selector_checker_test.go
@@ -36,12 +36,28 @@ func TestTwoSidecarsWithoutSelector(t *testing.T) {
 		[]*networking_v1beta1.Sidecar{
 			data.CreateSidecar("sidecar1", "bookinfo"),
 			data.CreateSidecar("sidecar2", "bookinfo"),
+			data.CreateSidecar("sidecar3", "bookinfo2"),
 		},
 		workloadList(),
 	).Check()
 
 	assertMultimatchFailure(t, "generic.multimatch.selectorless", validations, "sidecar1", []string{"sidecar2"})
 	assertMultimatchFailure(t, "generic.multimatch.selectorless", validations, "sidecar2", []string{"sidecar1"})
+}
+
+func TestTwoSidecarsWithoutSelectorDifferentNamespaces(t *testing.T) {
+	assert := assert.New(t)
+
+	validations := SidecarSelectorMultiMatchChecker(
+		"sidecar",
+		[]*networking_v1beta1.Sidecar{
+			data.CreateSidecar("sidecar1", "bookinfo"),
+			data.CreateSidecar("sidecar2", "bookinfo2"),
+		},
+		workloadList(),
+	).Check()
+
+	assert.Empty(validations)
 }
 
 func TestTwoSidecarsTargetingOneDeployment(t *testing.T) {
@@ -111,15 +127,15 @@ func TestSidecarsDifferentNamespaces(t *testing.T) {
 		}, data.CreateSidecar("sidecar1", "bookinfo")),
 		data.AddSelectorToSidecar(map[string]string{
 			"app":     "details",
-			"version": "v1",
+			"version": "v2",
 		}, data.CreateSidecar("sidecar2", "bookinfo2")),
 		data.AddSelectorToSidecar(map[string]string{
 			"app":     "details",
-			"version": "v1",
+			"version": "v3",
 		}, data.CreateSidecar("sidecar3", "bookinfo3")),
 		data.AddSelectorToSidecar(map[string]string{
 			"app":     "details",
-			"version": "v1",
+			"version": "v4",
 		}, data.CreateSidecar("sidecar4", "bookinfo4")),
 	}
 	validations := SidecarSelectorMultiMatchChecker(
@@ -162,5 +178,5 @@ func workloadList() map[string]models.WorkloadList {
 		data.CreateWorkloadListItem("details-v3", map[string]string{"app": "details", "version": "v3"}),
 	}
 
-	return data.CreateWorkloadsPerNamespace("bookinfo", wli...)
+	return data.CreateWorkloadsPerNamespace([]string{"bookinfo", "bookinfo2", "bookinfo3", "bookinfo4"}, wli...)
 }

--- a/business/checkers/common/workload_selector_checker_test.go
+++ b/business/checkers/common/workload_selector_checker_test.go
@@ -54,7 +54,7 @@ func testFailureWithWorkloadList(assert *assert.Assertions, selector map[string]
 }
 
 func testFailureWithEmptyWorkloadList(assert *assert.Assertions, selector map[string]string) {
-	testFailure(assert, selector, data.CreateWorkloadsPerNamespace("test", models.WorkloadListItem{}), "generic.selector.workloadnotfound")
+	testFailure(assert, selector, data.CreateWorkloadsPerNamespace([]string{"test"}, models.WorkloadListItem{}), "generic.selector.workloadnotfound")
 }
 
 func testFailure(assert *assert.Assertions, selector map[string]string, wl map[string]models.WorkloadList, code string) {

--- a/tests/data/validations/destinationrules/no-subset-labels-checker.yaml
+++ b/tests/data/validations/destinationrules/no-subset-labels-checker.yaml
@@ -1,0 +1,10 @@
+apiVersion: "networking.istio.io/v1beta1"
+kind: "DestinationRule"
+metadata:
+  name: "no-subset-labels"
+  namespace: "bookinfo"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/tests/data/workload_data.go
+++ b/tests/data/workload_data.go
@@ -2,9 +2,11 @@ package data
 
 import "github.com/kiali/kiali/models"
 
-func CreateWorkloadsPerNamespace(namespace string, items ...models.WorkloadListItem) map[string]models.WorkloadList {
+func CreateWorkloadsPerNamespace(namespaces []string, items ...models.WorkloadListItem) map[string]models.WorkloadList {
 	allWorkloads := map[string]models.WorkloadList{}
-	allWorkloads[namespace] = CreateWorkloadList(namespace, items...)
+	for _, namespace := range namespaces {
+		allWorkloads[namespace] = CreateWorkloadList(namespace, items...)
+	}
 	return allWorkloads
 }
 


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/5310
When checking "KIA0002 More than one selector-less object in the same namespace" and "KIA0003 More than one object applied to the same workload" for Sidecars, PeerAuthentications and RequestAuthentiations, it should show validation reference objects to only local namespace objects. Cross namespace validations are not supported for these object types.

Before: Sidecars, PeerAuths and RequestAuths validations of workload selectors "KIA0003" and "KIA0002" were considering objects from all namespaces.
![Screenshot from 2022-07-19 14-43-24](https://user-images.githubusercontent.com/604313/179753136-27ac110b-b858-4cdb-a412-2acd52313ddb.png)
![Screenshot from 2022-07-19 14-40-49](https://user-images.githubusercontent.com/604313/179753175-71335784-3732-4347-a529-34ba99534963.png)

Now: As those objects are not supporting cross-namespace validations, consider objects only from own namespace.
![Screenshot from 2022-07-19 14-41-35](https://user-images.githubusercontent.com/604313/179753208-5df3bbba-5e7d-41a2-9e26-39f72eb5e929.png)
![Screenshot from 2022-07-19 14-43-48](https://user-images.githubusercontent.com/604313/179754061-ed4c9c7d-66db-43a7-84cb-efd6c1712d26.png)
