### PR TITLE
Show time controls in a modal from mini-graph card

### DIFF
--- a/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -7,7 +7,8 @@ import {
   CardTitle,
   Dropdown,
   DropdownItem,
-  KebabToggle
+  KebabToggle,
+  Button
 } from '@patternfly/react-core';
 import history from '../../app/History';
 import GraphDataSource from '../../services/GraphDataSource';
@@ -23,6 +24,8 @@ import { KialiDagreGraph } from './graphs/KialiDagreGraph';
 import {KialiAppState} from "../../store/Store";
 import {connect} from "react-redux";
 import {isParentKiosk, kioskContextMenuAction} from "../Kiosk/KioskActions";
+import { KialiIcon } from 'config/KialiIcon';
+import { TimeDurationModal } from "../Time/TimeDurationModal";
 
 const initGraphContainerStyle = style({ width: '100%', height: '100%' });
 
@@ -39,6 +42,7 @@ type MiniGraphCardProps = ReduxProps & {
 
 type MiniGraphCardState = {
   isKebabOpen: boolean;
+  isTimeOptionsOpen: boolean;
   graphData: DecoratedGraphElements;
 };
 
@@ -48,7 +52,7 @@ class MiniGraphCard extends React.Component<MiniGraphCardProps, MiniGraphCardSta
   constructor(props) {
     super(props);
     this.cytoscapeGraphRef = React.createRef();
-    this.state = { isKebabOpen: false, graphData: props.dataSource.graphData };
+    this.state = { isKebabOpen: false, isTimeOptionsOpen: false, graphData: props.dataSource.graphData };
   }
 
   componentDidMount() {
@@ -88,63 +92,75 @@ class MiniGraphCard extends React.Component<MiniGraphCardProps, MiniGraphCardSta
       rangeEnd > 0 ? toRangeString(rangeStart, rangeEnd, { second: '2-digit' }, { second: '2-digit' }) : 'Loading';
 
     return (
-      <Card style={{ height: '100%' }} id={'MiniGraphCard'} data-test="mini-graph">
-        <CardHeader>
-          <CardActions>
-            <Dropdown
-              toggle={<KebabToggle onToggle={this.onGraphActionsToggle} />}
-              dropdownItems={graphCardActions}
-              isPlain
-              isOpen={this.state.isKebabOpen}
-              position={'right'}
-            />
-          </CardActions>
-          <CardTitle style={{ float: 'left' }}>{intervalTitle}</CardTitle>
-        </CardHeader>
-        <CardBody>
-          <div style={{ height: '100%' }}>
-            <CytoscapeGraph
-              compressOnHide={true}
-              containerClassName={
-                this.props.graphContainerStyle ? this.props.graphContainerStyle : initGraphContainerStyle
-              }
-              graphData={{
-                elements: this.state.graphData,
-                elementsChanged: true,
-                errorMessage: !!this.props.dataSource.errorMessage ? this.props.dataSource.errorMessage : undefined,
-                isError: this.props.dataSource.isError,
-                isLoading: this.props.dataSource.isLoading,
-                fetchParams: this.props.dataSource.fetchParameters,
-                timestamp: this.props.dataSource.graphTimestamp
-              }}
-              toggleIdleNodes={() => undefined}
-              edgeLabels={this.props.dataSource.fetchParameters.edgeLabels}
-              edgeMode={EdgeMode.ALL}
-              isMTLSEnabled={this.props.mtlsEnabled}
-              isMiniGraph={true}
-              onEdgeTap={this.props.onEdgeTap}
-              layout={KialiDagreGraph.getLayout()}
-              namespaceLayout={KialiDagreGraph.getLayout()}
-              onNodeTap={this.handleNodeTap}
-              // Ranking not enabled for minigraphs yet
-              rankBy={[]}
-              ref={refInstance => this.setCytoscapeGraph(refInstance)}
-              refreshInterval={0}
-              setRankResult={undefined}
-              showIdleEdges={false}
-              showMissingSidecars={true}
-              showOperationNodes={false}
-              showRank={false}
-              showSecurity={true}
-              showServiceNodes={true}
-              showTrafficAnimation={false}
-              showIdleNodes={false}
-              showVirtualServices={true}
-              summaryData={null}
-            />
-          </div>
-        </CardBody>
-      </Card>
+      <>
+        <Card style={{ height: '100%' }} id={'MiniGraphCard'} data-test="mini-graph">
+          <CardHeader>
+            <CardActions>
+              <Dropdown
+                toggle={<KebabToggle onToggle={this.onGraphActionsToggle} />}
+                dropdownItems={graphCardActions}
+                isPlain
+                isOpen={this.state.isKebabOpen}
+                position={'right'}
+              />
+            </CardActions>
+            <CardTitle style={{ float: 'left' }}>
+              {!isParentKiosk(this.props.kiosk) ? (
+                <>{intervalTitle}</>
+              ) : (
+                <Button variant="link" isLarge={true} icon={<KialiIcon.Clock />} onClick={this.toggleTimeOptionsVisibility}>{intervalTitle}</Button>
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardBody>
+            <div style={{ height: '100%' }}>
+              <CytoscapeGraph
+                compressOnHide={true}
+                containerClassName={
+                  this.props.graphContainerStyle ? this.props.graphContainerStyle : initGraphContainerStyle
+                }
+                graphData={{
+                  elements: this.state.graphData,
+                  elementsChanged: true,
+                  errorMessage: !!this.props.dataSource.errorMessage ? this.props.dataSource.errorMessage : undefined,
+                  isError: this.props.dataSource.isError,
+                  isLoading: this.props.dataSource.isLoading,
+                  fetchParams: this.props.dataSource.fetchParameters,
+                  timestamp: this.props.dataSource.graphTimestamp
+                }}
+                toggleIdleNodes={() => undefined}
+                edgeLabels={this.props.dataSource.fetchParameters.edgeLabels}
+                edgeMode={EdgeMode.ALL}
+                isMTLSEnabled={this.props.mtlsEnabled}
+                isMiniGraph={true}
+                onEdgeTap={this.props.onEdgeTap}
+                layout={KialiDagreGraph.getLayout()}
+                namespaceLayout={KialiDagreGraph.getLayout()}
+                onNodeTap={this.handleNodeTap}
+                // Ranking not enabled for minigraphs yet
+                rankBy={[]}
+                ref={refInstance => this.setCytoscapeGraph(refInstance)}
+                refreshInterval={0}
+                setRankResult={undefined}
+                showIdleEdges={false}
+                showMissingSidecars={true}
+                showOperationNodes={false}
+                showRank={false}
+                showSecurity={true}
+                showServiceNodes={true}
+                showTrafficAnimation={false}
+                showIdleNodes={false}
+                showVirtualServices={true}
+                summaryData={null}
+              />
+            </div>
+          </CardBody>
+        </Card>
+        <TimeDurationModal
+          isOpen={this.state.isTimeOptionsOpen}
+          onConfirm={this.toggleTimeOptionsVisibility}
+          onCancel={this.toggleTimeOptionsVisibility} />
+      </>
     );
   }
 
@@ -270,6 +286,10 @@ class MiniGraphCard extends React.Component<MiniGraphCardProps, MiniGraphCardSta
     // To ensure updated components get the updated URL, update the URL first and then the state
     history.push(makeNodeGraphUrlFromParams(urlParams));
   };
+
+  private toggleTimeOptionsVisibility = () => {
+    this.setState(prevState => ({ isTimeOptionsOpen: !prevState.isTimeOptionsOpen }) );
+  }
 }
 
 const mapStateToProps = (state: KialiAppState): ReduxProps => ({

--- a/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -108,7 +108,7 @@ class MiniGraphCard extends React.Component<MiniGraphCardProps, MiniGraphCardSta
               {!isParentKiosk(this.props.kiosk) ? (
                 <>{intervalTitle}</>
               ) : (
-                <Button variant="link" isLarge={true} icon={<KialiIcon.Clock />} onClick={this.toggleTimeOptionsVisibility}>{intervalTitle}</Button>
+                <Button variant="link" style={{font: 'inherit', padding: 0}} icon={<KialiIcon.Clock />} onClick={this.toggleTimeOptionsVisibility}>{intervalTitle}</Button>
               )}
             </CardTitle>
           </CardHeader>

--- a/frontend/src/components/DurationDropdown/DurationDropdown.tsx
+++ b/frontend/src/components/DurationDropdown/DurationDropdown.tsx
@@ -23,6 +23,7 @@ type DurationDropdownProps = ReduxProps & {
   disabled?: boolean;
   tooltip?: string;
   tooltipPosition?: TooltipPosition;
+  menuAppendTo?: HTMLElement | (() => HTMLElement) | 'parent' | 'inline';
   nameDropdown?: string;
   suffix?: string;
   prefix?: string;
@@ -43,12 +44,13 @@ export class DurationDropdown extends React.Component<DurationDropdownProps> {
         tooltip={this.props.tooltip}
         tooltipPosition={this.props.tooltipPosition}
         nameDropdown={this.props.nameDropdown}
+        menuAppendTo={this.props.menuAppendTo}
       />
     );
   }
 }
 
-export const withDurations = DurationDropdownComponent => {
+const withDurations = DurationDropdownComponent => {
   return (props: DurationDropdownProps) => {
     return (
       <DurationDropdownComponent durations={humanDurations(serverConfig, props.prefix, props.suffix)} {...props} />
@@ -56,7 +58,7 @@ export const withDurations = DurationDropdownComponent => {
   };
 };
 
-export const withURLAwareness = DurationDropdownComponent => {
+const withURLAwareness = DurationDropdownComponent => {
   return class extends React.Component<DurationDropdownProps> {
     constructor(props: DurationDropdownProps) {
       super(props);
@@ -88,7 +90,9 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAp
   };
 };
 
+export const DurationDropdownComponent = withDurations(DurationDropdown);
+
 export const DurationDropdownContainer = connect(
   mapStateToProps,
   mapDispatchToProps
-)(withURLAwareness(withDurations(DurationDropdown)));
+)(withURLAwareness(DurationDropdownComponent));

--- a/frontend/src/components/Refresh/Refresh.tsx
+++ b/frontend/src/components/Refresh/Refresh.tsx
@@ -23,7 +23,9 @@ type ComponentProps = {
   id: string;
   disabled?: boolean;
   hideLabel?: boolean;
+  hideRefreshButton?: boolean;
   manageURL?: boolean;
+  menuAppendTo?: HTMLElement | (() => HTMLElement) | 'parent' | 'inline';
 
   handleRefresh?: () => void;
 };
@@ -36,7 +38,7 @@ type State = {
 
 const REFRESH_INTERVALS = config.toolbar.refreshInterval;
 
-class Refresh extends React.PureComponent<Props, State> {
+export class Refresh extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
@@ -88,15 +90,16 @@ class Refresh extends React.PureComponent<Props, State> {
             handleSelect={value => this.updateRefreshInterval(Number(value))}
             value={String(this.props.refreshInterval)}
             label={REFRESH_INTERVALS[this.props.refreshInterval]}
+            menuAppendTo={this.props.menuAppendTo}
             options={REFRESH_INTERVALS}
             tooltip={'Refresh interval'}
             tooltipPosition={TooltipPosition.left}
           />
-          <RefreshButtonContainer handleRefresh={this.handleRefresh} disabled={this.props.disabled} />
+          {this.props.hideRefreshButton || <RefreshButtonContainer handleRefresh={this.handleRefresh} disabled={this.props.disabled}/>}
         </>
       );
     } else {
-      return <RefreshButtonContainer handleRefresh={this.handleRefresh} />;
+      return this.props.hideRefreshButton ? null : <RefreshButtonContainer handleRefresh={this.handleRefresh} />;
     }
   }
 

--- a/frontend/src/components/Time/TimeDurationModal.tsx
+++ b/frontend/src/components/Time/TimeDurationModal.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Button, Form, FormGroup, Modal, ModalVariant, TooltipPosition } from "@patternfly/react-core";
+import { UserSettingsActions } from "../../actions/UserSettingsActions";
+import { HistoryManager, URLParam } from "../../app/History";
+import { KialiAppState } from "../../store/Store";
+import { DurationInSeconds, IntervalInMilliseconds } from "../../types/Common";
+import { KialiDispatch } from "../../types/Redux";
+import { DurationDropdownComponent } from "../DurationDropdown/DurationDropdown";
+import { Refresh } from "../Refresh/Refresh";
+
+interface Props {
+  isOpen: boolean;
+
+  onCancel?: () => void;
+  onConfirm?: () => void;
+}
+
+export function TimeDurationModal(props: Props) {
+  const dispatch = useDispatch<KialiDispatch>();
+  const reduxDuration = useSelector<KialiAppState, DurationInSeconds>((state) => state.userSettings.duration);
+  const reduxRefreshInterval = useSelector<KialiAppState, IntervalInMilliseconds>((state) => state.userSettings.refreshInterval);
+
+  const [duration, setDuration] = React.useState<DurationInSeconds>(reduxDuration);
+  const [refreshInterval, setRefreshInterval] = React.useState<IntervalInMilliseconds>(reduxRefreshInterval);
+
+  function handleCancel() {
+    // reset the dialog
+    setDuration(reduxDuration);
+    setRefreshInterval(reduxRefreshInterval);
+    HistoryManager.setParam(URLParam.REFRESH_INTERVAL, String(reduxRefreshInterval));
+
+    if (props.onCancel) {
+      props.onCancel();
+    }
+  }
+
+  function handleConfirm() {
+    dispatch(UserSettingsActions.setDuration(duration));
+    dispatch(UserSettingsActions.setRefreshInterval(refreshInterval));
+    if (props.onConfirm) {
+      props.onConfirm();
+    }
+  }
+
+  function handleSetDuration(d: DurationInSeconds) {
+    setDuration(d);
+  }
+
+  function handleSetRefreshInterval(r: IntervalInMilliseconds) {
+    setRefreshInterval(r);
+  }
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      isOpen={props.isOpen}
+      showClose={false}
+      actions={[<Button key="confirm" variant="primary" onClick={handleConfirm}>Confirm</Button>,<Button key="cancel" variant="link" onClick={handleCancel}>Cancel</Button>]}
+    >
+      <Form isHorizontal={true}>
+        <FormGroup
+          label="Duration"
+          fieldId="drform-duration"
+        >
+          <DurationDropdownComponent
+            id={'drform-duration-dd'}
+            disabled={/*this.props.disabled*/ false}
+            duration={duration}
+            menuAppendTo="parent"
+            prefix="Last"
+            setDuration={handleSetDuration}
+            tooltip="Traffic metrics per refresh"
+            tooltipPosition={TooltipPosition.top}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Refresh interval"
+          fieldId="drform-refresh"
+        >
+          <Refresh
+            id="drform-metrics-refresh"
+            hideLabel={true}
+            hideRefreshButton={true}
+            menuAppendTo="parent"
+            refreshInterval={refreshInterval}
+            setRefreshInterval={handleSetRefreshInterval}
+            setLastRefreshAt={() => undefined}
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+}

--- a/frontend/src/components/Time/TimeRangeComponent.tsx
+++ b/frontend/src/components/Time/TimeRangeComponent.tsx
@@ -22,6 +22,7 @@ import { bindActionCreators } from 'redux';
 import { style } from 'typestyle';
 
 type Props = {
+  menuAppendTo?: HTMLElement | (() => HTMLElement) | 'parent' | 'inline';
   timeRange: TimeRange;
   tooltip: string;
   setTimeRange: (range: TimeRange) => void;
@@ -101,6 +102,7 @@ class TimeRangeComponent extends React.Component<Props> {
         initialLabel={d ? serverConfig.durations[d] : 'Custom'}
         options={options}
         tooltip={this.props.tooltip}
+        menuAppendTo={this.props.menuAppendTo}
       />
     );
   }

--- a/frontend/src/components/ToolbarDropdown/ToolbarDropdown.tsx
+++ b/frontend/src/components/ToolbarDropdown/ToolbarDropdown.tsx
@@ -19,6 +19,7 @@ type ToolbarDropdownProps = {
   initialLabel?: string;
   initialValue?: number | string;
   label?: string;
+  menuAppendTo?: HTMLElement | (() => HTMLElement) | 'parent' | 'inline';
   nameDropdown?: string;
   options: object;
   tooltip?: string;
@@ -77,6 +78,7 @@ export class ToolbarDropdown extends React.Component<ToolbarDropdownProps, Toolb
         isOpen={isOpen}
         aria-labelledby={this.props.id}
         isDisabled={this.props.disabled}
+        menuAppendTo={this.props.menuAppendTo}
         className={this.props.classNameSelect ? `${this.props.classNameSelect} ${widthAuto}` : widthAuto}
       >
         {Object.keys(this.props.options).map(key => {


### PR DESCRIPTION
**This only affects the kiosk=parent mode**

The _refresh interval_ and _duration_ controls are currently not available in the kiosk mode, because toolbars are not visible.

When Kiali is running under in kiosk mode, the title of the mini-graph card (i.e. the time range) will become clickable. When clicking, a modal dialog will appear offering the missing time controls.

Since this is done in the mini-graph card component, these changes are reflected in all detail pages (apps, workloads, services).

Related to kiali/openshift-servicemesh-plugin#42
