### PR TITLE
Refresh K8s Service Account Token (a)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -705,7 +705,7 @@ func NewConfig() (c *Config) {
 			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
-			TokenExpireDuration:         90 * 86400, // Default to 90 days
+			TokenExpireDuration:         60, // Default to 60 seconds
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},
 			QPS:                         175,
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -281,6 +281,9 @@ type KubernetesConfig struct {
 	// Kiali cache list of namespaces per user, this is typically short lived cache compared with the duration of the
 	// namespace cache defined by previous CacheDuration parameter
 	CacheTokenNamespaceDuration int `yaml:"cache_token_namespace_duration,omitempty"`
+	// Cache token duration (seconds)
+	// Refresh the SA token
+	TokenExpireDuration int `yaml:"token_expire_duration,omitempty"`
 	// List of controllers that won't be used for Workload calculation
 	// Kiali queries Deployment,ReplicaSet,ReplicationController,DeploymentConfig,StatefulSet,Job and CronJob controllers
 	// Deployment and ReplicaSet will be always queried, but ReplicationController,DeploymentConfig,StatefulSet,Job and CronJobs
@@ -702,6 +705,7 @@ func NewConfig() (c *Config) {
 			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
+			TokenExpireDuration:         90 * 86400, // Default to 30 days
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},
 			QPS:                         175,
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -705,7 +705,7 @@ func NewConfig() (c *Config) {
 			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
-			TokenExpireDuration:         90 * 86400, // Default to 30 days
+			TokenExpireDuration:         90 * 86400, // Default to 90 days
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},
 			QPS:                         175,
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -281,9 +281,6 @@ type KubernetesConfig struct {
 	// Kiali cache list of namespaces per user, this is typically short lived cache compared with the duration of the
 	// namespace cache defined by previous CacheDuration parameter
 	CacheTokenNamespaceDuration int `yaml:"cache_token_namespace_duration,omitempty"`
-	// Cache token duration (seconds)
-	// Refresh the SA token
-	TokenExpireDuration int `yaml:"token_expire_duration,omitempty"`
 	// List of controllers that won't be used for Workload calculation
 	// Kiali queries Deployment,ReplicaSet,ReplicationController,DeploymentConfig,StatefulSet,Job and CronJob controllers
 	// Deployment and ReplicaSet will be always queried, but ReplicationController,DeploymentConfig,StatefulSet,Job and CronJobs
@@ -705,7 +702,6 @@ func NewConfig() (c *Config) {
 			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
-			TokenExpireDuration:         60, // Default to 60 seconds
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},
 			QPS:                         175,
 		},

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -63,9 +63,10 @@ func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {
 		case config.AuthStrategyAnonymous:
 			log.Tracef("Access to the server endpoint is not secured with credentials - letting request come in. Url: [%s]", r.URL.String())
 			token, err := kubernetes.GetKialiToken()
-			if err == nil {
-				authInfo = &api.AuthInfo{Token: token}
+			if err != nil {
+				token = ""
 			}
+			authInfo = &api.AuthInfo{Token: token}
 		}
 
 		switch statusCode {

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -48,7 +48,6 @@ func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {
 		conf := config.Get()
 
 		var authInfo *api.AuthInfo
-		var token string
 
 		switch conf.Auth.Strategy {
 		case config.AuthStrategyToken, config.AuthStrategyOpenId, config.AuthStrategyOpenshift, config.AuthStrategyHeader:
@@ -63,8 +62,10 @@ func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {
 			}
 		case config.AuthStrategyAnonymous:
 			log.Tracef("Access to the server endpoint is not secured with credentials - letting request come in. Url: [%s]", r.URL.String())
-			token = aHandler.saToken
-			authInfo = &api.AuthInfo{Token: token}
+			token, err := kubernetes.GetKialiToken()
+			if err == nil {
+				authInfo = &api.AuthInfo{Token: token}
+			}
 		}
 
 		switch statusCode {

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -159,7 +159,7 @@ func NewKialiCache() (KialiCache, error) {
 			select {
 			case <-ticker.C:
 				if newToken, err := kubernetes.GetKialiToken(); err != nil {
-					log.Errorf("Error updating Kiali Token")
+					log.Errorf("Error updating Kiali Token %v", err)
 				} else {
 					log.Debug("Kiali Cache: Updating token")
 					istioConfig.BearerToken = newToken

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -163,7 +163,11 @@ func NewKialiCache() (KialiCache, error) {
 				} else {
 					log.Debug("Kiali Cache: Updating token")
 					istioConfig.BearerToken = newToken
-					istioClient, err = kubernetes.NewClientFromConfig(&istioConfig)
+					var errorInitClient error
+					istioClient, errorInitClient = kubernetes.NewClientFromConfig(&istioConfig)
+					if errorInitClient != nil {
+						log.Errorf("Error creating new Client From Config")
+					}
 					kialiCacheImpl.istioClient = *istioClient
 					kialiCacheImpl.k8sApi = istioClient.GetK8sApi()
 					kialiCacheImpl.istioApi = istioClient.Istio()

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -117,7 +117,6 @@ func NewKialiCache() (KialiCache, error) {
 
 	refreshDuration := time.Duration(kConfig.KubernetesConfig.CacheDuration) * time.Second
 	tokenNamespaceDuration := time.Duration(kConfig.KubernetesConfig.CacheTokenNamespaceDuration) * time.Second
-	tokenExpireDuration := time.Duration(kConfig.KubernetesConfig.TokenExpireDuration) * time.Second
 
 	cacheNamespaces := kConfig.KubernetesConfig.CacheNamespaces
 	cacheIstioTypes := make(map[string]bool)
@@ -153,7 +152,7 @@ func NewKialiCache() (KialiCache, error) {
 	kialiCacheImpl.istioApi = istioClient.Istio()
 
 	// Update SA Token
-	kialiCacheImpl.stopCacheChan = kialiCacheImpl.refreshCache(tokenExpireDuration, istioConfig)
+	kialiCacheImpl.stopCacheChan = kialiCacheImpl.refreshCache(istioConfig)
 	log.Infof("Kiali Cache is active for namespaces %v", cacheNamespaces)
 	return &kialiCacheImpl, nil
 }
@@ -242,8 +241,8 @@ func (c *kialiCacheImpl) RefreshNamespace(namespace string) {
 }
 
 // RefreshNamespace will delete the specific namespace's cache and create a new one.
-func (c *kialiCacheImpl) refreshCache(tokenExpireDuration time.Duration, istioConfig rest.Config) chan bool {
-	ticker := time.NewTicker(tokenExpireDuration)
+func (c *kialiCacheImpl) refreshCache(istioConfig rest.Config) chan bool {
+	ticker := time.NewTicker(60 * time.Second)
 	quit := make(chan bool)
 	go func() {
 		for {

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -166,7 +166,7 @@ func NewKialiCache() (KialiCache, error) {
 					var errorInitClient error
 					istioClient, errorInitClient = kubernetes.NewClientFromConfig(&istioConfig)
 					if errorInitClient != nil {
-						log.Errorf("Error creating new Client From Config")
+						log.Errorf("Error creating new Client From Config %v", errorInitClient)
 					}
 					kialiCacheImpl.istioClient = *istioClient
 					kialiCacheImpl.k8sApi = istioClient.GetK8sApi()

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -263,11 +263,13 @@ func (c *kialiCacheImpl) RefreshCache(tokenExpireDuration time.Duration, istioCo
 							c.istioClient = *istioClient
 							c.k8sApi = istioClient.GetK8sApi()
 							c.istioApi = istioClient.Istio()
-							c.RefreshTokenNamespaces()
+							for ns := range c.nsCache {
+								c.RefreshNamespace(ns)
+							}
 						}
 
 					} else {
-						log.Info("Kiali Cache: Nothing to refresh")
+						log.Debug("Kiali Cache: Nothing to refresh")
 					}
 				}
 			case <-quit:

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -3,8 +3,6 @@ package kubernetes
 import (
 	"io/ioutil"
 	"time"
-
-	kialiConfig "github.com/kiali/kiali/config"
 )
 
 // Be careful with how you use this token. This is the Kiali Service Account token, not the user token.
@@ -14,7 +12,6 @@ var DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/t
 
 var KialiToken string
 var tokenRead time.Time
-var tokenExpireDuration time.Duration
 
 func GetKialiToken() (string, error) {
 	// TODO:refresh the token when it changes rather than after it expires
@@ -36,12 +33,9 @@ func GetKialiToken() (string, error) {
 // Check if token expired based on the kubernetes configuration
 func shouldRefreshToken() bool {
 
-	if tokenExpireDuration == 0 {
-		kConfig := kialiConfig.Get()
-		tokenExpireDuration = time.Duration(kConfig.KubernetesConfig.TokenExpireDuration) * time.Second
-	}
+	timerDuration := time.Second * 60
 
-	if time.Since(tokenRead) > tokenExpireDuration {
+	if time.Since(tokenRead) > timerDuration {
 		return true
 	} else {
 		return false

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -17,7 +17,8 @@ var tokenRead time.Time
 var tokenExpireDuration time.Duration
 
 func GetKialiToken() (string, error) {
-	if KialiToken == "" || IsTokenExpired() {
+	// TODO:refresh the token when it changes rather than after it expires
+	if KialiToken == "" || shouldRefreshToken() {
 		if remoteSecret, err := GetRemoteSecret(RemoteSecretData); err == nil {
 			KialiToken = remoteSecret.Users[0].User.Token
 		} else {
@@ -32,8 +33,8 @@ func GetKialiToken() (string, error) {
 	return KialiToken, nil
 }
 
-// Check if token expired based on the k configuration
-func IsTokenExpired() bool {
+// Check if token expired based on the kubernetes configuration
+func shouldRefreshToken() bool {
 
 	if tokenExpireDuration == 0 {
 		kConfig := kialiConfig.Get()

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -46,13 +46,3 @@ func IsTokenExpired() bool {
 		return false
 	}
 }
-
-// Set ServiceAccountPath
-func SetDefaultServiceAccountPath(path string) {
-	DefaultServiceAccountPath = path
-}
-
-// Set Token Expiration
-func SetTokenExpireDuration(expireTime time.Duration) {
-	tokenExpireDuration = expireTime
-}

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -1,16 +1,23 @@
 package kubernetes
 
-import "io/ioutil"
+import (
+	"io/ioutil"
+	"time"
+
+	kialiConfig "github.com/kiali/kiali/config"
+)
 
 // Be careful with how you use this token. This is the Kiali Service Account token, not the user token.
 // We need the Service Account token to access third-party in-cluster services (e.g. Grafana).
 
-const DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+var DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 var KialiToken string
+var tokenRead time.Time
+var tokenExpireDuration time.Duration
 
 func GetKialiToken() (string, error) {
-	if KialiToken == "" {
+	if KialiToken == "" || IsTokenExpired() {
 		if remoteSecret, err := GetRemoteSecret(RemoteSecretData); err == nil {
 			KialiToken = remoteSecret.Users[0].User.Token
 		} else {
@@ -20,6 +27,32 @@ func GetKialiToken() (string, error) {
 			}
 			KialiToken = string(token)
 		}
+		tokenRead = time.Now()
 	}
 	return KialiToken, nil
+}
+
+// Check if token expired based on the k configuration
+func IsTokenExpired() bool {
+
+	if tokenExpireDuration == 0 {
+		kConfig := kialiConfig.Get()
+		tokenExpireDuration = time.Duration(kConfig.KubernetesConfig.TokenExpireDuration) * time.Second
+	}
+
+	if time.Since(tokenRead) > tokenExpireDuration {
+		return true
+	} else {
+		return false
+	}
+}
+
+// Set ServiceAccountPath
+func SetDefaultServiceAccountPath(path string) {
+	DefaultServiceAccountPath = path
+}
+
+// Set Token Expiration
+func SetTokenExpireDuration(expireTime time.Duration) {
+	tokenExpireDuration = expireTime
 }

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -17,16 +17,14 @@ func TestIsTokenExpired(t *testing.T) {
 	SetDefaultServiceAccountPath(tmpFileTokenExpired)
 	SetTokenExpireDuration(5 * time.Second)
 
-	errCr := setupFile("thisisarandomtoken", tmpFileTokenExpired)
-	assert.Nil(t, errCr)
+	setupFile("thisisarandomtoken", tmpFileTokenExpired, t)
 	token, err := GetKialiToken()
 	assert.Nil(t, err)
 
 	assert.True(t, token != "")
 	assert.False(t, IsTokenExpired())
 
-	errRm := removeFile(tmpFileTokenExpired)
-	assert.Nil(t, errRm)
+	removeFile(tmpFileTokenExpired, t)
 }
 
 // Test Kiali Get Token
@@ -34,26 +32,24 @@ func TestGetKialiToken(t *testing.T) {
 	SetDefaultServiceAccountPath(tmpFileGetToken)
 	data := "thisisarandomtoken"
 
-	errCr := setupFile(data, tmpFileGetToken)
-	assert.Nil(t, errCr)
+	setupFile(data, tmpFileGetToken, t)
 
 	token, err := GetKialiToken()
 	assert.Nil(t, err)
 
 	assert.True(t, data == token)
-	errRm := removeFile(tmpFileGetToken)
-	assert.Nil(t, errRm)
+	removeFile(tmpFileGetToken, t)
 }
 
 // Aux func to setup files
-func setupFile(content string, name string) error {
+func setupFile(content string, name string, t *testing.T) {
 	data := []byte(content)
 	err := os.WriteFile(name, data, 0644)
-	return err
+	assert.Nil(t, err)
 }
 
 // Aux func to remove file
-func removeFile(name string) error {
+func removeFile(name string, t *testing.T) {
 	err := os.Remove(name)
-	return err
+	assert.Nil(t, err)
 }

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -1,0 +1,61 @@
+package kubernetes
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
+)
+
+const tmpFile = "/tmp/token"
+
+// Test Token is Expired
+func TestIsTokenExpired(t *testing.T) {
+
+	SetDefaultServiceAccountPath(tmpFile)
+	SetTokenExpireDuration(5 * time.Second)
+
+	setupFile("thisisarandomtoken")
+	token, err := GetKialiToken()
+
+	assert.True(t, err == nil)
+	assert.True(t, token != "")
+	assert.False(t, IsTokenExpired())
+
+	SetTokenExpireDuration(0)
+	token, err = GetKialiToken()
+
+	assert.True(t, err == nil)
+	assert.True(t, token != "")
+	assert.True(t, IsTokenExpired())
+}
+
+// Test Kiali Get Token
+func TestGetKialiToken(t *testing.T) {
+	data := "thisisarandomtoken"
+	setupFile(data)
+	token, err := GetKialiToken()
+	if err != nil {
+		fmt.Println("Error getting token")
+	}
+	assert.True(t, data == token)
+	removeFile()
+}
+
+// Aux func to setup files
+func setupFile(content string) {
+	data := []byte(content)
+	err := os.WriteFile(tmpFile, data, 0644)
+	if err != nil {
+		fmt.Println("Error writting file")
+	}
+}
+
+// Aux func to remove file
+func removeFile() {
+	err := os.Remove(tmpFile)
+	if err != nil {
+		fmt.Println("Error writting file")
+	}
+}

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -22,7 +22,7 @@ func TestIsTokenExpired(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.True(t, token != "")
-	assert.False(t, IsTokenExpired())
+	assert.False(t, shouldRefreshToken())
 
 	removeFile(tmpFileTokenExpired, t)
 }

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -1,11 +1,9 @@
 package kubernetes
 
 import (
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const tmpFileTokenExpired = "/tmp/token"
@@ -15,7 +13,6 @@ const tmpFileGetToken = "/tmp/token2"
 func TestIsTokenExpired(t *testing.T) {
 
 	DefaultServiceAccountPath = tmpFileTokenExpired
-	tokenExpireDuration = 5 * time.Second
 
 	setupFile("thisisarandomtoken", tmpFileTokenExpired, t)
 	token, err := GetKialiToken()

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -1,10 +1,11 @@
 package kubernetes
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const tmpFileTokenExpired = "/tmp/token"

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -14,8 +14,8 @@ const tmpFileGetToken = "/tmp/token2"
 // Test Token is Expired
 func TestIsTokenExpired(t *testing.T) {
 
-	SetDefaultServiceAccountPath(tmpFileTokenExpired)
-	SetTokenExpireDuration(5 * time.Second)
+	DefaultServiceAccountPath = tmpFileTokenExpired
+	tokenExpireDuration = 5 * time.Second
 
 	setupFile("thisisarandomtoken", tmpFileTokenExpired, t)
 	token, err := GetKialiToken()
@@ -29,7 +29,7 @@ func TestIsTokenExpired(t *testing.T) {
 
 // Test Kiali Get Token
 func TestGetKialiToken(t *testing.T) {
-	SetDefaultServiceAccountPath(tmpFileGetToken)
+	DefaultServiceAccountPath = tmpFileGetToken
 	data := "thisisarandomtoken"
 
 	setupFile(data, tmpFileGetToken, t)

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 	"time"
-
+	
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +33,7 @@ func TestIsTokenExpired(t *testing.T) {
 func TestGetKialiToken(t *testing.T) {
 	SetDefaultServiceAccountPath(tmpFileGetToken)
 	data := "thisisarandomtoken"
-	
+
 	errCr := setupFile(data, tmpFileGetToken)
 	assert.Nil(t, errCr)
 

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -2,59 +2,57 @@ package kubernetes
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-const tmpFile = "/tmp/token"
+const tmpFileTokenExpired = "/tmp/token"
+const tmpFileGetToken = "/tmp/token2"
 
 // Test Token is Expired
 func TestIsTokenExpired(t *testing.T) {
 
-	SetDefaultServiceAccountPath(tmpFile)
+	SetDefaultServiceAccountPath(tmpFileTokenExpired)
 	SetTokenExpireDuration(5 * time.Second)
 
-	setupFile("thisisarandomtoken")
+	setupFile("thisisarandomtoken", tmpFileTokenExpired)
 	token, err := GetKialiToken()
 
 	assert.True(t, err == nil)
 	assert.True(t, token != "")
 	assert.False(t, IsTokenExpired())
 
-	SetTokenExpireDuration(0)
-	token, err = GetKialiToken()
-
-	assert.True(t, err == nil)
-	assert.True(t, token != "")
-	assert.True(t, IsTokenExpired())
+	removeFile(tmpFileTokenExpired)
 }
 
 // Test Kiali Get Token
 func TestGetKialiToken(t *testing.T) {
+	SetDefaultServiceAccountPath(tmpFileGetToken)
 	data := "thisisarandomtoken"
-	setupFile(data)
+	setupFile(data, tmpFileGetToken)
 	token, err := GetKialiToken()
 	if err != nil {
 		fmt.Println("Error getting token")
 	}
 	assert.True(t, data == token)
-	removeFile()
+	removeFile(tmpFileGetToken)
 }
 
 // Aux func to setup files
-func setupFile(content string) {
+func setupFile(content string, name string) {
 	data := []byte(content)
-	err := os.WriteFile(tmpFile, data, 0644)
+	err := os.WriteFile(name, data, 0644)
 	if err != nil {
 		fmt.Println("Error writting file")
 	}
 }
 
 // Aux func to remove file
-func removeFile() {
-	err := os.Remove(tmpFile)
+func removeFile(name string) {
+	err := os.Remove(name)
 	if err != nil {
 		fmt.Println("Error writting file")
 	}

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -1,9 +1,10 @@
 package kubernetes
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const tmpFileTokenExpired = "/tmp/token"

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -1,11 +1,10 @@
 package kubernetes
 
 import (
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
-	
-	"github.com/stretchr/testify/assert"
 )
 
 const tmpFileTokenExpired = "/tmp/token"

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -18,42 +17,43 @@ func TestIsTokenExpired(t *testing.T) {
 	SetDefaultServiceAccountPath(tmpFileTokenExpired)
 	SetTokenExpireDuration(5 * time.Second)
 
-	setupFile("thisisarandomtoken", tmpFileTokenExpired)
+	errCr := setupFile("thisisarandomtoken", tmpFileTokenExpired)
+	assert.Nil(t, errCr)
 	token, err := GetKialiToken()
+	assert.Nil(t, err)
 
-	assert.True(t, err == nil)
 	assert.True(t, token != "")
 	assert.False(t, IsTokenExpired())
 
-	removeFile(tmpFileTokenExpired)
+	errRm := removeFile(tmpFileTokenExpired)
+	assert.Nil(t, errRm)
 }
 
 // Test Kiali Get Token
 func TestGetKialiToken(t *testing.T) {
 	SetDefaultServiceAccountPath(tmpFileGetToken)
 	data := "thisisarandomtoken"
-	setupFile(data, tmpFileGetToken)
+	
+	errCr := setupFile(data, tmpFileGetToken)
+	assert.Nil(t, errCr)
+
 	token, err := GetKialiToken()
-	if err != nil {
-		fmt.Println("Error getting token")
-	}
+	assert.Nil(t, err)
+
 	assert.True(t, data == token)
-	removeFile(tmpFileGetToken)
+	errRm := removeFile(tmpFileGetToken)
+	assert.Nil(t, errRm)
 }
 
 // Aux func to setup files
-func setupFile(content string, name string) {
+func setupFile(content string, name string) error {
 	data := []byte(content)
 	err := os.WriteFile(name, data, 0644)
-	if err != nil {
-		fmt.Println("Error writting file")
-	}
+	return err
 }
 
 // Aux func to remove file
-func removeFile(name string) {
+func removeFile(name string) error {
 	err := os.Remove(name)
-	if err != nil {
-		fmt.Println("Error writting file")
-	}
+	return err
 }


### PR DESCRIPTION
k8s service token is never refreshed, so this PR is adding some logic to re-read the token:

- Setting the expire token time  in token_expire_duration, in seconds, defaults to 1 minute: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md 

The auth strategy "anonymous" uses this token also as the user auth token. As the user is anonymous, get the SA to inherit its permissions.

- the cache uses a timer that runs every tokenExpireDuration because it needs to create a new client with the new token for each restClient. 
- GetKialiToken also uses a refresh timestamp when it is called outside the cache

Fixes https://github.com/kiali/kiali/issues/5070