### PR TITLE
mTLS lock icon's tooltip contains hint about default "enableAutoMtls:true"

### DIFF
--- a/business/tls.go
+++ b/business/tls.go
@@ -56,7 +56,8 @@ func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, namespaces []strin
 	}
 
 	return models.MTLSStatus{
-		Status: mtlsStatus.MeshMtlsStatus().OverallStatus,
+		Status:          mtlsStatus.MeshMtlsStatus().OverallStatus,
+		AutoMTLSEnabled: *in.enabledAutoMtls,
 	}, nil
 }
 
@@ -97,7 +98,8 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace str
 	}
 
 	return models.MTLSStatus{
-		Status: mtlsStatus.NamespaceMtlsStatus(namespace).OverallStatus,
+		Status:          mtlsStatus.NamespaceMtlsStatus(namespace).OverallStatus,
+		AutoMTLSEnabled: *in.enabledAutoMtls,
 	}, nil
 }
 

--- a/frontend/src/app/AuthenticationController.tsx
+++ b/frontend/src/app/AuthenticationController.tsx
@@ -14,8 +14,6 @@ import InitializingScreen from './InitializingScreen';
 import {getKioskMode, isKioskMode} from '../utils/SearchParamUtils';
 import * as AlertUtils from '../utils/AlertUtils';
 import { setServerConfig, serverConfig, humanDurations } from '../config/ServerConfig';
-import { TLSStatus } from '../types/TLSStatus';
-import { MeshTlsActions } from '../actions/MeshTlsActions';
 import { AuthStrategy } from '../types/Auth';
 import { JaegerInfo } from '../types/JaegerInfo';
 import { ServerConfig } from '../types/ServerConfig';
@@ -43,7 +41,6 @@ interface AuthenticationControllerReduxProps {
   setDuration: (duration: DurationInSeconds) => void;
   setJaegerInfo: (jaegerInfo: JaegerInfo | null) => void;
   setLandingRoute: (route: string | undefined) => void;
-  setMeshTlsStatus: (meshStatus: TLSStatus) => void;
   setNamespaces: (namespaces: Namespace[], receivedAt: Date) => void;
   setRefreshInterval: (interval: IntervalInMilliseconds) => void;
   setTrafficRates: (rates: TrafficRate[]) => void;
@@ -365,7 +362,6 @@ const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   setDuration: bindActionCreators(UserSettingsActions.setDuration, dispatch),
   setJaegerInfo: bindActionCreators(JaegerActions.setInfo, dispatch),
   setLandingRoute: bindActionCreators(LoginActions.setLandingRoute, dispatch),
-  setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch),
   setNamespaces: bindActionCreators(NamespaceActions.receiveList, dispatch),
   setRefreshInterval: bindActionCreators(UserSettingsActions.setRefreshInterval, dispatch),
   setTrafficRates: bindActionCreators(GraphToolbarActions.setTrafficRates, dispatch),

--- a/frontend/src/components/MTls/MeshMTLSStatus.tsx
+++ b/frontend/src/components/MTls/MeshMTLSStatus.tsx
@@ -4,7 +4,12 @@ import { KialiAppState } from '../../store/Store';
 import { MTLSIconTypes } from './MTLSIcon';
 import { default as MTLSStatus, emptyDescriptor, StatusDescriptor } from './MTLSStatus';
 import { style } from 'typestyle';
-import { lastRefreshAtSelector, meshWideMTLSStatusSelector, namespaceItemsSelector } from '../../store/Selectors';
+import {
+  lastRefreshAtSelector,
+  meshWideMTLSEnabledSelector,
+  meshWideMTLSStatusSelector,
+  namespaceItemsSelector
+} from '../../store/Selectors';
 import { connect } from 'react-redux';
 import { MTLSStatuses, TLSStatus } from '../../types/TLSStatus';
 import * as AlertUtils from '../../utils/AlertUtils';
@@ -21,6 +26,7 @@ type ReduxProps = {
   setMeshTlsStatus: (meshStatus: TLSStatus) => void;
   namespaces: Namespace[] | undefined;
   status: string;
+  autoMTLSEnabled: boolean;
 };
 
 type Props = ReduxProps & {};
@@ -38,6 +44,22 @@ const statusDescriptors = new Map<string, StatusDescriptor>([
     MTLSStatuses.PARTIALLY,
     {
       message: 'Mesh-wide TLS is partially enabled',
+      icon: MTLSIconTypes.LOCK_HOLLOW,
+      showStatus: true
+    }
+  ],
+  [
+    MTLSStatuses.ENABLED_DEFAULT,
+    {
+      message: 'Mesh-wide mTLS is enabled, configured by default',
+      icon: MTLSIconTypes.LOCK_FULL,
+      showStatus: true
+    }
+  ],
+  [
+    MTLSStatuses.PARTIALLY_DEFAULT,
+    {
+      message: 'Mesh-wide TLS is partially enabled, configured by default',
       icon: MTLSIconTypes.LOCK_HOLLOW,
       showStatus: true
     }
@@ -80,13 +102,26 @@ class MeshMTLSStatus extends React.Component<Props> {
     });
   }
 
+  finalStatus() {
+    if (this.props.autoMTLSEnabled) {
+      if (this.props.status === MTLSStatuses.ENABLED) {
+        return MTLSStatuses.ENABLED_DEFAULT
+      }
+      if (this.props.status === MTLSStatuses.PARTIALLY) {
+        return MTLSStatuses.PARTIALLY_DEFAULT
+      }
+    }
+    return this.props.status
+  }
+
   render() {
-    return <MTLSStatus className={this.iconStyle()} status={this.props.status} statusDescriptors={statusDescriptors} />;
+    return <MTLSStatus className={this.iconStyle()} status={this.finalStatus()} statusDescriptors={statusDescriptors} />;
   }
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
   status: meshWideMTLSStatusSelector(state),
+  autoMTLSEnabled: meshWideMTLSEnabledSelector(state),
   lastRefreshAt: lastRefreshAtSelector(state),
   namespaces: namespaceItemsSelector(state)
 });

--- a/frontend/src/components/MTls/MeshMTLSStatus.tsx
+++ b/frontend/src/components/MTls/MeshMTLSStatus.tsx
@@ -130,5 +130,5 @@ const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch)
 });
 
-const MeshMTLSSatutsConnected = connect(mapStateToProps, mapDispatchToProps)(MeshMTLSStatus);
-export default MeshMTLSSatutsConnected;
+const MeshMTLSStatusConnected = connect(mapStateToProps, mapDispatchToProps)(MeshMTLSStatus);
+export default MeshMTLSStatusConnected;

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -418,7 +418,8 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       .then(results => {
         results.forEach(result => {
           result.nsInfo.tlsStatus = {
-            status: nsWideMTLSStatus(result.status.status, this.props.meshStatus)
+            status: nsWideMTLSStatus(result.status.status, this.props.meshStatus),
+            autoMTLSEnabled: result.status.autoMTLSEnabled
           };
         });
       })

--- a/frontend/src/reducers/MeshTlsState.ts
+++ b/frontend/src/reducers/MeshTlsState.ts
@@ -4,7 +4,8 @@ import { TLSStatus } from '../types/TLSStatus';
 import { MeshTlsActions } from '../actions/MeshTlsActions';
 
 export const INITIAL_MESH_TLS_STATE: TLSStatus = {
-  status: ''
+  status: '',
+  autoMTLSEnabled: false
 };
 
 // This Reducer allows changes to the 'graphDataState' portion of Redux Store
@@ -13,7 +14,8 @@ const MeshTlsState = (state: TLSStatus = INITIAL_MESH_TLS_STATE, action: KialiAp
     case getType(MeshTlsActions.setinfo):
       return {
         ...INITIAL_MESH_TLS_STATE,
-        status: action.payload.status
+        status: action.payload.status,
+        autoMTLSEnabled: action.payload.autoMTLSEnabled
       };
     default:
       return state;

--- a/frontend/src/store/Selectors.ts
+++ b/frontend/src/store/Selectors.ts
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect';
 import { KialiAppState } from './Store';
-import { isMTLSEnabled } from '../types/TLSStatus';
 import { TimeRange } from '../types/Common';
 // These memoized selectors are from Redux Reselect package
 
@@ -83,7 +82,7 @@ const meshwideMTLSStatus = (state: KialiAppState) => state.meshTLSStatus.status;
 
 export const meshWideMTLSStatusSelector = createIdentitySelector(meshwideMTLSStatus);
 
-const meshwideMTLSEnabled = (state: KialiAppState) => isMTLSEnabled(state.meshTLSStatus.status);
+const meshwideMTLSEnabled = (state: KialiAppState) => state.meshTLSStatus.autoMTLSEnabled;
 
 export const meshWideMTLSEnabledSelector = createIdentitySelector(meshwideMTLSEnabled);
 

--- a/frontend/src/types/TLSStatus.ts
+++ b/frontend/src/types/TLSStatus.ts
@@ -1,13 +1,16 @@
 export enum MTLSStatuses {
   ENABLED = 'MTLS_ENABLED',
+  ENABLED_DEFAULT = 'MTLS_ENABLED_DEFAULT',
   ENABLED_EXTENDED = 'MTLS_ENABLED_EXTENDED',
   PARTIALLY = 'MTLS_PARTIALLY_ENABLED',
+  PARTIALLY_DEFAULT = 'MTLS_PARTIALLY_ENABLED_DEFAULT',
   NOT_ENABLED = 'MTLS_NOT_ENABLED',
   DISABLED = 'MTLS_DISABLED'
 }
 
 export interface TLSStatus {
   status: string;
+  autoMTLSEnabled: boolean;
 }
 
 export const nsWideMTLSStatus = (nsStatus: string, meshStatus: string): string => {
@@ -20,8 +23,4 @@ export const nsWideMTLSStatus = (nsStatus: string, meshStatus: string): string =
   }
 
   return finalStatus;
-};
-
-export const isMTLSEnabled = (status: string): boolean => {
-  return status === MTLSStatuses.ENABLED;
 };

--- a/models/mtls_status.go
+++ b/models/mtls_status.go
@@ -5,5 +5,6 @@ type MTLSStatus struct {
 	// mTLS status: MTLS_ENABLED, MTLS_PARTIALLY_ENABLED, MTLS_NOT_ENABLED
 	// required: true
 	// example: MTLS_ENABLED
-	Status string `json:"status"`
+	Status          string `json:"status"`
+	AutoMTLSEnabled bool   `json:"autoMTLSEnabled""`
 }

--- a/models/mtls_status.go
+++ b/models/mtls_status.go
@@ -6,5 +6,5 @@ type MTLSStatus struct {
 	// required: true
 	// example: MTLS_ENABLED
 	Status          string `json:"status"`
-	AutoMTLSEnabled bool   `json:"autoMTLSEnabled""`
+	AutoMTLSEnabled bool   `json:"autoMTLSEnabled"`
 }


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5263

The idea of this change it to show Kiali users more information about mTLS configuration icon shown in toolbar.
When enableAutoMtls:true then mTLS status is taken from default config.

![Screenshot from 2022-09-06 13-44-30](https://user-images.githubusercontent.com/604313/188641644-f563df78-1396-46d3-b3a4-d5a780a60e89.png)

QE: Regression testing is required for "enableAutoMtls:true/false". Namespace wide TLS.