### PR TITLE
Adding Gateway API support into Service Wizard

### DIFF
--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -28,7 +28,7 @@ func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 	// Check Port naming for services in the service mesh
 	if p.hasMatchingPodsWithSidecar(p.Service) {
 		for portIndex, sp := range p.Service.Spec.Ports {
-			if strings.ToLower(string(sp.Protocol)) == "udp" {
+			if _, ok := p.Service.Labels["kiali_wizard"]; ok || strings.ToLower(string(sp.Protocol)) == "udp" {
 				continue
 			} else if sp.AppProtocol != nil {
 				if !kubernetes.MatchPortAppProtocolWithValidProtocols(sp.AppProtocol) {

--- a/business/checkers/services/port_mapping_checker_test.go
+++ b/business/checkers/services/port_mapping_checker_test.go
@@ -20,7 +20,7 @@ func TestPortMappingMatch(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http", nil, "test-namespace"),
+		Service:     getService(9080, "http", nil, "test-namespace", "app"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -36,7 +36,7 @@ func TestTargetPortMappingMatch(t *testing.T) {
 
 	assert := assert.New(t)
 
-	service := getService(9080, "http", nil, "test-namespace")
+	service := getService(9080, "http", nil, "test-namespace", "app")
 	service.Spec.Ports[0].TargetPort = intstr.FromInt(8080)
 
 	/*
@@ -74,7 +74,7 @@ func TestPortMappingMismatch(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http", nil, "test-namespace"),
+		Service:     getService(9080, "http", nil, "test-namespace", "app"),
 		Deployments: getDeployment(8080),
 		Pods:        getPods(true),
 	}
@@ -94,7 +94,7 @@ func TestPortMappingNoMismatchIstio(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http", nil, "istio-system"),
+		Service:     getService(9080, "http", nil, "istio-system", "app"),
 		Deployments: getDeployment(8080),
 		Pods:        getPods(true),
 	}
@@ -111,7 +111,7 @@ func TestServicePortNaming(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http2foo", nil, "test-namespace"),
+		Service:     getService(9080, "http2foo", nil, "test-namespace", "app"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -130,7 +130,7 @@ func TestServicePortNamingIstioSystem(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http2foo", nil, "istio-system"),
+		Service:     getService(9080, "http2foo", nil, "istio-system", "app"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -142,6 +142,23 @@ func TestServicePortNamingIstioSystem(t *testing.T) {
 	assert.Equal("spec/ports[0]", vals[0].Path)
 }
 
+func TestServicePortNamingWizard(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	pmc := PortMappingChecker{
+		Service:     getService(9080, "status-port", nil, "test-namespace", "kiali_wizard"),
+		Deployments: getDeployment(9080),
+		Pods:        getPods(true),
+	}
+
+	vals, valid := pmc.Check()
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
 func TestServicePortAppProtocol(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -150,7 +167,7 @@ func TestServicePortAppProtocol(t *testing.T) {
 
 	appProtocol := "mysql-wrong"
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "database", &appProtocol, "test-namespace"),
+		Service:     getService(9080, "database", &appProtocol, "test-namespace", "app"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -163,7 +180,7 @@ func TestServicePortAppProtocol(t *testing.T) {
 
 	appProtocol = "mysql"
 	pmc = PortMappingChecker{
-		Service:     getService(9080, "database", &appProtocol, "test-namespace"),
+		Service:     getService(9080, "database", &appProtocol, "test-namespace", "app"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(true),
 	}
@@ -180,7 +197,7 @@ func TestServicePortNamingWithoutSidecar(t *testing.T) {
 	assert := assert.New(t)
 
 	pmc := PortMappingChecker{
-		Service:     getService(9080, "http2foo", nil, "test-namespace"),
+		Service:     getService(9080, "http2foo", nil, "test-namespace", "app"),
 		Deployments: getDeployment(9080),
 		Pods:        getPods(false),
 	}
@@ -190,11 +207,13 @@ func TestServicePortNamingWithoutSidecar(t *testing.T) {
 	assert.Empty(vals)
 }
 
-func getService(servicePort int32, portName string, appProtocol *string, namespace string) v1.Service {
+func getService(servicePort int32, portName string, appProtocol *string, namespace string, labelKey string) v1.Service {
 	return v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "service1",
 			Namespace: namespace,
+			Labels: map[string]string{
+				labelKey: "labelName1"},
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{

--- a/business/services.go
+++ b/business/services.go
@@ -150,6 +150,8 @@ func (in *SvcService) GetServiceList(ctx context.Context, criteria ServiceCriter
 			Namespace:               criteria.Namespace,
 			IncludeDestinationRules: true,
 			IncludeGateways:         true,
+			IncludeK8sGateways:      true,
+			IncludeK8sHTTPRoutes:    true,
 			IncludeServiceEntries:   true,
 			IncludeVirtualServices:  true,
 		}
@@ -236,6 +238,7 @@ func (in *SvcService) buildKubernetesServices(svcs []core_v1.Service, pods []cor
 		svcDestinationRules := kubernetes.FilterDestinationRulesByService(istioConfigList.DestinationRules, item.Namespace, item.Name)
 		svcGateways := kubernetes.FilterGatewaysByVirtualServices(istioConfigList.Gateways, svcVirtualServices)
 		svcK8sHTTPRoutes := kubernetes.FilterK8sHTTPRoutesByService(istioConfigList.K8sHTTPRoutes, item.Namespace, item.Name)
+		svcK8sGateways := kubernetes.FilterK8sGatewaysByHTTPRoutes(istioConfigList.K8sGateways, svcK8sHTTPRoutes)
 		svcReferences := make([]*models.IstioValidationKey, 0)
 		for _, vs := range svcVirtualServices {
 			ref := models.BuildKey(vs.Kind, vs.Name, vs.Namespace)
@@ -246,6 +249,10 @@ func (in *SvcService) buildKubernetesServices(svcs []core_v1.Service, pods []cor
 			svcReferences = append(svcReferences, &ref)
 		}
 		for _, gw := range svcGateways {
+			ref := models.BuildKey(gw.Kind, gw.Name, gw.Namespace)
+			svcReferences = append(svcReferences, &ref)
+		}
+		for _, gw := range svcK8sGateways {
 			ref := models.BuildKey(gw.Kind, gw.Name, gw.Namespace)
 			svcReferences = append(svcReferences, &ref)
 		}

--- a/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -93,6 +93,7 @@ class MiniGraphCard extends React.Component<MiniGraphCardProps, MiniGraphCardSta
           <ServiceWizardActionsDropdownGroup
             virtualServices={this.props.serviceDetails.virtualServices || []}
             destinationRules={this.props.serviceDetails.destinationRules || []}
+            k8sHTTPRoutes={this.props.serviceDetails.k8sHTTPRoutes || []}
             istioPermissions={this.props.serviceDetails.istioPermissions}
             onAction={this.handleLaunchWizard}
             onDelete={this.handleDeleteTrafficRouting} />

--- a/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
+++ b/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
@@ -15,6 +15,7 @@ import {
   DestinationRule,
   Gateway,
   K8sGateway,
+  K8sHTTPRoute,
   PeerAuthentication,
   Sidecar,
   VirtualService
@@ -36,6 +37,7 @@ export type IstioConfigItem =
   | PeerAuthentication
   | Gateway
   | K8sGateway
+  | K8sHTTPRoute
   | VirtualService;
 
 export interface ConfigPreviewItem {

--- a/frontend/src/components/IstioWizards/ConfirmDeleteTrafficRoutingModal.tsx
+++ b/frontend/src/components/IstioWizards/ConfirmDeleteTrafficRoutingModal.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
-import { DestinationRuleC, VirtualService } from '../../types/IstioObjects';
+import {DestinationRuleC, K8sHTTPRoute, VirtualService} from '../../types/IstioObjects';
 
 type Props = {
   destinationRules: DestinationRuleC[];
   virtualServices: VirtualService[];
+  k8sHTTPRoutes: K8sHTTPRoute[];
   isOpen: boolean;
   onCancel: () => void;
   onConfirm: () => void;
@@ -43,6 +44,14 @@ const ConfirmDeleteTrafficRoutingModal: React.FunctionComponent<Props> = props =
           )}'`
         : '';
     deleteItems.push(<div key={`delete_item_${++i}`}>{paMessage}</div>);
+
+    let k8sHTTPRouteMessage =
+      props.k8sHTTPRoutes.length > 0
+        ? `K8s HTTPRoute${props.k8sHTTPRoutes.length > 1 ? 's' : ''}: '${props.k8sHTTPRoutes.map(
+          k8sr => k8sr.metadata.name
+        )}'`
+        : '';
+    deleteItems.push(<div key={`delete_item_${++i}`}>{k8sHTTPRouteMessage}</div>);
 
     return (
       <>

--- a/frontend/src/components/IstioWizards/GatewaySelector.tsx
+++ b/frontend/src/components/IstioWizards/GatewaySelector.tsx
@@ -9,25 +9,35 @@ import {
   Switch,
   TextInput
 } from '@patternfly/react-core';
+import { serverConfig } from '../../config';
 import { GATEWAY_TOOLTIP, wizardTooltip } from './WizardHelp';
 import { isValid } from 'utils/Common';
 
 type Props = {
   serviceName: string;
   hasGateway: boolean;
+  hasK8sGateway: boolean;
   gateway: string;
+  k8sGateway: string;
   isMesh: boolean;
   gateways: string[];
+  k8sGateways: string[];
   vsHosts: string[];
+  k8sRouteHosts: string[];
   onGatewayChange: (valid: boolean, gateway: GatewaySelectorState) => void;
+  onK8sGatewayChange: (valid: boolean, k8sGateway: GatewaySelectorState) => void;
 };
 
 export type GatewaySelectorState = {
   addGateway: boolean;
+  selectGateway: boolean;
+  selectK8sGateway: boolean;
   gwHosts: string;
   gwHostsValid: boolean;
   newGateway: boolean;
+  newK8sGateway: boolean;
   selectedGateway: string;
+  selectedK8sGateway: string;
   addMesh: boolean;
   port: number;
 };
@@ -38,7 +48,11 @@ enum GatewayForm {
   GW_HOSTS,
   SELECT,
   GATEWAY_SELECTED,
-  PORT
+  PORT,
+  SELECT_K8S,
+  NEW_GW,
+  NEW_K8S_GW,
+  K8S_GATEWAY_SELECTED,
 }
 
 class GatewaySelector extends React.Component<Props, GatewaySelectorState> {
@@ -46,10 +60,14 @@ class GatewaySelector extends React.Component<Props, GatewaySelectorState> {
     super(props);
     this.state = {
       addGateway: props.hasGateway,
+      selectGateway: props.gateways.length !== 0,
+      selectK8sGateway: props.k8sGateways.length !== 0 && props.gateways.length === 0,
       gwHosts: '*',
       gwHostsValid: true,
       newGateway: props.gateways.length === 0,
+      newK8sGateway: props.k8sGateways.length === 0 && props.gateways.length !== 0,
       selectedGateway: props.gateways.length > 0 ? (props.gateway !== '' ? props.gateway : props.gateways[0]) : '',
+      selectedK8sGateway: props.k8sGateways.length > 0 ? (props.k8sGateway !== '' ? props.k8sGateway : props.k8sGateways[0]) : '',
       addMesh: props.isMesh,
       port: 80
     };
@@ -102,9 +120,45 @@ class GatewaySelector extends React.Component<Props, GatewaySelectorState> {
       case GatewayForm.SELECT:
         this.setState(
           {
-            newGateway: value === 'true'
+            newGateway: false,
+            newK8sGateway: false,
+            selectGateway: true,
+            selectK8sGateway: false,
           },
           () => this.props.onGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case GatewayForm.SELECT_K8S:
+        this.setState(
+          {
+            newGateway: false,
+            newK8sGateway: false,
+            selectGateway: false,
+            selectK8sGateway: true,
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case GatewayForm.NEW_GW:
+        this.setState(
+          {
+            newGateway: true,
+            newK8sGateway: false,
+            selectGateway: false,
+            selectK8sGateway: false,
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case GatewayForm.NEW_K8S_GW:
+        this.setState(
+          {
+            newGateway: false,
+            newK8sGateway: true,
+            selectGateway: false,
+            selectK8sGateway: false,
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
         );
         break;
       case GatewayForm.GATEWAY_SELECTED:
@@ -113,6 +167,14 @@ class GatewaySelector extends React.Component<Props, GatewaySelectorState> {
             selectedGateway: value
           },
           () => this.props.onGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case GatewayForm.K8S_GATEWAY_SELECTED:
+        this.setState(
+          {
+            selectedK8sGateway: value
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
         );
         break;
       case GatewayForm.PORT:
@@ -134,13 +196,16 @@ class GatewaySelector extends React.Component<Props, GatewaySelectorState> {
     // Gateway added
     if (this.state.addGateway) {
       // Mesh can't use wildcard in the hosts
+      // @TODO Mesh for K8s Gateway is under development
       if (this.state.addMesh) {
         if (this.state.newGateway) {
           // If mesh, a new gateway can't use wildcard
           return !hasGwWildcard;
         } else {
           // If mesh, a selected gateway can't use wildcard
-          return !hasVsWildcard;
+          if (this.state.selectGateway) {
+            return !hasVsWildcard;
+          }
         }
       }
       return true;
@@ -171,48 +236,70 @@ class GatewaySelector extends React.Component<Props, GatewaySelectorState> {
         </FormGroup>
         {this.state.addGateway && (
           <>
-            <FormGroup
-              fieldId="includeMesh"
-              validated={isValid(this.isMeshGatewayValid())}
-              helperTextInvalid={"VirtualService Host '*' wildcard not allowed on mesh gateway."}
-            >
-              <Checkbox
-                id="includeMesh"
-                label={
-                  <>
-                    Include <b>mesh</b> gateway
-                  </>
-                }
-                isDisabled={!this.state.addGateway}
-                isChecked={this.state.addMesh}
-                onChange={() => this.onFormChange(GatewayForm.MESH, '')}
-              />
-            </FormGroup>
             <FormGroup fieldId="selectGateway">
               <Radio
                 id="existingGateway"
                 name="selectGateway"
                 label="Select Gateway"
                 isDisabled={!this.state.addGateway || this.props.gateways.length === 0}
-                isChecked={!this.state.newGateway}
-                onChange={() => this.onFormChange(GatewayForm.SELECT, 'false')}
+                isChecked={this.state.selectGateway}
+                onChange={() => this.onFormChange(GatewayForm.SELECT, '')}
               />
+              {serverConfig.gatewayAPIEnabled && (
+                <Radio
+                  id="existingK8sGateway"
+                  name="selectGateway"
+                  label="Select K8s API Gateway"
+                  isDisabled={!this.state.addGateway || this.props.k8sGateways.length === 0}
+                  isChecked={this.state.selectK8sGateway}
+                  onChange={() => this.onFormChange(GatewayForm.SELECT_K8S, '')}
+                />
+              )}
               <Radio
                 id="createGateway"
                 name="selectGateway"
                 label="Create Gateway"
                 isDisabled={!this.state.addGateway}
                 isChecked={this.state.newGateway}
-                onChange={() => this.onFormChange(GatewayForm.SELECT, 'true')}
+                onChange={() => this.onFormChange(GatewayForm.NEW_GW, '')}
               />
+              {serverConfig.gatewayAPIEnabled && (
+                <Radio
+                  id="createK8sGateway"
+                  name="selectGateway"
+                  label="Create K8s API Gateway"
+                  isDisabled={!this.state.addGateway}
+                  isChecked={this.state.newK8sGateway}
+                  onChange={() => this.onFormChange(GatewayForm.NEW_K8S_GW, '')}
+                />
+              )}
             </FormGroup>
-            {!this.state.newGateway && (
+            {(this.state.newGateway || this.state.selectGateway) && (
+              <FormGroup
+                fieldId="includeMesh"
+                validated={isValid(this.isMeshGatewayValid())}
+                helperTextInvalid={"VirtualService Host '*' wildcard not allowed on mesh gateway."}
+              >
+                <Checkbox
+                  id="includeMesh"
+                  label={
+                    <>
+                      Include <b>mesh</b> gateway
+                    </>
+                  }
+                  isDisabled={!this.state.addGateway}
+                  isChecked={this.state.addMesh}
+                  onChange={() => this.onFormChange(GatewayForm.MESH, '')}
+                />
+              </FormGroup>
+            )}
+            {this.state.addGateway && this.state.selectGateway && (
               <FormGroup fieldId="selectGateway" label="Gateway">
                 {this.props.gateways.length > 0 && (
                   <FormSelect
                     id="selectGateway"
                     value={this.state.selectedGateway}
-                    isDisabled={!this.state.addGateway || this.state.newGateway || this.props.gateways.length === 0}
+                    isDisabled={this.props.gateways.length === 0}
                     onChange={(gw: string) => this.onFormChange(GatewayForm.GATEWAY_SELECTED, gw)}
                   >
                     {this.props.gateways.map(gw => (
@@ -223,34 +310,71 @@ class GatewaySelector extends React.Component<Props, GatewaySelectorState> {
                 {this.props.gateways.length === 0 && <>There are no gateways to select.</>}
               </FormGroup>
             )}
-            {this.state.newGateway && (
+            {this.state.addGateway && this.state.selectK8sGateway && (
+              <FormGroup fieldId="selectK8sGateway" label="K8s Gateway">
+                {this.props.k8sGateways.length > 0 && (
+                  <FormSelect
+                    id="selectK8sGateway"
+                    value={this.state.selectedK8sGateway}
+                    isDisabled={this.props.k8sGateways.length === 0}
+                    onChange={(gw: string) => this.onFormChange(GatewayForm.K8S_GATEWAY_SELECTED, gw)}
+                  >
+                    {this.props.k8sGateways.map(gw => (
+                      <FormSelectOption key={gw} value={gw} label={gw} />
+                    ))}
+                  </FormSelect>
+                )}
+                {this.props.gateways.length === 0 && <>There are no K8s API gateways to select.</>}
+              </FormGroup>
+            )}
+            {(this.state.newGateway || this.state.newK8sGateway) && (
               <>
                 <FormGroup fieldId="gwPort" label="Port">
                   <TextInput
                     id="gwPort"
                     name="gwPort"
                     type="number"
-                    isDisabled={!this.state.addGateway || !this.state.newGateway}
+                    isDisabled={!this.state.addGateway || (!this.state.newK8sGateway && !this.state.newGateway)}
                     value={this.state.port}
                     onChange={value => this.onFormChange(GatewayForm.PORT, value)}
                   />
                 </FormGroup>
-                <FormGroup
-                  fieldId="gwHosts"
-                  label="Gateway Hosts"
-                  helperText="One or more hosts exposed by this gateway. Enter one or multiple hosts separated by comma."
-                  helperTextInvalid="Gateway hosts should be specified using FQDN format or '*' wildcard."
-                  validated={isValid(this.state.gwHostsValid)}
-                >
-                  <TextInput
-                    id="gwHosts"
-                    name="gwHosts"
-                    isDisabled={!this.state.addGateway || !this.state.newGateway}
-                    value={this.state.gwHosts}
-                    onChange={value => this.onFormChange(GatewayForm.GW_HOSTS, value)}
+                {this.state.newGateway && (
+                  <FormGroup
+                    fieldId="gwHosts"
+                    label="Gateway Hosts"
+                    helperText="One or more hosts exposed by this gateway. Enter one or multiple hosts separated by comma."
+                    helperTextInvalid="Gateway hosts should be specified using FQDN format or '*' wildcard."
                     validated={isValid(this.state.gwHostsValid)}
-                  />
-                </FormGroup>
+                  >
+                    <TextInput
+                      id="gwHosts"
+                      name="gwHosts"
+                      isDisabled={!this.state.addGateway || (!this.state.newK8sGateway && !this.state.newGateway)}
+                      value={this.state.gwHosts}
+                      onChange={value => this.onFormChange(GatewayForm.GW_HOSTS, value)}
+                      validated={isValid(this.state.gwHostsValid)}
+                    />
+                  </FormGroup>
+                )}
+                {this.state.newK8sGateway && (
+                  <FormGroup
+                    fieldId="gwHosts"
+                    label="K8s API Gateway Host"
+                    helperText="One host exposed by this gateway."
+                    helperTextInvalid="K8s API Gateway host should be specified using FQDN format or '*' wildcard."
+                    validated={isValid(this.state.gwHostsValid)}
+                  >
+                    <TextInput
+                      id="gwHosts"
+                      name="gwHosts"
+                      isDisabled={!this.state.addGateway || (!this.state.newK8sGateway && !this.state.newGateway)}
+                      value={this.state.gwHosts}
+                      onChange={value => this.onFormChange(GatewayForm.GW_HOSTS, value)}
+                      validated={isValid(this.state.gwHostsValid)}
+                    />
+                  </FormGroup>
+                )}
               </>
             )}
           </>

--- a/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
+++ b/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
@@ -1,0 +1,235 @@
+import * as React from 'react';
+import {
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Radio,
+  Switch,
+  TextInput
+} from '@patternfly/react-core';
+import { GATEWAY_TOOLTIP, wizardTooltip } from './WizardHelp';
+import { isValid } from 'utils/Common';
+
+type Props = {
+  serviceName: string;
+  hasK8sGateway: boolean;
+  k8sGateway: string;
+  isMesh: boolean;
+  gateways: string[];
+  k8sGateways: string[];
+  k8sRouteHosts: string[];
+  onK8sGatewayChange: (valid: boolean, k8sGateway:K8sGatewaySelectorState) => void;
+};
+
+export type K8sGatewaySelectorState = {
+  addGateway: boolean;
+  selectK8sGateway: boolean;
+  gwHosts: string;
+  gwHostsValid: boolean;
+  newK8sGateway: boolean;
+  selectedK8sGateway: string;
+  port: number;
+};
+
+enum K8sGatewayForm {
+  SWITCH,
+  GW_HOSTS,
+  PORT,
+  SELECT_K8S,
+  NEW_GW,
+  NEW_K8S_GW,
+  K8S_GATEWAY_SELECTED,
+}
+
+class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelectorState> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      addGateway: props.hasK8sGateway,
+      selectK8sGateway: props.k8sGateways.length !== 0 && props.gateways.length === 0,
+      gwHosts: '*',
+      gwHostsValid: true,
+      newK8sGateway: props.k8sGateways.length === 0 && props.gateways.length !== 0,
+      selectedK8sGateway: props.k8sGateways.length > 0 ? (props.k8sGateway !== '' ? props.k8sGateway : props.k8sGateways[0]) : '',
+      port: 80
+    };
+  }
+
+  checkGwHosts = (gwHosts: string): boolean => {
+    const hosts = gwHosts.split(',');
+    for (let i = 0; i < hosts.length; i++) {
+      if (hosts[i] === '*') {
+        continue;
+      }
+      if (!hosts[i].includes('.')) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  onFormChange = (component: K8sGatewayForm, value: string) => {
+    switch (component) {
+      case K8sGatewayForm.SWITCH:
+        this.setState(
+          prevState => {
+            return {
+              addGateway: !prevState.addGateway
+            };
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case K8sGatewayForm.GW_HOSTS:
+        this.setState(
+          {
+            gwHosts: value,
+            gwHostsValid: this.checkGwHosts(value)
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case K8sGatewayForm.SELECT_K8S:
+        this.setState(
+          {
+            newK8sGateway: false,
+            selectK8sGateway: true,
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case K8sGatewayForm.NEW_GW:
+        this.setState(
+          {
+            newK8sGateway: false,
+            selectK8sGateway: false,
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case K8sGatewayForm.NEW_K8S_GW:
+        this.setState(
+          {
+            newK8sGateway: true,
+            selectK8sGateway: false,
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case K8sGatewayForm.K8S_GATEWAY_SELECTED:
+        this.setState(
+          {
+            selectedK8sGateway: value
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      case K8sGatewayForm.PORT:
+        this.setState(
+          {
+            port: +value
+          },
+          () => this.props.onK8sGatewayChange(this.isGatewayValid(), this.state)
+        );
+        break;
+      default:
+      // No default action
+    }
+  };
+
+  isGatewayValid = (): boolean => {
+    // gwHostsValid is used as last validation, it's true by default
+    return this.state.gwHostsValid;
+  };
+
+  render() {
+    return (
+      <Form isHorizontal={true}>
+        <FormGroup label="Add Gateway" fieldId="gatewaySwitch">
+          <Switch
+            id="advanced-gwSwitch"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addGateway}
+            onChange={() => this.onFormChange(K8sGatewayForm.SWITCH, '')}
+          />
+          <span>{wizardTooltip(GATEWAY_TOOLTIP)}</span>
+        </FormGroup>
+        {this.state.addGateway && (
+          <>
+            <FormGroup fieldId="selectGateway">
+              <Radio
+                id="existingK8sGateway"
+                name="selectGateway"
+                label="Select K8s API Gateway"
+                isDisabled={!this.state.addGateway || this.props.k8sGateways.length === 0}
+                isChecked={this.state.selectK8sGateway}
+                onChange={() => this.onFormChange(K8sGatewayForm.SELECT_K8S, '')}
+              />
+              <Radio
+                id="createK8sGateway"
+                name="selectGateway"
+                label="Create K8s API Gateway"
+                isDisabled={!this.state.addGateway}
+                isChecked={this.state.newK8sGateway}
+                onChange={() => this.onFormChange(K8sGatewayForm.NEW_K8S_GW, '')}
+              />
+            </FormGroup>
+            {this.state.addGateway && this.state.selectK8sGateway && (
+              <FormGroup fieldId="selectK8sGateway" label="K8s Gateway">
+                {this.props.k8sGateways.length > 0 && (
+                  <FormSelect
+                    id="selectK8sGateway"
+                    value={this.state.selectedK8sGateway}
+                    isDisabled={this.props.k8sGateways.length === 0}
+                    onChange={(gw: string) => this.onFormChange(K8sGatewayForm.K8S_GATEWAY_SELECTED, gw)}
+                  >
+                    {this.props.k8sGateways.map(gw => (
+                      <FormSelectOption key={gw} value={gw} label={gw} />
+                    ))}
+                  </FormSelect>
+                )}
+                {this.props.gateways.length === 0 && <>There are no K8s API gateways to select.</>}
+              </FormGroup>
+            )}
+            {this.state.newK8sGateway && (
+              <>
+                <FormGroup fieldId="gwPort" label="Port">
+                  <TextInput
+                    id="gwPort"
+                    name="gwPort"
+                    type="number"
+                    isDisabled={!this.state.addGateway || !this.state.newK8sGateway}
+                    value={this.state.port}
+                    onChange={value => this.onFormChange(K8sGatewayForm.PORT, value)}
+                  />
+                </FormGroup>
+                {this.state.newK8sGateway && (
+                  <FormGroup
+                    fieldId="gwHosts"
+                    label="K8s API Gateway Host"
+                    helperText="One host exposed by this gateway."
+                    helperTextInvalid="K8s API Gateway host should be specified using FQDN format or '*' wildcard."
+                    validated={isValid(this.state.gwHostsValid)}
+                  >
+                    <TextInput
+                      id="gwHosts"
+                      name="gwHosts"
+                      isDisabled={!this.state.addGateway || !this.state.newK8sGateway}
+                      value={this.state.gwHosts}
+                      onChange={value => this.onFormChange(K8sGatewayForm.GW_HOSTS, value)}
+                      validated={isValid(this.state.gwHostsValid)}
+                    />
+                  </FormGroup>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </Form>
+    );
+  }
+}
+
+export default K8sGatewaySelector;

--- a/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
+++ b/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
@@ -15,7 +15,7 @@ type Props = {
   serviceName: string;
   hasGateway: boolean;
   gateway: string;
-  gateways: string[];
+  k8sGateways: string[];
   k8sRouteHosts: string[];
   onGatewayChange: (valid: boolean, gateway: K8sGatewaySelectorState) => void;
 };
@@ -44,10 +44,10 @@ class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelectorState>
     super(props);
     this.state = {
       addGateway: props.hasGateway,
-      gwHosts: '*',
+      gwHosts: props.k8sRouteHosts.join(','),
       gwHostsValid: true,
-      newGateway: props.gateways.length === 0,
-      selectedGateway: props.gateways.length > 0 ? (props.gateway !== '' ? props.gateway : props.gateways[0]) : '',
+      newGateway: props.k8sGateways.length === 0,
+      selectedGateway: props.k8sGateways.length > 0 ? (props.gateway !== '' ? props.gateway : props.k8sGateways[0]) : '',
       addMesh: false,
       port: 80
     };
@@ -141,7 +141,7 @@ class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelectorState>
                 id="existingGateway"
                 name="selectGateway"
                 label="Select K8s API Gateway"
-                isDisabled={!this.state.addGateway || this.props.gateways.length === 0}
+                isDisabled={!this.state.addGateway || this.props.k8sGateways.length === 0}
                 isChecked={!this.state.newGateway}
                 onChange={() => this.onFormChange(K8sGatewayForm.SELECT, 'false')}
               />
@@ -156,19 +156,19 @@ class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelectorState>
             </FormGroup>
             {!this.state.newGateway && (
               <FormGroup fieldId="selectGateway" label="K8sGateway">
-                {this.props.gateways.length > 0 && (
+                {this.props.k8sGateways.length > 0 && (
                   <FormSelect
                     id="selectGateway"
                     value={this.state.selectedGateway}
-                    isDisabled={!this.state.addGateway || this.state.newGateway || this.props.gateways.length === 0}
-                    onChange={(gw: string) => this.onFormChange(K8sGatewayForm.GATEWAY_SELECTED, gw)}
+                    isDisabled={!this.state.addGateway || this.state.newGateway || this.props.k8sGateways.length === 0}
+                    onChange={(k8sGateway: string) => this.onFormChange(K8sGatewayForm.GATEWAY_SELECTED, k8sGateway)}
                   >
-                    {this.props.gateways.map(gw => (
-                      <FormSelectOption key={gw} value={gw} label={gw} />
+                    {this.props.k8sGateways.map(k8sGateway => (
+                      <FormSelectOption key={k8sGateway} value={k8sGateway} label={k8sGateway} />
                     ))}
                   </FormSelect>
                 )}
-                {this.props.gateways.length === 0 && <>There are no K8s API gateways to select.</>}
+                {this.props.k8sGateways.length === 0 && <>There are no K8s API gateways to select.</>}
               </FormGroup>
             )}
             {this.state.newGateway && (
@@ -187,7 +187,7 @@ class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelectorState>
                   fieldId="gwHosts"
                   label="K8s API Gateway Hosts"
                   helperText="One or more hosts exposed by this gateway. Enter one or multiple hosts separated by comma."
-                  helperTextInvalid="K8s API Gateway hosts should be specified using FQDN format or '*' wildcard."
+                  helperTextInvalid="K8s API Gateway hosts should be specified using FQDN format or '*.' format."
                   validated={isValid(this.state.gwHostsValid)}
                 >
                   <TextInput

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -36,7 +36,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
     this.state = {
       category: PATH,
       operator: EXACT,
-      backendRefs: getDefaultBackendRefs(this.props.workloads),
+      backendRefs: getDefaultBackendRefs(this.props.workloads, this.props.serviceName),
       matches: [],
       headerName: '',
       queryParamName: '',
@@ -279,7 +279,6 @@ class K8sRequestRouting extends React.Component<Props, State> {
           onAddMatch={this.onAddMatch}
           matches={this.state.matches}
           onRemoveMatch={this.onRemoveMatch}
-          workloads={this.props.workloads}
           backendRefs={this.state.backendRefs}
           validationMsg={this.state.validationMsg}
           onAddRule={this.onAddK8sRule}

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -1,0 +1,330 @@
+import * as React from 'react';
+import { WorkloadOverview } from '../../types/ServiceInfo';
+import K8sRules, { MOVE_TYPE, Rule } from './K8sRequestRouting/K8sRules';
+import K8sRuleBuilder from './K8sRequestRouting/K8sRuleBuilder';
+import { ANYTHING, EXACT, HEADERS, PRESENCE, REGEX } from './RequestRouting/MatchBuilder';
+import { MSG_WEIGHTS_NOT_VALID, WorkloadWeight } from './TrafficShifting';
+import { getDefaultWeights } from './WizardActions';
+import { FaultInjectionRoute } from './FaultInjection';
+import { TimeoutRetryRoute } from './RequestTimeouts';
+
+type Props = {
+  serviceName: string;
+  workloads: WorkloadOverview[];
+  initRules: Rule[];
+  onChange: (valid: boolean, rules: Rule[]) => void;
+};
+
+type State = {
+  category: string;
+  operator: string;
+  workloadWeights: WorkloadWeight[];
+  matches: string[];
+  headerName: string;
+  matchValue: string;
+  faultInjectionRoute: FaultInjectionRoute;
+  timeoutRetryRoute: TimeoutRetryRoute;
+  rules: Rule[];
+  validationMsg: string;
+};
+
+const MSG_SAME_MATCHING = 'A Rule with same matching criteria is already added.';
+const MSG_HEADER_NAME_NON_EMPTY = 'Header name must be non empty';
+const MSG_HEADER_VALUE_NON_EMPTY = 'Header value must be non empty';
+
+class K8sRequestRouting extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      category: HEADERS,
+      operator: PRESENCE,
+      workloadWeights: getDefaultWeights(this.props.workloads),
+      faultInjectionRoute: {
+        workloads: [],
+        delayed: false,
+        delay: {
+          percentage: {
+            value: 100
+          },
+          fixedDelay: '5s'
+        },
+        isValidDelay: true,
+        aborted: false,
+        abort: {
+          percentage: {
+            value: 100
+          },
+          httpStatus: 503
+        },
+        isValidAbort: true
+      },
+      timeoutRetryRoute: {
+        workloads: [],
+        isTimeout: false,
+        timeout: '2s',
+        isValidTimeout: true,
+        isRetry: false,
+        retries: {
+          attempts: 3,
+          perTryTimeout: '2s',
+          retryOn: 'gateway-error,connect-failure,refused-stream'
+        },
+        isValidRetry: true
+      },
+      matches: [],
+      headerName: '',
+      matchValue: '',
+      rules: this.props.initRules,
+      validationMsg: ''
+    };
+  }
+
+  isMatchesIncluded = (rules: Rule[], rule: Rule) => {
+    let found = false;
+    for (let i = 0; i < rules.length; i++) {
+      const item = rules[i];
+      if (item.matches.length !== rule.matches.length) {
+        continue;
+      }
+      found = item.matches.every(value => rule.matches.includes(value));
+      if (found) {
+        break;
+      }
+    }
+    return found;
+  };
+
+  isValid = (rules: Rule[]): boolean => {
+    // Corner case, an empty rules shouldn't be a valid scenario to create a VS/DR
+    if (rules.length === 0) {
+      return false;
+    }
+    const matchAll: number = this.matchAllIndex(rules);
+    let isValid: boolean = true;
+    for (let index = 0; index < this.state.rules.length; index++) {
+      isValid = matchAll === -1 || index <= matchAll;
+      if (!isValid) {
+        return isValid;
+      }
+    }
+    return isValid;
+  };
+
+  onAddMatch = () => {
+    this.setState(prevState => {
+      let newMatch: string;
+      if (this.state.matchValue !== '') {
+        newMatch =
+          prevState.category +
+          (prevState.category === HEADERS ? ' [' + prevState.headerName + '] ' : ' ') +
+          prevState.operator +
+          ' ' +
+          prevState.matchValue;
+      } else {
+        newMatch = prevState.category + ' [' + prevState.headerName + '] ' + REGEX + ' ' + ANYTHING;
+      }
+      if (!prevState.matches.includes(newMatch)) {
+        prevState.matches.push(newMatch);
+      }
+      return {
+        matches: prevState.matches,
+        headerName: '',
+        matchValue: ''
+      };
+    });
+  };
+
+  onAddRule = () => {
+    this.setState(
+      prevState => {
+        const newWorkloadWeights: WorkloadWeight[] = [];
+        prevState.workloadWeights.forEach(ww =>
+          newWorkloadWeights.push({
+            name: ww.name,
+            weight: ww.weight,
+            locked: ww.locked,
+            maxWeight: ww.maxWeight,
+            mirrored: ww.mirrored
+          })
+        );
+        const newRule: Rule = {
+          matches: Object.assign([], prevState.matches),
+          workloadWeights: newWorkloadWeights
+        };
+        if (prevState.faultInjectionRoute.delayed && prevState.faultInjectionRoute.isValidDelay) {
+          newRule.delay = prevState.faultInjectionRoute.delay;
+        }
+        if (prevState.faultInjectionRoute.aborted && prevState.faultInjectionRoute.isValidAbort) {
+          newRule.abort = prevState.faultInjectionRoute.abort;
+        }
+        if (prevState.timeoutRetryRoute.isTimeout && prevState.timeoutRetryRoute.isValidTimeout) {
+          newRule.timeout = prevState.timeoutRetryRoute.timeout;
+        }
+        if (prevState.timeoutRetryRoute.isRetry && prevState.timeoutRetryRoute.isValidRetry) {
+          newRule.retries = prevState.timeoutRetryRoute.retries;
+        }
+        if (!this.isMatchesIncluded(prevState.rules, newRule)) {
+          prevState.rules.push(newRule);
+          return {
+            matches: prevState.matches,
+            headerName: prevState.headerName,
+            matchValue: prevState.matchValue,
+            rules: prevState.rules,
+            validationMsg: '',
+            faultInjectionRoute: prevState.faultInjectionRoute,
+            timeoutRetryRoute: prevState.timeoutRetryRoute
+          };
+        } else {
+          return {
+            matches: prevState.matches,
+            headerName: prevState.headerName,
+            matchValue: prevState.matchValue,
+            rules: prevState.rules,
+            validationMsg: MSG_SAME_MATCHING,
+            faultInjectionRoute: prevState.faultInjectionRoute,
+            timeoutRetryRoute: prevState.timeoutRetryRoute
+          };
+        }
+      },
+      () => this.props.onChange(this.isValid(this.state.rules), this.state.rules)
+    );
+  };
+
+  onRemoveMatch = (matchToRemove: string) => {
+    this.setState(prevState => {
+      return {
+        matches: prevState.matches.filter(m => matchToRemove !== m),
+        validationMsg: prevState.validationMsg === MSG_SAME_MATCHING ? '' : prevState.validationMsg
+      };
+    });
+  };
+
+  onRemoveRule = (index: number) => {
+    this.setState(
+      prevState => {
+        prevState.rules.splice(index, 1);
+        return {
+          rules: prevState.rules,
+          validationMsg: ''
+        };
+      },
+      () => this.props.onChange(this.isValid(this.state.rules), this.state.rules)
+    );
+  };
+
+  onHeaderNameChange = (headerName: string) => {
+    let validationMsg = '';
+    if (this.state.matchValue !== '' && headerName === '') {
+      validationMsg = MSG_HEADER_NAME_NON_EMPTY;
+    }
+    if (this.state.matchValue === '' && headerName !== '' && this.state.operator !== PRESENCE) {
+      validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
+    }
+    this.setState({
+      headerName: headerName,
+      validationMsg: validationMsg
+    });
+  };
+
+  onMatchValueChange = (matchValue: string) => {
+    let validationMsg = '';
+    if (this.state.category === HEADERS) {
+      if (this.state.headerName === '' && matchValue !== '') {
+        validationMsg = MSG_HEADER_NAME_NON_EMPTY;
+      }
+      if (this.state.headerName !== '' && matchValue === '') {
+        validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
+      }
+    }
+    if (matchValue === '') {
+      validationMsg = '';
+    }
+    this.setState({
+      matchValue: matchValue,
+      validationMsg: validationMsg
+    });
+  };
+
+  onSelectWeights = (valid: boolean, workloads: WorkloadWeight[]) => {
+    this.setState({
+      workloadWeights: workloads,
+      validationMsg: !valid ? MSG_WEIGHTS_NOT_VALID : ''
+    });
+  };
+
+  onMoveRule = (index: number, move: MOVE_TYPE) => {
+    this.setState(
+      prevState => {
+        const sourceRule = prevState.rules[index];
+        const targetIndex = move === MOVE_TYPE.UP ? index - 1 : index + 1;
+        const targetRule = prevState.rules[targetIndex];
+        prevState.rules[targetIndex] = sourceRule;
+        prevState.rules[index] = targetRule;
+        return {
+          rules: prevState.rules
+        };
+      },
+      () => this.props.onChange(this.isValid(this.state.rules), this.state.rules)
+    );
+  };
+
+  matchAllIndex = (rules: Rule[]): number => {
+    let matchAll: number = -1;
+    for (let index = 0; index < rules.length; index++) {
+      const rule = rules[index];
+      if (rule.matches.length === 0) {
+        matchAll = index;
+        break;
+      }
+    }
+    return matchAll;
+  };
+
+  componentDidMount() {
+    if (this.props.initRules.length > 0) {
+      this.setState(
+        {
+          rules: this.props.initRules
+        },
+        () => this.props.onChange(this.isValid(this.state.rules), this.state.rules)
+      );
+    }
+  }
+
+  render() {
+    return (
+      <>
+        <K8sRuleBuilder
+          category={this.state.category}
+          operator={this.state.operator}
+          headerName={this.state.headerName}
+          matchValue={this.state.matchValue}
+          isValid={this.state.validationMsg === ''}
+          onSelectCategory={(category: string) => {
+            this.setState(prevState => {
+              // PRESENCE operator only applies to HEADERS
+              return {
+                category: category,
+                operator: prevState.operator === PRESENCE && category !== HEADERS ? EXACT : prevState.operator
+              };
+            });
+          }}
+          onHeaderNameChange={this.onHeaderNameChange}
+          onSelectOperator={(operator: string) => this.setState({ operator: operator })}
+          onMatchValueChange={this.onMatchValueChange}
+          onAddMatch={this.onAddMatch}
+          matches={this.state.matches}
+          onRemoveMatch={this.onRemoveMatch}
+          workloads={this.props.workloads}
+          weights={this.state.workloadWeights}
+          onSelectWeights={this.onSelectWeights}
+          validationMsg={this.state.validationMsg}
+          onAddRule={this.onAddRule}
+        />
+        <K8sRules rules={this.state.rules} onRemoveRule={this.onRemoveRule} onMoveRule={this.onMoveRule} />
+      </>
+    );
+  }
+}
+
+export default K8sRequestRouting;

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -85,9 +85,9 @@ class K8sRequestRouting extends React.Component<Props, State> {
       } else if (prevState.category === HEADERS) {
         newMatch = prevState.category + ' [' + prevState.headerName + '] ' + prevState.operator + ' ' + prevState.matchValue;
       } else if (prevState.category === QUERY_PARAMS) {
-        newMatch = prevState.category + ' [' + prevState.queryParamName + '] ' + prevState.operator + ' ' + prevState.matchValue;
+        newMatch = prevState.category + ' ' + prevState.queryParamName + ' ' + prevState.operator + ' ' + prevState.matchValue;
       } else {
-        newMatch = prevState.category + ' [' + prevState.operator + ']';
+        newMatch = prevState.category + ' ' + prevState.operator;
       }
       if (!prevState.matches.includes(newMatch)) {
         prevState.matches.push(newMatch);
@@ -95,6 +95,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
       return {
         matches: prevState.matches,
         headerName: '',
+        queryParamName: '',
         matchValue: ''
       };
     });
@@ -182,7 +183,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
       validationMsg = MSG_QUERY_VALUE_NON_EMPTY;
     }
     this.setState({
-      headerName: queryParamName,
+      queryParamName: queryParamName,
       validationMsg: validationMsg
     });
   };
@@ -198,10 +199,10 @@ class K8sRequestRouting extends React.Component<Props, State> {
       }
     }
     if (this.state.category === QUERY_PARAMS) {
-      if (this.state.headerName === '' && matchValue !== '') {
+      if (this.state.queryParamName === '' && matchValue !== '') {
         validationMsg = MSG_QUERY_NAME_NON_EMPTY;
       }
-      if (this.state.headerName !== '' && matchValue === '') {
+      if (this.state.queryParamName !== '' && matchValue === '') {
         validationMsg = MSG_QUERY_VALUE_NON_EMPTY;
       }
     }

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { WorkloadOverview } from '../../types/ServiceInfo';
 import K8sRules, { MOVE_TYPE, Rule } from './K8sRequestRouting/K8sRules';
 import K8sRuleBuilder from './K8sRequestRouting/K8sRuleBuilder';
-import { EXACT, PATH, PREFIX, ANYWHERE, HEADERS, QUERY_PARAMS } from './K8sRequestRouting/K8sMatchBuilder';
+import { EXACT, PATH, METHOD, GET, HEADERS, QUERY_PARAMS } from './K8sRequestRouting/K8sMatchBuilder';
 import { MSG_WEIGHTS_NOT_VALID, WorkloadWeight } from './TrafficShifting';
 import { getDefaultWeights } from './WizardActions';
 import { FaultInjectionRoute } from './FaultInjection';
@@ -117,15 +117,14 @@ class K8sRequestRouting extends React.Component<Props, State> {
   onAddMatch = () => {
     this.setState(prevState => {
       let newMatch: string;
-      if (this.state.matchValue !== '') {
-        newMatch =
-          prevState.category +
-          (prevState.category === HEADERS ? ' [' + prevState.headerName + '] ' : ' ') +
-          prevState.operator +
-          ' ' +
-          prevState.matchValue;
+      if (prevState.category === PATH) {
+        newMatch = prevState.category + ' ' + prevState.operator + ' ' + prevState.matchValue;
+      } else if (prevState.category === HEADERS) {
+        newMatch = prevState.category + ' [' + prevState.headerName + '] ' + prevState.operator + ' ' + prevState.matchValue;
+      } else if (prevState.category === QUERY_PARAMS) {
+        newMatch = prevState.category + ' [' + prevState.queryParamName + '] ' + prevState.operator + ' ' + prevState.matchValue;
       } else {
-        newMatch = prevState.category + ' [' + prevState.headerName + '] ' + PREFIX + ' ' + ANYWHERE;
+        newMatch = prevState.category + ' [' + prevState.operator + ']';
       }
       if (!prevState.matches.includes(newMatch)) {
         prevState.matches.push(newMatch);
@@ -328,10 +327,10 @@ class K8sRequestRouting extends React.Component<Props, State> {
           matchValue={this.state.matchValue}
           isValid={this.state.validationMsg === ''}
           onSelectCategory={(category: string) => {
-            this.setState(prevState => {
+            this.setState(_ => {
               return {
                 category: category,
-                operator: prevState.operator === EXACT && category !== PATH ? EXACT : prevState.operator
+                operator: category === METHOD ? GET : EXACT
               };
             });
           }}

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatchBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatchBuilder.tsx
@@ -36,24 +36,22 @@ export const METHOD = 'method';
 
 const matchOptions: string[] = [PATH, HEADERS, QUERY_PARAMS, METHOD];
 
-export const ANYWHERE = '/';
-
 export const EXACT = 'Exact';
 export const PREFIX = 'PathPrefix';
 export const REGEX = 'RegularExpression';
+export const GET = 'GET';
 
 const allOptions = {
   [PATH]: [EXACT, PREFIX, REGEX],
   [HEADERS]: [EXACT, REGEX],
   [QUERY_PARAMS]: [EXACT, REGEX],
-  [METHOD]: ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"]
+  [METHOD]: ["CONNECT", "DELETE", GET, "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"]
 };
 
 const placeholderText = {
   [PATH]: 'Path value...',
   [HEADERS]: 'Header value...',
   [QUERY_PARAMS]: 'Query param value...',
-  [METHOD]: 'Method value...'
 };
 
 class K8sMatchBuilder extends React.Component<Props, State> {
@@ -141,14 +139,13 @@ class K8sMatchBuilder extends React.Component<Props, State> {
             </DropdownItem>
           ))}
         />
-        {this.props.operator !== METHOD && (
-          <TextInput
-            id="match-value-id"
-            value={this.props.matchValue}
-            onChange={this.props.onMatchValueChange}
-            placeholder={placeholderText[this.props.category]}
-          />
-        )}
+        <TextInput
+          id="match-value-id"
+          value={this.props.matchValue}
+          onChange={this.props.onMatchValueChange}
+          placeholder={placeholderText[this.props.category]}
+          isDisabled={this.props.category === METHOD}
+        />
         <Button
           variant={ButtonVariant.secondary}
           disabled={!this.props.isValid}

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatchBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatchBuilder.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import {
+  Button,
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  InputGroup,
+  TextInput,
+  ButtonVariant
+} from '@patternfly/react-core';
+
+type Props = {
+  category: string;
+  operator: string;
+  headerName: string;
+  matchValue: string;
+  isValid: boolean;
+  onSelectCategory: (category: string) => void;
+  onHeaderNameChange: (headerName: string) => void;
+  onSelectOperator: (operator: string) => void;
+  onMatchValueChange: (matchValue: string) => void;
+  onAddMatch: () => void;
+};
+
+type State = {
+  isMatchDropdown: boolean;
+  isOperatorDropdown: boolean;
+};
+
+export const HEADERS = 'headers';
+export const URI = 'uri';
+export const SCHEME = 'scheme';
+export const METHOD = 'method';
+export const AUTHORITY = 'authority';
+
+const matchOptions: string[] = [HEADERS, URI, SCHEME, METHOD, AUTHORITY];
+
+export const EXACT = 'exact';
+export const PREFIX = 'prefix';
+export const REGEX = 'regex';
+
+// Pseudo operator
+export const PRESENCE = 'is present';
+export const ANYTHING = '^.*$';
+
+const opOptions: string[] = [EXACT, PREFIX, REGEX];
+
+const placeholderText = {
+  [HEADERS]: 'Header value...',
+  [URI]: 'Uri value...',
+  [SCHEME]: 'Scheme value...',
+  [METHOD]: 'Method value...',
+  [AUTHORITY]: 'Authority value...'
+};
+
+class K8sMatchBuilder extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isMatchDropdown: false,
+      isOperatorDropdown: false
+    };
+  }
+
+  onMathOptionsToggle = () => {
+    this.setState({
+      isMatchDropdown: !this.state.isMatchDropdown
+    });
+  };
+
+  onOperatorToggle = () => {
+    this.setState({
+      isOperatorDropdown: !this.state.isOperatorDropdown
+    });
+  };
+
+  render() {
+    const renderOpOptions: string[] = this.props.category === HEADERS ? [PRESENCE, ...opOptions] : opOptions;
+    return (
+      <InputGroup>
+        <Dropdown
+          toggle={
+            <DropdownToggle onToggle={this.onMathOptionsToggle} data-test={'requestmatching-header-toggle'}>
+              {this.props.category}
+            </DropdownToggle>
+          }
+          isOpen={this.state.isMatchDropdown}
+          dropdownItems={matchOptions.map((mode, index) => (
+            <DropdownItem
+              key={mode + '_' + index}
+              value={mode}
+              component="button"
+              onClick={() => {
+                this.props.onSelectCategory(mode);
+                this.onMathOptionsToggle();
+              }}
+              data-test={'requestmatching-header-' + mode}
+            >
+              {mode}
+            </DropdownItem>
+          ))}
+        />
+        {this.props.category === HEADERS && (
+          <TextInput
+            id="header-name-id"
+            value={this.props.headerName}
+            onChange={this.props.onHeaderNameChange}
+            placeholder="Header name..."
+          />
+        )}
+        <Dropdown
+          toggle={
+            <DropdownToggle onToggle={this.onOperatorToggle} data-test={'requestmatching-match-toggle'}>
+              {this.props.operator}
+            </DropdownToggle>
+          }
+          isOpen={this.state.isOperatorDropdown}
+          dropdownItems={renderOpOptions.map((op, index) => (
+            <DropdownItem
+              key={op + '_' + index}
+              value={op}
+              component="button"
+              onClick={() => {
+                this.props.onSelectOperator(op);
+                this.onOperatorToggle();
+              }}
+              data-test={'requestmatching-match-' + op}
+            >
+              {op}
+            </DropdownItem>
+          ))}
+        />
+        {this.props.operator !== PRESENCE && (
+          <TextInput
+            id="match-value-id"
+            value={this.props.matchValue}
+            onChange={this.props.onMatchValueChange}
+            placeholder={placeholderText[this.props.category]}
+          />
+        )}
+        <Button
+          variant={ButtonVariant.secondary}
+          disabled={!this.props.isValid}
+          onClick={this.props.onAddMatch}
+          data-test="add-match"
+        >
+          Add Match
+        </Button>
+      </InputGroup>
+    );
+  }
+}
+
+export default K8sMatchBuilder;

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatchBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatchBuilder.tsx
@@ -13,10 +13,12 @@ type Props = {
   category: string;
   operator: string;
   headerName: string;
+  queryParamName: string;
   matchValue: string;
   isValid: boolean;
   onSelectCategory: (category: string) => void;
   onHeaderNameChange: (headerName: string) => void;
+  onQueryParamNameChange: (queryParamName: string) => void;
   onSelectOperator: (operator: string) => void;
   onMatchValueChange: (matchValue: string) => void;
   onAddMatch: () => void;
@@ -27,30 +29,31 @@ type State = {
   isOperatorDropdown: boolean;
 };
 
+export const PATH = 'path';
 export const HEADERS = 'headers';
-export const URI = 'uri';
-export const SCHEME = 'scheme';
+export const QUERY_PARAMS = 'queryParams';
 export const METHOD = 'method';
-export const AUTHORITY = 'authority';
 
-const matchOptions: string[] = [HEADERS, URI, SCHEME, METHOD, AUTHORITY];
+const matchOptions: string[] = [PATH, HEADERS, QUERY_PARAMS, METHOD];
 
-export const EXACT = 'exact';
-export const PREFIX = 'prefix';
-export const REGEX = 'regex';
+export const ANYWHERE = '/';
 
-// Pseudo operator
-export const PRESENCE = 'is present';
-export const ANYTHING = '^.*$';
+export const EXACT = 'Exact';
+export const PREFIX = 'PathPrefix';
+export const REGEX = 'RegularExpression';
 
-const opOptions: string[] = [EXACT, PREFIX, REGEX];
+const allOptions = {
+  [PATH]: [EXACT, PREFIX, REGEX],
+  [HEADERS]: [EXACT, REGEX],
+  [QUERY_PARAMS]: [EXACT, REGEX],
+  [METHOD]: ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"]
+};
 
 const placeholderText = {
+  [PATH]: 'Path value...',
   [HEADERS]: 'Header value...',
-  [URI]: 'Uri value...',
-  [SCHEME]: 'Scheme value...',
-  [METHOD]: 'Method value...',
-  [AUTHORITY]: 'Authority value...'
+  [QUERY_PARAMS]: 'Query param value...',
+  [METHOD]: 'Method value...'
 };
 
 class K8sMatchBuilder extends React.Component<Props, State> {
@@ -75,7 +78,7 @@ class K8sMatchBuilder extends React.Component<Props, State> {
   };
 
   render() {
-    const renderOpOptions: string[] = this.props.category === HEADERS ? [PRESENCE, ...opOptions] : opOptions;
+    const renderOpOptions: string[] = allOptions[this.props.category]
     return (
       <InputGroup>
         <Dropdown
@@ -108,6 +111,14 @@ class K8sMatchBuilder extends React.Component<Props, State> {
             placeholder="Header name..."
           />
         )}
+        {this.props.category === QUERY_PARAMS && (
+          <TextInput
+            id="query-param-id"
+            value={this.props.queryParamName}
+            onChange={this.props.onQueryParamNameChange}
+            placeholder="Query param name..."
+          />
+        )}
         <Dropdown
           toggle={
             <DropdownToggle onToggle={this.onOperatorToggle} data-test={'requestmatching-match-toggle'}>
@@ -130,7 +141,7 @@ class K8sMatchBuilder extends React.Component<Props, State> {
             </DropdownItem>
           ))}
         />
-        {this.props.operator !== PRESENCE && (
+        {this.props.operator !== METHOD && (
           <TextInput
             id="match-value-id"
             value={this.props.matchValue}

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatches.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatches.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Chip } from '@patternfly/react-core';
+import { style } from 'typestyle';
+import { MATCHING_SELECTED_TOOLTIP, wizardTooltip } from '../WizardHelp';
+
+type Props = {
+  matches: string[];
+  onRemoveMatch: (match: string) => void;
+};
+
+const labelContainerStyle = style({
+  marginTop: 20,
+  height: 40
+});
+
+class K8sMatches extends React.Component<Props> {
+  render() {
+    const matches: any[] = this.props.matches.map((match, index) => (
+      <span key={match + '-' + index} data-test={match}>
+        <Chip onClick={() => this.props.onRemoveMatch(match)} isOverflowChip={true}>
+          {match}
+        </Chip>{' '}
+      </span>
+    ));
+    return (
+      <div className={labelContainerStyle}>
+        <span
+          style={{
+            marginRight: '32px'
+          }}
+        >
+          Matching selected
+          {wizardTooltip(MATCHING_SELECTED_TOOLTIP)}
+        </span>
+        {matches.length > 0 ? matches : <b>Match any request</b>}
+      </div>
+    );
+  }
+}
+
+export default K8sMatches;

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -4,7 +4,7 @@ import K8sMatchBuilder from './K8sMatchBuilder';
 import K8sMatches from './K8sMatches';
 import { style } from 'typestyle';
 import { WorkloadOverview } from '../../../types/ServiceInfo';
-import TrafficShifting, { WorkloadWeight } from '../TrafficShifting';
+import { WorkloadWeight } from '../TrafficShifting';
 import { PFColors } from '../../Pf/PfColors';
 
 type Props = {
@@ -80,21 +80,6 @@ class K8sRuleBuilder extends React.Component<Props, State> {
             <div style={{ marginTop: '20px' }}>
               <K8sMatchBuilder {...this.props} />
               <K8sMatches {...this.props} />
-            </div>
-          </Tab>
-          <Tab eventKey={1} title={'Route To'} data-test={'Route To'}>
-            <div
-              style={{
-                marginBottom: '10px'
-              }}
-            >
-              <TrafficShifting
-                showValid={false}
-                workloads={this.props.workloads}
-                initWeights={this.props.weights}
-                showMirror={true}
-                onChange={this.props.onSelectWeights}
-              />
             </div>
           </Tab>
         </Tabs>

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { Button, Tabs, Tab, ButtonVariant } from '@patternfly/react-core';
+import K8sMatchBuilder from './K8sMatchBuilder';
+import K8sMatches from './K8sMatches';
+import { style } from 'typestyle';
+import { WorkloadOverview } from '../../../types/ServiceInfo';
+import TrafficShifting, { WorkloadWeight } from '../TrafficShifting';
+import { PFColors } from '../../Pf/PfColors';
+
+type Props = {
+  // K8sMatchBuilder props
+  category: string;
+  operator: string;
+  headerName: string;
+  matchValue: string;
+  isValid: boolean;
+  onSelectCategory: (category: string) => void;
+  onHeaderNameChange: (headerName: string) => void;
+  onSelectOperator: (operator: string) => void;
+  onMatchValueChange: (matchValue: string) => void;
+  onAddMatch: () => void;
+
+  // K8sMatches props
+  matches: string[];
+  onRemoveMatch: (match: string) => void;
+
+  workloads: WorkloadOverview[];
+  weights: WorkloadWeight[];
+  onSelectWeights: (valid: boolean, workloads: WorkloadWeight[]) => void;
+
+  // K8sRuleBuilder
+  validationMsg: string;
+  onAddRule: () => void;
+};
+
+type State = {
+  isWorkloadSelector: boolean;
+  ruleTabKey: number;
+};
+
+const addRuleStyle = style({
+  width: '100%',
+  textAlign: 'right'
+});
+
+const validationStyle = style({
+  marginRight: 20,
+  color: PFColors.Red100,
+  display: 'inline'
+});
+
+class K8sRuleBuilder extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isWorkloadSelector: false,
+      ruleTabKey: 0
+    };
+  }
+
+  onWorkloadsToggle = () => {
+    this.setState({
+      isWorkloadSelector: !this.state.isWorkloadSelector
+    });
+  };
+
+  ruleHandleTabClick = (_event, tabIndex) => {
+    this.setState({
+      ruleTabKey: tabIndex
+    });
+  };
+
+  render() {
+    return (
+      <>
+        <Tabs isFilled={true} activeKey={this.state.ruleTabKey} onSelect={this.ruleHandleTabClick}>
+          <Tab eventKey={0} title={'Request Matching'} data-test={'Request Matching'}>
+            <div style={{ marginTop: '20px' }}>
+              <K8sMatchBuilder {...this.props} />
+              <K8sMatches {...this.props} />
+            </div>
+          </Tab>
+          <Tab eventKey={1} title={'Route To'} data-test={'Route To'}>
+            <div
+              style={{
+                marginBottom: '10px'
+              }}
+            >
+              <TrafficShifting
+                showValid={false}
+                workloads={this.props.workloads}
+                initWeights={this.props.weights}
+                showMirror={true}
+                onChange={this.props.onSelectWeights}
+              />
+            </div>
+          </Tab>
+        </Tabs>
+        <div className={addRuleStyle}>
+          <span>
+            {this.props.validationMsg.length > 0 && <div className={validationStyle}>{this.props.validationMsg}</div>}
+            <Button
+              variant={ButtonVariant.secondary}
+              isDisabled={!this.props.isValid}
+              onClick={this.props.onAddRule}
+              data-test="add-route"
+            >
+              Add Route Rule
+            </Button>
+          </span>
+        </div>
+      </>
+    );
+  }
+}
+
+export default K8sRuleBuilder;

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -3,7 +3,6 @@ import { Button, Tabs, Tab, ButtonVariant } from '@patternfly/react-core';
 import K8sMatchBuilder from './K8sMatchBuilder';
 import K8sMatches from './K8sMatches';
 import { style } from 'typestyle';
-import { WorkloadOverview } from '../../../types/ServiceInfo';
 import { PFColors } from '../../Pf/PfColors';
 
 type Props = {
@@ -25,7 +24,6 @@ type Props = {
   matches: string[];
   onRemoveMatch: (match: string) => void;
 
-  workloads: WorkloadOverview[];
   backendRefs: K8sRouteBackendRef[];
 
   // K8sRuleBuilder

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -4,7 +4,6 @@ import K8sMatchBuilder from './K8sMatchBuilder';
 import K8sMatches from './K8sMatches';
 import { style } from 'typestyle';
 import { WorkloadOverview } from '../../../types/ServiceInfo';
-import { WorkloadWeight } from '../TrafficShifting';
 import { PFColors } from '../../Pf/PfColors';
 
 type Props = {
@@ -27,12 +26,17 @@ type Props = {
   onRemoveMatch: (match: string) => void;
 
   workloads: WorkloadOverview[];
-  weights: WorkloadWeight[];
-  onSelectWeights: (valid: boolean, workloads: WorkloadWeight[]) => void;
+  backendRefs: K8sRouteBackendRef[];
 
   // K8sRuleBuilder
   validationMsg: string;
   onAddRule: () => void;
+};
+
+export type K8sRouteBackendRef = {
+  name: string;
+  weight?: number;
+  port?: number;
 };
 
 type State = {

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -12,10 +12,12 @@ type Props = {
   category: string;
   operator: string;
   headerName: string;
+  queryParamName: string;
   matchValue: string;
   isValid: boolean;
   onSelectCategory: (category: string) => void;
   onHeaderNameChange: (headerName: string) => void;
+  onQueryParamNameChange: (matchValue: string) => void;
   onSelectOperator: (operator: string) => void;
   onMatchValueChange: (matchValue: string) => void;
   onAddMatch: () => void;

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRules.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRules.tsx
@@ -1,0 +1,225 @@
+import * as React from 'react';
+import { cellWidth, ICell, Table, TableHeader, TableBody } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PFColors } from '../../Pf/PfColors';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Title,
+  TitleSizes,
+  TooltipPosition
+} from '@patternfly/react-core';
+import { WorkloadWeight } from '../TrafficShifting';
+import { Abort, Delay, HTTPRetry } from '../../../types/IstioObjects';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
+import { ROUTE_RULES_TOOLTIP, wizardTooltip } from '../WizardHelp';
+
+export enum MOVE_TYPE {
+  UP,
+  DOWN
+}
+
+export type Rule = {
+  matches: string[];
+  workloadWeights: WorkloadWeight[];
+  delay?: Delay;
+  abort?: Abort;
+  timeout?: string;
+  retries?: HTTPRetry;
+};
+
+type Props = {
+  rules: Rule[];
+  onRemoveRule: (index: number) => void;
+  onMoveRule: (index: number, move: MOVE_TYPE) => void;
+};
+
+const validationStyle = style({
+  marginTop: 15,
+  color: PFColors.Red100
+});
+
+const noRulesStyle = style({
+  marginTop: 15,
+  color: PFColors.Red100,
+  textAlign: 'center',
+  width: '100%'
+});
+
+class K8sRules extends React.Component<Props> {
+  matchAllIndex = (rules: Rule[]): number => {
+    let matchAll: number = -1;
+    for (let index = 0; index < rules.length; index++) {
+      const rule = rules[index];
+      if (rule.matches.length === 0) {
+        matchAll = index;
+        break;
+      }
+    }
+    return matchAll;
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Rule',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => this.props.onRemoveRule(rowIndex)
+    };
+    const moveUpAction = {
+      title: 'Move Up',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => this.props.onMoveRule(rowIndex, MOVE_TYPE.UP)
+    };
+    const moveDownAction = {
+      title: 'Move Down',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => this.props.onMoveRule(rowIndex, MOVE_TYPE.DOWN)
+    };
+
+    const actions: any[] = [];
+    if (this.props.rules.length > 0) {
+      actions.push(removeAction);
+    }
+    if (rowIndex > 0) {
+      actions.push(moveUpAction);
+    }
+    if (rowIndex + 1 < this.props.rules.length) {
+      actions.push(moveDownAction);
+    }
+    return actions;
+  };
+
+  render() {
+    // TODO: Casting 'as any' because @patternfly/react-table@2.22.19 has a typing bug. Remove the casting when PF fixes it.
+    // https://github.com/patternfly/patternfly-next/issues/2373
+    const headerCells: ICell[] = [
+      {
+        title: 'Rule order',
+        transforms: [cellWidth(10) as any],
+        props: {}
+      },
+      {
+        title: 'Request Matching',
+        props: {}
+      },
+      {
+        title: 'Route To',
+        props: {}
+      }
+    ];
+
+    let isValid: boolean = true;
+    const matchAll: number = this.matchAllIndex(this.props.rules);
+    const routeRules =
+      this.props.rules.length > 0
+        ? this.props.rules.map((rule, order) => {
+            isValid = matchAll === -1 || order <= matchAll;
+            return {
+              cells: [
+                <>{order + 1}</>,
+                <>
+                  {rule.matches.length === 0
+                    ? 'Any request'
+                    : rule.matches.map((match, i) => <div key={'match_' + i}>{match}</div>)}
+                  {!isValid && (
+                    <div className={validationStyle}>
+                      Match 'Any request' is defined in a previous rule.
+                      <br />
+                      This rule is not accessible.
+                    </div>
+                  )}
+                </>,
+                <>
+                  <div key={'ww_' + order}>
+                    {rule.workloadWeights
+                      .filter(wk => !wk.mirrored)
+                      .map((wk, i) => {
+                        return (
+                          <div key={'wk_' + order + '_' + wk.name + '_' + i}>
+                            <PFBadge badge={PFBadges.Workload} position={TooltipPosition.top} />
+                            {wk.name} ({wk.weight}% routed traffic)
+                          </div>
+                        );
+                      })}
+                    {rule.workloadWeights
+                      .filter(wk => wk.mirrored)
+                      .map((wk, i) => {
+                        return (
+                          <div key={'wk_mirrored_' + order + '_' + wk.name + '_' + i}>
+                            <PFBadge badge={PFBadges.MirroredWorkload} position={TooltipPosition.top} />
+                            {wk.name} ({wk.weight}% mirrored traffic)
+                          </div>
+                        );
+                      })}
+                  </div>
+                  {rule.delay && (
+                    <div key={'delay_' + order}>
+                      <PFBadge badge={PFBadges.FaultInjectionDelay} position={TooltipPosition.top} />
+                      {rule.delay.percentage?.value}% requests delayed ({rule.delay.fixedDelay})
+                    </div>
+                  )}
+                  {rule.abort && (
+                    <div key={'abort_' + order}>
+                      <PFBadge badge={PFBadges.FaultInjectionAbort} position={TooltipPosition.top} />
+                      {rule.abort.percentage?.value}% requests aborted (HTTP Status {rule.abort.httpStatus})
+                    </div>
+                  )}
+                  {rule.timeout && (
+                    <div key={'timeout_' + order}>
+                      <PFBadge badge={PFBadges.RequestTimeout} position={TooltipPosition.top} />
+                      timeout ({rule.timeout})
+                    </div>
+                  )}
+                  {rule.retries && (
+                    <div key={'retries_' + order}>
+                      <PFBadge badge={PFBadges.RequestRetry} position={TooltipPosition.top} />
+                      {rule.retries.attempts} attempts with timeout ({rule.timeout})
+                    </div>
+                  )}
+                </>
+              ]
+            };
+          })
+        : [
+            {
+              key: 'rowEmpty',
+              cells: [
+                {
+                  title: (
+                    <EmptyState variant={EmptyStateVariant.full}>
+                      <Title headingLevel="h5" size={TitleSizes.lg}>
+                        No K8s Route Rules defined
+                      </Title>
+                      <EmptyStateBody className={noRulesStyle}>
+                        A Request Routing scenario needs at least a Route Rule
+                      </EmptyStateBody>
+                    </EmptyState>
+                  ),
+                  props: { colSpan: 3 }
+                }
+              ]
+            }
+          ];
+
+    return (
+      <>
+        Route K8sRules
+        {wizardTooltip(ROUTE_RULES_TOOLTIP)}
+        <Table
+          aria-label="K8sRules Created"
+          cells={headerCells}
+          rows={routeRules}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+      </>
+    );
+  }
+}
+
+export default K8sRules;

--- a/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
+++ b/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
@@ -25,7 +25,7 @@ class K8sRouteHosts extends React.Component<Props> {
     return (
       <Form isHorizontal={true}>
         <FormGroup
-          label="K8s Route Hosts"
+          label="K8s HTTPRoute Hosts"
           fieldId="advanced-k8sRouteHosts"
           validated={isValid(this.isK8sRouteHostsValid(this.props.k8sRouteHosts))}
           helperText="The route hosts to which traffic is being sent. Enter one or multiple hosts separated by comma."

--- a/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
+++ b/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
@@ -25,10 +25,10 @@ class K8sRouteHosts extends React.Component<Props> {
     return (
       <Form isHorizontal={true}>
         <FormGroup
-          label="K8s Gateway API Route Hosts"
+          label="K8s Route Hosts"
           fieldId="advanced-k8sRouteHosts"
           validated={isValid(this.isK8sRouteHostsValid(this.props.k8sRouteHosts))}
-          helperText="The destination hosts to which traffic is being sent. Enter one or multiple hosts separated by comma."
+          helperText="The route hosts to which traffic is being sent. Enter one or multiple hosts separated by comma."
           helperTextInvalid={"IPs are not allowed. A hostname may be prefixed with a wildcard label (*.)"}
         >
           <TextInput

--- a/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
+++ b/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Form, FormGroup, TextInput } from '@patternfly/react-core';
+import { K8sGatewaySelectorState } from './K8sGatewaySelector';
+import { isValid } from 'utils/Common';
+import {isGatewayHostValid} from "../../utils/IstioConfigUtils";
+type Props = {
+  k8sRouteHosts: string[];
+  gateway?: K8sGatewaySelectorState;
+  onK8sRouteHostsChange: (valid: boolean, k8sRouteHosts: string[]) => void;
+};
+
+class K8sRouteHosts extends React.Component<Props> {
+  isK8sRouteHostsValid = (k8sRouteHosts: string[]): boolean => {
+    k8sRouteHosts.forEach(host => {
+      if (!isGatewayHostValid(host)) {
+        return false;
+      }
+      return true;
+    })
+    return true;
+  };
+
+  render() {
+    const k8sRouteHosts = this.props.k8sRouteHosts.length > 0 ? this.props.k8sRouteHosts.join(',') : '';
+    return (
+      <Form isHorizontal={true}>
+        <FormGroup
+          label="K8s Gateway API Route Hosts"
+          fieldId="advanced-k8sRouteHosts"
+          validated={isValid(this.isK8sRouteHostsValid(this.props.k8sRouteHosts))}
+          helperText="The destination hosts to which traffic is being sent. Enter one or multiple hosts separated by comma."
+          helperTextInvalid={"IPs are not allowed. A hostname may be prefixed with a wildcard label (*.)"}
+        >
+          <TextInput
+            value={k8sRouteHosts}
+            id="advanced-k8sRouteHosts"
+            name="advanced-k8sRouteHosts"
+            onChange={value => {
+              const k8sRouteHosts = value.split(',');
+              const isValid = this.isK8sRouteHostsValid(k8sRouteHosts);
+              this.props.onK8sRouteHostsChange(isValid, k8sRouteHosts);
+            }}
+          />
+        </FormGroup>
+      </Form>
+    );
+  }
+}
+
+export default K8sRouteHosts;

--- a/frontend/src/components/IstioWizards/RequestRouting/Matches.tsx
+++ b/frontend/src/components/IstioWizards/RequestRouting/Matches.tsx
@@ -13,10 +13,14 @@ const labelContainerStyle = style({
   height: 40
 });
 
+const remove = style({
+  cursor: "not-allowed"
+});
+
 class Matches extends React.Component<Props> {
   render() {
     const matches: any[] = this.props.matches.map((match, index) => (
-      <span key={match + '-' + index} data-test={match}>
+      <span key={match + '-' + index} data-test={match} className={remove}>
         <Chip onClick={() => this.props.onRemoveMatch(match)} isOverflowChip={true}>
           {match}
         </Chip>{' '}

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -328,8 +328,9 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
         const vs = this.state.previews!.vs;
         const gw = this.state.previews!.gw;
         const k8sgw = this.state.previews!.k8sgw;
-        const k8sroute = this.state.previews!.k8sroute;
+        const k8shttproute = this.state.previews!.k8shttproute;
         const pa = this.state.previews!.pa;
+        console.log('!!! onCreateUpdate '+JSON.stringify(this.state.previews))
         // Gateway is only created when user has explicit selected this option
         if (gw) {
           promises.push(API.createIstioConfigDetail(this.props.namespace, 'gateways', JSON.stringify(gw)));
@@ -349,9 +350,9 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
               API.updateIstioConfigDetail(this.props.namespace, 'virtualservices', vs.metadata.name, JSON.stringify(vs))
             );
           }
-          if (k8sroute) {
+          if (k8shttproute) {
             promises.push(
-              API.updateIstioConfigDetail(this.props.namespace, 'k8shttproutes', k8sroute.metadata.name, JSON.stringify(k8sroute))
+              API.updateIstioConfigDetail(this.props.namespace, 'k8shttproutes', k8shttproute.metadata.name, JSON.stringify(k8shttproute))
             );
           }
 
@@ -366,8 +367,8 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
           if (vs) {
             promises.push(API.createIstioConfigDetail(this.props.namespace, 'virtualservices', JSON.stringify(vs)));
           }
-          if (k8sroute) {
-            promises.push(API.createIstioConfigDetail(this.props.namespace, 'k8shttproutes', JSON.stringify(k8sroute)));
+          if (k8shttproute) {
+            promises.push(API.createIstioConfigDetail(this.props.namespace, 'k8shttproutes', JSON.stringify(k8shttproute)));
           }
 
           if (pa) {
@@ -600,6 +601,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
       },
       () => this.setState({ showPreview: true })
     );
+    console.log('!!!previews ' + this.state.previews)
   };
 
   onConfirmPreview = (items: ConfigPreviewItem[]) => {
@@ -608,16 +610,18 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
     const k8sgw = items.filter(it => it.type === 'k8sgateway')[0];
     const pa = items.filter(it => it.type === 'peerauthentications')[0];
     const vs = items.filter(it => it.type === 'virtualservice')[0];
-    const k8sroute = items.filter(it => it.type === 'k8shttproute')[0];
+    const k8shttproute = items.filter(it => it.type === 'k8shttproute')[0];
     const previews: WizardPreviews = {
       dr: dr ? (dr.items[0] as DestinationRule) : undefined,
       gw: gw ? (gw.items[0] as Gateway) : undefined,
       k8sgw: k8sgw ? (k8sgw.items[0] as K8sGateway) : undefined,
       pa: pa ? (pa.items[0] as PeerAuthentication) : undefined,
       vs: vs ? (vs.items[0] as VirtualService) : undefined,
-      k8sroute: k8sroute ? (k8sroute.items[0] as K8sHTTPRoute) : undefined
+      k8shttproute: k8shttproute ? (k8shttproute.items[0] as K8sHTTPRoute) : undefined
     };
+    console.log('!!!onConfirmPreview before ' + JSON.stringify(items))
     this.setState({ previews, showPreview: false, showWizard: false, confirmationModal: true });
+    console.log('!!!onConfirmPreview after ' + JSON.stringify(this.state.previews))
   };
 
   getItems = () => {
@@ -632,8 +636,9 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
       if (this.state.previews.k8sgw) {
         items.push({ type: 'k8sgwgateway', items: [this.state.previews.k8sgw], title: 'K8s Gateway' });
       }
-      if (this.state.previews.k8sroute) {
-        items.push({ type: 'k8sroute', items: [this.state.previews.k8sroute], title: 'K8s HTTPRoute' });
+      if (this.state.previews.k8shttproute) {
+        console.log('!!!k8shttproute' + this.state.previews.k8shttproute)
+        items.push({ type: 'k8shttproute', items: [this.state.previews.k8shttproute], title: 'K8s HTTPRoute' });
       }
       if (this.state.previews.pa) {
         items.push({ type: 'peerauthentications', items: [this.state.previews.pa], title: 'Peer Authentication' });

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -327,16 +327,15 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
         const dr = this.state.previews!.dr;
         const vs = this.state.previews!.vs;
         const gw = this.state.previews!.gw;
-        const k8sgw = this.state.previews!.k8sgw;
+        const k8sgateway = this.state.previews!.k8sgateway;
         const k8shttproute = this.state.previews!.k8shttproute;
         const pa = this.state.previews!.pa;
-        console.log('!!! onCreateUpdate '+JSON.stringify(this.state.previews))
         // Gateway is only created when user has explicit selected this option
         if (gw) {
           promises.push(API.createIstioConfigDetail(this.props.namespace, 'gateways', JSON.stringify(gw)));
         }
-        if (k8sgw) {
-          promises.push(API.createIstioConfigDetail(this.props.namespace, 'k8sgateways', JSON.stringify(k8sgw)));
+        if (k8sgateway) {
+          promises.push(API.createIstioConfigDetail(this.props.namespace, 'k8sgateways', JSON.stringify(k8sgateway)));
         }
 
         if (this.props.update) {
@@ -601,27 +600,24 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
       },
       () => this.setState({ showPreview: true })
     );
-    console.log('!!!previews ' + this.state.previews)
   };
 
   onConfirmPreview = (items: ConfigPreviewItem[]) => {
     const dr = items.filter(it => it.type === 'destinationrule')[0];
     const gw = items.filter(it => it.type === 'gateway')[0];
-    const k8sgw = items.filter(it => it.type === 'k8sgateway')[0];
+    const k8sgateway = items.filter(it => it.type === 'k8sgateway')[0];
     const pa = items.filter(it => it.type === 'peerauthentications')[0];
     const vs = items.filter(it => it.type === 'virtualservice')[0];
     const k8shttproute = items.filter(it => it.type === 'k8shttproute')[0];
     const previews: WizardPreviews = {
       dr: dr ? (dr.items[0] as DestinationRule) : undefined,
       gw: gw ? (gw.items[0] as Gateway) : undefined,
-      k8sgw: k8sgw ? (k8sgw.items[0] as K8sGateway) : undefined,
+      k8sgateway: k8sgateway ? (k8sgateway.items[0] as K8sGateway) : undefined,
       pa: pa ? (pa.items[0] as PeerAuthentication) : undefined,
       vs: vs ? (vs.items[0] as VirtualService) : undefined,
       k8shttproute: k8shttproute ? (k8shttproute.items[0] as K8sHTTPRoute) : undefined
     };
-    console.log('!!!onConfirmPreview before ' + JSON.stringify(items))
     this.setState({ previews, showPreview: false, showWizard: false, confirmationModal: true });
-    console.log('!!!onConfirmPreview after ' + JSON.stringify(this.state.previews))
   };
 
   getItems = () => {
@@ -633,11 +629,10 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
       if (this.state.previews.gw) {
         items.push({ type: 'gateway', items: [this.state.previews.gw], title: 'Gateway' });
       }
-      if (this.state.previews.k8sgw) {
-        items.push({ type: 'k8sgwgateway', items: [this.state.previews.k8sgw], title: 'K8s Gateway' });
+      if (this.state.previews.k8sgateway) {
+        items.push({ type: 'k8sgateway', items: [this.state.previews.k8sgateway], title: 'K8s Gateway' });
       }
       if (this.state.previews.k8shttproute) {
-        console.log('!!!k8shttproute' + this.state.previews.k8shttproute)
         items.push({ type: 'k8shttproute', items: [this.state.previews.k8shttproute], title: 'K8s HTTPRoute' });
       }
       if (this.state.previews.pa) {

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -135,7 +135,8 @@ const emptyServiceWizardState = (fqdnServiceName: string): ServiceWizardState =>
       addOutlierDetection: false,
       outlierDetection: {}
     },
-    gateway: undefined
+    gateway: undefined,
+    k8sGateway: undefined
   };
 };
 
@@ -242,8 +243,9 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
         addGateway: false,
         gwHosts: '',
         gwHostsValid: false,
-        newK8sGateway: false,
-        selectedK8sGateway: '',
+        newGateway: false,
+        selectedGateway: '',
+        addMesh: false,
         port: 80
       };
       if (hasGateway(this.props.virtualServices)) {
@@ -255,8 +257,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
       if (hasK8sGateway(this.props.k8sHTTPRoutes)) {
         const gatewaySelected = getInitK8sGateway(this.props.k8sHTTPRoutes);
         k8sGateway.addGateway = true;
-        k8sGateway.selectK8sGateway = true;
-        k8sGateway.selectedK8sGateway = gatewaySelected;
+        k8sGateway.selectedGateway = gatewaySelected;
       }
       this.setState({
         showWizard: this.props.show,
@@ -277,7 +278,8 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
             ? initVsHosts
             : [fqdnServiceName(this.props.serviceName, this.props.namespace)],
         trafficPolicy: trafficPolicy,
-        gateway: gateway
+        gateway: gateway,
+        k8sGateway: k8sGateway
       });
     }
   }
@@ -462,7 +464,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
         valid: prevState.valid,
         gateway: gateway,
         k8sRouteHosts:
-          gateway.addGateway && gateway.newK8sGateway && gateway.gwHosts.length > 0
+          gateway.addGateway && gateway.newGateway && gateway.gwHosts.length > 0
             ? gateway.gwHosts.split(',')
             : prevState.k8sRouteHosts
       };
@@ -736,11 +738,11 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
                     {this.props.type === WIZARD_K8S_TRAFFIC_SHIFTING && (
                       <K8sGatewaySelector
                         serviceName={this.props.serviceName}
-                        hasK8sGateway={hasK8sGateway(this.props.k8sHTTPRoutes)}
-                        k8sGateway={k8sGatewaySelected}
-                        k8sGateways={this.props.k8sGateways}
+                        hasGateway={hasK8sGateway(this.props.k8sHTTPRoutes)}
+                        gateway={k8sGatewaySelected}
+                        gateways={this.props.k8sGateways}
                         k8sRouteHosts={this.state.k8sRouteHosts}
-                        onK8sGatewayChange={this.onK8sGateway}
+                        onGatewayChange={this.onK8sGateway}
                       />
                     )}
                     {this.props.type !== WIZARD_K8S_TRAFFIC_SHIFTING && (

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -642,7 +642,6 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
         items.push({ type: 'virtualservice', items: [this.state.previews.vs], title: 'VirtualService' });
       }
     }
-
     return items;
   };
 
@@ -878,7 +877,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
                       serviceName={this.props.serviceName}
                       hasGateway={hasK8sGateway(this.props.k8sHTTPRoutes)}
                       gateway={k8sGatewaySelected}
-                      gateways={this.props.k8sGateways}
+                      k8sGateways={this.props.k8sGateways}
                       k8sRouteHosts={this.state.k8sRouteHosts}
                       onGatewayChange={this.onK8sGateway}
                     />

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -22,7 +22,7 @@ import {
   getInitFaultInjectionRoute,
   getInitGateway,
   getInitHosts,
-  getInitK8sGateway,
+  getInitK8sGateway, getInitK8sHosts,
   getInitLoadBalancer,
   getInitOutlierDetection,
   getInitPeerAuthentication,
@@ -115,7 +115,7 @@ const emptyServiceWizardState = (fqdnServiceName: string): ServiceWizardState =>
     },
     advancedOptionsValid: true,
     vsHosts: [fqdnServiceName],
-    k8sRouteHosts: [],
+    k8sRouteHosts: [fqdnServiceName],
     trafficPolicy: {
       tlsModified: false,
       mtlsMode: UNSET,
@@ -162,7 +162,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
           isMainWizardValid = true;
           break;
         case WIZARD_K8S_REQUEST_ROUTING:
-          isMainWizardValid = true;
+          isMainWizardValid = false;
           break;
         // By default no rules is a no valid scenario
         case WIZARD_REQUEST_ROUTING:
@@ -175,6 +175,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
           break;
       }
       const initVsHosts = getInitHosts(this.props.virtualServices);
+      const initK8sRoutes = getInitK8sHosts(this.props.k8sHTTPRoutes);
       const [initMtlsMode, initClientCertificate, initPrivateKey, initCaCertificates] = getInitTlsMode(
         this.props.destinationRules
       );
@@ -281,6 +282,9 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
           initVsHosts.length > 1 || (initVsHosts.length === 1 && initVsHosts[0].length > 0)
             ? initVsHosts
             : [fqdnServiceName(this.props.serviceName, this.props.namespace)],
+        k8sRouteHosts: initK8sRoutes.length > 1 || (initK8sRoutes.length === 1 && initK8sRoutes[0].length > 0)
+          ? initK8sRoutes
+          : [fqdnServiceName(this.props.serviceName, this.props.namespace)],
         trafficPolicy: trafficPolicy,
         gateway: gateway,
         k8sGateway: k8sGateway

--- a/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
@@ -53,8 +53,8 @@ const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = props 
   }
 
   const actionItems = SERVICE_WIZARD_ACTIONS.map(eventKey => {
-    const disabled = (eventKey === WIZARD_K8S_REQUEST_ROUTING ? !serverConfig.gatewayAPIEnabled : props.isDisabled);
-    const enabledItem = !disabled && (!hasTrafficRouting() || (hasTrafficRouting() && updateLabel === eventKey));
+    const enabled = (eventKey === WIZARD_K8S_REQUEST_ROUTING ? serverConfig.gatewayAPIEnabled && !props.isDisabled : !props.isDisabled);
+    const enabledItem = enabled && (!hasTrafficRouting() || (hasTrafficRouting() && updateLabel === eventKey));
     const wizardItem = (
       <DropdownItem key={eventKey} component="button" isDisabled={!enabledItem} onClick={() => handleActionClick(eventKey)} data-test={eventKey}>
         {WIZARD_TITLES[eventKey]}

--- a/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
@@ -1,7 +1,13 @@
 import * as React from "react";
 import { DropdownGroup, DropdownItem, DropdownSeparator, Tooltip, TooltipPosition } from "@patternfly/react-core";
 import {serverConfig} from "config";
-import { DestinationRule, getVirtualServiceUpdateLabel, VirtualService } from "types/IstioObjects";
+import {
+  DestinationRule,
+  getK8sHTTPRouteUpdateLabel,
+  getVirtualServiceUpdateLabel,
+  K8sHTTPRoute,
+  VirtualService
+} from "types/IstioObjects";
 import { canDelete, ResourcePermissions } from "types/Permissions";
 import { SERVICE_WIZARD_ACTIONS, WIZARD_TITLES, WizardAction, WizardMode } from "./WizardActions";
 import { hasServiceDetailsTrafficRouting } from "../../types/ServiceInfo";
@@ -12,16 +18,17 @@ type Props = {
   isDisabled?: boolean;
   destinationRules: DestinationRule[];
   virtualServices: VirtualService[];
+  k8sHTTPRoutes: K8sHTTPRoute[];
   istioPermissions: ResourcePermissions;
   onAction?: (key: WizardAction, mode: WizardMode) => void;
   onDelete?: (key: string) => void;
 }
 
 const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = props => {
-  const updateLabel = getVirtualServiceUpdateLabel(props.virtualServices);
+  const updateLabel = (props.virtualServices && props.virtualServices.length > 0) ? getVirtualServiceUpdateLabel(props.virtualServices) : getK8sHTTPRouteUpdateLabel(props.k8sHTTPRoutes);
 
   function hasTrafficRouting() {
-    return hasServiceDetailsTrafficRouting(props.virtualServices, props.destinationRules);
+    return hasServiceDetailsTrafficRouting(props.virtualServices, props.destinationRules, props.k8sHTTPRoutes);
   }
 
   function handleActionClick(eventKey: string) {

--- a/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
@@ -42,19 +42,21 @@ const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = props 
     }
   }
 
-  function getDropdownItemTooltipMessage(): string {
+  function getDropdownItemTooltipMessage(isGatewayAPI: boolean): string {
     if (serverConfig.deployment.viewOnlyMode) {
       return 'User does not have permission';
     } else if (hasTrafficRouting()) {
       return 'Traffic routing already exists for this service';
+    } else if (isGatewayAPI) {
+      return "K8s Gateway API is not enabled";
     } else {
       return "Traffic routing doesn't exists for this service";
     }
   }
 
   const actionItems = SERVICE_WIZARD_ACTIONS.map(eventKey => {
-    const enabled = (eventKey === WIZARD_K8S_REQUEST_ROUTING ? serverConfig.gatewayAPIEnabled && !props.isDisabled : !props.isDisabled);
-    const enabledItem = enabled && (!hasTrafficRouting() || (hasTrafficRouting() && updateLabel === eventKey));
+    const isGatewayAPIEnabled = (eventKey === WIZARD_K8S_REQUEST_ROUTING ? serverConfig.gatewayAPIEnabled : true)
+    const enabledItem = isGatewayAPIEnabled && !props.isDisabled && (!hasTrafficRouting() || (hasTrafficRouting() && updateLabel === eventKey));
     const wizardItem = (
       <DropdownItem key={eventKey} component="button" isDisabled={!enabledItem} onClick={() => handleActionClick(eventKey)} data-test={eventKey}>
         {WIZARD_TITLES[eventKey]}
@@ -67,7 +69,7 @@ const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = props 
     // Otherwise, the item should be disabled
     if (!enabledItem) {
       return (
-        <Tooltip key={'tooltip_' + eventKey} position={TooltipPosition.left} content={<>{getDropdownItemTooltipMessage()}</>}>
+        <Tooltip key={'tooltip_' + eventKey} position={TooltipPosition.left} content={<>{getDropdownItemTooltipMessage(!isGatewayAPIEnabled)}</>}>
           <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>{wizardItem}</div>
         </Tooltip>
       )
@@ -93,7 +95,7 @@ const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = props 
 
   if (deleteDisabled) {
     deleteDropdownItem = (
-      <Tooltip key={'tooltip_' + DELETE_TRAFFIC_ROUTING} position={TooltipPosition.left} content={<>{getDropdownItemTooltipMessage()}</>}>
+      <Tooltip key={'tooltip_' + DELETE_TRAFFIC_ROUTING} position={TooltipPosition.left} content={<>{getDropdownItemTooltipMessage(false)}</>}>
         <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>{deleteDropdownItem}</div>
       </Tooltip>
     );

--- a/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
@@ -41,7 +41,8 @@ const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = props 
   }
 
   const actionItems = SERVICE_WIZARD_ACTIONS.map(eventKey => {
-    const enabledItem = props.isDisabled || !hasTrafficRouting() || (hasTrafficRouting() && updateLabel === eventKey);
+    const disabled = (eventKey.includes('k8s') ? !serverConfig.gatewayAPIEnabled : props.isDisabled);
+    const enabledItem = disabled || !hasTrafficRouting() || (hasTrafficRouting() && updateLabel === eventKey);
     const wizardItem = (
       <DropdownItem key={eventKey} component="button" isDisabled={!enabledItem} onClick={() => handleActionClick(eventKey)} data-test={eventKey}>
         {WIZARD_TITLES[eventKey]}

--- a/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
@@ -3,8 +3,7 @@ import { DropdownGroup, DropdownItem, DropdownSeparator, Tooltip, TooltipPositio
 import {serverConfig} from "config";
 import {
   DestinationRule,
-  getK8sHTTPRouteUpdateLabel,
-  getVirtualServiceUpdateLabel,
+  getWizardUpdateLabel,
   K8sHTTPRoute,
   VirtualService
 } from "types/IstioObjects";
@@ -25,7 +24,7 @@ type Props = {
 }
 
 const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = props => {
-  const updateLabel = (props.virtualServices && props.virtualServices.length > 0) ? getVirtualServiceUpdateLabel(props.virtualServices) : getK8sHTTPRouteUpdateLabel(props.k8sHTTPRoutes);
+  const updateLabel = getWizardUpdateLabel(props.virtualServices, props.k8sHTTPRoutes);
 
   function hasTrafficRouting() {
     return hasServiceDetailsTrafficRouting(props.virtualServices, props.destinationRules, props.k8sHTTPRoutes);

--- a/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
@@ -8,7 +8,13 @@ import {
   VirtualService
 } from "types/IstioObjects";
 import { canDelete, ResourcePermissions } from "types/Permissions";
-import { SERVICE_WIZARD_ACTIONS, WIZARD_TITLES, WizardAction, WizardMode } from "./WizardActions";
+import {
+  SERVICE_WIZARD_ACTIONS,
+  WIZARD_K8S_REQUEST_ROUTING,
+  WIZARD_TITLES,
+  WizardAction,
+  WizardMode
+} from "./WizardActions";
 import { hasServiceDetailsTrafficRouting } from "../../types/ServiceInfo";
 
 export const DELETE_TRAFFIC_ROUTING = 'delete_traffic_routing';
@@ -47,8 +53,8 @@ const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = props 
   }
 
   const actionItems = SERVICE_WIZARD_ACTIONS.map(eventKey => {
-    const disabled = (eventKey.includes('k8s') ? !serverConfig.gatewayAPIEnabled : props.isDisabled);
-    const enabledItem = disabled || !hasTrafficRouting() || (hasTrafficRouting() && updateLabel === eventKey);
+    const disabled = (eventKey === WIZARD_K8S_REQUEST_ROUTING ? !serverConfig.gatewayAPIEnabled : props.isDisabled);
+    const enabledItem = !disabled && (!hasTrafficRouting() || (hasTrafficRouting() && updateLabel === eventKey));
     const wizardItem = (
       <DropdownItem key={eventKey} component="button" isDisabled={!enabledItem} onClick={() => handleActionClick(eventKey)} data-test={eventKey}>
         {WIZARD_TITLES[eventKey]}

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -10,7 +10,7 @@ import { WorkloadOverview } from '../../types/ServiceInfo';
 import {
   DestinationRule,
   DestinationRuleC,
-  getVirtualServiceUpdateLabel,
+  getWizardUpdateLabel,
   K8sHTTPRoute,
   PeerAuthentication,
   VirtualService
@@ -103,7 +103,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
   };
 
   onAction = (key: string) => {
-    const updateLabel = getVirtualServiceUpdateLabel(this.props.virtualServices);
+    const updateLabel = getWizardUpdateLabel(this.props.virtualServices, this.props.k8sHTTPRoutes);
     switch (key) {
       case WIZARD_REQUEST_ROUTING:
       case WIZARD_FAULT_INJECTION:

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -11,6 +11,7 @@ import {
   DestinationRule,
   DestinationRuleC,
   getVirtualServiceUpdateLabel,
+  K8sHTTPRoute,
   PeerAuthentication,
   VirtualService
 } from '../../types/IstioObjects';
@@ -39,6 +40,8 @@ type Props = {
   destinationRules: DestinationRule[];
   istioPermissions: ResourcePermissions;
   gateways: string[];
+  k8sGateways: string[];
+  k8sHTTPRoutes: K8sHTTPRoute[];
   peerAuthentications: PeerAuthentication[];
   tlsStatus?: TLSStatus;
   onChange: () => void;
@@ -218,6 +221,8 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
           virtualServices={this.props.virtualServices}
           destinationRules={this.props.destinationRules}
           gateways={this.props.gateways}
+          k8sGateways={this.props.k8sGateways}
+          k8sHTTPRoutes={this.props.k8sHTTPRoutes}
           peerAuthentications={this.props.peerAuthentications}
           tlsStatus={this.props.tlsStatus}
           onClose={this.onClose}

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -36,6 +36,7 @@ type Props = {
   namespace: string;
   serviceName: string;
   show: boolean;
+  readOnly: boolean;
   workloads: WorkloadOverview[];
   virtualServices: VirtualService[];
   destinationRules: DestinationRule[];
@@ -174,7 +175,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
     return [
       <ServiceWizardActionsDropdownGroup
         key="service_wizard_actions_dropdown_group"
-        isDisabled={this.state.isDeleting}
+        isDisabled={this.state.isDeleting || this.props.readOnly}
         virtualServices={this.props.virtualServices}
         destinationRules={this.props.destinationRules}
         k8sHTTPRoutes={this.props.k8sHTTPRoutes || []}

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -177,6 +177,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
         isDisabled={this.state.isDeleting}
         virtualServices={this.props.virtualServices}
         destinationRules={this.props.destinationRules}
+        k8sHTTPRoutes={this.props.k8sHTTPRoutes || []}
         istioPermissions={this.props.istioPermissions}
         onAction={this.onAction}
         onDelete={this.onAction}

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -24,7 +24,7 @@ import {
   WIZARD_TRAFFIC_SHIFTING,
   WIZARD_REQUEST_TIMEOUTS,
   WIZARD_TCP_TRAFFIC_SHIFTING,
-  WIZARD_K8S_TRAFFIC_SHIFTING
+  WIZARD_K8S_REQUEST_ROUTING
 } from './WizardActions';
 import ServiceWizard from './ServiceWizard';
 import { canCreate, canUpdate, ResourcePermissions } from '../../types/Permissions';
@@ -109,7 +109,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
       case WIZARD_FAULT_INJECTION:
       case WIZARD_TRAFFIC_SHIFTING:
       case WIZARD_TCP_TRAFFIC_SHIFTING:
-      case WIZARD_K8S_TRAFFIC_SHIFTING:
+      case WIZARD_K8S_REQUEST_ROUTING:
       case WIZARD_REQUEST_TIMEOUTS: {
         this.setState({ showWizard: true, wizardType: key, updateWizard: key === updateLabel });
         break;

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -23,7 +23,8 @@ import {
   WIZARD_FAULT_INJECTION,
   WIZARD_TRAFFIC_SHIFTING,
   WIZARD_REQUEST_TIMEOUTS,
-  WIZARD_TCP_TRAFFIC_SHIFTING
+  WIZARD_TCP_TRAFFIC_SHIFTING,
+  WIZARD_K8S_TRAFFIC_SHIFTING
 } from './WizardActions';
 import ServiceWizard from './ServiceWizard';
 import { canCreate, canUpdate, ResourcePermissions } from '../../types/Permissions';
@@ -108,6 +109,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
       case WIZARD_FAULT_INJECTION:
       case WIZARD_TRAFFIC_SHIFTING:
       case WIZARD_TCP_TRAFFIC_SHIFTING:
+      case WIZARD_K8S_TRAFFIC_SHIFTING:
       case WIZARD_REQUEST_TIMEOUTS: {
         this.setState({ showWizard: true, wizardType: key, updateWizard: key === updateLabel });
         break;

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -147,7 +147,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
       isDeleting: true
     });
     this.hideConfirmDelete();
-    deleteServiceTrafficRouting(this.props.virtualServices, DestinationRuleC.fromDrArray(this.props.destinationRules))
+    deleteServiceTrafficRouting(this.props.virtualServices, DestinationRuleC.fromDrArray(this.props.destinationRules), this.props.k8sHTTPRoutes)
       .then(_results => {
         this.setState({
           isDeleting: false
@@ -233,6 +233,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
         <ConfirmDeleteTrafficRoutingModal
           destinationRules={DestinationRuleC.fromDrArray(this.props.destinationRules)}
           virtualServices={this.props.virtualServices}
+          k8sHTTPRoutes={this.props.k8sHTTPRoutes}
           isOpen={this.state.showConfirmDelete}
           onCancel={this.hideConfirmDelete}
           onConfirm={this.onDelete}

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -54,7 +54,7 @@ export const WIZARD_REQUEST_ROUTING = 'request_routing';
 export const WIZARD_FAULT_INJECTION = 'fault_injection';
 export const WIZARD_REQUEST_TIMEOUTS = 'request_timeouts';
 
-export const WIZARD_K8S_TRAFFIC_SHIFTING = 'k8s_traffic_shifting';
+export const WIZARD_K8S_REQUEST_ROUTING = 'k8s_request_routing';
 
 export const WIZARD_ENABLE_AUTO_INJECTION = 'enable_auto_injection';
 export const WIZARD_DISABLE_AUTO_INJECTION = 'disable_auto_injection';
@@ -66,7 +66,7 @@ export const SERVICE_WIZARD_ACTIONS = [
   WIZARD_TRAFFIC_SHIFTING,
   WIZARD_TCP_TRAFFIC_SHIFTING,
   WIZARD_REQUEST_TIMEOUTS,
-  WIZARD_K8S_TRAFFIC_SHIFTING
+  WIZARD_K8S_REQUEST_ROUTING
 ];
 
 export type WizardAction =
@@ -83,7 +83,7 @@ export const WIZARD_TITLES = {
   [WIZARD_TRAFFIC_SHIFTING]: 'Traffic Shifting',
   [WIZARD_TCP_TRAFFIC_SHIFTING]: 'TCP Traffic Shifting',
   [WIZARD_REQUEST_TIMEOUTS]: 'Request Timeouts',
-  [WIZARD_K8S_TRAFFIC_SHIFTING]: 'K8s Traffic Shifting',
+  [WIZARD_K8S_REQUEST_ROUTING]: 'K8s Gateway API Routing',
 };
 
 export type ServiceWizardProps = {

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -78,7 +78,8 @@ export type WizardAction =
   | 'fault_injection'
   | 'traffic_shifting'
   | 'tcp_traffic_shifting'
-  | 'request_timeouts';
+  | 'request_timeouts'
+  | 'k8s_request_routing';
 export type WizardMode = 'create' | 'update';
 
 export const WIZARD_TITLES = {
@@ -123,7 +124,7 @@ export type WizardPreviews = {
   dr?: DestinationRule;
   vs?: VirtualService;
   gw?: Gateway;
-  k8sgw?: K8sGateway;
+  k8sgateway?: K8sGateway;
   k8shttproute?: K8sHTTPRoute;
   pa?: PeerAuthentication;
 };
@@ -880,8 +881,7 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
       }
     }
   }
-  console.log('RETURN ' + JSON.stringify(wizardK8sHTTPRoute))
-  return { dr: wizardDR, vs: wizardVS, gw: wizardGW, k8sgw: wizardK8sGW, pa: wizardPA, k8shttproute: wizardK8sHTTPRoute };
+  return { dr: wizardDR, vs: wizardVS, gw: wizardGW, k8sgateway: wizardK8sGW, pa: wizardPA, k8shttproute: wizardK8sHTTPRoute };
 };
 
 const getWorkloadsByVersion = (
@@ -902,11 +902,13 @@ const getWorkloadsByVersion = (
   return wkdVersionName;
 };
 
-export const getDefaultBackendRefs = (workloads: WorkloadOverview[]): K8sRouteBackendRef[] => {
+export const getDefaultBackendRefs = (workloads: WorkloadOverview[], serviceName: string): K8sRouteBackendRef[] => {
   const wkTraffic = workloads.length < 100 ? Math.floor(100 / workloads.length) : 0;
   const remainTraffic = workloads.length < 100 ? 100 % workloads.length : 0;
-  const backendRefs: K8sRouteBackendRef[] = workloads.map(workload => ({
-    name: workload.name,
+  const backendRefs: K8sRouteBackendRef[] = workloads.map(_ => ({
+    name: serviceName,
+    // @TODO add support of services per versions
+    //name: workload.name,
     weight: wkTraffic,
   }));
   if (remainTraffic > 0) {

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -274,7 +274,7 @@ const buildK8sHTTPMatchRequest = (matches: string[]): K8sHTTPRouteMatch[] => {
       // match follows format: <name> <op> <value>
       const i = match.indexOf(' ');
       const value = match.substring(i).trim();
-      matchRequests.push({method: {value: value}});
+      matchRequests.push({method: value});
     });
   return matchRequests;
 };
@@ -333,7 +333,7 @@ const parseK8sHTTPMatchRequest = (httpRouteMatch: K8sHTTPRouteMatch): string[] =
     })
   }
   if (httpRouteMatch.method) {
-    matches.push('method ' + httpRouteMatch.method.value);
+    matches.push('method ' + httpRouteMatch.method);
   }
 
   return matches;

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -320,9 +320,8 @@ const parseK8sHTTPMatchRequest = (httpRouteMatch: K8sHTTPRouteMatch): string[] =
   const matches: string[] = [];
   // Headers
   if (httpRouteMatch.headers) {
-    Object.keys(httpRouteMatch.headers).forEach(headerName => {
-      const value = httpRouteMatch.headers![headerName];
-      matches.push('headers [' + headerName + '] ' + value);
+    httpRouteMatch.headers.forEach(header => {
+      matches.push('headers [' + header.name + '] ' + header.type + ' ' + header.value);
     });
   }
   if (httpRouteMatch.path) {
@@ -1091,6 +1090,7 @@ export const getInitK8sRules = (
         httpRoute.backendRefs.forEach(bRef => {
           rule.backendRefs.push({
             name: bRef.name,
+            weight: !bRef.weight || bRef.weight === 1 ? 100 : bRef.weight
           });
         });
       }

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -34,6 +34,7 @@ import {
 } from '../../types/IstioObjects';
 import { serverConfig } from '../../config';
 import { GatewaySelectorState } from './GatewaySelector';
+import { K8sGatewaySelectorState } from './K8sGatewaySelector';
 import { ConsistentHashType, MUTUAL, TrafficPolicyState, UNSET } from './TrafficPolicy';
 import { GatewayState } from '../../pages/IstioConfigNew/GatewayForm';
 import { K8sGatewayState } from '../../pages/IstioConfigNew/K8sGatewayForm';
@@ -138,6 +139,7 @@ export type ServiceWizardState = {
   k8sRouteHosts: string[];
   trafficPolicy: TrafficPolicyState;
   gateway?: GatewaySelectorState;
+  k8sGateway?: K8sGatewaySelectorState;
 };
 
 export type WorkloadWizardValid = {};
@@ -366,7 +368,7 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
         }
       : undefined;
   const wizardK8sGW: K8sGateway | undefined =
-    wState.gateway && wState.gateway.addGateway && wState.gateway.newK8sGateway
+    wState.k8sGateway && wState.k8sGateway.addGateway && wState.k8sGateway.newGateway
       ? {
         kind: 'Gateway',
         apiVersion: GATEWAY_NETWORKING_VERSION,
@@ -384,8 +386,8 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
             {
               name: 'default',
               // here gwHosts for K8s API Gateway contains single host
-              hostname: wState.gateway.gwHosts,
-              port: wState.gateway.port,
+              hostname: wState.k8sGateway.gwHosts,
+              port: wState.k8sGateway.port,
               protocol: 'HTTP',
               allowedRoutes: {
                 namespaces: {

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -107,6 +107,7 @@ export type ServiceWizardProps = {
 export type ServiceWizardValid = {
   mainWizard: boolean;
   vsHosts: boolean;
+  k8sRouteHosts: boolean;
   tls: boolean;
   lb: boolean;
   gateway: boolean;

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -1100,6 +1100,19 @@ export const getInitHosts = (virtualServices: VirtualService[]): string[] => {
   return [];
 };
 
+export const getInitK8sHosts = (k8sHTTPRoutes: K8sHTTPRoute[]): string[] => {
+  if (
+    k8sHTTPRoutes &&
+    k8sHTTPRoutes.length === 1 &&
+    k8sHTTPRoutes[0] &&
+    k8sHTTPRoutes[0].spec.hostnames &&
+    k8sHTTPRoutes[0].spec.hostnames.length > 0
+  ) {
+    return k8sHTTPRoutes[0].spec.hostnames;
+  }
+  return [];
+};
+
 // VirtualServices added from the Kiali Wizard only support to add a single gateway
 // and optionally a mesh gateway.
 // This method returns a gateway selected by the user and if mesh is present

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -53,6 +53,8 @@ export const WIZARD_REQUEST_ROUTING = 'request_routing';
 export const WIZARD_FAULT_INJECTION = 'fault_injection';
 export const WIZARD_REQUEST_TIMEOUTS = 'request_timeouts';
 
+export const WIZARD_K8S_TRAFFIC_SHIFTING = 'k8s_traffic_shifting';
+
 export const WIZARD_ENABLE_AUTO_INJECTION = 'enable_auto_injection';
 export const WIZARD_DISABLE_AUTO_INJECTION = 'disable_auto_injection';
 export const WIZARD_REMOVE_AUTO_INJECTION = 'remove_auto_injection';
@@ -62,7 +64,8 @@ export const SERVICE_WIZARD_ACTIONS = [
   WIZARD_FAULT_INJECTION,
   WIZARD_TRAFFIC_SHIFTING,
   WIZARD_TCP_TRAFFIC_SHIFTING,
-  WIZARD_REQUEST_TIMEOUTS
+  WIZARD_REQUEST_TIMEOUTS,
+  WIZARD_K8S_TRAFFIC_SHIFTING
 ];
 
 export type WizardAction =
@@ -78,7 +81,8 @@ export const WIZARD_TITLES = {
   [WIZARD_FAULT_INJECTION]: 'Fault Injection',
   [WIZARD_TRAFFIC_SHIFTING]: 'Traffic Shifting',
   [WIZARD_TCP_TRAFFIC_SHIFTING]: 'TCP Traffic Shifting',
-  [WIZARD_REQUEST_TIMEOUTS]: 'Request Timeouts'
+  [WIZARD_REQUEST_TIMEOUTS]: 'Request Timeouts',
+  [WIZARD_K8S_TRAFFIC_SHIFTING]: 'K8s Traffic Shifting',
 };
 
 export type ServiceWizardProps = {

--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -165,6 +165,7 @@ type WizardsData = {
 
   // Data (payload) sent to the wizard or the confirm delete dialog
   gateways: string[];
+  k8sGateways: string[];
   peerAuthentications: PeerAuthentication[];
   namespace: string;
   serviceDetails?: ServiceDetailsInfo;
@@ -332,6 +333,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
         wizardType: '',
         updateMode: false,
         gateways: [],
+        k8sGateways: [],
         peerAuthentications: [],
         namespace: ''
       },
@@ -539,6 +541,8 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
           virtualServices={this.state.wizardsData.serviceDetails?.virtualServices || []}
           destinationRules={this.state.wizardsData.serviceDetails?.destinationRules || []}
           gateways={this.state.wizardsData.gateways || []}
+          k8sGateways={this.state.wizardsData.k8sGateways || []}
+          k8sHTTPRoutes={this.state.wizardsData.serviceDetails?.k8sHTTPRoutes || []}
           peerAuthentications={this.state.wizardsData.peerAuthentications || []}
           tlsStatus={this.state.wizardsData.serviceDetails?.namespaceMTLS}
           onClose={this.handleWizardClose}

--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -552,6 +552,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
             isOpen={true}
             destinationRules={DestinationRuleC.fromDrArray(this.state.wizardsData.serviceDetails!.destinationRules)}
             virtualServices={this.state.wizardsData.serviceDetails!.virtualServices}
+            k8sHTTPRoutes={this.state.wizardsData.serviceDetails!.k8sHTTPRoutes}
             onCancel={() => this.setState({showConfirmDeleteTrafficRouting: false})}
             onConfirm={this.handleConfirmDeleteServiceTrafficRouting} />
         )}

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -143,6 +143,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
           <ServiceWizardActionsDropdownGroup
             virtualServices={this.props.serviceDetails.virtualServices || []}
             destinationRules={this.props.serviceDetails.destinationRules || []}
+            k8sHTTPRoutes={this.props.serviceDetails.k8sHTTPRoutes || []}
             istioPermissions={this.props.serviceDetails.istioPermissions}
             onAction={this.handleLaunchWizard}
             onDelete={this.handleDeleteTrafficRouting} />

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -16,14 +16,14 @@ import TrafficDetails from 'components/TrafficList/TrafficDetails';
 import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
-import { ServiceDetailsInfo } from '../../types/ServiceInfo';
+import {getServiceWizardLabel, ServiceDetailsInfo} from '../../types/ServiceInfo';
 import {
   Gateway,
   K8sGateway,
   getGatewaysAsList,
   PeerAuthentication,
   Validations,
-  getK8sGatewaysAsList
+  getK8sGatewaysAsList,
 } from '../../types/IstioObjects';
 import ServiceWizardDropdown from '../../components/IstioWizards/ServiceWizardDropdown';
 import TimeControl from '../../components/Time/TimeControl';
@@ -208,6 +208,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         namespace={this.props.match.params.namespace}
         serviceName={this.state.serviceDetails.service.name}
         show={false}
+        readOnly={getServiceWizardLabel(this.state.serviceDetails.service) !== ''}
         workloads={this.state.serviceDetails.workloads || []}
         virtualServices={this.state.serviceDetails.virtualServices}
         k8sHTTPRoutes={this.state.serviceDetails.k8sHTTPRoutes}

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -17,7 +17,14 @@ import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
-import { Gateway, getGatewaysAsList, PeerAuthentication, Validations } from '../../types/IstioObjects';
+import {
+  Gateway,
+  K8sGateway,
+  getGatewaysAsList,
+  PeerAuthentication,
+  Validations,
+  getK8sGatewaysAsList
+} from '../../types/IstioObjects';
 import ServiceWizardDropdown from '../../components/IstioWizards/ServiceWizardDropdown';
 import TimeControl from '../../components/Time/TimeControl';
 import RenderHeaderContainer from "../../components/Nav/Page/RenderHeader";
@@ -28,6 +35,7 @@ import connectRefresh from "../../components/Refresh/connectRefresh";
 type ServiceDetailsState = {
   currentTab: string;
   gateways: Gateway[];
+  k8sGateways: K8sGateway[];
   serviceDetails?: ServiceDetailsInfo;
   peerAuthentications: PeerAuthentication[];
   validations: Validations;
@@ -59,6 +67,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
     this.state = {
       currentTab: activeTab(tabName, defaultTab),
       gateways: [],
+      k8sGateways: [],
       validations: {},
       peerAuthentications: []
     };
@@ -88,13 +97,16 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
   private fetchService = () => {
     this.promises.cancelAll();
     this.promises
-      .register('gateways', API.getAllIstioConfigs([], ['gateways'], false, '', ''))
+      .register('gateways', API.getAllIstioConfigs([], ['gateways', 'k8sgateways'], false, '', ''))
       .then(response => {
         const gws: Gateway[] = [];
+        const k8sGws: K8sGateway[] = [];
         Object.values(response.data).forEach(item => {
           gws.push(...item.gateways);
+          k8sGws.push(...item.k8sGateways);
         });
         this.setState({ gateways: gws });
+        this.setState({ k8sGateways: k8sGws });
       })
       .catch(gwError => {
         AlertUtils.addError('Could not fetch Gateways list.', gwError);
@@ -132,6 +144,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
           service={this.props.match.params.service}
           serviceDetails={this.state.serviceDetails}
           gateways={this.state.gateways}
+          k8sGateways={this.state.k8sGateways}
           peerAuthentications={this.state.peerAuthentications}
           validations={this.state.validations}
         />
@@ -197,9 +210,11 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         show={false}
         workloads={this.state.serviceDetails.workloads || []}
         virtualServices={this.state.serviceDetails.virtualServices}
+        k8sHTTPRoutes={this.state.serviceDetails.k8sHTTPRoutes}
         destinationRules={this.state.serviceDetails.destinationRules}
         istioPermissions={this.state.serviceDetails.istioPermissions}
         gateways={getGatewaysAsList(this.state.gateways)}
+        k8sGateways={getK8sGatewaysAsList(this.state.k8sGateways)}
         peerAuthentications={this.state.peerAuthentications}
         tlsStatus={this.state.serviceDetails.namespaceMTLS}
         onChange={this.fetchService}

--- a/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -23,7 +23,7 @@ import {
   gwToIstioItems,
   seToIstioItems,
   k8sHTTPRouteToIstioItems,
-  validationKey
+  validationKey, k8sGwToIstioItems
 } from '../../types/IstioConfigList';
 import { canCreate, canUpdate } from "../../types/Permissions";
 import { KialiAppState } from '../../store/Store';
@@ -169,6 +169,13 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
             this.props.serviceDetails.validations
           )
         : [];
+    const k8sGwIstioConfigItems =
+      this.props?.k8sGateways && this.props.serviceDetails?.k8sHTTPRoutes
+        ? k8sGwToIstioItems(
+          this.props?.k8sGateways,
+          this.props.serviceDetails.k8sHTTPRoutes
+        )
+        : [];
     const seIstioConfigItems = this.props.serviceDetails?.serviceEntries
       ? seToIstioItems(this.props.serviceDetails.serviceEntries, this.props.serviceDetails.validations)
       : [];
@@ -176,7 +183,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
       ? k8sHTTPRouteToIstioItems(this.props.serviceDetails.k8sHTTPRoutes)
       : [];
     const istioConfigItems = seIstioConfigItems.concat(
-      gwIstioConfigItems.concat(vsIstioConfigItems.concat(drIstioConfigItems.concat(k8sHTTPRouteIstioConfigItems)))
+      gwIstioConfigItems.concat(k8sGwIstioConfigItems.concat(vsIstioConfigItems.concat(drIstioConfigItems.concat(k8sHTTPRouteIstioConfigItems))))
     );
 
     // RenderComponentScroll handles height to provide an inner scroll combined with tabs

--- a/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -247,6 +247,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
           <ConfirmDeleteTrafficRoutingModal
             destinationRules={DestinationRuleC.fromDrArray(this.props.serviceDetails!.destinationRules)}
             virtualServices={this.props.serviceDetails!.virtualServices}
+            k8sHTTPRoutes={this.props.serviceDetails!.k8sHTTPRoutes}
             isOpen={true}
             onCancel={() => this.setState({showConfirmDeleteTrafficRouting: false})}
             onConfirm={this.handleConfirmDeleteServiceTrafficRouting}

--- a/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -22,6 +22,7 @@ import {
   vsToIstioItems,
   gwToIstioItems,
   seToIstioItems,
+  k8sHTTPRouteToIstioItems,
   validationKey
 } from '../../types/IstioConfigList';
 import { canCreate, canUpdate } from "../../types/Permissions";
@@ -171,8 +172,11 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
     const seIstioConfigItems = this.props.serviceDetails?.serviceEntries
       ? seToIstioItems(this.props.serviceDetails.serviceEntries, this.props.serviceDetails.validations)
       : [];
+    const k8sHTTPRouteIstioConfigItems = this.props.serviceDetails?.k8sHTTPRoutes
+      ? k8sHTTPRouteToIstioItems(this.props.serviceDetails.k8sHTTPRoutes)
+      : [];
     const istioConfigItems = seIstioConfigItems.concat(
-      gwIstioConfigItems.concat(vsIstioConfigItems.concat(drIstioConfigItems))
+      gwIstioConfigItems.concat(vsIstioConfigItems.concat(drIstioConfigItems.concat(k8sHTTPRouteIstioConfigItems)))
     );
 
     // RenderComponentScroll handles height to provide an inner scroll combined with tabs

--- a/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -8,7 +8,7 @@ import { ServiceDetailsInfo } from '../../types/ServiceInfo';
 import {
   DestinationRuleC,
   Gateway,
-  getGatewaysAsList,
+  getGatewaysAsList, getK8sGatewaysAsList, K8sGateway,
   ObjectValidation,
   PeerAuthentication,
   Validations
@@ -44,6 +44,7 @@ interface Props extends ServiceId {
   mtlsEnabled: boolean;
   serviceDetails?: ServiceDetailsInfo;
   gateways: Gateway[];
+  k8sGateways: K8sGateway[];
   peerAuthentications: PeerAuthentication[];
   validations: Validations;
 }
@@ -225,6 +226,8 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
           virtualServices={this.props.serviceDetails?.virtualServices || []}
           destinationRules={this.props.serviceDetails?.destinationRules || []}
           gateways={getGatewaysAsList(this.props.gateways)}
+          k8sGateways={getK8sGatewaysAsList(this.props.k8sGateways)}
+          k8sHTTPRoutes={this.props.serviceDetails?.k8sHTTPRoutes || []}
           peerAuthentications={this.props.peerAuthentications}
           tlsStatus={this.props.serviceDetails?.namespaceMTLS}
           onClose={this.handleWizardClose}

--- a/frontend/src/services/__mockData__/getServiceDetail.ts
+++ b/frontend/src/services/__mockData__/getServiceDetail.ts
@@ -79,6 +79,7 @@ export const SERVICE_DETAILS: ServiceDetailsInfo = {
       }
     }
   ],
+  k8sHTTPRoutes: [],
   destinationRules: [
     {
       metadata: {

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -347,3 +347,26 @@ export const seToIstioItems = (see: ServiceEntry[], validations: Validations): I
   });
   return istioItems;
 };
+
+export const k8sHTTPRouteToIstioItems = (routes: K8sHTTPRoute[]): IstioConfigItem[] => {
+  const istioItems: IstioConfigItem[] = [];
+
+  const typeNameProto = dicIstioType['k8shttproutes']; // ex. serviceEntries -> ServiceEntry
+  const typeName = typeNameProto.toLowerCase(); // ex. ServiceEntry -> serviceentry
+  const entryName = typeNameProto.charAt(0).toLowerCase() + typeNameProto.slice(1);
+
+  routes.forEach(route => {
+    const item = {
+      namespace: route.metadata.namespace || '',
+      type: typeName,
+      name: route.metadata.name,
+      creationTimestamp: route.metadata.creationTimestamp,
+      resourceVersion: route.metadata.resourceVersion,
+      // @TODO Validations
+      validation: undefined
+    };
+    item[entryName] = route;
+    istioItems.push(item);
+  });
+  return istioItems;
+};

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -324,6 +324,42 @@ export const gwToIstioItems = (gws: Gateway[], vss: VirtualService[], validation
   return istioItems;
 };
 
+export const k8sGwToIstioItems = (gws: K8sGateway[], k8srs: K8sHTTPRoute[]): IstioConfigItem[] => {
+  const istioItems: IstioConfigItem[] = [];
+  const k8sGateways = new Set();
+
+  const typeNameProto = dicIstioType['k8sgateways']; // ex. serviceEntries -> ServiceEntry
+  const typeName = typeNameProto.toLowerCase(); // ex. ServiceEntry -> serviceentry
+  const entryName = typeNameProto.charAt(0).toLowerCase() + typeNameProto.slice(1);
+
+  k8srs.forEach(k8sr => {
+    k8sr.spec.parentRefs?.forEach(parentRef => {
+      if (!parentRef.namespace) {
+        k8sGateways.add(k8sr.metadata.namespace + '/' + parentRef.name);
+      } else {
+        k8sGateways.add(parentRef.namespace + '/' + parentRef.name);
+      }
+    });
+  });
+
+  gws.forEach(gw => {
+    if (k8sGateways.has(gw.metadata.namespace + '/' + gw.metadata.name)) {
+      const item = {
+        namespace: gw.metadata.namespace || '',
+        type: typeName,
+        name: gw.metadata.name,
+        creationTimestamp: gw.metadata.creationTimestamp,
+        resourceVersion: gw.metadata.resourceVersion,
+        // @TODO Validations
+        validation: undefined
+      };
+      item[entryName] = gw;
+      istioItems.push(item);
+    }
+  });
+  return istioItems;
+};
+
 export const seToIstioItems = (see: ServiceEntry[], validations: Validations): IstioConfigItem[] => {
   const istioItems: IstioConfigItem[] = [];
   const hasValidations = (vKey: string) => validations.serviceentry && validations.serviceentry[vKey];

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -814,7 +814,7 @@ export interface K8sHTTPRouteMatch {
   path?: HTTPMatch;
   headers?: HTTPMatch[];
   queryParams?: HTTPMatch[];
-  method?: HTTPMatch;
+  method?: string;
 }
 
 export interface HTTPMatch {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -754,7 +754,43 @@ export interface K8sGateway extends IstioObject {
 
 export interface K8sHTTPRouteSpec {
   parentRefs?: ParentRef[];
-  hostnames: string[];
+  hostnames?: string[];
+  rules?: K8sRouteRule[];
+}
+
+export interface K8sRouteRule {
+  matches?:     K8sHTTPRouteMatch[];
+  backendRefs?: K8sRouteBackendRef[];
+}
+
+export interface K8sRouteBackendRef {
+  name:       string;
+  weight?:    number;
+  port?:      number;
+  namespace?: string;
+  filters?:   K8sHTTPRouteFilter[];
+}
+
+export interface K8sHTTPRouteFilter {
+  requestRedirect?: K8sHTTPRouteRequestRedirect;
+  type?:            string;
+}
+
+export interface K8sHTTPRouteRequestRedirect {
+  statusCode?: number;
+}
+
+export interface K8sHTTPRouteMatch {
+  path?: HTTPMatch;
+  headers?: HTTPMatch[];
+  queryParams?: HTTPMatch[];
+  method?: HTTPMatch;
+}
+
+export interface HTTPMatch {
+  type?:  string;
+  name?: string;
+  value?: string;
 }
 
 export interface K8sHTTPRoute extends IstioObject {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -701,6 +701,14 @@ export function getGatewaysAsList(gws: Gateway[]): string[] {
   return gws.map(gateway => gateway.metadata.namespace + '/' + gateway.metadata.name).sort();
 }
 
+export function getK8sGatewaysAsList(k8sGws: K8sGateway[]): string[] {
+  if (k8sGws) {
+    return k8sGws.map(gateway => gateway.metadata.namespace + '/' + gateway.metadata.name).sort();
+  } else {
+    return []
+  }
+}
+
 // K8s Gateway API https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/
 
 export interface Listener {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -655,6 +655,14 @@ export interface VirtualService extends IstioObject {
   spec: VirtualServiceSpec;
 }
 
+export function getWizardUpdateLabel(vs: VirtualService | VirtualService[] | null, k8sr: K8sHTTPRoute | K8sHTTPRoute[] | null) {
+  let label = getVirtualServiceUpdateLabel(vs)
+  if (label === '') {
+    label = getK8sHTTPRouteUpdateLabel(k8sr)
+  }
+  return label
+}
+
 export function getVirtualServiceUpdateLabel(vs: VirtualService | VirtualService[] | null) {
   if (!vs) {
     return '';

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -677,6 +677,28 @@ export function getVirtualServiceUpdateLabel(vs: VirtualService | VirtualService
   }
 }
 
+export function getK8sHTTPRouteUpdateLabel(k8sr: K8sHTTPRoute | K8sHTTPRoute[] | null) {
+  if (!k8sr) {
+    return '';
+  }
+
+  let k8sHTTPRoute: K8sHTTPRoute | null = null;
+  if ('length' in k8sr) {
+    if (k8sr.length === 1) {
+      k8sHTTPRoute = k8sr[0];
+    }
+  } else {
+    k8sHTTPRoute = k8sr;
+  }
+
+  if (k8sHTTPRoute && k8sHTTPRoute.metadata.labels &&
+    k8sHTTPRoute.metadata.labels[KIALI_WIZARD_LABEL]) {
+    return k8sHTTPRoute.metadata.labels[KIALI_WIZARD_LABEL];
+  } else {
+    return '';
+  }
+}
+
 export interface K8sOwnerReference {
   apiVersion?: string;
   kind?: string;

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -1,7 +1,7 @@
 import { DEGRADED, FAILURE, HEALTHY, NA, ServiceHealth, Status } from './Health';
 import {
   DestinationRule,
-  getVirtualServiceUpdateLabel,
+  getVirtualServiceUpdateLabel, K8sHTTPRoute,
   ObjectCheck,
   ObjectValidation,
   ServiceEntry,
@@ -62,6 +62,7 @@ export interface ServiceDetailsInfo {
   endpoints?: Endpoints[];
   istioSidecar: boolean;
   virtualServices: VirtualService[];
+  k8sHTTPRoutes: K8sHTTPRoute[];
   destinationRules: DestinationRule[];
   serviceEntries: ServiceEntry[];
   istioPermissions: ResourcePermissions;

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -12,6 +12,7 @@ import {
 import { TLSStatus } from './TLSStatus';
 import { AdditionalItem } from './Workload';
 import { ResourcePermissions } from './Permissions';
+import {KIALI_WIZARD_LABEL} from "../components/IstioWizards/WizardActions";
 
 export interface ServicePort {
   name: string;
@@ -161,3 +162,12 @@ export const checkForPath = (object: ObjectValidation | undefined, path: string)
 export const globalChecks = (object: ObjectValidation): ObjectCheck[] => {
   return checkForPath(object, '');
 };
+
+export function getServiceWizardLabel(serviceDetails: Service): string {
+  if (serviceDetails && serviceDetails.labels &&
+    serviceDetails.labels[KIALI_WIZARD_LABEL]) {
+    return serviceDetails.labels[KIALI_WIZARD_LABEL];
+  } else {
+    return '';
+  }
+}

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -78,10 +78,11 @@ export function getServiceDetailsUpdateLabel(serviceDetails: ServiceDetailsInfo 
 }
 
 export function hasServiceDetailsTrafficRouting(serviceDetails: ServiceDetailsInfo | null);
-export function hasServiceDetailsTrafficRouting(vsList: VirtualService[], drList: DestinationRule[]);
-export function hasServiceDetailsTrafficRouting(serviceDetailsOrVsList: ServiceDetailsInfo | VirtualService[] | null, drList?: DestinationRule[]) {
+export function hasServiceDetailsTrafficRouting(vsList: VirtualService[], drList: DestinationRule[], routeList?: K8sHTTPRoute[]);
+export function hasServiceDetailsTrafficRouting(serviceDetailsOrVsList: ServiceDetailsInfo | VirtualService[] | null, drList?: DestinationRule[], routeList?: K8sHTTPRoute[]) {
   let virtualServicesList: VirtualService[];
   let destinationRulesList: DestinationRule[];
+  let httpRoutesList: K8sHTTPRoute[];
 
   if (serviceDetailsOrVsList === null) {
     return false;
@@ -90,12 +91,15 @@ export function hasServiceDetailsTrafficRouting(serviceDetailsOrVsList: ServiceD
   if ('length' in serviceDetailsOrVsList) {
     virtualServicesList = serviceDetailsOrVsList;
     destinationRulesList = drList || [];
+    httpRoutesList = routeList || [];
   } else {
     virtualServicesList = serviceDetailsOrVsList.virtualServices;
     destinationRulesList = serviceDetailsOrVsList.destinationRules;
+    httpRoutesList = serviceDetailsOrVsList.k8sHTTPRoutes;
+
   }
 
-  return virtualServicesList.length > 0 || destinationRulesList.length > 0;
+  return virtualServicesList.length > 0 || destinationRulesList.length > 0 || httpRoutesList.length > 0;
 }
 
 const higherThan = [

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -1,7 +1,7 @@
 import { DEGRADED, FAILURE, HEALTHY, NA, ServiceHealth, Status } from './Health';
 import {
   DestinationRule,
-  getVirtualServiceUpdateLabel, K8sHTTPRoute,
+  getWizardUpdateLabel, K8sHTTPRoute,
   ObjectCheck,
   ObjectValidation,
   ServiceEntry,
@@ -74,7 +74,7 @@ export interface ServiceDetailsInfo {
 }
 
 export function getServiceDetailsUpdateLabel(serviceDetails: ServiceDetailsInfo | null) {
-  return getVirtualServiceUpdateLabel(serviceDetails?.virtualServices || null);
+  return getWizardUpdateLabel(serviceDetails?.virtualServices || null, serviceDetails?.k8sHTTPRoutes || null);
 }
 
 export function hasServiceDetailsTrafficRouting(serviceDetails: ServiceDetailsInfo | null);

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -500,9 +500,11 @@ func FilterK8sHTTPRoutesByService(allRoutes []*k8s_networking_v1alpha2.HTTPRoute
 	for _, route := range allRoutes {
 		appendRoute := serviceName == ""
 		if !appendRoute {
-			for _, hostname := range route.Spec.Hostnames {
-				if string(hostname) != "" && FilterByHost(string(hostname), route.Namespace, serviceName, namespace) {
-					appendRoute = true
+			for _, rule := range route.Spec.Rules {
+				for _, backendRef := range rule.BackendRefs {
+					if string(backendRef.Name) != "" && FilterByHost(string(backendRef.Name), route.Namespace, serviceName, namespace) {
+						appendRoute = true
+					}
 				}
 			}
 		}

--- a/models/service.go
+++ b/models/service.go
@@ -4,6 +4,7 @@ import (
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8s_networking_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -65,6 +66,7 @@ type ServiceDetails struct {
 	Endpoints        Endpoints                             `json:"endpoints"`
 	VirtualServices  []*networking_v1beta1.VirtualService  `json:"virtualServices"`
 	DestinationRules []*networking_v1beta1.DestinationRule `json:"destinationRules"`
+	K8sHTTPRoutes    []*k8s_networking_v1alpha2.HTTPRoute  `json:"k8sHTTPRoutes"`
 	ServiceEntries   []*networking_v1beta1.ServiceEntry    `json:"serviceEntries"`
 	IstioPermissions ResourcePermissions                   `json:"istioPermissions"`
 	Workloads        WorkloadOverviews                     `json:"workloads"`


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5502

Added a feature of Creating, Reading, Updating and Deleting of K8s Gateway API Routes for Service details page.
Currently it can create only  "Match" Rules from https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteRule
 The rest of supported filters will be added in further PRs.

![Screenshot from 2022-11-01 14-32-16](https://user-images.githubusercontent.com/604313/199246231-016120cb-21c0-4430-bb83-458d01a420d6.png)
![Screenshot from 2022-11-01 14-33-59](https://user-images.githubusercontent.com/604313/199246220-5a671fcd-d56d-4021-8c20-8220ca5bc1c5.png)
![Screenshot from 2022-11-01 14-33-16](https://user-images.githubusercontent.com/604313/199246222-6a678d11-d7c1-4530-ba08-1891f6db9e70.png)
![Screenshot from 2022-11-01 14-32-50](https://user-images.githubusercontent.com/604313/199246225-955dc2d8-619b-4822-900f-a42448cd5cee.png)
![Screenshot from 2022-11-01 14-32-29](https://user-images.githubusercontent.com/604313/199246229-2c6391d1-5ea8-4886-a75d-43bd47fc8c6a.png)
![Screenshot from 2022-11-01 14-34-11](https://user-images.githubusercontent.com/604313/199246215-4d2828cf-a48a-4524-9255-6bb524f17a79.png)
![Screenshot from 2022-11-01 14-36-36](https://user-images.githubusercontent.com/604313/199246286-9211489c-33ff-4636-a194-1aae90f2fbee.png)
![Screenshot from 2022-11-01 14-37-18](https://user-images.githubusercontent.com/604313/199246420-e429382a-340d-499c-b6b7-04b4f842d6dd.png)

The feature can be reviewed now.

There is one bug code now about auto created default "path PathPrefix /" match which is under investigation.
