### PR TITLE
Force use kindest version 1.24 by default in CI

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -62,6 +62,8 @@ elif [ "${ISTIO_VERSION}" == "1.10.0" ]; then
   KIND_NODE_IMAGE="kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c"
 elif [ "${ISTIO_VERSION}" == "1.13.0" ]; then
   KIND_NODE_IMAGE="kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
+else
+  KIND_NODE_IMAGE="kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98"
 fi
 
 # print out our settings for debug purposes


### PR DESCRIPTION
Workaround for #5441 while https://github.com/kiali/kiali/pull/5442 is not fixed