### PR TITLE
Do not omit namespace when querying for traces

### DIFF
--- a/jaeger/client.go
+++ b/jaeger/client.go
@@ -262,7 +262,7 @@ func readSpansStream(stream SpansStreamer) (map[jaegerModel.TraceID]*jaegerModel
 
 func buildJaegerServiceName(namespace, app string) string {
 	conf := config.Get()
-	if conf.ExternalServices.Tracing.NamespaceSelector && namespace != conf.IstioNamespace {
+	if conf.ExternalServices.Tracing.NamespaceSelector {
 		return app + "." + namespace
 	}
 	return app


### PR DESCRIPTION
In the past, the name recorded for services in the istio namespace didn't include the namespaces in traces. Currently, that is no longer the case, apparently.

Since Kiali was omitting the namespace for services in the istio namespace, traces/spans of such services weren't being fetched and were missing in Kiali. Most notably, this was the case for istio gateways workloads (either ingress or egress).

This is removing the conditional to omit the namespace based only on configuration flags.

Fixes #4935
