### PR TITLE
Adjust the view in Grafana and View in tracing link

### DIFF
--- a/frontend/src/components/JaegerIntegration/TracesComponent.tsx
+++ b/frontend/src/components/JaegerIntegration/TracesComponent.tsx
@@ -248,18 +248,17 @@ class TracesComponent extends React.Component<TracesProps, TracesState> {
                       disabled={this.state.toolbarDisabled}
                     />
                   </ToolbarItem>
-                </ToolbarGroup>
-                {jaegerURL && (
-                  <ToolbarGroup style={{ marginLeft: 'auto' }}>
-                    <ToolbarItem>
-                      <Tooltip content={<>Open Chart in Jaeger UI</>}>
-                        <a href={jaegerURL} target="_blank" rel="noopener noreferrer" style={{ marginLeft: '10px' }}>
-                          View in Tracing <ExternalLinkAltIcon />
-                        </a>
-                      </Tooltip>
+                  {jaegerURL && (
+                    <ToolbarItem style={{ marginLeft: 'auto' }}>
+                        <Tooltip content={<>Open Chart in Jaeger UI</>}>
+                          <a href={jaegerURL} target="_blank" rel="noopener noreferrer" style={{ marginLeft: '10px' }}>
+                            View in Tracing <ExternalLinkAltIcon />
+                          </a>
+                        </Tooltip>
                     </ToolbarItem>
-                  </ToolbarGroup>
-                )}
+                  )}
+                </ToolbarGroup>
+
               </Toolbar>
               <JaegerScatter
                 showSpansAverage={this.state.displaySettings.showSpansAverage}

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -307,7 +307,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
   private renderOptionsBar() {
     return (
       <div ref={this.toolbarRef}>
-        <Toolbar style={{ padding: 0 }}>
+        <Toolbar style={{ padding: 0, marginBottom: "20px" }}>
           <ToolbarGroup>
             <ToolbarItem>
               <MetricsSettingsDropdown
@@ -345,14 +345,14 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
                 onChange={checked => this.onTrendlines(checked)}
               />
             </ToolbarItem>
-          </ToolbarGroup>
-          <ToolbarGroup style={{ marginLeft: 'auto', paddingRight: '20px' }}>
-            <GrafanaLinks
-              links={this.state.grafanaLinks}
-              namespace={this.props.namespace}
-              object={this.props.object}
-              objectType={this.props.objectType}
-            />
+            <ToolbarItem style={{ marginLeft: 'auto', paddingRight: '20px' }}>
+              <GrafanaLinks
+                links={this.state.grafanaLinks}
+                namespace={this.props.namespace}
+                object={this.props.object}
+                objectType={this.props.objectType}
+              />
+            </ToolbarItem>
           </ToolbarGroup>
         </Toolbar>
       </div>


### PR DESCRIPTION
Place "View in Grafana" link in the same row of the metrics filters. 

Also place "View in Tracing" link in the same row that the filters. It looks to have the same issue:

![Screenshot from 2022-07-20 10-45-57](https://user-images.githubusercontent.com/49480155/179952889-ca8efce1-114f-4c23-a29f-ec1b672f37be.png)


Fixes #5273 
Fixes #5287