### PR TITLE
Launch Wizards from MiniGraphCard.tsx

### DIFF
--- a/frontend/src/components/IstioWizards/LoadingWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/LoadingWizardActionsDropdownGroup.tsx
@@ -1,0 +1,12 @@
+import { DropdownGroup, DropdownItem, Spinner } from "@patternfly/react-core";
+import * as React from "react";
+
+export function LoadingWizardActionsDropdownGroup() {
+  return (
+    <DropdownGroup key="wizards" label="Actions" className="kiali-group-menu">
+      <DropdownItem isDisabled={true}>
+        <Spinner isSVG={true} size="md" aria-label="Loading actions..." />
+      </DropdownItem>
+    </DropdownGroup>
+  );
+}

--- a/frontend/src/hooks/services.ts
+++ b/frontend/src/hooks/services.ts
@@ -3,7 +3,7 @@ import { CancelablePromise } from "../utils/CancelablePromises";
 import * as API from "../services/Api";
 import { DurationInSeconds, TimeInMilliseconds } from "../types/Common";
 import { ServiceDetailsInfo } from "../types/ServiceInfo";
-import { PeerAuthentication } from "../types/IstioObjects";
+import { getGatewaysAsList, PeerAuthentication } from "../types/IstioObjects";
 import { AxiosError } from "axios";
 import { DecoratedGraphNodeData, NodeType } from "../types/Graph";
 import * as AlertUtils from "../utils/AlertUtils";
@@ -31,7 +31,7 @@ export function useServiceDetail(namespace: string, serviceName: string, duratio
     allPromise.promise
       .then(results => {
         setServiceDetails(results[0]);
-        setGateways(Object.values(results[1].data).map(nsCfg => nsCfg.gateways.map(gateway => gateway.metadata.namespace + '/' + gateway.metadata.name)).flat().sort());
+        setGateways(Object.values(results[1].data).map(nsCfg => getGatewaysAsList(nsCfg.gateways)).flat().sort());
         setPeerAuthentications(results[2].data.peerAuthentications);
         setFetchError(null);
         setIsLoading(false);

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -21,7 +21,6 @@ import {
   DropdownPosition,
   ExpandableSection,
   KebabToggle,
-  Spinner,
   Tab
 } from '@patternfly/react-core';
 import { KialiAppState } from 'store/Store';
@@ -32,6 +31,7 @@ import { JaegerState } from 'reducers/JaegerState';
 import { classes, style } from 'typestyle';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { ServiceDetailsInfo } from "types/ServiceInfo";
+import { LoadingWizardActionsDropdownGroup } from "components/IstioWizards/LoadingWizardActionsDropdownGroup";
 import { WizardAction, WizardMode } from "components/IstioWizards/WizardActions";
 import ServiceWizardActionsDropdownGroup from "components/IstioWizards/ServiceWizardActionsDropdownGroup";
 import { PeerAuthentication } from "../../types/IstioObjects";
@@ -138,11 +138,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
     if (nodeType === NodeType.SERVICE) {
       if (this.props.serviceDetails === undefined) {
         items.push(
-          <DropdownGroup key="wizards" label="Actions" className="kiali-group-menu">
-            <DropdownItem isDisabled={true}>
-              <Spinner isSVG={true} size="md" aria-label="Loading actions..." />
-            </DropdownItem>
-          </DropdownGroup>
+          <LoadingWizardActionsDropdownGroup />
         );
       } else if (this.props.serviceDetails !== null) {
         items.push(

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -17,7 +17,7 @@ import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
-import { Gateway, PeerAuthentication, Validations } from '../../types/IstioObjects';
+import { Gateway, getGatewaysAsList, PeerAuthentication, Validations } from '../../types/IstioObjects';
 import ServiceWizardDropdown from '../../components/IstioWizards/ServiceWizardDropdown';
 import TimeControl from '../../components/Time/TimeControl';
 import RenderHeaderContainer from "../../components/Nav/Page/RenderHeader";
@@ -89,9 +89,11 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
     this.promises
       .register('gateways', API.getAllIstioConfigs([], ['gateways'], false, '', ''))
       .then(response => {
+        const gws: Gateway[] = [];
         Object.values(response.data).forEach(item => {
-          this.setState({ gateways: this.state.gateways.concat(item.gateways) });
+          gws.push(...item.gateways);
         });
+        this.setState({ gateways: gws });
       })
       .catch(gwError => {
         AlertUtils.addError('Could not fetch Gateways list.', gwError);
@@ -120,10 +122,6 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         AlertUtils.addError('Could not fetch PeerAuthentications.', error);
       });
   };
-
-  private getGatewaysAsList(): string[] {
-    return this.state.gateways.map(gateway => gateway.metadata.namespace + '/' + gateway.metadata.name).sort();
-  }
 
   private renderTabs() {
     const overTab = (
@@ -197,7 +195,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         virtualServices={this.state.serviceDetails.virtualServices}
         destinationRules={this.state.serviceDetails.destinationRules}
         istioPermissions={this.state.serviceDetails.istioPermissions}
-        gateways={this.getGatewaysAsList()}
+        gateways={getGatewaysAsList(this.state.gateways)}
         peerAuthentications={this.state.peerAuthentications}
         tlsStatus={this.state.serviceDetails.namespaceMTLS}
         onChange={this.fetchService}

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -697,6 +697,10 @@ export interface Gateway extends IstioObject {
   spec: GatewaySpec;
 }
 
+export function getGatewaysAsList(gws: Gateway[]): string[] {
+  return gws.map(gateway => gateway.metadata.namespace + '/' + gateway.metadata.name).sort();
+}
+
 // Sidecar resource https://preliminary.istio.io/docs/reference/config/networking/v1alpha3/sidecar
 
 // 1.6


### PR DESCRIPTION
In Kiosk mode, the actions drop-down is not available. Thus, the wizards cannot be launched.

To allow usage of the wizards in the Kiosk mode, this is adding the relevant entries to the Kebab menu of the MiniGraphCard.tsx.

![image](https://user-images.githubusercontent.com/23639005/187767582-714a2a6b-a204-45b5-9c8b-07e676fc6a8f.png)


Fixes kiali/openshift-servicemesh-plugin#43
