### PR TITLE
Adding support for IMB's p/z arch to bookinfo install script

### DIFF
--- a/hack/istio/kustomization/bookinfo-ppc64le.yaml
+++ b/hack/istio/kustomization/bookinfo-ppc64le.yaml
@@ -1,0 +1,22 @@
+resources:
+- bookinfo.yaml
+images:
+# bookinfo.yaml
+- name: docker.io/istio/examples-bookinfo-details-v1
+  newName: quay.io/maistra/examples-bookinfo-details-v1
+  newTag: 2.0.0-ibm-p
+- name: docker.io/istio/examples-bookinfo-ratings-v1
+  newName: quay.io/maistra/examples-bookinfo-ratings-v1
+  newTag: 2.0.0-ibm-p
+- name: docker.io/istio/examples-bookinfo-reviews-v1
+  newName: quay.io/maistra/examples-bookinfo-reviews-v1
+  newTag: 2.0.0-ibm-p
+- name: docker.io/istio/examples-bookinfo-reviews-v2
+  newName: quay.io/maistra/examples-bookinfo-reviews-v2
+  newTag: 2.0.0-ibm-p
+- name: docker.io/istio/examples-bookinfo-reviews-v3
+  newName: quay.io/maistra/examples-bookinfo-reviews-v3
+  newTag: 2.0.0-ibm-p
+- name: docker.io/istio/examples-bookinfo-productpage-v1
+  newName: quay.io/maistra/examples-bookinfo-productpage-v1
+  newTag: 2.0.0-ibm-p

--- a/hack/istio/kustomization/bookinfo-s390x.yaml
+++ b/hack/istio/kustomization/bookinfo-s390x.yaml
@@ -1,0 +1,21 @@
+resources:
+- bookinfo.yaml
+images:
+- name: docker.io/istio/examples-bookinfo-details-v1
+  newName: quay.io/maistra/examples-bookinfo-details-v1
+  newTag: 2.0.0-ibm-z
+- name: docker.io/istio/examples-bookinfo-ratings-v1
+  newName: quay.io/maistra/examples-bookinfo-ratings-v1
+  newTag: 2.0.0-ibm-z
+- name: docker.io/istio/examples-bookinfo-reviews-v1
+  newName: quay.io/maistra/examples-bookinfo-reviews-v1
+  newTag: 2.0.0-ibm-z
+- name: docker.io/istio/examples-bookinfo-reviews-v2
+  newName: quay.io/maistra/examples-bookinfo-reviews-v2
+  newTag: 2.0.0-ibm-z
+- name: docker.io/istio/examples-bookinfo-reviews-v3
+  newName: quay.io/maistra/examples-bookinfo-reviews-v3
+  newTag: 2.0.0-ibm-z
+- name: docker.io/istio/examples-bookinfo-productpage-v1
+  newName: quay.io/maistra/examples-bookinfo-productpage-v1
+  newTag: 2.0.0-ibm-z


### PR DESCRIPTION
This is required by IBM p/z teams as there are no official ppc64le and s390x bookinfo images. This change allows to specify architecture to use matching bookinfo images.
