### PR TITLE
Refresh K8s Service Account Token

### DIFF
--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -48,7 +48,6 @@ func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {
 		conf := config.Get()
 
 		var authInfo *api.AuthInfo
-		var token string
 
 		switch conf.Auth.Strategy {
 		case config.AuthStrategyToken, config.AuthStrategyOpenId, config.AuthStrategyOpenshift, config.AuthStrategyHeader:
@@ -63,8 +62,11 @@ func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {
 			}
 		case config.AuthStrategyAnonymous:
 			log.Tracef("Access to the server endpoint is not secured with credentials - letting request come in. Url: [%s]", r.URL.String())
-			token = aHandler.saToken
-			authInfo = &api.AuthInfo{Token: token}
+
+			token, err := kubernetes.GetKialiToken()
+			if err == nil {
+				authInfo = &api.AuthInfo{Token: token}
+			}
 		}
 
 		switch statusCode {

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -1,10 +1,11 @@
 package kubernetes
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
+
+	"github.com/kiali/kiali/log"
 )
 
 // Be careful with how you use this token. This is the Kiali Service Account token, not the user token.
@@ -40,7 +41,7 @@ func GetKialiToken() (string, error) {
 			errUpdating := updateKialiToken()
 			isRemote = false
 			if errUpdating != nil {
-				fmt.Errorf("Error updating Kiali token: " + errUpdating.Error())
+				log.Error("Error updating Kiali token: " + errUpdating.Error())
 			}
 		}
 	}
@@ -51,7 +52,7 @@ func GetKialiToken() (string, error) {
 func updateKialiToken() error {
 	token, errRead := ioutil.ReadFile(getDefaultServiceAccountPath())
 	if errRead != nil {
-		fmt.Println(errRead)
+		log.Errorf("Error reading file %v", errRead)
 	}
 	KialiToken = string(token)
 	LastRead = time.Now()

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -10,7 +10,8 @@ import (
 // Be careful with how you use this token. This is the Kiali Service Account token, not the user token.
 // We need the Service Account token to access third-party in-cluster services (e.g. Grafana).
 
-const DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+var DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+var refreshTime = int64(60)
 
 var KialiToken string
 var LastRead, timer time.Time
@@ -18,6 +19,14 @@ var isRemote bool
 
 func getDefaultServiceAccountPath() string {
 	return DefaultServiceAccountPath
+}
+
+func setDefaultServiceAccountPath(path string) {
+	DefaultServiceAccountPath = path
+}
+
+func setRefreshTime(secs int64) {
+	refreshTime = secs
 }
 
 func GetKialiToken() (string, error) {
@@ -63,7 +72,7 @@ func getLastModified(fileName string) (time.Time, error) {
 // Just checking once every minute
 func IsTokenExpired() (bool, error) {
 
-	if time.Now().Unix()-timer.Unix() > 60 {
+	if time.Now().Unix()-timer.Unix() > refreshTime {
 		path := getDefaultServiceAccountPath()
 		if isRemote {
 			path = RemoteSecretData

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -1,6 +1,11 @@
 package kubernetes
 
-import "io/ioutil"
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+)
 
 // Be careful with how you use this token. This is the Kiali Service Account token, not the user token.
 // We need the Service Account token to access third-party in-cluster services (e.g. Grafana).
@@ -8,18 +13,57 @@ import "io/ioutil"
 const DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 var KialiToken string
+var LastRead time.Time
 
 func GetKialiToken() (string, error) {
-	if KialiToken == "" {
+	expired, err := IsTokenExpired()
+	if KialiToken == "" || (expired && err == nil) {
 		if remoteSecret, err := GetRemoteSecret(RemoteSecretData); err == nil {
 			KialiToken = remoteSecret.Users[0].User.Token
 		} else {
-			token, err := ioutil.ReadFile(DefaultServiceAccountPath)
-			if err != nil {
-				return "", err
+			errUpdating := updateKialiToken()
+			if errUpdating != nil {
+				fmt.Errorf("Error updating Kiali token: " + errUpdating.Error())
 			}
-			KialiToken = string(token)
 		}
 	}
 	return KialiToken, nil
+}
+
+func updateKialiToken() error {
+	var err error
+	LastRead, err = getLastModified(DefaultServiceAccountPath)
+	if err != nil {
+		return err
+	}
+	token, errRead := ioutil.ReadFile(DefaultServiceAccountPath)
+	if errRead != nil {
+		fmt.Println(errRead)
+	}
+	KialiToken = string(token)
+	return nil
+}
+
+// Return time for when a file was last modified
+func getLastModified(fileName string) (time.Time, error) {
+
+	file, err := os.Stat(fileName)
+	if err != nil {
+		fmt.Println(err)
+		return time.Time{}, err
+	}
+	return file.ModTime(), nil
+}
+
+// Is token expired is token file has been modified
+func IsTokenExpired() (bool, error) {
+	checkModifiedTime, err := getLastModified(DefaultServiceAccountPath)
+	if err != nil {
+		fmt.Println(err)
+		return false, err
+	}
+	if checkModifiedTime.Unix() > LastRead.Unix() {
+		return true, nil
+	}
+	return false, nil
 }

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -14,18 +14,13 @@ func TestIsTokenExpired(t *testing.T) {
 
 	setDefaultServiceAccountPath(tempFile)
 	token, err := GetKialiToken()
-	if err != nil {
-		fmt.Println("Error getting token")
-	} else {
-		assert.True(t, token != "")
-	}
+	assert.True(t, err != nil)
+	assert.True(t, token != "")
 
 	setupFile("thisisarandomtoken")
 
 	test, err := IsTokenExpired()
-	if err != nil {
-		fmt.Println("Error getting token")
-	}
+	assert.True(t, err != nil)
 	assert.False(t, test)
 
 	setRefreshTime(int64(2))
@@ -33,18 +28,17 @@ func TestIsTokenExpired(t *testing.T) {
 	setupFile("thisisarandomModifiedtoken")
 
 	test2, err2 := IsTokenExpired()
+	assert.True(t, err2 != nil)
 	assert.True(t, test2)
 
 	time.Sleep(5000000000) // It looks like update stats of the file takes a while
-	token, err = GetKialiToken()
-	if err2 != nil {
-		fmt.Println("Error getting token")
-	} else {
-		assert.True(t, token != "")
-	}
+	token, errGetToken := GetKialiToken()
+	assert.True(t, errGetToken == nil)
+
 	time.Sleep(6000000000)
 
-	test3, err := IsTokenExpired()
+	test3, err3 := IsTokenExpired()
+	assert.True(t, err3 != nil)
 	assert.False(t, test3)
 }
 

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -1,0 +1,64 @@
+package kubernetes
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
+)
+
+const tempFile = "/tmp/token"
+
+func TestIsTokenExpired(t *testing.T) {
+
+	setDefaultServiceAccountPath(tempFile)
+	GetKialiToken()
+
+	setupFile("thisisarandomtoken")
+
+	test, err := IsTokenExpired()
+	if err != nil {
+		fmt.Println("Error getting token")
+	}
+	assert.False(t, test)
+
+	setRefreshTime(int64(2))
+	time.Sleep(3000000000)
+	setupFile("thisisarandomModifiedtoken")
+
+	test2, err := IsTokenExpired()
+	assert.True(t, test2)
+
+	time.Sleep(5000000000) // It looks like update stats of the file takes a while
+	GetKialiToken()
+	time.Sleep(6000000000)
+
+	test3, err := IsTokenExpired()
+	assert.False(t, test3)
+}
+
+func TestGetLastModified(t *testing.T) {
+
+	setDefaultServiceAccountPath(tempFile)
+	GetKialiToken()
+
+	setupFile("thisisarandomtoken")
+
+	lastModified, err := getLastModified(tempFile)
+	if err != nil {
+		fmt.Println("Error getting token")
+	}
+
+	time.Sleep(3000000000) // Take some time to let the file stats get updated
+	assert.True(t, lastModified.Unix() < time.Now().Unix())
+
+}
+
+func setupFile(content string) {
+	data := []byte(content)
+	err := os.WriteFile(tempFile, data, 0644)
+	if err != nil {
+		fmt.Println("Error writting file")
+	}
+}

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -13,7 +13,12 @@ const tempFile = "/tmp/token"
 func TestIsTokenExpired(t *testing.T) {
 
 	setDefaultServiceAccountPath(tempFile)
-	GetKialiToken()
+	token, err := GetKialiToken()
+	if err != nil {
+		fmt.Println("Error getting token")
+	} else {
+		assert.True(t, token != "")
+	}
 
 	setupFile("thisisarandomtoken")
 
@@ -27,11 +32,16 @@ func TestIsTokenExpired(t *testing.T) {
 	time.Sleep(3000000000)
 	setupFile("thisisarandomModifiedtoken")
 
-	test2, err := IsTokenExpired()
+	test2, err2 := IsTokenExpired()
 	assert.True(t, test2)
 
 	time.Sleep(5000000000) // It looks like update stats of the file takes a while
-	GetKialiToken()
+	token, err = GetKialiToken()
+	if err2 != nil {
+		fmt.Println("Error getting token")
+	} else {
+		assert.True(t, token != "")
+	}
 	time.Sleep(6000000000)
 
 	test3, err := IsTokenExpired()
@@ -41,7 +51,12 @@ func TestIsTokenExpired(t *testing.T) {
 func TestGetLastModified(t *testing.T) {
 
 	setDefaultServiceAccountPath(tempFile)
-	GetKialiToken()
+	token, err := GetKialiToken()
+	if err != nil {
+		fmt.Println("Error getting token")
+	} else {
+		assert.True(t, token != "")
+	}
 
 	setupFile("thisisarandomtoken")
 

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -15,13 +15,13 @@ func TestIsTokenExpired(t *testing.T) {
 
 	setDefaultServiceAccountPath(tempFile)
 	token, err := GetKialiToken()
-	assert.True(t, err != nil)
+	assert.True(t, err == nil)
 	assert.True(t, token != "")
 
 	setupFile("thisisarandomtoken")
 
 	test, err := IsTokenExpired()
-	assert.True(t, err != nil)
+	assert.True(t, err == nil)
 	assert.False(t, test)
 
 	setRefreshTime(int64(2))
@@ -29,7 +29,7 @@ func TestIsTokenExpired(t *testing.T) {
 	setupFile("thisisarandomModifiedtoken")
 
 	test2, err2 := IsTokenExpired()
-	assert.True(t, err2 != nil)
+	assert.True(t, err2 == nil)
 	assert.True(t, test2)
 
 	time.Sleep(5000000000) // It looks like update stats of the file takes a while
@@ -40,7 +40,7 @@ func TestIsTokenExpired(t *testing.T) {
 	time.Sleep(6000000000)
 
 	test3, err3 := IsTokenExpired()
-	assert.True(t, err3 != nil)
+	assert.True(t, err3 == nil)
 	assert.False(t, test3)
 }
 

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -55,6 +55,17 @@ func TestGetLastModified(t *testing.T) {
 
 }
 
+func TestGetKialiToken(t *testing.T) {
+	data := "thisisarandomtoken"
+	setupFile(data)
+	token, err := GetKialiToken()
+	if err == nil {
+		fmt.Println("Error getting token")
+	}
+	assert.True(t, data == token)
+
+}
+
 func setupFile(content string) {
 	data := []byte(content)
 	err := os.WriteFile(tempFile, data, 0644)

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -2,10 +2,11 @@ package kubernetes
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const tempFile = "/tmp/token"
@@ -32,8 +33,9 @@ func TestIsTokenExpired(t *testing.T) {
 	assert.True(t, test2)
 
 	time.Sleep(5000000000) // It looks like update stats of the file takes a while
-	token, errGetToken := GetKialiToken()
+	token2, errGetToken := GetKialiToken()
 	assert.True(t, errGetToken == nil)
+	assert.True(t, token2 != "")
 
 	time.Sleep(6000000000)
 


### PR DESCRIPTION
k8s service token is never refreshed, so this PR is adding some logic to re-read the token:

- No more than once every minute
- If the SA token file has been modified

The auth strategy "anonymous" uses this token also as the user auth token. As the user is anonymous, get the SA to inherit its permissions. 

TODO: Still need to verify if the token is properly refreshed in the cache to be used when other auth strategies are set. 

Fixes https://github.com/kiali/kiali/issues/5070