### PR TITLE
[make] Force the operator image to always be pulled when debugging via OLM

### DIFF
--- a/make/Makefile.olm.mk
+++ b/make/Makefile.olm.mk
@@ -68,6 +68,7 @@ build-olm-bundle: .prepare-olm-cluster-names .determine-olm-bundle-version
 	  fi ;\
 	  csv="$$(ls -1 ${OUTDIR}/bundle/manifests/kiali*clusterserviceversion.yaml)" ;\
 	  sed -i "s/replaces:.*/#replaces:/g" $${csv} ;\
+	  sed -i "s/IfNotPresent/Always/g" $${csv} ;\
 	  sed -i "s|image: .*kiali.*operator.*|image: ${CLUSTER_OPERATOR_INTERNAL_NAME}:${OPERATOR_CONTAINER_VERSION}|g" $${csv} ;\
 	  sed -i "s|containerImage: .*kiali.*operator.*|containerImage: ${CLUSTER_OPERATOR_INTERNAL_NAME}:${OPERATOR_CONTAINER_VERSION}|g" $${csv} ;\
 	  sed -E -i "/.*kiali.*-operator.*/ n; s~(value:)(.*/.*-kiali-.*)~\1 ${CLUSTER_KIALI_INTERNAL_NAME}:${CONTAINER_VERSION}~g" $${csv} ;\


### PR DESCRIPTION
Without this fix, you'll never get the latest image to be used
even after doing a make cluster-push-operator. And it will drive
you crazy wondering why your changes aren't getting picked up.