### PR TITLE
Show Kiali configuration 

### DIFF
--- a/frontend/src/components/DebugInformation/KialiConfiguration.tsx
+++ b/frontend/src/components/DebugInformation/KialiConfiguration.tsx
@@ -50,7 +50,7 @@ const copyToClipboardOptions = {
   message: 'We failed to automatically copy the text, please use: #{key}, Enter\t'
 };
 
-export class DebugInformation extends React.PureComponent<DebugInformationProps, DebugInformationState> {
+export class KialiConfiguration extends React.PureComponent<DebugInformationProps, DebugInformationState> {
   aceEditorRef: React.RefObject<AceEditor>;
 
   constructor(props: DebugInformationProps) {
@@ -135,7 +135,7 @@ export class DebugInformation extends React.PureComponent<DebugInformationProps,
         variant={ModalVariant.small}
         isOpen={this.state.show}
         onClose={this.close}
-        title="Debug information"
+        title="Kiali Configuration"
         actions={[
           <Button onClick={this.close}>Close</Button>,
           <CopyToClipboard onCopy={this.copyCallback} text={renderDebugInformation()} options={copyToClipboardOptions}>
@@ -175,7 +175,7 @@ export class DebugInformation extends React.PureComponent<DebugInformationProps,
             setOptions={aceOptions || { foldStyle: 'markbegin' }}
             value={renderDebugInformation()}
           />
-          </CopyToClipboard>
+        </CopyToClipboard>
       </Modal>
     );
   }
@@ -185,6 +185,6 @@ const mapStateToProps = (state: KialiAppState) => ({
   appState: state
 });
 
-const DebugInformationContainer = connect(mapStateToProps, null, null, { forwardRef: true })(DebugInformation);
+const KialiConfigurationContainer = connect(mapStateToProps, null, null, { forwardRef: true })(KialiConfiguration);
 
-export default DebugInformationContainer;
+export default KialiConfigurationContainer;

--- a/frontend/src/components/DebugInformation/KialiConfiguration.tsx
+++ b/frontend/src/components/DebugInformation/KialiConfiguration.tsx
@@ -1,25 +1,15 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import _ from 'lodash';
-import beautify from 'json-beautify';
-
-import authenticationConfig from '../../config/AuthenticationConfig';
 import { serverConfig } from '../../config';
-import { ComputedServerConfig } from '../../config/ServerConfig';
-import { AuthConfig } from '../../types/Auth';
 import { KialiAppState } from '../../store/Store';
 import {
-  Alert,
-  AlertActionCloseButton,
-  AlertVariant,
   Button,
   ButtonVariant,
   Modal,
   ModalVariant
 } from '@patternfly/react-core';
-import {aceOptions} from "../../types/IstioConfigDetails";
-import AceEditor from "react-ace";
+import {ICell, Table, TableBody, TableHeader, TableVariant} from "@patternfly/react-table";
 
 enum CopyStatus {
   NOT_COPIED, // We haven't copied the current output
@@ -27,37 +17,41 @@ enum CopyStatus {
   OLD_COPY // We copied the prev output, but there are changes in the KialiAppState
 }
 
-type DebugInformationProps = {
-  appState: KialiAppState;
-  ref: React.RefObject<any>;
-};
-
 type DebugInformationState = {
   show: boolean;
   copyStatus: CopyStatus;
-};
-
-type DebugInformationData = {
-  backendConfigs: {
-    authenticationConfig: AuthConfig;
-    computedServerConfig: ComputedServerConfig;
-  };
-  currentURL: string;
-  reduxState: KialiAppState;
+  config: Array<string>;
 };
 
 const copyToClipboardOptions = {
   message: 'We failed to automatically copy the text, please use: #{key}, Enter\t'
 };
 
-export class KialiConfiguration extends React.PureComponent<DebugInformationProps, DebugInformationState> {
-  aceEditorRef: React.RefObject<AceEditor>;
+const propsToShow = ["clusters", "gatewayAPIEnabled", "istioConfigMap", "istioIdentityDomain"];
 
-  constructor(props: DebugInformationProps) {
+type Props = {
+  ref: React.RefObject<any>;
+}
+
+export class KialiConfiguration extends React.Component<Props, DebugInformationState> {
+
+  constructor(props: Props) {
     super(props);
-    this.aceEditorRef = React.createRef();
 
-    this.state = { show: false, copyStatus: CopyStatus.NOT_COPIED };
+    let showConfig = [];
+
+    for (const key in serverConfig) {
+      if (propsToShow.includes(key)) {
+        // @ts-ignore
+        showConfig.push(key)
+      }
+    }
+
+    this.state = {
+      show: false,
+      copyStatus: CopyStatus.NOT_COPIED,
+      config: showConfig
+    };
   }
 
   open = () => {
@@ -72,64 +66,20 @@ export class KialiConfiguration extends React.PureComponent<DebugInformationProp
     this.setState({ copyStatus: result ? CopyStatus.COPIED : CopyStatus.NOT_COPIED });
   };
 
-  hideAlert = () => {
-    this.setState({ copyStatus: CopyStatus.NOT_COPIED });
-  };
-
-  componentDidUpdate(prevProps: DebugInformationProps, _prevState: DebugInformationState) {
-    if (this.props.appState !== prevProps.appState && this.state.copyStatus === CopyStatus.COPIED) {
-      this.setState({ copyStatus: CopyStatus.OLD_COPY });
-    }
-  }
-
-  renderHealthConfig = (config: Array<any> | Object | RegExp | string) => {
-    if (Array.isArray(config)) {
-      let arr = [];
-      for (let v of config) {
-        arr.push(this.renderHealthConfig(v) as never);
-      }
-      return arr;
-    }
-    let result = {};
-    for (let [key, value] of Object.entries(config)) {
-      if ((value as Object).constructor.toString().includes('RegExp')) {
-        result[key] = (value as RegExp).toString();
-      } else if (typeof value !== 'object') {
-        result[key] = value;
-      } else {
-        result[key] = this.renderHealthConfig(value);
-      }
-    }
-    return result;
+  private columns = (): ICell[] => {
+    return [{ title: 'Configuration' }, { title: 'Value' }];
   };
 
   render() {
-    const parseConfig = (key: string, value: any) => {
-      // We have to patch some runtime properties  we don't want to serialize
-      if (['cyRef', 'summaryTarget', 'token', 'username'].includes(key)) {
-        return null;
+
+    const config = this.state.config.map((k) => {
+      if (typeof serverConfig[k] === "string") {
+        return [k, serverConfig[k]]
+      } else {
+        return [k, JSON.stringify(serverConfig[k])]
       }
-      if ('healthConfig' === key) {
-        return this.renderHealthConfig(value);
-      }
-      return value;
-    };
-    const renderDebugInformation = _.memoize(() => {
-      const debugInformation: DebugInformationData = {
-        backendConfigs: {
-          authenticationConfig: authenticationConfig,
-          computedServerConfig: serverConfig
-        },
-        currentURL: "",
-        reduxState: this.props.appState
-      };
-      return beautify(debugInformation, parseConfig, 2);
+
     });
-
-    if (!this.state.show) {
-      return null;
-    }
-
     return (
       <Modal
         variant={ModalVariant.small}
@@ -138,44 +88,23 @@ export class KialiConfiguration extends React.PureComponent<DebugInformationProp
         title="Kiali Configuration"
         actions={[
           <Button onClick={this.close}>Close</Button>,
-          <CopyToClipboard onCopy={this.copyCallback} text={renderDebugInformation()} options={copyToClipboardOptions}>
+          <CopyToClipboard onCopy={this.copyCallback} text={this.state.config} options={copyToClipboardOptions}>
             <Button variant={ButtonVariant.primary}>Copy</Button>
           </CopyToClipboard>
         ]}
       >
-        {this.state.copyStatus === CopyStatus.COPIED && (
-          <Alert
-            style={{ marginBottom: '20px' }}
-            title="Debug information has been copied to your clipboard."
-            variant={AlertVariant.success}
-            isInline={true}
-            actionClose={<AlertActionCloseButton onClose={this.hideAlert} />}
-          />
-        )}
-        {this.state.copyStatus === CopyStatus.OLD_COPY && (
-          <Alert
-            style={{ marginBottom: '20px' }}
-            title="Debug information was copied to your clipboard, but is outdated now. It could be caused by new data received by auto refresh timers."
-            variant={AlertVariant.warning}
-            isInline={true}
-            actionClose={<AlertActionCloseButton onClose={this.hideAlert} />}
-          />
-        )}
-        <span>Please include this information when opening a bug:</span>
-        <CopyToClipboard onCopy={this.copyCallback} text={renderDebugInformation()} options={copyToClipboardOptions}>
-          <AceEditor
-            ref={this.aceEditorRef}
-            mode="yaml"
-            theme="eclipse"
-            width={'100%'}
-            //height={height.toString() + 'px'}
-            className={'istio-ace-editor'}
-            wrapEnabled={true}
-            readOnly={true}
-            setOptions={aceOptions || { foldStyle: 'markbegin' }}
-            value={renderDebugInformation()}
-          />
-        </CopyToClipboard>
+        <div>
+
+          <Table
+            header={<></>}
+            variant={TableVariant.compact}
+            cells={this.columns()}
+            rows={config}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </div>
       </Modal>
     );
   }

--- a/frontend/src/components/KialiConfiguration/KialiConfiguration.tsx
+++ b/frontend/src/components/KialiConfiguration/KialiConfiguration.tsx
@@ -27,7 +27,7 @@ const copyToClipboardOptions = {
   message: 'We failed to automatically copy the text, please use: #{key}, Enter\t'
 };
 
-const propsToShow = ["clusters", "gatewayAPIEnabled", "istioConfigMap", "istioIdentityDomain"];
+const propsToShow = ["accesibleNamespaces", "authStrategy", "clusters", "gatewayAPIEnabled", "istioConfigMap", "istioIdentityDomain", "istioNamespace", "istioStatusEnabled", "logLevel"];
 
 type Props = {
   ref: React.RefObject<any>;
@@ -38,14 +38,14 @@ export class KialiConfiguration extends React.Component<Props, DebugInformationS
   constructor(props: Props) {
     super(props);
 
-    let showConfig = [];
+    let showConfig = Array<string>();
 
     for (const key in serverConfig) {
       if (propsToShow.includes(key)) {
-        // @ts-ignore
         showConfig.push(key)
       }
     }
+    showConfig = showConfig.sort();
 
     this.state = {
       show: false,

--- a/frontend/src/components/Nav/Masthead/HelpDropdown.tsx
+++ b/frontend/src/components/Nav/Masthead/HelpDropdown.tsx
@@ -9,6 +9,7 @@ import { isUpstream } from '../../UpstreamDetector/UpstreamDetector';
 import { Status, ExternalServiceInfo, StatusKey } from '../../../types/StatusState';
 import { config, serverConfig } from '../../../config';
 import IstioCertsInfoConnected from 'components/IstioCertsInfo/IstioCertsInfo';
+import KialiConfigurationContainer from "../../DebugInformation/KialiConfiguration";
 
 type HelpDropdownProps = {
   status: Status;
@@ -24,6 +25,7 @@ class HelpDropdownContainer extends React.Component<HelpDropdownProps, HelpDropd
   about: React.RefObject<AboutUIModal>;
   debugInformation: React.RefObject<any>;
   certsInformation: React.RefObject<any>;
+  configuration: React.RefObject<any>;
 
   constructor(props: HelpDropdownProps) {
     super(props);
@@ -31,6 +33,7 @@ class HelpDropdownContainer extends React.Component<HelpDropdownProps, HelpDropd
     this.about = React.createRef<AboutUIModal>();
     this.debugInformation = React.createRef();
     this.certsInformation = React.createRef();
+    this.configuration = React.createRef();
   }
 
   openAbout = () => {
@@ -44,6 +47,10 @@ class HelpDropdownContainer extends React.Component<HelpDropdownProps, HelpDropd
 
   openCertsInformation = () => {
     this.certsInformation.current!.open();
+  };
+
+  openConfig = () => {
+    this.configuration.current!.open();
   };
 
   onDropdownToggle = isDropdownOpen => {
@@ -108,6 +115,12 @@ class HelpDropdownContainer extends React.Component<HelpDropdownProps, HelpDropd
     }
 
     items.push(
+      <DropdownItem component={'span'} key={'kiali_config'} onClick={this.openConfig}>
+        Configuration
+      </DropdownItem>
+    );
+
+    items.push(
       <DropdownItem component={'span'} key={'view_about_info'} onClick={this.openAbout}>
         About
       </DropdownItem>
@@ -124,6 +137,7 @@ class HelpDropdownContainer extends React.Component<HelpDropdownProps, HelpDropd
         {serverConfig.kialiFeatureFlags.certificatesInformationIndicators.enabled && (
           <IstioCertsInfoConnected ref={this.certsInformation} />
         )}
+        <KialiConfigurationContainer ref={this.configuration} />
         <Dropdown
           data-test="about-help-button"
           isPlain={true}

--- a/frontend/src/components/Nav/Masthead/HelpDropdown.tsx
+++ b/frontend/src/components/Nav/Masthead/HelpDropdown.tsx
@@ -9,7 +9,7 @@ import { isUpstream } from '../../UpstreamDetector/UpstreamDetector';
 import { Status, ExternalServiceInfo, StatusKey } from '../../../types/StatusState';
 import { config, serverConfig } from '../../../config';
 import IstioCertsInfoConnected from 'components/IstioCertsInfo/IstioCertsInfo';
-import KialiConfigurationContainer from "../../DebugInformation/KialiConfiguration";
+import KialiConfigurationContainer from "../../KialiConfiguration/KialiConfiguration";
 
 type HelpDropdownProps = {
   status: Status;
@@ -116,7 +116,7 @@ class HelpDropdownContainer extends React.Component<HelpDropdownProps, HelpDropd
 
     items.push(
       <DropdownItem component={'span'} key={'kiali_config'} onClick={this.openConfig}>
-        Configuration
+        Kiali Config
       </DropdownItem>
     );
 

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -50,6 +50,8 @@ const computeValidDurations = (cfg: ComputedServerConfig) => {
 // Set some reasonable defaults. Initial values should be valid for fields
 // than may not be providedby/set on the server.
 const defaultServerConfig: ComputedServerConfig = {
+  accesibleNamespaces: [],
+  authStrategy: '',
   clusters: {},
   durations: {},
   gatewayAPIEnabled: false,
@@ -99,6 +101,7 @@ const defaultServerConfig: ComputedServerConfig = {
       }
     }
   },
+  logLevel: '',
   prometheus: {
     globalScrapeInterval: 15,
     storageTsdbRetention: 21600

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -67,8 +67,11 @@ export const generateRequestHealth = (
 };
 
 export const serverRateConfig = {
+  accesibleNamespaces: [],
+  authStrategy: '',
   clusters: {},
   gatewayAPIEnabled: false,
+  logLevel: '',
   kialiFeatureFlags: {
     certificatesInformationIndicators: {
       enabled: true

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -109,7 +109,7 @@ export interface ToleranceConfig {
 */
 
 export interface ServerConfig {
-  accesibleNamespaces: [];
+  accesibleNamespaces: Array<string>;
   authStrategy: string;
   clusterInfo?: ClusterInfo;
   clusters: { [key: string]: MeshCluster };

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -109,6 +109,8 @@ export interface ToleranceConfig {
 */
 
 export interface ServerConfig {
+  accesibleNamespaces: [];
+  authStrategy: string;
   clusterInfo?: ClusterInfo;
   clusters: { [key: string]: MeshCluster };
   deployment: DeploymentConfig;
@@ -121,6 +123,7 @@ export interface ServerConfig {
   istioNamespace: string;
   istioLabels: { [key in IstioLabelKey]: string };
   kialiFeatureFlags: KialiFeatureFlags;
+  logLevel: string,
   prometheus: {
     globalScrapeInterval?: DurationInSeconds;
     storageTsdbRetention?: DurationInSeconds;

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -1,8 +1,11 @@
 import { getExpr } from '../../config/HealthConfig';
 
 export const healthConfig = {
+  accesibleNamespaces: [],
+  authStrategy: '',
   clusters: {},
   gatewayAPIEnabled: false,
+  logLevel: '',
   kialiFeatureFlags: {
     certificatesInformationIndicators: {
       enabled: true

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -49,6 +49,8 @@ type DeploymentConfig struct {
 // PublicConfig is a subset of Kiali configuration that can be exposed to clients to
 // help them interact with the system.
 type PublicConfig struct {
+	AccesibleNamespaces []string                    `json:"accesibleNamespaces,omitempty"`
+	AuthStrategy        string                      `json:"authStrategy,omitempty"`
 	ClusterInfo         ClusterInfo                 `json:"clusterInfo,omitempty"`
 	Clusters            map[string]business.Cluster `json:"clusters,omitempty"`
 	Deployment          DeploymentConfig            `json:"deployment,omitempty"`
@@ -63,6 +65,7 @@ type PublicConfig struct {
 	IstioLabels         config.IstioLabels          `json:"istioLabels,omitempty"`
 	IstioConfigMap      string                      `json:"istioConfigMap"`
 	KialiFeatureFlags   config.KialiFeatureFlags    `json:"kialiFeatureFlags,omitempty"`
+	LogLevel            string                      `json:"logLevel,omitempty"`
 	Prometheus          PrometheusConfig            `json:"prometheus,omitempty"`
 }
 
@@ -75,7 +78,9 @@ func Config(w http.ResponseWriter, r *http.Request) {
 	promConfig := getPrometheusConfig()
 	config := config.Get()
 	publicConfig := PublicConfig{
-		Clusters: make(map[string]business.Cluster),
+		AccesibleNamespaces: config.Deployment.AccessibleNamespaces,
+		AuthStrategy:        config.Auth.Strategy,
+		Clusters:            make(map[string]business.Cluster),
 		Deployment: DeploymentConfig{
 			ViewOnlyMode: config.Deployment.ViewOnlyMode,
 		},
@@ -98,6 +103,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 			GlobalScrapeInterval: promConfig.GlobalScrapeInterval,
 			StorageTsdbRetention: promConfig.StorageTsdbRetention,
 		},
+		LogLevel: log.GetLogLevel().String(),
 	}
 
 	// The following code fetches the cluster info. Cluster info is not critical.

--- a/log/log.go
+++ b/log/log.go
@@ -118,6 +118,10 @@ func Fatalf(format string, args ...interface{}) {
 	log.Fatal().Msgf(format, args...)
 }
 
+func GetLogLevel() zerolog.Level {
+	return log.Logger.GetLevel()
+}
+
 // Resolves the environment settings for the log level. Considers the verbose_mode from server version <=1.25.
 func resolveLogLevelFromEnv() zerolog.Level {
 	logLevel, isDefined := os.LookupEnv("LOG_LEVEL")


### PR DESCRIPTION
The changes include, update the debug information Modal: 

![image](https://user-images.githubusercontent.com/49480155/200610059-cdcd3dac-3f2b-4443-ad38-49b9011586b7.png)

And show the kiali configuration: 

![image](https://user-images.githubusercontent.com/49480155/200610217-5e61c3ef-92a4-491d-8123-46b36daae25e.png)

This is just a draft as a proposal about how to show this information. 

I wasn't sure about the information to be shown. I've thought in having a list of headers to filter items from the already available config. Another possibility is to create an specific API returning just the specific information (Get the spec from the kiali CR?). Depending on the information, add the security checks. 

Fixes #5588 