### PR TITLE
Fix cypress graph toggle flake

### DIFF
--- a/frontend/cypress/integration/common/kiali_sidebar_toggle.ts
+++ b/frontend/cypress/integration/common/kiali_sidebar_toggle.ts
@@ -1,6 +1,11 @@
 import {And, When, Then} from "cypress-cucumber-preprocessor/steps";
 
 When('the sidebar is open', () => {
+  cy.get('#page-sidebar').should('be.visible').then(($sidebar) => {
+    if ($sidebar.attr('aria-hidden') === 'true') {
+      cy.get('#nav-toggle').click()
+    }
+  })
   cy.get('#page-sidebar').should('be.visible');
 });
 
@@ -13,8 +18,8 @@ Then('user cannot see the sidebar', () => {
 });
 
 When('the sidebar is closed', () => {
-  cy.get('#page-sidebar').should('exist').then(($sidebar) => {
-    if($sidebar.attr('aria-hidden') === 'false') {
+  cy.get('#page-sidebar').should('be.visible').then(($sidebar) => {
+    if ($sidebar.attr('aria-hidden') === 'false') {
       cy.get('#nav-toggle').click()
     }
   })


### PR DESCRIPTION
Updates the assertion in the test to `be.visible`. Using `exists` would cause the `then` statement to fail because the element can exist in the dom but not be visible yet.

Example of flake: https://github.com/kiali/kiali/runs/8140114181?check_suite_focus=true