### PR TITLE
[make] fix pull secret

### DIFF
--- a/make/Makefile.cluster.mk
+++ b/make/Makefile.cluster.mk
@@ -5,7 +5,7 @@
 # If using OpenShift, you must expose the image registry externally.
 #
 
-.prepare-ocp-image-registry: .ensure-oc-exists
+.prepare-ocp-image-registry: .ensure-oc-login
 	@if [ "$(shell ${OC} get config.imageregistry.operator.openshift.io/cluster -o jsonpath='{.spec.managementState}')" != "Managed" ]; then echo "Manually patching image registry operator to ensure it is managed"; ${OC} patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"managementState":"Managed"}}'; sleep 3; fi
 	@if [ "$(shell ${OC} get config.imageregistry.operator.openshift.io/cluster -o jsonpath='{.spec.defaultRoute}')" != "true" ]; then echo "Manually patching image registry operator to expose the cluster internal image registry"; ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge; sleep 3; routehost="$$(${OC} get image.config.openshift.io/cluster -o custom-columns=EXT:.status.externalRegistryHostnames[0] --no-headers 2>/dev/null)"; while [ "$${routehost}" == "<none>" -o "$${routehost}" == "" ]; do echo "Waiting for image registry route to start..."; sleep 3; routehost="$$(${OC} get image.config.openshift.io/cluster -o custom-columns=EXT:.status.externalRegistryHostnames[0] --no-headers 2>/dev/null)"; done; fi
 

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -15,7 +15,7 @@
 .prepare-operator-pull-secret: .prepare-cluster
 ifeq ($(CLUSTER_TYPE),openshift)
 	@# base64 encode a pull secret (using the 'default' sa secret) that can be used to pull the operator image from the OpenShift internal registry
-	@$(eval OPERATOR_IMAGE_PULL_SECRET_JSON = $(shell ${OC} registry login --registry="$(shell ${OC} registry info --internal)" --namespace=${OPERATOR_IMAGE_NAMESPACE} -z default --to=- | base64 -w0))
+	@$(eval OPERATOR_IMAGE_PULL_SECRET_JSON = $(shell ${OC} registry login --registry="$(shell ${OC} registry info --internal)" --namespace=${OPERATOR_IMAGE_NAMESPACE} --to=- | base64 -w0))
 	@$(eval OPERATOR_IMAGE_PULL_SECRET_NAME ?= kiali-operator-pull-secret)
 else
 	@$(eval OPERATOR_IMAGE_PULL_SECRET_JSON = )


### PR DESCRIPTION
OpenShift 4.11 no longer provides a secret with SAs. We need to fix our dev tools to work with 4.11 (but don't break when on 4.10 and before).