### PR TITLE
Update testing demos to be compatible with OpenShift 4.11

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -322,6 +322,9 @@ if [ "${TRAFFIC_GENERATOR_ENABLED}" == "true" ]; then
   fi
 
   if [ "${INGRESS_ROUTE}" != "" ] ; then
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+      $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n ${NAMESPACE}
+    fi
     # TODO - these access the "openshift" yaml files - but there are no kubernetes specific versions. using --validate=false
     curl https://raw.githubusercontent.com/kiali/kiali-test-mesh/master/traffic-generator/openshift/traffic-generator-configmap.yaml | DURATION='0s' ROUTE="http://${INGRESS_ROUTE}/productpage" RATE="${RATE}" envsubst | $CLIENT_EXE apply -n ${NAMESPACE} -f -
     curl https://raw.githubusercontent.com/kiali/kiali-test-mesh/master/traffic-generator/openshift/traffic-generator.yaml | $CLIENT_EXE apply --validate=false -n ${NAMESPACE} -f -

--- a/hack/istio/install-error-rates-demo.sh
+++ b/hack/istio/install-error-rates-demo.sh
@@ -132,10 +132,12 @@ if [ "${ENABLE_INJECTION}" == "true" ]; then
   ${CLIENT_EXE} label namespace ${NAMESPACE_BETA} istio-injection=enabled
 fi
 
-# Deploy the demo
+# For OpenShift 4.11, adds default service account in the current ns to use as a user
+if [ "${IS_OPENSHIFT}" == "true" ]; then
+  $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n ${NAMESPACE_ALPHA}
+  $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n ${NAMESPACE_BETA}
+fi
 
-${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/error-rates/alpha.yaml") -n ${NAMESPACE_ALPHA}
-${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/error-rates/beta.yaml") -n ${NAMESPACE_BETA}
 
 if [ "${IS_MAISTRA}" == "true" ]; then
   prepare_maistra "${NAMESPACE_ALPHA}"
@@ -173,3 +175,7 @@ users:
 - "system:serviceaccount:${NAMESPACE_BETA}:default"
 SCC
 fi
+
+# Deploy the demo
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/error-rates/alpha.yaml") -n ${NAMESPACE_ALPHA}
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/error-rates/beta.yaml") -n ${NAMESPACE_BETA}

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -18,8 +18,6 @@ install_sleep_app() {
   
   ${CLIENT_EXE} label namespace "sleep" istio-injection=enabled --overwrite=true
 
-  ${CLIENT_EXE} apply -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
-
   if [ "${IS_OPENSHIFT}" == "true" ]; then
       cat <<NAD | $CLIENT_EXE -n sleep apply -f -
 apiVersion: "k8s.cni.cncf.io/v1"
@@ -43,6 +41,14 @@ users:
 - "system:serviceaccount:sleep:sleep"
 SCC
   fi
+
+  # For OpenShift 4.11, adds default service account in the current ns to use as a user
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n sleep
+  fi
+
+  ${CLIENT_EXE} apply -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
+
 }
 
 SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -61,6 +61,9 @@ SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 # install the Istio release that was last downloaded (that's the -t option to ls)
 ISTIO_DIR=$(ls -dt1 ${SCRIPT_DIR}/../../_output/istio-* | head -n1)
 
+# only used when cluster is minikube
+MINIKUBE_PROFILE="minikube"
+
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMOS:=false}
 
@@ -75,11 +78,16 @@ while [ $# -gt 0 ]; do
       DELETE_DEMOS="$2"
       shift;shift
       ;;
+    -mp|--minikube-profile)
+      MINIKUBE_PROFILE="$2"
+      shift;shift
+      ;;
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
   -c|--client: either 'oc' or 'kubectl'
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
+  -mp|--minikube-profile <name>: If using minikube, this is the minikube profile name (default: minikube).
   -h|--help: this text
 HELPMSG
       exit 1
@@ -121,7 +129,7 @@ if [ "${DELETE_DEMOS}" != "true" ]; then
     "${SCRIPT_DIR}/install-error-rates-demo.sh"
   else
     echo "Deploying bookinfo demo..."
-    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -tg
+    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -mp ${MINIKUBE_PROFILE} -tg
     echo "Deploying error rates demo..."
     "${SCRIPT_DIR}/install-error-rates-demo.sh" -c kubectl
   fi

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -11,7 +11,7 @@ set -eu
   
 install_sleep_app() {
 
-  if [[ "${ISTIO_DIR}" = "" ]]; then
+  if [ "${ISTIO_DIR}" == "" ]; then
     ISTIO_DIR=$(ls -dt1 ${SCRIPT_DIR}/../../_output/istio-* | head -n1)
   fi
 

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -10,6 +10,11 @@
 set -eu
   
 install_sleep_app() {
+
+  if [[ "${ISTIO_DIR}" = "" ]]; then
+    ISTIO_DIR=$(ls -dt1 ${SCRIPT_DIR}/../../_output/istio-* | head -n1)
+  fi
+
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     ${CLIENT_EXE} get project "sleep" || ${CLIENT_EXE} new-project "sleep"
   else

--- a/hack/istio/install-travel-agency-demo.sh
+++ b/hack/istio/install-travel-agency-demo.sh
@@ -197,20 +197,12 @@ NAD
   fi
 fi
 
-# Deploy the demo
-
-${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/travels/travel_agency.yaml") -n ${NAMESPACE_AGENCY}
-${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/travels/travel_portal.yaml") -n ${NAMESPACE_PORTAL}
-${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/travels/travel_control.yaml") -n ${NAMESPACE_CONTROL}
-
-if [ "${IS_MAISTRA}" == "true" ]; then
-  prepare_maistra "${NAMESPACE_AGENCY}"
-  prepare_maistra "${NAMESPACE_PORTAL}"
-  prepare_maistra "${NAMESPACE_CONTROL}"
-fi
-
 # Add SCC for OpenShift
 if [ "${IS_OPENSHIFT}" == "true" ]; then
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid -z default -n ${NAMESPACE_AGENCY}
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid -z default -n ${NAMESPACE_PORTAL}
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid -z default -n ${NAMESPACE_CONTROL}
+
   cat <<SCC | $CLIENT_EXE apply -f -
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -227,6 +219,18 @@ users:
 - "system:serviceaccount:${NAMESPACE_PORTAL}:default"
 - "system:serviceaccount:${NAMESPACE_CONTROL}:default"
 SCC
+fi
+
+# Deploy the demo
+
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/travels/travel_agency.yaml") -n ${NAMESPACE_AGENCY}
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/travels/travel_portal.yaml") -n ${NAMESPACE_PORTAL}
+${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/travels/travel_control.yaml") -n ${NAMESPACE_CONTROL}
+
+if [ "${IS_MAISTRA}" == "true" ]; then
+  prepare_maistra "${NAMESPACE_AGENCY}"
+  prepare_maistra "${NAMESPACE_PORTAL}"
+  prepare_maistra "${NAMESPACE_CONTROL}"
 fi
 
 # Set up metric classification


### PR DESCRIPTION
- Moved the creation of the scc before apply any yaml in the namespace to avoid warnings. 
- Added scc for the user. Related: https://istio.io/latest/docs/setup/platform-setup/openshift/ (The Istio sidecar injected into each application pod runs with user ID 1337, which is not allowed by default in OpenShift. )

- [x]  Need to be tested in previous versions (4.10 compatible)
- [x] Test solution: https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/240/files

Fixes #5394