### PR TITLE
For Tracing queries, add QueryScope support (analogous to Prometheus)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -187,14 +187,15 @@ type GrafanaVariablesConfig struct {
 
 // TracingConfig describes configuration used for tracing links
 type TracingConfig struct {
-	Auth                 Auth     `yaml:"auth"`
-	Enabled              bool     `yaml:"enabled"` // Enable Jaeger in Kiali
-	InClusterURL         string   `yaml:"in_cluster_url"`
-	IsCore               bool     `yaml:"is_core,omitempty"`
-	NamespaceSelector    bool     `yaml:"namespace_selector"`
-	URL                  string   `yaml:"url"`
-	UseGRPC              bool     `yaml:"use_grpc"`
-	WhiteListIstioSystem []string `yaml:"whitelist_istio_system"`
+	Auth                 Auth              `yaml:"auth"`
+	Enabled              bool              `yaml:"enabled"` // Enable Jaeger in Kiali
+	InClusterURL         string            `yaml:"in_cluster_url"`
+	IsCore               bool              `yaml:"is_core,omitempty"`
+	NamespaceSelector    bool              `yaml:"namespace_selector"`
+	QueryScope           map[string]string `yaml:"query_scope,omitempty"`
+	URL                  string            `yaml:"url"`
+	UseGRPC              bool              `yaml:"use_grpc"`
+	WhiteListIstioSystem []string          `yaml:"whitelist_istio_system"`
 }
 
 // IstioConfig describes configuration used for istio links
@@ -621,6 +622,7 @@ func NewConfig() (c *Config) {
 				InClusterURL:         "http://tracing.istio-system:16685/jaeger",
 				IsCore:               false,
 				NamespaceSelector:    true,
+				QueryScope:           map[string]string{},
 				URL:                  "",
 				UseGRPC:              true,
 				WhiteListIstioSystem: []string{"jaeger-query", "istio-ingressgateway"},

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -232,6 +232,7 @@ func readQuery(values url.Values) (models.TracingQuery, error) {
 		Limit: 100,
 		Tags:  make(map[string]string),
 	}
+
 	if v := values.Get("startMicros"); v != "" {
 		if num, err := strconv.ParseInt(v, 10, 64); err == nil {
 			q.Start = time.Unix(0, num*int64(time.Microsecond))
@@ -268,5 +269,10 @@ func readQuery(values url.Values) (models.TracingQuery, error) {
 			return models.TracingQuery{}, fmt.Errorf("Cannot parse parameter 'minDuration': " + err.Error())
 		}
 	}
+
+	for key, value := range config.Get().ExternalServices.Tracing.QueryScope {
+		q.Tags[key] = value
+	}
+
 	return q, nil
 }

--- a/jaeger/client.go
+++ b/jaeger/client.go
@@ -201,6 +201,10 @@ func (in *Client) GetErrorTraces(ns, app string, duration time.Duration) (int, e
 		End:   now,
 		Tags:  map[string]string{"error": "true"},
 	}
+	for key, value := range config.Get().ExternalServices.Tracing.QueryScope {
+		query.Tags[key] = value
+	}
+
 	traces, err := in.GetAppTraces(ns, app, query)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Closes https://github.com/kiali/kiali/issues/4635

**Operator PR: ** https://github.com/kiali/kiali-operator/pull/558

As an example, By adding this to the Kiali CR:

```
spec:
  external_services:
    tracing:
      query_scope:
        test: test-value
```

I then get this in the Jaeger query:

```
2022-08-19T15:04:38Z INF Prepared Jaeger query: query:{service_name:"x-server.alpha" tags:{key:"test" value:"test-value"} start_time_min:{seconds:1660921234} start_time_max:{seconds:1660921478 nanos:862887247} duration_min:{} search_depth:15}
```


