### PR TITLE
[v1.59] compat matrix for istio 1.16

### DIFF
--- a/config/version-compatibility-matrix.yaml
+++ b/config/version-compatibility-matrix.yaml
@@ -1,9 +1,12 @@
 # The Compatible Version Matrix between upstream Istio and Kiali
 - meshName: "Istio"
   versionRange:
+    - meshVersion: "1.16"
+      kialiMinimumVersion: "1.59.1"
+      kialiMaximumVersion: ""
     - meshVersion: "1.15"
       kialiMinimumVersion: "1.55.0"
-      kialiMaximumVersion: ""
+      kialiMaximumVersion: "1.59.0"
     - meshVersion: "1.14"
       kialiMinimumVersion: "1.50.0"
       kialiMaximumVersion: "1.54"

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -285,6 +285,24 @@ func TestMeshVersionCompatible(t *testing.T) {
 	versionsToTest := []versionsToTestStruct{
 		{
 			name:        "Istio",
+			version:     "1.59.1",
+			meshVersion: "1.16",
+			supported:   true,
+		},
+		{
+			name:        "Istio",
+			version:     "1.59.0",
+			meshVersion: "1.16",
+			supported:   false,
+		},
+		{
+			name:        "Istio",
+			version:     "1.59.0",
+			meshVersion: "1.15",
+			supported:   true,
+		},
+		{
+			name:        "Istio",
 			version:     "1.55.0",
 			meshVersion: "1.15",
 			supported:   true,


### PR DESCRIPTION
backport of https://github.com/kiali/kiali/pull/5628