### PR TITLE
[e2e] Ignore cluster info checking, as Kiali ignores it in case of any problem

### DIFF
--- a/tests/integration/tests/kiali_urls_test.go
+++ b/tests/integration/tests/kiali_urls_test.go
@@ -26,8 +26,6 @@ func TestKialiConfig(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(200, statusCode)
 	assert.NotEmpty(response)
-	assert.NotEmpty(response.ClusterInfo)
-	assert.NotEmpty(response.ClusterInfo.Name)
 }
 
 func TestIstioPermissions(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of https://github.com/kiali/kiali/pull/5573 from v1.57 into master.