### PR TITLE
Logs tab page has wrong container when navigating from trace tab

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -77,21 +77,23 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
       this.props.duration !== prevProps.duration
     ) {
       if (currentTab === 'info' || currentTab === 'logs' || currentTab === 'envoy') {
-        this.fetchWorkload();
+        this.fetchWorkload().then(() => {
+            if (currentTab !== this.state.currentTab) {
+              this.setState({ currentTab: currentTab });
+            }
+        });
       }
-      if (currentTab !== this.state.currentTab) {
-        this.setState({ currentTab: currentTab });
-      }
+
     }
   }
 
-  private fetchWorkload = () => {
+  private fetchWorkload = async () => {
     const params: { [key: string]: string } = {
       validate: 'true',
       rateInterval: String(this.props.duration) + 's',
       health: 'true'
     };
-    API.getWorkload(this.props.match.params.namespace, this.props.match.params.workload, params)
+    await API.getWorkload(this.props.match.params.namespace, this.props.match.params.workload, params)
       .then(details => {
         this.setState({
           workload: details.data,

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -82,6 +82,10 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
               this.setState({ currentTab: currentTab });
             }
         });
+      } else {
+        if (currentTab !== this.state.currentTab) {
+          this.setState({ currentTab: currentTab });
+        }
       }
 
     }


### PR DESCRIPTION
The error seems to be reproduced when selecting a trace that belongs to a pod from another namespace. 

The WorkloadPodLogs component is initialized using: 

```
namespace={this.props.match.params.namespace}
workload={this.props.match.params.workload}
pods={this.state.workload!.pods}
```
The workload and the namespace are correct, because they come from the current call, but, the pod is retrieved from the current state, which is not yet updated, because the API call to fetch the current workload has not finished. 

This fix uses await to make the fetchWorkload async and update the state once the fetch has finished.  

Fixes https://github.com/kiali/kiali/issues/5289 