### PR TITLE
[make][molecule] purge the podman volume if an old one still exists

### DIFF
--- a/make/Makefile.molecule.mk
+++ b/make/Makefile.molecule.mk
@@ -159,6 +159,7 @@ ifeq ($(DORP),docker)
 	@echo "Docker is not supported for running the molecule tests. Ignoring 'dorp=docker' and using podman."
 endif
 
+	podman volume exists molecule-tests-volume && echo "Podman volume already exists; deleting it" && podman volume rm molecule-tests-volume || true
 	podman volume create molecule-tests-volume
 	podman create -v molecule-tests-volume:/data --name molecule-volume-helper docker.io/busybox true
 	podman cp "${HELM_CHARTS_REPO}" molecule-volume-helper:/data/helm-charts-repo


### PR DESCRIPTION
On the occasions when you run the molecule tests and you need to abort the test, you can kill the running podman process. But in some cases when you abort, the podman volume remains. Then when you attempt to run the molecule tests again, it will fail with:
```
podman volume create molecule-tests-volume
Error: volume with name molecule-tests-volume already exists: volume already exists
make: *** [make/Makefile.molecule.mk:162: .prepare-molecule-data-volume] Error 125
```
Thus the developer is forced to manually remove the volume.
This PR automatically purges any old/obsolete podman volume if it exists thus cleaning up after a failed attempt without requiring the developer to manually do it.