### PR TITLE
add 2.3 compat information.

### DIFF
--- a/config/version-compatibility-matrix.yaml
+++ b/config/version-compatibility-matrix.yaml
@@ -53,6 +53,9 @@
 # The Compatible Version Matrix between OpenShift Service Mesh and Kiali (there is a 1-to-1 relationship between Kiali and OSSM versions)
 - meshName: "OpenShift Service Mesh"
   versionRange: 
+    - meshVersion: "2.3"
+      kialiFixedVersion:
+      - "1.57"
     - meshVersion: "2.2"
       kialiFixedVersion: 
       - "1.48"


### PR DESCRIPTION
Right now it looks like it will be 1.57, but this could change.

See: https://issues.redhat.com/browse/OSSM-1964