### PR TITLE
Pass go test flags through make

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -47,7 +47,7 @@ jobs:
           CGO_ENABLED: ${{ github.base_ref && '1' }}
 
       - name: Test backend
-        run: make test-race
+        run: GO_TEST_FLAGS="-race" make test
 
       - name: Upload go binary
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -47,7 +47,7 @@ jobs:
           CGO_ENABLED: ${{ github.base_ref && '1' }}
 
       - name: Test backend
-        run: GO_TEST_FLAGS="-race" make test
+        run: make -e GO_TEST_FLAGS="-race" test
 
       - name: Upload go binary
         uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ VERSION_LABEL ?= ${VERSION}
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
 GO_VERSION_KIALI = 1.17.10
+GO_TEST_FLAGS ?=
 
 # Identifies the Kiali container image that will be built.
 IMAGE_ORG ?= kiali

--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,7 @@ cd $KIALI_SOURCES/kiali
 make build test
 
 # You can pass go test flags through the GO_TEST_FLAGS env var
-# GO_TEST_FLAGS="-race -v -run=\"TestCanConnectToIstiodReachable\"" make test
+# make -e GO_TEST_FLAGS="-race -v -run=\"TestCanConnectToIstiodReachable\"" test
 
 # Build the front-end and run the tests
 make build-ui-test

--- a/README.adoc
+++ b/README.adoc
@@ -61,6 +61,9 @@ ln -s $KIALI_SOURCES/kiali-operator kiali/operator
 cd $KIALI_SOURCES/kiali
 make build test
 
+# You can pass go test flags through the GO_TEST_FLAGS env var
+# GO_TEST_FLAGS="-race -v -run=\"TestCanConnectToIstiodReachable\"" make test
+
 # Build the front-end and run the tests
 make build-ui-test
 ----

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -72,16 +72,6 @@ test:
 	@echo Running tests, excluding third party tests under vendor
 	${GO} test ${GO_TEST_FLAGS} $(shell ${GO} list ./... | grep -v -e /vendor/ -e /frontend/ -e /tests/integration/)
 
-## test-debug: Run tests in debug mode, excluding third party tests under vendor and frontend. Runs `go test -v`
-test-debug:
-	@echo Running tests in debug mode, excluding third party tests under vendor
-	${GO} test -v ${GO_TEST_FLAGS} $(shell ${GO} list ./... | grep -v -e /vendor/ -e /frontend/ -e /tests/integration/)
-
-## test-race: Run tests with race detection, excluding third party tests under vendor and frontend. Runs `go test -race`
-test-race:
-	@echo Running tests with race detection, excluding third party tests under vendor
-	${GO} test -race ${GO_TEST_FLAGS} $(shell ${GO} list ./... | grep -v -e /vendor/ -e /frontend/ -e /tests/integration/)
-
 ## test-integration-setup: Setup go library for converting test result into junit xml
 test-integration-setup:
 	@echo Setting up Integration tests

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -70,17 +70,17 @@ build-system-test:
 ## test: Run tests, excluding third party tests under vendor and frontend. Runs `go test` internally
 test:
 	@echo Running tests, excluding third party tests under vendor
-	${GO} test $(shell ${GO} list ./... | grep -v -e /vendor/ -e /frontend/ -e /tests/integration/)
+	${GO} test ${GO_TEST_FLAGS} $(shell ${GO} list ./... | grep -v -e /vendor/ -e /frontend/ -e /tests/integration/)
 
 ## test-debug: Run tests in debug mode, excluding third party tests under vendor and frontend. Runs `go test -v`
 test-debug:
 	@echo Running tests in debug mode, excluding third party tests under vendor
-	${GO} test -v $(shell ${GO} list ./... | grep -v -e /vendor/ -e /frontend/ -e /tests/integration/)
+	${GO} test -v ${GO_TEST_FLAGS} $(shell ${GO} list ./... | grep -v -e /vendor/ -e /frontend/ -e /tests/integration/)
 
 ## test-race: Run tests with race detection, excluding third party tests under vendor and frontend. Runs `go test -race`
 test-race:
 	@echo Running tests with race detection, excluding third party tests under vendor
-	${GO} test -race $(shell ${GO} list ./... | grep -v -e /vendor/ -e /frontend/ -e /tests/integration/)
+	${GO} test -race ${GO_TEST_FLAGS} $(shell ${GO} list ./... | grep -v -e /vendor/ -e /frontend/ -e /tests/integration/)
 
 ## test-integration-setup: Setup go library for converting test result into junit xml
 test-integration-setup:
@@ -90,7 +90,7 @@ test-integration-setup:
 ## test-integration: Run Integration test suite
 test-integration: test-integration-setup
 	@echo Running Integration tests
-	cd tests/integration/tests && ${GO} test -v 2>&1 | go-junit-report > ../junit-rest-report.xml
+	cd tests/integration/tests && ${GO} test ${GO_TEST_FLAGS} -v 2>&1 | go-junit-report > ../junit-rest-report.xml
 	@echo Test results can be found here: $$(ls -1 ${ROOTDIR}/tests/integration/junit-rest-report.xml)
 
 #


### PR DESCRIPTION
Adds ability to pass go test flags through make. Enables you to run individual tests and/or set other options while still using the `make test` command.