### PR TITLE
[Cypress] Istio Config filters

### DIFF
--- a/frontend/cypress/integration/common/istio_config_type_filters.ts
+++ b/frontend/cypress/integration/common/istio_config_type_filters.ts
@@ -1,0 +1,116 @@
+import { When, Then, And } from "cypress-cucumber-preprocessor/steps";
+import { activeFilters, showMore} from "./label_check"
+
+function enableFilter(category:string){
+  cy.get('button[aria-label="Options menu"]').click(); 
+  cy.get('[data-test=istio-type-dropdown]').contains(category)
+  .should('be.visible').click();
+}
+
+When("user types {string} into the input", (input:string) => {
+  // cy.get('button[aria-label="Options menu"]').click();
+  cy.get('input[placeholder="Filter by Istio Type"]').type(input);
+});
+
+Then("the {string} phrase is displayed", (phrase:string) => {
+  cy.get('#filter-selection').contains(phrase).should('be.visible'); 
+});
+
+And('user filters by {string}', (filterCategory:string) => {
+  cy.get('select[aria-label="filter_select_type"]').select(filterCategory)
+});
+
+And('no filters are active', () => {
+  cy.get('#filter-selection > :nth-child(2)').should('be.hidden');
+});
+
+When('user chooses a {string}', (category:string) => {
+  enableFilter(category);
+});
+
+Then('user can see only the {string}', (category:string) => {
+  cy.get('#filter-selection > :nth-child(2)').contains(category)
+.parent().should('be.visible').and('have.length', 1);
+});
+
+When('a type filter {string} is applied', (category:string) => {
+  cy.get('button[aria-label="Options menu"]').click();
+    cy.get('[data-test=istio-type-dropdown]').contains(category)
+    .should('be.visible').click().then( () =>{
+      cy.get('#filter-selection > :nth-child(2)').contains(category)
+      .parent().should('be.visible');    
+  }); 
+});
+
+And('user clicks the cross next to the {string}', (category:string) => {
+  cy.get('#filter-selection > :nth-child(2)').contains(category).parent()
+  .find('[aria-label="close"]').click();
+});
+
+Then('the filter {string} is no longer active', (category:string) => {
+  cy.get('#filter-selection').contains(category)
+  .should('not.exist');
+});
+
+And('the {string} type filter is applied again', (category:string) => {
+  enableFilter(category);
+});
+
+Then('the filter {string} should be visible only once', (category:string) => {
+  cy.get('#filter-selection > :nth-child(2)').find("span")
+  .contains(category).each(() => {
+  })
+  .then(($lis) => {
+    expect($lis).to.have.length(1);
+  });
+});
+
+When("user chooses {int} type filters", (count:number) => {
+  for (let i = 1; i <= count; i++) {
+    cy.get('button[aria-label="Options menu"]').click(); 
+    cy.get(`[data-test=istio-type-dropdown] > :nth-child(${i})`)
+    .should('be.visible').click();
+  };
+});
+
+And("user clicks the cross on one of them", () => {
+  cy.get('#filter-selection > :nth-child(2)').find('[aria-label="close"]')
+  .first().click();
+});
+
+Then("{int} filters should be visible", (count:number) => {
+  activeFilters(count);
+});
+
+Then("he can only see {int} right away", (count:number) => {
+  activeFilters(count);
+});
+
+And("clicks on the button next to them", () => {
+  showMore();
+});
+
+Then("he can see the remaining filter", () => {
+  activeFilters(4);
+});
+
+And("makes them all visible", () => {
+  showMore();
+  activeFilters(4);
+});
+
+When("user clicks on {string}", (label:string) => {
+  cy.get('#filter-selection > :nth-child(2)').contains(label).click();
+});
+
+Then("he can see only {int} filters", (count:number) => {
+  activeFilters(count);
+});
+
+When("all type filters are enabled", () => {
+  for (let i = 1; i <= 11; i++) {
+      cy.get('button[aria-label="Options menu"]').click(); 
+      cy.get(`[data-test=istio-type-dropdown] > :nth-child(${i})`)
+      .should('be.visible').click();
+    };
+});

--- a/frontend/cypress/integration/common/istio_config_validation_filters.ts
+++ b/frontend/cypress/integration/common/istio_config_validation_filters.ts
@@ -1,0 +1,38 @@
+import { When, Then, And } from "cypress-cucumber-preprocessor/steps";
+
+// Some of the steps from istio_config_validation_filters.feature are implemented in
+// the istio_config_type_filters.ts file. This is because some steps are identical.
+
+function enableFilter(category:string){
+  cy.get('select[aria-label="filter_select_value"]').select(category); 
+}
+
+When('user filters by {string} option', (category:string) => {
+  enableFilter(category);
+});
+
+Then('user can see only the {string}', (category:string) => {
+  cy.get('#filter-selection > :nth-child(2)').contains(category)
+.parent().should('be.visible').and('have.length', 1);
+});
+
+When('a validation filter {string} is applied', (category:string) => {
+  cy.get('select[aria-label="filter_select_value"]').select(category);
+  cy.get('#filter-selection > :nth-child(2)').contains(category)
+  .parent().should('be.visible');    
+});
+
+Then('the validation filter {string} is no longer active', (category:string) => {
+  cy.get('#filter-selection').contains(category)
+  .should('be.hidden');
+});
+
+And('the {string} validation filter is applied again', (category:string) => {
+  enableFilter(category);
+});
+
+When("user chooses {int} validation filters", (count:number) => {
+  for (let i = 1; i <= count; i++) {
+    cy.get('select[aria-label="filter_select_value"]').select(i);
+  };
+});

--- a/frontend/cypress/integration/common/label_check.ts
+++ b/frontend/cypress/integration/common/label_check.ts
@@ -1,0 +1,13 @@
+export function activeFilters(count:number){
+  cy.get('#filter-selection > :nth-child(2)').find('[aria-label="close"]')
+    .each(() => {
+    })
+    .then(($lis) => {
+      cy.wrap($lis).should('have.length', count);
+  }); 
+}
+
+export function showMore(){
+  cy.get('#filter-selection > :nth-child(2)').contains('more').click();
+}
+

--- a/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
@@ -1,0 +1,95 @@
+@istio-page
+Feature: Kiali Istio Config page
+
+  On the Istio Config page, an admin should be able to choose all of the filters present. 
+  The admin should also be able close a single filter either with it's cross, or with the Close All feature.
+
+  Background:
+    Given user is at administrator perspective
+    And user is at the "istio" page
+    And user selects the "istio-system" namespace
+    And user filters by "Istio Type" 
+    And no filters are active
+
+    Scenario Outline: All of the filters should be available for turning on
+    When user chooses a "<category>"
+    Then user can see only the "<category>"  
+    Examples:
+    | category |
+    | AuthorizationPolicy |
+    | DestinationRule |
+    | EnvoyFilter |
+    | Gateway |
+    | PeerAuthentication |
+    | RequestAuthentication |
+    | ServiceEntry |
+    | Sidecar |
+    | VirtualService |
+    | WorkloadEntry |
+    | WorkloadGroup |
+
+Scenario Outline: All of the filters can be turned off with their cross
+    When a type filter "<category>" is applied
+    And user clicks the cross next to the "<category>" 
+    Then the filter "<category>" is no longer active  
+    Examples:
+    | category |
+    | AuthorizationPolicy |
+    | DestinationRule |
+    | EnvoyFilter |
+    | Gateway |
+    | PeerAuthentication |
+    | RequestAuthentication |
+    | ServiceEntry |
+    | Sidecar |
+    | VirtualService |
+    | WorkloadEntry |
+    | WorkloadGroup |
+
+Scenario Outline: Filter cannot be selected twice
+  When a type filter "<category>" is applied  
+  And the "<category>" type filter is applied again
+  Then the filter "<category>" should be visible only once
+  Examples:
+    | category |
+    | AuthorizationPolicy |
+    | DestinationRule |
+    | EnvoyFilter |
+    | Gateway |
+    | PeerAuthentication |
+    | RequestAuthentication |
+    | ServiceEntry |
+    | Sidecar |
+    | VirtualService |
+    | WorkloadEntry |
+    | WorkloadGroup |
+
+Scenario: Deleting a single filter should not delete more filters
+  When user chooses 3 type filters
+  And user clicks the cross on one of them
+  Then 2 filters should be visible
+
+Scenario: When 4 or more filters are chosen, only 3 are visible right away
+  When user chooses 4 type filters
+  Then he can only see 3 right away
+  
+Scenario: Show the view of all chosen filters
+  When user chooses 4 type filters
+  And clicks on the button next to them
+  Then he can see the remaining filter
+
+Scenario: Hide the menu of all chosen filters 
+  When user chooses 4 type filters
+  And makes them all visible
+  When user clicks on "Show Less"
+  Then he can see only 3 filters
+
+Scenario: Deleting all filters at once
+  When all type filters are enabled
+  And user clicks on "Clear all filters"
+  Then no filters are active
+
+Scenario: Fill the input form with nonsense
+  When user types "foo bar" into the input
+  Then the "No results found" phrase is displayed
+  And no filters are active

--- a/frontend/cypress/integration/featureFiles/istio_config_validation_filters.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_validation_filters.feature
@@ -1,0 +1,69 @@
+@istio-page
+Feature: Kiali Istio Config page
+
+  On the Istio Config page, an admin should be able to choose all of the filters present. 
+  The admin should also be able close a single filter either with it's cross, or with the Close All feature.
+
+  Background:
+    Given user is at administrator perspective
+    And user is at the "istio" page
+    And user selects the "istio-system" namespace
+    And user filters by "Config" 
+    And no filters are active
+
+  Scenario Outline: All of the filters should be available for turning on
+    When user filters by "<category>" option
+    Then user can see only the "<category>"  
+    Examples:
+    | category |
+    | Valid |
+    | Warning |
+    | Not Valid |
+    | Not Validated |
+
+Scenario Outline: All of the filters can be turned off with their cross
+    When a validation filter "<category>" is applied
+    And user clicks the cross next to the "<category>" 
+    Then the validation filter "<category>" is no longer active  
+    Examples:
+    | category |
+    | Valid |
+    | Warning |
+    | Not Valid |
+    | Not Validated |
+
+Scenario Outline: Filter cannot be selected twice
+  When a validation filter "<category>" is applied  
+  And the "<category>" validation filter is applied again
+  Then the filter "<category>" should be visible only once
+  Examples:
+    | category |
+    | Valid |
+    | Warning |
+    | Not Valid |
+    | Not Validated |
+
+Scenario: Deleting a single filter should not delete more filters
+  When user chooses 3 validation filters
+  And user clicks the cross on one of them
+  Then 2 filters should be visible
+
+Scenario: When 4 or more filters are chosen, only 3 are visible right away
+  When user chooses 4 validation filters
+  Then he can only see 3 right away
+  
+Scenario: Show the view of all chosen filters
+  When user chooses 4 validation filters
+  And clicks on the button next to them
+  Then he can see the remaining filter
+
+Scenario: Hide the menu of all chosen filters 
+  When user chooses 4 validation filters
+  And makes them all visible
+  When user clicks on "Show Less"
+  Then he can see only 3 filters
+
+Scenario: Deleting all filters at once
+  When user chooses 4 validation filters
+  And user clicks on "Clear all filters"
+  Then no filters are active

--- a/frontend/src/components/Filters/StatefulFilters.tsx
+++ b/frontend/src/components/Filters/StatefulFilters.tsx
@@ -278,6 +278,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
           aria-label="filter_select_value"
           placeholderText={currentFilterType.placeholder}
           width="auto"
+          data-test="istio-type-dropdown"
         >
           {currentFilterType.filterValues.map((filter, index) => (
             <SelectOption key={'filter_' + index} value={filter.id} label={filter.title} />


### PR DESCRIPTION
Another migration from the Selenium. These suites are supposed to check whether are all of the filters usable or not.

Most of the implementation is in the istio_config_type_filters.ts, because some of the steps in both gherkins are identical. 

This PR is related to #5392 and #5393.
