### PR TITLE
Add kiosk actions for refresh and duration

### DIFF
--- a/frontend/src/components/DurationDropdown/DurationDropdown.tsx
+++ b/frontend/src/components/DurationDropdown/DurationDropdown.tsx
@@ -11,6 +11,8 @@ import { connect } from 'react-redux';
 import { HistoryManager, URLParam } from '../../app/History';
 import history from '../../app/History';
 import { TooltipPosition } from '@patternfly/react-core';
+import {isKioskMode} from "../../utils/SearchParamUtils";
+import {kioskDurationAction} from "../Kiosk/KioskActions";
 
 type ReduxProps = {
   duration: DurationInSeconds;
@@ -29,6 +31,7 @@ type DurationDropdownProps = ReduxProps & {
 };
 
 export class DurationDropdown extends React.Component<DurationDropdownProps> {
+
   render() {
     const durations = humanDurations(serverConfig, this.props.prefix, this.props.suffix);
 
@@ -36,7 +39,7 @@ export class DurationDropdown extends React.Component<DurationDropdownProps> {
       <ToolbarDropdown
         id={this.props.id}
         disabled={this.props.disabled}
-        handleSelect={key => this.props.setDuration(Number(key))}
+        handleSelect={key => this.updateDurationInterval(Number(key))}
         value={String(this.props.duration)}
         label={durations[this.props.duration]}
         options={durations}
@@ -47,6 +50,14 @@ export class DurationDropdown extends React.Component<DurationDropdownProps> {
       />
     );
   }
+
+  private updateDurationInterval = (duration: number) => {
+    this.props.setDuration(duration); // notify redux of the change
+    if (isKioskMode() ) {
+      kioskDurationAction(duration);
+    }
+  };
+
 }
 
 const withDurations = DurationDropdownComponent => {
@@ -88,7 +99,6 @@ const mapDispatchToProps = (dispatch: KialiDispatch) => {
     setDuration: bindActionCreators(UserSettingsActions.setDuration, dispatch)
   };
 };
-
 export const DurationDropdownComponent = withDurations(DurationDropdown);
 
 export const DurationDropdownContainer = connect(

--- a/frontend/src/components/Kiosk/KioskActions.ts
+++ b/frontend/src/components/Kiosk/KioskActions.ts
@@ -53,6 +53,16 @@ export const kioskOverviewAction = (showType: Show, namespace: string, duration:
   sendParentMessage(showInParent);
 };
 
+export const kioskDurationAction = (duration: DurationInSeconds) => {
+  const showInParent = 'duration=' + duration;
+  sendParentMessage(showInParent);
+}
+
+export const kioskRefreshAction = (refreshInterval: IntervalInMilliseconds) => {
+  const showInParent = 'refresh=' + refreshInterval;
+  sendParentMessage(showInParent);
+}
+
 export const isKiosk = (kiosk: string): boolean => {
   return kiosk.length > 0;
 }

--- a/frontend/src/components/Refresh/Refresh.tsx
+++ b/frontend/src/components/Refresh/Refresh.tsx
@@ -11,6 +11,8 @@ import RefreshButtonContainer from './RefreshButton';
 import { HistoryManager, URLParam } from 'app/History';
 import { TooltipPosition } from '@patternfly/react-core';
 import { triggerRefresh } from "../../hooks/refresh";
+import {isKioskMode} from "../../utils/SearchParamUtils";
+import {kioskRefreshAction} from "../Kiosk/KioskActions";
 
 type ReduxProps = {
   refreshInterval: IntervalInMilliseconds;
@@ -80,6 +82,9 @@ export class Refresh extends React.PureComponent<Props> {
 
   private updateRefreshInterval = (refreshInterval: IntervalInMilliseconds) => {
     this.props.setRefreshInterval(refreshInterval); // notify redux of the change
+    if (isKioskMode() ) {
+      kioskRefreshAction(refreshInterval);
+    }
   };
 }
 


### PR DESCRIPTION
Add kiosk actions when update refresh or duration to send a message to the parent.

Fixes [53](https://github.com/kiali/openshift-servicemesh-plugin/issues/53)