### PR TITLE
Skip workloads when summarizing config validations in Overview page and in Graph

### DIFF
--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -421,7 +421,7 @@ func (iv IstioValidations) MergeReferences(validations IstioValidations) IstioVa
 func (iv IstioValidations) SummarizeValidation(ns string) *IstioValidationSummary {
 	ivs := IstioValidationSummary{}
 	for k, v := range iv {
-		if k.Namespace == ns {
+		if k.Namespace == ns && k.ObjectType != "workload" {
 			ivs.mergeSummaries(v.Checks)
 		}
 	}


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/5343

Before, it was considering workloads as well into analyzed objects for namespace validations summary:
![Screenshot from 2022-07-27 21-05-05](https://user-images.githubusercontent.com/604313/181352353-482657b9-66a0-44ca-884b-9e0849d18265.png)

Now, only configs are counted:
![Screenshot from 2022-07-27 21-06-01](https://user-images.githubusercontent.com/604313/181352453-f19add6b-cf04-47d9-a412-904ece99c009.png)

![Screenshot from 2022-07-27 21-08-00](https://user-images.githubusercontent.com/604313/181352678-b0e7d6eb-c77d-42cb-9689-d37e1c3fd52e.png)


