### PR TITLE
[Cypress] "Help" dropdown test migration

### DIFF
--- a/frontend/cypress/integration/common/kiali_help.ts
+++ b/frontend/cypress/integration/common/kiali_help.ts
@@ -1,0 +1,26 @@
+import { When, Then, And } from "cypress-cucumber-preprocessor/steps";
+import { TableDefinition } from 'cypress-cucumber-preprocessor';
+
+
+When('user clicks on Help Button', () => {
+    cy.getBySel('about-help-button').click();
+});
+
+Then("user can see all of the Help dropdown options", (options: TableDefinition) => {
+  const names = options.raw()[0];
+  names.forEach(function (value) {
+    cy.get('li[role="menuitem"]').contains(value).should('be.visible');
+  });  
+});
+
+And("the {string} button has a link", (title:string) => {
+  cy.get('li[role="menuitem"]').contains(title).should('have.attr', 'href');
+});
+
+When('user clicks on the {string} button', (title:string) => {
+  cy.get('li[role="menuitem"]').contains(title).click();
+});
+
+Then('user sees the {string} modal', (title:string) => {
+  cy.contains(title).should('be.visible')  
+});

--- a/frontend/cypress/integration/common/kiali_help.ts
+++ b/frontend/cypress/integration/common/kiali_help.ts
@@ -22,5 +22,5 @@ When('user clicks on the {string} button', (title:string) => {
 });
 
 Then('user sees the {string} modal', (title:string) => {
-  cy.contains(title).should('be.visible')  
+  cy.get('h1.pf-c-modal-box__title').contains(title).should('be.visible')  
 });

--- a/frontend/cypress/integration/featureFiles/kiali_help.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_help.feature
@@ -1,0 +1,21 @@
+Feature: Kiali help dropdown verify
+
+  User wants to verify the Kiali help about information
+  
+  Background: 
+    Given user is at administrator perspective
+    And user is at the "overivew" page
+    When user clicks on Help Button
+    
+  Scenario: Open Kiali help dropdown
+    Then user can see all of the Help dropdown options
+      | Documentation | View Debug Info | View Certificates Info | About |
+    And the "Documentation" button has a link
+
+  Scenario: User opens the View Debug Info section
+    When user clicks on the "View Debug Info" button
+    Then user sees the "Debug information" modal
+
+  Scenario: User opens the View Certificates Info section
+    When user clicks on the "View Certificates Info" button
+    Then user sees the "Certificates information" modal


### PR DESCRIPTION
Some tests from the old [Selenium](https://github.com/Kiali-QE/kiali-qe-python/blob/master/kiali_qe/tests/test_menu.py) suite revolved around the "Help" dropdown, now migrated into the Cypress framework 

It does everything the old suite did and a little more:
- Clicks on the "Help" button
- Checks if all the 4 options are present
- Checks if the "Documentation" link exists
- Opens modals for debug and certificates

Due to some inconsistencies mentioned in #5384 , I am not able to properly test the text fields in the "View Debug Info" modal. Right now, it only checks if the modal has opened. 