### PR TITLE
Tag creator workflow

### DIFF
--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -1,0 +1,100 @@
+name: Tag Creator
+
+on:
+  workflow_dispatch:
+    inputs:      
+      tag_branch:
+        description: Branch to tag, (Separate branches by commas. Ex v1.36,v1.48)
+        required: true
+        default: v1.48
+        type: string
+
+jobs:
+  initialize:
+    name: Initialize
+    runs-on: ubuntu-20.04
+    outputs:
+      branches: ${{ steps.branches.outputs.branches }}        
+    steps:
+      - name: Prepare script to var
+        id: script_convert
+        run: |
+          cat <<-EOF > conversor.py
+          import sys, json
+
+          branch_arg = sys.argv[1]        
+          branches = branch_arg.split(',')
+
+          print(json.dumps(branches))
+          EOF
+
+      - name: Set Branch
+        id: branches
+        env:
+          TAG_BRANCHES: ${{ github.event.inputs.tag_branch }}
+        run: |
+          BRANCHES=$(python conversor.py $TAG_BRANCHES)
+          echo "::set-output name=branches::$BRANCHES"          
+  create_tag:      
+    needs: [ initialize ]
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        branch: ${{fromJson(needs.initialize.outputs.branches)}}          
+    steps:                
+      - name: Checkout Backend
+        uses: actions/checkout@v3        
+        with:
+          ref: ${{matrix.branch}}          
+      - name: Configure git backend
+        run: |
+          git config user.email 'kiali-dev@googlegroups.com'
+
+          git config user.name 'kiali-bot'    
+      - name: Create Tag in kiali/kiali
+        id: tag_kiali
+        env:
+            BRANCH: ${{matrix.branch}}
+        run: |
+          RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
+          # Remove any pre release identifier (ie: "-SNAPSHOT")
+          RELEASE_VERSION=${RAW_VERSION%-*}    
+          RELEASE_VERSION=$(echo $RELEASE_VERSION | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}')          
+
+          echo "::set-output name=release_version::$RELEASE_VERSION"
+
+          sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
+
+          if [[ $BRANCH != "v1.36" && $BRANCH != "v1.24" ]]; then
+            sed -i -r 's/"version": (.*)/"version": "'${RELEASE_VERSION:1}'"/' frontend/package.json              
+            git add frontend/package.json              
+          fi
+
+          git add Makefile
+          git commit -m "Release $RELEASE_VERSION"
+          git push origin && git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+          
+      # Check if version requested have the UI in our kiali/kiali-ui repo
+      - name: Checkout UI
+        if: ${{ matrix.branch == 'v1.24' || matrix.branch == 'v1.36'}}
+        uses: actions/checkout@v3        
+        with:
+          token: ${{ secrets.KIALI_TOKEN || github.token}}
+          repository: kiali/kiali-ui
+          ref: ${{matrix.branch}}  
+      - name: Configure git UI
+        if: ${{ matrix.branch == 'v1.24' || matrix.branch == 'v1.36'}}
+        run: |
+          git config user.email 'kiali-dev@googlegroups.com'
+
+          git config user.name 'kiali-bot'    
+      - name: Check if need old UI
+        id: check_ui_tag
+        env:
+            RELEASE_VERSION: ${{ steps.tag_kiali.outputs.release_version }}
+        if: ${{ matrix.branch == 'v1.24' || matrix.branch == 'v1.36'}}
+        run: |
+          sed -i -r 's/"version": (.*)/"version": "'${RELEASE_VERSION:1}'"/' package.json      
+          git add package.json
+          git commit -m "Release $RELEASE_VERSION"
+          git push origin && git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION


### PR DESCRIPTION
This workflow let us create for n releases (Ex: v1.24,v1.36) their tags.

This check if the version is an old one where the UI is in kiali/kiali-ui.

We need a secret called KIALI_TOKEN with rights to create tags in kiali/kiali-ui otherwise is going to use the token of kiali/kiali. I don't know if GH actions has rights inside org.

This was tested in my locally repos https://github.com/aljesusg/kiali/runs/7685956294?check_suite_focus=true