### PR TITLE
Use traffic data for node health rates

### DIFF
--- a/business/health.go
+++ b/business/health.go
@@ -21,10 +21,10 @@ type HealthService struct {
 }
 
 type NamespaceHealthCriteria struct {
-	Namespace              string
+	Namespace      string
 	IncludeMetrics bool
-	RateInterval           string
-	QueryTime              time.Time
+	RateInterval   string
+	QueryTime      time.Time
 }
 
 // Annotation Filter for Health

--- a/business/health.go
+++ b/business/health.go
@@ -20,6 +20,13 @@ type HealthService struct {
 	businessLayer *Layer
 }
 
+type NamespaceHealthCriteria struct {
+	Namespace              string
+	IncludeMetrics bool
+	RateInterval           string
+	QueryTime              time.Time
+}
+
 // Annotation Filter for Health
 var HealthAnnotation = []models.AnnotationKey{models.RateHealthAnnotation}
 
@@ -109,25 +116,28 @@ func (in *HealthService) GetWorkloadHealth(ctx context.Context, namespace, workl
 }
 
 // GetNamespaceAppHealth returns a health for all apps in given Namespace (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetNamespaceAppHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error) {
+func (in *HealthService) GetNamespaceAppHealth(ctx context.Context, criteria NamespaceHealthCriteria) (models.NamespaceAppHealth, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetNamespaceAppHealth",
 		observability.Attribute("package", "business"),
-		observability.Attribute("namespace", namespace),
-		observability.Attribute("rateInterval", rateInterval),
-		observability.Attribute("queryTime", queryTime),
+		observability.Attribute("namespace", criteria.Namespace),
+		observability.Attribute("rateInterval", criteria.RateInterval),
+		observability.Attribute("queryTime", criteria.QueryTime),
 	)
 	defer end()
 
-	appEntities, err := fetchNamespaceApps(ctx, in.businessLayer, namespace, "")
+	appEntities, err := fetchNamespaceApps(ctx, in.businessLayer, criteria.Namespace, "")
 	if err != nil {
 		return nil, err
 	}
 
-	return in.getNamespaceAppHealth(namespace, appEntities, rateInterval, queryTime)
+	return in.getNamespaceAppHealth(appEntities, criteria)
 }
 
-func (in *HealthService) getNamespaceAppHealth(namespace string, appEntities namespaceApps, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error) {
+func (in *HealthService) getNamespaceAppHealth(appEntities namespaceApps, criteria NamespaceHealthCriteria) (models.NamespaceAppHealth, error) {
+	namespace := criteria.Namespace
+	queryTime := criteria.QueryTime
+	rateInterval := criteria.RateInterval
 	allHealth := make(models.NamespaceAppHealth)
 
 	// Perf: do not bother fetching request rate if no workloads or no workload has sidecar
@@ -150,7 +160,7 @@ func (in *HealthService) getNamespaceAppHealth(namespace string, appEntities nam
 		}
 	}
 
-	if sidecarPresent {
+	if sidecarPresent && criteria.IncludeMetrics {
 		// Fetch services requests rates
 		rates, err := in.prom.GetAllRequestRates(namespace, rateInterval, queryTime)
 		if err != nil {
@@ -164,7 +174,10 @@ func (in *HealthService) getNamespaceAppHealth(namespace string, appEntities nam
 }
 
 // GetNamespaceServiceHealth returns a health for all services in given Namespace (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetNamespaceServiceHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceServiceHealth, error) {
+func (in *HealthService) GetNamespaceServiceHealth(ctx context.Context, criteria NamespaceHealthCriteria) (models.NamespaceServiceHealth, error) {
+	namespace := criteria.Namespace
+	queryTime := criteria.QueryTime
+	rateInterval := criteria.RateInterval
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetNamespaceServiceHealth",
 		observability.Attribute("package", "business"),
@@ -182,20 +195,23 @@ func (in *HealthService) GetNamespaceServiceHealth(ctx context.Context, namespac
 		return nil, err
 	}
 
-	criteria := ServiceCriteria{
+	svcCriteria := ServiceCriteria{
 		Namespace:              namespace,
 		IncludeOnlyDefinitions: true,
 		IncludeIstioResources:  false,
 		Health:                 false,
 	}
-	services, err = in.businessLayer.Svc.GetServiceList(ctx, criteria)
+	services, err = in.businessLayer.Svc.GetServiceList(ctx, svcCriteria)
 	if err != nil {
 		return nil, err
 	}
-	return in.getNamespaceServiceHealth(namespace, services, rateInterval, queryTime), nil
+	return in.getNamespaceServiceHealth(services, criteria), nil
 }
 
-func (in *HealthService) getNamespaceServiceHealth(namespace string, services *models.ServiceList, rateInterval string, queryTime time.Time) models.NamespaceServiceHealth {
+func (in *HealthService) getNamespaceServiceHealth(services *models.ServiceList, criteria NamespaceHealthCriteria) models.NamespaceServiceHealth {
+	namespace := criteria.Namespace
+	queryTime := criteria.QueryTime
+	rateInterval := criteria.RateInterval
 	allHealth := make(models.NamespaceServiceHealth)
 
 	// Prepare all data (note that it's important to provide data for all services, even those which may not have any health, for overview cards)
@@ -207,24 +223,29 @@ func (in *HealthService) getNamespaceServiceHealth(namespace string, services *m
 		}
 	}
 
-	// Fetch services requests rates
-	rates, _ := in.prom.GetNamespaceServicesRequestRates(namespace, rateInterval, queryTime)
-	// Fill with collected request rates
-	lblDestSvc := model.LabelName("destination_service_name")
-	for _, sample := range rates {
-		service := string(sample.Metric[lblDestSvc])
-		if health, ok := allHealth[service]; ok {
-			health.Requests.AggregateInbound(sample)
+	if criteria.IncludeMetrics {
+		// Fetch services requests rates
+		rates, _ := in.prom.GetNamespaceServicesRequestRates(namespace, rateInterval, queryTime)
+		// Fill with collected request rates
+		lblDestSvc := model.LabelName("destination_service_name")
+		for _, sample := range rates {
+			service := string(sample.Metric[lblDestSvc])
+			if health, ok := allHealth[service]; ok {
+				health.Requests.AggregateInbound(sample)
+			}
 		}
-	}
-	for _, health := range allHealth {
-		health.Requests.CombineReporters()
+		for _, health := range allHealth {
+			health.Requests.CombineReporters()
+		}
 	}
 	return allHealth
 }
 
 // GetNamespaceWorkloadHealth returns a health for all workloads in given Namespace (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetNamespaceWorkloadHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error) {
+func (in *HealthService) GetNamespaceWorkloadHealth(ctx context.Context, criteria NamespaceHealthCriteria) (models.NamespaceWorkloadHealth, error) {
+	namespace := criteria.Namespace
+	rateInterval := criteria.RateInterval
+	queryTime := criteria.QueryTime
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetNamespaceWorkloadHealth",
 		observability.Attribute("package", "business"),
@@ -239,12 +260,15 @@ func (in *HealthService) GetNamespaceWorkloadHealth(ctx context.Context, namespa
 		return nil, err
 	}
 
-	return in.getNamespaceWorkloadHealth(namespace, wl, rateInterval, queryTime)
+	return in.getNamespaceWorkloadHealth(wl, criteria)
 }
 
-func (in *HealthService) getNamespaceWorkloadHealth(namespace string, ws models.Workloads, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error) {
+func (in *HealthService) getNamespaceWorkloadHealth(ws models.Workloads, criteria NamespaceHealthCriteria) (models.NamespaceWorkloadHealth, error) {
 	// Perf: do not bother fetching request rate if no workloads or no workload has sidecar
 	hasSidecar := false
+	namespace := criteria.Namespace
+	rateInterval := criteria.RateInterval
+	queryTime := criteria.QueryTime
 
 	allHealth := make(models.NamespaceWorkloadHealth)
 	for _, w := range ws {
@@ -256,7 +280,7 @@ func (in *HealthService) getNamespaceWorkloadHealth(namespace string, ws models.
 		}
 	}
 
-	if hasSidecar {
+	if hasSidecar && criteria.IncludeMetrics {
 		// Fetch services requests rates
 		rates, err := in.prom.GetAllRequestRates(namespace, rateInterval, queryTime)
 		if err != nil {

--- a/business/health.go
+++ b/business/health.go
@@ -21,10 +21,10 @@ type HealthService struct {
 }
 
 type NamespaceHealthCriteria struct {
-	Namespace      string
 	IncludeMetrics bool
-	RateInterval   string
+	Namespace      string
 	QueryTime      time.Time
+	RateInterval   string
 }
 
 // Annotation Filter for Health

--- a/business/health_test.go
+++ b/business/health_test.go
@@ -31,7 +31,7 @@ func TestGetServiceHealth(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	queryTime := time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC)
+	queryTime := time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC)
 	prom.MockServiceRequestRates("ns", "httpbin", serviceRates)
 	k8s.On("IsOpenShift").Return(true)
 	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
@@ -46,7 +46,7 @@ func TestGetServiceHealth(t *testing.T) {
 	health, _ := hs.GetServiceHealth(context.TODO(), "ns", "httpbin", "1m", queryTime, &mockSvc)
 
 	prom.AssertNumberOfCalls(t, "GetServiceRequestRates", 1)
-	var result = map[string]map[string]float64{
+	result := map[string]map[string]float64{
 		"http": {
 			"200": 14,
 			"404": 1.4,
@@ -78,7 +78,7 @@ func TestGetAppHealth(t *testing.T) {
 
 	hs := HealthService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
 
-	queryTime := time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC)
+	queryTime := time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC)
 	prom.MockAppRequestRates("ns", "reviews", otherRatesIn, otherRatesOut)
 
 	mockWkd := models.Workload{}
@@ -92,7 +92,7 @@ func TestGetAppHealth(t *testing.T) {
 	health, _ := hs.GetAppHealth(context.TODO(), "ns", "reviews", "1m", queryTime, &mockApp)
 
 	prom.AssertNumberOfCalls(t, "GetAppRequestRates", 1)
-	var result = map[string]map[string]float64{
+	result := map[string]map[string]float64{
 		"http": {
 			"500": 1.6,
 		},
@@ -127,7 +127,7 @@ func TestGetWorkloadHealth(t *testing.T) {
 	k8s.On("GetPods", "ns", "").Return(fakePodsHealthReview(), nil)
 	k8s.On("GetProxyStatus").Return([]*kubernetes.ProxyStatus{}, nil)
 
-	queryTime := time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC)
+	queryTime := time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC)
 	prom.MockWorkloadRequestRates("ns", "reviews-v1", otherRatesIn, otherRatesOut)
 
 	hs := HealthService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
@@ -139,7 +139,7 @@ func TestGetWorkloadHealth(t *testing.T) {
 	health, _ := hs.GetWorkloadHealth(context.TODO(), "ns", "reviews-v1", "1m", queryTime, &mockWorkload)
 
 	prom.AssertNumberOfCalls(t, "GetWorkloadRequestRates", 1)
-	var result = map[string]map[string]float64{
+	result := map[string]map[string]float64{
 		"http": {
 			"500": 1.6,
 		},
@@ -173,7 +173,7 @@ func TestGetAppHealthWithoutIstio(t *testing.T) {
 	k8s.On("GetDeployments", "ns").Return(fakeDeploymentsHealthReview(), nil)
 	k8s.On("GetPods", "ns", "app=reviews").Return(fakePodsHealthReviewWithoutIstio(), nil)
 
-	queryTime := time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC)
+	queryTime := time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC)
 	prom.MockAppRequestRates("ns", "reviews", otherRatesIn, otherRatesOut)
 
 	hs := HealthService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
@@ -203,7 +203,7 @@ func TestGetWorkloadHealthWithoutIstio(t *testing.T) {
 	k8s.On("GetPods", "ns", "").Return(fakePodsHealthReviewWithoutIstio(), nil)
 	k8s.On("GetWorkload", "ns", "wk", "", false).Return(&models.Workload{}, nil)
 
-	queryTime := time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC)
+	queryTime := time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC)
 	prom.MockWorkloadRequestRates("ns", "reviews-v1", otherRatesIn, otherRatesOut)
 
 	hs := HealthService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
@@ -233,7 +233,7 @@ func TestGetNamespaceAppHealthWithoutIstio(t *testing.T) {
 	k8s.On("GetPods", "ns", "").Return(fakePodsHealthReviewWithoutIstio(), nil)
 
 	hs := HealthService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
-	criteria := NamespaceHealthCriteria{Namespace: "ns", RateInterval: "1m", QueryTime: time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
+	criteria := NamespaceHealthCriteria{Namespace: "ns", RateInterval: "1m", QueryTime: time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
 	_, _ = hs.GetNamespaceAppHealth(context.TODO(), criteria)
 
 	// Make sure unnecessary call isn't performed
@@ -256,15 +256,15 @@ func TestGetNamespaceServiceHealthWithNA(t *testing.T) {
 
 	hs := HealthService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
 
-	criteria := NamespaceHealthCriteria{Namespace: "tutorial", RateInterval: "1m", QueryTime: time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
-	health, err := hs.GetNamespaceServiceHealth(context.TODO(), criteria) 
+	criteria := NamespaceHealthCriteria{Namespace: "tutorial", RateInterval: "1m", QueryTime: time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
+	health, err := hs.GetNamespaceServiceHealth(context.TODO(), criteria)
 
 	assert.Nil(err)
 	// Make sure we get services with N/A health
 	assert.Len(health, 2)
 	assert.Equal(emptyResult, health["reviews"].Requests.Inbound)
 	assert.Equal(emptyResult, health["reviews"].Requests.Outbound)
-	var result = map[string]map[string]float64{
+	result := map[string]map[string]float64{
 		"http": {
 			"200": 14,
 			"404": 1.4,
@@ -436,22 +436,33 @@ func fakeDeploymentsHealthReview() []apps_v1.Deployment {
 	return []apps_v1.Deployment{
 		{
 			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "reviews-v1"},
+				Name: "reviews-v1",
+			},
 			Status: apps_v1.DeploymentStatus{
 				Replicas:            3,
 				AvailableReplicas:   2,
-				UnavailableReplicas: 1},
+				UnavailableReplicas: 1,
+			},
 			Spec: apps_v1.DeploymentSpec{
 				Selector: &meta_v1.LabelSelector{
-					MatchLabels: map[string]string{"app": "reviews", "version": "v1"}}}},
+					MatchLabels: map[string]string{"app": "reviews", "version": "v1"},
+				},
+			},
+		},
 		{
 			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "reviews-v2"},
+				Name: "reviews-v2",
+			},
 			Status: apps_v1.DeploymentStatus{
 				Replicas:            2,
 				AvailableReplicas:   1,
-				UnavailableReplicas: 1},
+				UnavailableReplicas: 1,
+			},
 			Spec: apps_v1.DeploymentSpec{
 				Selector: &meta_v1.LabelSelector{
-					MatchLabels: map[string]string{"app": "reviews", "version": "v2"}}}}}
+					MatchLabels: map[string]string{"app": "reviews", "version": "v2"},
+				},
+			},
+		},
+	}
 }

--- a/business/health_test.go
+++ b/business/health_test.go
@@ -233,8 +233,8 @@ func TestGetNamespaceAppHealthWithoutIstio(t *testing.T) {
 	k8s.On("GetPods", "ns", "").Return(fakePodsHealthReviewWithoutIstio(), nil)
 
 	hs := HealthService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
-
-	_, _ = hs.GetNamespaceAppHealth(context.TODO(), "ns", "1m", time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC))
+	criteria := NamespaceHealthCriteria{Namespace: "ns", RateInterval: "1m", QueryTime: time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
+	_, _ = hs.GetNamespaceAppHealth(context.TODO(), criteria)
 
 	// Make sure unnecessary call isn't performed
 	prom.AssertNumberOfCalls(t, "GetAllRequestRates", 0)
@@ -256,7 +256,8 @@ func TestGetNamespaceServiceHealthWithNA(t *testing.T) {
 
 	hs := HealthService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
 
-	health, err := hs.GetNamespaceServiceHealth(context.TODO(), "tutorial", "1m", time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC))
+	criteria := NamespaceHealthCriteria{Namespace: "tutorial", RateInterval: "1m", QueryTime: time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
+	health, err := hs.GetNamespaceServiceHealth(context.TODO(), criteria) 
 
 	assert.Nil(err)
 	// Make sure we get services with N/A health

--- a/graph/options.go
+++ b/graph/options.go
@@ -84,20 +84,6 @@ type RequestedAppenders struct {
 	AppenderNames []string
 }
 
-func (ra *RequestedAppenders) Includes(name string) bool {
-	if ra.All {
-		return true
-	}
-
-	for _, appenderName := range ra.AppenderNames {
-		if appenderName == name {
-			return true
-		}
-	}
-
-	return false
-}
-
 type RequestedRates struct {
 	Grpc string
 	Http string

--- a/graph/options.go
+++ b/graph/options.go
@@ -84,6 +84,20 @@ type RequestedAppenders struct {
 	AppenderNames []string
 }
 
+func (ra *RequestedAppenders) Includes(name string) bool {
+	if ra.All {
+		return true
+	}
+
+	for _, appenderName := range ra.AppenderNames {
+		if appenderName == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 type RequestedRates struct {
 	Grpc string
 	Http string

--- a/graph/telemetry/istio/appender/health_test.go
+++ b/graph/telemetry/istio/appender/health_test.go
@@ -135,6 +135,301 @@ func TestHealthDataPresent(t *testing.T) {
 	}
 }
 
+func TestHealthDataPresent200SvcWk(t *testing.T) {
+	assert := assert.New(t)
+
+	config.Set(config.NewConfig())
+	svcNodes := buildServiceTrafficMap()
+	appNodes := buildAppTrafficMap()
+	wkNodes := buildWorkloadTrafficMap()
+	trafficMap := make(graph.TrafficMap)
+	var (
+		svc *graph.Node
+		wk  *graph.Node
+	)
+	for k, v := range svcNodes {
+		trafficMap[k] = v
+		svc = v
+	}
+	for k, v := range appNodes {
+		trafficMap[k] = v
+	}
+	for k, v := range wkNodes {
+		trafficMap[k] = v
+		wk = v
+	}
+	edge := svc.AddEdge(wk)
+	/* Example of edge data:
+	{
+	 	"traffic": {
+	 		"protocol": "http",
+	 		"rates": {
+	 			"http": "1.93",
+	 			"httpPercentReq": "100.0"
+	 		},
+	 		"responses": {
+	 			"200": {
+	 				"flags": {
+	 					"-": "100.0"
+	 				},
+	 				"hosts": {
+	 					"v-server.beta.svc.cluster.local": "100.0"
+	 				}
+	 			}
+	 		}
+	 	}
+	 }
+	*/
+	edge.Metadata[graph.ProtocolKey] = "http"
+	edge.Metadata[graph.MetadataKey(graph.HTTP.EdgeResponses)] = graph.Responses{
+		"200": &graph.ResponseDetail{
+			Flags: graph.ResponseFlags{"-": 100.0},
+			Hosts: map[string]float64{"v-server.beta.svc.cluster.local": 100.0},
+		},
+	}
+	businessLayer := setupHealthConfig(buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	a := HealthAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	for _, node := range trafficMap {
+		assert.Contains(node.Metadata, graph.HealthData)
+	}
+	source := trafficMap[svc.ID]
+	sourceHealth := source.Metadata[graph.HealthData].(*models.ServiceHealth)
+	assert.Equal(sourceHealth.Requests.Outbound["http"]["200"], 100.0)
+
+	dest := trafficMap[wk.ID]
+	destHealth := dest.Metadata[graph.HealthData].(*models.WorkloadHealth)
+	assert.Equal(destHealth.Requests.Inbound["http"]["200"], 100.0)
+}
+
+func TestHealthDataPresent200500WkSvc(t *testing.T) {
+	assert := assert.New(t)
+
+	config.Set(config.NewConfig())
+	svcNodes := buildServiceTrafficMap()
+	appNodes := buildAppTrafficMap()
+	wkNodes := buildWorkloadTrafficMap()
+	trafficMap := make(graph.TrafficMap)
+	var (
+		svc *graph.Node
+		wk  *graph.Node
+	)
+	for k, v := range svcNodes {
+		trafficMap[k] = v
+		svc = v
+	}
+	for k, v := range appNodes {
+		trafficMap[k] = v
+	}
+	for k, v := range wkNodes {
+		trafficMap[k] = v
+		wk = v
+	}
+	edge := wk.AddEdge(svc)
+	edge.Metadata[graph.ProtocolKey] = "http"
+	edge.Metadata[graph.MetadataKey(graph.HTTP.EdgeResponses)] = graph.Responses{
+		"200": &graph.ResponseDetail{
+			Flags: graph.ResponseFlags{"-": 100.0},
+			Hosts: map[string]float64{"v-server.beta.svc.cluster.local": 100.0},
+		},
+		"500": &graph.ResponseDetail{
+			Flags: graph.ResponseFlags{"-": 10.0},
+			Hosts: map[string]float64{"v-server.beta.svc.cluster.local": 10.0},
+		},
+	}
+	businessLayer := setupHealthConfig(buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	a := HealthAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	for _, node := range trafficMap {
+		assert.Contains(node.Metadata, graph.HealthData)
+	}
+	source := trafficMap[wk.ID]
+	sourceHealth := source.Metadata[graph.HealthData].(*models.WorkloadHealth)
+	assert.Equal(sourceHealth.Requests.Outbound["http"]["200"], 100.0)
+	assert.Equal(sourceHealth.Requests.Outbound["http"]["500"], 10.0)
+
+	dest := trafficMap[svc.ID]
+	destHealth := dest.Metadata[graph.HealthData].(*models.ServiceHealth)
+	assert.Equal(destHealth.Requests.Inbound["http"]["200"], 100.0)
+	assert.Equal(destHealth.Requests.Inbound["http"]["500"], 10.0)
+}
+
+func TestHealthDataPresentToApp(t *testing.T) {
+	assert := assert.New(t)
+
+	config.Set(config.NewConfig())
+	svcNodes := buildServiceTrafficMap()
+	appNodes := buildAppTrafficMap()
+	wkNodes := buildWorkloadTrafficMap()
+	trafficMap := make(graph.TrafficMap)
+	var (
+		svc *graph.Node
+		app *graph.Node
+	)
+	for k, v := range svcNodes {
+		trafficMap[k] = v
+		svc = v
+	}
+	for k, v := range appNodes {
+		trafficMap[k] = v
+		app = v
+	}
+	for k, v := range wkNodes {
+		trafficMap[k] = v
+	}
+	edge := svc.AddEdge(app)
+	edge.Metadata[graph.ProtocolKey] = "http"
+	edge.Metadata[graph.MetadataKey(graph.HTTP.EdgeResponses)] = graph.Responses{
+		"200": &graph.ResponseDetail{
+			Flags: graph.ResponseFlags{"-": 100.0},
+			Hosts: map[string]float64{"v-server.beta.svc.cluster.local": 100.0},
+		},
+	}
+	businessLayer := setupHealthConfig(buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	a := HealthAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	for _, node := range trafficMap {
+		assert.Contains(node.Metadata, graph.HealthData)
+	}
+	source := trafficMap[svc.ID]
+	sourceHealth := source.Metadata[graph.HealthData].(*models.ServiceHealth)
+	assert.Equal(sourceHealth.Requests.Outbound["http"]["200"], 100.0)
+
+	dest := trafficMap[app.ID]
+	destHealth := dest.Metadata[graph.HealthData].(*models.AppHealth)
+	assert.Equal(destHealth.Requests.Inbound["http"]["200"], 100.0)
+}
+
+func TestHealthDataPresentFromApp(t *testing.T) {
+	assert := assert.New(t)
+
+	config.Set(config.NewConfig())
+	svcNodes := buildServiceTrafficMap()
+	appNodes := buildAppTrafficMap()
+	wkNodes := buildWorkloadTrafficMap()
+	trafficMap := make(graph.TrafficMap)
+	var (
+		svc *graph.Node
+		app *graph.Node
+	)
+	for k, v := range svcNodes {
+		trafficMap[k] = v
+		svc = v
+	}
+	for k, v := range appNodes {
+		trafficMap[k] = v
+		app = v
+	}
+	for k, v := range wkNodes {
+		trafficMap[k] = v
+		app.Workload = v.Workload
+	}
+	edge := app.AddEdge(svc)
+	edge.Metadata[graph.ProtocolKey] = "http"
+	edge.Metadata[graph.MetadataKey(graph.HTTP.EdgeResponses)] = graph.Responses{
+		"200": &graph.ResponseDetail{
+			Flags: graph.ResponseFlags{"-": 100.0},
+			Hosts: map[string]float64{"v-server.beta.svc.cluster.local": 100.0},
+		},
+	}
+	businessLayer := setupHealthConfig(buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	a := HealthAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	for _, node := range trafficMap {
+		assert.Contains(node.Metadata, graph.HealthData)
+	}
+	source := trafficMap[app.ID]
+	sourceHealth := source.Metadata[graph.HealthData].(*models.AppHealth)
+	assert.Equal(sourceHealth.Requests.Outbound["http"]["200"], 100.0)
+	assert.Contains(source.Metadata, graph.HealthDataApp)
+	sourceAppHealth := source.Metadata[graph.HealthDataApp].(*models.AppHealth)
+	assert.Equal(sourceAppHealth.Requests.Outbound["http"]["200"], 100.0)
+
+	dest := trafficMap[svc.ID]
+	destHealth := dest.Metadata[graph.HealthData].(*models.ServiceHealth)
+	assert.Equal(destHealth.Requests.Inbound["http"]["200"], 100.0)
+}
+
+func TestHealthDataBadResponses(t *testing.T) {
+	assert := assert.New(t)
+
+	config.Set(config.NewConfig())
+	svcNodes := buildServiceTrafficMap()
+	appNodes := buildAppTrafficMap()
+	wkNodes := buildWorkloadTrafficMap()
+	trafficMap := make(graph.TrafficMap)
+	var (
+		svc *graph.Node
+		wk  *graph.Node
+		app *graph.Node
+	)
+	for k, v := range svcNodes {
+		trafficMap[k] = v
+		svc = v
+	}
+	for k, v := range appNodes {
+		trafficMap[k] = v
+		app = v
+	}
+	for k, v := range wkNodes {
+		trafficMap[k] = v
+		wk = v
+	}
+	edge1 := app.AddEdge(svc)
+	edge1.Metadata[graph.ProtocolKey] = "badprotocol"
+	edge1.Metadata[graph.MetadataKey("badprotocol")] = graph.Responses{
+		"200": &graph.ResponseDetail{
+			Flags: graph.ResponseFlags{"-": 100.0},
+			Hosts: map[string]float64{"v-server.beta.svc.cluster.local": 100.0},
+		},
+	}
+	edge2 := wk.AddEdge(svc)
+	edge2.Metadata[graph.ProtocolKey] = 20000
+	businessLayer := setupHealthConfig(buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
+
+	a := HealthAppender{}
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	for _, node := range trafficMap {
+		assert.Contains(node.Metadata, graph.HealthData)
+	}
+	source := trafficMap[app.ID]
+	sourceHealth := source.Metadata[graph.HealthData].(*models.AppHealth)
+	assert.Empty(sourceHealth.Requests.Outbound)
+
+	dest := trafficMap[svc.ID]
+	destHealth := dest.Metadata[graph.HealthData].(*models.ServiceHealth)
+	assert.Empty(destHealth.Requests.Inbound)
+}
+
 func TestErrorCausesPanic(t *testing.T) {
 	assert := assert.New(t)
 

--- a/graph/telemetry/istio/appender/health_test.go
+++ b/graph/telemetry/istio/appender/health_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/kiali/kiali/prometheus/prometheustest"
 )
 
-const rateDefinition = "400,10,20,http,inbound"
-const rateWorkloadDefinition = "4xx,20,30,http,inbound"
+const (
+	rateDefinition         = "400,10,20,http,inbound"
+	rateWorkloadDefinition = "4xx,20,30,http,inbound"
+)
 
 func TestServicesHealthConfigPasses(t *testing.T) {
 	config.Set(config.NewConfig())
@@ -135,7 +137,6 @@ func TestHealthDataPresent(t *testing.T) {
 
 func TestErrorCausesPanic(t *testing.T) {
 	assert := assert.New(t)
-
 
 	config.Set(config.NewConfig())
 	trafficMap := buildAppTrafficMap()

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -393,7 +393,7 @@ func addEdgeTraffic(trafficMap graph.TrafficMap, val float64, protocol, code, fl
 			break
 		}
 	}
-	if edge == nil {
+	if nil == edge {
 		edge = source.AddEdge(dest)
 		edge.Metadata[graph.ProtocolKey] = protocol
 		edge.Metadata[tsHashMap] = make(map[string]bool)

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -39,7 +39,6 @@ import (
 	"github.com/kiali/kiali/graph/telemetry/istio/appender"
 	"github.com/kiali/kiali/graph/telemetry/istio/util"
 	"github.com/kiali/kiali/log"
-	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/observability"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
@@ -50,9 +49,7 @@ const (
 	tsHashMap graph.MetadataKey = "tsHashMap"
 )
 
-var (
-	grpcMetric = regexp.MustCompile(`istio_.*_messages`)
-)
+var grpcMetric = regexp.MustCompile(`istio_.*_messages`)
 
 // BuildNamespacesTrafficMap is required by the graph/TelemtryVendor interface
 func BuildNamespacesTrafficMap(ctx context.Context, o graph.TelemetryOptions, client *prometheus.Client, globalInfo *graph.AppenderGlobalInfo) graph.TrafficMap {
@@ -386,23 +383,6 @@ func addTraffic(trafficMap graph.TrafficMap, metric string, inject bool, val flo
 	}
 }
 
-func initHealthData(node *graph.Node) {
-	if _, ok := node.Metadata[graph.HealthData]; !ok {
-		if node.NodeType == graph.NodeTypeService {
-			m := models.EmptyServiceHealth()
-			node.Metadata[graph.HealthData] = &m
-		} else if node.NodeType == graph.NodeTypeWorkload {
-			m := models.EmptyWorkloadHealth()
-			node.Metadata[graph.HealthData] = m
-		} else if node.NodeType == graph.NodeTypeApp {
-			m := models.EmptyAppHealth()
-			mApp := models.EmptyAppHealth()
-			node.Metadata[graph.HealthData] = &m
-			node.Metadata[graph.HealthDataApp] = &mApp
-		}
-	}
-}
-
 // addEdgeTraffic uses edgeTSHash that the metric information has not been applied to the edge. Returns true
 // if the the metric information is applied, false if it determined to be a duplicate.
 func addEdgeTraffic(trafficMap graph.TrafficMap, val float64, protocol, code, flags, host string, source, dest *graph.Node, edgeTSHash string, o graph.TelemetryOptions) bool {
@@ -422,59 +402,10 @@ func addEdgeTraffic(trafficMap graph.TrafficMap, val float64, protocol, code, fl
 	if _, ok := edge.Metadata[tsHashMap].(map[string]bool)[edgeTSHash]; !ok {
 		edge.Metadata[tsHashMap].(map[string]bool)[edgeTSHash] = true
 		graph.AddToMetadata(protocol, val, code, flags, host, source.Metadata, dest.Metadata, edge.Metadata)
-		if o.Appenders.Includes(appender.HealthAppenderName) {
-			initHealthData(source)
-			initHealthData(dest)
-			switch source.NodeType {
-			case graph.NodeTypeService:
-				health := source.Metadata[graph.HealthData].(*models.ServiceHealth)
-				addValueToRequests(health.Requests.Outbound, protocol, code, val)
-				source.Metadata[graph.HealthData] = health
-			case graph.NodeTypeWorkload:
-				health := source.Metadata[graph.HealthData].(*models.WorkloadHealth)
-				addValueToRequests(health.Requests.Outbound, protocol, code, val)
-				source.Metadata[graph.HealthData] = health
-			case graph.NodeTypeApp:
-				health := source.Metadata[graph.HealthData].(*models.AppHealth)
-				addValueToRequests(health.Requests.Outbound, protocol, code, val)
-				source.Metadata[graph.HealthData] = health
-				health = source.Metadata[graph.HealthDataApp].(*models.AppHealth)
-				addValueToRequests(health.Requests.Outbound, protocol, code, val)
-				source.Metadata[graph.HealthDataApp] = health
-			}
-
-			switch dest.NodeType {
-			case graph.NodeTypeService:
-				health := dest.Metadata[graph.HealthData].(*models.ServiceHealth)
-				addValueToRequests(health.Requests.Inbound, protocol, code, val)
-				dest.Metadata[graph.HealthData] = health
-			case graph.NodeTypeWorkload:
-				health := dest.Metadata[graph.HealthData].(*models.WorkloadHealth)
-				addValueToRequests(health.Requests.Inbound, protocol, code, val)
-				dest.Metadata[graph.HealthData] = health
-			case graph.NodeTypeApp:
-				health := dest.Metadata[graph.HealthData].(*models.AppHealth)
-				addValueToRequests(health.Requests.Inbound, protocol, code, val)
-				dest.Metadata[graph.HealthData] = health
-				health = dest.Metadata[graph.HealthDataApp].(*models.AppHealth)
-				addValueToRequests(health.Requests.Inbound, protocol, code, val)
-				dest.Metadata[graph.HealthDataApp] = health
-			}
-		}
 		return true
 	}
 
 	return false
-}
-
-func addValueToRequests(requests map[string]map[string]float64, protocol, code string, val float64) {
-	if _, ok := requests[protocol]; !ok {
-		requests[protocol] = make(map[string]float64)
-	}
-	if _, ok := requests[protocol][code]; !ok {
-		requests[protocol][code] = 0
-	}
-	requests[protocol][code] += val
 }
 
 func addToDestServices(md graph.Metadata, cluster, namespace, service string) {

--- a/graph/types.go
+++ b/graph/types.go
@@ -87,6 +87,15 @@ func (s *ServiceName) Key() string {
 // namespace.
 type TrafficMap map[string]*Node
 
+// Edges returns all of the edges in the traffic map.
+func (tm TrafficMap) Edges() []*Edge {
+	var edges []*Edge
+	for _, n := range tm {
+		edges = append(edges, n.Edges...)
+	}
+	return edges
+}
+
 // NewNode constructor
 func NewNode(cluster, serviceNamespace, service, workloadNamespace, workload, app, version, graphType string) Node {
 	id, nodeType := Id(cluster, serviceNamespace, service, workloadNamespace, workload, app, version, graphType)

--- a/graph/util.go
+++ b/graph/util.go
@@ -35,7 +35,7 @@ func Panic(message string, code int) Response {
 // CheckError panics with the supplied error if it is non-nil
 func CheckError(err error) {
 	if err != nil {
-		panic(err.Error)
+		panic(err.Error())
 	}
 }
 


### PR DESCRIPTION
Adds node health data when traffic map is being generated. The health appender is still responsible for gathering the workload statuses and annotations for apps/services/workloads.

Fixes #4566 