### PR TITLE
[Cypress] Minor improvements regarding visual regression testing

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -107,3 +107,7 @@ Then('the application should be listed as {string}', function (healthStatus: str
 Then('the health status of the application should be {string}', function (healthStatus: string) {
   checkHealthStatusInTable(this.targetNamespace, null, this.targetApp, healthStatus);
 });
+
+Then('user cannot see any apps in the table', () => {
+  cy.get('h5').contains('No applications found').should('exist');
+});

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -32,6 +32,11 @@ Feature: Kiali Apps List page
     And user sees "kiali-traffic-generator"
 
   @apps-page
+  Scenario: Filter workloads table by Istio Sidecar not being present
+    When the user filters by "Istio Sidecar" for "Not Present"
+    Then user cannot see any apps in the table
+
+  @apps-page
   Scenario: Filter Apps by Istio Type
     When the user filters by "Istio Type" for "VirtualService"
     Then user only sees "productpage"

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -58,6 +58,22 @@ Feature: Kiali Workloads page
     And user should only see healthy workloads in workloads table
 
   @workloads-page
+  Scenario: Filter workloads table by App Label
+    When user selects the "bookinfo" namespace
+    And user selects filter "App Label"
+    And user filters for app label "Present"
+    Then user sees "workloads" in workloads table
+    And user should only see workloads with the "app" label 
+
+  @workloads-page
+  Scenario: Filter workloads table by Version Label
+    When user selects the "bookinfo" namespace
+    And user selects filter "Version Label"
+    And user filters for version "Present"
+    Then user sees "workloads" in workloads table
+    And user should only see workloads with the "version" label
+
+  @workloads-page
   Scenario: Filter workloads table by label
     When user selects the "bookinfo" namespace
     And user selects filter "Label"


### PR DESCRIPTION
Some minor additions to existing tests. All of these are visual regression tests. This PR contains small test on the Apps page and also filtering on the Workloads page by app and version labels, which was not present before. 

I'll turn this as "Ready for review" if the CI won't fail.