### PR TITLE
Support Telemetry and WasmPlugin Istio objects

### DIFF
--- a/business/checkers/telemetries_checker.go
+++ b/business/checkers/telemetries_checker.go
@@ -1,0 +1,23 @@
+package checkers
+
+import (
+	"github.com/kiali/kiali/models"
+	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
+)
+
+const TelemetryCheckerType = "telemetry"
+
+type TelemetryChecker struct {
+	Namespaces  models.Namespaces
+	Telemetries []*v1alpha1.Telemetry
+}
+
+// An Object Checker runs all checkers for an specific object type (i.e.: pod, route rule,...)
+// It run two kinds of checkers:
+// 1. Individual checks: validating individual objects.
+// 2. Group checks: validating behaviour between configurations.
+func (in TelemetryChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	return validations
+}

--- a/business/checkers/telemetries_checker.go
+++ b/business/checkers/telemetries_checker.go
@@ -1,8 +1,9 @@
 package checkers
 
 import (
-	"github.com/kiali/kiali/models"
 	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
+
+	"github.com/kiali/kiali/models"
 )
 
 const TelemetryCheckerType = "telemetry"

--- a/business/checkers/wasm_plugin_checker.go
+++ b/business/checkers/wasm_plugin_checker.go
@@ -1,0 +1,23 @@
+package checkers
+
+import (
+	"github.com/kiali/kiali/models"
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+)
+
+const WasmPluginCheckerType = "wasmplugin"
+
+type WasmPluginChecker struct {
+	Namespaces  models.Namespaces
+	WasmPlugins []*extentions_v1alpha1.WasmPlugin
+}
+
+// An Object Checker runs all checkers for an specific object type (i.e.: pod, route rule,...)
+// It run two kinds of checkers:
+// 1. Individual checks: validating individual objects.
+// 2. Group checks: validating behaviour between configurations.
+func (in WasmPluginChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	return validations
+}

--- a/business/checkers/wasm_plugin_checker.go
+++ b/business/checkers/wasm_plugin_checker.go
@@ -1,8 +1,9 @@
 package checkers
 
 import (
-	"github.com/kiali/kiali/models"
 	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+
+	"github.com/kiali/kiali/models"
 )
 
 const WasmPluginCheckerType = "wasmplugin"

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -569,13 +569,13 @@ func (in *IstioConfigService) GetIstioConfigDetails(ctx context.Context, namespa
 		istioConfigDetail.WasmPlugin, err = in.k8s.Istio().ExtensionsV1alpha1().WasmPlugins(namespace).Get(ctx, object, getOpts)
 		if err == nil {
 			istioConfigDetail.WasmPlugin.Kind = kubernetes.WasmPluginType
-			istioConfigDetail.WasmPlugin.APIVersion = kubernetes.ApiNetworkingVersionV1Alpha3
+			istioConfigDetail.WasmPlugin.APIVersion = kubernetes.ApiExtensionV1Alpha1
 		}
 	case kubernetes.Telemetries:
 		istioConfigDetail.Telemetry, err = in.k8s.Istio().TelemetryV1alpha1().Telemetries(namespace).Get(ctx, object, getOpts)
 		if err == nil {
-			istioConfigDetail.Telemetry.Kind = kubernetes.Telemetries
-			istioConfigDetail.Telemetry.APIVersion = kubernetes.ApiNetworkingVersionV1Beta1
+			istioConfigDetail.Telemetry.Kind = kubernetes.TelemetryType
+			istioConfigDetail.Telemetry.APIVersion = kubernetes.ApiTelemetryV1Alpha1
 		}
 	case kubernetes.AuthorizationPolicies:
 		istioConfigDetail.AuthorizationPolicy, err = in.k8s.Istio().SecurityV1beta1().AuthorizationPolicies(namespace).Get(ctx, object, getOpts)
@@ -721,7 +721,7 @@ func (in *IstioConfigService) GetIstioConfigDetailsFromRegistry(ctx context.Cont
 			if cfg.Name == object && cfg.Namespace == namespace {
 				istioConfigDetail.WasmPlugin = cfg
 				istioConfigDetail.WasmPlugin.Kind = kubernetes.WasmPluginType
-				istioConfigDetail.WasmPlugin.APIVersion = kubernetes.ApiNetworkingVersionV1Beta1
+				istioConfigDetail.WasmPlugin.APIVersion = kubernetes.ApiExtensionV1Alpha1
 				return istioConfigDetail, nil
 			}
 		}
@@ -731,7 +731,7 @@ func (in *IstioConfigService) GetIstioConfigDetailsFromRegistry(ctx context.Cont
 			if cfg.Name == object && cfg.Namespace == namespace {
 				istioConfigDetail.Telemetry = cfg
 				istioConfigDetail.Telemetry.Kind = kubernetes.TelemetryType
-				istioConfigDetail.Telemetry.APIVersion = kubernetes.ApiNetworkingVersionV1Beta1
+				istioConfigDetail.Telemetry.APIVersion = kubernetes.ApiTelemetryV1Alpha1
 				return istioConfigDetail, nil
 			}
 		}
@@ -866,6 +866,12 @@ func (in *IstioConfigService) UpdateIstioConfigDetail(namespace, resourceType, n
 	case kubernetes.RequestAuthentications:
 		istioConfigDetail.RequestAuthentication = &security_v1beta1.RequestAuthentication{}
 		istioConfigDetail.RequestAuthentication, err = in.k8s.Istio().SecurityV1beta1().RequestAuthentications(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
+	case kubernetes.WasmPlugins:
+		istioConfigDetail.WasmPlugin = &extentions_v1alpha1.WasmPlugin{}
+		istioConfigDetail.WasmPlugin, err = in.k8s.Istio().ExtensionsV1alpha1().WasmPlugins(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
+	case kubernetes.Telemetries:
+		istioConfigDetail.Telemetry = &v1alpha1.Telemetry{}
+		istioConfigDetail.Telemetry, err = in.k8s.Istio().TelemetryV1alpha1().Telemetries(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
 	default:
 		err = fmt.Errorf("object type not found: %v", resourceType)
 	}

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -5,14 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
-	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	"strings"
 	"sync"
 
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api_types "k8s.io/apimachinery/pkg/types"
@@ -575,7 +575,7 @@ func (in *IstioConfigService) GetIstioConfigDetails(ctx context.Context, namespa
 		istioConfigDetail.Telemetry, err = in.k8s.Istio().TelemetryV1alpha1().Telemetries(namespace).Get(ctx, object, getOpts)
 		if err == nil {
 			istioConfigDetail.Telemetry.Kind = kubernetes.Telemetries
-			istioConfigDetail.Telemetry.APIVersion = kubernetes.ApiNetworkingVersionV1Alpha3
+			istioConfigDetail.Telemetry.APIVersion = kubernetes.ApiNetworkingVersionV1Beta1
 		}
 	case kubernetes.AuthorizationPolicies:
 		istioConfigDetail.AuthorizationPolicy, err = in.k8s.Istio().SecurityV1beta1().AuthorizationPolicies(namespace).Get(ctx, object, getOpts)

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -571,6 +571,12 @@ func (in *IstioConfigService) GetIstioConfigDetails(ctx context.Context, namespa
 			istioConfigDetail.WasmPlugin.Kind = kubernetes.WasmPluginType
 			istioConfigDetail.WasmPlugin.APIVersion = kubernetes.ApiNetworkingVersionV1Alpha3
 		}
+	case kubernetes.Telemetries:
+		istioConfigDetail.Telemetry, err = in.k8s.Istio().TelemetryV1alpha1().Telemetries(namespace).Get(ctx, object, getOpts)
+		if err == nil {
+			istioConfigDetail.Telemetry.Kind = kubernetes.Telemetries
+			istioConfigDetail.Telemetry.APIVersion = kubernetes.ApiNetworkingVersionV1Alpha3
+		}
 	case kubernetes.AuthorizationPolicies:
 		istioConfigDetail.AuthorizationPolicy, err = in.k8s.Istio().SecurityV1beta1().AuthorizationPolicies(namespace).Get(ctx, object, getOpts)
 		if err == nil {

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -369,7 +369,7 @@ func (in *IstioConfigService) GetIstioConfigList(ctx context.Context, criteria I
 		if criteria.Include(kubernetes.WasmPlugins) {
 			var err error
 			if IsResourceCached(criteria.Namespace, kubernetes.WasmPlugins) {
-				istioConfigList.WorkloadGroups, err = kialiCache.GetWorkloadGroups(criteria.Namespace, criteria.LabelSelector)
+				istioConfigList.WasmPlugins, err = kialiCache.GetWasmPlugins(criteria.Namespace, criteria.LabelSelector)
 			} else {
 				wgl, e := in.k8s.Istio().ExtensionsV1alpha1().WasmPlugins(criteria.Namespace).List(ctx, listOpts)
 				istioConfigList.WasmPlugins = wgl.Items

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -137,6 +137,8 @@ func (in *IstioValidationsService) getAllObjectCheckers(istioConfigList models.I
 		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadsPerNamespace: workloadsPerNamespace, ServiceEntries: istioConfigList.ServiceEntries, RegistryServices: registryServices},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.WorkloadChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, WorkloadsPerNamespace: workloadsPerNamespace},
+		checkers.WasmPluginChecker{WasmPlugins: istioConfigList.WasmPlugins, Namespaces: namespaces},
+		checkers.TelemetryChecker{Telemetries: istioConfigList.Telemetries, Namespaces: namespaces},
 	}
 }
 
@@ -229,6 +231,10 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 		objectCheckers = []ObjectChecker{requestAuthnChecker}
 	case kubernetes.EnvoyFilters:
 		// Validation on EnvoyFilters are not yet in place
+	case kubernetes.WasmPlugins:
+		// TODO
+	case kubernetes.Telemetries:
+		// TODO
 	default:
 		err = fmt.Errorf("object type not found: %v", objectType)
 	}

--- a/business/registry_status.go
+++ b/business/registry_status.go
@@ -121,6 +121,18 @@ func filterRegistryConfiguration(registryStatus *kubernetes.RegistryStatus, crit
 		}
 	}
 
+	for _, wp := range registryStatus.Configuration.WasmPlugins {
+		if wp.Namespace == criteria.Namespace {
+			filtered.WasmPlugins = append(filtered.WasmPlugins, wp)
+		}
+	}
+
+	for _, tm := range registryStatus.Configuration.Telemetries {
+		if tm.Namespace == criteria.Namespace {
+			filtered.Telemetries = append(filtered.Telemetries, tm)
+		}
+	}
+
 	for _, ap := range registryStatus.Configuration.AuthorizationPolicies {
 		if ap.Namespace == criteria.Namespace {
 			filtered.AuthorizationPolicies = append(filtered.AuthorizationPolicies, ap)

--- a/frontend/src/components/Pf/PfBadges.tsx
+++ b/frontend/src/components/Pf/PfBadges.tsx
@@ -58,6 +58,8 @@ export const PFBadges: { [key: string]: PFBadgeType } = Object.freeze({
   ServiceRole: { badge: 'SR', tt: 'Service Role' } as PFBadgeType,
   ServiceRoleBinding: { badge: 'SRB', tt: 'Service Role Binding' } as PFBadgeType,
   Sidecar: { badge: 'SC', tt: 'Istio Sidecar Proxy' } as PFBadgeType,
+  WasmPlugin: { badge: 'WP', tt: 'Istio Wasm Plugin' } as PFBadgeType,
+  Telemetry: { badge: 'TM', tt: 'Istio Telemetry' } as PFBadgeType,
   Template: { badge: 'T', tt: 'Template' } as PFBadgeType,
   Unknown: { badge: 'U', tt: 'Unknown' } as PFBadgeType,
   VirtualService: { badge: 'VS', tt: 'Virtual Service' } as PFBadgeType,

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -218,6 +218,8 @@ export const IstioTypes = {
   workloadentry: { name: 'WorkloadEntry', url: 'workloadentries', badge: PFBadges.WorkloadEntry } as istioConfigType,
   workloadgroup: { name: 'WorkloadGroup', url: 'workloadgroups', badge: PFBadges.WorkloadGroup } as istioConfigType,
   envoyfilter: { name: 'EnvoyFilter', url: 'envoyfilters', badge: PFBadges.EnvoyFilter } as istioConfigType,
+  wasmplugin: {name: 'WasmPlugin', url: 'wasmplugins', badge: PFBadges.WasmPlugin} as istioConfigType,
+  telemetry: {name: 'Telemetry', url: 'telemetry', badge: PFBadges.Telemetry} as istioConfigType,
   attributemanifest: {
     name: 'AttributeManifest',
     url: 'attributemanifests',

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -220,6 +220,7 @@ export const IstioTypes = {
   envoyfilter: { name: 'EnvoyFilter', url: 'envoyfilters', badge: PFBadges.EnvoyFilter } as istioConfigType,
   wasmplugin: {name: 'WasmPlugin', url: 'wasmplugins', badge: PFBadges.WasmPlugin} as istioConfigType,
   telemetry: {name: 'Telemetry', url: 'telemetries', badge: PFBadges.Telemetry} as istioConfigType,
+  telemetries: {name: 'Telemetry', url: 'telemetries', badge: PFBadges.Telemetry} as istioConfigType,
   attributemanifest: {
     name: 'AttributeManifest',
     url: 'attributemanifests',

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -219,7 +219,7 @@ export const IstioTypes = {
   workloadgroup: { name: 'WorkloadGroup', url: 'workloadgroups', badge: PFBadges.WorkloadGroup } as istioConfigType,
   envoyfilter: { name: 'EnvoyFilter', url: 'envoyfilters', badge: PFBadges.EnvoyFilter } as istioConfigType,
   wasmplugin: {name: 'WasmPlugin', url: 'wasmplugins', badge: PFBadges.WasmPlugin} as istioConfigType,
-  telemetry: {name: 'Telemetry', url: 'telemetry', badge: PFBadges.Telemetry} as istioConfigType,
+  telemetry: {name: 'Telemetry', url: 'telemetries', badge: PFBadges.Telemetry} as istioConfigType,
   attributemanifest: {
     name: 'AttributeManifest',
     url: 'attributemanifests',

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -220,7 +220,6 @@ export const IstioTypes = {
   envoyfilter: { name: 'EnvoyFilter', url: 'envoyfilters', badge: PFBadges.EnvoyFilter } as istioConfigType,
   wasmplugin: {name: 'WasmPlugin', url: 'wasmplugins', badge: PFBadges.WasmPlugin} as istioConfigType,
   telemetry: {name: 'Telemetry', url: 'telemetries', badge: PFBadges.Telemetry} as istioConfigType,
-  telemetries: {name: 'Telemetry', url: 'telemetries', badge: PFBadges.Telemetry} as istioConfigType,
   attributemanifest: {
     name: 'AttributeManifest',
     url: 'attributemanifests',

--- a/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -110,8 +110,16 @@ export const istioTypeFilter: FilterType = {
       title: 'Sidecar'
     },
     {
+      id: 'Telemetry',
+      title: 'Telemetry'
+    },
+    {
       id: 'VirtualService',
       title: 'VirtualService'
+    },
+    {
+      id: 'WasmPlugin',
+      title: 'WasmPlugin'
     },
     {
       id: 'WorkloadEntry',

--- a/frontend/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/frontend/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -19,7 +19,9 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     workloadGroups: [],
     envoyFilters: [],
     validations: {},
-    permissions: {}
+    permissions: {},
+    wasmPlugins: [],
+    telemetries: [],
   };
   names.forEach(name => {
     testData.authorizationPolicies.push({ metadata: { name: name + '0' }, spec: {} });
@@ -53,6 +55,8 @@ describe('IstioConfigListContainer#filterByName', () => {
     expect(filtered.virtualServices.length).toBe(0);
     expect(filtered.destinationRules.length).toBe(0);
     expect(filtered.serviceEntries.length).toBe(0);
+    expect(filtered.wasmPlugins.length).toBe(0);
+    expect(filtered.telemetries.length).toBe(0);
   });
 });
 
@@ -79,7 +83,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
     expect(sorted).toBeDefined();
-    expect(sorted.length).toBe(15);
+    expect(sorted.length).toBe(17);
 
     const first = sorted[0];
     expect(first.authorizationPolicy).toBeDefined();
@@ -102,7 +106,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     // Descending
     const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
     expect(sorted).toBeDefined();
-    expect(sorted.length).toBe(15);
+    expect(sorted.length).toBe(17);
 
     const first = sorted[0];
     expect(first.virtualService).toBeDefined();
@@ -120,7 +124,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
     expect(sorted).toBeDefined();
-    expect(sorted.length).toBe(15);
+    expect(sorted.length).toBe(17);
 
     const first = sorted[0];
     expect(first.authorizationPolicy).toBeDefined();
@@ -142,7 +146,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
     expect(sorted).toBeDefined();
-    expect(sorted.length).toBe(15);
+    expect(sorted.length).toBe(17);
 
     const first = sorted[0];
     expect(first.virtualService).toBeDefined();

--- a/frontend/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/frontend/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -83,7 +83,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
     expect(sorted).toBeDefined();
-    expect(sorted.length).toBe(17);
+    expect(sorted.length).toBe(15);
 
     const first = sorted[0];
     expect(first.authorizationPolicy).toBeDefined();
@@ -106,7 +106,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     // Descending
     const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
     expect(sorted).toBeDefined();
-    expect(sorted.length).toBe(17);
+    expect(sorted.length).toBe(15);
 
     const first = sorted[0];
     expect(first.virtualService).toBeDefined();
@@ -124,7 +124,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
     expect(sorted).toBeDefined();
-    expect(sorted.length).toBe(17);
+    expect(sorted.length).toBe(15);
 
     const first = sorted[0];
     expect(first.authorizationPolicy).toBeDefined();
@@ -146,7 +146,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
     expect(sorted).toBeDefined();
-    expect(sorted.length).toBe(17);
+    expect(sorted.length).toBe(15);
 
     const first = sorted[0];
     expect(first.virtualService).toBeDefined();

--- a/frontend/src/types/IstioConfigDetails.ts
+++ b/frontend/src/types/IstioConfigDetails.ts
@@ -15,7 +15,7 @@ import {
   EnvoyFilter,
   WorkloadGroup,
   References,
-  HelpMessage
+  HelpMessage, WasmPlugin, Telemetry
 } from './IstioObjects';
 import { AceOptions } from 'react-ace/types';
 
@@ -35,6 +35,8 @@ export interface IstioConfigDetails {
   workloadEntry: WorkloadEntry;
   workloadGroup: WorkloadGroup;
   envoyFilter: EnvoyFilter;
+  wasmPlugin: WasmPlugin;
+  telemetry: Telemetry;
   authorizationPolicy: AuthorizationPolicy;
   peerAuthentication: PeerAuthentication;
   requestAuthentication: RequestAuthentication;

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -88,7 +88,7 @@ export const dicIstioType = {
   workloadgroups: 'WorkloadGroup',
   envoyfilters: 'EnvoyFilter',
   telemetries: 'Telemetry',
-  wasmPlugins: 'WasmPlugin',
+  wasmplugins: 'WasmPlugin',
 
   gateway: 'Gateway',
   virtualservice: 'VirtualService',

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -9,6 +9,8 @@ import {
   RequestAuthentication,
   ServiceEntry,
   Sidecar,
+  WasmPlugin,
+  Telemetry,
   Validations,
   VirtualService,
   WorkloadEntry,
@@ -28,6 +30,8 @@ export interface IstioConfigItem {
   serviceEntry?: ServiceEntry;
   authorizationPolicy?: AuthorizationPolicy;
   sidecar?: Sidecar;
+  wasmPlugin?: WasmPlugin;
+  telemetry?: Telemetry;
   peerAuthentication?: PeerAuthentication;
   requestAuthentication?: RequestAuthentication;
   workloadEntry?: WorkloadEntry;
@@ -49,6 +53,8 @@ export interface IstioConfigList {
   envoyFilters: EnvoyFilter[];
   authorizationPolicies: AuthorizationPolicy[];
   sidecars: Sidecar[];
+  wasmPlugins: WasmPlugin[];
+  telemetries: Telemetry[];
   peerAuthentications: PeerAuthentication[];
   requestAuthentications: RequestAuthentication[];
   permissions: { [key: string]: ResourcePermissions };
@@ -67,6 +73,8 @@ export const dicIstioType = {
   WorkloadEntry: 'workloadentries',
   WorkloadGroup: 'workloadgroups',
   EnvoyFilter: 'envoyfilters',
+  WasmPlugin: 'wasmPlugins',
+  Telemetry: 'telemetries',
 
   gateways: 'Gateway',
   virtualservices: 'VirtualService',
@@ -79,6 +87,8 @@ export const dicIstioType = {
   workloadentries: 'WorkloadEntry',
   workloadgroups: 'WorkloadGroup',
   envoyfilters: 'EnvoyFilter',
+  telemetries: 'Telemetry',
+  wasmPlugins: 'WasmPlugin',
 
   gateway: 'Gateway',
   virtualservice: 'VirtualService',
@@ -127,6 +137,8 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     workloadEntries: unfiltered.workloadEntries.filter(we => includeName(we.metadata.name, names)),
     workloadGroups: unfiltered.workloadGroups.filter(wg => includeName(wg.metadata.name, names)),
     envoyFilters: unfiltered.envoyFilters.filter(ef => includeName(ef.metadata.name, names)),
+    wasmPlugins: unfiltered.wasmPlugins.filter(ef => includeName(ef.metadata.name, names)),
+    telemetries: unfiltered.telemetries.filter(ef => includeName(ef.metadata.name, names)),
     validations: unfiltered.validations,
     permissions: unfiltered.permissions
   };

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -96,6 +96,8 @@ export const dicIstioType = {
   serviceentry: 'ServiceEntry',
   authorizationpolicy: 'AuthorizationPolicy',
   sidecar: 'Sidecar',
+  wasmplugin: 'WasmPlugin',
+  telemetry: 'Telemetry',
   peerauthentication: 'PeerAuthentication',
   requestauthentication: 'RequestAuthentication',
   workloadentry: 'WorkloadEntry',
@@ -137,8 +139,8 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     workloadEntries: unfiltered.workloadEntries.filter(we => includeName(we.metadata.name, names)),
     workloadGroups: unfiltered.workloadGroups.filter(wg => includeName(wg.metadata.name, names)),
     envoyFilters: unfiltered.envoyFilters.filter(ef => includeName(ef.metadata.name, names)),
-    wasmPlugins: unfiltered.wasmPlugins.filter(ef => includeName(ef.metadata.name, names)),
-    telemetries: unfiltered.telemetries.filter(ef => includeName(ef.metadata.name, names)),
+    wasmPlugins: unfiltered.wasmPlugins.filter(wp => includeName(wp.metadata.name, names)),
+    telemetries: unfiltered.telemetries.filter(tm => includeName(tm.metadata.name, names)),
     validations: unfiltered.validations,
     permissions: unfiltered.permissions
   };

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -802,6 +802,24 @@ export interface ServiceEntry extends IstioObject {
   spec: ServiceEntrySpec;
 }
 
+export interface WasmPlugin extends IstioObject {
+  spec: WasmPluginSpec;
+}
+
+export interface WasmPluginSpec extends IstioObject {
+  workloadSelector?: WorkloadSelector;
+  url: string;
+  pluginName: string;
+}
+
+export interface Telemetry extends IstioObject {
+  spec: TelemetrySpec;
+}
+
+export interface TelemetrySpec extends IstioObject {
+  workloadSelector?: WorkloadSelector;
+}
+
 export interface Endpoint {
   address: string;
   ports: { [key: string]: number };

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -45,6 +45,10 @@ export const getIstioObject = (istioObjectDetails?: IstioConfigDetails | IstioCo
       istioObject = istioObjectDetails.requestAuthentication;
     } else if (istioObjectDetails.sidecar) {
       istioObject = istioObjectDetails.sidecar;
+    } else if (istioObjectDetails.wasmPlugin) {
+      istioObject = istioObjectDetails.wasmPlugin;
+    } else if (istioObjectDetails.telemetry) {
+      istioObject = istioObjectDetails.telemetry;
     }
   }
   return istioObject;

--- a/kubernetes/cache/istio.go
+++ b/kubernetes/cache/istio.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"errors"
 	"fmt"
+
 	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -12,9 +12,12 @@ import (
 
 	"gopkg.in/yaml.v2"
 	api_networking_v1beta1 "istio.io/api/networking/v1beta1"
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
+
 	istio "istio.io/client-go/pkg/clientset/versioned"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -252,6 +255,8 @@ func ParseRegistryConfig(config map[string][]byte) (*RegistryConfiguration, erro
 		Sidecars:         []*networking_v1beta1.Sidecar{},
 		WorkloadEntries:  []*networking_v1beta1.WorkloadEntry{},
 		WorkloadGroups:   []*networking_v1beta1.WorkloadGroup{},
+		WasmPlugins:      []*extentions_v1alpha1.WasmPlugin{},
+		Telemetries:      []*v1alpha1.Telemetry{},
 
 		AuthorizationPolicies:  []*security_v1beta1.AuthorizationPolicy{},
 		PeerAuthentications:    []*security_v1beta1.PeerAuthentication{},
@@ -276,7 +281,7 @@ func ParseRegistryConfig(config map[string][]byte) (*RegistryConfiguration, erro
 				if mItem, ok := iItem.(map[string]interface{}); ok {
 					kind := mItem["kind"].(string)
 					switch kind {
-					case "DestinationRule", "EnvoyFilter", "Gateway", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication":
+					case "DestinationRule", "EnvoyFilter", "Gateway", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication", "WasmPlugin", "Telemetry":
 						bItem, err := json.Marshal(iItem)
 						rbItem := bytes.NewReader(bItem)
 						bDec := json.NewDecoder(rbItem)
@@ -341,6 +346,20 @@ func ParseRegistryConfig(config map[string][]byte) (*RegistryConfiguration, erro
 								log.Errorf("Error parsing RegistryConfig results for WorkloadGroup: %s", err)
 							}
 							registry.WorkloadGroups = append(registry.WorkloadGroups, wg)
+						case "WasmPlugin":
+							var wp *extentions_v1alpha1.WasmPlugin
+							err := bDec.Decode(&wp)
+							if err != nil {
+								log.Errorf("Error parsing RegistryConfig results for WasmPlugin: %s", err)
+							}
+							registry.WasmPlugins = append(registry.WasmPlugins, wp)
+						case "Telemetry":
+							var tm *v1alpha1.Telemetry
+							err := bDec.Decode(&tm)
+							if err != nil {
+								log.Errorf("Error parsing RegistryConfig results for Telemetry: %s", err)
+							}
+							registry.Telemetries = append(registry.Telemetries, tm)
 						case "AuthorizationPolicy":
 							var ap *security_v1beta1.AuthorizationPolicy
 							err := bDec.Decode(&ap)

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -1,13 +1,13 @@
 package kubernetes
 
 import (
-	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
-	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	"time"
 
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
+	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	"time"
 
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -51,6 +53,12 @@ const (
 	WorkloadGroups    = "workloadgroups"
 	WorkloadGroupType = "WorkloadGroup"
 
+	WasmPlugins    = "wasmPlugins"
+	WasmPluginType = "WasmPlugin"
+
+	Telemetries   = "telemetries"
+	TelemetryType = "TelemetryType"
+
 	// Authorization PeerAuthentications
 	AuthorizationPolicies     = "authorizationpolicies"
 	AuthorizationPoliciesType = "AuthorizationPolicy"
@@ -93,6 +101,8 @@ var (
 		WorkloadEntries:  WorkloadEntryType,
 		WorkloadGroups:   WorkloadGroupType,
 		EnvoyFilters:     EnvoyFilterType,
+		WasmPlugins:      WasmPluginType,
+		Telemetries:      TelemetryType,
 
 		// Security
 		AuthorizationPolicies:  AuthorizationPoliciesType,
@@ -101,14 +111,17 @@ var (
 	}
 
 	ResourceTypesToAPI = map[string]string{
-		DestinationRules:       NetworkingGroupVersionV1Beta1.Group,
-		EnvoyFilters:           NetworkingGroupVersionV1Alpha3.Group,
-		Gateways:               NetworkingGroupVersionV1Beta1.Group,
-		ServiceEntries:         NetworkingGroupVersionV1Beta1.Group,
-		Sidecars:               NetworkingGroupVersionV1Beta1.Group,
-		VirtualServices:        NetworkingGroupVersionV1Beta1.Group,
-		WorkloadEntries:        NetworkingGroupVersionV1Beta1.Group,
-		WorkloadGroups:         NetworkingGroupVersionV1Beta1.Group,
+		DestinationRules: NetworkingGroupVersionV1Beta1.Group,
+		EnvoyFilters:     NetworkingGroupVersionV1Alpha3.Group,
+		Gateways:         NetworkingGroupVersionV1Beta1.Group,
+		ServiceEntries:   NetworkingGroupVersionV1Beta1.Group,
+		Sidecars:         NetworkingGroupVersionV1Beta1.Group,
+		VirtualServices:  NetworkingGroupVersionV1Beta1.Group,
+		WorkloadEntries:  NetworkingGroupVersionV1Beta1.Group,
+		WorkloadGroups:   NetworkingGroupVersionV1Beta1.Group,
+		WasmPlugins:      NetworkingGroupVersionV1Alpha3.Group,
+		Telemetries:      NetworkingGroupVersionV1Beta1.Group,
+
 		AuthorizationPolicies:  SecurityGroupVersion.Group,
 		PeerAuthentications:    SecurityGroupVersion.Group,
 		RequestAuthentications: SecurityGroupVersion.Group,
@@ -165,6 +178,9 @@ type RegistryConfiguration struct {
 	VirtualServices  []*networking_v1beta1.VirtualService
 	WorkloadEntries  []*networking_v1beta1.WorkloadEntry
 	WorkloadGroups   []*networking_v1beta1.WorkloadGroup
+	WasmPlugins      []*extentions_v1alpha1.WasmPlugin
+	Telemetries      []*v1alpha1.Telemetry
+
 	// Security
 	AuthorizationPolicies  []*security_v1beta.AuthorizationPolicy
 	PeerAuthentications    []*security_v1beta.PeerAuthentication

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -53,7 +53,7 @@ const (
 	WorkloadGroups    = "workloadgroups"
 	WorkloadGroupType = "WorkloadGroup"
 
-	WasmPlugins    = "wasmPlugins"
+	WasmPlugins    = "wasmplugins"
 	WasmPluginType = "WasmPlugin"
 
 	Telemetries   = "telemetries"

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -131,8 +131,8 @@ var (
 		VirtualServices:  NetworkingGroupVersionV1Beta1.Group,
 		WorkloadEntries:  NetworkingGroupVersionV1Beta1.Group,
 		WorkloadGroups:   NetworkingGroupVersionV1Beta1.Group,
-		WasmPlugins:      NetworkingGroupVersionV1Alpha3.Group,
-		Telemetries:      NetworkingGroupVersionV1Beta1.Group,
+		WasmPlugins:      ExtensionGroupVersionV1Alpha1.Group,
+		Telemetries:      TelemetryGroupV1Alpha1.Group,
 
 		AuthorizationPolicies:  SecurityGroupVersion.Group,
 		PeerAuthentications:    SecurityGroupVersion.Group,

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -57,7 +57,7 @@ const (
 	WasmPluginType = "WasmPlugin"
 
 	Telemetries   = "telemetries"
-	TelemetryType = "TelemetryType"
+	TelemetryType = "Telemetry"
 
 	// Authorization PeerAuthentications
 	AuthorizationPolicies     = "authorizationpolicies"
@@ -90,6 +90,18 @@ var (
 		Version: "v1beta1",
 	}
 	ApiSecurityVersion = SecurityGroupVersion.Group + "/" + SecurityGroupVersion.Version
+
+	ExtensionGroupVersionV1Alpha1 = schema.GroupVersion{
+		Group:   "extensions.istio.io",
+		Version: "v1alpha1",
+	}
+	ApiExtensionV1Alpha1 = ExtensionGroupVersionV1Alpha1.Group + "/" + ExtensionGroupVersionV1Alpha1.Version
+
+	TelemetryGroupV1Alpha1 = schema.GroupVersion{
+		Group:   "telemetry.istio.io",
+		Version: "v1alpha1",
+	}
+	ApiTelemetryV1Alpha1 = TelemetryGroupV1Alpha1.Group + "/" + TelemetryGroupV1Alpha1.Version
 
 	PluralType = map[string]string{
 		// Networking

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -149,10 +149,10 @@ var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 		{ObjectField: "spec.probe", Message: "ReadinessProbe describes the configuration the user must provide for healthchecking on their workload."},
 	},
 	"wasmplugins": {
-		{ObjectField: "", Message: "TODO"},
+		{ObjectField: "spec.metadata", Message: "TODO"},
 	},
 	"telemetries": {
-		{ObjectField: "", Message: "TODO"},
+		{ObjectField: "spec.metadata", Message: "TODO"},
 	},
 	"internal": {
 		{ObjectField: "", Message: "Internal resources are not editable"},

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -148,11 +148,11 @@ var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 		{ObjectField: "spec.template", Message: "Template to be used for the generation of WorkloadEntry resources that belong to this WorkloadGroup."},
 		{ObjectField: "spec.probe", Message: "ReadinessProbe describes the configuration the user must provide for healthchecking on their workload."},
 	},
-	"wasmplugins": {
-		{ObjectField: "spec.metadata", Message: "TODO"},
+	"wasmplugins": { //TODO
+		{},
 	},
-	"telemetries": {
-		{ObjectField: "spec.metadata", Message: "TODO"},
+	"telemetries": { //TODO
+		{},
 	},
 	"internal": {
 		{ObjectField: "", Message: "Internal resources are not editable"},

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -1,9 +1,11 @@
 package models
 
 import (
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
+	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 )
 
 // IstioConfigList istioConfigList
@@ -25,6 +27,8 @@ type IstioConfigList struct {
 	VirtualServices  []*networking_v1beta1.VirtualService  `json:"virtualServices"`
 	WorkloadEntries  []*networking_v1beta1.WorkloadEntry   `json:"workloadEntries"`
 	WorkloadGroups   []*networking_v1beta1.WorkloadGroup   `json:"workloadGroups"`
+	WasmPlugins      []*extentions_v1alpha1.WasmPlugin     `json:"WasmPlugins"`
+	Telemetries      []*v1alpha1.Telemetry                 `json:"Telemetries"`
 
 	AuthorizationPolicies  []*security_v1beta.AuthorizationPolicy   `json:"authorizationPolicies"`
 	PeerAuthentications    []*security_v1beta.PeerAuthentication    `json:"peerAuthentications"`
@@ -47,6 +51,8 @@ type IstioConfigDetails struct {
 	VirtualService        *networking_v1beta1.VirtualService     `json:"virtualService"`
 	WorkloadEntry         *networking_v1beta1.WorkloadEntry      `json:"workloadEntry"`
 	WorkloadGroup         *networking_v1beta1.WorkloadGroup      `json:"workloadGroup"`
+	WasmPlugin            *extentions_v1alpha1.WasmPlugin        `json:"wasmPlugin"`
+	Telemetry             *v1alpha1.Telemetry                    `json:"telemetry"`
 
 	Permissions           ResourcePermissions `json:"permissions"`
 	IstioValidation       *IstioValidation    `json:"validation"`
@@ -142,6 +148,12 @@ var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 		{ObjectField: "spec.template", Message: "Template to be used for the generation of WorkloadEntry resources that belong to this WorkloadGroup."},
 		{ObjectField: "spec.probe", Message: "ReadinessProbe describes the configuration the user must provide for healthchecking on their workload."},
 	},
+	"wasmplugins": {
+		{ObjectField: "", Message: "TODO"},
+	},
+	"telemetries": {
+		{ObjectField: "", Message: "TODO"},
+	},
 	"internal": {
 		{ObjectField: "", Message: "Internal resources are not editable"},
 	},
@@ -184,6 +196,8 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 			filtered[ns].AuthorizationPolicies = []*security_v1beta.AuthorizationPolicy{}
 			filtered[ns].PeerAuthentications = []*security_v1beta.PeerAuthentication{}
 			filtered[ns].RequestAuthentications = []*security_v1beta.RequestAuthentication{}
+			filtered[ns].WasmPlugins = []*extentions_v1alpha1.WasmPlugin{}
+			filtered[ns].Telemetries = []*v1alpha1.Telemetry{}
 		}
 		for _, dr := range configList.DestinationRules {
 			if dr.Namespace == ns {
@@ -230,6 +244,18 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 		for _, wg := range configList.WorkloadGroups {
 			if wg.Namespace == ns {
 				filtered[ns].WorkloadGroups = append(filtered[ns].WorkloadGroups, wg)
+			}
+		}
+
+		for _, wp := range configList.WasmPlugins {
+			if wp.Namespace == ns {
+				filtered[ns].WasmPlugins = append(filtered[ns].WasmPlugins, wp)
+			}
+		}
+
+		for _, tm := range configList.Telemetries {
+			if tm.Namespace == ns {
+				filtered[ns].Telemetries = append(filtered[ns].Telemetries, tm)
 			}
 		}
 

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -27,7 +27,7 @@ type IstioConfigList struct {
 	VirtualServices  []*networking_v1beta1.VirtualService  `json:"virtualServices"`
 	WorkloadEntries  []*networking_v1beta1.WorkloadEntry   `json:"workloadEntries"`
 	WorkloadGroups   []*networking_v1beta1.WorkloadGroup   `json:"workloadGroups"`
-	WasmPlugins      []*extentions_v1alpha1.WasmPlugin     `json:"WasmPlugins"`
+	WasmPlugins      []*extentions_v1alpha1.WasmPlugin     `json:"wasmPlugins"`
 	Telemetries      []*v1alpha1.Telemetry                 `json:"Telemetries"`
 
 	AuthorizationPolicies  []*security_v1beta.AuthorizationPolicy   `json:"authorizationPolicies"`

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -28,7 +28,7 @@ type IstioConfigList struct {
 	WorkloadEntries  []*networking_v1beta1.WorkloadEntry   `json:"workloadEntries"`
 	WorkloadGroups   []*networking_v1beta1.WorkloadGroup   `json:"workloadGroups"`
 	WasmPlugins      []*extentions_v1alpha1.WasmPlugin     `json:"wasmPlugins"`
-	Telemetries      []*v1alpha1.Telemetry                 `json:"Telemetries"`
+	Telemetries      []*v1alpha1.Telemetry                 `json:"telemetries"`
 
 	AuthorizationPolicies  []*security_v1beta.AuthorizationPolicy   `json:"authorizationPolicies"`
 	PeerAuthentications    []*security_v1beta.PeerAuthentication    `json:"peerAuthentications"`

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -112,6 +112,8 @@ var ObjectTypeSingular = map[string]string{
 	"peerauthentications":    "peerauthentication",
 	"requestauthentications": "requestauthentication",
 	"workloads":              "workload",
+	"wasmplugins":            "wasmpluin",
+	"telemetries":            "telemetry",
 }
 
 var checkDescriptors = map[string]IstioCheck{


### PR DESCRIPTION
New Istio Types support, excluding validations at this stage. 

![image](https://user-images.githubusercontent.com/49480155/185963253-a41bef6c-a4c1-47ae-ba41-d746d29f7cfa.png)

Telemetry example: 

![image](https://user-images.githubusercontent.com/49480155/185963327-a39eb99c-0e95-472d-b265-bc9a2739f775.png)

wasm plugin:

![image](https://user-images.githubusercontent.com/49480155/185964025-9896dc00-d10f-43bb-b0f9-2c10ac2bad2b.png)


The types have been tested with the following yaml in crc: 

oc apply -f telemetry.yaml

```
apiVersion: telemetry.istio.io/v1alpha1
kind: Telemetry
metadata:
  name: mesh-default
  namespace: bookinfo
spec:
  # no selector specified, applies to all workloads
  tracing:
  - randomSamplingPercentage: 10.00
    customTags:
      my_new_foo_tag:
        literal:
          value: "foo"
```

oc apply -f wasmplugin.yaml

```
apiVersion: extensions.istio.io/v1alpha1
kind: WasmPlugin
metadata:
  name: openid-connect
  namespace: bookinfo
spec:
  selector:
    matchLabels:
      istio: ingressgateway
  url: oci://private-registry:5000/openid-connect/openid:latest
  imagePullPolicy: IfNotPresent
  imagePullSecret: private-registry-pull-secret
  phase: AUTHN
  pluginConfig:
    openid_server: authn
    openid_realm: ingress
```

Fixes #5274 