### PR TITLE
Fix refresh interval in Kiosk mode

### DIFF
--- a/frontend/src/actions/GlobalActions.ts
+++ b/frontend/src/actions/GlobalActions.ts
@@ -1,7 +1,7 @@
 // Action Creators allow us to create typesafe utilities for dispatching actions
 import { ActionType, createAction, createStandardAction } from 'typesafe-actions';
 import { ActionKeys } from './ActionKeys';
-import { KioskMode, TimeInMilliseconds  } from '../types/Common';
+import { KioskMode } from '../types/Common';
 
 export const GlobalActions = {
   unknown: createAction('KIALI_UNKNOWN'), // helper for testing
@@ -9,7 +9,6 @@ export const GlobalActions = {
   decrementLoadingCounter: createAction(ActionKeys.DECREMENT_LOADING_COUNTER),
   setPageVisibilityHidden: createAction(ActionKeys.SET_PAGE_VISIBILITY_HIDDEN),
   setPageVisibilityVisible: createAction(ActionKeys.SET_PAGE_VISIBILITY_VISIBLE),
-  setLastRefreshAt: createStandardAction(ActionKeys.SET_LAST_REFRESH)<TimeInMilliseconds>(),
   setKiosk: createStandardAction(ActionKeys.SET_KIOSK)<KioskMode>(),
 };
 

--- a/frontend/src/components/Envoy/EnvoyDetails.tsx
+++ b/frontend/src/components/Envoy/EnvoyDetails.tsx
@@ -36,6 +36,7 @@ import { serverConfig } from 'config';
 import { FilterSelected } from 'components/Filters/StatefulFilters';
 import history from '../../app/History';
 import {tabName as workloadTabName, defaultTab as workloadDefaultTab} from '../../pages/WorkloadDetails/WorkloadDetailsPage';
+import { TimeInMilliseconds } from "../../types/Common";
 
 // Enables the search box for the ACEeditor
 require('ace-builds/src-noconflict/ext-searchbox');
@@ -59,6 +60,7 @@ type ReduxProps = {
 };
 
 type EnvoyDetailsProps = ReduxProps & {
+  lastRefreshAt: TimeInMilliseconds;
   namespace: string;
   workload: Workload;
 };
@@ -318,6 +320,7 @@ class EnvoyDetails extends React.Component<EnvoyDetailsProps, EnvoyDetailsState>
                 </div>
               ) : this.showMetrics() && envoyMetricsDashboardRef ? (
                 <CustomMetricsContainer
+                  lastRefreshAt={this.props.lastRefreshAt}
                   namespace={this.props.namespace}
                   app={app}
                   version={version}

--- a/frontend/src/components/IstioActions/IstioActionsButtons.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsButtons.tsx
@@ -1,10 +1,4 @@
 import * as React from 'react';
-import { TimeInMilliseconds } from '../../types/Common';
-import { connect } from 'react-redux';
-import { ThunkDispatch } from 'redux-thunk';
-import { KialiAppAction } from '../../actions/KialiAppAction';
-import { KialiAppState } from '../../store/Store';
-import { GlobalActions } from '../../actions/GlobalActions';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { triggerRefresh } from "../../hooks/refresh";
 

--- a/frontend/src/components/IstioActions/IstioActionsButtons.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsButtons.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import { TimeInMilliseconds } from '../../types/Common';
 import { connect } from 'react-redux';
-import { KialiDispatch } from 'types/Redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { KialiAppAction } from '../../actions/KialiAppAction';
+import { KialiAppState } from '../../store/Store';
 import { GlobalActions } from '../../actions/GlobalActions';
 import { Button, ButtonVariant } from '@patternfly/react-core';
+import { triggerRefresh } from "../../hooks/refresh";
 
-type ReduxProps = {
-  setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
-};
-
-type Props = ReduxProps & {
+type Props = {
   objectName: string;
   readOnly: boolean;
   canUpdate: boolean;
@@ -70,18 +69,8 @@ class IstioActionButtons extends React.Component<Props, State> {
 
   private handleRefresh = () => {
     this.props.onRefresh();
-    this.props.setLastRefreshAt(Date.now());
+    triggerRefresh();
   };
 }
 
-const mapDispatchToProps = (dispatch: KialiDispatch) => {
-  return {
-    setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => {
-      dispatch(GlobalActions.setLastRefreshAt(lastRefreshAt));
-    }
-  };
-};
-
-const IstioActionButtonsContainer = connect(null, mapDispatchToProps)(IstioActionButtons);
-
-export default IstioActionButtonsContainer;
+export default IstioActionButtons;

--- a/frontend/src/components/IstioCertsInfo/IstioCertsInfo.tsx
+++ b/frontend/src/components/IstioCertsInfo/IstioCertsInfo.tsx
@@ -15,7 +15,7 @@ import {
   TooltipPosition
 } from '@patternfly/react-core';
 import { KialiAppState } from 'store/Store';
-import { istioCertsInfoSelector, lastRefreshAtSelector } from 'store/Selectors';
+import { istioCertsInfoSelector } from 'store/Selectors';
 import { KialiDispatch } from 'types/Redux';
 import { bindActionCreators } from 'redux';
 import { IstioCertsInfoActions } from 'actions/IstioCertsInfoActions';
@@ -25,6 +25,7 @@ import { CertsInfo } from 'types/CertsInfo';
 import { PFColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
 import { infoStyle } from 'styles/DropdownStyles';
+import connectRefresh from "../Refresh/connectRefresh";
 
 type IstioCertsInfoState = {
   showModal: boolean;
@@ -32,12 +33,12 @@ type IstioCertsInfoState = {
 };
 
 type ReduxProps = {
-  lastRefreshAt: TimeInMilliseconds;
   setIstioCertsInfo: (istioCertsInfo: CertsInfo[]) => void;
   certsInfo: CertsInfo[];
 };
 
 type IstioCertsInfoProps = ReduxProps & {
+  lastRefreshAt: TimeInMilliseconds;
   ref: React.RefObject<any>;
 };
 
@@ -171,15 +172,14 @@ class IstioCertsInfo extends React.Component<IstioCertsInfoProps, IstioCertsInfo
 
 const mapStateToProps = (state: KialiAppState) => ({
   certsInfo: istioCertsInfoSelector(state),
-  lastRefreshAt: lastRefreshAtSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   setIstioCertsInfo: bindActionCreators(IstioCertsInfoActions.setinfo, dispatch)
 });
 
-const IstioCertsInfoConnected = connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(
+const IstioCertsInfoConnected = connectRefresh(connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(
   IstioCertsInfo
-);
+));
 
 export default IstioCertsInfoConnected;

--- a/frontend/src/components/IstioStatus/IstioStatus.tsx
+++ b/frontend/src/components/IstioStatus/IstioStatus.tsx
@@ -6,7 +6,7 @@ import { ComponentStatus, Status } from '../../types/IstioStatus';
 import { MessageType } from '../../types/MessageCenter';
 import Namespace from '../../types/Namespace';
 import { KialiAppState } from '../../store/Store';
-import { istioStatusSelector, lastRefreshAtSelector, namespaceItemsSelector } from '../../store/Selectors';
+import { istioStatusSelector, namespaceItemsSelector } from '../../store/Selectors';
 import { bindActionCreators } from 'redux';
 import { IstioStatusActions } from '../../actions/IstioStatusActions';
 import { connect } from 'react-redux';
@@ -17,16 +17,18 @@ import './IstioStatus.css';
 import { ResourcesFullIcon } from '@patternfly/react-icons';
 import { KialiDispatch } from 'types/Redux';
 import NamespaceThunkActions from '../../actions/NamespaceThunkActions';
+import connectRefresh from "../Refresh/connectRefresh";
 
 type ReduxProps = {
-  lastRefreshAt: TimeInMilliseconds;
   setIstioStatus: (istioStatus: ComponentStatus[]) => void;
   refreshNamespaces: () => void;
   namespaces: Namespace[] | undefined;
   status: ComponentStatus[];
 };
 
-type Props = ReduxProps & {};
+type Props = ReduxProps & {
+  lastRefreshAt: TimeInMilliseconds;
+};
 
 const ValidToColor = {
   'true-true-true': PFColors.Danger,
@@ -114,7 +116,6 @@ export class IstioStatus extends React.Component<Props> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   status: istioStatusSelector(state),
-  lastRefreshAt: lastRefreshAtSelector(state),
   namespaces: namespaceItemsSelector(state)
 });
 
@@ -125,6 +126,6 @@ const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   }
 });
 
-const IstioStatusConnected = connect(mapStateToProps, mapDispatchToProps)(IstioStatus);
+const IstioStatusConnected = connectRefresh(connect(mapStateToProps, mapDispatchToProps)(IstioStatus));
 
 export default IstioStatusConnected;

--- a/frontend/src/components/JaegerIntegration/TracesComponent.tsx
+++ b/frontend/src/components/JaegerIntegration/TracesComponent.tsx
@@ -32,7 +32,6 @@ import { TimeDurationIndicatorButton } from "../Time/TimeDurationIndicatorButton
  */
 
 type ReduxProps = {
-  lastRefreshAt: TimeInMilliseconds;
   namespaceSelector: boolean;
   selectedTrace?: JaegerTrace;
   timeRange: TimeRange;
@@ -40,6 +39,7 @@ type ReduxProps = {
 };
 
 type TracesProps = ReduxProps & {
+  lastRefreshAt: TimeInMilliseconds;
   namespace: string;
   target: string;
   targetKind: TargetKind;
@@ -333,7 +333,6 @@ const mapStateToProps = (state: KialiAppState) => {
     urlJaeger: state.jaegerState.info ? state.jaegerState.info.url : '',
     namespaceSelector: state.jaegerState.info ? state.jaegerState.info.namespaceSelector : true,
     selectedTrace: state.jaegerState.selectedTrace,
-    lastRefreshAt: state.globalState.lastRefreshAt
   };
 };
 

--- a/frontend/src/components/MTls/MeshMTLSStatus.tsx
+++ b/frontend/src/components/MTls/MeshMTLSStatus.tsx
@@ -5,7 +5,6 @@ import { MTLSIconTypes } from './MTLSIcon';
 import { default as MTLSStatus, emptyDescriptor, StatusDescriptor } from './MTLSStatus';
 import { style } from 'typestyle';
 import {
-  lastRefreshAtSelector,
   meshWideMTLSEnabledSelector,
   meshWideMTLSStatusSelector,
   namespaceItemsSelector
@@ -20,16 +19,18 @@ import { bindActionCreators } from 'redux';
 import { MeshTlsActions } from '../../actions/MeshTlsActions';
 import { TimeInMilliseconds } from '../../types/Common';
 import Namespace from '../../types/Namespace';
+import connectRefresh from "../Refresh/connectRefresh";
 
 type ReduxProps = {
-  lastRefreshAt: TimeInMilliseconds;
   setMeshTlsStatus: (meshStatus: TLSStatus) => void;
   namespaces: Namespace[] | undefined;
   status: string;
   autoMTLSEnabled: boolean;
 };
 
-type Props = ReduxProps & {};
+type Props = ReduxProps & {
+  lastRefreshAt: TimeInMilliseconds;
+};
 
 const statusDescriptors = new Map<string, StatusDescriptor>([
   [
@@ -122,7 +123,6 @@ class MeshMTLSStatus extends React.Component<Props> {
 const mapStateToProps = (state: KialiAppState) => ({
   status: meshWideMTLSStatusSelector(state),
   autoMTLSEnabled: meshWideMTLSEnabledSelector(state),
-  lastRefreshAt: lastRefreshAtSelector(state),
   namespaces: namespaceItemsSelector(state)
 });
 
@@ -130,5 +130,5 @@ const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch)
 });
 
-const MeshMTLSStatusConnected = connect(mapStateToProps, mapDispatchToProps)(MeshMTLSStatus);
+const MeshMTLSStatusConnected = connectRefresh(connect(mapStateToProps, mapDispatchToProps)(MeshMTLSStatus));
 export default MeshMTLSStatusConnected;

--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -43,6 +43,7 @@ type MetricsState = {
 type CustomMetricsProps = RouteComponentProps<{}> & {
   namespace: string;
   app: string;
+  lastRefreshAt: TimeInMilliseconds;
   version?: string;
   workload?: string;
   workloadType?: string;
@@ -53,7 +54,6 @@ type CustomMetricsProps = RouteComponentProps<{}> & {
 
 type ReduxProps = {
   jaegerIntegration: boolean;
-  lastRefreshAt: TimeInMilliseconds;
   timeRange: TimeRange;
   setTimeRange: (range: TimeRange) => void;
 };
@@ -328,7 +328,6 @@ class CustomMetrics extends React.Component<Props, MetricsState> {
 const mapStateToProps = (state: KialiAppState) => {
   return {
     jaegerIntegration: state.jaegerState.info ? state.jaegerState.info.integration : false,
-    lastRefreshAt: state.globalState.lastRefreshAt,
     timeRange: timeRangeSelector(state)
   };
 };

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -59,11 +59,12 @@ type IstioMetricsProps = ObjectId &
   RouteComponentProps<{}> & {
     objectType: MetricsObjectTypes;
     direction: Direction;
+  } & {
+  lastRefreshAt: TimeInMilliseconds;
   };
 
 type ReduxProps = {
   jaegerIntegration: boolean;
-  lastRefreshAt: TimeInMilliseconds;
   timeRange: TimeRange;
   refreshInterval: IntervalInMilliseconds;
   setTimeRange: (range: TimeRange) => void;
@@ -415,7 +416,6 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
 const mapStateToProps = (state: KialiAppState) => {
   return {
     jaegerIntegration: state.jaegerState.info ? state.jaegerState.info.integration : false,
-    lastRefreshAt: state.globalState.lastRefreshAt,
     timeRange: timeRangeSelector(state),
     refreshInterval: refreshIntervalSelector(state)
   };

--- a/frontend/src/components/Metrics/__tests__/IstioMetrics.test.tsx
+++ b/frontend/src/components/Metrics/__tests__/IstioMetrics.test.tsx
@@ -105,6 +105,7 @@ describe('Metrics for a service', () => {
             render={props => (
               <IstioMetrics
                 {...props}
+                lastRefreshAt={Date.now()}
                 namespace="ns"
                 object="svc"
                 objectType={MetricsObjectTypes.SERVICE}
@@ -123,7 +124,7 @@ describe('Metrics for a service', () => {
     new MounterMocker()
       .addMock('getServiceDashboard', dashboard)
       .mountWithStore(
-        <IstioMetrics namespace="ns" object="svc" objectType={MetricsObjectTypes.SERVICE} direction={'inbound'} />
+        <IstioMetrics namespace="ns" object="svc" objectType={MetricsObjectTypes.SERVICE} direction={'inbound'} lastRefreshAt={Date.now()} />
       )
       .run(done, wrapper => {
         expect(wrapper.find('Chart')).toHaveLength(0);
@@ -146,7 +147,7 @@ describe('Metrics for a service', () => {
     new MounterMocker()
       .addMock('getServiceDashboard', dashboard)
       .mountWithStore(
-        <IstioMetrics namespace="ns" object="svc" objectType={MetricsObjectTypes.SERVICE} direction={'inbound'} />
+        <IstioMetrics namespace="ns" object="svc" objectType={MetricsObjectTypes.SERVICE} direction={'inbound'} lastRefreshAt={Date.now()} />
       )
       .run(done, wrapper => {
         expect(wrapper.find('Chart')).toHaveLength(4);
@@ -180,6 +181,7 @@ describe('Inbound Metrics for a workload', () => {
           render={props => (
             <IstioMetrics
               {...props}
+              lastRefreshAt={Date.now()}
               namespace="ns"
               object="svc"
               objectType={MetricsObjectTypes.WORKLOAD}
@@ -197,7 +199,7 @@ describe('Inbound Metrics for a workload', () => {
     new MounterMocker()
       .addMock('getWorkloadDashboard', dashboard)
       .mountWithStore(
-        <IstioMetrics namespace="ns" object="wkd" objectType={MetricsObjectTypes.WORKLOAD} direction={'inbound'} />
+        <IstioMetrics namespace="ns" object="wkd" objectType={MetricsObjectTypes.WORKLOAD} direction={'inbound'} lastRefreshAt={Date.now()} />
       )
       .run(done, wrapper => {
         expect(wrapper.find('Chart')).toHaveLength(0);
@@ -220,7 +222,7 @@ describe('Inbound Metrics for a workload', () => {
     new MounterMocker()
       .addMock('getWorkloadDashboard', dashboard)
       .mountWithStore(
-        <IstioMetrics namespace="ns" object="wkd" objectType={MetricsObjectTypes.WORKLOAD} direction={'inbound'} />
+        <IstioMetrics namespace="ns" object="wkd" objectType={MetricsObjectTypes.WORKLOAD} direction={'inbound'} lastRefreshAt={Date.now()} />
       )
       .run(done, wrapper => {
         expect(wrapper.find('Chart')).toHaveLength(4);

--- a/frontend/src/components/Refresh/Refresh.tsx
+++ b/frontend/src/components/Refresh/Refresh.tsx
@@ -4,18 +4,17 @@ import { KialiDispatch } from 'types/Redux';
 import { KialiAppState } from '../../store/Store';
 import { refreshIntervalSelector } from '../../store/Selectors';
 import { config } from '../../config';
-import { IntervalInMilliseconds, TimeInMilliseconds } from '../../types/Common';
+import { IntervalInMilliseconds } from '../../types/Common';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import RefreshButtonContainer from './RefreshButton';
-import { GlobalActions } from '../../actions/GlobalActions';
 import { HistoryManager, URLParam } from 'app/History';
 import { TooltipPosition } from '@patternfly/react-core';
+import { triggerRefresh } from "../../hooks/refresh";
 
 type ReduxProps = {
   refreshInterval: IntervalInMilliseconds;
   setRefreshInterval: (refreshInterval: IntervalInMilliseconds) => void;
-  setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
 };
 
 type ComponentProps = {
@@ -25,19 +24,13 @@ type ComponentProps = {
   hideRefreshButton?: boolean;
   manageURL?: boolean;
   menuAppendTo?: HTMLElement | (() => HTMLElement) | 'parent' | 'inline';
-
-  handleRefresh?: () => void;
 };
 
 type Props = ComponentProps & ReduxProps;
 
-type State = {
-  refresherRef?: number;
-};
-
 const REFRESH_INTERVALS = config.toolbar.refreshInterval;
 
-export class Refresh extends React.PureComponent<Props, State> {
+export class Refresh extends React.PureComponent<Props> {
   constructor(props: Props) {
     super(props);
 
@@ -52,29 +45,12 @@ export class Refresh extends React.PureComponent<Props, State> {
       }
       HistoryManager.setParam(URLParam.REFRESH_INTERVAL, String(refreshInterval));
     }
-
-    this.state = {
-      refresherRef: undefined
-    };
   }
 
-  componentDidMount() {
-    this.updateRefresher();
-  }
-
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate() {
     // ensure redux state and URL are aligned
     if (this.props.manageURL) {
       HistoryManager.setParam(URLParam.REFRESH_INTERVAL, String(this.props.refreshInterval));
-    }
-    if (prevProps.refreshInterval !== this.props.refreshInterval) {
-      this.updateRefresher();
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.state.refresherRef) {
-      clearInterval(this.state.refresherRef);
     }
   }
 
@@ -94,35 +70,16 @@ export class Refresh extends React.PureComponent<Props, State> {
             tooltip={'Refresh interval'}
             tooltipPosition={TooltipPosition.left}
           />
-          {this.props.hideRefreshButton || <RefreshButtonContainer handleRefresh={this.handleRefresh} disabled={this.props.disabled}/>}
+          {this.props.hideRefreshButton || <RefreshButtonContainer handleRefresh={triggerRefresh} disabled={this.props.disabled}/>}
         </>
       );
     } else {
-      return this.props.hideRefreshButton ? null : <RefreshButtonContainer handleRefresh={this.handleRefresh} />;
+      return this.props.hideRefreshButton ? null : <RefreshButtonContainer handleRefresh={triggerRefresh} />;
     }
   }
 
-  private updateRefresher = () => {
-    if (this.state.refresherRef) {
-      clearInterval(this.state.refresherRef);
-    }
-    let refresherRef: number | undefined = undefined;
-    if (this.props.refreshInterval > 0) {
-      refresherRef = window.setInterval(this.handleRefresh, this.props.refreshInterval);
-      this.setState({ refresherRef: refresherRef });
-    }
-  };
-
   private updateRefreshInterval = (refreshInterval: IntervalInMilliseconds) => {
     this.props.setRefreshInterval(refreshInterval); // notify redux of the change
-  };
-
-  private handleRefresh = () => {
-    this.props.setLastRefreshAt(Date.now());
-    // Components may connect to the lastRefreshAt property instead to pass a refreshMethod
-    if (this.props.handleRefresh) {
-      this.props.handleRefresh();
-    }
   };
 }
 
@@ -134,9 +91,6 @@ const mapDispatchToProps = (dispatch: KialiDispatch) => {
   return {
     setRefreshInterval: (refresh: IntervalInMilliseconds) => {
       dispatch(UserSettingsActions.setRefreshInterval(refresh));
-    },
-    setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => {
-      dispatch(GlobalActions.setLastRefreshAt(lastRefreshAt));
     }
   };
 };

--- a/frontend/src/components/Refresh/RefreshButton.tsx
+++ b/frontend/src/components/Refresh/RefreshButton.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
-import { TimeInMilliseconds } from '../../types/Common';
-import { KialiDispatch } from 'types/Redux';
-import { GlobalActions } from '../../actions/GlobalActions';
 
 type ComponentProps = {
   id?: string;
@@ -12,13 +8,7 @@ type ComponentProps = {
   handleRefresh: () => void;
 };
 
-type ReduxProps = {
-  setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
-};
-
-type Props = ComponentProps & ReduxProps;
-
-class RefreshButton extends React.Component<Props> {
+class RefreshButton extends React.Component<ComponentProps> {
   getElementId() {
     return this.props.id || 'refresh_button';
   }
@@ -45,19 +35,8 @@ class RefreshButton extends React.Component<Props> {
   }
 
   private handleRefresh = () => {
-    this.props.setLastRefreshAt(Date.now());
     this.props.handleRefresh();
   };
 }
 
-const mapDispatchToProps = (dispatch: KialiDispatch) => {
-  return {
-    setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => {
-      dispatch(GlobalActions.setLastRefreshAt(lastRefreshAt));
-    }
-  };
-};
-
-const RefreshButtonContainer = connect(null, mapDispatchToProps)(RefreshButton);
-
-export default RefreshButtonContainer;
+export default RefreshButton;

--- a/frontend/src/components/Refresh/RefreshNotifier.tsx
+++ b/frontend/src/components/Refresh/RefreshNotifier.tsx
@@ -6,6 +6,12 @@ interface Props {
   onTick: (timestamp: TimeInMilliseconds) => void;
 }
 
+// RefreshNotifier won't render any visual element. Its work is limited to calling
+// the onTick function passed in the props. The onTick function will be called
+// each time a global refresh event is emitted (i.e. when the user specified
+// refresh interval has elapsed). Class components wanting to watch for these
+// global refresh events should use this <RefreshNotifier onTick={yourCallBack}> component.
+// For function components, use the useRefreshInterval() hook.
 export default function RefreshNotifier({ onTick }: Props) {
   const refreshing = useRefreshInterval();
 

--- a/frontend/src/components/Refresh/RefreshNotifier.tsx
+++ b/frontend/src/components/Refresh/RefreshNotifier.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { TimeInMilliseconds } from "../../types/Common";
+import useRefreshInterval from "../../hooks/refresh";
+
+interface Props {
+  onTick: (timestamp: TimeInMilliseconds) => void;
+}
+
+export default function RefreshNotifier({ onTick }: Props) {
+  const refreshing = useRefreshInterval();
+
+  useEffect(() => {
+    if (refreshing.previousRefreshAt !== refreshing.lastRefreshAt) {
+      // We only want to notify when a refresh happens. At mount, previousRefreshAt == lastRefreshAt.
+      // So, we notify only when both values are different.
+      onTick(refreshing.lastRefreshAt);
+
+      // NOTE: This won't handle well the case when props.onTick changes. If that happens,
+      // this will immediately call props.onTick, even if a refresh hasn't been fired.
+    }
+  }, [onTick, refreshing.previousRefreshAt, refreshing.lastRefreshAt]);
+
+  return null;
+}

--- a/frontend/src/components/Refresh/connectRefresh.tsx
+++ b/frontend/src/components/Refresh/connectRefresh.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import useRefreshInterval from "../../hooks/refresh";
+
+// TODO: This is a transition component. Please, avoid using this HOC/function.
+//  Prefer usage of the useRefreshInterval hook for function components, or the RefreshNotifier component for class components.
+export default function connectRefresh<P extends { lastRefreshAt: number }>(Component: React.ComponentType<P>) {
+  return function (props: Omit<P, 'lastRefreshAt'>) {
+    const refreshing = useRefreshInterval();
+
+    console.log('Rendering connectedRefresh component:', Component, refreshing.lastRefreshAt);
+
+    return (
+      <Component {...props as P} lastRefreshAt={refreshing.lastRefreshAt} />
+    );
+  };
+}

--- a/frontend/src/components/Refresh/connectRefresh.tsx
+++ b/frontend/src/components/Refresh/connectRefresh.tsx
@@ -4,13 +4,11 @@ import useRefreshInterval from "../../hooks/refresh";
 // TODO: This is a transition component. Please, avoid using this HOC/function.
 //  Prefer usage of the useRefreshInterval hook for function components, or the RefreshNotifier component for class components.
 export default function connectRefresh<P extends { lastRefreshAt: number }>(Component: React.ComponentType<P>) {
-  return function (props: Omit<P, 'lastRefreshAt'>) {
+  return React.forwardRef((props: Omit<P, 'lastRefreshAt'>, ref) => {
     const refreshing = useRefreshInterval();
 
-    console.log('Rendering connectedRefresh component:', Component, refreshing.lastRefreshAt);
-
     return (
-      <Component {...props as P} lastRefreshAt={refreshing.lastRefreshAt} />
+      <Component {...props as P} ref={ref} lastRefreshAt={refreshing.lastRefreshAt} />
     );
-  };
+  });
 }

--- a/frontend/src/components/Time/TimeDurationComponent.tsx
+++ b/frontend/src/components/Time/TimeDurationComponent.tsx
@@ -22,8 +22,6 @@ type TimeControlsProps = ReduxProps & {
   disabled: boolean;
   id: string;
   supportsReplay?: boolean;
-
-  handleRefresh?: () => void;
 };
 
 export class TimeDurationComponent extends React.PureComponent<TimeControlsProps> {
@@ -58,7 +56,6 @@ export class TimeDurationComponent extends React.PureComponent<TimeControlsProps
             id="time_range_refresh"
             disabled={this.props.disabled}
             hideLabel={true}
-            handleRefresh={this.props.handleRefresh}
             manageURL={true}
           />
         )}

--- a/frontend/src/components/Time/TimeDurationModal.tsx
+++ b/frontend/src/components/Time/TimeDurationModal.tsx
@@ -110,7 +110,6 @@ export function TimeDurationModal(props: Props) {
             menuAppendTo="parent"
             refreshInterval={refreshInterval}
             setRefreshInterval={handleSetRefreshInterval}
-            setLastRefreshAt={() => undefined}
           />
         </FormGroup>
       </Form>

--- a/frontend/src/components/TrafficList/TrafficDetails.tsx
+++ b/frontend/src/components/TrafficList/TrafficDetails.tsx
@@ -68,12 +68,12 @@ export interface TrafficItem {
 
 type ReduxProps = {
   duration: DurationInSeconds;
-  lastRefreshAt: TimeInMilliseconds;
 }
 
 type TrafficDetailsProps = ReduxProps & {
   itemName: string;
   itemType: MetricsObjectTypes;
+  lastRefreshAt: TimeInMilliseconds;
   namespace: string;
 };
 
@@ -333,7 +333,6 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
 const mapStateToProps = (state: KialiAppState) => {
   return {
     duration: durationSelector(state),
-    lastRefreshAt: state.globalState.lastRefreshAt
   };
 };
 

--- a/frontend/src/hooks/refresh.ts
+++ b/frontend/src/hooks/refresh.ts
@@ -1,0 +1,61 @@
+import { useSelector } from "react-redux";
+import { KialiAppState } from "../store/Store";
+import { IntervalInMilliseconds, TimeInMilliseconds } from "../types/Common";
+import { useEffect, useState } from "react";
+
+let numSubscribers = 0;
+let intervalId: null | number = null;
+
+function doTick(time?: TimeInMilliseconds) {
+  const refreshTick = new CustomEvent('refreshTick', {detail: time ?? Date.now()});
+  document.dispatchEvent(refreshTick);
+}
+
+export function triggerRefresh(time?: TimeInMilliseconds) {
+  doTick(time);
+}
+
+export default function useRefreshInterval() {
+  const refreshInterval = useSelector<KialiAppState, IntervalInMilliseconds>((state) => state.userSettings.refreshInterval);
+  const [lastRefreshAt, setLastRefreshAt] = useState<TimeInMilliseconds>(Date.now());
+  const [previousRefreshAt, setPreviousRefreshAt] = useState<TimeInMilliseconds>(lastRefreshAt);
+
+  useEffect(() => {
+    function handleTick(e: CustomEventInit<TimeInMilliseconds>) {
+      setPreviousRefreshAt(lastRefreshAt);
+      setLastRefreshAt(e.detail!);
+    }
+
+    // Subscribe
+    document.addEventListener('refreshTick', handleTick);
+    numSubscribers++;
+
+    return function () {
+      // Unsubscribe;
+      document.removeEventListener('refreshTick', handleTick);
+      numSubscribers--;
+    };
+  }, [lastRefreshAt]);
+
+  useEffect(() => {
+    if (intervalId !== null) {
+      // When mounting, reset the timer.
+      // Also, if refreshInterval changed, set a new timer.
+      window.clearInterval(intervalId);
+      intervalId = null;
+    }
+
+    if (numSubscribers !== 0 && refreshInterval !== 0) {
+      intervalId = window.setInterval(triggerRefresh, refreshInterval);
+    }
+
+    return function () {
+      if (intervalId !== null && numSubscribers === 0) {
+        window.clearInterval(intervalId);
+        intervalId = null;
+      }
+    }
+  }, [refreshInterval]);
+
+  return { lastRefreshAt, previousRefreshAt, refreshInterval };
+}

--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -23,6 +23,7 @@ import { AppHealth } from 'types/Health';
 import RenderHeaderContainer from "../../components/Nav/Page/RenderHeader";
 import {ErrorMsg} from "../../types/ErrorMsg";
 import ErrorSection from "../../components/ErrorSection/ErrorSection";
+import connectRefresh from "../../components/Refresh/connectRefresh";
 
 type AppDetailsState = {
   app?: App;
@@ -36,11 +37,12 @@ type AppDetailsState = {
 type ReduxProps = {
   duration: DurationInSeconds;
   jaegerInfo?: JaegerInfo;
-  lastRefreshAt: TimeInMilliseconds;
   timeRange: TimeRange;
 };
 
-type AppDetailsProps = RouteComponentProps<AppId> & ReduxProps;
+type AppDetailsProps = RouteComponentProps<AppId> & ReduxProps & {
+  lastRefreshAt: TimeInMilliseconds;
+};
 
 const tabName = 'tab';
 const defaultTab = 'info';
@@ -117,6 +119,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
             const tab = (
               <Tab title={dashboard.title} key={'cd-' + dashboard.template} eventKey={tabKey}>
                 <CustomMetricsContainer
+                  lastRefreshAt={this.props.lastRefreshAt}
                   namespace={this.props.match.params.namespace}
                   app={this.props.match.params.app}
                   template={dashboard.template}
@@ -145,6 +148,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
         <TrafficDetails
           itemName={this.props.match.params.app}
           itemType={MetricsObjectTypes.APP}
+          lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.match.params.namespace}
         />
       </Tab>
@@ -154,6 +158,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
       <Tab title="Inbound Metrics" eventKey={2} key={'Inbound Metrics'}>
         <IstioMetricsContainer
           data-test="inbound-metrics-component"
+          lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.match.params.namespace}
           object={this.props.match.params.app}
           objectType={MetricsObjectTypes.APP}
@@ -166,6 +171,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
       <Tab title="Outbound Metrics" eventKey={3} key={'Outbound Metrics'}>
         <IstioMetricsContainer
           data-test="outbound-metrics-component"
+          lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.match.params.namespace}
           object={this.props.match.params.app}
           objectType={MetricsObjectTypes.APP}
@@ -183,6 +189,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
         tabsArray.push(
           <Tab eventKey={4} style={{ textAlign: 'center' }} title={'Traces'} key={tracesTabName}>
             <TracesComponent
+              lastRefreshAt={this.props.lastRefreshAt}
               namespace={this.props.match.params.namespace}
               target={this.props.match.params.app}
               targetKind={'app'}
@@ -259,9 +266,8 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   duration: durationSelector(state),
-  jaegerInfo: state.jaegerState.info,
-  lastRefreshAt: state.globalState.lastRefreshAt
+  jaegerInfo: state.jaegerState.info
 });
 
-const AppDetailsContainer = connect(mapStateToProps)(AppDetails);
+const AppDetailsContainer = connectRefresh(connect(mapStateToProps)(AppDetails));
 export default AppDetailsContainer;

--- a/frontend/src/pages/AppDetails/AppInfo.tsx
+++ b/frontend/src/pages/AppDetails/AppInfo.tsx
@@ -3,7 +3,7 @@ import { Grid, GridItem } from '@patternfly/react-core';
 import AppDescription from './AppDescription';
 import { App } from '../../types/App';
 import { RenderComponentScroll } from '../../components/Nav/Page';
-import { DurationInSeconds, TimeInMilliseconds } from 'types/Common';
+import { DurationInSeconds } from 'types/Common';
 import GraphDataSource from 'services/GraphDataSource';
 import { AppHealth } from 'types/Health';
 import { KialiAppState } from '../../store/Store';
@@ -18,7 +18,6 @@ type AppInfoProps = {
   app?: App;
   duration: DurationInSeconds;
   health?: AppHealth;
-  lastRefreshAt: TimeInMilliseconds;
   mtlsEnabled: boolean;
 };
 
@@ -93,7 +92,6 @@ class AppInfo extends React.Component<AppInfoProps, AppInfoState> {
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
-  lastRefreshAt: state.globalState.lastRefreshAt,
   mtlsEnabled: meshWideMTLSEnabledSelector(state)
 });
 

--- a/frontend/src/pages/AppList/AppListPage.tsx
+++ b/frontend/src/pages/AppList/AppListPage.tsx
@@ -19,6 +19,7 @@ import * as API from '../../services/Api';
 import * as AppListClass from './AppListClass';
 import VirtualList from '../../components/VirtualList/VirtualList';
 import TimeDurationContainer from '../../components/Time/TimeDurationComponent';
+import RefreshNotifier from "../../components/Refresh/RefreshNotifier";
 
 type AppListPageState = FilterComponent.State<AppListItem>;
 
@@ -113,13 +114,13 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
   render() {
     return (
       <>
+        <RefreshNotifier onTick={this.updateListItems} />
         <div style={{ backgroundColor: '#fff' }}>
           <DefaultSecondaryMasthead
             rightToolbar={
               <TimeDurationContainer
                 key={'DurationDropdown'}
                 id="app-list-duration-dropdown"
-                handleRefresh={this.updateListItems}
                 disabled={false}
               />
             }

--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -44,7 +44,6 @@ import {
   findValueSelector,
   graphTypeSelector,
   hideValueSelector,
-  lastRefreshAtSelector,
   meshWideMTLSEnabledSelector,
   refreshIntervalSelector,
   replayActiveSelector,
@@ -64,7 +63,6 @@ import { toRangeString } from 'components/Time/Utils';
 import { replayBorder } from 'components/Time/Replay';
 import GraphDataSource, { FetchParams, EMPTY_GRAPH_DATA } from '../../services/GraphDataSource';
 import { NamespaceActions } from '../../actions/NamespaceAction';
-import { GlobalActions } from "../../actions/GlobalActions";
 import GraphThunkActions from '../../actions/GraphThunkActions';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { KialiDispatch } from "types/Redux";
@@ -81,6 +79,8 @@ import { WizardAction, WizardMode } from "components/IstioWizards/WizardActions"
 import ConfirmDeleteTrafficRoutingModal from "components/IstioWizards/ConfirmDeleteTrafficRoutingModal";
 import { deleteServiceTrafficRouting } from "services/Api";
 import { canCreate, canUpdate } from "../../types/Permissions";
+import connectRefresh from "../../components/Refresh/connectRefresh";
+import { triggerRefresh } from "../../hooks/refresh";
 
 // GraphURLPathProps holds path variable values.  Currently all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -108,7 +108,6 @@ type ReduxProps = {
   hideValue: string;
   isPageVisible: boolean;
   kiosk: string;
-  lastRefreshAt: TimeInMilliseconds;
   layout: Layout;
   namespaceLayout: Layout;
   mtlsEnabled: boolean;
@@ -121,7 +120,6 @@ type ReduxProps = {
   replayQueryTime: TimeInMilliseconds;
   setActiveNamespaces: (namespaces: Namespace[]) => void;
   setGraphDefinition: (graphDefinition: GraphDefinition) => void;
-  setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
   setRankResult: (result: RankResult) => void;
   setNode: (node?: NodeParamsType) => void;
   setTraceId: (traceId?: string) => void;
@@ -145,7 +143,9 @@ type ReduxProps = {
   updateSummary: (event: CytoscapeEvent) => void;
 };
 
-export type GraphPageProps = RouteComponentProps<Partial<GraphURLPathProps>> & ReduxProps;
+export type GraphPageProps = RouteComponentProps<Partial<GraphURLPathProps>> & ReduxProps & {
+  lastRefreshAt: TimeInMilliseconds;
+};
 
 export type GraphData = {
   elements: DecoratedGraphElements;
@@ -760,7 +760,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
           showWizard: false
         }
       }));
-      this.props.setLastRefreshAt(Date.now());
+      triggerRefresh();
     } else {
       this.setState(prevState => ({
         wizardsData: {
@@ -788,7 +788,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
 
     deleteServiceTrafficRouting(this.state.wizardsData!.serviceDetails!)
       .then(_results => {
-        this.props.setLastRefreshAt(Date.now());
+        triggerRefresh();
       })
       .catch(error => {
         AlertUtils.addError('Could not delete Istio config objects.', error);
@@ -862,7 +862,6 @@ const mapStateToProps = (state: KialiAppState) => ({
   hideValue: hideValueSelector(state),
   isPageVisible: state.globalState.isPageVisible,
   kiosk: state.globalState.kiosk,
-  lastRefreshAt: lastRefreshAtSelector(state),
   layout: state.graph.layout,
   mtlsEnabled: meshWideMTLSEnabledSelector(state),
   namespaceLayout: state.graph.namespaceLayout,
@@ -892,7 +891,6 @@ const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   onReady: (cy: Cy.Core) => dispatch(GraphThunkActions.graphReady(cy)),
   setActiveNamespaces: (namespaces: Namespace[]) => dispatch(NamespaceActions.setActiveNamespaces(namespaces)),
   setGraphDefinition: bindActionCreators(GraphActions.setGraphDefinition, dispatch),
-  setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => dispatch(GlobalActions.setLastRefreshAt(lastRefreshAt)),
   setNode: bindActionCreators(GraphActions.setNode, dispatch),
   setRankResult: bindActionCreators(GraphActions.setRankResult, dispatch),
   setTraceId: (traceId?: string) => dispatch(JaegerThunkActions.setTraceId(traceId)),
@@ -903,5 +901,5 @@ const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   updateSummary: (event: CytoscapeEvent) => dispatch(GraphActions.updateSummary(event))
 });
 
-const GraphPageContainer = connect(mapStateToProps, mapDispatchToProps)(GraphPage);
+const GraphPageContainer = connectRefresh(connect(mapStateToProps, mapDispatchToProps)(GraphPage));
 export default GraphPageContainer;

--- a/frontend/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
@@ -17,7 +17,6 @@ type GraphSecondaryMastheadProps = {
 
   onToggleHelp: () => void;
   onGraphTypeChange: (graphType: GraphType) => void;
-  onHandleRefresh: () => void;
 };
 
 const mastheadStyle = style({
@@ -79,7 +78,6 @@ export default class GraphSecondaryMasthead extends React.PureComponent<GraphSec
               <TimeDurationContainer
                 id="graph_time_range"
                 disabled={this.props.disabled}
-                handleRefresh={this.props.onHandleRefresh}
                 supportsReplay={true}
               />
             </TourStopContainer>

--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -64,7 +64,6 @@ type GraphToolbarProps = ReduxProps & {
   disabled: boolean;
   elementsChanged: boolean;
   onToggleHelp: () => void;
-  onRefresh?: () => void;
 };
 
 export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
@@ -183,7 +182,6 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
           isNodeGraph={!!this.props.node}
           onToggleHelp={this.props.onToggleHelp}
           onGraphTypeChange={this.props.setGraphType}
-          onHandleRefresh={this.handleRefresh}
         />
         <Toolbar style={{ width: '100%' }}>
           <ToolbarGroup aria-label="graph settings" style={{ margin: 0, alignItems: "flex-start"}}>
@@ -228,12 +226,6 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
       </>
     );
   }
-
-  private handleRefresh = () => {
-    if (this.props.onRefresh) {
-      this.props.onRefresh();
-    }
-  };
 
   private handleNamespaceReturn = () => {
     if (

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -56,6 +56,7 @@ import { Annotation } from 'react-ace/types';
 import RenderHeaderContainer from "../../components/Nav/Page/RenderHeader";
 import {ErrorMsg} from "../../types/ErrorMsg";
 import ErrorSection from "../../components/ErrorSection/ErrorSection";
+import RefreshNotifier from "../../components/Refresh/RefreshNotifier";
 
 // Enables the search box for the ACEeditor
 require('ace-builds/src-noconflict/ext-searchbox');
@@ -563,9 +564,10 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   render() {
     return (
       <>
+        <RefreshNotifier onTick={this.onRefresh} />
         <RenderHeaderContainer
           location={this.props.location}
-          rightToolbar={<RefreshContainer id="config_details_refresh" hideLabel={true} handleRefresh={this.onRefresh} />}
+          rightToolbar={<RefreshContainer id="config_details_refresh" hideLabel={true} />}
           actionsToolbar={!this.state.error ? this.renderActions() : undefined}
         />
         {this.state.error && (

--- a/frontend/src/pages/Overview/OverviewToolbar.tsx
+++ b/frontend/src/pages/Overview/OverviewToolbar.tsx
@@ -19,6 +19,7 @@ import { style } from 'typestyle';
 import { PFColors } from '../../components/Pf/PfColors';
 import TimeDurationContainer from '../../components/Time/TimeDurationComponent';
 import { KialiDispatch } from "../../types/Redux";
+import RefreshNotifier from "../../components/Refresh/RefreshNotifier";
 
 type ReduxProps = {
   duration: DurationInSeconds;
@@ -218,11 +219,11 @@ export class OverviewToolbar extends React.Component<Props, State> {
     );
     const timeToolbar = (
       <div className={timeToolbarStyle}>
+        <RefreshNotifier onTick={this.props.onRefresh} />
         <TimeDurationContainer
           key="overview-time-range"
           id="overview-time-range"
           disabled={false}
-          handleRefresh={this.props.onRefresh}
         />
       </div>
     );

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -23,6 +23,7 @@ import TimeControl from '../../components/Time/TimeControl';
 import RenderHeaderContainer from "../../components/Nav/Page/RenderHeader";
 import {ErrorMsg} from "../../types/ErrorMsg";
 import ErrorSection from "../../components/ErrorSection/ErrorSection";
+import connectRefresh from "../../components/Refresh/connectRefresh";
 
 type ServiceDetailsState = {
   currentTab: string;
@@ -141,6 +142,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         <TrafficDetails
           itemName={this.props.match.params.service}
           itemType={MetricsObjectTypes.SERVICE}
+          lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.match.params.namespace}
         />
       </Tab>
@@ -149,6 +151,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
     const inTab = (
       <Tab eventKey={2} title="Inbound Metrics" key="Inbound Metrics">
         <IstioMetricsContainer
+          lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.match.params.namespace}
           object={this.props.match.params.service}
           objectType={MetricsObjectTypes.SERVICE}
@@ -163,6 +166,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
       tabsArray.push(
         <Tab eventKey={3} title="Traces" key="Traces">
           <TracesComponent
+            lastRefreshAt={this.props.lastRefreshAt}
             namespace={this.props.match.params.namespace}
             target={this.props.match.params.service}
             targetKind={'service'}
@@ -235,8 +239,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
 
 const mapStateToProps = (state: KialiAppState) => ({
   jaegerInfo: state.jaegerState.info,
-  lastRefreshAt: state.globalState.lastRefreshAt
 });
 
-const ServiceDetailsPageContainer = connect(mapStateToProps)(ServiceDetails);
+const ServiceDetailsPageContainer = connectRefresh( connect(mapStateToProps)(ServiceDetails));
 export default ServiceDetailsPageContainer;

--- a/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../types/IstioObjects';
 import { RenderComponentScroll } from '../../components/Nav/Page';
 import { PromisesRegistry } from 'utils/CancelablePromises';
-import { DurationInSeconds, TimeInMilliseconds } from 'types/Common';
+import { DurationInSeconds } from 'types/Common';
 import GraphDataSource from 'services/GraphDataSource';
 import {
   drToIstioItems,
@@ -42,7 +42,6 @@ import * as AlertUtils from "../../utils/AlertUtils";
 
 interface Props extends ServiceId {
   duration: DurationInSeconds;
-  lastRefreshAt: TimeInMilliseconds;
   mtlsEnabled: boolean;
   serviceDetails?: ServiceDetailsInfo;
   setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
@@ -248,7 +247,6 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   duration: durationSelector(state),
-  lastRefreshAt: state.globalState.lastRefreshAt,
   mtlsEnabled: meshWideMTLSEnabledSelector(state)
 });
 

--- a/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -25,9 +25,7 @@ import {
   validationKey
 } from '../../types/IstioConfigList';
 import { canCreate, canUpdate } from "../../types/Permissions";
-import { KialiDispatch } from "../../types/Redux";
 import { KialiAppState } from '../../store/Store';
-import { GlobalActions } from "../../actions/GlobalActions";
 import { durationSelector, meshWideMTLSEnabledSelector } from '../../store/Selectors';
 import ServiceNetwork from './ServiceNetwork';
 import { GraphEdgeTapEvent } from '../../components/CytoscapeGraph/CytoscapeGraph';
@@ -39,12 +37,12 @@ import ConfirmDeleteTrafficRoutingModal from "../../components/IstioWizards/Conf
 import { WizardAction, WizardMode } from "../../components/IstioWizards/WizardActions";
 import { deleteServiceTrafficRouting } from "../../services/Api";
 import * as AlertUtils from "../../utils/AlertUtils";
+import { triggerRefresh } from "../../hooks/refresh";
 
 interface Props extends ServiceId {
   duration: DurationInSeconds;
   mtlsEnabled: boolean;
   serviceDetails?: ServiceDetailsInfo;
-  setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
   gateways: Gateway[];
   peerAuthentications: PeerAuthentication[];
   validations: Validations;
@@ -124,7 +122,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
     });
 
     if (changed) {
-      this.props.setLastRefreshAt(Date.now());
+      triggerRefresh();
     }
   }
 
@@ -135,7 +133,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
 
     deleteServiceTrafficRouting(this.props.serviceDetails!)
       .then(_results => {
-        this.props.setLastRefreshAt(Date.now());
+        triggerRefresh();
       })
       .catch(error => {
         AlertUtils.addError('Could not delete Istio config objects.', error);
@@ -250,9 +248,5 @@ const mapStateToProps = (state: KialiAppState) => ({
   mtlsEnabled: meshWideMTLSEnabledSelector(state)
 });
 
-const mapDispatchToProps = (dispatch: KialiDispatch) => ({
-  setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => dispatch(GlobalActions.setLastRefreshAt(lastRefreshAt))
-});
-
-const ServiceInfoContainer = connect(mapStateToProps, mapDispatchToProps)(ServiceInfo);
+const ServiceInfoContainer = connect(mapStateToProps)(ServiceInfo);
 export default ServiceInfoContainer;

--- a/frontend/src/pages/ServiceList/ServiceListPage.tsx
+++ b/frontend/src/pages/ServiceList/ServiceListPage.tsx
@@ -22,6 +22,7 @@ import TimeDurationContainer from '../../components/Time/TimeDurationComponent';
 import { sortIstioReferences } from '../AppList/FiltersAndSorts';
 import { validationKey } from '../../types/IstioConfigList';
 import { ServiceHealth } from '../../types/Health';
+import RefreshNotifier from "../../components/Refresh/RefreshNotifier";
 
 type ServiceListPageState = FilterComponent.State<ServiceListItem>;
 
@@ -153,13 +154,13 @@ class ServiceListPageComponent extends FilterComponent.Component<
   render() {
     return (
       <>
+        <RefreshNotifier onTick={this.updateListItems} />
         <div style={{ backgroundColor: '#fff' }}>
           <DefaultSecondaryMasthead
             rightToolbar={
               <TimeDurationContainer
                 key={'DurationDropdown'}
                 id="service-list-duration-dropdown"
-                handleRefresh={this.updateListItems}
                 disabled={false}
               />
             }

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -26,6 +26,7 @@ import { WorkloadHealth } from 'types/Health';
 import RenderHeaderContainer from "../../components/Nav/Page/RenderHeader";
 import ErrorSection from "../../components/ErrorSection/ErrorSection";
 import {ErrorMsg} from "../../types/ErrorMsg";
+import connectRefresh from "../../components/Refresh/connectRefresh";
 
 
 type WorkloadDetailsState = {
@@ -38,11 +39,12 @@ type WorkloadDetailsState = {
 type ReduxProps = {
   duration: DurationInSeconds;
   jaegerInfo?: JaegerInfo;
-  lastRefreshAt: TimeInMilliseconds;
   statusState: StatusState;
 };
 
-type WorkloadDetailsPageProps = ReduxProps & RouteComponentProps<WorkloadId>;
+type WorkloadDetailsPageProps = ReduxProps & RouteComponentProps<WorkloadId> & {
+  lastRefreshAt: TimeInMilliseconds;
+};
 
 export const tabName = 'tab';
 export const defaultTab = 'info';
@@ -138,6 +140,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
         <TrafficDetails
           itemName={this.props.match.params.workload}
           itemType={MetricsObjectTypes.WORKLOAD}
+          lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.match.params.namespace}
         />
       </Tab>
@@ -149,6 +152,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
         <Tab title="Logs" eventKey={2} key={'Logs'} data-test={"workload-details-logs-tab"}>
           {hasPods ? (
             <WorkloadPodLogs
+              lastRefreshAt={this.props.lastRefreshAt}
               namespace={this.props.match.params.namespace}
               workload={this.props.match.params.workload}
               pods={this.state.workload!.pods}
@@ -170,6 +174,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
       <Tab title="Inbound Metrics" eventKey={3} key={'Inbound Metrics'}>
         <IstioMetricsContainer
           data-test="inbound-metrics-component"
+          lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.match.params.namespace}
           object={this.props.match.params.workload}
           objectType={MetricsObjectTypes.WORKLOAD}
@@ -183,6 +188,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
       <Tab title="Outbound Metrics" eventKey={4} key={'Outbound Metrics'}>
         <IstioMetricsContainer
           data-test="outbound-metrics-component"
+          lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.match.params.namespace}
           object={this.props.match.params.workload}
           objectType={MetricsObjectTypes.WORKLOAD}
@@ -196,6 +202,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
       tabsArray.push(
         <Tab eventKey={5} title="Traces" key="Traces">
           <TracesComponent
+            lastRefreshAt={this.props.lastRefreshAt}
             namespace={this.props.match.params.namespace}
             target={this.props.match.params.workload}
             targetKind={'workload'}
@@ -207,7 +214,10 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
       const envoyTab = (
         <Tab title="Envoy" eventKey={10} key={'Envoy'}>
           {this.state.workload && (
-            <EnvoyDetailsContainer namespace={this.props.match.params.namespace} workload={this.state.workload} />
+            <EnvoyDetailsContainer
+              lastRefreshAt={this.props.lastRefreshAt}
+              namespace={this.props.match.params.namespace}
+              workload={this.state.workload} />
           )}
         </Tab>
       );
@@ -254,6 +264,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
               const tab = (
                 <Tab key={dashboard.template} title={dashboard.title} eventKey={tabKey}>
                   <CustomMetricsContainer
+                    lastRefreshAt={this.props.lastRefreshAt}
                     namespace={this.props.match.params.namespace}
                     app={app}
                     version={version}
@@ -338,10 +349,9 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
 const mapStateToProps = (state: KialiAppState) => ({
   duration: durationSelector(state),
   jaegerInfo: state.jaegerState.info,
-  lastRefreshAt: state.globalState.lastRefreshAt,
   statusState: state.statusState,
 });
 
-const WorkloadDetailsContainer = connect(mapStateToProps)(WorkloadDetails);
+const WorkloadDetailsContainer = connectRefresh(connect(mapStateToProps)(WorkloadDetails));
 
 export default WorkloadDetailsContainer;

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -10,7 +10,7 @@ import { Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import { activeTab } from '../../components/Tab/Tabs';
 import { RenderComponentScroll } from '../../components/Nav/Page';
 import GraphDataSource from '../../services/GraphDataSource';
-import { DurationInSeconds, TimeInMilliseconds } from 'types/Common';
+import { DurationInSeconds } from 'types/Common';
 import { isIstioNamespace } from '../../config/ServerConfig';
 import { IstioConfigList, toIstioItems } from '../../types/IstioConfigList';
 import { KialiAppState } from '../../store/Store';
@@ -26,7 +26,6 @@ type WorkloadInfoProps = {
   duration: DurationInSeconds;
   namespace: string;
   workload?: Workload;
-  lastRefreshAt: TimeInMilliseconds;
   health?: WorkloadHealth;
   mtlsEnabled: boolean;
   refreshWorkload: () => void;
@@ -289,7 +288,6 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
-  lastRefreshAt: state.globalState.lastRefreshAt,
   mtlsEnabled: meshWideMTLSEnabledSelector(state)
 });
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -59,11 +59,11 @@ const spanColor = PFColors.Cyan300;
 
 type ReduxProps = {
   kiosk: string;
-  lastRefreshAt: TimeInMilliseconds;
   timeRange: TimeRange;
 };
 
 export type WorkloadPodLogsProps = ReduxProps & {
+  lastRefreshAt: TimeInMilliseconds;
   namespace: string;
   pods: Pod[];
   workload: string;
@@ -1049,7 +1049,6 @@ const mapStateToProps = (state: KialiAppState) => {
   return {
     kiosk: state.globalState.kiosk,
     timeRange: timeRangeSelector(state),
-    lastRefreshAt: state.globalState.lastRefreshAt
   };
 };
 

--- a/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -21,6 +21,7 @@ import TimeDurationContainer from '../../components/Time/TimeDurationComponent';
 import { sortIstioReferences } from '../AppList/FiltersAndSorts';
 import { hasMissingAuthPolicy } from 'utils/IstioConfigUtils';
 import { WorkloadHealth } from '../../types/Health';
+import RefreshNotifier from "../../components/Refresh/RefreshNotifier";
 
 type WorkloadListPageState = FilterComponent.State<WorkloadListItem>;
 
@@ -142,13 +143,13 @@ class WorkloadListPageComponent extends FilterComponent.Component<
   render() {
     return (
       <>
+        <RefreshNotifier onTick={this.updateListItems} />
         <div style={{ backgroundColor: '#fff' }}>
           <DefaultSecondaryMasthead
             rightToolbar={
               <TimeDurationContainer
                 key={'DurationDropdown'}
                 id="workload-list-duration-dropdown"
-                handleRefresh={this.updateListItems}
                 disabled={false}
               />
             }

--- a/frontend/src/reducers/GlobalState.ts
+++ b/frontend/src/reducers/GlobalState.ts
@@ -7,8 +7,7 @@ import { getType } from 'typesafe-actions';
 export const INITIAL_GLOBAL_STATE: GlobalState = {
   loadingCounter: 0,
   isPageVisible: true,
-  kiosk: '',
-  lastRefreshAt: 0,
+  kiosk: ''
 };
 
 // This Reducer allows changes to the 'globalState' portion of Redux Store
@@ -22,8 +21,6 @@ const globalState = (state: GlobalState = INITIAL_GLOBAL_STATE, action: KialiApp
       return updateState(state, { isPageVisible: false });
     case getType(GlobalActions.setPageVisibilityVisible):
       return updateState(state, { isPageVisible: true });
-    case getType(GlobalActions.setLastRefreshAt):
-      return updateState(state, { lastRefreshAt: action.payload });
     case getType(GlobalActions.setKiosk):
       const kiosk = action.payload;
       return updateState(state, { kiosk: kiosk });

--- a/frontend/src/reducers/__tests__/GlobalStateReducer.test.ts
+++ b/frontend/src/reducers/__tests__/GlobalStateReducer.test.ts
@@ -22,8 +22,7 @@ describe('GlobalState reducer', () => {
     expect(globalState(undefined, GlobalActions.unknown())).toEqual({
       loadingCounter: 0,
       isPageVisible: true,
-      kiosk: '',
-      lastRefreshAt: 0
+      kiosk: ''
     });
   });
 
@@ -33,16 +32,14 @@ describe('GlobalState reducer', () => {
         {
           loadingCounter: 0,
           isPageVisible: true,
-          kiosk: '',
-          lastRefreshAt: currentDate
+          kiosk: ''
         },
         GlobalActions.incrementLoadingCounter()
       )
     ).toEqual({
       loadingCounter: 1,
       isPageVisible: true,
-      kiosk: '',
-      lastRefreshAt: currentDate
+      kiosk: ''
     });
   });
 
@@ -52,16 +49,14 @@ describe('GlobalState reducer', () => {
         {
           loadingCounter: 1,
           isPageVisible: true,
-          kiosk: '',
-          lastRefreshAt: currentDate
+          kiosk: ''
         },
         GlobalActions.decrementLoadingCounter()
       )
     ).toEqual({
       loadingCounter: 0,
       isPageVisible: true,
-      kiosk: '',
-      lastRefreshAt: currentDate
+      kiosk: ''
     });
   });
 
@@ -71,16 +66,14 @@ describe('GlobalState reducer', () => {
         {
           loadingCounter: 1,
           isPageVisible: true,
-          kiosk: '',
-          lastRefreshAt: currentDate
+          kiosk: ''
         },
         GlobalActions.incrementLoadingCounter()
       )
     ).toEqual({
       loadingCounter: 2,
       isPageVisible: true,
-      kiosk: '',
-      lastRefreshAt: currentDate
+      kiosk: ''
     });
   });
 
@@ -90,16 +83,14 @@ describe('GlobalState reducer', () => {
         {
           loadingCounter: 2,
           isPageVisible: true,
-          kiosk: '',
-          lastRefreshAt: currentDate
+          kiosk: ''
         },
         GlobalActions.decrementLoadingCounter()
       )
     ).toEqual({
       loadingCounter: 1,
       isPageVisible: true,
-      kiosk: '',
-      lastRefreshAt: currentDate
+      kiosk: ''
     });
   });
   it('should turn on page visibility status', () => {
@@ -108,16 +99,14 @@ describe('GlobalState reducer', () => {
         {
           loadingCounter: 0,
           isPageVisible: false,
-          kiosk: '',
-          lastRefreshAt: currentDate
+          kiosk: ''
         },
         GlobalActions.setPageVisibilityVisible()
       )
     ).toEqual({
       loadingCounter: 0,
       isPageVisible: true,
-      kiosk: '',
-      lastRefreshAt: currentDate
+      kiosk: ''
     });
   });
   it('should turn off page visibility status', () => {
@@ -126,16 +115,14 @@ describe('GlobalState reducer', () => {
         {
           loadingCounter: 0,
           isPageVisible: true,
-          kiosk: '',
-          lastRefreshAt: currentDate
+          kiosk: ''
         },
         GlobalActions.setPageVisibilityHidden()
       )
     ).toEqual({
       loadingCounter: 0,
       isPageVisible: false,
-      kiosk: '',
-      lastRefreshAt: currentDate
+      kiosk: ''
     });
   });
   it('should turn on kiosk status', () => {
@@ -144,16 +131,14 @@ describe('GlobalState reducer', () => {
         {
           loadingCounter: 0,
           isPageVisible: true,
-          kiosk: '',
-          lastRefreshAt: currentDate
+          kiosk: ''
         },
         GlobalActions.setKiosk('test')
       )
     ).toEqual({
       loadingCounter: 0,
       isPageVisible: true,
-      kiosk: 'test',
-      lastRefreshAt: currentDate
+      kiosk: 'test'
     });
   });
 });

--- a/frontend/src/store/Selectors.ts
+++ b/frontend/src/store/Selectors.ts
@@ -66,10 +66,6 @@ const replayQueryTime = (state: KialiAppState) => state.userSettings.replayQuery
 
 export const replayQueryTimeSelector = createIdentitySelector(replayQueryTime);
 
-const lastRefreshAt = (state: KialiAppState) => state.globalState.lastRefreshAt;
-
-export const lastRefreshAtSelector = createIdentitySelector(lastRefreshAt);
-
 const showIdleNodes = (state: KialiAppState) => state.graph.toolbarState.showIdleNodes;
 
 export const showIdleNodesSelector = createIdentitySelector(showIdleNodes);

--- a/frontend/src/store/Store.ts
+++ b/frontend/src/store/Store.ts
@@ -34,7 +34,6 @@ export interface GlobalState {
   readonly loadingCounter: number;
   readonly isPageVisible: boolean;
   readonly kiosk: string;
-  lastRefreshAt: TimeInMilliseconds;
 }
 
 export interface NamespaceState {


### PR DESCRIPTION
The Refresh.tsx component (and redux) was being used for refresh logic. Since this is the component that is added in pages that need refresh data periodically (and thus, need the duration/time-interval and refresh interval controls), it made sense that this component also fired the refreshes. But in Kiosk mode this component is not rendered, thus refreshes are not being fired.

To fix the refresh for Kiosk mode, the timer has to be removed from the Refresh.tsx component, and also Redux is no longer involved for triggering refreshes (although Redux is still involved for storing/updating the desired interval). A useRefreshInterval custom react-hook is created to host the timer and this is the hook that function components should use to watch/subscribe for refreshes. For class components, the new RefreshNotifier.tsx component exposes similar functionality.

The refresh timer will be active while there are active "subscriptions" and the auto-refresh is not "paused". Since Redux is no longer involved in refreshes, a triggerRefresh function is also created to programmatically trigger a refresh (i.e. for refresh buttons).

Since several components were relying on Redux to watch/listen when a refresh is triggered, a connectRefresh.tsx HOC is also created to provide a similar interface, and mainly to reduce the churn of the changes required for the fix. However, it is probably better to use the useRefreshInterval hook or the RefreshNotifier.tsx component because they make explicit to "clients" when a refresh is happening, rather than trying to determine the refresh event in the componentDidUpdate method.

Related kiali/openshift-servicemesh-plugin#42
