### PR TITLE
[v1.57] Ignore cluster info checking, as Kiali ignores it in case of any problem

### DIFF
--- a/tests/integration/tests/kiali_urls_test.go
+++ b/tests/integration/tests/kiali_urls_test.go
@@ -26,8 +26,6 @@ func TestKialiConfig(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(200, statusCode)
 	assert.NotEmpty(response)
-	assert.NotEmpty(response.ClusterInfo)
-	assert.NotEmpty(response.ClusterInfo.Name)
 }
 
 func TestIstioPermissions(t *testing.T) {


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSM-2138

Not critical check of Cluster name is removed.
On OCP clusters retrieving Cluster ID from istiod pod fails and is ignored on Kiali side.
https://github.com/kiali/kiali/blob/master/handlers/config.go#L106