### PR TITLE
[Cypress] Istio page filters migration (refinement)

### DIFF
--- a/frontend/cypress/integration/common/istio_config_type_filters.ts
+++ b/frontend/cypress/integration/common/istio_config_type_filters.ts
@@ -1,0 +1,146 @@
+import { When, Then, And } from "cypress-cucumber-preprocessor/steps";
+import { activeFilters, showMore} from "./label_check";
+
+function optionCheck(name:string){
+  cy.get('[aria-label="filter_select_value"]').contains(name).should('exist');
+}
+
+When("user types {string} into the input", (input:string) => {
+  cy.get('input[placeholder="Filter by Istio Type"]').type(input);
+});
+
+Then("the {string} phrase is displayed", (phrase:string) => {
+  cy.get('#filter-selection').contains(phrase).should('be.visible'); 
+});
+
+And('user filters by {string}', (filterCategory:string) => {
+  cy.intercept({
+        pathname:  '**/api/istio/config',
+        query: {
+          objects: "",  
+        },
+  }).as('noFilters');
+  cy.get('select[aria-label="filter_select_type"]').select(filterCategory)
+});
+
+And('no filters are active', () => {
+  cy.get('#filter-selection > :nth-child(2)').should('be.hidden');
+});
+
+When('user expands the {string} dropdown', (placeholder:string) => {
+  cy.get(`input[placeholder="${placeholder}"]`).click();
+});
+
+Then('user can see the filter options', () => {
+  var filters: string[] = ['AuthorizationPolicy',
+                            'DestinationRule',
+                            'EnvoyFilter',
+                            'Gateway',
+                            'PeerAuthentication',
+                            'RequestAuthentication',
+                            'ServiceEntry',
+                            'Sidecar',
+                            'Telemetry',
+                            'VirtualService',
+                            'WasmPlugin',
+                            'WorkloadEntry',
+                            'WorkloadGroup',
+                           ];
+  filters.forEach((optionCheck));
+});
+
+When('chosen from the {string} dropdown', (placeholder:string) => {
+  cy.intercept({
+    pathname: '**/api/istio/config',
+    query: {
+      objects: "authorizationpolicies",  
+    },
+  }).as('filterActive');
+  cy.get(`input[placeholder="${placeholder}"]`).type('AuthorizationPolicy{enter}');
+});
+
+Then('the filter is applied', () => {
+  cy.wait('@filterActive').its('response.statusCode').should('eq', 200);
+});
+
+When('multiple filters are chosen', () => {
+  cy.intercept({
+        pathname: '**/api/istio/config',
+        query: {
+          objects: "authorizationpolicies,destinationrules",  
+        },
+  }).as('multipleFilters');
+  cy.get('input[placeholder="Filter by Istio Type"]')
+  .type('AuthorizationPolicy{enter}');
+  cy.get('input[placeholder="Filter by Istio Type"]')
+  .type('DestinationRule{enter}');
+});
+
+Then('multiple filters are active', () => {
+  cy.wait('@multipleFilters').its('response.statusCode').should('eq', 200);
+});
+
+When('a type filter {string} is applied', (category:string) => {
+  cy.get('input[placeholder="Filter by Istio Type"]')
+  .type(`${category}{enter}`);
+});
+
+And('user clicks the cross next to the {string}', (category:string) => {
+    cy.get('#filter-selection > :nth-child(2)').contains(category).parent()
+  .find('[aria-label="close"]').click();
+});
+
+Then('the filter is no longer active', () => {
+  cy.wait('@noFilters').its('response.statusCode').should('eq', 200);
+});
+
+Then('the filter {string} should be visible only once', (category:string) => {
+  cy.get('#filter-selection > :nth-child(2)').find("span")
+  .contains(category).each(() => {
+  })
+  .then(($lis) => {
+    expect($lis).to.have.length(1);
+  });
+});
+
+When("user chooses {int} type filters", (count:number) => {
+  for (let i = 1; i <= count; i++) {
+    cy.get('input[placeholder="Filter by Istio Type"]').click();
+    cy.get(`[data-test=istio-type-dropdown] > :nth-child(${i})`)
+    .should('be.visible').click();
+  };
+});
+
+And("user clicks the cross on one of them", () => {
+  cy.get('#filter-selection > :nth-child(2)').find('[aria-label="close"]')
+  .first().click();
+});
+
+Then("{int} filters should be visible", (count:number) => {
+  activeFilters(count);
+});
+
+Then("he can only see {int} right away", (count:number) => {
+  activeFilters(count);
+});
+
+And("clicks on the button next to them", () => {
+  showMore();
+});
+
+Then("he can see the remaining filter", () => {
+  activeFilters(4);
+});
+
+And("makes them all visible", () => {
+  showMore();
+  activeFilters(4);
+});
+
+When("user clicks on {string}", (label:string) => {
+  cy.get('#filter-selection > :nth-child(2)').contains(label).click();
+});
+
+Then("he can see only {int} filters", (count:number) => {
+  activeFilters(count);
+});

--- a/frontend/cypress/integration/common/istio_config_validation_filters.ts
+++ b/frontend/cypress/integration/common/istio_config_validation_filters.ts
@@ -1,0 +1,57 @@
+import { When, Then, And } from "cypress-cucumber-preprocessor/steps";
+
+// Some of the steps from istio_config_validation_filters.feature are implemented in
+// the istio_config_type_filters.ts file. This is because some steps are identical.
+
+function enableFilter(category:string){
+  cy.get('select[aria-label="filter_select_value"]').select(category); 
+}
+
+function optionCheck(name:string){
+  cy.get('@filterDropdown').contains(name).should('exist');
+}
+
+Then('user can see the Filter by Config Validation dropdown', () => {
+  cy.get('[aria-label="filter_select_value"]').as("filterDropdown").should('be.visible');
+});
+
+And('the dropdown contains all of the filters', () => {
+  var filters: string[] = ['Valid', 'Not Valid', 'Not Validated', 'Warning'];
+  filters.forEach((optionCheck));
+});
+
+When('a validation filter is chosen from the dropdown', () => {
+  cy.intercept({
+    pathname: '**/api/istio/config',
+  }).as('tableReload');
+  enableFilter("Valid");
+});
+
+Then('the filter is applied and visible', () => {
+  cy.wait('@tableReload').its('response.statusCode').should('eq', 200);
+  cy.get('#filter-selection > :nth-child(2)').contains('Valid')
+  .should('be.visible')
+});
+
+Then('user can see only the {string}', (category:string) => {
+  cy.get('#filter-selection > :nth-child(2)').contains(category)
+.parent().should('be.visible').and('have.length', 1);
+});
+
+When('a validation filter {string} is applied', (category:string) => {
+  cy.get('select[aria-label="filter_select_value"]').select(category);
+  cy.get('#filter-selection > :nth-child(2)').contains(category)
+  .parent().should('be.visible');    
+});
+
+Then('the validation filter {string} is no longer active', (category:string) => {
+  cy.wait('@tableReload').its('response.statusCode').should('eq', 200);
+  cy.get('#filter-selection').contains(category)
+  .should('be.hidden');
+});
+
+When("user chooses {int} validation filters", (count:number) => {
+  for (let i = 1; i <= count; i++) {
+    cy.get('select[aria-label="filter_select_value"]').select(i);
+  };
+});

--- a/frontend/cypress/integration/common/label_check.ts
+++ b/frontend/cypress/integration/common/label_check.ts
@@ -1,0 +1,13 @@
+export function activeFilters(count:number){
+  cy.get('#filter-selection > :nth-child(2)').find('[aria-label="close"]')
+    .each(() => {
+    })
+    .then(($lis) => {
+      cy.wrap($lis).should('have.length', count);
+  }); 
+}
+
+export function showMore(){
+  cy.get('#filter-selection > :nth-child(2)').contains('more').click();
+}
+

--- a/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
@@ -1,0 +1,55 @@
+@istio-page
+Feature: Kiali Istio Config page
+
+  On the Istio Config page, an admin should be able to choose all of the filters present. 
+  The admin should also be able close a single filter either with it's cross, or with the Close All feature.
+
+  Background:
+    Given user is at administrator perspective
+    And user is at the "istio" page
+    And user selects the "istio-system" namespace
+    And user filters by "Istio Type" 
+    And no filters are active
+    
+  Scenario: Fill the input form with nonsense
+    When user types "foo bar" into the input
+    Then the "No results found" phrase is displayed
+    And no filters are active
+
+  Scenario: Filters should be available in the dropdown
+    When user expands the "Filter by Istio Type" dropdown
+    Then user can see the filter options  
+
+  Scenario: Single filter should be usable 
+    When chosen from the "Filter by Istio Type" dropdown
+    Then the filter is applied 
+
+  Scenario: Multiple filters should be usable
+    When multiple filters are chosen
+    Then multiple filters are active
+
+  Scenario: Filter should be deletable 
+    When a type filter "AuthorizationPolicy" is applied  
+    And user clicks the cross next to the "AuthorizationPolicy" 
+    Then the filter is no longer active 
+
+  Scenario: Deleting all filters at once
+    When a type filter "AuthorizationPolicy" is applied
+    And user clicks on "Clear all filters"
+    Then the filter is no longer active 
+
+  Scenario: When 4 or more filters are chosen, only 3 are visible right away
+    When user chooses 4 type filters
+    Then he can only see 3 right away
+    
+  Scenario: Show the view of all chosen filters
+    When user chooses 4 type filters
+    And clicks on the button next to them
+    Then he can see the remaining filter
+
+  Scenario: Hide the menu of all chosen filters 
+    When user chooses 4 type filters
+    And makes them all visible
+    When user clicks on "Show Less"
+    Then he can see only 3 filters
+  

--- a/frontend/cypress/integration/featureFiles/istio_config_validation_filters.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_validation_filters.feature
@@ -1,0 +1,45 @@
+@istio-page
+Feature: Kiali Istio Config page
+
+  On the Istio Config page, an admin should be able to choose all of the filters present. 
+  The admin should also be able close a single filter either with it's cross, or with the Close All feature.
+
+  Background:
+    Given user is at administrator perspective
+    And user is at the "istio" page
+    And user selects the "istio-system" namespace
+    And user filters by "Config" 
+    And no filters are active
+
+  Scenario: Filters should be available in the dropdown 
+    Then user can see the Filter by Config Validation dropdown
+    And the dropdown contains all of the filters 
+
+  Scenario: Single filter should be usable 
+    When a validation filter is chosen from the dropdown
+    Then the filter is applied and visible
+
+  Scenario: Filter should be deletable 
+    When a validation filter "Valid" is applied  
+    And user clicks the cross next to the "Valid" 
+    Then the filter is no longer active 
+
+  Scenario: Deleting all filters at once
+    When a validation filter "Valid" is applied
+    And user clicks on "Clear all filters"
+    Then the filter is no longer active 
+
+  Scenario: When 4 or more filters are chosen, only 3 are visible right away
+    When user chooses 4 validation filters
+    Then he can only see 3 right away
+    
+  Scenario: Show the view of all chosen filters
+    When user chooses 4 validation filters
+    And clicks on the button next to them
+    Then he can see the remaining filter
+
+  Scenario: Hide the menu of all chosen filters 
+    When user chooses 4 validation filters
+    And makes them all visible
+    When user clicks on "Show Less"
+    Then he can see only 3 filters

--- a/frontend/src/components/Filters/StatefulFilters.tsx
+++ b/frontend/src/components/Filters/StatefulFilters.tsx
@@ -278,6 +278,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
           aria-label="filter_select_value"
           placeholderText={currentFilterType.placeholder}
           width="auto"
+          data-test="istio-type-dropdown"
         >
           {currentFilterType.filterValues.map((filter, index) => (
             <SelectOption key={'filter_' + index} value={filter.id} label={filter.title} />


### PR DESCRIPTION
This is the refinement of the #5424, which I decided to close due to heavy changes in all of the code.

Another migration from the Selenium. These suites are supposed to check whether are all of the filters usable or not.

Most of the implementation is in the istio_config_type_filters.ts. The files doesn't take that much time and I also use `cy.intercept()` on many places to verify that the filtering happend.

This PR is related to https://github.com/kiali/kiali/issues/5392 and https://github.com/kiali/kiali/issues/5393 issues.