### PR TITLE
An attempt to fix timing issue resulting in missing side car

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -32,6 +32,8 @@ spec:
 EOM
 
   if [ "${AUTO_INJECTION}" == "true" ]; then
+    # let's wait for smmr to be Ready before enabling sidecar injection
+    ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
     for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
     do
       echo "Enabling sidecar injection for deployment: ${d}"


### PR DESCRIPTION
In some environments some bookinfo pods are started without a side car even though everything is configured correctly. This is an attempt to fix this behavior so the pods are not patched before smmr is Ready.