### PR TITLE
[Cypress] Navbar toggle test

### DIFF
--- a/frontend/cypress/integration/common/kiali_sidebar_toggle.ts
+++ b/frontend/cypress/integration/common/kiali_sidebar_toggle.ts
@@ -1,0 +1,26 @@
+import {And, When, Then} from "cypress-cucumber-preprocessor/steps";
+
+When('the sidebar is open', () => {
+  cy.get('#page-sidebar').should('be.visible');
+});
+
+And('user presses the navigation toggle button', () => {
+  cy.get('#nav-toggle').click()
+});
+
+Then('user cannot see the sidebar', () => {
+  cy.get('#page-sidebar').should('not.be.visible');
+});
+
+When('the sidebar is closed', () => {
+  cy.get('#page-sidebar').should('exist').then(($sidebar) => {
+    if($sidebar.attr('aria-hidden') === 'false') {
+      cy.get('#nav-toggle').click()
+    }
+  })
+  cy.get('#page-sidebar').should('not.be.visible');
+});
+
+Then('user sees the sidebar', () => {
+  cy.get('#page-sidebar').should('be.visible');
+});

--- a/frontend/cypress/integration/featureFiles/kiali_sidebar_toggle.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_sidebar_toggle.feature
@@ -1,0 +1,20 @@
+Feature: Sidebar toggle 
+
+User opens the Overview page and toggles the main sidebar.
+
+  Background:
+    Given user is at administrator perspective
+    And user opens the overview page
+
+  @sidebar-toggle
+  Scenario: Close the sidebar
+    When the sidebar is open
+    And user presses the navigation toggle button
+    Then user cannot see the sidebar
+
+  @sidebar-toggle
+  Scenario: Open the sidebar
+    When the sidebar is closed
+    And user presses the navigation toggle button
+    Then user sees the sidebar
+  


### PR DESCRIPTION
Another migrated test from the old [Selenium](https://github.com/Kiali-QE/kiali-qe-python/blob/6acc35c8e2f38bf9b7daa5db5ee14114e867772a/kiali_qe/tests/test_menu.py#L47) suite.

Does nothing less than toggling the sidebar and verifying if it is or is not visible.