### PR TITLE
Add Control Plane status indicator in Overview card

### DIFF
--- a/frontend/src/components/IstioStatus/IstioStatus.tsx
+++ b/frontend/src/components/IstioStatus/IstioStatus.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { SVGIconProps } from "@patternfly/react-icons/dist/esm/createIcon";
 import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { TimeInMilliseconds } from '../../types/Common';
@@ -26,8 +27,16 @@ type ReduxProps = {
   status: ComponentStatus[];
 };
 
+type StatusIcons = {
+  ErrorIcon?: React.ComponentClass<SVGIconProps>,
+  WarningIcon?: React.ComponentClass<SVGIconProps>,
+  InfoIcon?: React.ComponentClass<SVGIconProps>,
+  HealthyIcon?: React.ComponentClass<SVGIconProps>
+};
+
 type Props = ReduxProps & {
   lastRefreshAt: TimeInMilliseconds;
+  icons?: StatusIcons
 };
 
 const ValidToColor = {
@@ -40,6 +49,13 @@ const ValidToColor = {
   'false-false-true': PFColors.Info,
   'false-false-false': PFColors.Success
 };
+
+const defaultIcons = {
+  ErrorIcon: ResourcesFullIcon,
+  WarningIcon: ResourcesFullIcon,
+  InfoIcon: ResourcesFullIcon,
+  HealthyIcon: ResourcesFullIcon
+}
 
 export class IstioStatus extends React.Component<Props> {
   componentDidMount() {
@@ -103,9 +119,23 @@ export class IstioStatus extends React.Component<Props> {
 
   render() {
     if (!this.healthyComponents()) {
+      const icons = this.props.icons ? { ...defaultIcons, ...this.props.icons } : defaultIcons;
+      const iconColor = this.tooltipColor();
+      let Icon: React.ComponentClass<SVGIconProps> = ResourcesFullIcon;
+
+      if (iconColor === PFColors.Danger) {
+        Icon = icons.ErrorIcon;
+      } else if (iconColor === PFColors.Warning) {
+        Icon = icons.WarningIcon;
+      } else if (iconColor === PFColors.Info) {
+        Icon = icons.InfoIcon;
+      } else if (iconColor === PFColors.Success) {
+        Icon = icons.HealthyIcon;
+      }
+
       return (
         <Tooltip position={TooltipPosition.left} enableFlip={true} content={this.tooltipContent()} maxWidth={'25rem'}>
-          <ResourcesFullIcon color={this.tooltipColor()} style={{ verticalAlign: '-0.2em', marginRight: -8 }} />
+          <Icon color={iconColor} style={{ verticalAlign: '-0.2em', marginRight: -8 }} />
         </Tooltip>
       );
     }

--- a/frontend/src/components/IstioStatus/IstioStatusInline.tsx
+++ b/frontend/src/components/IstioStatus/IstioStatusInline.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import IstioStatus from "./IstioStatus";
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  MinusCircleIcon
+} from "@patternfly/react-icons";
+
+export default function IstioStatusInline() {
+  return <IstioStatus icons={{
+    ErrorIcon: ExclamationCircleIcon,
+    HealthyIcon: CheckCircleIcon,
+    InfoIcon: MinusCircleIcon,
+    WarningIcon: ExclamationTriangleIcon
+  }} />;
+}

--- a/frontend/src/pages/Overview/ControlPlaneBadge.tsx
+++ b/frontend/src/pages/Overview/ControlPlaneBadge.tsx
@@ -1,10 +1,14 @@
 import { Label } from '@patternfly/react-core';
 import * as React from 'react';
+import IstioStatusInline from "../../components/IstioStatus/IstioStatusInline";
 
 class ControlPlaneBadge extends React.Component<{}> {
     render() {
         return (
-            <Label style={{ marginLeft: 5 }} color="green" isCompact>Control Plane</Label>
+            <>
+              <Label style={{ marginLeft: 5 }} color="green" isCompact>Control Plane</Label>
+              {' '} <IstioStatusInline />
+            </>
         );
     }
 }

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -380,24 +380,6 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       .catch(err => this.handleAxiosError('Could not fetch health', err));
   }
 
-  // fetchControlPlaneMetrics() {
-  //   const duration = FilterHelper.currentDuration();
-  //   const rateParams = computePrometheusRateParams(duration, 10);
-  //   const options: MetricsQuery = {
-  //     duration: duration,
-  //     step: rateParams.step,
-  //     rateInterval: rateParams.rateInterval,
-  //   };
-
-  //   API.getControlPlaneMetrics(options)
-  //   .then(response => {
-  //     this.setState({controlPlaneMetrics: response.data});
-  //   })
-  //   .catch(error => {
-  //     AlertUtils.addError('Error fetching control plane metrics.', error, 'default', MessageType.ERROR);
-  //   });
-  // }
-
   fetchMetrics(direction: DirectionType) {
     const duration = FilterHelper.currentDuration();
     // debounce async for back-pressure, ten by ten


### PR DESCRIPTION
This replicates the status indicator for control plane components in the control plane card of OverviewPage.tsx.

For the card, the indicator icon is changed to match the icons used in the tooltip. The masthead indicator is unchanged.

The shown/hidden behavior of the indicator in the control plane card is the same as in the masthead: it is hidden if all components are OK, and it is shown if something has some potential issue.

![cpStatusCard](https://user-images.githubusercontent.com/23639005/197653353-d2cd6e57-25e4-49d6-b4e9-cd47e1182bfc.gif)


Fixes #5525
