### PR TITLE
Skip "Missing Sidecar" on Ingress Gateways from all namespaces.

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -218,7 +218,7 @@ func (in *AppService) GetAppDetails(ctx context.Context, criteria AppCriteria) (
 
 	(*appInstance).Workloads = make([]models.WorkloadItem, len(appDetails.Workloads))
 	for i, wkd := range appDetails.Workloads {
-		(*appInstance).Workloads[i] = models.WorkloadItem{WorkloadName: wkd.Name, IstioSidecar: wkd.IstioSidecar, ServiceAccountNames: wkd.Pods.ServiceAccounts()}
+		(*appInstance).Workloads[i] = models.WorkloadItem{WorkloadName: wkd.Name, IstioSidecar: wkd.IstioSidecar, Labels: wkd.Labels, ServiceAccountNames: wkd.Pods.ServiceAccounts()}
 	}
 
 	(*appInstance).ServiceNames = make([]string, len(appDetails.Services))

--- a/frontend/src/components/Details/DetailDescription.tsx
+++ b/frontend/src/components/Details/DetailDescription.tsx
@@ -13,6 +13,7 @@ import { KialiIcon } from '../../config/KialiIcon';
 import {KialiAppState} from "../../store/Store";
 import {connect} from "react-redux";
 import {isParentKiosk, kioskContextMenuAction} from "../Kiosk/KioskActions";
+import { isIngressGateway } from "../../helpers/LabelFilterHelper";
 
 type ReduxProps = {
   kiosk: string;
@@ -149,7 +150,7 @@ class DetailDescription extends React.Component<Props> {
           <KialiIcon.Info className={infoStyle} />
         </Tooltip>
         {!workload.istioSidecar && (
-          <MissingSidecar namespace={this.props.namespace} tooltip={true} style={{ marginLeft: '10px' }} text={''} />
+          <MissingSidecar namespace={this.props.namespace} isIngressGateway={isIngressGateway(workload.labels)} tooltip={true} style={{ marginLeft: '10px' }} text={''} />
         )}
       </span>
     );
@@ -200,7 +201,7 @@ class DetailDescription extends React.Component<Props> {
             <span style={{ marginLeft: '10px' }}>{createIcon(sub.status)}</span>
           </Tooltip>
           {!workload.istioSidecar && (
-            <MissingSidecar namespace={this.props.namespace} tooltip={true} style={{ marginLeft: '10px' }} text={''} />
+            <MissingSidecar namespace={this.props.namespace} isIngressGateway={isIngressGateway(workload.labels)} tooltip={true} style={{ marginLeft: '10px' }} text={''} />
           )}
         </span>
       );

--- a/frontend/src/components/Details/DetailDescription.tsx
+++ b/frontend/src/components/Details/DetailDescription.tsx
@@ -13,7 +13,7 @@ import { KialiIcon } from '../../config/KialiIcon';
 import {KialiAppState} from "../../store/Store";
 import {connect} from "react-redux";
 import {isParentKiosk, kioskContextMenuAction} from "../Kiosk/KioskActions";
-import { isIngressGateway } from "../../helpers/LabelFilterHelper";
+import { isGateway } from "../../helpers/LabelFilterHelper";
 
 type ReduxProps = {
   kiosk: string;
@@ -150,7 +150,7 @@ class DetailDescription extends React.Component<Props> {
           <KialiIcon.Info className={infoStyle} />
         </Tooltip>
         {!workload.istioSidecar && (
-          <MissingSidecar namespace={this.props.namespace} isIngressGateway={isIngressGateway(workload.labels)} tooltip={true} style={{ marginLeft: '10px' }} text={''} />
+          <MissingSidecar namespace={this.props.namespace} isGateway={isGateway(workload.labels)} tooltip={true} style={{ marginLeft: '10px' }} text={''} />
         )}
       </span>
     );
@@ -201,7 +201,7 @@ class DetailDescription extends React.Component<Props> {
             <span style={{ marginLeft: '10px' }}>{createIcon(sub.status)}</span>
           </Tooltip>
           {!workload.istioSidecar && (
-            <MissingSidecar namespace={this.props.namespace} isIngressGateway={isIngressGateway(workload.labels)} tooltip={true} style={{ marginLeft: '10px' }} text={''} />
+            <MissingSidecar namespace={this.props.namespace} isGateway={isGateway(workload.labels)} tooltip={true} style={{ marginLeft: '10px' }} text={''} />
           )}
         </span>
       );

--- a/frontend/src/components/MissingSidecar/MissingSidecar.tsx
+++ b/frontend/src/components/MissingSidecar/MissingSidecar.tsx
@@ -15,7 +15,7 @@ type MissingSidecarProps = {
   color: string;
   namespace: string;
   style?: React.CSSProperties;
-  isIngressGateway?: boolean;
+  isGateway?: boolean;
 };
 
 const infoStyle = style({
@@ -54,7 +54,7 @@ class MissingSidecar extends React.Component<MissingSidecarProps, {}> {
       </span>
     );
 
-    if (isIstioNamespace(namespace) || this.props.isIngressGateway) {
+    if (isIstioNamespace(namespace) || this.props.isGateway) {
       return <></>;
     }
 

--- a/frontend/src/components/MissingSidecar/MissingSidecar.tsx
+++ b/frontend/src/components/MissingSidecar/MissingSidecar.tsx
@@ -15,6 +15,7 @@ type MissingSidecarProps = {
   color: string;
   namespace: string;
   style?: React.CSSProperties;
+  isIngressGateway?: boolean;
 };
 
 const infoStyle = style({
@@ -53,7 +54,7 @@ class MissingSidecar extends React.Component<MissingSidecarProps, {}> {
       </span>
     );
 
-    if (isIstioNamespace(namespace)) {
+    if (isIstioNamespace(namespace) || this.props.isIngressGateway) {
       return <></>;
     }
 

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -12,7 +12,7 @@ import NamespaceInfo from '../../pages/Overview/NamespaceInfo';
 import * as React from 'react';
 import { StatefulFilters } from '../Filters/StatefulFilters';
 import { PFBadges, PFBadgeType } from '../../components/Pf/PfBadges';
-import { isIngressGateway } from "../../helpers/LabelFilterHelper";
+import { isGateway } from "../../helpers/LabelFilterHelper";
 
 export type SortResource = AppListItem | WorkloadListItem | ServiceListItem;
 export type TResource = SortResource | IstioConfigItem;
@@ -31,7 +31,7 @@ export function hasHealth(r: RenderResource): r is SortResource {
 }
 
 export const hasMissingSidecar = (r: SortResource): boolean => {
-  return !isIstioNamespace(r.namespace) && !r.istioSidecar && !isIngressGateway(r.labels);
+  return !isIstioNamespace(r.namespace) && !r.istioSidecar && !isGateway(r.labels);
 };
 
 type ResourceType<R extends RenderResource> = {

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -12,6 +12,7 @@ import NamespaceInfo from '../../pages/Overview/NamespaceInfo';
 import * as React from 'react';
 import { StatefulFilters } from '../Filters/StatefulFilters';
 import { PFBadges, PFBadgeType } from '../../components/Pf/PfBadges';
+import { isIngressGateway } from "../../helpers/LabelFilterHelper";
 
 export type SortResource = AppListItem | WorkloadListItem | ServiceListItem;
 export type TResource = SortResource | IstioConfigItem;
@@ -30,7 +31,7 @@ export function hasHealth(r: RenderResource): r is SortResource {
 }
 
 export const hasMissingSidecar = (r: SortResource): boolean => {
-  return !isIstioNamespace(r.namespace) && !r.istioSidecar;
+  return !isIstioNamespace(r.namespace) && !r.istioSidecar && !isIngressGateway(r.labels);
 };
 
 type ResourceType<R extends RenderResource> = {

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -34,7 +34,7 @@ import Label from 'components/Label/Label';
 import { serverConfig } from 'config/ServerConfig';
 import ControlPlaneBadge from 'pages/Overview/ControlPlaneBadge';
 import NamespaceStatuses from 'pages/Overview/NamespaceStatuses';
-import { isIngressGateway } from "../../helpers/LabelFilterHelper";
+import { isGateway } from "../../helpers/LabelFilterHelper";
 
 // Links
 
@@ -84,7 +84,7 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
         )}
         {hasMissingSC && (
           <li>
-            <MissingSidecar namespace={item.namespace} isIngressGateway={isIngressGateway(item.labels)}/>
+            <MissingSidecar namespace={item.namespace} isGateway={isGateway(item.labels)}/>
           </li>
         )}
         {isWorkload && (hasMissingApp || hasMissingVersion) && (

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -34,6 +34,7 @@ import Label from 'components/Label/Label';
 import { serverConfig } from 'config/ServerConfig';
 import ControlPlaneBadge from 'pages/Overview/ControlPlaneBadge';
 import NamespaceStatuses from 'pages/Overview/NamespaceStatuses';
+import { isIngressGateway } from "../../helpers/LabelFilterHelper";
 
 // Links
 
@@ -83,7 +84,7 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
         )}
         {hasMissingSC && (
           <li>
-            <MissingSidecar namespace={item.namespace} />
+            <MissingSidecar namespace={item.namespace} isIngressGateway={isIngressGateway(item.labels)}/>
           </li>
         )}
         {isWorkload && (hasMissingApp || hasMissingVersion) && (
@@ -150,8 +151,8 @@ export const status: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
         className="pf-m-center"
         style={{ verticalAlign: 'middle' }}
       >
-        { ns.status && 
-          <NamespaceStatuses key={ns.name} name={ns.name} status={ns.status} type={OverviewToolbar.currentOverviewType()} /> 
+        { ns.status &&
+          <NamespaceStatuses key={ns.name} name={ns.name} status={ns.status} type={OverviewToolbar.currentOverviewType()} />
         }
         <OverviewCardSparklineCharts
           key={ns.name}
@@ -174,7 +175,7 @@ export const nsItem: Renderer<NamespaceInfo> = (ns: NamespaceInfo, _config: Reso
       <PFBadge badge={badge} />
       {ns.name}
       {ns.name === serverConfig.istioNamespace &&
-        <ControlPlaneBadge />                         
+        <ControlPlaneBadge />
       }
     </td>
   );

--- a/frontend/src/helpers/LabelFilterHelper.ts
+++ b/frontend/src/helpers/LabelFilterHelper.ts
@@ -99,6 +99,6 @@ const getKeyAndValues = (filters: string[]): { keys: string[]; keyValues: string
   return { keys, keyValues };
 };
 
-export const isIngressGateway = (labels: { [key: string]: string }): boolean => {
-  return labels && 'istio' in labels && labels['istio'] === 'ingressgateway'
+export const isGateway = (labels: { [key: string]: string }): boolean => {
+  return labels && 'istio' in labels && (labels['istio'] === 'ingressgateway' || labels['istio'] === 'egressgateway')
 };

--- a/frontend/src/helpers/LabelFilterHelper.ts
+++ b/frontend/src/helpers/LabelFilterHelper.ts
@@ -98,3 +98,7 @@ const getKeyAndValues = (filters: string[]): { keys: string[]; keyValues: string
   const keyValues = filters.filter(f => f.includes('='));
   return { keys, keyValues };
 };
+
+export const isIngressGateway = (labels: { [key: string]: string }): boolean => {
+  return 'istio' in labels && labels['istio'] === 'ingressgateway'
+};

--- a/frontend/src/helpers/LabelFilterHelper.ts
+++ b/frontend/src/helpers/LabelFilterHelper.ts
@@ -100,5 +100,5 @@ const getKeyAndValues = (filters: string[]): { keys: string[]; keyValues: string
 };
 
 export const isIngressGateway = (labels: { [key: string]: string }): boolean => {
-  return 'istio' in labels && labels['istio'] === 'ingressgateway'
+  return labels && 'istio' in labels && labels['istio'] === 'ingressgateway'
 };

--- a/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
+++ b/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
@@ -1,4 +1,4 @@
-import { filterByLabel } from '../LabelFilterHelper';
+import { filterByLabel, isIngressGateway } from '../LabelFilterHelper';
 import { AppListItem } from '../../types/AppList';
 import { AppHealth, WorkloadHealth, ServiceHealth } from '../../types/Health';
 import { WorkloadListItem } from '../../types/Workload';
@@ -290,5 +290,15 @@ describe('LabelFilter', () => {
         serviceRegistry: 'Kubernetes'
       }
     ]);
+  });
+
+  it('check is IngressGateway when false', () => {
+    const result = isIngressGateway({'istio': 'wrong'});
+    expect(result).toBeFalsy();
+  });
+
+  it('check is IngressGateway when true', () => {
+    const result = isIngressGateway({'istio': 'ingressgateway'});
+    expect(result).toBeTruthy();
   });
 });

--- a/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
+++ b/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
@@ -1,4 +1,4 @@
-import { filterByLabel, isIngressGateway } from '../LabelFilterHelper';
+import { filterByLabel, isGateway } from '../LabelFilterHelper';
 import { AppListItem } from '../../types/AppList';
 import { AppHealth, WorkloadHealth, ServiceHealth } from '../../types/Health';
 import { WorkloadListItem } from '../../types/Workload';
@@ -292,13 +292,18 @@ describe('LabelFilter', () => {
     ]);
   });
 
-  it('check is IngressGateway when false', () => {
-    const result = isIngressGateway({'istio': 'wrong'});
+  it('check is Ingress/Egress Gateway when false', () => {
+    const result = isGateway({'istio': 'wrong'});
     expect(result).toBeFalsy();
   });
 
-  it('check is IngressGateway when true', () => {
-    const result = isIngressGateway({'istio': 'ingressgateway'});
+  it('check is Ingress Gateway when true', () => {
+    const result = isGateway({'istio': 'ingressgateway'});
+    expect(result).toBeTruthy();
+  });
+
+  it('check is Egress Gateway when true', () => {
+    const result = isGateway({'istio': 'egressgateway'});
     expect(result).toBeTruthy();
   });
 });

--- a/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -81,7 +81,8 @@ class ServiceDescription extends React.Component<ServiceInfoDescriptionProps, St
             workloads.push({
               workloadName: wk.name,
               istioSidecar: wk.istioSidecar,
-              serviceAccountNames: wk.serviceAccountNames
+              serviceAccountNames: wk.serviceAccountNames,
+              labels: wk.labels ? wk.labels : {}
             });
           });
       }

--- a/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -16,6 +16,7 @@ import MissingLabel from '../../components/MissingLabel/MissingLabel';
 import MissingAuthPolicy from 'components/MissingAuthPolicy/MissingAuthPolicy';
 import { hasMissingAuthPolicy } from 'utils/IstioConfigUtils';
 import DetailDescriptionContainer from "../../components/Details/DetailDescription";
+import { isIngressGateway } from "../../helpers/LabelFilterHelper";
 
 type WorkloadDescriptionProps = {
   workload?: Workload;
@@ -146,6 +147,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
                 tooltip={true}
                 style={{ marginLeft: '10px' }}
                 text={''}
+                isIngressGateway={isIngressGateway(workload.labels)}
               />
             )}
             {this.props.workload && hasMissingAuthPolicy(this.props.workload.name, this.props.workload.validations) && (

--- a/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -16,7 +16,7 @@ import MissingLabel from '../../components/MissingLabel/MissingLabel';
 import MissingAuthPolicy from 'components/MissingAuthPolicy/MissingAuthPolicy';
 import { hasMissingAuthPolicy } from 'utils/IstioConfigUtils';
 import DetailDescriptionContainer from "../../components/Details/DetailDescription";
-import { isIngressGateway } from "../../helpers/LabelFilterHelper";
+import { isGateway } from "../../helpers/LabelFilterHelper";
 
 type WorkloadDescriptionProps = {
   workload?: Workload;
@@ -147,7 +147,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
                 tooltip={true}
                 style={{ marginLeft: '10px' }}
                 text={''}
-                isIngressGateway={isIngressGateway(workload.labels)}
+                isGateway={isGateway(workload.labels)}
               />
             )}
             {this.props.workload && hasMissingAuthPolicy(this.props.workload.name, this.props.workload.validations) && (

--- a/frontend/src/types/App.ts
+++ b/frontend/src/types/App.ts
@@ -11,6 +11,7 @@ export interface AppWorkload {
   workloadName: string;
   istioSidecar: boolean;
   serviceAccountNames: string[];
+  labels: { [key: string]: string };
 }
 
 export interface App {

--- a/models/app.go
+++ b/models/app.go
@@ -44,6 +44,9 @@ type WorkloadItem struct {
 	// example: true
 	IstioSidecar bool `json:"istioSidecar"`
 
+	// Labels for Workload
+	Labels map[string]string `json:"labels"`
+
 	// List of service accounts involved in this application
 	// required: true
 	ServiceAccountNames []string `json:"serviceAccountNames"`


### PR DESCRIPTION
Original issue happens in Service Mesh and is: When there is additional Ingress Gateways created not in control plane namespace, it shows warning "Missing Sidecar" on that Gateway's Workload and Application List and Details pages.
Before:
![Screenshot from 2022-11-29 18-29-52](https://user-images.githubusercontent.com/604313/204606353-2b462405-2277-4b4f-ace1-9b238177e4da.png)

This fix is ignoring showing "Missing Gateways" on any Workload or Application which contains label "istio=ingressgateway". This label value is hardcoded for now.
After:
![Screenshot from 2022-11-29 18-30-30](https://user-images.githubusercontent.com/604313/204606783-2d118705-b23e-4c53-832d-3df1243fd2e7.png)

To test this on Kiali upstream, it needs to create any Deployment on some namespace besides "istio-system" and make sure that it does not have sidecar injected and has label "istio=ingressgateway".