### PR TITLE
Added K8s Route Filtering into wizard

### DIFF
--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -186,12 +186,29 @@ class K8sRequestRouting extends React.Component<Props, State> {
     );
   };
 
-  onHeaderNameChange = (headerName: string) => {
+  onMatchHeaderNameChange = (headerName: string) => {
+    console.log("headerName " + headerName)
     let validationMsg = '';
-    if (!headerName && (!!this.state.matchValue || this.state.headerOp === REMOVE)) {
+    if (!headerName && !!this.state.matchValue) {
       validationMsg = MSG_HEADER_NAME_NON_EMPTY;
     }
-    if (this.state.matchValue === '' && headerName !== '' && this.state.headerOp !== REMOVE) {
+    if (!this.state.matchValue && !!headerName) {
+      validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
+    }
+    this.setState({
+      headerName: headerName,
+      validationMsg: validationMsg
+    });
+  };
+
+  onHeaderNameChange = (headerName: string) => {
+    console.log("headerName " + headerName)
+    console.log("headerValue " + this.state.headerValue)
+    let validationMsg = '';
+    if (!headerName) {
+      validationMsg = MSG_HEADER_NAME_NON_EMPTY;
+    }
+    if (!this.state.headerValue && this.state.headerOp !== REMOVE) {
       validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
     }
     this.setState({
@@ -201,6 +218,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
   };
 
   onQueryParamNameChange = (queryParamName: string) => {
+    console.log("queryParamName " + queryParamName)
     let validationMsg = '';
     if (this.state.matchValue !== '' && queryParamName === '') {
       validationMsg = MSG_QUERY_NAME_NON_EMPTY;
@@ -215,6 +233,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
   };
 
   onMatchValueChange = (matchValue: string) => {
+    console.log("matchValue " + matchValue)
     let validationMsg = '';
     if (this.state.category === HEADERS) {
       if (this.state.headerName === '' && matchValue !== '') {
@@ -232,9 +251,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
         validationMsg = MSG_QUERY_VALUE_NON_EMPTY;
       }
     }
-    if (matchValue === '') {
-      validationMsg = '';
-    }
+
     this.setState({
       matchValue: matchValue,
       validationMsg: validationMsg
@@ -311,17 +328,15 @@ class K8sRequestRouting extends React.Component<Props, State> {
   };
 
   onHeaderValueChange = (headerValue: string) => {
+    console.log("headerValue " + headerValue)
     let validationMsg = '';
-    if (this.state.filterType === REQ_MOD || this.state.filterType === RESP_MOD) {
-      if (this.state.headerName === '' && (headerValue !== '' || this.state.headerOp === REMOVE)) {
+    if ((this.state.filterType === REQ_MOD || this.state.filterType === RESP_MOD) && this.state.headerOp !== REMOVE) {
+      if (!this.state.headerName) {
         validationMsg = MSG_HEADER_NAME_NON_EMPTY;
       }
-      if (this.state.headerName !== '' && headerValue === '' && this.state.headerOp !== REMOVE) {
+      if (!headerValue) {
         validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
       }
-    }
-    if (headerValue === '') {
-      validationMsg = '';
     }
     this.setState({
       headerValue: headerValue,
@@ -330,6 +345,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
   }
 
   onHostNameChange = (hostName: string) => {
+    console.log("hostName " + hostName)
     let validationMsg = '';
     if (!hostName || !isServerHostValid(hostName, false) ) {
       validationMsg = MSG_HOSTNAME_NON_EMPTY;
@@ -341,6 +357,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
   }
 
   onPortValueChange = (portValue: string) => {
+    console.log("portValue " + portValue)
     let validationMsg = '';
     if (!portValue || isNaN(Number(portValue))) {
       validationMsg = MSG_PORT_NON_EMPTY;
@@ -379,6 +396,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
             });
           }}
           onHeaderNameChange={this.onHeaderNameChange}
+          onMatchHeaderNameChange={this.onMatchHeaderNameChange}
           onQueryParamNameChange={this.onQueryParamNameChange}
           onSelectOperator={(operator: string) => this.setState({ operator: operator })}
           onMatchValueChange={this.onMatchValueChange}

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -177,7 +177,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
 
   onHeaderNameChange = (headerName: string) => {
     let validationMsg = '';
-    if ((this.state.matchValue !== '' || this.state.headerOp === REMOVE) && headerName === '') {
+    if (!headerName && (!!this.state.matchValue || this.state.headerOp === REMOVE)) {
       validationMsg = MSG_HEADER_NAME_NON_EMPTY;
     }
     if (this.state.matchValue === '' && headerName !== '' && this.state.headerOp !== REMOVE) {

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -23,7 +23,7 @@ type State = {
   matchValue: string;
   k8sRules: K8sRule[];
   validationMsg: string;
-  headerType: string;
+  headerOp: string;
   headerValue: string;
   filterType: string;
   filterValue: string;
@@ -51,7 +51,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
       validationMsg: '',
       filterValue: '',
       filters: [],
-      headerType: SET,
+      headerOp: SET,
       headerValue: '',
       filterType: REQ_MOD
     };
@@ -132,6 +132,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
           prevState.k8sRules.push(newRule);
           return {
             matches: prevState.matches,
+            filters: prevState.filters,
             headerName: prevState.headerName,
             matchValue: prevState.matchValue,
             k8sRules: prevState.k8sRules,
@@ -140,6 +141,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
         } else {
           return {
             matches: prevState.matches,
+            filters: prevState.filters,
             headerName: prevState.headerName,
             matchValue: prevState.matchValue,
             k8sRules: prevState.k8sRules,
@@ -175,10 +177,10 @@ class K8sRequestRouting extends React.Component<Props, State> {
 
   onHeaderNameChange = (headerName: string) => {
     let validationMsg = '';
-    if ((this.state.matchValue !== '' || this.state.headerType === REMOVE) && headerName === '') {
+    if ((this.state.matchValue !== '' || this.state.headerOp === REMOVE) && headerName === '') {
       validationMsg = MSG_HEADER_NAME_NON_EMPTY;
     }
-    if (this.state.matchValue === '' && headerName !== '' && this.state.headerType !== REMOVE) {
+    if (this.state.matchValue === '' && headerName !== '' && this.state.headerOp !== REMOVE) {
       validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
     }
     this.setState({
@@ -278,10 +280,10 @@ class K8sRequestRouting extends React.Component<Props, State> {
     this.setState(prevState => {
       let newFilter: string;
       if (this.state.filterType === REQ_MOD || this.state.filterType === RESP_MOD) {
-        if (this.state.headerType !== REMOVE) {
-          newFilter = prevState.filterType + ' [' + prevState.headerName + '] ' + prevState.headerType + ' ' + prevState.headerValue;
+        if (this.state.headerOp !== REMOVE) {
+          newFilter = prevState.filterType + ' [' + prevState.headerName + '] ' + prevState.headerOp + ' ' + prevState.headerValue;
         } else {
-          newFilter = prevState.filterType + ' [' + prevState.headerName + '] ' + prevState.headerType;
+          newFilter = prevState.filterType + ' [' + prevState.headerName + '] ' + prevState.headerOp;
         }
         if (!prevState.filters.includes(newFilter)) {
           prevState.filters.push(newFilter);
@@ -299,10 +301,10 @@ class K8sRequestRouting extends React.Component<Props, State> {
   onHeaderValueChange = (headerValue: string) => {
     let validationMsg = '';
     if (this.state.filterType === REQ_MOD || this.state.filterType === RESP_MOD) {
-      if (this.state.headerName === '' && (headerValue !== '' || this.state.headerType === REMOVE)) {
+      if (this.state.headerName === '' && (headerValue !== '' || this.state.headerOp === REMOVE)) {
         validationMsg = MSG_HEADER_NAME_NON_EMPTY;
       }
-      if (this.state.headerName !== '' && headerValue === '' && this.state.headerType !== REMOVE) {
+      if (this.state.headerName !== '' && headerValue === '' && this.state.headerOp !== REMOVE) {
         validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
       }
     }
@@ -359,11 +361,11 @@ class K8sRequestRouting extends React.Component<Props, State> {
           filters={this.state.filters}
           filterValue={this.state.filterValue}
           onHeaderValueChange={this.onHeaderValueChange}
-          headerType={this.state.headerType}
+          headerOp={this.state.headerOp}
           filterType={this.state.filterType}
           headerValue={this.state.headerValue}
           onSelectFilterType={(filterType: string) => this.setState({ filterType: filterType })}
-          onSelectHeaderType={(headerType: string) => this.setState({ headerType: headerType })}
+          onSelectHeaderOp={(headerOp: string) => this.setState({ headerOp: headerOp })}
         />
         <K8sRules k8sRules={this.state.k8sRules} onRemoveRule={this.onRemoveRule} onMoveRule={this.onMoveRule} />
       </>

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -5,6 +5,7 @@ import {K8sRouteBackendRef} from './K8sTrafficShifting';
 import { EXACT, PATH, METHOD, GET, HEADERS, QUERY_PARAMS } from './K8sRequestRouting/K8sMatchBuilder';
 import {getDefaultBackendRefs} from './WizardActions';
 import {ServiceOverview} from "../../types/ServiceList";
+import {REQ_MOD} from "./K8sRequestRouting/K8sFilterBuilder";
 
 type Props = {
   subServices: ServiceOverview[];
@@ -22,6 +23,11 @@ type State = {
   matchValue: string;
   k8sRules: K8sRule[];
   validationMsg: string;
+  headerType: string;
+  headerValue: string;
+  filterType: string;
+  filterValue: string;
+  filters: string[];
 };
 
 const MSG_SAME_MATCHING = 'A Rule with same matching criteria is already added.';
@@ -42,7 +48,12 @@ class K8sRequestRouting extends React.Component<Props, State> {
       queryParamName: '',
       matchValue: '',
       k8sRules: this.props.initRules,
-      validationMsg: ''
+      validationMsg: '',
+      filterValue: '',
+      filters: [],
+      headerType: '',
+      headerValue: '',
+      filterType: REQ_MOD
     };
   }
 
@@ -262,6 +273,30 @@ class K8sRequestRouting extends React.Component<Props, State> {
     }
   }
 
+  onAddFilter = () => {
+
+  }
+
+  onHeaderValueChange = () => {
+
+  }
+
+  onFilterValueChange = () => {
+
+  }
+
+  onSelectFilterType = () => {
+
+  }
+
+  onSelectHeaderType = () => {
+
+  }
+
+  onRemoveFilter = () => {
+
+  }
+
   render() {
     return (
       <>
@@ -292,6 +327,17 @@ class K8sRequestRouting extends React.Component<Props, State> {
           backendRefs={this.state.backendRefs}
           validationMsg={this.state.validationMsg}
           onAddRule={this.onAddK8sRule}
+          onAddFilter={this.onAddFilter}
+          onFilterValueChange={this.onFilterValueChange}
+          onRemoveFilter={this.onRemoveFilter}
+          filters={this.state.filters}
+          filterValue={this.state.filterValue}
+          onHeaderValueChange={this.onHeaderValueChange}
+          headerType={this.state.headerType}
+          filterType={this.state.filterType}
+          headerValue={this.state.headerValue}
+          onSelectFilterType={this.onSelectFilterType}
+          onSelectHeaderType={this.onSelectHeaderType}
         />
         <K8sRules k8sRules={this.state.k8sRules} onRemoveRule={this.onRemoveRule} onMoveRule={this.onMoveRule} />
       </>

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -187,7 +187,6 @@ class K8sRequestRouting extends React.Component<Props, State> {
   };
 
   onMatchHeaderNameChange = (headerName: string) => {
-    console.log("headerName " + headerName)
     let validationMsg = '';
     if (!headerName && !!this.state.matchValue) {
       validationMsg = MSG_HEADER_NAME_NON_EMPTY;
@@ -202,8 +201,6 @@ class K8sRequestRouting extends React.Component<Props, State> {
   };
 
   onHeaderNameChange = (headerName: string) => {
-    console.log("headerName " + headerName)
-    console.log("headerValue " + this.state.headerValue)
     let validationMsg = '';
     if (!headerName) {
       validationMsg = MSG_HEADER_NAME_NON_EMPTY;
@@ -218,8 +215,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
   };
 
   onQueryParamNameChange = (queryParamName: string) => {
-    console.log("queryParamName " + queryParamName)
-    let validationMsg = '';
+      let validationMsg = '';
     if (this.state.matchValue !== '' && queryParamName === '') {
       validationMsg = MSG_QUERY_NAME_NON_EMPTY;
     }
@@ -233,7 +229,6 @@ class K8sRequestRouting extends React.Component<Props, State> {
   };
 
   onMatchValueChange = (matchValue: string) => {
-    console.log("matchValue " + matchValue)
     let validationMsg = '';
     if (this.state.category === HEADERS) {
       if (this.state.headerName === '' && matchValue !== '') {
@@ -328,7 +323,6 @@ class K8sRequestRouting extends React.Component<Props, State> {
   };
 
   onHeaderValueChange = (headerValue: string) => {
-    console.log("headerValue " + headerValue)
     let validationMsg = '';
     if ((this.state.filterType === REQ_MOD || this.state.filterType === RESP_MOD) && this.state.headerOp !== REMOVE) {
       if (!this.state.headerName) {
@@ -345,7 +339,6 @@ class K8sRequestRouting extends React.Component<Props, State> {
   }
 
   onHostNameChange = (hostName: string) => {
-    console.log("hostName " + hostName)
     let validationMsg = '';
     if (!hostName || !isServerHostValid(hostName, false) ) {
       validationMsg = MSG_HOSTNAME_NON_EMPTY;
@@ -357,7 +350,6 @@ class K8sRequestRouting extends React.Component<Props, State> {
   }
 
   onPortValueChange = (portValue: string) => {
-    console.log("portValue " + portValue)
     let validationMsg = '';
     if (!portValue || isNaN(Number(portValue))) {
       validationMsg = MSG_PORT_NON_EMPTY;

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -281,7 +281,7 @@ class K8sRequestRouting extends React.Component<Props, State> {
       let newFilter: string;
       if (this.state.filterType === REQ_MOD || this.state.filterType === RESP_MOD) {
         if (this.state.headerOp !== REMOVE) {
-          newFilter = prevState.filterType + ' [' + prevState.headerName + '] ' + prevState.headerOp + ' ' + prevState.headerValue;
+          newFilter = `${prevState.filterType} [${prevState.headerName}] ${prevState.headerOp} ${prevState.headerValue}`;
         } else {
           newFilter = prevState.filterType + ' [' + prevState.headerName + '] ' + prevState.headerOp;
         }

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
@@ -11,14 +11,14 @@ import {
 
 type Props = {
   filterType: string;
-  headerType: string;
+  headerOp: string;
   headerName: string;
   headerValue: string;
   isValid: boolean;
   onSelectFilterType: (filterType: string) => void;
   onHeaderNameChange: (headerName: string) => void;
   onHeaderValueChange: (headerValue: string) => void;
-  onSelectHeaderType: (headerType: string) => void;
+  onSelectHeaderOp: (headerOp: string) => void;
   onAddFilter: () => void;
 };
 
@@ -34,7 +34,7 @@ export const REQ_RED = 'requestRedirect';
 export const URL_REW = 'URLRewrite';
 export const EXT_REF = 'extensionRef';
 
-const filterOptions: string[] = [REQ_MOD, RESP_MOD];
+const filterOptions: string[] = [REQ_MOD];
 
 export const SET = 'set';
 export const ADD = 'add';
@@ -60,7 +60,7 @@ class K8sFilterBuilder extends React.Component<Props, State> {
     });
   };
 
-  onHeaderTypeToggle = () => {
+  onHeaderOpToggle = () => {
     this.setState({
       isHeaderDropdown: !this.state.isHeaderDropdown
     });
@@ -94,8 +94,8 @@ class K8sFilterBuilder extends React.Component<Props, State> {
         />
         <Dropdown
           toggle={
-            <DropdownToggle onToggle={this.onHeaderTypeToggle} data-test={'header-type-toggle'}>
-              {this.props.headerType}
+            <DropdownToggle onToggle={this.onHeaderOpToggle} data-test={'header-type-toggle'}>
+              {this.props.headerOp}
             </DropdownToggle>
           }
           isOpen={this.state.isHeaderDropdown}
@@ -105,8 +105,8 @@ class K8sFilterBuilder extends React.Component<Props, State> {
               value={op}
               component="button"
               onClick={() => {
-                this.props.onSelectHeaderType(op);
-                this.onHeaderTypeToggle();
+                this.props.onSelectHeaderOp(op);
+                this.onHeaderOpToggle();
               }}
               data-test={'header-type-' + op}
             >
@@ -122,7 +122,7 @@ class K8sFilterBuilder extends React.Component<Props, State> {
             placeholder="Header name..."
           />
         )}
-        {(this.props.filterType === REQ_MOD || this.props.filterType === RESP_MOD) && this.props.headerType !== REMOVE && (
+        {(this.props.filterType === REQ_MOD || this.props.filterType === RESP_MOD) && this.props.headerOp !== REMOVE && (
           <TextInput
             id="header-value-id"
             value={this.props.headerValue}

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react';
+import {
+  Button,
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  InputGroup,
+  TextInput,
+  ButtonVariant
+} from '@patternfly/react-core';
+
+type Props = {
+  filterType: string;
+  filterValue: string;
+  headerType: string;
+  headerName: string;
+  headerValue: string;
+  isValid: boolean;
+  onSelectFilterType: (filterType: string) => void;
+  onHeaderNameChange: (headerName: string) => void;
+  onHeaderValueChange: (headerValue: string) => void;
+  onSelectHeaderType: (headerType: string) => void;
+  onAddFilter: () => void;
+};
+
+type State = {
+  isFilterDropdown: boolean;
+  isOperatorDropdown: boolean;
+};
+
+export const REQ_MOD = 'RequestHeaderModifier';
+export const RESP_MOD = 'ResponseHeaderModifier';
+export const REQ_MIR = 'RequestMirror';
+export const REQ_RED = 'RequestRedirect';
+export const URL_REW = 'URLRewrite';
+export const EXT_REF = 'ExtensionRef';
+
+const filterOptions: string[] = [REQ_MOD, RESP_MOD];
+
+export const SET = 'set';
+export const ADD = 'add';
+export const REMOVE = 'remove';
+
+const allOptions = {
+  [REQ_MOD]: [SET, ADD, REMOVE],
+  [RESP_MOD]: [SET, ADD, REMOVE],
+};
+
+class K8sFilterBuilder extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isFilterDropdown: false,
+      isOperatorDropdown: false
+    };
+  }
+
+  onFilterTypeToggle = () => {
+    this.setState({
+      isFilterDropdown: !this.state.isFilterDropdown
+    });
+  };
+
+  onHeaderTypeToggle = () => {
+    this.setState({
+      isOperatorDropdown: !this.state.isOperatorDropdown
+    });
+  };
+
+  render() {
+    const renderFilterOptions: string[] = allOptions[this.props.filterType]
+    console.log("renderFilterOptions " + renderFilterOptions)
+    return (
+      <InputGroup>
+        <Dropdown
+          toggle={
+            <DropdownToggle onToggle={this.onFilterTypeToggle} data-test={'filtering-type-toggle'}>
+              {this.props.filterType}
+            </DropdownToggle>
+          }
+          isOpen={this.state.isFilterDropdown}
+          dropdownItems={filterOptions.map((mode, index) => (
+            <DropdownItem
+              key={mode + '_' + index}
+              value={mode}
+              component="button"
+              onClick={() => {
+                this.props.onSelectFilterType(mode);
+                this.onFilterTypeToggle();
+              }}
+              data-test={'filtering-type-' + mode}
+            >
+              {mode}
+            </DropdownItem>
+          ))}
+        />
+        <Dropdown
+          toggle={
+            <DropdownToggle onToggle={this.onHeaderTypeToggle} data-test={'header-type-toggle'}>
+              {this.props.headerType}
+            </DropdownToggle>
+          }
+          dropdownItems={renderFilterOptions.map((op, index) => (
+            <DropdownItem
+              key={op + '_' + index}
+              value={op}
+              component="button"
+              onClick={() => {
+                this.props.onSelectHeaderType(op);
+                this.onHeaderTypeToggle();
+              }}
+              data-test={'header-type-' + op}
+            >
+              {op}
+            </DropdownItem>
+          ))}
+        />
+        {(this.props.filterType === REQ_MOD || this.props.filterType === RESP_MOD) && (
+          <TextInput
+            id="header-name-id"
+            value={this.props.headerName}
+            onChange={this.props.onHeaderNameChange}
+            placeholder="Header name..."
+          />
+        )}
+        {(this.props.filterType === REQ_MOD || this.props.filterType === RESP_MOD) && this.props.headerType !== REMOVE && (
+          <TextInput
+            id="header-value-id"
+            value={this.props.headerValue}
+            onChange={this.props.onHeaderValueChange}
+            placeholder="Header Value..."
+          />
+        )}
+        <Button
+          variant={ButtonVariant.secondary}
+          disabled={!this.props.isValid}
+          onClick={this.props.onAddFilter}
+          data-test="add-Filter"
+        >
+          Add Filter
+        </Button>
+      </InputGroup>
+    );
+  }
+}
+
+export default K8sFilterBuilder;

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
@@ -11,7 +11,6 @@ import {
 
 type Props = {
   filterType: string;
-  filterValue: string;
   headerType: string;
   headerName: string;
   headerValue: string;
@@ -25,15 +24,15 @@ type Props = {
 
 type State = {
   isFilterDropdown: boolean;
-  isOperatorDropdown: boolean;
+  isHeaderDropdown: boolean;
 };
 
-export const REQ_MOD = 'RequestHeaderModifier';
-export const RESP_MOD = 'ResponseHeaderModifier';
-export const REQ_MIR = 'RequestMirror';
-export const REQ_RED = 'RequestRedirect';
+export const REQ_MOD = 'requestHeaderModifier';
+export const RESP_MOD = 'responseHeaderModifier';
+export const REQ_MIR = 'requestMirror';
+export const REQ_RED = 'requestRedirect';
 export const URL_REW = 'URLRewrite';
-export const EXT_REF = 'ExtensionRef';
+export const EXT_REF = 'extensionRef';
 
 const filterOptions: string[] = [REQ_MOD, RESP_MOD];
 
@@ -51,7 +50,7 @@ class K8sFilterBuilder extends React.Component<Props, State> {
     super(props);
     this.state = {
       isFilterDropdown: false,
-      isOperatorDropdown: false
+      isHeaderDropdown: false
     };
   }
 
@@ -63,13 +62,12 @@ class K8sFilterBuilder extends React.Component<Props, State> {
 
   onHeaderTypeToggle = () => {
     this.setState({
-      isOperatorDropdown: !this.state.isOperatorDropdown
+      isHeaderDropdown: !this.state.isHeaderDropdown
     });
   };
 
   render() {
     const renderFilterOptions: string[] = allOptions[this.props.filterType]
-    console.log("renderFilterOptions " + renderFilterOptions)
     return (
       <InputGroup>
         <Dropdown
@@ -100,6 +98,7 @@ class K8sFilterBuilder extends React.Component<Props, State> {
               {this.props.headerType}
             </DropdownToggle>
           }
+          isOpen={this.state.isHeaderDropdown}
           dropdownItems={renderFilterOptions.map((op, index) => (
             <DropdownItem
               key={op + '_' + index}

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
@@ -70,7 +70,7 @@ class K8sFilterBuilder extends React.Component<Props, State> {
       isFilterDropdown: false,
       isHeaderDropdown: false,
       isSchemeDropdown: false,
-      isStatusCodeDropdown: false
+      isStatusCodeDropdown: false,
     };
   }
 
@@ -230,7 +230,7 @@ class K8sFilterBuilder extends React.Component<Props, State> {
         )}
         <Button
           variant={ButtonVariant.secondary}
-          disabled={!this.props.isValid}
+          isDisabled={!this.props.isValid}
           onClick={this.props.onAddFilter}
           data-test="add-Filter"
         >

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
@@ -14,17 +14,27 @@ type Props = {
   headerOp: string;
   headerName: string;
   headerValue: string;
+  hostName: string;
   isValid: boolean;
   onSelectFilterType: (filterType: string) => void;
   onHeaderNameChange: (headerName: string) => void;
   onHeaderValueChange: (headerValue: string) => void;
+  onHostNameChange: (hostName: string) => void;
+  onPortValueChange: (portValue: string) => void;
+  onSelectStatusCodeOp: (statusCodeOp: string) => void;
   onSelectHeaderOp: (headerOp: string) => void;
+  onSelectSchemeOp: (schemeOp: string) => void;
   onAddFilter: () => void;
+  portValue: string;
+  schemeOp: string;
+  statusCodeOp: string;
 };
 
 type State = {
   isFilterDropdown: boolean;
   isHeaderDropdown: boolean;
+  isSchemeDropdown: boolean;
+  isStatusCodeDropdown: boolean;
 };
 
 export const REQ_MOD = 'requestHeaderModifier';
@@ -34,7 +44,15 @@ export const REQ_RED = 'requestRedirect';
 export const URL_REW = 'URLRewrite';
 export const EXT_REF = 'extensionRef';
 
-const filterOptions: string[] = [REQ_MOD];
+export const HTTP = 'http';
+export const HTTPS = 'https';
+
+export const SC301 = '301';
+export const SC302 = '302';
+
+const filterOptions: string[] = [REQ_MOD, REQ_RED];
+const schemeOptions: string[] = [HTTP, HTTPS];
+const statusOptions: string[] = [SC301, SC302];
 
 export const SET = 'set';
 export const ADD = 'add';
@@ -50,7 +68,9 @@ class K8sFilterBuilder extends React.Component<Props, State> {
     super(props);
     this.state = {
       isFilterDropdown: false,
-      isHeaderDropdown: false
+      isHeaderDropdown: false,
+      isSchemeDropdown: false,
+      isStatusCodeDropdown: false
     };
   }
 
@@ -63,6 +83,18 @@ class K8sFilterBuilder extends React.Component<Props, State> {
   onHeaderOpToggle = () => {
     this.setState({
       isHeaderDropdown: !this.state.isHeaderDropdown
+    });
+  };
+
+  onSchemeOpToggle = () => {
+    this.setState({
+      isSchemeDropdown: !this.state.isSchemeDropdown
+    });
+  };
+
+  onStatusCodeOpToggle = () => {
+    this.setState({
+      isStatusCodeDropdown: !this.state.isStatusCodeDropdown
     });
   };
 
@@ -92,28 +124,30 @@ class K8sFilterBuilder extends React.Component<Props, State> {
             </DropdownItem>
           ))}
         />
-        <Dropdown
-          toggle={
-            <DropdownToggle onToggle={this.onHeaderOpToggle} data-test={'header-type-toggle'}>
-              {this.props.headerOp}
-            </DropdownToggle>
-          }
-          isOpen={this.state.isHeaderDropdown}
-          dropdownItems={renderFilterOptions.map((op, index) => (
-            <DropdownItem
-              key={op + '_' + index}
-              value={op}
-              component="button"
-              onClick={() => {
-                this.props.onSelectHeaderOp(op);
-                this.onHeaderOpToggle();
-              }}
-              data-test={'header-type-' + op}
-            >
-              {op}
-            </DropdownItem>
-          ))}
-        />
+        {(this.props.filterType === REQ_MOD || this.props.filterType === RESP_MOD) && (
+          <Dropdown
+            toggle={
+              <DropdownToggle onToggle={this.onHeaderOpToggle} data-test={'header-type-toggle'}>
+                {this.props.headerOp}
+              </DropdownToggle>
+            }
+            isOpen={this.state.isHeaderDropdown}
+            dropdownItems={renderFilterOptions.map((op, index) => (
+              <DropdownItem
+                key={op + '_' + index}
+                value={op}
+                component="button"
+                onClick={() => {
+                  this.props.onSelectHeaderOp(op);
+                  this.onHeaderOpToggle();
+                }}
+                data-test={'header-type-' + op}
+              >
+                {op}
+              </DropdownItem>
+            ))}
+          />
+        )}
         {(this.props.filterType === REQ_MOD || this.props.filterType === RESP_MOD) && (
           <TextInput
             id="header-name-id"
@@ -128,6 +162,70 @@ class K8sFilterBuilder extends React.Component<Props, State> {
             value={this.props.headerValue}
             onChange={this.props.onHeaderValueChange}
             placeholder="Header Value..."
+          />
+        )}
+        {(this.props.filterType === REQ_RED) && (
+          <Dropdown
+            toggle={
+              <DropdownToggle onToggle={this.onSchemeOpToggle} data-test={'scheme-toggle'}>
+                {this.props.schemeOp}
+              </DropdownToggle>
+            }
+            isOpen={this.state.isSchemeDropdown}
+            dropdownItems={schemeOptions.map((op, index) => (
+              <DropdownItem
+                key={op + '_' + index}
+                value={op}
+                component="button"
+                onClick={() => {
+                  this.props.onSelectSchemeOp(op);
+                  this.onSchemeOpToggle();
+                }}
+                data-test={'scheme-' + op}
+              >
+                {op}
+              </DropdownItem>
+            ))}
+          />
+        )}
+        {(this.props.filterType === REQ_RED) && (
+          <TextInput
+            id="hostname"
+            value={this.props.hostName}
+            onChange={this.props.onHostNameChange}
+            placeholder="Hostname..."
+          />
+        )}
+        {(this.props.filterType === REQ_RED) && (
+          <TextInput
+            id="portValue"
+            value={this.props.portValue}
+            onChange={this.props.onPortValueChange}
+            placeholder="Port..."
+          />
+        )}
+        {(this.props.filterType === REQ_RED) && (
+          <Dropdown
+            toggle={
+              <DropdownToggle onToggle={this.onStatusCodeOpToggle} data-test={'status-code'}>
+                {this.props.statusCodeOp}
+              </DropdownToggle>
+            }
+            isOpen={this.state.isStatusCodeDropdown}
+            dropdownItems={statusOptions.map((op, index) => (
+              <DropdownItem
+                key={op + '_' + index}
+                value={op}
+                component="button"
+                onClick={() => {
+                  this.props.onSelectStatusCodeOp(op);
+                  this.onStatusCodeOpToggle();
+                }}
+                data-test={'status-code-' + op}
+              >
+                {op}
+              </DropdownItem>
+            ))}
           />
         )}
         <Button

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
@@ -36,7 +36,7 @@ class K8sFilters extends React.Component<Props> {
           Filtering selected
           {wizardTooltip(FILTERING_SELECTED_TOOLTIP)}
         </span>
-        {filters.length > 0 ? filters : <b>Filter any request</b>}
+        {filters.length > 0 ? filters : <b>No Request Filter</b>}
       </div>
     );
   }

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
@@ -19,7 +19,6 @@ const remove = style({
 
 class K8sFilters extends React.Component<Props> {
   render() {
-    console.log("this.props.filters " + JSON.stringify(this.props.filters))
     const filters: any[] = this.props.filters.map((filter, index) => (
       <span key={filter + '-' + index} data-test={filter} className={remove}>
         <Chip onClick={() => this.props.onRemoveFilter(filter)} isOverflowChip={true}>

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { Chip } from '@patternfly/react-core';
+import { style } from 'typestyle';
+import {FILTERING_SELECTED_TOOLTIP, wizardTooltip} from '../WizardHelp';
+
+type Props = {
+  filters: string[];
+  onRemoveFilter: (filter: string) => void;
+};
+
+const labelContainerStyle = style({
+  marginTop: 20,
+  height: 40
+});
+
+const remove = style({
+  cursor: "not-allowed"
+});
+
+class K8sFilters extends React.Component<Props> {
+  render() {
+    const filters: any[] = this.props.filters.map((filter, index) => (
+      <span key={filter + '-' + index} data-test={filter} className={remove}>
+        <Chip onClick={() => this.props.onRemoveFilter(filter)} isOverflowChip={true}>
+          {filter}
+        </Chip>{' '}
+      </span>
+    ));
+    return (
+      <div className={labelContainerStyle}>
+        <span
+          style={{
+            marginRight: '32px'
+          }}
+        >
+          Filtering selected
+          {wizardTooltip(FILTERING_SELECTED_TOOLTIP)}
+        </span>
+        {filters.length > 0 ? filters : <b>Filter any request</b>}
+      </div>
+    );
+  }
+}
+
+export default K8sFilters;

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
@@ -19,6 +19,7 @@ const remove = style({
 
 class K8sFilters extends React.Component<Props> {
   render() {
+    console.log("this.props.filters " + JSON.stringify(this.props.filters))
     const filters: any[] = this.props.filters.map((filter, index) => (
       <span key={filter + '-' + index} data-test={filter} className={remove}>
         <Chip onClick={() => this.props.onRemoveFilter(filter)} isOverflowChip={true}>

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatchBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatchBuilder.tsx
@@ -17,7 +17,7 @@ type Props = {
   matchValue: string;
   isValid: boolean;
   onSelectCategory: (category: string) => void;
-  onHeaderNameChange: (headerName: string) => void;
+  onMatchHeaderNameChange: (headerName: string) => void;
   onQueryParamNameChange: (queryParamName: string) => void;
   onSelectOperator: (operator: string) => void;
   onMatchValueChange: (matchValue: string) => void;
@@ -105,7 +105,7 @@ class K8sMatchBuilder extends React.Component<Props, State> {
           <TextInput
             id="header-name-id"
             value={this.props.headerName}
-            onChange={this.props.onHeaderNameChange}
+            onChange={this.props.onMatchHeaderNameChange}
             placeholder="Header name..."
           />
         )}

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -32,11 +32,19 @@ type Props = {
   filterType: string;
   filterValue: string;
   headerOp: string;
+  schemeOp: string;
   headerValue: string;
+  hostName: string;
+  portValue: string;
+  statusCodeOp: string;
   filters: string[];
   onSelectFilterType: (filterType: string) => void;
   onHeaderValueChange: (headerValue: string) => void;
+  onHostNameChange: (hostName: string) => void;
+  onPortValueChange: (portValue: string) => void;
+  onSelectStatusCodeOp: (statusCodeOp: string) => void;
   onSelectHeaderOp: (headerOp: string) => void;
+  onSelectSchemeOp: (schemeOp: string) => void;
   onRemoveFilter: (filter: string) => void;
   onAddFilter: () => void;
 

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -6,6 +6,8 @@ import { style } from 'typestyle';
 import { PFColors } from '../../Pf/PfColors';
 import K8sTrafficShifting, { K8sRouteBackendRef } from '../K8sTrafficShifting';
 import {ServiceOverview} from "../../../types/ServiceList";
+import K8sFilterBuilder from "./K8sFilterBuilder";
+import K8sFilters from "./K8sFilters";
 
 type Props = {
   // K8sMatchBuilder props
@@ -25,6 +27,19 @@ type Props = {
   // K8sMatches props
   matches: string[];
   onRemoveMatch: (match: string) => void;
+
+  // K8sFilters props
+  filterType: string;
+  filterValue: string;
+  headerType: string;
+  headerValue: string;
+  filters: string[];
+  onSelectFilterType: (filterType: string) => void;
+  onHeaderValueChange: (headerValue: string) => void;
+  onSelectHeaderType: (headerType: string) => void;
+  onFilterValueChange: (filterValue: string) => void;
+  onRemoveFilter: (filter: string) => void;
+  onAddFilter: () => void;
 
   subServices: ServiceOverview[];
   onSelectWeights: (backendRefs: K8sRouteBackendRef[]) => void;
@@ -95,6 +110,12 @@ class K8sRuleBuilder extends React.Component<Props, State> {
                 initRefs={this.props.backendRefs}
                 onChange={this.props.onSelectWeights}
               />
+            </div>
+          </Tab>
+          <Tab eventKey={2} title={'Route Filtering'} data-test={'Route Filtering'}>
+            <div style={{ marginTop: '20px' }}>
+              <K8sFilterBuilder {...this.props} />
+              <K8sFilters {...this.props} />
             </div>
           </Tab>
         </Tabs>

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -37,7 +37,6 @@ type Props = {
   onSelectFilterType: (filterType: string) => void;
   onHeaderValueChange: (headerValue: string) => void;
   onSelectHeaderType: (headerType: string) => void;
-  onFilterValueChange: (filterValue: string) => void;
   onRemoveFilter: (filter: string) => void;
   onAddFilter: () => void;
 

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -31,12 +31,12 @@ type Props = {
   // K8sFilters props
   filterType: string;
   filterValue: string;
-  headerType: string;
+  headerOp: string;
   headerValue: string;
   filters: string[];
   onSelectFilterType: (filterType: string) => void;
   onHeaderValueChange: (headerValue: string) => void;
-  onSelectHeaderType: (headerType: string) => void;
+  onSelectHeaderOp: (headerOp: string) => void;
   onRemoveFilter: (filter: string) => void;
   onAddFilter: () => void;
 

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -19,6 +19,7 @@ type Props = {
   isValid: boolean;
   onSelectCategory: (category: string) => void;
   onHeaderNameChange: (headerName: string) => void;
+  onMatchHeaderNameChange: (headerName: string) => void;
   onQueryParamNameChange: (matchValue: string) => void;
   onSelectOperator: (operator: string) => void;
   onMatchValueChange: (matchValue: string) => void;
@@ -131,7 +132,6 @@ class K8sRuleBuilder extends React.Component<Props, State> {
             {this.props.validationMsg.length > 0 && <div className={validationStyle}>{this.props.validationMsg}</div>}
             <Button
               variant={ButtonVariant.secondary}
-              isDisabled={!this.props.isValid}
               onClick={this.props.onAddRule}
               data-test="add-route"
             >

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRules.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRules.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { ROUTE_RULES_TOOLTIP, wizardTooltip } from '../WizardHelp';
-import {K8sRouteBackendRef, K8sRouteFilter} from '../K8sTrafficShifting';
+import {K8sRouteBackendRef} from '../K8sTrafficShifting';
 
 export enum MOVE_TYPE {
   UP,
@@ -21,7 +21,7 @@ export enum MOVE_TYPE {
 
 export type K8sRule = {
   matches: string[];
-  filters: K8sRouteFilter[];
+  filters: string[];
   backendRefs: K8sRouteBackendRef[];
 };
 
@@ -101,6 +101,10 @@ class K8sRules extends React.Component<Props> {
         props: {}
       },
       {
+        title: 'Route Filtering',
+        props: {}
+      },
+      {
         title: 'Route To',
         props: {}
       }
@@ -126,6 +130,11 @@ class K8sRules extends React.Component<Props> {
                       This rule is not accessible.
                     </div>
                   )}
+                </>,
+                <>
+                  {!rule.filters || rule.filters.length === 0
+                    ? 'No Request Filter'
+                    : rule.filters.map((filter, i) => <div key={'filter_' + i}>{filter}</div>)}
                 </>,
                 <>
                   <div key={'br_' + order}>

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRules.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRules.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { ROUTE_RULES_TOOLTIP, wizardTooltip } from '../WizardHelp';
-import {K8sRouteBackendRef} from '../K8sTrafficShifting';
+import {K8sRouteBackendRef, K8sRouteFilter} from '../K8sTrafficShifting';
 
 export enum MOVE_TYPE {
   UP,
@@ -21,6 +21,7 @@ export enum MOVE_TYPE {
 
 export type K8sRule = {
   matches: string[];
+  filters: K8sRouteFilter[];
   backendRefs: K8sRouteBackendRef[];
 };
 

--- a/frontend/src/components/IstioWizards/K8sTrafficShifting.tsx
+++ b/frontend/src/components/IstioWizards/K8sTrafficShifting.tsx
@@ -21,6 +21,23 @@ export type K8sRouteBackendRef = {
   port?: number;
 };
 
+export type K8sRouteFilter = {
+  type: string;
+  requestHeaderModifier?: K8sHeaderFilter;
+  responseHeaderModifier?: K8sHeaderFilter;
+};
+
+export type K8sHeaderFilter = {
+  set?: K8sHeader[];
+  add?: K8sHeader[];
+  remove?: string[];
+};
+
+export type K8sHeader = {
+  name: string;
+  value: string;
+};
+
 type State = {
   backendRefs: K8sRouteBackendRef[];
 };

--- a/frontend/src/components/IstioWizards/K8sTrafficShifting.tsx
+++ b/frontend/src/components/IstioWizards/K8sTrafficShifting.tsx
@@ -24,7 +24,6 @@ export type K8sRouteBackendRef = {
 export type K8sRouteFilter = {
   type: string;
   requestHeaderModifier?: K8sHeaderFilter;
-  responseHeaderModifier?: K8sHeaderFilter;
 };
 
 export type K8sHeaderFilter = {

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -296,7 +296,6 @@ const buildK8sHTTPRouteMatch = (matches: string[]): K8sHTTPRouteMatch => {
 
 const buildK8sHTTPRouteFilter = (filters: string[]): K8sHTTPRouteFilter[] => {
   const routeFilter: K8sHTTPRouteFilter[] = [];
-  console.log("filters " + filters)
   filters
     .filter(filter => filter.startsWith(REQ_MOD))
     .forEach(filter => {
@@ -398,7 +397,6 @@ const parseHttpMatchRequest = (httpMatchRequest: HTTPMatchRequest): string[] => 
 };
 
 const parseK8sHTTPMatchRequest = (httpRouteMatch: K8sHTTPRouteMatch): string[] => {
-  console.log("httpRouteMatch " + JSON.stringify(httpRouteMatch))
   const matches: string[] = [];
   if (httpRouteMatch.path) {
     matches.push('path ' + httpRouteMatch.path?.type + ' ' + httpRouteMatch.path?.value);
@@ -422,7 +420,6 @@ const parseK8sHTTPMatchRequest = (httpRouteMatch: K8sHTTPRouteMatch): string[] =
 };
 
 const parseK8sHTTPRouteFilter = (httpRouteFilter: K8sHTTPRouteFilter): string[] => {
-  console.log("httpRouteFilter " + JSON.stringify(httpRouteFilter))
   let matches: string[] = [];
   if (httpRouteFilter.requestHeaderModifier) {
     matches = matches.concat(parseK8sHTTPHeaderFilter("requestHeaderModifier", httpRouteFilter.requestHeaderModifier));
@@ -435,7 +432,6 @@ const parseK8sHTTPRouteFilter = (httpRouteFilter: K8sHTTPRouteFilter): string[] 
 
 const parseK8sHTTPHeaderFilter = (filterType: string, httpHeaderFilter: K8sHTTPHeaderFilter): string[] => {
   const filters: string[] = [];
-  console.log("httpHeaderFilter " + JSON.stringify(httpHeaderFilter))
   if (httpHeaderFilter.set) {
     httpHeaderFilter.set.forEach(set => {
       filters.push(filterType + ' [' + set.name + '] set ' + set.value);

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -1100,6 +1100,7 @@ export const getInitK8sRules = (
     httpRoutes[0].spec.rules.forEach(httpRoute => {
       const rule: K8sRule = {
         matches: [],
+        filters: [],
         backendRefs: []
       };
       if (httpRoute.matches) {

--- a/frontend/src/components/IstioWizards/WizardHelp.tsx
+++ b/frontend/src/components/IstioWizards/WizardHelp.tsx
@@ -73,6 +73,15 @@ export const MATCHING_SELECTED_TOOLTIP = (
   </>
 );
 
+export const FILTERING_SELECTED_TOOLTIP = (
+  <>
+    <div style={{ marginBottom: 5 }}>Filters applies for the requests being forwarded by rules defined here.</div>
+    <div>
+      Kiali Wizard will create all conditions with an <span className={importantTooltip}>OR</span> semantic.
+    </div>
+  </>
+);
+
 export const OUTLIER_DETECTION_TOOLTIP = (
   <>
     <div style={{ marginBottom: 5 }}>

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -790,6 +790,7 @@ export interface K8sHTTPRouteSpec {
 
 export interface K8sRouteRule {
   matches?:     K8sHTTPRouteMatch[];
+  filters?:     K8sHTTPRouteFilter[];
   backendRefs?: K8sRouteBackendRef[];
 }
 
@@ -803,7 +804,14 @@ export interface K8sRouteBackendRef {
 
 export interface K8sHTTPRouteFilter {
   requestRedirect?: K8sHTTPRouteRequestRedirect;
+  requestHeaderModifier?: K8sHTTPHeaderFilter;
   type?:            string;
+}
+
+export interface K8sHTTPHeaderFilter {
+  set?: HTTPHeader[];
+  add?: HTTPHeader[];
+  remove?: string[];
 }
 
 export interface K8sHTTPRouteRequestRedirect {
@@ -1258,7 +1266,7 @@ export interface APIKey {
   cookie?: string;
 }
 
-export interface CanaryUpgradeStatus { 
+export interface CanaryUpgradeStatus {
   currentVersion: string;
   upgradeVersion: string;
   migratedNamespaces: string[];

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -815,6 +815,9 @@ export interface K8sHTTPHeaderFilter {
 }
 
 export interface K8sHTTPRouteRequestRedirect {
+  scheme?: string;
+  hostname?: string;
+  port?: number;
   statusCode?: number;
 }
 


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5502

Added a new tab in K8s Gateway API Routing wizard: "Route Filtering".
It supports only "RequestHeaderModifier" type of filtering so far. The rest of filter types will be added in further PRs.


![Screenshot from 2022-12-08 18-59-45](https://user-images.githubusercontent.com/604313/206529332-93805397-a57b-4dd0-a8fa-1ff3dda0fb0a.png)
![Screenshot from 2022-12-08 18-59-25](https://user-images.githubusercontent.com/604313/206529340-cfd72d37-2dbe-48cf-833c-fcdac9687533.png)
