### PR TITLE
Improvements in CP card for min TLS

### DIFF
--- a/frontend/src/components/Overview/TLSInfo.tsx
+++ b/frontend/src/components/Overview/TLSInfo.tsx
@@ -6,9 +6,10 @@ import {KialiAppState} from "../../store/Store";
 import {istioCertsInfoSelector} from "../../store/Selectors";
 import {CertsInfo} from "../../types/CertsInfo";
 import {connect} from "react-redux";
+import {infoStyle} from "../../pages/Overview/OverviewCardControlPlaneNamespace";
 
 type Props = {
-  mTLS: boolean,
+  certificatesInformationIndicators: boolean,
   version?: string,
   certsInfo: CertsInfo[];
 };
@@ -17,7 +18,7 @@ const lockIconStyle = style({ marginLeft: '5px' });
 
 function showCerts(certs) {
   if (certs) {
-    let rows = certs.map(function(item){
+    let rows = certs.map(function(item) {
       return (<div>
         <div style={{ display: 'inline-block', width: '125px', whiteSpace: 'nowrap' }}>From {item.issuer}</div>
         <div>
@@ -48,12 +49,14 @@ function showCerts(certs) {
 function LockIcon(props) {
 
   return (
-    <Tooltip
-      position={TooltipPosition.top}
-      content={showCerts(props.certsInfo)}
-    >
-      {props.mTLS ? (<div data-test={"lockerCA"}><KialiIcon.MtlsLock className={lockIconStyle} /></div>) : (<KialiIcon.MtlsUnlock className={lockIconStyle}/>)}
-    </Tooltip>
+    props.certificatesInformationIndicators === true ? (
+      <Tooltip
+        position={TooltipPosition.top}
+        content={showCerts(props.certsInfo)}
+      >
+          <KialiIcon.MtlsLock className={lockIconStyle}/>
+      </Tooltip>)
+      : (<KialiIcon.MtlsLock className={lockIconStyle}/>)
   );
 };
 
@@ -64,9 +67,15 @@ class TLSInfo extends React.Component<Props> {
       <div style={{ textAlign: 'left' }}>
           <div>
             <div style={{ display: 'inline-block', width: '125px', whiteSpace: 'nowrap' }}>Min TLS Version</div>
-            <Label isCompact color="blue" data-test={"label-TLS"}>
-              {this.props.version} <LockIcon mTLS={this.props.mTLS} certsInfo={this.props.certsInfo}></LockIcon>
-            </Label>
+              <Label isCompact color="blue" data-test={"label-TLS"}>
+                {this.props.version} <LockIcon certificatesInformationIndicators={this.props.certificatesInformationIndicators} certsInfo={this.props.certsInfo}></LockIcon>
+                <Tooltip
+                  position={TooltipPosition.right}
+                  content={<div style={{ textAlign: 'left' }}>The meshConfig.meshMTL.minProtocolVersion field specifies the minimum TLS version for the TLS connections among Istio workloads. N/A if it was not set.</div>}
+                >
+                  <KialiIcon.Info className={infoStyle} />
+                </Tooltip>
+              </Label>
           </div>
       </div>
     );

--- a/frontend/src/components/Overview/TLSInfo.tsx
+++ b/frontend/src/components/Overview/TLSInfo.tsx
@@ -71,7 +71,7 @@ class TLSInfo extends React.Component<Props> {
                 {this.props.version} <LockIcon certificatesInformationIndicators={this.props.certificatesInformationIndicators} certsInfo={this.props.certsInfo}></LockIcon>
                 <Tooltip
                   position={TooltipPosition.right}
-                  content={<div style={{ textAlign: 'left' }}>The meshConfig.meshMTL.minProtocolVersion field specifies the minimum TLS version for the TLS connections among Istio workloads. N/A if it was not set.</div>}
+                  content={<div style={{ textAlign: 'left' }}>The meshConfig.meshMTLS.minProtocolVersion field specifies the minimum TLS version for the TLS connections among Istio workloads. N/A if it was not set.</div>}
                 >
                   <KialiIcon.Info className={infoStyle} />
                 </Tooltip>

--- a/frontend/src/components/Overview/TLSInfo.tsx
+++ b/frontend/src/components/Overview/TLSInfo.tsx
@@ -54,7 +54,9 @@ function LockIcon(props) {
         position={TooltipPosition.top}
         content={showCerts(props.certsInfo)}
       >
+        <div data-test={"lockerCA"}>
           <KialiIcon.MtlsLock className={lockIconStyle}/>
+        </div>
       </Tooltip>)
       : (<KialiIcon.MtlsLock className={lockIconStyle}/>)
   );

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -877,7 +877,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
                                 </div>
                                 { ns.status && <NamespaceStatuses key={ns.name} name={ns.name} status={ns.status} type={this.state.type} />}
                                 { this.state.displayMode === OverviewDisplayMode.EXPAND && <ControlPlaneNamespaceStatus outboundTrafficPolicy={this.state.outboundPolicyMode} namespace={ns}></ControlPlaneNamespaceStatus>}
-                                { this.state.displayMode === OverviewDisplayMode.EXPAND && <TLSInfo mTLS={true} version={this.props.minTLS}></TLSInfo> }
+                                { this.state.displayMode === OverviewDisplayMode.EXPAND && <TLSInfo certificatesInformationIndicators={serverConfig.kialiFeatureFlags.certificatesInformationIndicators.enabled} version={this.props.minTLS}></TLSInfo> }
                               </GridItem>
                               {ns.name === serverConfig.istioNamespace &&
                                 <GridItem md={9}>


### PR DESCRIPTION
Fixes #5597

Adding information tooltip: 

![image](https://user-images.githubusercontent.com/49480155/199680599-3120d6fa-46f4-480e-9ff4-b4891bf36a0e.png)

Also, if serverConfig.kialiFeatureFlags.certificatesInformationIndicators.enabled is false, not shows the tooltip with certificates information in the lock icon