### PR TITLE
Filter K8sGateways by GatewayClass Names, which by default is 'istio'

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -176,7 +176,7 @@ func (in *IstioConfigService) GetIstioConfigList(ctx context.Context, criteria I
 			istioConfigList.Gateways = kubernetes.FilterSupportedGateways(registryConfiguration.Gateways)
 		}
 		if criteria.Include(kubernetes.K8sGateways) {
-			istioConfigList.K8sGateways = registryConfiguration.K8sGateways
+			istioConfigList.K8sGateways = kubernetes.FilterSupportedK8sGateways(registryConfiguration.K8sGateways)
 		}
 		if criteria.Include(kubernetes.K8sHTTPRoutes) {
 			istioConfigList.K8sHTTPRoutes = registryConfiguration.K8sHTTPRoutes

--- a/config/config.go
+++ b/config/config.go
@@ -220,6 +220,7 @@ type IstioConfig struct {
 	Registry                          *RegistryConfig     `yaml:"registry,omitempty"`
 	RootNamespace                     string              `yaml:"root_namespace,omitempty"`
 	UrlServiceVersion                 string              `yaml:"url_service_version"`
+	GatewayAPIClassName               string              `yaml:"gateway_api_class_name,omitempty"`
 }
 
 type IstioCanaryRevision struct {
@@ -606,6 +607,7 @@ func NewConfig() (c *Config) {
 				IstiodPodMonitoringPort:           15014,
 				RootNamespace:                     "istio-system",
 				UrlServiceVersion:                 "http://istiod.istio-system:15014/version",
+				GatewayAPIClassName:               "istio",
 			},
 			Prometheus: PrometheusConfig{
 				Auth: Auth{

--- a/config/config.go
+++ b/config/config.go
@@ -210,6 +210,7 @@ type IstioConfig struct {
 	ComponentStatuses                 ComponentStatuses   `yaml:"component_status,omitempty"`
 	ConfigMapName                     string              `yaml:"config_map_name,omitempty"`
 	EnvoyAdminLocalPort               int                 `yaml:"envoy_admin_local_port,omitempty"`
+	GatewayAPIClassName               string              `yaml:"gateway_api_class_name,omitempty"`
 	IstioCanaryRevision               IstioCanaryRevision `yaml:"istio_canary_revision,omitempty"`
 	IstioIdentityDomain               string              `yaml:"istio_identity_domain,omitempty"`
 	IstioInjectionAnnotation          string              `yaml:"istio_injection_annotation,omitempty"`
@@ -220,7 +221,6 @@ type IstioConfig struct {
 	Registry                          *RegistryConfig     `yaml:"registry,omitempty"`
 	RootNamespace                     string              `yaml:"root_namespace,omitempty"`
 	UrlServiceVersion                 string              `yaml:"url_service_version"`
-	GatewayAPIClassName               string              `yaml:"gateway_api_class_name,omitempty"`
 }
 
 type IstioCanaryRevision struct {

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -9,6 +9,7 @@ import (
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8s_networking_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kiali/kiali/config"
 )
@@ -153,6 +154,20 @@ func FilterSupportedGateways(gateways []*networking_v1beta1.Gateway) []*networki
 	filtered := []*networking_v1beta1.Gateway{}
 	for _, gw := range gateways {
 		if gw.APIVersion == ApiNetworkingVersionV1Beta1 || gw.APIVersion == ApiNetworkingVersionV1Alpha3 {
+			filtered = append(filtered, gw)
+		}
+	}
+	return filtered
+}
+
+func FilterSupportedK8sGateways(gateways []*k8s_networking_v1alpha2.Gateway) []*k8s_networking_v1alpha2.Gateway {
+	var gatewayAPIClassName = config.Get().ExternalServices.Istio.GatewayAPIClassName
+	if gatewayAPIClassName == "" {
+		gatewayAPIClassName = "istio"
+	}
+	filtered := []*k8s_networking_v1alpha2.Gateway{}
+	for _, gw := range gateways {
+		if string(gw.Spec.GatewayClassName) == gatewayAPIClassName {
 			filtered = append(filtered, gw)
 		}
 	}


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/5594

Filtering K8s API Gateways to show only those ones which are pointing to GatewayClass created by Istio.

Using 'istio' as default GatewayClass Name to filter K8sGatgeways from Gateway API.