### PR TITLE
Adding more space between the chart name and the y axis value

### DIFF
--- a/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
+++ b/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
@@ -94,7 +94,7 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
                                     direction={{ md: 'column' }}
                                     spaceItems={{ md: 'spaceItemsNone' }}
                                     justifyContent={{ md: 'justifyContentCenter' }}
-                                    style={{ textAlign: "right" }}
+                                    style={{ textAlign: "right", paddingRight: 30 }}
                                 >
                                     <FlexItem>
                                         <b>Memory</b>
@@ -133,7 +133,7 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
                                     direction={{ md: 'column' }}
                                     spaceItems={{ md: 'spaceItemsNone' }}
                                     justifyContent={{ md: 'justifyContentCenter' }}
-                                    style={{ textAlign: "right" }}
+                                    style={{ textAlign: "right", paddingRight: 30 }}
                                 >
                                     <FlexItem>
                                         <b>CPU</b>


### PR DESCRIPTION
Fixes #5495 

![image](https://user-images.githubusercontent.com/1286393/192785752-a265a4c2-abaa-45fb-bc91-13e280e18056.png)

Note: After approval, I will create a backport PR to v1.57