### PR TITLE
[v1.55] new istio 1.15 compat matrix info

### DIFF
--- a/config/version-compatibility-matrix.yaml
+++ b/config/version-compatibility-matrix.yaml
@@ -1,9 +1,12 @@
 # The Compatible Version Matrix between upstream Istio and Kiali
 - meshName: "Istio"
   versionRange:
+    - meshVersion: "1.15"
+      kialiMinimumVersion: "1.55.0"
+      kialiMaximumVersion: ""
     - meshVersion: "1.14"
       kialiMinimumVersion: "1.50.0"
-      kialiMaximumVersion: ""
+      kialiMaximumVersion: "1.54"
     - meshVersion: "1.13"
       kialiMinimumVersion: "1.45.1"
       kialiMaximumVersion: "1.49"

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -285,6 +285,18 @@ func TestMeshVersionCompatible(t *testing.T) {
 	versionsToTest := []versionsToTestStruct{
 		{
 			name:        "Istio",
+			version:     "1.55.0",
+			meshVersion: "1.15",
+			supported:   true,
+		},
+		{
+			name:        "Istio",
+			version:     "1.54.0",
+			meshVersion: "1.15",
+			supported:   false,
+		},
+		{
+			name:        "Istio",
 			version:     "1.45.1",
 			meshVersion: "1.14",
 			supported:   false,


### PR DESCRIPTION
cherry pick of baa62a2a348ee08f165a01f0a6bcfaaebc50f128 which comes from https://github.com/kiali/kiali/pull/5401

fixes: https://github.com/kiali/kiali/issues/5420
