### PR TITLE
Soften test for idle edges

### DIFF
--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -47,7 +47,6 @@ When('user {string} {string} edge labels', (action, edgeLabel) => {
 });
 
 When('user {string} {string} option', (action, option: string) => {
-  let id: string;
   switch (option.toLowerCase()) {
     case 'cluster boxes':
       option = 'boxByCluster';
@@ -164,7 +163,7 @@ Then('the graph reflects default settings', () => {
     });
 });
 
-Then('user sees {string} edge labels', el => {
+Then('user sees {string} edge labels', (el: string) => {
   validateInput(el, 'appear');
 
   let rate;
@@ -189,7 +188,7 @@ Then('user sees {string} edge labels', el => {
     });
 });
 
-Then('user sees {string} edge label option is closed', edgeLabel => {
+Then('user sees {string} edge label option is closed', (edgeLabel: string) => {
   validateInput(edgeLabel, 'does not appear');
 });
 
@@ -206,7 +205,14 @@ Then('user does not see {string} boxing', (boxByType: string) => {
     });
 });
 
-Then('idle edges {string} in the graph', action => {
+// In older versions of Istio, when this was written, this istio-system namespace
+// would typicaly have some idle edges.  That is no longer the case.  It is not easy
+// to force an idle edge to exist, especially in the timeframe of a test, a demo would
+// need to generate an edge, then stop, and wait for it to become idle (i.e. at least a
+// minute depending on the duration used in the test.) In the future we could possibly
+// try to add something like this, but for now I am changing the test to just ensure
+// that non-idle edges don't disappear.
+Then('idle edges {string} in the graph', (action: string) => {
   validateInput('filterIdleEdges', action);
 
   cy.waitForReact();
@@ -214,16 +220,19 @@ Then('idle edges {string} in the graph', action => {
     .should('have.length', '1')
     .getCurrentState()
     .then(state => {
-      const numEdges = state.cy.edges(`[^hasTraffic]`).length;
+      const numEdges = state.cy.edges(`[hasTraffic]`).length;
+      const numIdleEdges = state.cy.edges(`[^hasTraffic]`).length;
       if (action === 'appear') {
         assert.isAbove(numEdges, 0);
+        assert.isAtLeast(numIdleEdges, 0);
       } else {
-        assert.equal(numEdges, 0);
+        assert.isAbove(numEdges, 0);
+        assert.equal(numIdleEdges, 0);
       }
     });
 });
 
-Then('idle nodes {string} in the graph', action => {
+Then('idle nodes {string} in the graph', (action: string) => {
   validateInput('filterIdleNodes', action);
 
   cy.waitForReact();
@@ -240,7 +249,7 @@ Then('idle nodes {string} in the graph', action => {
     });
 });
 
-Then('ranks {string} in the graph', action => {
+Then('ranks {string} in the graph', (action: string) => {
   validateInput('rank', action);
 
   cy.waitForReact();
@@ -270,7 +279,7 @@ Then('user does not see service nodes', () => {
     });
 });
 
-Then('security {string} in the graph', action => {
+Then('security {string} in the graph', (action: string) => {
   validateInput('filterSecurity', action);
 
   cy.waitForReact();
@@ -287,8 +296,7 @@ Then('security {string} in the graph', action => {
     });
 });
 
-Then('{string} option {string} in the graph', (option, action) => {
-  let id: string;
+Then('{string} option {string} in the graph', (option: string, action: string) => {
   switch (option.toLowerCase()) {
     case 'missing sidecars':
       option = 'filterSidecars';

--- a/frontend/cypress/integration/featureFiles/graph_display.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display.feature
@@ -7,7 +7,7 @@ Feature: Kiali Graph page - Display menu
 
 # NOTE: Graph Find/Hide (compressOnHide) has its own test script
 # NOTE: Operation nodes has its own test script
-# NOTE: Traffic animation, missing sidecars, virtual service options are nominally tested
+# NOTE: Traffic animation, missing sidecars, virtual service, and idle edge options are nominally tested
 
 @graph-page-display
 Scenario: Graph no namespaces


### PR DESCRIPTION
Soften test for idle edges, the control plane can no longer be counted on for generating them (which is a good thing).  The error-rates demo sometimes does generate them, but not always, and more often in upstream than ossm.

Also, fix some linter issues.

https://issues.redhat.com/browse/OSSM-2096
