### PR TITLE
Refresh Duration in Details page for Overview and propagate parameter…

### DIFF
--- a/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -177,7 +177,7 @@ class MiniGraphCard extends React.Component<MiniGraphCardProps, MiniGraphCardSta
           </CardBody>
         </Card>
         <TimeDurationModal
-          customDuration={false}
+          customDuration={true}
           isOpen={this.state.isTimeOptionsOpen}
           onConfirm={this.toggleTimeOptionsVisibility}
           onCancel={this.toggleTimeOptionsVisibility} />

--- a/frontend/src/components/TrafficList/TrafficDetails.tsx
+++ b/frontend/src/components/TrafficList/TrafficDetails.tsx
@@ -128,7 +128,7 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
                     <ToolbarGroup>
                       <KioskElement>
                         <ToolbarItem style={{ marginLeft: 'auto' }}>
-                          <TimeDurationIndicatorButton isDuration={true} onClick={this.toggleTimeOptionsVisibility} />
+                          <TimeDurationIndicatorButton onClick={this.toggleTimeOptionsVisibility} />
                         </ToolbarItem>
                       </KioskElement>
                     </ToolbarGroup>
@@ -144,7 +144,7 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
           </Grid>
         </RenderComponentScroll>
         <TimeDurationModal
-          customDuration={false}
+          customDuration={true}
           isOpen={this.state.isTimeOptionsOpen}
           onConfirm={this.toggleTimeOptionsVisibility}
           onCancel={this.toggleTimeOptionsVisibility} />


### PR DESCRIPTION
Refresh Duration in Details page for Overview tab and propagate parameters in Traffic tab

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/94 

- If customDuration is set to false, the Duration is not refreshed. This is because the duration is not refreshed in the TimeDuration Modal component, it is expecting a time range. 
- Based on this, Is this the expected behavior? Or the component should be fixed? 