### PR TITLE
[Cypress] Migration from Selenium (graph buttons and legend sidebar test)

### DIFF
--- a/frontend/cypress/integration/common/graph_toolbar_legend.ts
+++ b/frontend/cypress/integration/common/graph_toolbar_legend.ts
@@ -1,0 +1,69 @@
+import { Then, And, When } from "cypress-cucumber-preprocessor/steps";
+
+function buttonClick(label:string){
+    cy.get(`button[aria-label="${label}"]`).click();
+};
+
+function buttonPrepare(label:string, active:boolean){
+    cy.waitForReact();
+    cy.getReact("Button",{ props: { 'aria-label': `${label}`}})
+    .should('have.length', '1')
+    .getProps()
+    .then((props => {
+        if (props.isActive !== active){
+            buttonClick(label);
+        }
+    }));
+};
+
+function buttonState(label:string, active:boolean){
+    cy.waitForReact();
+    cy.getReact("Button",{ props: { 'aria-label': `${label}`}})
+    .should('have.length', '1')
+    .getProps('isActive')
+    .should('eq', active);
+}
+
+Then("the toggle button {string} is enabled", (label: string) => {
+    cy.get(`button[aria-label="${label}"]`).should('have.attr', 'aria-disabled', 'false');
+});
+
+And("the toggle button {string} is enabled", (label: string) => {
+    cy.get(`button[aria-label="${label}"]`).should('have.attr', 'aria-disabled', 'false');
+});
+
+And("the button {string} is clicked", (label: string) => {
+    buttonClick(label);
+});
+
+Then("the button {string} is active", (label: string) => {
+   buttonState(label, true); 
+});
+
+Then("the button {string} is not active", (label: string) => {
+   buttonState(label, false); 
+});
+
+And("the {string} is turned on", (label: string) => {
+   buttonPrepare(label, true); 
+});
+
+And("the {string} is turned off", (label: string) => {
+   buttonPrepare(label, false); 
+});
+
+Then("user can see the legend section", () => {
+    cy.get("[data-test='graph-legend']").should("be.visible");
+});
+
+When("the Legend section is visible", () => {
+    buttonClick("Show Legend");
+});
+
+And ("the cross is clicked", () => {
+    cy.get("#legend_close").click()
+});
+
+Then("user cannot see the legend section", () => {
+    cy.get("[data-test='graph-legend']").should("not.exist");
+});

--- a/frontend/cypress/integration/featureFiles/graph_toolbar_legend.feature
+++ b/frontend/cypress/integration/featureFiles/graph_toolbar_legend.feature
@@ -1,0 +1,143 @@
+Feature: Kiali Graph page - Graph toolbar and legend sidebar 
+
+  User opens the Graph page and manipulates the "alpha", "beta" namespace graph with buttons
+    located at the bottom of the page 
+
+  Background:
+    Given user is at administrator perspective
+    And user graphs "alpha,beta" namespaces
+
+@graph-page-manipulation
+Scenario Outline: Check if the <label> button is usable
+  Then the toggle button "<label>" is enabled
+  Examples:
+  | label |
+  | Toggle Drag |
+  | Zoom to Fit |
+  | Hide Healthy Edges |
+  | Hide All Edges |
+  | Graph Layout Default Style |
+  | Graph Layout Style 1 |
+  | Graph Layout Style 2 |
+  | Graph Layout Style 3 |
+  | Namespace Layout Style 1 |
+  | Namespace Layout Style 2 |
+  | Show Legend |
+     
+@graph-page-manipulation
+Scenario: Check if the Toggle Drag Graph button can be turned off 
+  When the button "Toggle Drag" is clicked
+  Then the button "Toggle Drag" is not active
+
+@graph-page-manipulation
+Scenario: Check if the Toggle Drag Graph button can be turned on 
+  When the "Toggle Drag" is turned off 
+  And the button "Toggle Drag" is clicked
+  Then the button "Toggle Drag" is active
+
+@graph-page-manipulation
+Scenario Outline: Check if the not active by default <label> Graph button can be turned on  
+  When the button "<label>" is clicked
+  Then the button "<label>" is active
+  Examples:
+      | label |
+      | Hide Healthy Edges | 
+      | Hide All Edges | 
+      | Graph Layout Style 1 | 
+      | Graph Layout Style 2 | 
+      | Graph Layout Style 3 | 
+      | Namespace Layout Style 2 | 
+
+@graph-page-manipulation
+Scenario Outline: Check if the not active by default <label> Graph button can be turned off 
+  When the "<label>" is turned on
+  And the button "<label>" is clicked 
+  Then the button "<label>" is not active
+  Examples:
+      | label |
+      | Hide Healthy Edges | 
+      | Hide All Edges | 
+
+@graph-page-manipulation
+Scenario: The Hide Healthy Edges is turned off by turning on the Hide All Edges
+  When the "Hide Healthy Edges" is turned off 
+  And the "Hide All Edges" is turned off 
+  And the button "Hide Healthy Edges" is clicked
+  And the button "Hide All Edges" is clicked
+  Then the button "Hide Healthy Edges" is not active
+  And the button "Hide All Edges" is active
+
+@graph-page-manipulation
+Scenario: The Hide All Edges is turned off by turning on the Hide Healthy Edges
+  When the "Hide Healthy Edges" is turned off 
+  And the "Hide All Edges" is turned off 
+  And the button "Hide All Edges" is clicked
+  And the button "Hide Healthy Edges" is clicked
+  Then the button "Hide Healthy Edges" is active
+  And the button "Hide All Edges" is not active
+
+@graph-page-manipulation
+Scenario: The Namespace Layout Style 1 is turned off by turning on the Namespace Layout Style 2 
+  When the "Namespace Layout Style 1" is turned off 
+  And the "Namespace Layout Style 2" is turned off 
+  And the button "Namespace Layout Style 1" is clicked
+  And the button "Namespace Layout Style 2" is clicked  
+  Then the button "Namespace Layout Style 1" is not active
+  And the button "Namespace Layout Style 2" is active
+
+@graph-page-manipulation
+Scenario: The Namespace Layout Style 2 is turned off by turning on the Namespace Layout Style 1 
+  When the "Namespace Layout Style 1" is turned off 
+  And the "Namespace Layout Style 2" is turned off 
+  And the button "Namespace Layout Style 2" is clicked
+  And the button "Namespace Layout Style 1" is clicked  
+  Then the button "Namespace Layout Style 1" is active
+  And the button "Namespace Layout Style 2" is not active
+
+@graph-page-manipulation
+Scenario: First 3 Graph Layout Style buttons are mutually exclusive
+  When the "Graph Layout Default Style" is turned on 
+  And the "Graph Layout Style 1" is turned off 
+  And the "Graph Layout Style 2" is turned off 
+  And the "Graph Layout Style 3" is turned off 
+  And the button "Graph Layout Style 1" is clicked
+  And the button "Graph Layout Style 2" is clicked
+  And the button "Graph Layout Style 3" is clicked
+  Then the button "Graph Layout Default Style" is not active
+  And the button "Graph Layout Style 1" is not active
+  And the button "Graph Layout Style 2" is not active
+  And the button "Graph Layout Style 3" is active
+
+@graph-page-manipulation
+Scenario: The last Graph Layout Style button is mutually exclusive with the rest 
+  When the "Graph Layout Default Style" is turned off 
+  And the "Graph Layout Style 1" is turned off 
+  And the "Graph Layout Style 2" is turned off 
+  And the "Graph Layout Style 3" is turned on
+  And the button "Graph Layout Style 2" is clicked
+  And the button "Graph Layout Style 1" is clicked
+  And the button "Graph Layout Default Style" is clicked
+  Then the button "Graph Layout Default Style" is active
+  And the button "Graph Layout Style 1" is not active
+  And the button "Graph Layout Style 2" is not active
+  And the button "Graph Layout Style 3" is not active     
+
+@graph-page-manipulation
+Scenario: Show the Legend
+  When the button "Show Legend" is clicked
+  Then user can see the legend section
+  And the button "Show Legend" is active 
+
+@graph-page-manipulation
+Scenario: Close the Legend using the button
+  When the Legend section is visible 
+  And the button "Show Legend" is clicked 
+  Then user cannot see the legend section  
+  And the button "Show Legend" is not active 
+
+@graph-page-manipulation
+Scenario: Close the Legend using the cross
+  When the Legend section is visible 
+  And the cross is clicked
+  Then user cannot see the legend section  
+  And the button "Show Legend" is not active 

--- a/frontend/src/pages/Graph/GraphLegend.tsx
+++ b/frontend/src/pages/Graph/GraphLegend.tsx
@@ -41,7 +41,7 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
     });
 
     return (
-      <div className={legendBoxStyle} style={summaryFont}>
+      <div className={legendBoxStyle} style={summaryFont} data-test="graph-legend">
         <div className={`${headerStyle} ${summaryTitle}`}>
           <span>Legend</span>
           <span className={closeBoxStyle}>

--- a/frontend/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/frontend/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`GraphLegend test should render correctly 1`] = `
 <div
   className="fsg7me4"
+  data-test="graph-legend"
   style={
     Object {
       "fontSize": "var(--graph-side-panel--font-size)",


### PR DESCRIPTION
Another migrated [suite from Selenium](https://github.com/Kiali-QE/kiali-qe-python/blob/75f60eed7cb290e7e3c94f71cf870d1445154468/kiali_qe/tests/test_graph_page.py#L124).

The old suite most likely switched between the 4 available graph layouts. The new suite tests all of the buttons, as well as button groups (for example you should not be able to have active more than one Graph Layout at once). It also briefly checks the opening and closing of the Legend sidebar. 

The tests mess only with the buttons, not with the graph itself. We might do that sometimes in a future, however it is not a priority now.

Related issue: #5390