### PR TITLE
Milliseconds precision for sorting log entries in the Logs tab

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -527,6 +527,8 @@ func parseLogLine(line string, isProxy bool, engardeParser *parser.Parser) *LogE
 	if len(precision) > 1 {
 		ms := precision[1]
 		milliseconds = ms[:3]
+		splittedms := strings.Fields(milliseconds) // This is needed to avoid invalid dates in ms like 200
+		milliseconds = splittedms[0]
 	} else {
 		milliseconds = "000"
 	}

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -527,18 +527,18 @@ func parseLogLine(line string, isProxy bool, engardeParser *parser.Parser) *LogE
 	}
 
 	// override the timestamp with a simpler format
-	milis := strings.Split(parsedTimestamp.String(), ".")
-	var m, milisec string
-	if len(milis) > 1 {
-		m = milis[1]
-		milisec = m[:3]
+	precision := strings.Split(parsedTimestamp.String(), ".")
+	var milliseconds string
+	if len(precision) > 1 {
+		ms := precision[1]
+		milliseconds = ms[:3]
 	} else {
-		milisec = "000"
+		milliseconds = "000"
 	}
 
 	timestamp := fmt.Sprintf("%d-%02d-%02d %02d:%02d:%02d.%s",
 		parsedTimestamp.Year(), parsedTimestamp.Month(), parsedTimestamp.Day(),
-		parsedTimestamp.Hour(), parsedTimestamp.Minute(), parsedTimestamp.Second(), milisec)
+		parsedTimestamp.Hour(), parsedTimestamp.Minute(), parsedTimestamp.Second(), milliseconds)
 	entry.Timestamp = timestamp
 	entry.TimestampUnix = parsedTimestamp.UnixMilli()
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -541,7 +541,6 @@ func parseLogLine(line string, isProxy bool, engardeParser *parser.Parser) *LogE
 	entry.Timestamp = timestamp
 	entry.TimestampUnix = parsedTimestamp.Unix()
 
-	fmt.Println("timestamp: " + timestamp + " message:  " + entry.Message)
 	return &entry
 }
 
@@ -1846,7 +1845,7 @@ func (in *WorkloadService) streamParsedLogs(namespace, name string, opts *LogOpt
 	}
 
 	engardeParser := parser.New(parser.IstioProxyAccessLogsPattern)
-	//engardeParser := parser.New(`\[%{TIMESTAMP:timestamp:ts-"YYYY-MM-dd HH:mm:ss[,.]SSS"}\] \"%{DATA:method} (?:(?:%{URIPATH:uri_path}(?:%{URIPARAM:uri_param})?)|%{DATA}) %{DATA:protocol}\" %{NUMBER:status_code} %{DATA:response_flags} \"%{DATA:mixer_status}\"(?: \"%{DATA:upstream_failure_reason}\")? %{NUMBER:bytes_received} %{NUMBER:bytes_sent} %{NUMBER:duration} (?:%{NUMBER:upstream_service_time}|%{DATA:tcp_service_time}) \"%{DATA:forwarded_for}\" \"%{DATA:user_agent}\" \"%{DATA:request_id}\" \"%{DATA:authority}\" \"%{DATA:upstream_service}\" %{DATA:upstream_cluster} %{DATA:upstream_local} %{DATA:downstream_local} %{DATA:downstream_remote} %{DATA:requested_server}(?: %{DATA:route_name})?$`)
+
 	// To avoid high memory usage, the JSON will be written
 	// to the HTTP Response as it's received from the cluster API.
 	// That is, each log line is parsed, decorated with Kiali's metadata,

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -467,6 +467,7 @@ func parseLogLine(line string, isProxy bool, engardeParser *parser.Parser) *LogE
 	}
 
 	// k8s promises RFC3339 or RFC3339Nano timestamp, ensure RFC3339
+	// Split by blanks, to get the miliseconds for sorting, try RFC3339Nano
 	splittedTimestamp := strings.Fields(splitted[0])
 	if len(splittedTimestamp) == 1 {
 		entry.Timestamp = splittedTimestamp[0]

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -539,7 +539,7 @@ func parseLogLine(line string, isProxy bool, engardeParser *parser.Parser) *LogE
 		parsedTimestamp.Year(), parsedTimestamp.Month(), parsedTimestamp.Day(),
 		parsedTimestamp.Hour(), parsedTimestamp.Minute(), parsedTimestamp.Second(), milisec)
 	entry.Timestamp = timestamp
-	entry.TimestampUnix = parsedTimestamp.Unix()
+	entry.TimestampUnix = parsedTimestamp.UnixMilli()
 
 	return &entry
 }

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -468,12 +468,7 @@ func parseLogLine(line string, isProxy bool, engardeParser *parser.Parser) *LogE
 
 	// k8s promises RFC3339 or RFC3339Nano timestamp, ensure RFC3339
 	// Split by blanks, to get the miliseconds for sorting, try RFC3339Nano
-	splittedTimestamp := strings.Fields(splitted[0])
-	if len(splittedTimestamp) == 1 {
-		entry.Timestamp = splittedTimestamp[0]
-	} else {
-		entry.Timestamp = fmt.Sprintf("%sZ", splittedTimestamp[0])
-	}
+	entry.Timestamp = splitted[0]
 
 	entry.Message = strings.TrimSpace(splitted[1])
 	if entry.Message == "" {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -436,7 +436,7 @@ func (in *WorkloadService) BuildLogOptionsCriteria(container, duration, isProxy,
 			return nil, fmt.Errorf("Invalid sinceTime [%s]: %v", sinceTime, err)
 		}
 
-		opts.SinceTime = &meta_v1.Time{Time: time.Unix(numTime, 1000000)}
+		opts.SinceTime = &meta_v1.Time{Time: time.Unix(numTime, 0)}
 	}
 
 	if maxLines != "" {

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -573,23 +573,23 @@ func TestGetPodLogs(t *testing.T) {
 
 	assert.Equal(len(podLogs.Entries), 4)
 
-	assert.Equal("2018-01-02 03:34:28", podLogs.Entries[0].Timestamp)
-	assert.Equal(int64(1514864068), podLogs.Entries[0].TimestampUnix)
+	assert.Equal("2018-01-02 03:34:28.000", podLogs.Entries[0].Timestamp)
+	assert.Equal(int64(1514864068000), podLogs.Entries[0].TimestampUnix)
 	assert.Equal("INFO #1 Log Message", podLogs.Entries[0].Message)
 	assert.Equal("INFO", podLogs.Entries[0].Severity)
 
-	assert.Equal("2018-01-02 04:34:28", podLogs.Entries[1].Timestamp)
-	assert.Equal(int64(1514867668), podLogs.Entries[1].TimestampUnix)
+	assert.Equal("2018-01-02 04:34:28.000", podLogs.Entries[1].Timestamp)
+	assert.Equal(int64(1514867668000), podLogs.Entries[1].TimestampUnix)
 	assert.Equal("WARN #2 Log Message", podLogs.Entries[1].Message)
 	assert.Equal("WARN", podLogs.Entries[1].Severity)
 
-	assert.Equal("2018-01-02 05:34:28", podLogs.Entries[2].Timestamp)
-	assert.Equal(int64(1514871268), podLogs.Entries[2].TimestampUnix)
+	assert.Equal("2018-01-02 05:34:28.000", podLogs.Entries[2].Timestamp)
+	assert.Equal(int64(1514871268000), podLogs.Entries[2].TimestampUnix)
 	assert.Equal("#3 Log Message", podLogs.Entries[2].Message)
 	assert.Equal("INFO", podLogs.Entries[2].Severity)
 
-	assert.Equal("2018-01-02 06:34:28", podLogs.Entries[3].Timestamp)
-	assert.Equal(int64(1514874868), podLogs.Entries[3].TimestampUnix)
+	assert.Equal("2018-01-02 06:34:28.000", podLogs.Entries[3].Timestamp)
+	assert.Equal(int64(1514874868000), podLogs.Entries[3].TimestampUnix)
 	assert.Equal("#4 Log error Message", podLogs.Entries[3].Message)
 	assert.Equal("ERROR", podLogs.Entries[3].Severity)
 }
@@ -714,12 +714,12 @@ func TestGetPodLogsProxy(t *testing.T) {
 	assert.Equal(1, len(podLogs.Entries))
 	entry := podLogs.Entries[0]
 	assert.Equal(`[2021-02-01T21:34:35.533Z] "GET /hotels/Ljubljana HTTP/1.1" 200 - via_upstream - "-" 0 99 14 14 "-" "Go-http-client/1.1" "7e7e2dd0-0a96-4535-950b-e303805b7e27" "hotels.travel-agency:8000" "127.0.2021-02-01T21:34:38.761055140Z 0.1:8000" inbound|8000|| 127.0.0.1:33704 10.129.0.72:8000 10.128.0.79:39880 outbound_.8000_._.hotels.travel-agency.svc.cluster.local default`, entry.Message)
-	assert.Equal("2021-02-01 21:34:35", entry.Timestamp)
+	assert.Equal("2021-02-01 21:34:35.533", entry.Timestamp)
 	assert.NotNil(entry.AccessLog)
 	assert.Equal("GET", entry.AccessLog.Method)
 	assert.Equal("200", entry.AccessLog.StatusCode)
 	assert.Equal("2021-02-01T21:34:35.533Z", entry.AccessLog.Timestamp)
-	assert.Equal(int64(1612215275), entry.TimestampUnix)
+	assert.Equal(int64(1612215275533), entry.TimestampUnix)
 }
 
 func TestDuplicatedControllers(t *testing.T) {

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -924,15 +924,14 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
       .registerAll('logs', promises)
       .then(responses => {
         let entries = [] as Entry[];
-
         if (showSpans) {
           const spans = showSpans ? (responses[0].data as Span[]) : ([] as Span[]);
           entries = spans.map(span => {
-            span.startTime = Math.floor(span.startTime / 1000000);
+             span.startTime = Math.floor(span.startTime / 1000);
             return {
-              timestamp: moment(span.startTime * 1000)
+              timestamp: moment(span.startTime)
                 .utc()
-                .format('YYYY-MM-DD HH:mm:ss.sss'),
+                .format('YYYY-MM-DD HH:mm:ss.SSS'),
               timestampUnix: span.startTime,
               span: span
             } as Entry;

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -959,7 +959,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
         }
 
         const sortedEntries = entries.sort((a, b) => {
-          return a.timestampUnix - b.timestampUnix
+          return a.timestampUnix - b.timestampUnix;
         });
 
         this.setState({

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -1022,7 +1022,8 @@ const formatDate = (timestamp: string): string => {
 
   let entryTimestamp = moment(timestamp)
       .format('YYYY-MM-DD HH:mm:ss.SSS')
-    return entryTimestamp
+
+  return entryTimestamp
 };
 
 const mapStateToProps = (state: KialiAppState) => {

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -501,7 +501,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
       <div key={`al-${index}`} style={{ height: '22px', lineHeight: '22px', paddingLeft: '10px', ...style }}>
         {this.state.showTimestamps && (
           <span key={`al-s-${index}`} style={{ color: le.color!, fontSize: '12px', marginRight: '5px' }}>
-                          {e.timestamp}
+                          {formatDate(le.timestamp)}
                         </span>
         )}
         <Tooltip
@@ -1005,9 +1005,10 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
   };
 
   private entryToString = (entry: Entry): string => {
+
     if (entry.logEntry) {
       const le = entry.logEntry;
-      return this.state.showTimestamps ? `${entry.timestamp} ${le.message}` : le.message;
+      return this.state.showTimestamps ? `${formatDate(entry.timestamp)} ${le.message}` : le.message;
     }
 
     const { duration, operationName } = entry.span!;
@@ -1016,6 +1017,14 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
 
   private hasEntries = (entries: Entry[]): boolean => !!entries && entries.length > 0;
 }
+
+const formatDate = (timestamp: string): string => {
+
+  let entryTimestamp = moment(timestamp)
+      .utc()
+      .format('YYYY-MM-DD HH:mm:ss.SSS')
+    return entryTimestamp
+};
 
 const mapStateToProps = (state: KialiAppState) => {
   return {

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -75,6 +75,7 @@ type ContainerOption = {
 };
 
 type Entry = {
+  milis: TimeInMilliseconds;
   logEntry?: LogEntry;
   span?: Span;
   timestamp: string;
@@ -932,7 +933,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
             return {
               timestamp: moment(span.startTime * 1000)
                 .utc()
-                .format('YYYY-MM-DD HH:mm:ss'),
+                .format('YYYY-MM-DD HH:mm:ss.sss'),
               timestampUnix: span.startTime,
               span: span
             } as Entry;
@@ -950,7 +951,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
           const color = selectedContainers[i].color;
           containerLogEntries.forEach(le => {
             le.color = color;
-            entries.push({ timestamp: le.timestamp, timestampUnix: le.timestampUnix, logEntry: le } as Entry);
+            entries.push({ timestamp: le.timestamp, timestampUnix: le.timestampUnix, milis: le.milis, logEntry: le } as Entry);
           });
 
           if (response.linesTruncated) {
@@ -959,7 +960,10 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
         }
 
         const sortedEntries = entries.sort((a, b) => {
-          return a.timestampUnix - b.timestampUnix;
+          //return a.milis - b.milis;
+          console.log(a.timestamp)
+          console.log(moment(b.timestamp).milliseconds())
+          return moment(a.timestamp).milliseconds() - moment(b.timestamp).milliseconds()
         });
 
         this.setState({
@@ -984,10 +988,12 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
             {
               timestamp: now.toString(),
               timestampUnix: now,
+              milis: now,
               logEntry: {
                 severity: 'Error',
                 timestamp: now.toString(),
                 timestampUnix: now,
+                milis: now,
                 message: `Failed to fetch workload logs: ${errorMsg}`
               }
             }

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -78,7 +78,7 @@ type Entry = {
   logEntry?: LogEntry;
   span?: Span;
   timestamp: string;
-  timestampUnix: TimeInMilliseconds;
+  timestampUnix: TimeInSeconds;
 };
 
 interface WorkloadPodLogsState {

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -927,12 +927,12 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
         if (showSpans) {
           const spans = showSpans ? (responses[0].data as Span[]) : ([] as Span[]);
           entries = spans.map(span => {
-             span.startTime = Math.floor(span.startTime / 1000);
+             let startTimeU = Math.floor(span.startTime / 1000);
             return {
-              timestamp: moment(span.startTime)
+              timestamp: moment(startTimeU)
                 .utc()
                 .format('YYYY-MM-DD HH:mm:ss.SSS'),
-              timestampUnix: span.startTime,
+              timestampUnix: startTimeU,
               span: span
             } as Entry;
           });
@@ -1021,7 +1021,6 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
 const formatDate = (timestamp: string): string => {
 
   let entryTimestamp = moment(timestamp)
-      .utc()
       .format('YYYY-MM-DD HH:mm:ss.SSS')
     return entryTimestamp
 };

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -959,12 +959,6 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
         }
 
         const sortedEntries = entries.sort((a, b) => {
-
-          if (a.timestampUnix == b.timestampUnix) {
-            let at = a.timestamp.substring(a.timestamp.indexOf(".")+1, a.timestamp.length)
-            let bt = b.timestamp.substring(b.timestamp.indexOf(".")+1, b.timestamp.length)
-            return parseInt(at) - parseInt(bt)
-          }
           return a.timestampUnix - b.timestampUnix
         });
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -75,11 +75,10 @@ type ContainerOption = {
 };
 
 type Entry = {
-  milis: TimeInMilliseconds;
   logEntry?: LogEntry;
   span?: Span;
   timestamp: string;
-  timestampUnix: TimeInSeconds;
+  timestampUnix: TimeInMilliseconds;
 };
 
 interface WorkloadPodLogsState {
@@ -951,7 +950,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
           const color = selectedContainers[i].color;
           containerLogEntries.forEach(le => {
             le.color = color;
-            entries.push({ timestamp: le.timestamp, timestampUnix: le.timestampUnix, milis: le.milis, logEntry: le } as Entry);
+            entries.push({ timestamp: le.timestamp, timestampUnix: le.timestampUnix, logEntry: le } as Entry);
           });
 
           if (response.linesTruncated) {
@@ -960,10 +959,13 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
         }
 
         const sortedEntries = entries.sort((a, b) => {
-          //return a.milis - b.milis;
-          console.log(a.timestamp)
-          console.log(moment(b.timestamp).milliseconds())
-          return moment(a.timestamp).milliseconds() - moment(b.timestamp).milliseconds()
+
+          if (a.timestampUnix == b.timestampUnix) {
+            let at = a.timestamp.substring(a.timestamp.indexOf(".")+1, a.timestamp.length)
+            let bt = b.timestamp.substring(b.timestamp.indexOf(".")+1, b.timestamp.length)
+            return parseInt(at) - parseInt(bt)
+          }
+          return a.timestampUnix - b.timestampUnix
         });
 
         this.setState({
@@ -988,12 +990,10 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
             {
               timestamp: now.toString(),
               timestampUnix: now,
-              milis: now,
               logEntry: {
                 severity: 'Error',
                 timestamp: now.toString(),
                 timestampUnix: now,
-                milis: now,
                 message: `Failed to fetch workload logs: ${errorMsg}`
               }
             }

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -1,7 +1,7 @@
 import Namespace from './Namespace';
 import { ServicePort } from './ServiceInfo';
 import { ProxyStatus } from './Health';
-import { TimeInSeconds } from './Common';
+import {TimeInMilliseconds, TimeInSeconds} from './Common';
 import { PFColorVal } from 'components/Pf/PfColors';
 
 // Common types
@@ -232,6 +232,7 @@ export type AccessLog = {
 };
 
 export type LogEntry = {
+  milis: TimeInMilliseconds;
   accessLog?: AccessLog;
   color?: PFColorVal;
   message: string;

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -1,7 +1,7 @@
 import Namespace from './Namespace';
 import { ServicePort } from './ServiceInfo';
 import { ProxyStatus } from './Health';
-import {TimeInMilliseconds, TimeInSeconds} from './Common';
+import {TimeInMilliseconds} from './Common';
 import { PFColorVal } from 'components/Pf/PfColors';
 
 // Common types
@@ -232,13 +232,12 @@ export type AccessLog = {
 };
 
 export type LogEntry = {
-  milis: TimeInMilliseconds;
   accessLog?: AccessLog;
   color?: PFColorVal;
   message: string;
   severity: string;
   timestamp: string;
-  timestampUnix: TimeInSeconds;
+  timestampUnix: TimeInMilliseconds;
 };
 
 export interface PodLogs {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -1,7 +1,7 @@
 import Namespace from './Namespace';
 import { ServicePort } from './ServiceInfo';
 import { ProxyStatus } from './Health';
-import {TimeInMilliseconds} from './Common';
+import { TimeInSeconds } from './Common';
 import { PFColorVal } from 'components/Pf/PfColors';
 
 // Common types
@@ -237,7 +237,7 @@ export type LogEntry = {
   message: string;
   severity: string;
   timestamp: string;
-  timestampUnix: TimeInMilliseconds;
+  timestampUnix: TimeInSeconds;
 };
 
 export interface PodLogs {


### PR DESCRIPTION
Retrieve miliseconds in the WorkloadPodLogs so logs can be sorted using decimals. 

Fixes #5246 