### PR TITLE
Set refresh time to 0 for sidecar_injection tests

### DIFF
--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -243,7 +243,7 @@ When('I remove override configuration for sidecar injection in the namespace', f
 });
 
 function switchWorkloadSidecarInjection(enableOrDisable) {
-    cy.visit(`/console/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}`);
+    cy.visit(`/console/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?refresh=0`);
     cy.get('[data-test="workload-actions-dropdown"] button').click();
     cy.get(`button[data-test=${enableOrDisable}_auto_injection]`).click();
     ensureKialiFinishedLoading();


### PR DESCRIPTION
Test flake - Sidecar injection override default policy

I was not able to reproduce this error in my environment, I guess it depends, as this is a test flake. 
But I've changed the refresh time to 0 - See if that helps.
 
It is weird, the message seems to be the same as when you are selecting a non existent namespace, but in that screenshot, the menu with the <Overview, Traffic, Logs, etc> links seems to be moved to the bottom of the page. 
See example: 
![image](https://user-images.githubusercontent.com/49480155/181797322-39610bd6-e99a-4142-a344-e63cfe146865.png)

Fixes #5236 