### PR TITLE
K8s Gateway object creation in Wizard

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1195,7 +1195,7 @@ func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, nam
 
 		// Join networking and security permissions into a single result
 		for _, ns := range namespaces {
-			allRP := make(models.ResourcesPermissions, len(newNetworkingConfigTypes)+len(newSecurityConfigTypes))
+			allRP := make(models.ResourcesPermissions, len(newNetworkingConfigTypes)+len(newSecurityConfigTypes)+len(newK8sNetworkingConfigTypes))
 			istioConfigPermissions[ns] = &allRP
 			for resource, permissions := range *networkingPermissions[ns] {
 				(*istioConfigPermissions[ns])[resource] = permissions

--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -314,6 +314,27 @@ Then('the user can create a {string} Istio object', (object: string) => {
   cy.url().should('include', page);
 });
 
+Then('the user can create a {string} K8s Istio object', (object: string) => {
+  cy.request('GET', '/api/config').should(response => {
+    expect(response.status).to.equal(200);
+    const gatewayAPIEnabled = response.body.gatewayAPIEnabled;
+
+    if (gatewayAPIEnabled) {
+      cy.getBySel('actions-dropdown').click();
+      cy.getBySel('actions-dropdown').within(() => {
+        cy.contains(object).click();
+      });
+      const page = `/istio/new/${object}`;
+      cy.url().should('include', page);
+    } else {
+      cy.getBySel('actions-dropdown').click();
+      cy.getBySel('actions-dropdown').within(() => {
+        cy.get(object).should('not.exist');
+      });
+    }
+  });
+});
+
 Then('the AuthorizationPolicy should have a {string}', function(healthStatus: string) {
   cy.get(`[data-test=VirtualItem_Ns${this.targetNamespace}_authorizationpolicy_${this.targetAuthorizationPolicy}] svg`)
       .invoke('attr', 'style')

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -36,6 +36,9 @@ Feature: Kiali Istio Config page
   Scenario: Ability to create a Gateway object
     Then the user can create a "Gateway" Istio object
 
+  Scenario: Ability to create a K8sGateway object
+    Then the user can create a "K8sGateway" K8s Istio object
+
   Scenario: Ability to create a PeerAuthentication object
     Then the user can create a "PeerAuthentication" Istio object
 

--- a/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
@@ -45,7 +45,7 @@ class IstioActionsNamespaceDropdown extends React.Component<Props, State> {
       (r): ActionItem => ({
         name: r.value,
         action: (
-          <DropdownItem key={'createIstioConfig_' + r.value} isDisabled={r.value == K8SGATEWAY ? !serverConfig.gatewayAPIEnabled : r.disabled} onClick={() => this.onClickCreate(r.value)}>
+          <DropdownItem key={'createIstioConfig_' + r.value} isDisabled={r.value === K8SGATEWAY ? !serverConfig.gatewayAPIEnabled : r.disabled} onClick={() => this.onClickCreate(r.value)}>
             {r.label}
           </DropdownItem>
         )

--- a/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { Dropdown, DropdownGroup, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
 import history from '../../app/History';
+import { serverConfig } from '../../config';
 import { NEW_ISTIO_RESOURCE } from '../../pages/IstioConfigNew/IstioConfigNewPage';
+import {K8SGATEWAY} from "../../pages/IstioConfigNew/K8sGatewayForm";
 
 type Props = {};
 
@@ -43,7 +45,7 @@ class IstioActionsNamespaceDropdown extends React.Component<Props, State> {
       (r): ActionItem => ({
         name: r.value,
         action: (
-          <DropdownItem key={'createIstioConfig_' + r.value} onClick={() => this.onClickCreate(r.value)}>
+          <DropdownItem key={'createIstioConfig_' + r.value} isDisabled={r.value == K8SGATEWAY ? !serverConfig.gatewayAPIEnabled : r.disabled} onClick={() => this.onClickCreate(r.value)}>
             {r.label}
           </DropdownItem>
         )

--- a/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
+++ b/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
@@ -14,6 +14,7 @@ import {
   AuthorizationPolicy,
   DestinationRule,
   Gateway,
+  K8sGateway,
   PeerAuthentication,
   Sidecar,
   VirtualService
@@ -34,6 +35,7 @@ export type IstioConfigItem =
   | DestinationRule
   | PeerAuthentication
   | Gateway
+  | K8sGateway
   | VirtualService;
 
 export interface ConfigPreviewItem {

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -1376,7 +1376,11 @@ export const buildK8sGateway = (name: string, namespace: string, state: K8sGatew
             }
           },
         }
-      }))
+      })),
+      addresses: state.addresses.map(s => ({
+        type: s.type,
+        value: s.value
+      })),
     }
   };
   state.workloadSelectorLabels

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -1370,8 +1370,11 @@ export const buildK8sGateway = (name: string, namespace: string, state: K8sGatew
         hostname: s.hostname,
         allowedRoutes: {
           namespaces: {
-            from: s.allowedRoutes.namespaces.from
-          }
+            from: s.allowedRoutes.namespaces.from,
+            selector: {
+              matchLabels: s.allowedRoutes.namespaces.selector?.matchLabels
+            }
+          },
         }
       }))
     }

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -1368,7 +1368,11 @@ export const buildK8sGateway = (name: string, namespace: string, state: K8sGatew
         port: s.port,
         protocol: s.protocol,
         hostname: s.hostname,
-        tls: s.tls || {}
+        allowedRoutes: {
+          namespaces: {
+            from: s.allowedRoutes.namespaces.from
+          }
+        }
       }))
     }
   };

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -12,7 +12,7 @@ import {
   Gateway,
   HTTPMatchRequest,
   HTTPRoute,
-  HTTPRouteDestination,
+  HTTPRouteDestination, K8sGateway,
   LoadBalancerSettings,
   Operation,
   OutlierDetection,
@@ -151,6 +151,7 @@ export const KIALI_RELATED_LABEL = 'kiali_wizard_related';
 // Wizard don't operate with EnvoyFilters so they can use the v1beta1 version
 export const ISTIO_NETWORKING_VERSION = 'networking.istio.io/v1beta1';
 export const ISTIO_SECURITY_VERSION = 'security.istio.io/v1beta1';
+export const GATEWAY_NETWORKING_VERSION = 'gateway.networking.k8s.io/v1alpha2';
 
 export const fqdnServiceName = (serviceName: string, namespace: string): string => {
   return serviceName + '.' + namespace + '.' + serverConfig.istioIdentityDomain;
@@ -1348,10 +1349,10 @@ export const buildGateway = (name: string, namespace: string, state: GatewayStat
   return gw;
 };
 
-export const buildK8sGateway = (name: string, namespace: string, state: K8sGatewayState): Gateway => {
-  const gw: Gateway = {
+export const buildK8sGateway = (name: string, namespace: string, state: K8sGatewayState): K8sGateway => {
+  const gw: K8sGateway = {
     kind: 'Gateway',
-    apiVersion: ISTIO_NETWORKING_VERSION,
+    apiVersion: GATEWAY_NETWORKING_VERSION,
     metadata: {
       name: name,
       namespace: namespace,
@@ -1361,10 +1362,12 @@ export const buildK8sGateway = (name: string, namespace: string, state: K8sGatew
     },
     spec: {
       // Default for istio scenarios, user may change it editing YAML
-      selector: {},
-      servers: state.gatewayServers.map(s => ({
+      gatewayClassName: 'istio',
+      listeners: state.listeners.map(s => ({
+        name: s.name,
         port: s.port,
-        hosts: s.hosts,
+        protocol: s.protocol,
+        hostname: s.hostname,
         tls: s.tls || {}
       }))
     }
@@ -1375,8 +1378,10 @@ export const buildK8sGateway = (name: string, namespace: string, state: K8sGatew
     .forEach(split => {
       const labels = split.trim().split('=');
       // It should be already validated with workloadSelectorValid, but just to add extra safe check
-      if (gw.spec.selector && labels.length === 2) {
-        gw.spec.selector[labels[0].trim()] = labels[1].trim();
+      if (labels.length === 2) {
+        if (gw.metadata.labels) {
+          gw.metadata.labels[labels[0].trim()] = labels[1].trim();
+        }
       }
     });
   return gw;

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -52,6 +52,7 @@ const computeValidDurations = (cfg: ComputedServerConfig) => {
 const defaultServerConfig: ComputedServerConfig = {
   clusters: {},
   durations: {},
+  gatewayAPIEnabled: false,
   healthConfig: {
     rate: []
   },

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/AddressBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/AddressBuilder.tsx
@@ -1,0 +1,160 @@
+import * as React from 'react';
+import { Button, ButtonVariant, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PFColors } from '../../../components/Pf/PfColors';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import {isGatewayHostValid, isValidIp} from '../../../utils/IstioConfigUtils';
+import { Address } from '../../../types/IstioObjects';
+import { isValid } from 'utils/Common';
+
+type Props = {
+  onAddAddress: (address: Address) => void;
+};
+
+type State = {
+  isValueValid: boolean;
+  newType: string;
+  newValue: string;
+};
+
+const warningStyle = style({
+  marginLeft: 25,
+  color: PFColors.Red100,
+  textAlign: 'center'
+});
+
+const addAddressStyle = style({
+  marginLeft: 0,
+  paddingLeft: 0
+});
+
+const addressHeader: ICell[] = [
+  {
+    title: 'Type',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Value',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+];
+
+const addressTypes = ['IPAddress', 'Hostname'];
+
+
+class AddressBuilder extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      isValueValid: false,
+      newType: addressTypes[0],
+      newValue: '',
+    };
+  }
+
+  canAddAddress = (): boolean => {
+    return this.state.isValueValid;
+  };
+
+  isValueValid = (value: string): boolean => {
+    if (this.state.newType === addressTypes[0]) {
+      return isValidIp(value)
+    }
+    if (this.state.newType === addressTypes[1]) {
+      return isGatewayHostValid(value)
+    }
+    return false;
+  };
+
+  onAddValue = (value: string, _) => {
+    this.setState({
+      newValue: value,
+      isValueValid: this.isValueValid(value)
+    });
+  };
+
+  onAddType = (value: string, _) => {
+    this.setState({
+      newType: value
+    });
+  };
+
+  onAddAddress = () => {
+    const newAddress: Address = {
+      type: this.state.newType,
+      value: this.state.newValue,
+    };
+    this.setState(
+      {
+        isValueValid: false,
+        newType: addressTypes[0],
+        newValue: '',
+      },
+      () => this.props.onAddAddress(newAddress)
+    );
+  };
+
+  addressRows() {
+    return [
+      {
+        keys: 'gatewayAddressNew',
+        cells: [
+          <>
+            <FormSelect
+              value={this.state.newType}
+              id="addType"
+              name="addType"
+              onChange={this.onAddType}
+            >
+              {addressTypes.map((option, index) => (
+                <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+              ))}
+            </FormSelect>
+          </>,
+          <>
+            <TextInput
+              value={this.state.newValue}
+              type="text"
+              id="addValue"
+              aria-describedby="add value"
+              name="addVale"
+              onChange={this.onAddValue}
+              validated={isValid(this.state.isValueValid)}
+            />
+          </>,
+        ]
+      }
+    ];
+  }
+
+  render() {
+    return (
+      <>
+        <FormGroup label="Address" isRequired={false} fieldId="address">
+          <Table aria-label="Address Rows" cells={addressHeader} rows={this.addressRows()}>
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </FormGroup>
+        <FormGroup fieldId="addAddress">
+          <Button
+            variant={ButtonVariant.link}
+            icon={<PlusCircleIcon />}
+            onClick={this.onAddAddress}
+            isDisabled={!this.canAddAddress()}
+            className={addAddressStyle}
+          >
+            Add Address to Address List
+          </Button>
+          {!this.canAddAddress() && <span className={warningStyle}>A Address needs Type and Value sections defined</span>}
+        </FormGroup>
+      </>
+    );
+  }
+}
+
+export default AddressBuilder;

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/AddressBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/AddressBuilder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonVariant, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { style } from 'typestyle';
@@ -134,24 +134,20 @@ class AddressBuilder extends React.Component<Props, State> {
   render() {
     return (
       <>
-        <FormGroup label="Address" isRequired={false} fieldId="address">
-          <Table aria-label="Address Rows" cells={addressHeader} rows={this.addressRows()}>
-            <TableHeader />
-            <TableBody />
-          </Table>
-        </FormGroup>
-        <FormGroup fieldId="addAddress">
-          <Button
-            variant={ButtonVariant.link}
-            icon={<PlusCircleIcon />}
-            onClick={this.onAddAddress}
-            isDisabled={!this.canAddAddress()}
-            className={addAddressStyle}
-          >
-            Add Address to Address List
-          </Button>
-          {!this.canAddAddress() && <span className={warningStyle}>A Address needs Type and Value sections defined</span>}
-        </FormGroup>
+        <Table aria-label="Address Rows" cells={addressHeader} rows={this.addressRows()}>
+          <TableHeader />
+          <TableBody />
+        </Table>
+        <Button
+          variant={ButtonVariant.link}
+          icon={<PlusCircleIcon />}
+          onClick={this.onAddAddress}
+          isDisabled={!this.canAddAddress()}
+          className={addAddressStyle}
+        >
+          Add Address to Address List
+        </Button>
+        {!this.canAddAddress() && <span className={warningStyle}>A Address needs Type and Value sections defined</span>}
       </>
     );
   }

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/AddressList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/AddressList.tsx
@@ -18,12 +18,12 @@ const noAddressStyle = style({
 
 const headerCells: ICell[] = [
   {
-    title: 'Type',
+    title: '',
     transforms: [cellWidth(40) as any],
     props: {}
   },
   {
-    title: 'Value',
+    title: '',
     transforms: [cellWidth(60) as any],
     props: {}
   },

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/AddressList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/AddressList.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { Address } from '../../../types/IstioObjects';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PFColors } from '../../../components/Pf/PfColors';
+
+type Props = {
+  addressList: Address[];
+  onRemoveAddress: (index: number) => void;
+};
+
+const noAddressStyle = style({
+  marginTop: 10,
+  color: PFColors.Red100,
+  textAlign: 'center',
+  width: '100%'
+});
+
+const headerCells: ICell[] = [
+  {
+    title: 'Type',
+    transforms: [cellWidth(40) as any],
+    props: {}
+  },
+  {
+    title: 'Value',
+    transforms: [cellWidth(60) as any],
+    props: {}
+  },
+];
+
+class AddressList extends React.Component<Props> {
+  rows = () => {
+    return this.props.addressList.map((address, i) => {
+      return {
+        key: 'address_' + i,
+        cells: [
+          <>
+            <div>{address.type}</div>
+          </>,
+          <>
+            <div>{address.value}</div>
+          </>,
+        ]
+      };
+    });
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Address',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemoveAddress(rowIndex);
+      }
+    };
+    return [removeAction];
+  };
+
+  render() {
+    return (
+      <>
+        <Table
+          aria-label="Address List"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        {this.props.addressList.length === 0 && <div className={noAddressStyle}>No Addresses defined</div>}
+      </>
+    );
+  }
+}
+
+export default AddressList;

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -207,7 +207,7 @@ class ListenerBuilder extends React.Component<Props, State> {
     );
   };
 
-  portRows() {
+  listenerRows() {
     return [
       {
         keys: 'gatewayListenerNew',
@@ -278,8 +278,8 @@ class ListenerBuilder extends React.Component<Props, State> {
     const showSelector = this.state.newFrom === 'Selector';
     return (
       <>
-        <FormGroup label="Listener" isRequired={true} fieldId="listener-port">
-          <Table aria-label="Port Level MTLS" cells={listenerHeader} rows={this.portRows()}>
+        <FormGroup label="Listener" isRequired={true} fieldId="listener">
+          <Table aria-label="Listener Rows" cells={listenerHeader} rows={this.listenerRows()}>
             <TableHeader />
             <TableBody />
           </Table>

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonVariant, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { style } from 'typestyle';
@@ -48,17 +48,22 @@ const listenerHeader: ICell[] = [
   },
   {
     title: 'Port',
-    transforms: [cellWidth(20) as any],
+    transforms: [cellWidth(10) as any],
     props: {}
   },
   {
     title: 'Protocol',
-    transforms: [cellWidth(20) as any],
+    transforms: [cellWidth(10) as any],
     props: {}
   },
   {
     title: 'From Namespaces',
-    transforms: [cellWidth(20) as any],
+    transforms: [cellWidth(10) as any],
+    props: {}
+  },
+  {
+    title: 'Labels',
+    transforms: [cellWidth(25) as any],
     props: {}
   }
 ];
@@ -208,6 +213,7 @@ class ListenerBuilder extends React.Component<Props, State> {
   };
 
   listenerRows() {
+    const showSelector = this.state.newFrom === 'Selector';
     return [
       {
         keys: 'gatewayListenerNew',
@@ -268,6 +274,16 @@ class ListenerBuilder extends React.Component<Props, State> {
                 <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
               ))}
             </FormSelect>
+          </>,
+          <>
+            <TextInput
+              id="addSelectorLabels"
+              name="addSelectorLabels"
+              value={this.state.newSelectorLabels}
+              onChange={this.addSelectorLabels}
+              isDisabled={!showSelector}
+              validated={isValid(!showSelector || this.state.isLabelSelectorValid)}
+            />
           </>
         ]
       }
@@ -275,43 +291,22 @@ class ListenerBuilder extends React.Component<Props, State> {
   }
 
   render() {
-    const showSelector = this.state.newFrom === 'Selector';
     return (
       <>
-        <FormGroup label="Listener" isRequired={true} fieldId="listener">
-          <Table aria-label="Listener Rows" cells={listenerHeader} rows={this.listenerRows()}>
-            <TableHeader />
-            <TableBody />
-          </Table>
-        </FormGroup>
-        {showSelector && (
-          <FormGroup
-            fieldId="selectorLabels"
-            label="Labels"
-            helperText="One or more labels to select a workload where the Gateway is applied."
-            helperTextInvalid="Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
-            validated={isValid(this.state.isLabelSelectorValid)}
-          >
-            <TextInput
-              id="gwHosts"
-              name="gwHosts"
-              onChange={this.addSelectorLabels}
-              validated={isValid(this.state.isLabelSelectorValid)}
-            />
-          </FormGroup>
-        )}
-        <FormGroup fieldId="addRule">
-          <Button
-            variant={ButtonVariant.link}
-            icon={<PlusCircleIcon />}
-            onClick={this.onAddListener}
-            isDisabled={!this.canAddListener()}
-            className={addListenerStyle}
-          >
-            Add Listener to Listener List
-          </Button>
-          {!this.canAddListener() && <span className={warningStyle}>A Listener needs Hostname and Port sections defined</span>}
-        </FormGroup>
+        <Table aria-label="Listener Rows" cells={listenerHeader} rows={this.listenerRows()}>
+          <TableHeader />
+          <TableBody />
+        </Table>
+        <Button
+          variant={ButtonVariant.link}
+          icon={<PlusCircleIcon />}
+          onClick={this.onAddListener}
+          isDisabled={!this.canAddListener()}
+          className={addListenerStyle}
+        >
+          Add Listener to Listener List
+        </Button>
+        {!this.canAddListener() && <span className={warningStyle}>A Listener needs Hostname and Port sections defined</span>}
       </>
     );
   }

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -1,0 +1,340 @@
+import * as React from 'react';
+import { Button, ButtonVariant, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PFColors } from '../../../components/Pf/PfColors';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { isGatewayHostValid } from '../../../utils/IstioConfigUtils';
+import { Listener } from '../../../types/IstioObjects';
+import { isValid } from 'utils/Common';
+
+type Props = {
+  onAddListener: (listener: Listener) => void;
+};
+
+type State = {
+  isHostValid: boolean;
+  newHostname: string;
+  newPort: string;
+  newName: string;
+  newProtocol: string;
+  newTlsMode: string;
+  newTlsServerCertificate: string;
+  newTlsPrivateKey: string;
+  newTlsCaCertificate: string;
+};
+
+const warningStyle = style({
+  marginLeft: 25,
+  color: PFColors.Red100,
+  textAlign: 'center'
+});
+
+const addListenerStyle = style({
+  marginLeft: 0,
+  paddingLeft: 0
+});
+
+const listenerHeader: ICell[] = [
+  {
+    title: 'Name',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Hostname',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Port',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Protocol',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  }
+];
+
+const protocols = ['HTTP', 'HTTPS', 'GRPC', 'HTTP2', 'MONGO', 'TCP', 'TLS'];
+
+//const allowedRoutes = ['All', 'Same', 'Selector'];
+
+const tlsModes = ['PASSTHROUGH', 'SIMPLE', 'MUTUAL', 'AUTO_PASSTHROUGH', 'ISTIO_MUTUAL'];
+
+class ListenerBuilder extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      newHostname: '',
+      isHostValid: false,
+      newPort: '',
+      newName: '',
+      newProtocol: protocols[0],
+      newTlsMode: tlsModes[1], // SIMPLE
+      newTlsServerCertificate: '',
+      newTlsPrivateKey: '',
+      newTlsCaCertificate: ''
+    };
+  }
+
+  canAddListener = (): boolean => {
+    const hostValid = this.state.isHostValid;
+    const portNumberValid = this.state.newPort.length > 0 && !isNaN(Number(this.state.newPort));
+    const portNameValid = this.state.newName.length > 0;
+    const tlsRequired = this.state.newProtocol === 'HTTPS' || this.state.newProtocol === 'TLS';
+    const tlsCertsValid = tlsRequired
+      ? this.state.newTlsMode === 'SIMPLE' || this.state.newTlsMode === 'MUTUAL'
+        ? this.state.newTlsServerCertificate.length > 0 && this.state.newTlsPrivateKey.length > 0
+        : true
+      : true;
+    const tlsCaValid =
+      tlsRequired && this.state.newTlsMode === 'MUTUAL' ? this.state.newTlsCaCertificate.length > 0 : true;
+    return hostValid && portNumberValid && portNameValid && tlsCertsValid && tlsCaValid;
+  };
+
+  isValidHost = (host: string): boolean => {
+    return isGatewayHostValid(host);
+  };
+
+  onAddHostname = (value: string, _) => {
+    this.setState({
+      newHostname: value,
+      isHostValid: this.isValidHost(value)
+    });
+  };
+
+  onAddPort = (value: string, _) => {
+    this.setState({
+      newPort: value.trim()
+    });
+  };
+
+  onAddName = (value: string, _) => {
+    this.setState({
+      newName: value.trim()
+    });
+  };
+
+  onAddProtocol = (value: string, _) => {
+    this.setState({
+      newPort: value
+    });
+  };
+
+  onAddListener = () => {
+    const newListener: Listener = {
+      hostname: this.state.newHostname,
+      port: +this.state.newPort,
+      name: this.state.newName,
+      protocol: this.state.newProtocol
+    };
+    if (this.state.newProtocol === 'HTTPS' || this.state.newProtocol === 'TLS') {
+      newListener.tls = {
+        mode: this.state.newTlsMode
+      };
+      if (this.state.newTlsMode === 'SIMPLE' || this.state.newTlsMode === 'MUTUAL') {
+        newListener.tls.privateKey = this.state.newTlsPrivateKey;
+        newListener.tls.serverCertificate = this.state.newTlsServerCertificate;
+      }
+      if (this.state.newTlsMode === 'MUTUAL') {
+        newListener.tls.caCertificates = this.state.newTlsCaCertificate;
+      }
+    }
+    this.setState(
+      {
+        newHostname: '',
+        isHostValid: false,
+        newPort: '',
+        newName: '',
+        newProtocol: protocols[0],
+        newTlsMode: tlsModes[1], // SIMPLE
+        newTlsServerCertificate: '',
+        newTlsPrivateKey: '',
+        newTlsCaCertificate: ''
+      },
+      () => this.props.onAddListener(newListener)
+    );
+  };
+
+  onAddTlsMode = (value: string, _) => {
+    this.setState({
+      newTlsMode: value
+    });
+  };
+
+  onAddTlsServerCertificate = (value: string, _) => {
+    this.setState({
+      newTlsServerCertificate: value
+    });
+  };
+
+  onAddTlsPrivateKey = (value: string, _) => {
+    this.setState({
+      newTlsPrivateKey: value
+    });
+  };
+
+  onAddTlsCaCertificate = (value: string, _) => {
+    this.setState({
+      newTlsCaCertificate: value
+    });
+  };
+
+  portRows() {
+    return [
+      {
+        keys: 'gatewayListenerNew',
+        cells: [
+          <>
+            <TextInput
+              value={this.state.newName}
+              type="text"
+              id="addName"
+              aria-describedby="add name"
+              name="addName"
+              onChange={this.onAddName}
+              validated={isValid(this.state.newName.length > 0)}
+            />
+          </>,
+          <>
+            <TextInput
+              value={this.state.newHostname}
+              type="text"
+              id="addHostname"
+              aria-describedby="add hostname"
+              name="addHostname"
+              onChange={this.onAddHostname}
+              validated={isValid(this.state.newHostname.length > 0)}
+            />
+          </>,
+          <>
+            <TextInput
+              value={this.state.newPort}
+              type="text"
+              id="addPort"
+              aria-describedby="add port"
+              name="addPortNumber"
+              onChange={this.onAddPort}
+              validated={isValid(this.state.newPort.length > 0 && !isNaN(Number(this.state.newPort)))}
+            />
+          </>,
+          <>
+            <FormSelect
+              value={this.state.newProtocol}
+              id="addPortProtocol"
+              name="addPortProtocol"
+              onChange={this.onAddProtocol}
+            >
+              {protocols.map((option, index) => (
+                <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+              ))}
+            </FormSelect>
+          </>
+        ]
+      }
+    ];
+  }
+
+  render() {
+    const showTls = this.state.newProtocol === 'HTTPS' || this.state.newProtocol === 'TLS';
+    return (
+      <>
+        <FormGroup label="Listener" isRequired={true} fieldId="listener-port">
+          <Table aria-label="Port Level MTLS" cells={listenerHeader} rows={this.portRows()}>
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </FormGroup>
+        {showTls && (
+          <FormGroup label="TLS Mode" isRequired={true} fieldId="addTlsMode">
+            <FormSelect value={this.state.newTlsMode} id="addTlsMode" name="addTlsMode" onChange={this.onAddTlsMode}>
+              {tlsModes.map((option, index) => (
+                <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+        )}
+        {showTls && (this.state.newTlsMode === 'SIMPLE' || this.state.newTlsMode === 'MUTUAL') && (
+          <>
+            <FormGroup
+              label="Server Certificate"
+              isRequired={true}
+              fieldId="server-certificate"
+              validated={isValid(this.state.newTlsServerCertificate.length > 0)}
+              helperTextInvalid={'The path to the file holding the listener-side TLS certificate to use.'}
+            >
+              <TextInput
+                value={this.state.newTlsServerCertificate}
+                isRequired={true}
+                type="text"
+                id="server-certificate"
+                aria-describedby="server-certificate"
+                name="server-certificate"
+                onChange={this.onAddTlsServerCertificate}
+                validated={isValid(this.state.newTlsServerCertificate.length > 0)}
+              />
+            </FormGroup>
+            <FormGroup
+              label="Private Key"
+              isRequired={true}
+              fieldId="private-key"
+              validated={isValid(this.state.newTlsPrivateKey.length > 0)}
+              helperTextInvalid={'The path to the file holding the listener’s private key.'}
+            >
+              <TextInput
+                value={this.state.newTlsPrivateKey}
+                isRequired={true}
+                type="text"
+                id="private-key"
+                aria-describedby="private-key"
+                name="private-key"
+                onChange={this.onAddTlsPrivateKey}
+                validated={isValid(this.state.newTlsPrivateKey.length > 0)}
+              />
+            </FormGroup>
+          </>
+        )}
+        {showTls && this.state.newTlsMode === 'MUTUAL' && (
+          <FormGroup
+            label="CA Certificate"
+            isRequired={true}
+            fieldId="ca-certificate"
+            validated={isValid(this.state.newTlsCaCertificate.length > 0)}
+            helperTextInvalid={
+              'The path to a file containing certificate authority certificates to use in verifying a presented client side certificate.'
+            }
+          >
+            <TextInput
+              value={this.state.newTlsCaCertificate}
+              isRequired={true}
+              type="text"
+              id="ca-certificate"
+              aria-describedby="ca-certificate"
+              name="ca-certificate"
+              onChange={this.onAddTlsCaCertificate}
+              validated={isValid(this.state.newTlsCaCertificate.length > 0)}
+            />
+          </FormGroup>
+        )}
+        <FormGroup fieldId="addRule">
+          <Button
+            variant={ButtonVariant.link}
+            icon={<PlusCircleIcon />}
+            onClick={this.onAddListener}
+            isDisabled={!this.canAddListener()}
+            className={addListenerStyle}
+          >
+            Add Listener to Listener List
+          </Button>
+          {!this.canAddListener() && <span className={warningStyle}>A Listener needs Hostname and Port sections defined</span>}
+        </FormGroup>
+      </>
+    );
+  }
+}
+
+export default ListenerBuilder;

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -18,23 +18,33 @@ const noListenerStyle = style({
 
 const headerCells: ICell[] = [
   {
-    title: 'Name',
+    title: '',
     transforms: [cellWidth(20) as any],
     props: {}
   },
   {
-    title: 'Hostname',
-    transforms: [cellWidth(40) as any],
-    props: {}
-  },
-  {
-    title: 'Port',
+    title: '',
     transforms: [cellWidth(20) as any],
     props: {}
   },
   {
-    title: 'From Namespaces',
-    transforms: [cellWidth(40) as any],
+    title: '',
+    transforms: [cellWidth(10) as any],
+    props: {}
+  },
+  {
+    title: '',
+    transforms: [cellWidth(10) as any],
+    props: {}
+  },
+  {
+    title: '',
+    transforms: [cellWidth(10) as any],
+    props: {}
+  },
+  {
+    title: '',
+    transforms: [cellWidth(25) as any],
     props: {}
   },
 ];
@@ -53,11 +63,18 @@ class ListenerList extends React.Component<Props> {
           </>,
           <>
             <div>
-              [{listener.port}, {listener.protocol}]
+              {listener.port}
+            </div>
+          </>,
+          <>
+            <div>
+              {listener.protocol}
             </div>
           </>,
           <>
             <div>{listener.allowedRoutes.namespaces.from}</div>
+          </>,
+          <>
             <div>{Object.keys(listener.allowedRoutes.namespaces.selector?.matchLabels).length !== 0 ? JSON.stringify(listener.allowedRoutes.namespaces.selector.matchLabels) : ''}</div>
           </>,
         ]

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -58,6 +58,7 @@ class ListenerList extends React.Component<Props> {
           </>,
           <>
             <div>{listener.allowedRoutes.namespaces.from}</div>
+            <div>{Object.keys(listener.allowedRoutes.namespaces.selector?.matchLabels).length != 0 ? JSON.stringify(listener.allowedRoutes.namespaces.selector.matchLabels) : ''}</div>
           </>,
         ]
       };

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -58,7 +58,7 @@ class ListenerList extends React.Component<Props> {
           </>,
           <>
             <div>{listener.allowedRoutes.namespaces.from}</div>
-            <div>{Object.keys(listener.allowedRoutes.namespaces.selector?.matchLabels).length != 0 ? JSON.stringify(listener.allowedRoutes.namespaces.selector.matchLabels) : ''}</div>
+            <div>{Object.keys(listener.allowedRoutes.namespaces.selector?.matchLabels).length !== 0 ? JSON.stringify(listener.allowedRoutes.namespaces.selector.matchLabels) : ''}</div>
           </>,
         ]
       };

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import { Listener } from '../../../types/IstioObjects';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PFColors } from '../../../components/Pf/PfColors';
+
+type Props = {
+  listenerList: Listener[];
+  onRemoveListener: (index: number) => void;
+};
+
+const noListenerStyle = style({
+  marginTop: 10,
+  color: PFColors.Red100,
+  textAlign: 'center',
+  width: '100%'
+});
+
+const headerCells: ICell[] = [
+  {
+    title: 'Listener Name',
+    transforms: [cellWidth(100) as any],
+    props: {}
+  },
+  {
+    title: 'Port',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'TLS',
+    transforms: [cellWidth(100) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+class ListenerList extends React.Component<Props> {
+  rows = () => {
+    return this.props.listenerList.map((listener, i) => {
+      return {
+        key: 'listener_' + i,
+        cells: [
+          <>
+            <div>{listener.name}</div>
+          </>,
+          <>
+            <div>{listener.hostname}</div>
+            <div>
+              [{listener.port}, {listener.protocol}]
+            </div>
+          </>,
+          <>
+            {listener.tls ? (
+              <>
+                <div>{listener.tls.mode}</div>
+                {listener.tls.serverCertificate && listener.tls.serverCertificate.length > 0 ? (
+                  <div>[{listener.tls.serverCertificate}]</div>
+                ) : undefined}
+                {listener.tls.privateKey && listener.tls.privateKey.length > 0 ? (
+                  <div>[{listener.tls.privateKey}]</div>
+                ) : undefined}
+                {listener.tls.caCertificates && listener.tls.caCertificates.length > 0 ? (
+                  <div>[{listener.tls.caCertificates}]</div>
+                ) : undefined}
+              </>
+            ) : undefined}
+          </>,
+          <></>
+        ]
+      };
+    });
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Rule',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemoveListener(rowIndex);
+      }
+    };
+    return [removeAction];
+  };
+
+  render() {
+    return (
+      <>
+        <Table
+          aria-label="Server List"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        {this.props.listenerList.length === 0 && <div className={noListenerStyle}>No Listeners defined</div>}
+      </>
+    );
+  }
+}
+
+export default ListenerList;

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -18,8 +18,13 @@ const noListenerStyle = style({
 
 const headerCells: ICell[] = [
   {
-    title: 'Listener Name',
-    transforms: [cellWidth(100) as any],
+    title: 'Name',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Hostname',
+    transforms: [cellWidth(40) as any],
     props: {}
   },
   {
@@ -28,14 +33,10 @@ const headerCells: ICell[] = [
     props: {}
   },
   {
-    title: 'TLS',
-    transforms: [cellWidth(100) as any],
+    title: 'From Namespaces',
+    transforms: [cellWidth(40) as any],
     props: {}
   },
-  {
-    title: '',
-    props: {}
-  }
 ];
 
 class ListenerList extends React.Component<Props> {
@@ -49,27 +50,15 @@ class ListenerList extends React.Component<Props> {
           </>,
           <>
             <div>{listener.hostname}</div>
+          </>,
+          <>
             <div>
               [{listener.port}, {listener.protocol}]
             </div>
           </>,
           <>
-            {listener.tls ? (
-              <>
-                <div>{listener.tls.mode}</div>
-                {listener.tls.serverCertificate && listener.tls.serverCertificate.length > 0 ? (
-                  <div>[{listener.tls.serverCertificate}]</div>
-                ) : undefined}
-                {listener.tls.privateKey && listener.tls.privateKey.length > 0 ? (
-                  <div>[{listener.tls.privateKey}]</div>
-                ) : undefined}
-                {listener.tls.caCertificates && listener.tls.caCertificates.length > 0 ? (
-                  <div>[{listener.tls.caCertificates}]</div>
-                ) : undefined}
-              </>
-            ) : undefined}
+            <div>{listener.allowedRoutes.namespaces.from}</div>
           </>,
-          <></>
         ]
       };
     });
@@ -91,7 +80,7 @@ class ListenerList extends React.Component<Props> {
     return (
       <>
         <Table
-          aria-label="Server List"
+          aria-label="Listener List"
           cells={headerCells}
           rows={this.rows()}
           // @ts-ignore

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -68,7 +68,7 @@ class ListenerList extends React.Component<Props> {
   // @ts-ignore
   actionResolver = (rowData, { rowIndex }) => {
     const removeAction = {
-      title: 'Remove Rule',
+      title: 'Remove Listener',
       // @ts-ignore
       onClick: (event, rowIndex, rowData, extraData) => {
         this.props.onRemoveListener(rowIndex);

--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -7,6 +7,7 @@ import { ActionGroup, Button, ButtonVariant, Form, FormGroup, TextInput } from '
 import { RenderContent } from '../../components/Nav/Page';
 import { style } from 'typestyle';
 import GatewayForm, { GATEWAY, GATEWAYS, GatewayState, initGateway, isGatewayStateValid } from './GatewayForm';
+import K8sGatewayForm, { K8SGATEWAY, K8SGATEWAYS, K8sGatewayState, initK8sGateway, isK8sGatewayStateValid } from './K8sGatewayForm';
 import SidecarForm, { initSidecar, isSidecarStateValid, SIDECAR, SIDECARS, SidecarState } from './SidecarForm';
 import { Paths, serverConfig } from '../../config';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
@@ -17,6 +18,7 @@ import history from '../../app/History';
 import {
   buildAuthorizationPolicy,
   buildGateway,
+  buildK8sGateway,
   buildPeerAuthentication,
   buildRequestAuthentication,
   buildServiceEntry,
@@ -73,6 +75,7 @@ type State = {
   istioPermissions: IstioPermissions;
   authorizationPolicy: AuthorizationPolicyState;
   gateway: GatewayState;
+  k8sGateway: K8sGatewayState;
   peerAuthentication: PeerAuthenticationState;
   requestAuthentication: RequestAuthenticationState;
   serviceEntry: ServiceEntryState;
@@ -91,6 +94,7 @@ const warningStyle = style({
 const DIC = {
   AuthorizationPolicy: AUTHORIZATION_POLICIES,
   Gateway: GATEWAYS,
+  K8sGateway: K8SGATEWAYS,
   PeerAuthentication: PEER_AUTHENTICATIONS,
   RequestAuthentication: REQUEST_AUTHENTICATIONS,
   ServiceEntry: SERVICE_ENTRIES,
@@ -101,6 +105,7 @@ const DIC = {
 export const NEW_ISTIO_RESOURCE = [
   { value: AUTHORIZACION_POLICY, label: AUTHORIZACION_POLICY, disabled: false },
   { value: GATEWAY, label: GATEWAY, disabled: false },
+  { value: K8SGATEWAY, label: K8SGATEWAY, disabled: false },
   { value: PEER_AUTHENTICATION, label: PEER_AUTHENTICATION, disabled: false },
   { value: REQUEST_AUTHENTICATION, label: REQUEST_AUTHENTICATION, disabled: false },
   { value: SERVICE_ENTRY, label: SERVICE_ENTRY, disabled: false },
@@ -114,6 +119,7 @@ const initState = (): State => ({
   itemsPreview: [],
   authorizationPolicy: initAuthorizationPolicy(),
   gateway: initGateway(),
+  k8sGateway: initK8sGateway(),
   peerAuthentication: initPeerAuthentication(),
   requestAuthentication: initRequestAuthentication(),
   serviceEntry: initServiceEntry(),
@@ -230,6 +236,13 @@ class IstioConfigNewPage extends React.Component<Props, State> {
             items: [buildGateway(this.state.name, ns.name, this.state.gateway)]
           });
           break;
+        case K8SGATEWAY:
+          items.push({
+            title: 'K8sGateway',
+            type: 'k8sGateway',
+            items: [buildK8sGateway(this.state.name, ns.name, this.state.k8sGateway)]
+          });
+          break;
         case PEER_AUTHENTICATION:
           items.push({
             title: 'Peer Authentication',
@@ -277,6 +290,8 @@ class IstioConfigNewPage extends React.Component<Props, State> {
         return isAuthorizationPolicyStateValid(this.state.authorizationPolicy);
       case GATEWAY:
         return isGatewayStateValid(this.state.gateway);
+      case K8SGATEWAY:
+        return isK8sGatewayStateValid(this.state.k8sGateway);
       case PEER_AUTHENTICATION:
         return isPeerAuthenticationStateValid(this.state.peerAuthentication);
       case REQUEST_AUTHENTICATION:
@@ -306,6 +321,15 @@ class IstioConfigNewPage extends React.Component<Props, State> {
       Object.keys(prevState.gateway).forEach(key => (prevState.gateway[key] = gateway[key]));
       return {
         gateway: prevState.gateway
+      };
+    });
+  };
+
+  onChangeK8sGateway = (k8sGateway: K8sGatewayState) => {
+    this.setState(prevState => {
+      Object.keys(prevState.k8sGateway).forEach(key => (prevState.k8sGateway[key] = k8sGateway[key]));
+      return {
+        k8sGateway: prevState.k8sGateway
       };
     });
   };
@@ -388,6 +412,9 @@ class IstioConfigNewPage extends React.Component<Props, State> {
             )}
             {this.props.match.params.objectType === GATEWAY && (
               <GatewayForm gateway={this.state.gateway} onChange={this.onChangeGateway} />
+            )}
+            {this.props.match.params.objectType === K8SGATEWAY && (
+              <K8sGatewayForm k8sGateway={this.state.k8sGateway} onChange={this.onChangeK8sGateway} />
             )}
             {this.props.match.params.objectType === PEER_AUTHENTICATION && (
               <PeerAuthenticationForm

--- a/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
@@ -1,0 +1,199 @@
+import * as React from 'react';
+// Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
+import { FormGroup, Switch, TextInputBase as TextInput } from '@patternfly/react-core';
+import { isGatewayHostValid } from '../../utils/IstioConfigUtils';
+import ServerBuilder from './GatewayForm/ServerBuilder';
+import ServerList from './GatewayForm/ServerList';
+import { Server } from '../../types/IstioObjects';
+import { isValid } from 'utils/Common';
+
+export const K8SGATEWAY = 'K8sGateway';
+export const K8SGATEWAYS = 'k8sgateways';
+
+type Props = {
+  k8sGateway: K8sGatewayState;
+  onChange: (k8sGateway: K8sGatewayState) => void;
+};
+
+// Gateway and Sidecar states are consolidated in the parent page
+export type K8sGatewayState = {
+  addWorkloadSelector: boolean;
+  workloadSelectorValid: boolean;
+  workloadSelectorLabels: string;
+  gatewayServers: Server[];
+  addGatewayServer: Server;
+  validHosts: boolean;
+};
+
+export const initK8sGateway = (): K8sGatewayState => ({
+  addWorkloadSelector: false,
+  workloadSelectorLabels: 'istio=ingressgateway',
+  workloadSelectorValid: true,
+  gatewayServers: [],
+  addGatewayServer: {
+    hosts: [],
+    port: {
+      number: 80,
+      name: 'http',
+      protocol: 'HTTP'
+    }
+  },
+  validHosts: false
+});
+
+export const isK8sGatewayStateValid = (g: K8sGatewayState): boolean => {
+  return g.workloadSelectorValid && g.gatewayServers.length > 0;
+};
+
+class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
+  constructor(props: Props) {
+    super(props);
+    this.state = initK8sGateway();
+  }
+
+  componentDidMount() {
+    this.setState(this.props.k8sGateway);
+  }
+
+  addWorkloadLabels = (value: string, _) => {
+    if (value.length === 0) {
+      this.setState(
+        {
+          workloadSelectorValid: false,
+          workloadSelectorLabels: ''
+        },
+        () => this.props.onChange(this.state)
+      );
+      return;
+    }
+    value = value.trim();
+    const labels: string[] = value.split(',');
+    let isValid = true;
+    // Some smoke validation rules for the labels
+    for (let i = 0; i < labels.length; i++) {
+      const label = labels[i];
+      if (label.indexOf('=') < 0) {
+        isValid = false;
+        break;
+      }
+      const splitLabel: string[] = label.split('=');
+      if (splitLabel.length !== 2) {
+        isValid = false;
+        break;
+      }
+      if (splitLabel[0].trim().length === 0 || splitLabel[1].trim().length === 0) {
+        isValid = false;
+        break;
+      }
+    }
+    this.setState(
+      {
+        workloadSelectorValid: isValid,
+        workloadSelectorLabels: value
+      },
+      () => this.props.onChange(this.state)
+    );
+  };
+
+  areValidHosts = (hosts: string[]): boolean => {
+    if (hosts.length === 0) {
+      return false;
+    }
+    let isValid = true;
+    for (let i = 0; i < hosts.length; i++) {
+      if (!isGatewayHostValid(hosts[i])) {
+        isValid = false;
+        break;
+      }
+    }
+    return isValid;
+  };
+
+  onAddServer = () => {
+    this.setState(
+      prevState => {
+        prevState.gatewayServers.push(prevState.addGatewayServer);
+        return {
+          gatewayServers: prevState.gatewayServers,
+          addGatewayServer: {
+            hosts: [],
+            port: {
+              number: 80,
+              name: 'http',
+              protocol: 'HTTP'
+            }
+          }
+        };
+      },
+      () => this.props.onChange(this.state)
+    );
+  };
+
+  onRemoveServer = (index: number) => {
+    this.setState(
+      prevState => {
+        prevState.gatewayServers.splice(index, 1);
+        return {
+          gatewayServers: prevState.gatewayServers
+        };
+      },
+      () => this.props.onChange(this.state)
+    );
+  };
+
+  render() {
+    return (
+      <>
+        <FormGroup label="Workload Selector" fieldId="workloadSelectorSwitch">
+          <Switch
+            id="workloadSelectorSwitch"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addWorkloadSelector}
+            onChange={() => {
+              this.setState(
+                prevState => ({
+                  addWorkloadSelector: !prevState.addWorkloadSelector
+                }),
+                () => this.props.onChange(this.state)
+              );
+            }}
+          />
+        </FormGroup>
+        {this.state.addWorkloadSelector && (
+          <FormGroup
+            fieldId="workloadLabels"
+            label="Labels"
+            helperText="One or more labels to select a workload where the Gateway is applied."
+            helperTextInvalid="Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            validated={isValid(this.state.workloadSelectorValid)}
+          >
+            <TextInput
+              id="gwHosts"
+              name="gwHosts"
+              isDisabled={!this.state.addWorkloadSelector}
+              value={this.state.workloadSelectorLabels}
+              onChange={this.addWorkloadLabels}
+              validated={isValid(this.state.workloadSelectorValid)}
+            />
+          </FormGroup>
+        )}
+        <ServerBuilder
+          onAddServer={server => {
+            this.setState(
+              {
+                addGatewayServer: server
+              },
+              () => this.onAddServer()
+            );
+          }}
+        />
+        <FormGroup label="Server List" fieldId="gwServerList">
+          <ServerList serverList={this.state.gatewayServers} onRemoveServer={this.onRemoveServer} />
+        </FormGroup>
+      </>
+    );
+  }
+}
+
+export default K8sGatewayForm;

--- a/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
-import { FormGroup } from '@patternfly/react-core';
+import { FormGroup, TextInputBase as TextInput } from '@patternfly/react-core';
 import ListenerBuilder from "./GatewayForm/ListenerBuilder";
 import { Listener } from '../../types/IstioObjects';
 import { isValid } from 'utils/Common';
@@ -31,7 +31,8 @@ export const initK8sGateway = (): K8sGatewayState => ({
     hostname: '',
     port: 80,
     name: 'default',
-    protocol: 'HTTP'
+    protocol: 'HTTP',
+    allowedRoutes: {namespaces: {from: "Same"}}
   },
   validHosts: false
 });
@@ -100,7 +101,8 @@ class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
             hostname: '',
             port: 80,
             name: 'http',
-            protocol: 'HTTP'
+            protocol: 'HTTP',
+            allowedRoutes: {namespaces: {from: "Same"}}
           }
         };
       },
@@ -130,6 +132,13 @@ class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
           helperTextInvalid="Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
           validated={isValid(this.state.workloadSelectorValid)}
         >
+          <TextInput
+            id="gwLabels"
+            name="gwLabels"
+            value={this.state.workloadSelectorLabels}
+            onChange={this.addWorkloadLabels}
+            validated={isValid(this.state.workloadSelectorValid)}
+          />
         </FormGroup>
         <ListenerBuilder
           onAddListener={listener => {

--- a/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
@@ -32,7 +32,7 @@ export const initK8sGateway = (): K8sGatewayState => ({
     port: 80,
     name: 'default',
     protocol: 'HTTP',
-    allowedRoutes: {namespaces: {from: "Same"}}
+    allowedRoutes: {namespaces: {from: "Same", selector: {matchLabels: {}}}}
   },
   validHosts: false
 });
@@ -102,7 +102,7 @@ class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
             port: 80,
             name: 'http',
             protocol: 'HTTP',
-            allowedRoutes: {namespaces: {from: "Same"}}
+            allowedRoutes: {namespaces: {from: "Same", selector: {matchLabels: {}}}}
           }
         };
       },

--- a/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
@@ -177,30 +177,30 @@ class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
             validated={isValid(this.state.workloadSelectorValid)}
           />
         </FormGroup>
-        <ListenerBuilder
-          onAddListener={listener => {
-            this.setState(
-              {
-                addListener: listener
-              },
-              () => this.onAddListener()
-            );
-          }}
-        />
-        <FormGroup label="Listener List" fieldId="gwListenerList">
+        <FormGroup label="Listeners" fieldId="listener" isRequired={true}>
+          <ListenerBuilder
+            onAddListener={listener => {
+              this.setState(
+                {
+                  addListener: listener
+                },
+                () => this.onAddListener()
+              );
+            }}
+          />
           <ListenerList listenerList={this.state.listeners} onRemoveListener={this.onRemoveListener} />
         </FormGroup>
-        <AddressBuilder
-          onAddAddress={address => {
-            this.setState(
-              {
-                addAddress: address
-              },
-              () => this.onAddAddress()
-            );
-          }}
-        />
-        <FormGroup label="Address List" fieldId="gwAddressList">
+        <FormGroup label="Addresses" fieldId="gwAddressList">
+          <AddressBuilder
+            onAddAddress={address => {
+              this.setState(
+                {
+                  addAddress: address
+                },
+                () => this.onAddAddress()
+              );
+            }}
+          />
           <AddressList addressList={this.state.addresses} onRemoveAddress={this.onRemoveAddress} />
         </FormGroup>
       </>

--- a/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
 import { FormGroup, TextInputBase as TextInput } from '@patternfly/react-core';
 import ListenerBuilder from "./GatewayForm/ListenerBuilder";
-import { Listener } from '../../types/IstioObjects';
-import { isValid } from 'utils/Common';
+import AddressBuilder from "./GatewayForm/AddressBuilder";
 import ListenerList from "./GatewayForm/ListenerList";
+import AddressList from "./GatewayForm/AddressList";
+import {Address, Listener} from '../../types/IstioObjects';
+import { isValid } from 'utils/Common';
 
 export const K8SGATEWAY = 'K8sGateway';
 export const K8SGATEWAYS = 'k8sgateways';
@@ -19,7 +21,9 @@ export type K8sGatewayState = {
   workloadSelectorValid: boolean;
   workloadSelectorLabels: string;
   listeners: Listener[];
+  addresses: Address[];
   addListener: Listener;
+  addAddress: Address;
   validHosts: boolean;
 };
 
@@ -27,12 +31,17 @@ export const initK8sGateway = (): K8sGatewayState => ({
   workloadSelectorLabels: 'app=gatewayapi',
   workloadSelectorValid: true,
   listeners: [],
+  addresses: [],
   addListener: {
     hostname: '',
     port: 80,
     name: 'default',
     protocol: 'HTTP',
     allowedRoutes: {namespaces: {from: "Same", selector: {matchLabels: {}}}}
+  },
+  addAddress: {
+    type: 'IPAddress',
+    value: '',
   },
   validHosts: false
 });
@@ -122,6 +131,34 @@ class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
     );
   };
 
+  onAddAddress = () => {
+    this.setState(
+      prevState => {
+        prevState.addresses.push(prevState.addAddress);
+        return {
+          addresses: prevState.addresses,
+          addAddress: {
+            type: 'IPAddress',
+            value: '',
+          }
+        };
+      },
+      () => this.props.onChange(this.state)
+    );
+  };
+
+  onRemoveAddress = (index: number) => {
+    this.setState(
+      prevState => {
+        prevState.addresses.splice(index, 1);
+        return {
+          addresses: prevState.addresses
+        };
+      },
+      () => this.props.onChange(this.state)
+    );
+  };
+
   render() {
     return (
       <>
@@ -152,6 +189,19 @@ class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
         />
         <FormGroup label="Listener List" fieldId="gwListenerList">
           <ListenerList listenerList={this.state.listeners} onRemoveListener={this.onRemoveListener} />
+        </FormGroup>
+        <AddressBuilder
+          onAddAddress={address => {
+            this.setState(
+              {
+                addAddress: address
+              },
+              () => this.onAddAddress()
+            );
+          }}
+        />
+        <FormGroup label="Address List" fieldId="gwAddressList">
+          <AddressList addressList={this.state.addresses} onRemoveAddress={this.onRemoveAddress} />
         </FormGroup>
       </>
     );

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -68,6 +68,7 @@ export const generateRequestHealth = (
 
 export const serverRateConfig = {
   clusters: {},
+  gatewayAPIEnabled: false,
   kialiFeatureFlags: {
     certificatesInformationIndicators: {
       enabled: true

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -708,7 +708,15 @@ export interface Listener {
   hostname: string;
   port: number;
   protocol: string;
-  tls?: ServerTLSSettings;
+  allowedRoutes: AllowedRoutes;
+}
+
+export interface AllowedRoutes {
+  namespaces: FromNamespaces;
+}
+
+export interface FromNamespaces {
+  from: string;
 }
 
 export interface ParentRef {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -708,6 +708,7 @@ export interface Listener {
   hostname: string;
   port: number;
   protocol: string;
+  tls?: ServerTLSSettings;
 }
 
 export interface ParentRef {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -711,6 +711,11 @@ export interface Listener {
   allowedRoutes: AllowedRoutes;
 }
 
+export interface Address {
+  type: string;
+  value: string;
+}
+
 export interface AllowedRoutes {
   namespaces: FromNamespaces;
 }
@@ -731,6 +736,7 @@ export interface ParentRef {
 
 export interface K8sGatewaySpec {
   listeners?: Listener[];
+  addresses?: Address[];
   gatewayClassName: string;
 }
 

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -715,8 +715,13 @@ export interface AllowedRoutes {
   namespaces: FromNamespaces;
 }
 
+export interface LabelSelector {
+  matchLabels?: { [key: string]: string };
+}
+
 export interface FromNamespaces {
   from: string;
+  selector?: LabelSelector;
 }
 
 export interface ParentRef {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -716,12 +716,12 @@ export interface AllowedRoutes {
 }
 
 export interface LabelSelector {
-  matchLabels?: { [key: string]: string };
+  matchLabels: { [key: string]: string };
 }
 
 export interface FromNamespaces {
   from: string;
-  selector?: LabelSelector;
+  selector: LabelSelector;
 }
 
 export interface ParentRef {

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -112,6 +112,7 @@ export interface ServerConfig {
   clusterInfo?: ClusterInfo;
   clusters: { [key: string]: MeshCluster };
   deployment: DeploymentConfig;
+  gatewayAPIEnabled: boolean;
   healthConfig: HealthConfig;
   installationTag?: string;
   istioAnnotations: IstioAnnotations;

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -2,6 +2,7 @@ import { getExpr } from '../../config/HealthConfig';
 
 export const healthConfig = {
   clusters: {},
+  gatewayAPIEnabled: false,
   kialiFeatureFlags: {
     certificatesInformationIndicators: {
       enabled: true

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -52,6 +52,7 @@ type PublicConfig struct {
 	ClusterInfo         ClusterInfo                 `json:"clusterInfo,omitempty"`
 	Clusters            map[string]business.Cluster `json:"clusters,omitempty"`
 	Deployment          DeploymentConfig            `json:"deployment,omitempty"`
+	GatewayAPIEnabled   bool                        `json:"gatewayAPIEnabled,omitempty"`
 	HealthConfig        config.HealthConfig         `json:"healthConfig,omitempty"`
 	InstallationTag     string                      `json:"installationTag,omitempty"`
 	IstioAnnotations    IstioAnnotations            `json:"istioAnnotations,omitempty"`
@@ -138,6 +139,12 @@ func Config(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		log.Warningf("Failed to fetch Kiali token when resolving cluster info: %s", getTokenErr.Error())
+	}
+
+	// Get business layer
+	bLayer, err := getBusiness(r)
+	if err == nil {
+		publicConfig.GatewayAPIEnabled = bLayer.IstioConfig.IsGatewayAPI()
 	}
 
 	RespondWithJSONIndent(w, http.StatusOK, publicConfig)


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5502

![Screenshot from 2022-10-10 12-58-35](https://user-images.githubusercontent.com/604313/194851305-4282e99e-5465-4ed4-8da1-6ffee896e5bb.png)
![Screenshot from 2022-10-10 12-57-22](https://user-images.githubusercontent.com/604313/194851308-1d61a74e-f271-4864-83c8-f77568765430.png)

For testing:
Go to Istio Config list page.
"Actions" dropdown, added new option "Create K8s Gateway".
When Gateway API is enabled (https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/ also add 'app' label into Gateway object), newly added option is enabled. What Gateway API CRD is not installed, then option is disabled.


