### PR TITLE
[CI] Fix test validating that the degraded status of a service is reported

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -155,6 +155,12 @@ helm install \
   --set external_services.grafana.url="http://grafana.istio-system:3000" \
   --set external_services.grafana.dashboards[0].name="Istio Mesh Dashboard" \
   --set external_services.tracing.url="http://tracing.istio-system:16685/jaeger" \
+  --set health_config.rate[0].kind="service" \
+  --set health_config.rate[0].name="y-server" \
+  --set health_config.rate[0].namespace="alpha" \
+  --set health_config.rate[0].tolerance[0].code="5xx" \
+  --set health_config.rate[0].tolerance[0].degraded=2 \
+  --set health_config.rate[0].tolerance[0].failure=100 \
   kiali-server \
   helm-charts/_output/charts/kiali-server-*-SNAPSHOT.tgz
 


### PR DESCRIPTION
This is a cypress tests which was failing at times. Looks like, the source of the issue is the environment which sometimes records more errors than expected leading to an error status of a service that is expected to give only up to degraded status.

This changes Kiali configuration to extremely tolerant with the relevant service: only if 100% of the traffic is erring, the service will be flagged as faulty. Otherwise, its health will be degraded as long as more than 2% of the traffic fails.

Fixes #5226
