### PR TITLE
[make] clean up after no longer using default SA secret

### DIFF
--- a/make/Makefile.cluster.mk
+++ b/make/Makefile.cluster.mk
@@ -29,8 +29,6 @@
 	@${OC} get namespace ${OPERATOR_IMAGE_NAMESPACE} &> /dev/null || \
 	  ${OC} create namespace ${OPERATOR_IMAGE_NAMESPACE} &> /dev/null
 	@${OC} policy add-role-to-group system:image-puller system:serviceaccounts:${OPERATOR_NAMESPACE} --namespace=${OPERATOR_IMAGE_NAMESPACE} &> /dev/null
-	@# we need to make sure the 'default' service account is created - we'll need it later for the pull secret
-	@for i in {1..5}; do ${OC} get sa default -n ${OPERATOR_IMAGE_NAMESPACE} &> /dev/null && break || echo -n "." && sleep 1; done; echo
 
 .prepare-minikube: .ensure-oc-exists .ensure-minikube-exists
 	@$(eval CLUSTER_REPO_INTERNAL ?= localhost:5000)

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -14,7 +14,7 @@
 
 .prepare-operator-pull-secret: .prepare-cluster
 ifeq ($(CLUSTER_TYPE),openshift)
-	@# base64 encode a pull secret (using the 'default' sa secret) that can be used to pull the operator image from the OpenShift internal registry
+	@# base64 encode a pull secret (using the logged in user token) that can be used to pull the operator image from the OpenShift internal registry
 	@$(eval OPERATOR_IMAGE_PULL_SECRET_JSON = $(shell ${OC} registry login --registry="$(shell ${OC} registry info --internal)" --namespace=${OPERATOR_IMAGE_NAMESPACE} --to=- | base64 -w0))
 	@$(eval OPERATOR_IMAGE_PULL_SECRET_NAME ?= kiali-operator-pull-secret)
 else


### PR DESCRIPTION
Now that OpenShift 4.11 (and related k8s versions) no longer have secrets in SAs by default,
we no longer rely on them. This cleans up some stuff a bit due to that.