### PR TITLE
Adding support for IMB's p/z arch to error rates install script

### DIFF
--- a/hack/istio/install-error-rates-demo.sh
+++ b/hack/istio/install-error-rates-demo.sh
@@ -33,6 +33,7 @@ EOM
 }
 
 : ${CLIENT_EXE:=oc}
+: ${ARCH:=amd64}
 : ${DELETE_DEMO:=false}
 : ${ENABLE_INJECTION:=true}
 : ${ISTIO_NAMESPACE:=istio-system}
@@ -43,6 +44,10 @@ EOM
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
+    -a|--arch)
+      ARCH="$2"
+      shift;shift
+      ;;
     -c|--client)
       CLIENT_EXE="$2"
       shift;shift
@@ -62,6 +67,7 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
+  -a|--arch <amd64|ppc64le|s390x>: Images for given arch will be used (default: amd64).
   -c|--client: either 'oc' or 'kubectl'
   -d|--delete: either 'true' or 'false'. If 'true' the demo will be deleted, not installed.
   -ei|--enable-injection: either 'true' or 'false' (default is true). If 'true' auto-inject proxies for the workloads.
@@ -84,12 +90,19 @@ done
 
 echo Will deploy Error Rates Demo using these settings:
 echo CLIENT_EXE=${CLIENT_EXE}
+echo ARCH=${ARCH}
 echo DELETE_DEMO=${DELETE_DEMO}
 echo ENABLE_INJECTION=${ENABLE_INJECTION}
 echo ISTIO_NAMESPACE=${ISTIO_NAMESPACE}
 echo NAMESPACE_ALPHA=${NAMESPACE_ALPHA}
 echo NAMESPACE_BETA=${NAMESPACE_BETA}
 echo SOURCE=${SOURCE}
+
+# check arch values
+if [ "${ARCH}" != "ppc64le" ] && [ "${ARCH}" != "s390x" ] && [ "${ARCH}" != "amd64" ]; then
+  echo "${ARCH} is not supported. Exiting."
+  exit 1
+fi
 
 IS_OPENSHIFT="false"
 IS_MAISTRA="false"
@@ -175,8 +188,22 @@ SCC
 fi
 
 # Deploy the demo
-${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/error-rates/alpha.yaml") -n ${NAMESPACE_ALPHA}
-${CLIENT_EXE} apply -f <(curl -L "${SOURCE}/error-rates/beta.yaml") -n ${NAMESPACE_BETA}
+url_alpha="${SOURCE}/error-rates/alpha.yaml"
+url_beta="${SOURCE}/error-rates/beta.yaml"
+sed_client_p="s;kiali/demo_error_rates_client;maistra/demo_error_rates_client-p;g"
+sed_server_p="s;kiali/demo_error_rates_server;maistra/demo_error_rates_server-p;g"
+sed_client_z="s;kiali/demo_error_rates_client;maistra/demo_error_rates_client-z;g"
+sed_server_z="s;kiali/demo_error_rates_server;maistra/demo_error_rates_server-z;g"
+if [ "${ARCH}" == "ppc64le" ]; then
+  ${CLIENT_EXE} apply -f <(curl -L ${url_alpha} | sed "${sed_client_p}" | sed "${sed_server_p}") -n ${NAMESPACE_ALPHA}
+  ${CLIENT_EXE} apply -f <(curl -L "${url_beta}" | sed "${sed_client_p}" | sed "${sed_server_p}") -n ${NAMESPACE_BETA}
+elif [ "${ARCH}" == "s390x" ]; then
+  ${CLIENT_EXE} apply -f <(curl -L ${url_alpha} | sed "${sed_client_z}" | sed "${sed_server_z}") -n ${NAMESPACE_ALPHA}
+  ${CLIENT_EXE} apply -f <(curl -L "${url_beta}" | sed "${sed_client_z}" | sed "${sed_server_z}") -n ${NAMESPACE_BETA}
+else
+  ${CLIENT_EXE} apply -f <(curl -L ${url_alpha}) -n ${NAMESPACE_ALPHA}
+  ${CLIENT_EXE} apply -f <(curl -L "${url_beta}") -n ${NAMESPACE_BETA}
+fi
 
 # we need to update deployment annotations after we create it
 if [ "${IS_MAISTRA}" == "true" ]; then

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -97,12 +97,17 @@ ISTIO_DIR=$(ls -dt1 ${SCRIPT_DIR}/../../_output/istio-* | head -n1)
 MINIKUBE_PROFILE="minikube"
 
 : ${CLIENT_EXE:=oc}
+: ${ARCH:=amd64}
 : ${DELETE_DEMOS:=false}
 ISTIO_NAMESPACE="istio-system"
 
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
+    -a|--arch)
+      ARCH="$2"
+      shift;shift
+      ;;
     -c|--client)
       CLIENT_EXE="$2"
       shift;shift
@@ -122,6 +127,7 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
+  -a|--arch <amd64|ppc64le|s390x>: Images for given arch will be used (default: amd64).
   -c|--client: either 'oc' or 'kubectl'
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
   -mp|--minikube-profile <name>: If using minikube, this is the minikube profile name (default: minikube).
@@ -137,6 +143,12 @@ HELPMSG
   esac
 done
 
+# check arch values
+if [ "${ARCH}" != "ppc64le" ] && [ "${ARCH}" != "s390x" ] && [ "${ARCH}" != "amd64" ]; then
+  echo "${ARCH} is not supported. Exiting."
+  exit 1
+fi
+
 IS_OPENSHIFT="false"
 IS_MAISTRA="false"
 if [[ "${CLIENT_EXE}" = *"oc" ]]; then
@@ -145,6 +157,7 @@ if [[ "${CLIENT_EXE}" = *"oc" ]]; then
 fi
 
 echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "ARCH=${ARCH}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
 echo "IS_MAISTRA=${IS_MAISTRA}"
 
@@ -165,14 +178,16 @@ if [ "${DELETE_DEMOS}" != "true" ]; then
   # Only the args passed to the scripts differ from each other.
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     echo "Deploying bookinfo demo ..."
-    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -tg -in ${ISTIO_NAMESPACE}
+    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -tg -in ${ISTIO_NAMESPACE} -a ${ARCH}
     echo "Deploying error rates demo ..."
-    "${SCRIPT_DIR}/install-error-rates-demo.sh" -in ${ISTIO_NAMESPACE}
+    "${SCRIPT_DIR}/install-error-rates-demo.sh" -in ${ISTIO_NAMESPACE} -a ${ARCH}
+
   else
     echo "Deploying bookinfo demo..."
-    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -mp ${MINIKUBE_PROFILE} -tg -in ${ISTIO_NAMESPACE}
+    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -mp ${MINIKUBE_PROFILE} -tg -in ${ISTIO_NAMESPACE} -a ${ARCH}
+
     echo "Deploying error rates demo..."
-    "${SCRIPT_DIR}/install-error-rates-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE}
+    "${SCRIPT_DIR}/install-error-rates-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE} -a ${ARCH}
   fi
 
   echo "Installing the 'sleep' app in the 'sleep' namespace..."


### PR DESCRIPTION
This is required by IBM p/z teams as there are no official ppc64le and s390x error rates images. This change allows to specify architecture to use matching error rates images. Also updating install-testing-demos.sh to work with new arch.
