### PR TITLE
[Cypress] fixing failing test for OCP platform

### DIFF
--- a/frontend/cypress/integration/common/kiali_homepage.ts
+++ b/frontend/cypress/integration/common/kiali_homepage.ts
@@ -1,9 +1,8 @@
-import { Given } from '@badeball/cypress-cucumber-preprocessor';
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, And, Then } from '@badeball/cypress-cucumber-preprocessor';
 
 const url = '/';
 
-Given('I open Kiali URL', () => {
+And('I open Kiali URL', () => {
   cy.visit(url);
 });
 

--- a/frontend/cypress/integration/featureFiles/kiali_homepage.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_homepage.feature
@@ -1,8 +1,11 @@
 Feature: Kiali login
 
-  I want to login to Kiali and see landing page
+  After login, I want to see Kiali landing page
+
+  Background:
+    Given user is at administrator perspective
 
   @smoke  
-  Scenario: Open Kaili home page
-    Given I open Kiali URL
+  Scenario: Open Kaili home page and check for title
+    And I open Kiali URL
     Then I see "Kiali" in the title


### PR DESCRIPTION
adding small fix for cypress smoke test related to OCP platforms

tested on upstream OCP, passing :heavy_check_mark: 