### PR TITLE
[v1.57] Trace scatter-chart tooltips pull stats from the backend to show heatmaps

### DIFF
--- a/frontend/src/actions/MetricsStatsThunkActions.ts
+++ b/frontend/src/actions/MetricsStatsThunkActions.ts
@@ -1,6 +1,6 @@
 import { KialiAppState } from '../store/Store';
 import * as API from '../services/Api';
-import { KialiDispatch } from "../types/Redux";
+import { KialiDispatch } from '../types/Redux';
 import { MetricsStatsActions } from './MetricsStatsActions';
 import { MetricsStatsQuery, statsQueryToKey } from 'types/MetricsOptions';
 import { addError, addInfo } from 'utils/AlertUtils';
@@ -18,7 +18,7 @@ const MetricsStatsThunkActions = {
       const newStats = new Map(Array.from(oldStats).filter(([_, v]) => now - v.timestamp < expiry));
       const filtered = queries.filter(q => !newStats.has(statsQueryToKey(q)));
       if (filtered.length > 0) {
-        API.getMetricsStats(filtered)
+        return API.getMetricsStats(filtered)
           .then(res => {
             // Merge result
             Object.entries(res.data.stats).forEach(e => newStats.set(e[0], { ...e[1], timestamp: now }));
@@ -30,6 +30,8 @@ const MetricsStatsThunkActions = {
           .catch(err => {
             addError('Could not fetch metrics stats.', err);
           });
+      } else {
+        return Promise.resolve();
       }
     };
   }

--- a/frontend/src/components/Charts/ChartWithLegend.tsx
+++ b/frontend/src/components/Charts/ChartWithLegend.tsx
@@ -40,6 +40,8 @@ type Props<T extends RichDataPoint, O extends LineInfo> = {
   sizeRatio?: number;
   moreChartProps?: ChartProps;
   onClick?: (datum: RawOrBucket<O>) => void;
+  onTooltipClose?: (datum: RawOrBucket<O>) => void;
+  onTooltipOpen?: (datum: RawOrBucket<O>) => void;
   brushHandlers?: BrushHandlers;
   overlay?: Overlay<O>;
   timeWindow?: [Date, Date];
@@ -115,16 +117,22 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
     window.removeEventListener('resize', this.handleResize);
   }
 
+  private onTooltipClose = () => {
+    if (this.props.onTooltipClose) {
+      this.props.onTooltipClose(this.hoveredItem as RawOrBucket<O>);
+    }
+    this.hoveredItem = undefined;
+  };
+
   private onTooltipOpen = (points?: VCDataPoint[]) => {
     if (points && points.length > 0) {
       this.hoveredItem = points[0];
     } else {
       this.hoveredItem = undefined;
     }
-  };
-
-  private onTooltipClose = () => {
-    this.hoveredItem = undefined;
+    if (this.props.onTooltipOpen) {
+      this.props.onTooltipOpen(this.hoveredItem as RawOrBucket<O>);
+    }
   };
 
   private onShowMoreLegend = () => {

--- a/frontend/src/components/JaegerIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/JaegerIntegration/TraceTooltip.tsx
@@ -1,20 +1,10 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { KialiDispatch } from 'types/Redux';
 import { pluralize } from '@patternfly/react-core';
 import { ChartCursorFlyout, ChartLabelProps } from '@patternfly/react-charts';
 import { style } from 'typestyle';
-
 import { KialiAppState } from 'store/Store';
-import {
-  averageSpanDuration,
-  buildQueriesFromSpans,
-  allStatsIntervals,
-  reduceMetricsStats,
-  StatsMatrix
-} from 'utils/tracing/TraceStats';
-import { MetricsStatsQuery } from 'types/MetricsOptions';
-import MetricsStatsThunkActions from 'actions/MetricsStatsThunkActions';
+import { averageSpanDuration, allStatsIntervals, reduceMetricsStats, StatsMatrix } from 'utils/tracing/TraceStats';
 import { JaegerLineInfo } from './JaegerScatter';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { renderTraceHeatMap } from './JaegerResults/StatsComparison';
@@ -45,17 +35,11 @@ const leftStyle = style({ width: '35%', height: '100%', float: 'left' });
 
 type LabelProps = ChartLabelProps & {
   trace: JaegerTrace;
-  loadMetricsStats: (queries: MetricsStatsQuery[]) => void;
   statsMatrix?: StatsMatrix;
   isStatsMatrixComplete: boolean;
 };
 
 class TraceLabel extends React.Component<LabelProps> {
-  componentDidMount() {
-    const queries = buildQueriesFromSpans(this.props.trace.spans);
-    this.props.loadMetricsStats(queries);
-  }
-
   render() {
     const left = flyoutMargin + (this.props.x || 0) - flyoutWidth / 2;
     const top = flyoutMargin + (this.props.y || 0) - flyoutHeight / 2;
@@ -92,11 +76,7 @@ const mapStateToProps = (state: KialiAppState, props: any) => {
   };
 };
 
-const mapDispatchToProps = (dispatch: KialiDispatch) => ({
-  loadMetricsStats: (queries: MetricsStatsQuery[]) => dispatch(MetricsStatsThunkActions.load(queries))
-});
-
-const TraceLabelContainer = connect(mapStateToProps, mapDispatchToProps)(TraceLabel);
+const TraceLabelContainer = connect(mapStateToProps)(TraceLabel);
 
 export class TraceTooltip extends React.Component<HookedTooltipProps<JaegerLineInfo>> {
   render() {


### PR DESCRIPTION
v1.57 Backport of https://github.com/kiali/kiali/pull/5600

Trace scatter-chart tooltips pull stats from the backend to show heatmaps.

Prevent flooding the backend with concurrent calls as the user drags across the chart:
- move launch of the backend request from the N tooltip components to the single JaegerScatter component, to be able to throttle the api calls. Add some callback props for this support.
- ensure the thunk action returns a promise and use it to preven the concurrent calls.
- ignore making calls for points that are just moused-over while moving across the chart.

http://github.com/kiali/kiali/issues/5584