### PR TITLE
[Cypress] Mismatched node type graph fix testing

### DIFF
--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -24,6 +24,12 @@ And('user is at the details page for the {string} {string}', (detail: detailType
       break;
     case detailType.Service:
       pageDetail = 'services';
+      cy.intercept({
+        pathname: '**/api/namespaces/bookinfo/services/productpage',
+        query: {
+          objects: ''
+        }
+      }).as('waitForCall');
       break;
     case detailType.Workload:
       pageDetail = 'workloads';

--- a/frontend/cypress/integration/common/service_details.ts
+++ b/frontend/cypress/integration/common/service_details.ts
@@ -1,4 +1,4 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Then, And } from '@badeball/cypress-cucumber-preprocessor';
 
 function openTab(tab: string) {
   cy.get('.pf-c-tabs__list').should('be.visible').contains(tab).click();
@@ -70,4 +70,15 @@ Then('sd::user does not see No data message in the {string} graph', (graph: stri
     .children()
     .contains(graph)
     .should('not.contain', 'No data available');
+});
+
+And('user chooses the {string} option', (title: string) => {
+  cy.wait('@waitForCall');
+  cy.get('button[aria-label="Actions"]').click();
+  cy.contains(title).should('be.visible');
+  cy.contains(title).click();
+});
+
+Then('the graph type is disabled', () => {
+  cy.get('button[aria-label="Options menu"]').should('be.disabled');
 });

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -59,3 +59,9 @@ Feature: Kiali Service Details page
     And user sees trace information
     When user selects a trace
     Then user sees span details
+
+  @service-details-page
+  Scenario: Verify that the Graph type dropdown is disabled when changing to Show node graph
+    When user sees a minigraph
+    And user chooses the "Show node graph" option
+    Then the graph type is disabled


### PR DESCRIPTION
This is a little test case related [to this issue fix](https://github.com/kiali/kiali-ui/pull/2328) from 1.48.  

It toggles the node graph on the services/<detail>/ page and then checks that the graph type dropdown on the top of the page is disabled.

