### PR TITLE
Remove icon prop to DropdownToggle causing js error

### DIFF
--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -13,7 +13,6 @@ import {
   Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
-import { CaretDownIcon } from '@patternfly/react-icons';
 import { WorkloadOverview } from '../../types/ServiceInfo';
 import { DestinationRule, PeerAuthentication, VirtualService } from '../../types/IstioObjects';
 import * as AlertUtils from '../../utils/AlertUtils';
@@ -366,7 +365,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
         position={DropdownPosition.right}
         onSelect={this.onActionsSelect}
         toggle={
-          <DropdownToggle onToggle={this.onActionsToggle} icon={CaretDownIcon} data-test="wizard-actions">
+          <DropdownToggle onToggle={this.onActionsToggle} data-test="wizard-actions">
             Actions
           </DropdownToggle>
         }

--- a/frontend/src/components/IstioWizards/WorkloadWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadWizardDropdown.tsx
@@ -7,7 +7,6 @@ import {
   Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
-import { CaretDownIcon } from '@patternfly/react-icons';
 import { serverConfig } from '../../config';
 import { Workload } from '../../types/Workload';
 import {
@@ -204,7 +203,7 @@ class WorkloadWizardDropdown extends React.Component<Props, State> {
         position={DropdownPosition.right}
         onSelect={this.onActionsSelect}
         toggle={
-          <DropdownToggle onToggle={this.onActionsToggle} icon={CaretDownIcon}>
+          <DropdownToggle onToggle={this.onActionsToggle}>
             Actions
           </DropdownToggle>
         }


### PR DESCRIPTION
It looks like the "Tab" component from Patternfly is not using the key in its implementation: 

```
<li
      className={css(styles.tabsItem, eventKey === localActiveKey && styles.modifiers.current, childClassName)}
      ref={innerRef}
    >
```

---

Removed the icon from the DropdownToggle component that was causing the error. It looks to not be having any effect on the component, as it was the default icon. This change affects the Service and Workload details views. 

Fixes #5360