### PR TITLE
[perf] reduce computation needs of Kiali heatmap tooltips

### DIFF
--- a/frontend/src/actions/MetricsStatsThunkActions.ts
+++ b/frontend/src/actions/MetricsStatsThunkActions.ts
@@ -10,18 +10,24 @@ type ExpiringStats = MetricsStats & { timestamp: number };
 
 const expiry = 2 * 60 * 1000;
 const MetricsStatsThunkActions = {
-  load: (queries: MetricsStatsQuery[]) => {
+  load: (queries: MetricsStatsQuery[], isCompact: boolean) => {
     return (dispatch: KialiDispatch, getState: () => KialiAppState) => {
       const oldStats = getState().metricsStats.data as Map<string, ExpiringStats>;
       const now = Date.now();
-      // Keep only queries for stats we don't already have
+      // Keep only queries for stats we don't already have, that aren't expired, and are sufficient
       const newStats = new Map(Array.from(oldStats).filter(([_, v]) => now - v.timestamp < expiry));
-      const filtered = queries.filter(q => !newStats.has(statsQueryToKey(q)));
+      const filtered = queries.filter(q => {
+        const existingStat = newStats.get(statsQueryToKey(q));
+        // perform the query if we don't have the stat, or if we need full stats and only have compact stats
+        return !existingStat || (!isCompact && existingStat.isCompact);
+      });
       if (filtered.length > 0) {
         return API.getMetricsStats(filtered)
           .then(res => {
             // Merge result
-            Object.entries(res.data.stats).forEach(e => newStats.set(e[0], { ...e[1], timestamp: now }));
+            Object.entries(res.data.stats).forEach(e =>
+              newStats.set(e[0], { ...e[1], timestamp: now, isCompact: isCompact })
+            );
             dispatch(MetricsStatsActions.setStats(newStats));
             if (res.data.warnings && res.data.warnings.length > 0) {
               addInfo(res.data.warnings.join('; '), false);

--- a/frontend/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
@@ -48,7 +48,7 @@ import { isParentKiosk, kioskContextMenuAction } from '../../Kiosk/KioskActions'
 
 type ReduxProps = {
   kiosk: string;
-  loadMetricsStats: (queries: MetricsStatsQuery[]) => void;
+  loadMetricsStats: (queries: MetricsStatsQuery[], isCompact: boolean) => void;
   metricsStats: Map<string, MetricsStats>;
 };
 
@@ -177,8 +177,8 @@ class SpanTable extends React.Component<Props, State> {
   }
 
   private fetchComparisonMetrics(items: RichSpanData[]) {
-    const queries = buildQueriesFromSpans(items);
-    this.props.loadMetricsStats(queries);
+    const queries = buildQueriesFromSpans(items, false);
+    this.props.loadMetricsStats(queries, false);
   }
 
   private rows = (): IRow[] => {
@@ -576,7 +576,8 @@ const mapStateToProps = (state: KialiAppState) => ({
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch) => ({
-  loadMetricsStats: (queries: MetricsStatsQuery[]) => dispatch(MetricsStatsThunkActions.load(queries))
+  loadMetricsStats: (queries: MetricsStatsQuery[], isCompact: boolean) =>
+    dispatch(MetricsStatsThunkActions.load(queries, isCompact))
 });
 
 const Container = connect(mapStateToProps, mapDispatchToProps)(SpanTable);

--- a/frontend/src/components/JaegerIntegration/JaegerResults/StatsComparison.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/StatsComparison.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { InfoAltIcon } from '@patternfly/react-icons';
 import _round from 'lodash/round';
-
 import { HeatMap } from 'components/HeatMap/HeatMap';
 import { MetricsStats } from 'types/Metrics';
 import { PFColors } from 'components/Pf/PfColors';
@@ -9,14 +8,15 @@ import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { EnvoySpanInfo, RichSpanData } from 'types/JaegerInfo';
 import {
   compactStatsIntervals,
-  allStatsIntervals,
+  statsIntervals,
   getSpanStats,
-  statsAvgWithQuantiles,
+  statsQuantilesWithAvg,
   StatsMatrix,
   statsToMatrix,
   StatsWithIntervalIndex,
   statsPerPeer,
-  statsCompareKind
+  statsCompareKind,
+  compactStatsQuantilesWithAvg
 } from 'utils/tracing/TraceStats';
 
 const statToText = {
@@ -29,20 +29,18 @@ const statToText = {
   '0.999': { short: 'p99.9', long: '99.9th percentile' }
 };
 
-const renderHeatMap = (
-  item: RichSpanData,
-  stats: StatsWithIntervalIndex[],
-  intervals: string[],
-  compactMode: boolean
-) => {
+const renderHeatMap = (item: RichSpanData, stats: StatsWithIntervalIndex[], isCompact: boolean) => {
   const key = `${item.spanID}-hm`;
+  const intervals = isCompact ? compactStatsIntervals : statsIntervals;
+  const quantilesWithAvg = isCompact ? compactStatsQuantilesWithAvg : statsQuantilesWithAvg;
+
   return (
     <HeatMap
       key={key}
-      xLabels={statsAvgWithQuantiles.map(s => statToText[s]?.short || s)}
+      xLabels={quantilesWithAvg.map(s => statToText[s]?.short || s)}
       yLabels={intervals}
       data={statsToMatrix(stats, intervals)}
-      displayMode={compactMode ? 'compact' : 'normal'}
+      displayMode={isCompact ? 'compact' : 'normal'}
       colorMap={HeatMap.HealthColorMap}
       dataRange={{ from: -10, to: 10 }}
       colorUndefined={PFColors.Black200}
@@ -50,7 +48,7 @@ const renderHeatMap = (
       tooltip={(x, y, v) => {
         // Build explanation tooltip
         const slowOrFast = v > 0 ? 'slower' : 'faster';
-        const stat = statToText[statsAvgWithQuantiles[x]]?.long || statsAvgWithQuantiles[x];
+        const stat = statToText[quantilesWithAvg[x]]?.long || quantilesWithAvg[x];
         const interval = intervals[y];
         const info = item.info as EnvoySpanInfo;
         let dir = 'from',
@@ -71,17 +69,16 @@ const renderHeatMap = (
 
 export const renderMetricsComparison = (
   item: RichSpanData,
-  compactMode: boolean,
+  isCompact: boolean,
   metricsStats: Map<string, MetricsStats>,
   load: () => void
 ) => {
-  const intervals = compactMode ? compactStatsIntervals : allStatsIntervals;
-  const itemStats = getSpanStats(item, intervals, metricsStats);
+  const itemStats = getSpanStats(item, metricsStats, isCompact);
   const key = `${item.spanID}-metcomp`;
   if (itemStats.length > 0) {
     return (
       <React.Fragment key={key}>
-        {!compactMode && (
+        {!isCompact && (
           <Tooltip
             key={`${key}-tt`}
             content="This heatmap is a comparison matrix of this request duration against duration statistics aggregated over time. Move the pointer over cells to get more details."
@@ -91,7 +88,7 @@ export const renderMetricsComparison = (
             </>
           </Tooltip>
         )}
-        {renderHeatMap(item, itemStats, intervals, compactMode)}
+        {renderHeatMap(item, itemStats, isCompact)}
       </React.Fragment>
     );
   }
@@ -104,13 +101,15 @@ export const renderMetricsComparison = (
   );
 };
 
-export const renderTraceHeatMap = (matrix: StatsMatrix, intervals: string[], compactMode: boolean) => {
+export const renderTraceHeatMap = (matrix: StatsMatrix, isCompact: boolean) => {
+  const intervals = isCompact ? compactStatsIntervals : statsIntervals;
+  const quantilesWithAvg = isCompact ? compactStatsQuantilesWithAvg : statsQuantilesWithAvg;
   return (
     <HeatMap
-      xLabels={statsAvgWithQuantiles.map(s => statToText[s]?.short || s)}
+      xLabels={quantilesWithAvg.map(s => statToText[s]?.short || s)}
       yLabels={intervals}
       data={matrix}
-      displayMode={compactMode ? 'compact' : 'normal'}
+      displayMode={isCompact ? 'compact' : 'normal'}
       colorMap={HeatMap.HealthColorMap}
       dataRange={{ from: -10, to: 10 }}
       colorUndefined={PFColors.Black200}
@@ -118,7 +117,7 @@ export const renderTraceHeatMap = (matrix: StatsMatrix, intervals: string[], com
       tooltip={(x, y, v) => {
         // Build explanation tooltip
         const slowOrFast = v > 0 ? 'slower' : 'faster';
-        const stat = statToText[statsAvgWithQuantiles[x]]?.long || statsAvgWithQuantiles[x];
+        const stat = statToText[quantilesWithAvg[x]]?.long || quantilesWithAvg[x];
         const interval = intervals[y];
         return `Trace requests have been, in average, ${_round(
           Math.abs(v),

--- a/frontend/src/components/JaegerIntegration/JaegerResults/TraceDetails.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/TraceDetails.tsx
@@ -4,7 +4,6 @@ import { KialiDispatch } from 'types/Redux';
 import _round from 'lodash/round';
 import { Button, ButtonVariant, Card, CardBody, Grid, GridItem, Tooltip } from '@patternfly/react-core';
 import { InfoAltIcon, WarningTriangleIcon } from '@patternfly/react-icons';
-
 import { JaegerTrace, RichSpanData } from 'types/JaegerInfo';
 import JaegerTraceTitleContainer from './JaegerTraceTitle';
 import { CytoscapeGraphSelectorBuilder } from 'components/CytoscapeGraph/CytoscapeGraphSelector';
@@ -31,23 +30,22 @@ import { HeatMap } from 'components/HeatMap/HeatMap';
 import { formatDuration, sameSpans } from 'utils/tracing/TracingHelper';
 
 type ReduxProps = {
-  loadMetricsStats: (queries: MetricsStatsQuery[]) => void;
+  loadMetricsStats: (queries: MetricsStatsQuery[], isCompact: boolean) => void;
   setTraceId: (traceId?: string) => void;
 };
 
 type Props = ReduxProps & {
-  otherTraces: JaegerTrace[];
+  isStatsMatrixComplete: boolean;
   jaegerURL: string;
   namespace: string;
+  otherTraces: JaegerTrace[];
+  statsMatrix?: StatsMatrix;
   target: string;
   targetKind: TargetKind;
   trace?: JaegerTrace;
-  statsMatrix?: StatsMatrix;
-  isStatsMatrixComplete: boolean;
-}
+};
 
 interface State {}
-export const heatmapIntervals = ['10m', '60m', '6h'];
 
 class TraceDetails extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -75,8 +73,8 @@ class TraceDetails extends React.Component<Props, State> {
   }
 
   private fetchComparisonMetrics(spans: RichSpanData[]) {
-    const queries = buildQueriesFromSpans(spans);
-    this.props.loadMetricsStats(queries);
+    const queries = buildQueriesFromSpans(spans, false);
+    this.props.loadMetricsStats(queries, false);
   }
 
   private getGraphURL = (traceID: string) => {
@@ -223,7 +221,7 @@ class TraceDetails extends React.Component<Props, State> {
               {this.props.statsMatrix && (
                 <>
                   <strong>Compared with metrics: </strong>
-                  {renderTraceHeatMap(this.props.statsMatrix, heatmapIntervals, false)}
+                  {renderTraceHeatMap(this.props.statsMatrix, false)}
                   {!this.props.isStatsMatrixComplete && (
                     <>
                       <WarningTriangleIcon /> Incomplete data, check Span Details
@@ -252,11 +250,7 @@ class TraceDetails extends React.Component<Props, State> {
 
 const mapStateToProps = (state: KialiAppState) => {
   if (state.jaegerState.selectedTrace) {
-    const { matrix, isComplete } = reduceMetricsStats(
-      state.jaegerState.selectedTrace,
-      heatmapIntervals,
-      state.metricsStats.data
-    );
+    const { matrix, isComplete } = reduceMetricsStats(state.jaegerState.selectedTrace, state.metricsStats.data, false);
     return {
       trace: state.jaegerState.selectedTrace,
       statsMatrix: matrix,
@@ -271,7 +265,8 @@ const mapStateToProps = (state: KialiAppState) => {
 
 const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   setTraceId: (traceId?: string) => dispatch(JaegerThunkActions.setTraceId(traceId)),
-  loadMetricsStats: (queries: MetricsStatsQuery[]) => dispatch(MetricsStatsThunkActions.load(queries))
+  loadMetricsStats: (queries: MetricsStatsQuery[], isCompact: boolean) =>
+    dispatch(MetricsStatsThunkActions.load(queries, isCompact))
 });
 
 const TraceDetailsContainer = connect(mapStateToProps, mapDispatchToProps)(TraceDetails);

--- a/frontend/src/components/JaegerIntegration/JaegerScatter.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerScatter.tsx
@@ -22,7 +22,7 @@ interface JaegerScatterProps {
   duration: number;
   errorFetchTraces?: JaegerError[];
   errorTraces?: boolean;
-  loadMetricsStats: (queries: MetricsStatsQuery[]) => Promise<any>;
+  loadMetricsStats: (queries: MetricsStatsQuery[], isCompact: boolean) => Promise<any>;
   selectedTrace?: JaegerTrace;
   setTraceId: (traceId?: string) => void;
   showSpansAverage: boolean;
@@ -151,17 +151,17 @@ class JaegerScatter extends React.Component<JaegerScatterProps> {
     }
   };
 
-  private loadTraceMetrics(trace: JaegerTrace) {
+  private loadTraceTooltipMetrics(trace: JaegerTrace) {
     this.isLoading = true;
-    const queries = buildQueriesFromSpans(trace.spans);
+    const queries = buildQueriesFromSpans(trace.spans, true);
 
     this.props
-      .loadMetricsStats(queries)
+      .loadMetricsStats(queries, true)
       .then(_response => {
         if (this.nextToLoad) {
           const nextTrace = this.nextToLoad;
           this.nextToLoad = undefined;
-          this.loadTraceMetrics(nextTrace);
+          this.loadTraceTooltipMetrics(nextTrace);
         } else {
           this.isLoading = false;
         }
@@ -179,7 +179,7 @@ class JaegerScatter extends React.Component<JaegerScatterProps> {
       // replace any pending load with a load for the currently hovered trace
       this.nextToLoad = trace;
     } else {
-      this.loadTraceMetrics(trace);
+      this.loadTraceTooltipMetrics(trace);
     }
   };
 }
@@ -190,7 +190,8 @@ const mapStateToProps = (state: KialiAppState) => ({
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch) => ({
-  loadMetricsStats: (queries: MetricsStatsQuery[]) => dispatch(MetricsStatsThunkActions.load(queries)),
+  loadMetricsStats: (queries: MetricsStatsQuery[], isCompact: boolean) =>
+    dispatch(MetricsStatsThunkActions.load(queries, isCompact)),
   setTraceId: (traceId?: string) => dispatch(JaegerThunkActions.setTraceId(traceId))
 });
 

--- a/frontend/src/components/JaegerIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/JaegerIntegration/TraceTooltip.tsx
@@ -4,7 +4,7 @@ import { pluralize } from '@patternfly/react-core';
 import { ChartCursorFlyout, ChartLabelProps } from '@patternfly/react-charts';
 import { style } from 'typestyle';
 import { KialiAppState } from 'store/Store';
-import { averageSpanDuration, allStatsIntervals, reduceMetricsStats, StatsMatrix } from 'utils/tracing/TraceStats';
+import { averageSpanDuration, reduceMetricsStats, StatsMatrix } from 'utils/tracing/TraceStats';
 import { JaegerLineInfo } from './JaegerScatter';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { renderTraceHeatMap } from './JaegerResults/StatsComparison';
@@ -51,9 +51,7 @@ class TraceLabel extends React.Component<LabelProps> {
           <div className={titleStyle}>{this.props.trace.traceName || '(Missing root span)'}</div>
           <br />
           <div className={contentStyle}>
-            <div className={leftStyle}>
-              {hasStats ? renderTraceHeatMap(this.props.statsMatrix!, allStatsIntervals, true) : 'n/a'}
-            </div>
+            <div className={leftStyle}>{hasStats ? renderTraceHeatMap(this.props.statsMatrix!, true) : 'n/a'}</div>
             <div>
               {formatDuration(this.props.trace.duration)}
               <br />
@@ -69,7 +67,7 @@ class TraceLabel extends React.Component<LabelProps> {
 }
 
 const mapStateToProps = (state: KialiAppState, props: any) => {
-  const { matrix, isComplete } = reduceMetricsStats(props.trace, allStatsIntervals, state.metricsStats.data);
+  const { matrix, isComplete } = reduceMetricsStats(props.trace, state.metricsStats.data, true);
   return {
     statsMatrix: matrix,
     isStatsMatrixComplete: isComplete

--- a/frontend/src/components/JaegerIntegration/TracesComponent.tsx
+++ b/frontend/src/components/JaegerIntegration/TracesComponent.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { Card, CardBody, Tab, Tabs, Toolbar, ToolbarGroup, ToolbarItem, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { connect } from 'react-redux';
-
 import * as API from 'services/Api';
 import * as AlertUtils from 'utils/AlertUtils';
 import { RenderComponentScroll } from '../Nav/Page';
-import { KioskElement } from "../Kiosk/KioskElement";
-import { TimeDurationModal } from "../Time/TimeDurationModal";
+import { KioskElement } from '../Kiosk/KioskElement';
+import { TimeDurationModal } from '../Time/TimeDurationModal';
 import { KialiAppState } from 'store/Store';
 import { JaegerError, JaegerTrace } from 'types/JaegerInfo';
 import TraceDetails from './JaegerResults/TraceDetails';
@@ -21,15 +20,7 @@ import { TracesDisplayOptions, QuerySettings, DisplaySettings, percentilesOption
 import { Direction, genStatsKey, MetricsStatsQuery } from 'types/MetricsOptions';
 import { MetricsStatsResult } from 'types/Metrics';
 import { getSpanId } from 'utils/SearchParamUtils';
-import TimeDurationIndicatorContainer from "../Time/TimeDurationIndicatorComponent";
-
-/*
-    timeRange: timeRangeSelector(state),
-    urlJaeger: state.jaegerState.info ? state.jaegerState.info.url : '',
-    namespaceSelector: state.jaegerState.info ? state.jaegerState.info.namespaceSelector : true,
-    selectedTrace: state.jaegerState.selectedTrace,
-    lastRefreshAt: state.globalState.lastRefreshAt
- */
+import TimeDurationIndicatorContainer from '../Time/TimeDurationIndicatorComponent';
 
 type ReduxProps = {
   namespaceSelector: boolean;
@@ -43,7 +34,7 @@ type TracesProps = ReduxProps & {
   namespace: string;
   target: string;
   targetKind: TargetKind;
-}
+};
 
 interface TracesState {
   isTimeOptionsOpen: boolean;
@@ -91,6 +82,7 @@ class TracesComponent extends React.Component<TracesProps, TracesState> {
         this.setState({ jaegerErrors: errors, toolbarDisabled: true });
       }
     });
+    // This establishes the percentile-based filtering levels
     this.percentilesPromise = this.fetchPercentiles();
   }
 
@@ -132,9 +124,9 @@ class TracesComponent extends React.Component<TracesProps, TracesState> {
       spanLimit: this.state.querySettings.limit,
       tags: this.getTags()
     };
+    // If percentil filter is set fetch only traces above the specified percentile
+    // Percentiles (99th, 90th, 75th) are pre-computed from metrics bound to this app/workload/service object.
     if (this.state.querySettings.percentile && this.state.querySettings.percentile !== 'all') {
-      // Fetching traces above a percentile
-      // Percentiles (99th, 90th, 75th) are pre-computed from metrics bound to this app/workload/service object.
       try {
         const percentiles = await this.percentilesPromise;
         options.minDuration = percentiles.get(this.state.querySettings.percentile);
@@ -142,9 +134,10 @@ class TracesComponent extends React.Component<TracesProps, TracesState> {
           AlertUtils.addWarning('Cannot perform query above the requested percentile (value unknown).');
         }
       } catch (err) {
-        AlertUtils.addError('Could not fetch percentiles.', err);
+        AlertUtils.addError(`Could not fetch percentiles: ${err}`);
       }
     }
+
     this.fetcher.fetch(options, this.state.traces);
   };
 
@@ -237,8 +230,8 @@ class TracesComponent extends React.Component<TracesProps, TracesState> {
   };
 
   private toggleTimeOptionsVisibility = () => {
-    this.setState(prevState => ({ isTimeOptionsOpen: !prevState.isTimeOptionsOpen }) );
-  }
+    this.setState(prevState => ({ isTimeOptionsOpen: !prevState.isTimeOptionsOpen }));
+  };
 
   render() {
     const jaegerURL = this.getJaegerUrl();
@@ -262,11 +255,11 @@ class TracesComponent extends React.Component<TracesProps, TracesState> {
                   </ToolbarItem>
                   {jaegerURL && (
                     <ToolbarItem>
-                        <Tooltip content={<>Open Chart in Jaeger UI</>}>
-                          <a href={jaegerURL} target="_blank" rel="noopener noreferrer" style={{ marginLeft: '10px' }}>
-                            View in Tracing <ExternalLinkAltIcon />
-                          </a>
-                        </Tooltip>
+                      <Tooltip content={<>Open Chart in Jaeger UI</>}>
+                        <a href={jaegerURL} target="_blank" rel="noopener noreferrer" style={{ marginLeft: '10px' }}>
+                          View in Tracing <ExternalLinkAltIcon />
+                        </a>
+                      </Tooltip>
                     </ToolbarItem>
                   )}
                   <KioskElement>
@@ -321,7 +314,8 @@ class TracesComponent extends React.Component<TracesProps, TracesState> {
           customDuration={true}
           isOpen={this.state.isTimeOptionsOpen}
           onConfirm={this.toggleTimeOptionsVisibility}
-          onCancel={this.toggleTimeOptionsVisibility} />
+          onCancel={this.toggleTimeOptionsVisibility}
+        />
       </>
     );
   }
@@ -332,7 +326,7 @@ const mapStateToProps = (state: KialiAppState) => {
     timeRange: timeRangeSelector(state),
     urlJaeger: state.jaegerState.info ? state.jaegerState.info.url : '',
     namespaceSelector: state.jaegerState.info ? state.jaegerState.info.namespaceSelector : true,
-    selectedTrace: state.jaegerState.selectedTrace,
+    selectedTrace: state.jaegerState.selectedTrace
   };
 };
 

--- a/frontend/src/types/Metrics.ts
+++ b/frontend/src/types/Metrics.ts
@@ -12,7 +12,7 @@ export type ControlPlaneMetricsMap = {
   istiod_proxy_time?: Metric[];
   istiod_cpu?: Metric[];
   istiod_mem?: Metric[];
-}
+};
 
 export type IstioMetricsMap = {
   grpc_received?: Metric[];
@@ -48,6 +48,7 @@ export interface MetricsStatsResult {
 export type MetricsStatsMap = { [key: string]: MetricsStats };
 
 export interface MetricsStats {
+  isCompact: boolean;
   responseTimes: Stat[];
 }
 

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -38,13 +38,13 @@ export interface Target {
 }
 
 export interface MetricsStatsQuery {
-  target: Target;
-  peerTarget?: Target;
-  queryTime: number;
-  interval: string;
-  direction: Direction;
   avg: boolean;
+  direction: Direction;
+  interval: string;
+  peerTarget?: Target;
   quantiles: string[];
+  queryTime: number;
+  target: Target;
 }
 
 export const statsQueryToKey = (q: MetricsStatsQuery) => genStatsKey(q.target, q.peerTarget, q.direction, q.interval);


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/5634

This PR introduces BEHAVIORAL CHANGE:  

- reduce the trace scatter chart tooltips to use "compact" heatmaps
  - a compact heatmap is 2 x 3 as opposed to the previous 3 x 4 [60m,3h] x [avg,50%,90%] vs [10m,60m,6h] x [avg,50%,90%,99%]
  - we fetch only what we need.  it's less information that before but hopefully enough to indicate if it's an interesting trace
- we still fetch the full stats when the user clicks a trace
  - but note that we have replaced 6h with 3h.  This means prom needs to read/aggregate ~50% less data per query.
- the trace detail span table will also render the 2 x 3.  This is more for simplicity/consistency than perf, because we are alerady fetching the full stats for a selected trace. Server Side:
- Chunk the prometheus queries so that we launch no more than 10 concurrently.  This additional throttling will hopefully help avoid resource consumption and timeouts.  Note that Prom does perform some of its own query management, this is hopefully complementary.

The tester should be aware of the new compact heatmaps.  The look is different:

Before:
![image](https://user-images.githubusercontent.com/2104052/203418881-6a801658-e09c-436a-a72f-de7e30d034b8.png)

After:
![image](https://user-images.githubusercontent.com/2104052/203419096-3ab5c3c4-be0d-4e84-b78e-953cdc322c54.png)
