### PR TITLE
For Argo rollout, use the controller's replica sets as workloads

### DIFF
--- a/business/test_util.go
+++ b/business/test_util.go
@@ -807,7 +807,7 @@ func FakePodsFromCustomController() []core_v1.Pod {
 				OwnerReferences: []meta_v1.OwnerReference{{
 					Controller: &controller,
 					Kind:       "ReplicaSet",
-					Name:       "custom-controller-123",
+					Name:       "custom-controller-RS-123",
 				}},
 				Annotations: kubetest.FakeIstioAnnotations(),
 			},
@@ -838,7 +838,7 @@ func FakeCustomControllerRSSyncedWithPods() []apps_v1.ReplicaSet {
 				Kind: "ReplicaSet",
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
-				Name:              "custom-controller-123",
+				Name:              "custom-controller-RS-123",
 				CreationTimestamp: meta_v1.NewTime(t1),
 				OwnerReferences: []meta_v1.OwnerReference{{
 					Controller: &controller,

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -410,8 +410,8 @@ func TestGetWorkloadListFromPods(t *testing.T) {
 	assert.Equal("Namespace", workloadList.Namespace.Name)
 
 	assert.Equal(1, len(workloads))
-	assert.Equal("custom-controller", workloads[0].Name)
-	assert.Equal("CustomController", workloads[0].Type)
+	assert.Equal("custom-controller-RS-123", workloads[0].Name)
+	assert.Equal("ReplicaSet", workloads[0].Type)
 	assert.Equal(true, workloads[0].AppLabel)
 	assert.Equal(true, workloads[0].VersionLabel)
 }

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -526,8 +526,14 @@ func TestGetWorkloadFromPods(t *testing.T) {
 	criteria := WorkloadCriteria{Namespace: "Namespace", WorkloadName: "custom-controller", WorkloadType: "", IncludeServices: false}
 	workload, _ := svc.GetWorkload(context.TODO(), criteria)
 
-	assert.Equal("custom-controller", workload.Name)
-	assert.Equal("CustomController", workload.Type)
+	// custom controller is not a workload type, only its replica set(s)
+	assert.Equal((*models.Workload)(nil), workload)
+
+	criteria = WorkloadCriteria{Namespace: "Namespace", WorkloadName: "custom-controller-RS-123", WorkloadType: "", IncludeServices: false}
+	workload, _ = svc.GetWorkload(context.TODO(), criteria)
+
+	assert.Equal("custom-controller-RS-123", workload.Name)
+	assert.Equal("ReplicaSet", workload.Type)
 	assert.Equal(true, workload.AppLabel)
 	assert.Equal(true, workload.VersionLabel)
 	assert.Equal(0, len(workload.Runtimes))
@@ -1009,9 +1015,12 @@ func TestGetWorkloadListRSOwnedByCustom(t *testing.T) {
 	workload, _ := svc.GetWorkload(context.TODO(), criteria)
 
 	assert.Equal(len(workloads), 1)
-	assert.NotNil(workload)
+	assert.Nil(workload)
 
-	assert.Equal(len(pods), len(workload.Pods))
+	criteria.WorkloadName = workloads[0].Name
+	workload, _ = svc.GetWorkload(context.TODO(), criteria)
+
+	assert.NotNil(workload)
 }
 
 func TestGetPodLogsWithoutAccessLogs(t *testing.T) {

--- a/kubernetes/cache/kubernetes.go
+++ b/kubernetes/cache/kubernetes.go
@@ -233,12 +233,13 @@ func (c *kialiCacheImpl) GetReplicaSets(namespace string) ([]apps_v1.ReplicaSet,
 			if len(rs.OwnerReferences) > 0 {
 				for _, ownerRef := range rs.OwnerReferences {
 					if ownerRef.Controller != nil && *ownerRef.Controller {
-						if currRS, ok := activeRSMap[fmt.Sprintf("%s_%s_%s", ownerRef.Name, rs.Name, rs.ResourceVersion)]; ok {
+						key := fmt.Sprintf("%s_%s_%s", ownerRef.Name, rs.Name, rs.ResourceVersion)
+						if currRS, ok := activeRSMap[key]; ok {
 							if currRS.CreationTimestamp.Time.Before(rs.CreationTimestamp.Time) {
-								activeRSMap[ownerRef.Name] = rs
+								activeRSMap[key] = rs
 							}
 						} else {
-							activeRSMap[ownerRef.Name] = rs
+							activeRSMap[key] = rs
 						}
 					}
 				}


### PR DESCRIPTION
For a custom controller that manages replica sets (like Argo Rollout), defer to the replica sets as the workloads, and not the custom controller. The controller may control multiple replica sets, it may not live in the same namespace as the replica sets, and it may have unusual characteristics. But maybe most importantly, Istio telemetry will report the RS as the workload, and so it is critical to the graph, and linking, to use the RS as the workload.

Closes https://github.com/kiali/kiali/issues/5261
Closes #4210 
