### PR TITLE
Include three additional options in Graph's factory reset

### DIFF
--- a/frontend/src/reducers/GraphDataState.ts
+++ b/frontend/src/reducers/GraphDataState.ts
@@ -137,6 +137,9 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
       });
     case getType(GraphToolbarActions.resetSettings):
       return updateState(state, {
+        edgeMode: INITIAL_GRAPH_STATE.edgeMode,
+        layout: INITIAL_GRAPH_STATE.layout,
+        namespaceLayout: INITIAL_GRAPH_STATE.namespaceLayout,
         toolbarState: INITIAL_GRAPH_STATE.toolbarState
       });
     case getType(GraphToolbarActions.toggleBoxByCluster):


### PR DESCRIPTION
Add the following options for factory reset:
* Edge mode (hide all/healthy edges)
* Graph layout
* Namespace layout

Fixes #4817 