### PR TITLE
Added smoke test for the new Overview page brought in 1.57.

### DIFF
--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -1,4 +1,5 @@
-import { Before, Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Before, Given, Then, When, And } from '@badeball/cypress-cucumber-preprocessor';
+import { ensureKialiFinishedLoading } from './transition';
 
 Before(() => {
   // Focing to not stop cypress on unexpected errors not related to the tests.
@@ -187,7 +188,12 @@ Then('the {string} application indicator should list the application', function 
 // New CP Card validations
 When('user hovers over the MinTLS locker', view => {
   cy.get('[data-test="lockerCA"]')
-      .should('exist');
+  .should('exist');
+});
+
+When ('user clicks the toggle on the right side of the {string} namespace card', (ns:string) => {
+  ensureKialiFinishedLoading(); 
+  cy.get('article[data-test^="' + ns + '"]').find('button').click();
 });
 
 Then('the user sees the certificates information', view => {
@@ -199,7 +205,7 @@ Then('the user sees the certificates information', view => {
 
 // We will suppose that the min TLS Version was not set
 // So we verify the default
-Then("the minimum TLS version", view => {
+Then('the minimum TLS version', view => {
   cy.get('[data-test="label-TLS"]')
       .contains('N/A');
 });
@@ -212,4 +218,24 @@ Then("the user sees no information related to canary upgrades", view => {
 Then("the user sees information related to canary upgrades", view => {
   cy.get('[data-test="canary-upgrade"]')
       .should('exist');
+});
+
+Then('user can see links to external services',() =>{
+  cy.get('article[data-test^="istio-system"]').as("plane").within(() => {
+    cy.request('GET', '/api/grafana').should(response => {
+      expect(response.status).to.equal(200);
+      response.body.externalLinks.forEach(elem => {
+        if (elem.name != 'Istio Service Dashboard' && elem.name != 'Istio Workload Dashboard'){
+          cy.get('@plane').find('a').contains(elem.name);
+        }
+      });
+    });
+  });
+});
+
+And('user sees the {string} label in the {string} namespace card', (label: string, ns: string) => {
+  cy.log(label);
+  cy.get('article[data-test^="' + ns + '"]')
+    .contains(label)
+    .should('be.visible');
 });

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -3,11 +3,11 @@ Feature: Kiali Overview page
   User opens the Overview page and see the demo "error-rates" namespaces.
 
   Health indicators in overview page
-    Kiali is capable of calculating the health of services in the mesh/cluster
-    using several data sources like workload availability and errors in traffic.
-    Kiali offers health status at different levels of granularity: from namespace
-    level, to the individual pod. In the overview page, health indicators have
-    namespace level and app level granularity.
+  Kiali is capable of calculating the health of services in the mesh/cluster
+  using several data sources like workload availability and errors in traffic.
+  Kiali offers health status at different levels of granularity: from namespace
+  level, to the individual pod. In the overview page, health indicators have
+  namespace level and app level granularity.
 
   Background:
     Given user is at administrator perspective
@@ -114,3 +114,11 @@ Feature: Kiali Overview page
   @overview-page
   Scenario: The canary upgrade information is not present when there is no canary configured
     Then the user sees no information related to canary upgrades
+
+  @overview-page
+  Scenario: The Istio panel should be visible in the control panel
+    Then user sees the "istio-system" namespace card
+    And user sees the "Control plane" label in the "istio-system" namespace card
+    And user sees the "Outbound policy" label in the "istio-system" namespace card
+    When user clicks the toggle on the right side of the "istio-system" namespace card
+    Then user can see links to external services


### PR DESCRIPTION
One of the tests for the new features added in the OSSM 2.3 version of Kiali

The test checks the new Control plane for Istio in the overview page. It also checks some additional links in its kebab menu, which are not available in the other namespaces.