### PR TITLE
Kiosk mode for config views made read-only.

### DIFF
--- a/frontend/src/components/Link/KioskLink.tsx
+++ b/frontend/src/components/Link/KioskLink.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { isParentKiosk, kioskContextMenuAction } from "../Kiosk/KioskActions";
+import {KialiAppState} from "../../store/Store";
+import {connect} from "react-redux";
+
+type ReduxProps = {
+  kiosk: string;
+}
+
+type Props = {
+  linkName: string;
+  href: string;
+  dataTest: string;
+}
+
+type KioskProps = ReduxProps & Props;
+
+export class KioskLink extends React.Component<Props> {
+  render() {
+    const { linkName, href, dataTest } = this.props;
+
+    return (
+      <>
+        <KioskLinkContainer linkName={linkName} href={href} dataTest={dataTest} />
+      </>
+    );
+  }
+}
+
+class KioskLinkItem extends React.Component<KioskProps> {
+  render() {
+    return isParentKiosk(this.props.kiosk) ? (
+      <Link
+        to={''}
+        onClick={() => {
+          kioskContextMenuAction(this.props.href);
+        }}
+      >{this.props.linkName}</Link>
+    ) : (
+      <Link to={this.props.href} data-test={this.props.dataTest}>
+        {this.props.linkName}
+      </Link>
+    );
+  }
+}
+
+const mapStateToProps = (state: KialiAppState): ReduxProps => ({
+  kiosk: state.globalState.kiosk,
+});
+
+const KioskLinkContainer = connect(mapStateToProps)(KioskLinkItem);

--- a/frontend/src/components/Link/ServiceLink.tsx
+++ b/frontend/src/components/Link/ServiceLink.tsx
@@ -1,24 +1,14 @@
 import * as React from 'react';
 import { Paths } from '../../config';
-import { Link } from 'react-router-dom';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { TooltipPosition } from '@patternfly/react-core';
-import { connect } from "react-redux";
-import { isParentKiosk, kioskContextMenuAction } from "../Kiosk/KioskActions";
-import { KialiAppState } from "../../store/Store";
-
-type ReduxProps = {
-  kiosk: string;
-}
+import {KioskLink} from "./KioskLink";
 
 type Props = {
   name: string;
   namespace: string;
   query?: string;
 }
-
-type ServiceProps = ReduxProps & Props & {
-};
 
 export const getServiceURL = (name: string, namespace: string, query?: string): string => {
   let to = '/namespaces/' + namespace + '/' + Paths.SERVICES;
@@ -39,34 +29,16 @@ export class ServiceLink extends React.Component<Props> {
     return (
       <>
         <PFBadge badge={PFBadges.Service} position={TooltipPosition.top} />
-        <ServiceLinkContainer name={name} namespace={namespace} query={query} />
+        <ServiceLinkItem name={name} namespace={namespace} query={query} />
       </>
     );
   }
 }
 
-class ServiceLinkItem extends React.Component<ServiceProps> {
+class ServiceLinkItem extends React.Component<Props> {
   render() {
     const { name, namespace, query } = this.props;
     const href = getServiceURL(name, namespace, query);
-    return isParentKiosk(this.props.kiosk) ? (
-      <Link
-        to={''}
-        onClick={() => {
-          kioskContextMenuAction(href);
-        }}
-      >{namespace}/{name}</Link>
-    ) : (
-      <Link to={getServiceURL(name, namespace, query)} data-test={'service-' + namespace + '-' + name}>
-        {namespace}/{name}
-      </Link>
-    );
+    return (<KioskLink linkName={namespace + '/' + name} dataTest={'service-' + namespace + '-' + name} href={href}></KioskLink>)
   }
 }
-
-const mapStateToProps = (state: KialiAppState): ReduxProps => ({
-  kiosk: state.globalState.kiosk,
-});
-
-const ServiceLinkContainer = connect(mapStateToProps)(ServiceLinkItem);
-export default ServiceLinkContainer;

--- a/frontend/src/components/Link/ServiceLink.tsx
+++ b/frontend/src/components/Link/ServiceLink.tsx
@@ -3,12 +3,22 @@ import { Paths } from '../../config';
 import { Link } from 'react-router-dom';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { TooltipPosition } from '@patternfly/react-core';
+import { connect } from "react-redux";
+import { isParentKiosk, kioskContextMenuAction } from "../Kiosk/KioskActions";
+import { KialiAppState } from "../../store/Store";
 
-interface Props {
+type ReduxProps = {
+  kiosk: string;
+}
+
+type Props = {
   name: string;
   namespace: string;
   query?: string;
 }
+
+type ServiceProps = ReduxProps & Props & {
+};
 
 export const getServiceURL = (name: string, namespace: string, query?: string): string => {
   let to = '/namespaces/' + namespace + '/' + Paths.SERVICES;
@@ -29,12 +39,34 @@ export class ServiceLink extends React.Component<Props> {
     return (
       <>
         <PFBadge badge={PFBadges.Service} position={TooltipPosition.top} />
-        <Link to={getServiceURL(name, namespace, query)} data-test={'service-' + namespace + '-' + name}>
-          {namespace}/{name}
-        </Link>
+        <ServiceLinkContainer name={name} namespace={namespace} query={query} />
       </>
     );
   }
 }
 
-export default ServiceLink;
+class ServiceLinkItem extends React.Component<ServiceProps> {
+  render() {
+    const { name, namespace, query } = this.props;
+    const href = getServiceURL(name, namespace, query);
+    return isParentKiosk(this.props.kiosk) ? (
+      <Link
+        to={''}
+        onClick={() => {
+          kioskContextMenuAction(href);
+        }}
+      >{namespace}/{name}</Link>
+    ) : (
+      <Link to={getServiceURL(name, namespace, query)} data-test={'service-' + namespace + '-' + name}>
+        {namespace}/{name}
+      </Link>
+    );
+  }
+}
+
+const mapStateToProps = (state: KialiAppState): ReduxProps => ({
+  kiosk: state.globalState.kiosk,
+});
+
+const ServiceLinkContainer = connect(mapStateToProps)(ServiceLinkItem);
+export default ServiceLinkContainer;

--- a/frontend/src/components/Link/WorkloadLink.tsx
+++ b/frontend/src/components/Link/WorkloadLink.tsx
@@ -1,24 +1,14 @@
 import * as React from 'react';
 import { Paths } from '../../config';
-import { Link } from 'react-router-dom';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { TooltipPosition } from '@patternfly/react-core';
-import { KialiAppState } from "../../store/Store";
-import { connect } from "react-redux";
-import { isParentKiosk, kioskContextMenuAction } from "../Kiosk/KioskActions";
-
-type ReduxProps = {
-  kiosk: string;
-}
+import {KioskLink} from "./KioskLink";
 
 type Props = {
   name: string;
   namespace: string;
   query?: string;
 }
-
-type WorkloadProps = ReduxProps & Props & {
-};
 
 export const getWorkloadLink = (name: string, namespace: string, query?: string): string => {
   let to = '/namespaces/' + namespace + '/' + Paths.WORKLOADS;
@@ -39,34 +29,16 @@ export class WorkloadLink extends React.Component<Props> {
     return (
       <>
         <PFBadge badge={PFBadges.Workload} position={TooltipPosition.top} />
-        <WorkloadLinkContainer namespace={namespace} name={name} query={query} />
+        <WorkloadLinkItem namespace={namespace} name={name} query={query} />
       </>
     );
   }
 }
 
-class WorkloadLinkItem extends React.Component<WorkloadProps> {
+class WorkloadLinkItem extends React.Component<Props> {
   render() {
     const { name, namespace, query } = this.props;
     const href = getWorkloadLink(name, namespace, query);
-    return isParentKiosk(this.props.kiosk) ? (
-      <Link
-        to={''}
-        onClick={() => {
-          kioskContextMenuAction(href);
-        }}
-      >{namespace}/{name}</Link>
-    ) : (
-      <Link to={href} data-test={'workload-' + namespace + '-' + name}>
-        {namespace}/{name}
-      </Link>
-    );
+    return (<KioskLink linkName={namespace + '/' + name} dataTest={'workload-' + namespace + '-' + name} href={href}></KioskLink>)
   }
 }
-
-const mapStateToProps = (state: KialiAppState): ReduxProps => ({
-  kiosk: state.globalState.kiosk,
-});
-
-const WorkloadLinkContainer = connect(mapStateToProps)(WorkloadLinkItem);
-export default WorkloadLinkContainer;

--- a/frontend/src/components/Link/WorkloadLink.tsx
+++ b/frontend/src/components/Link/WorkloadLink.tsx
@@ -3,12 +3,22 @@ import { Paths } from '../../config';
 import { Link } from 'react-router-dom';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { TooltipPosition } from '@patternfly/react-core';
+import { KialiAppState } from "../../store/Store";
+import { connect } from "react-redux";
+import { isParentKiosk, kioskContextMenuAction } from "../Kiosk/KioskActions";
 
-interface Props {
+type ReduxProps = {
+  kiosk: string;
+}
+
+type Props = {
   name: string;
   namespace: string;
   query?: string;
 }
+
+type WorkloadProps = ReduxProps & Props & {
+};
 
 export const getWorkloadLink = (name: string, namespace: string, query?: string): string => {
   let to = '/namespaces/' + namespace + '/' + Paths.WORKLOADS;
@@ -29,12 +39,34 @@ export class WorkloadLink extends React.Component<Props> {
     return (
       <>
         <PFBadge badge={PFBadges.Workload} position={TooltipPosition.top} />
-        <Link to={getWorkloadLink(name, namespace, query)} data-test={'workload-' + namespace + '-' + name}>
-          {namespace}/{name}
-        </Link>
+        <WorkloadLinkContainer namespace={namespace} name={name} query={query} />
       </>
     );
   }
 }
 
-export default WorkloadLink;
+class WorkloadLinkItem extends React.Component<WorkloadProps> {
+  render() {
+    const { name, namespace, query } = this.props;
+    const href = getWorkloadLink(name, namespace, query);
+    return isParentKiosk(this.props.kiosk) ? (
+      <Link
+        to={''}
+        onClick={() => {
+          kioskContextMenuAction(href);
+        }}
+      >{namespace}/{name}</Link>
+    ) : (
+      <Link to={href} data-test={'workload-' + namespace + '-' + name}>
+        {namespace}/{name}
+      </Link>
+    );
+  }
+}
+
+const mapStateToProps = (state: KialiAppState): ReduxProps => ({
+  kiosk: state.globalState.kiosk,
+});
+
+const WorkloadLinkContainer = connect(mapStateToProps)(WorkloadLinkItem);
+export default WorkloadLinkContainer;

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -57,6 +57,9 @@ import RenderHeaderContainer from "../../components/Nav/Page/RenderHeader";
 import {ErrorMsg} from "../../types/ErrorMsg";
 import ErrorSection from "../../components/ErrorSection/ErrorSection";
 import RefreshNotifier from "../../components/Refresh/RefreshNotifier";
+import {isParentKiosk} from "../../components/Kiosk/KioskActions";
+import {KialiAppState} from "../../store/Store";
+import {connect} from "react-redux";
 
 // Enables the search box for the ACEeditor
 require('ace-builds/src-noconflict/ext-searchbox');
@@ -89,13 +92,17 @@ const paramToTab: { [key: string]: number } = {
   yaml: 0
 };
 
-class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioConfigId>, IstioConfigDetailsState> {
+interface IstioConfigDetailsProps extends RouteComponentProps<IstioConfigId> {
+  kiosk: string;
+}
+
+class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetailsProps, IstioConfigDetailsState> {
   aceEditorRef: React.RefObject<AceEditor>;
-  drawerRef: React.RefObject<IstioConfigDetailsPage>;
+  drawerRef: React.RefObject<IstioConfigDetails>;
   promptTo: string;
   timerId: number;
 
-  constructor(props: RouteComponentProps<IstioConfigId>) {
+  constructor(props: IstioConfigDetailsProps) {
     super(props);
     this.state = {
       isModified: false,
@@ -498,7 +505,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           width={'100%'}
           className={'istio-ace-editor'}
           wrapEnabled={true}
-          readOnly={!this.canUpdate()}
+          readOnly={!this.canUpdate() || isParentKiosk(this.props.kiosk)}
           setOptions={aceOptions}
           value={this.state.istioObjectDetails ? yamlSource : undefined}
           annotations={editorValidations.annotations}
@@ -527,7 +534,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   renderActionButtons = (showOverview: boolean) => {
     // User won't save if file has yaml errors
     const yamlErrors = !!(this.state.yamlValidations && this.state.yamlValidations.markers.length > 0);
-    return (
+    return !isParentKiosk(this.props.kiosk) ? (
       <IstioActionButtonsContainer
         objectName={this.props.match.params.object}
         readOnly={!this.canUpdate()}
@@ -539,7 +546,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         overview={this.state.isExpanded}
         onOverview={this.onDrawerToggle}
       />
-    );
+    ) : ('');
   };
 
   renderActions = () => {
@@ -609,4 +616,9 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   }
 }
 
+const mapStateToProps = (state: KialiAppState) => ({
+  kiosk: state.globalState.kiosk,
+});
+
+const IstioConfigDetailsPage = connect(mapStateToProps, null)(IstioConfigDetailsPageComponent);
 export default IstioConfigDetailsPage;

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -487,9 +487,11 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
               </>
             )}
           </div>
-          <DrawerActions>
-            <DrawerCloseButton onClick={this.onDrawerClose} />
-          </DrawerActions>
+          {!isParentKiosk(this.props.kiosk) && (
+            <DrawerActions>
+              <DrawerCloseButton onClick={this.onDrawerClose} />
+            </DrawerActions>
+          )}
         </DrawerHead>
       </DrawerPanelContent>
     );
@@ -501,7 +503,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
           mode="yaml"
           theme="eclipse"
           onChange={this.onEditorChange}
-          height={'var(--kiali-yaml-editor-height)'}
+          height={`calc(var(--kiali-yaml-editor-height) + ${isParentKiosk(this.props.kiosk) ? '100px' : '0px'})`}
           width={'100%'}
           className={'istio-ace-editor'}
           wrapEnabled={true}

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -595,7 +595,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
           mountOnEnter={false}
           unmountOnExit={true}
         >
-          <Tab key="istio-yaml" title={`YAML ${this.state.isModified ? ' * ' : ''}`} eventKey={0}>
+          <Tab key="istio-yaml" title={`${!isParentKiosk(this.props.kiosk) ? 'YAML' : 'Validations'} ${this.state.isModified ? ' * ' : ''}`} eventKey={0}>
             <RenderComponentScroll>{this.renderEditor()}</RenderComponentScroll>
           </Tab>
         </ParameterizedTabs>

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -582,7 +582,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
         {this.state.error && (
           <ErrorSection error={this.state.error} />
         )}
-        {!this.state.error && (
+        {!this.state.error && !isParentKiosk(this.props.kiosk) && (
         <ParameterizedTabs
           id="basic-tabs"
           onSelect={tabValue => {
@@ -595,11 +595,14 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
           mountOnEnter={false}
           unmountOnExit={true}
         >
-          <Tab key="istio-yaml" title={`${!isParentKiosk(this.props.kiosk) ? 'YAML' : 'Validations'} ${this.state.isModified ? ' * ' : ''}`} eventKey={0}>
+          <Tab key="istio-yaml" title={`YAML ${this.state.isModified ? ' * ' : ''}`} eventKey={0}>
             <RenderComponentScroll>{this.renderEditor()}</RenderComponentScroll>
           </Tab>
         </ParameterizedTabs>
           )}
+        {!this.state.error && isParentKiosk(this.props.kiosk) && (
+          <RenderComponentScroll>{this.renderEditor()}</RenderComponentScroll>
+        )}
         <Prompt
           message={location => {
             if (this.state.isModified) {

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -107,7 +107,8 @@ class IstioConfigOverview extends React.Component<IstioConfigOverviewProps> {
 
     let urlInKiali = "";
     if (istioObject !== undefined && istioObject.metadata.namespace !== undefined && istioObject.kind !== undefined) {
-      urlInKiali = GetIstioObjectUrl(istioObject.metadata.name, istioObject.metadata.namespace , istioObject.kind.toLowerCase() );
+      // here a "/console" is required as external link is used
+      urlInKiali = "/console" + GetIstioObjectUrl(istioObject.metadata.name, istioObject.metadata.namespace , istioObject.kind.toLowerCase() );
     }
 
     return (

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -105,9 +105,9 @@ class IstioConfigOverview extends React.Component<IstioConfigOverviewProps> {
       </div>
     );
 
-    let url = "";
+    let urlInKiali = "";
     if (istioObject !== undefined && istioObject.metadata.namespace !== undefined && istioObject.kind !== undefined) {
-      url = GetIstioObjectUrl(istioObject.metadata.name, istioObject.metadata.namespace , istioObject.kind.toLowerCase() );
+      urlInKiali = GetIstioObjectUrl(istioObject.metadata.name, istioObject.metadata.namespace , istioObject.kind.toLowerCase() );
     }
 
     return (
@@ -188,7 +188,7 @@ class IstioConfigOverview extends React.Component<IstioConfigOverviewProps> {
             <Tooltip content={"This is a Read only view of the YAML including Validations. It is possible to edit directly in Kiali "} position={TooltipPosition.top}>
               <Label color="green" isCompact>Read only mode</Label>
             </Tooltip>
-            <a href={url} style={{marginLeft: '5px', fontSize: '85%', color: PFColors.ActiveText}} target="_blank">Edit in Kiali</a>
+            <a href={urlInKiali} style={{marginLeft: '5px', fontSize: '85%', color: PFColors.ActiveText}} target="_blank" rel="noreferrer">Edit in Kiali</a>
           </StackItem>
         )}
       </Stack>

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -30,7 +30,7 @@ import IstioConfigHelp from './IstioConfigHelp';
 import IstioConfigReferences from './IstioConfigReferences';
 import IstioConfigValidationReferences from './IstioConfigValidationReferences';
 import IstioStatusMessageList from './IstioStatusMessageList';
-import {isKioskMode} from "../../../utils/SearchParamUtils";
+import { KioskElement } from "../../../components/Kiosk/KioskElement";
 import {PFColors} from "../../../components/Pf/PfColors";
 import {GetIstioObjectUrl} from "../../../components/Link/IstioObjectLink";
 
@@ -183,14 +183,14 @@ class IstioConfigOverview extends React.Component<IstioConfigOverviewProps> {
             ></IstioConfigHelp>
           </StackItem>
         )}
-        {isKioskMode() && (
+        <KioskElement>
           <StackItem>
             <Tooltip content={"This is a Read only view of the YAML including Validations. It is possible to edit directly in Kiali "} position={TooltipPosition.top}>
               <Label color="green" isCompact>Read only mode</Label>
             </Tooltip>
             <a href={urlInKiali} style={{marginLeft: '5px', fontSize: '85%', color: PFColors.ActiveText}} target="_blank" rel="noreferrer">Edit in Kiali</a>
           </StackItem>
-        )}
+        </KioskElement>
       </Stack>
     );
   }

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -1,4 +1,12 @@
-import { Stack, StackItem, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import {
+  Label,
+  Stack,
+  StackItem,
+  Title,
+  TitleSizes,
+  Tooltip,
+  TooltipPosition
+} from '@patternfly/react-core';
 import Labels from 'components/Label/Labels';
 import { PFBadge } from 'components/Pf/PfBadges';
 import LocalTime from 'components/Time/LocalTime';
@@ -22,6 +30,9 @@ import IstioConfigHelp from './IstioConfigHelp';
 import IstioConfigReferences from './IstioConfigReferences';
 import IstioConfigValidationReferences from './IstioConfigValidationReferences';
 import IstioStatusMessageList from './IstioStatusMessageList';
+import {isKioskMode} from "../../../utils/SearchParamUtils";
+import {PFColors} from "../../../components/Pf/PfColors";
+import {GetIstioObjectUrl} from "../../../components/Link/IstioObjectLink";
 
 interface IstioConfigOverviewProps {
   istioObjectDetails: IstioConfigDetails;
@@ -94,6 +105,11 @@ class IstioConfigOverview extends React.Component<IstioConfigOverviewProps> {
       </div>
     );
 
+    let url = "";
+    if (istioObject !== undefined && istioObject.metadata.namespace !== undefined && istioObject.kind !== undefined) {
+      url = GetIstioObjectUrl(istioObject.metadata.name, istioObject.metadata.namespace , istioObject.kind.toLowerCase() );
+    }
+
     return (
       <Stack hasGutter={true}>
         <StackItem>
@@ -165,6 +181,14 @@ class IstioConfigOverview extends React.Component<IstioConfigOverviewProps> {
               helpMessages={this.props.helpMessages}
               selectedLine={this.props.selectedLine}
             ></IstioConfigHelp>
+          </StackItem>
+        )}
+        {isKioskMode() && (
+          <StackItem>
+            <Tooltip content={"This is a Read only view of the YAML including Validations. It is possible to edit directly in Kiali "} position={TooltipPosition.top}>
+              <Label color="green" isCompact>Read only mode</Label>
+            </Tooltip>
+            <a href={url} style={{marginLeft: '5px', fontSize: '85%', color: PFColors.ActiveText}} target="_blank">Edit in Kiali</a>
           </StackItem>
         )}
       </Stack>

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigReferences.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigReferences.tsx
@@ -1,7 +1,7 @@
 import { Stack, StackItem, Title, TitleSizes } from '@patternfly/react-core';
 import { ReferenceIstioObjectLink } from 'components/Link/IstioObjectLink';
-import ServiceLink from 'components/Link/ServiceLink';
-import WorkloadLink from 'components/Link/WorkloadLink';
+import { ServiceLink } from 'components/Link/ServiceLink';
+import { WorkloadLink } from 'components/Link/WorkloadLink';
 import * as React from 'react';
 import { ObjectReference, ServiceReference, WorkloadReference } from 'types/IstioObjects';
 


### PR DESCRIPTION
RFE https://github.com/kiali/openshift-servicemesh-plugin/issues/52

Kiosk mode for config views made read-only.
Fixed kiosk mode Workload and Service links in Istio Config Overview page

![Screenshot from 2022-11-08 13-48-31](https://user-images.githubusercontent.com/604313/200567815-acb16734-3e4a-4596-8d66-cc4c322a2e5f.png)

