### PR TITLE
Use cache only for workload service

### DIFF
--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -159,7 +159,7 @@ func mockWorkLoadService(k8s *kubetest.K8SClientMock) WorkloadService {
 	k8s.On("GetPods", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(fakePods().Items, nil)
 	k8s.On("GetConfigMap", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.ConfigMap{}, nil)
 
-	svc := setupWorkloadService(k8s)
+	svc := setupWorkloadService(k8s, config.Get())
 	return svc
 }
 
@@ -245,7 +245,8 @@ func fakeIstioConfigList() *models.IstioConfigList {
 	istioConfigList.VirtualServices = []*networking_v1beta1.VirtualService{
 		data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("product", "v1", -1),
 			data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("product2", "v1", -1),
-				data.CreateEmptyVirtualService("product-vs", "test", []string{"product"})))}
+				data.CreateEmptyVirtualService("product-vs", "test", []string{"product"}))),
+	}
 
 	istioConfigList.DestinationRules = []*networking_v1beta1.DestinationRule{
 		data.AddSubsetToDestinationRule(data.CreateSubset("v1", "v1"), data.CreateEmptyDestinationRule("test", "product-dr", "product")),
@@ -334,7 +335,8 @@ func getGateway(name, namespace string) []*networking_v1beta1.Gateway {
 		data.AddServerToGateway(data.CreateServer([]string{"valid"}, 80, "http", "http"),
 			data.CreateEmptyGateway(name, namespace, map[string]string{
 				"app": "real",
-			}))}
+			})),
+	}
 }
 
 func loadVirtualService(file string, t *testing.T) *networking_v1beta1.VirtualService {

--- a/business/layer.go
+++ b/business/layer.go
@@ -14,7 +14,9 @@ import (
 	"github.com/kiali/kiali/prometheus"
 )
 
-// Layer is a container for fast access to inner services
+// Layer is a container for fast access to inner services.
+// A business layer is created per token/user. Any data that
+// needs to be saved across layers is saved in the Kiali Cache.
 type Layer struct {
 	App            AppService
 	Health         HealthService
@@ -55,6 +57,7 @@ func initKialiCache() {
 		}
 	}
 
+	// TODO: Remove conditonal once cache is fully mandatory.
 	if config.Get().KubernetesConfig.CacheEnabled {
 		log.Infof("Initializing Kiali Cache")
 
@@ -112,7 +115,7 @@ func IsResourceCached(namespace string, resource string) bool {
 }
 
 func Start() {
-	// Kiali Cache will be initialized once at first use of Business layer
+	// Kiali Cache will be initialized once at start up.
 	once.Do(initKialiCache)
 }
 
@@ -186,7 +189,18 @@ func NewWithBackends(k8s kubernetes.ClientInterface, prom prometheus.ClientInter
 	temporaryLayer.TLS = TLSService{k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.TokenReview = NewTokenReview(k8s)
 	temporaryLayer.Validations = IstioValidationsService{k8s: k8s, businessLayer: temporaryLayer}
-	temporaryLayer.Workload = WorkloadService{k8s: k8s, prom: prom, businessLayer: temporaryLayer}
+	// TODO: Remove conditional once cache is fully mandatory.
+	if config.Get().KubernetesConfig.CacheEnabled {
+		// The caching client effectively uses two different SA account tokens.
+		// The kiali SA token is used for all cache methods. The cache methods are
+		// read-only. Methods that are not cached and methods that modify objects
+		// use the user's token through the normal client.
+		// TODO: Always pass caching client once caching is mandatory.
+		cachingClient := cache.NewCachingClient(kialiCache, k8s)
+		temporaryLayer.Workload = *NewWorkloadService(cachingClient, prom, kialiCache, temporaryLayer, config.Get())
+	} else {
+		temporaryLayer.Workload = *NewWorkloadService(k8s, prom, kialiCache, temporaryLayer, config.Get())
+	}
 
 	return temporaryLayer
 }

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -28,6 +28,7 @@ func FakeDeployments() []apps_v1.Deployment {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v1",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.DeploymentSpec{
@@ -49,6 +50,7 @@ func FakeDeployments() []apps_v1.Deployment {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v2",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.DeploymentSpec{
@@ -70,6 +72,7 @@ func FakeDeployments() []apps_v1.Deployment {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v3",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.DeploymentSpec{
@@ -132,6 +135,7 @@ func FakeReplicaSets() []apps_v1.ReplicaSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v1",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.ReplicaSetSpec{
@@ -153,6 +157,7 @@ func FakeReplicaSets() []apps_v1.ReplicaSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v2",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.ReplicaSetSpec{
@@ -174,6 +179,7 @@ func FakeReplicaSets() []apps_v1.ReplicaSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v3",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.ReplicaSetSpec{
@@ -205,7 +211,8 @@ func FakeDuplicatedReplicaSets() []apps_v1.ReplicaSet {
 				Kind: "ReplicaSet",
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
-				Name:              "duplicated-v1-12345",
+				Name: "duplicated-v1-12345",
+
 				CreationTimestamp: meta_v1.NewTime(t1),
 				OwnerReferences: []meta_v1.OwnerReference{{
 					Controller: &controller,
@@ -244,6 +251,7 @@ func FakeReplicationControllers() []core_v1.ReplicationController {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v1",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: core_v1.ReplicationControllerSpec{
@@ -265,6 +273,7 @@ func FakeReplicationControllers() []core_v1.ReplicationController {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v2",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: core_v1.ReplicationControllerSpec{
@@ -286,6 +295,7 @@ func FakeReplicationControllers() []core_v1.ReplicationController {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v3",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: core_v1.ReplicationControllerSpec{
@@ -318,6 +328,7 @@ func FakeDeploymentConfigs() []osapps_v1.DeploymentConfig {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v1",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: osapps_v1.DeploymentConfigSpec{
@@ -339,6 +350,7 @@ func FakeDeploymentConfigs() []osapps_v1.DeploymentConfig {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v2",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: osapps_v1.DeploymentConfigSpec{
@@ -360,6 +372,7 @@ func FakeDeploymentConfigs() []osapps_v1.DeploymentConfig {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v3",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: osapps_v1.DeploymentConfigSpec{
@@ -392,6 +405,7 @@ func FakeStatefulSets() []apps_v1.StatefulSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v1",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.StatefulSetSpec{
@@ -412,6 +426,7 @@ func FakeStatefulSets() []apps_v1.StatefulSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v2",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.StatefulSetSpec{
@@ -432,6 +447,7 @@ func FakeStatefulSets() []apps_v1.StatefulSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v3",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.StatefulSetSpec{
@@ -463,6 +479,7 @@ func FakeDaemonSets() []apps_v1.DaemonSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v1",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.DaemonSetSpec{
@@ -484,6 +501,7 @@ func FakeDaemonSets() []apps_v1.DaemonSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v2",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.DaemonSetSpec{
@@ -505,6 +523,7 @@ func FakeDaemonSets() []apps_v1.DaemonSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "httpbin-v3",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.DaemonSetSpec{
@@ -536,6 +555,7 @@ func FakeDuplicatedStatefulSets() []apps_v1.StatefulSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "duplicated-v1",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.StatefulSetSpec{
@@ -566,6 +586,7 @@ func FakeDepSyncedWithRS() []apps_v1.Deployment {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "details-v1",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 			},
 			Spec: apps_v1.DeploymentSpec{
@@ -598,6 +619,7 @@ func FakeRSSyncedWithPods() []apps_v1.ReplicaSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "details-v1-3618568057",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 				OwnerReferences: []meta_v1.OwnerReference{{
 					Controller: &controller,
@@ -632,6 +654,7 @@ func FakePodsSyncedWithDeployments() []core_v1.Pod {
 		{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "details-v1-3618568057-dnkjp",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 				Labels:            map[string]string{appLabel: "httpbin", versionLabel: "v1"},
 				OwnerReferences: []meta_v1.OwnerReference{{
@@ -665,6 +688,7 @@ func FakePodSyncedWithDeployments() *core_v1.Pod {
 	return &core_v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:              "details-v1-3618568057-dnkjp",
+			Namespace:         "Namespace",
 			CreationTimestamp: meta_v1.NewTime(t1),
 			Labels:            map[string]string{appLabel: "httpbin", versionLabel: "v1"},
 			OwnerReferences: []meta_v1.OwnerReference{{
@@ -713,6 +737,7 @@ func FakePodsSyncedWithDuplicated() []core_v1.Pod {
 		{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "duplicated-v1-3618568057-1",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 				Labels:            map[string]string{appLabel: "duplicated", versionLabel: "v1"},
 				OwnerReferences: []meta_v1.OwnerReference{{
@@ -736,6 +761,7 @@ func FakePodsSyncedWithDuplicated() []core_v1.Pod {
 		{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "duplicated-v1-3618568057-3",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 				Labels:            map[string]string{appLabel: "duplicated", versionLabel: "v1"},
 				OwnerReferences: []meta_v1.OwnerReference{{
@@ -773,6 +799,7 @@ func FakePodsNoController() []core_v1.Pod {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "orphan-pod",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 				Labels:            map[string]string{appLabel: "httpbin", versionLabel: "v1"},
 				Annotations:       kubetest.FakeIstioAnnotations(),
@@ -802,6 +829,7 @@ func FakePodsFromCustomController() []core_v1.Pod {
 		{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "custom-controller-pod",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 				Labels:            map[string]string{appLabel: "httpbin", versionLabel: "v1"},
 				OwnerReferences: []meta_v1.OwnerReference{{
@@ -839,6 +867,7 @@ func FakeCustomControllerRSSyncedWithPods() []apps_v1.ReplicaSet {
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:              "custom-controller-RS-123",
+				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 				OwnerReferences: []meta_v1.OwnerReference{{
 					Controller: &controller,
@@ -865,7 +894,7 @@ func FakeCustomControllerRSSyncedWithPods() []apps_v1.ReplicaSet {
 func FakeServices() []core_v1.Service {
 	return []core_v1.Service{
 		{
-			ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin"},
+			ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "Namespace"},
 			Spec: core_v1.ServiceSpec{
 				Selector: map[string]string{"app": "httpbin"},
 			},

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -386,7 +386,10 @@ func (in *WorkloadService) UpdateWorkload(ctx context.Context, namespace string,
 	// Cache is stopped after a Create/Update/Delete operation to force a refresh.
 	// Refresh once after all the updates have gone through since Update Workload will update
 	// every single workload type of that matches name/namespace and we only want to refresh once.
-	in.cache.Refresh(namespace)
+	// TODO: Remove conditional once cache is mandatory
+	if in.cache != nil {
+		in.cache.Refresh(namespace)
+	}
 
 	// After the update we fetch the whole workload
 	return in.GetWorkload(ctx, WorkloadCriteria{Namespace: namespace, WorkloadName: workloadName, WorkloadType: workloadType, IncludeServices: includeServices})

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -27,17 +27,33 @@ import (
 	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/observability"
 	"github.com/kiali/kiali/prometheus"
 )
 
+func NewWorkloadService(k8s kubernetes.ClientInterface, prom prometheus.ClientInterface, cache cache.KialiCache, layer *Layer, config *config.Config) *WorkloadService {
+	return &WorkloadService{
+		k8s:           k8s,
+		prom:          prom,
+		cache:         cache,
+		businessLayer: layer,
+		config:        config,
+	}
+}
+
 // WorkloadService deals with fetching istio/kubernetes workloads related content and convert to kiali model
 type WorkloadService struct {
-	prom          prometheus.ClientInterface
-	k8s           kubernetes.ClientInterface
+	prom prometheus.ClientInterface
+	k8s  kubernetes.ClientInterface
+	// Careful not to call the workload service from here as that would be a infinite loop.
 	businessLayer *Layer
+	// The global kiali cache. This should be passed into the workload service rather than created inside of it.
+	cache cache.KialiCache
+	// The global kiali config.
+	config *config.Config
 }
 
 type WorkloadCriteria struct {
@@ -320,7 +336,7 @@ func (in *WorkloadService) GetWorkload(ctx context.Context, criteria WorkloadCri
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		conf := config.Get()
+		conf := in.config
 		app := workload.Labels[conf.IstioLabels.AppLabelName]
 		version := workload.Labels[conf.IstioLabels.VersionLabelName]
 		runtimes = NewDashboardsService(ns, workload).GetCustomDashboardRefs(criteria.Namespace, app, version, workload.Pods)
@@ -362,15 +378,15 @@ func (in *WorkloadService) UpdateWorkload(ctx context.Context, namespace string,
 	defer end()
 
 	// Identify controller and apply patch to workload
-	err := updateWorkload(in.businessLayer, namespace, workloadName, workloadType, jsonPatch)
+	err := in.updateWorkload(namespace, workloadName, workloadType, jsonPatch)
 	if err != nil {
 		return nil, err
 	}
 
-	// Cache is stopped after a Create/Update/Delete operation to force a refresh
-	if kialiCache != nil && err == nil {
-		kialiCache.Refresh(namespace)
-	}
+	// Cache is stopped after a Create/Update/Delete operation to force a refresh.
+	// Refresh once after all the updates have gone through since Update Workload will update
+	// every single workload type of that matches name/namespace and we only want to refresh once.
+	in.cache.Refresh(namespace)
 
 	// After the update we fetch the whole workload
 	return in.GetWorkload(ctx, WorkloadCriteria{Namespace: namespace, WorkloadName: workloadName, WorkloadType: workloadType, IncludeServices: includeServices})
@@ -385,21 +401,17 @@ func (in *WorkloadService) GetPods(ctx context.Context, namespace string, labelS
 	)
 	defer end()
 
-	var err error
-	var ps []core_v1.Pod
-	// Check if namespace is cached
-	if IsNamespaceCached(namespace) {
-		// Cache uses Kiali ServiceAccount, check if user can access to the namespace
-		if _, err = in.businessLayer.Namespace.GetNamespace(ctx, namespace); err == nil {
-			ps, err = kialiCache.GetPods(namespace, labelSelector)
-		}
-	} else {
-		ps, err = in.k8s.GetPods(namespace, labelSelector)
-	}
-
-	if err != nil {
+	// Check if user has access to the namespace
+	if _, err := in.businessLayer.Namespace.GetNamespace(ctx, namespace); err != nil {
 		return nil, err
 	}
+
+	var ps []core_v1.Pod
+	var err error
+	if ps, err = in.k8s.GetPods(namespace, labelSelector); err != nil {
+		return nil, err
+	}
+
 	pods := models.Pods{}
 	pods.Parse(ps)
 	return pods, nil
@@ -426,7 +438,7 @@ func (in *WorkloadService) BuildLogOptionsCriteria(container, duration, isProxy,
 	if duration != "" {
 		duration, err := time.ParseDuration(duration)
 		if err != nil {
-			return nil, fmt.Errorf("Invalid duration [%s]: %v", duration, err)
+			return nil, fmt.Errorf("invalid duration [%s]: %v", duration, err)
 		}
 
 		opts.Duration = &duration
@@ -437,7 +449,7 @@ func (in *WorkloadService) BuildLogOptionsCriteria(container, duration, isProxy,
 	if sinceTime != "" {
 		numTime, err := strconv.ParseInt(sinceTime, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("Invalid sinceTime [%s]: %v", sinceTime, err)
+			return nil, fmt.Errorf("invalid sinceTime [%s]: %v", sinceTime, err)
 		}
 
 		opts.SinceTime = &meta_v1.Time{Time: time.Unix(numTime, 0)}
@@ -449,7 +461,7 @@ func (in *WorkloadService) BuildLogOptionsCriteria(container, duration, isProxy,
 				opts.MaxLines = &numLines
 			}
 		} else {
-			return nil, fmt.Errorf("Invalid maxLines [%s]: %v", maxLines, err)
+			return nil, fmt.Errorf("invalid maxLines [%s]: %v", maxLines, err)
 		}
 	}
 
@@ -604,15 +616,8 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 	// Pods are always fetched
 	go func() {
 		defer wg.Done()
-
-		// Check if namespace is cached
-		// Namespace access is checked in the upper caller
 		var err error
-		if IsNamespaceCached(namespace) {
-			pods, err = kialiCache.GetPods(namespace, labelSelector)
-		} else {
-			pods, err = layer.k8s.GetPods(namespace, labelSelector)
-		}
+		pods, err = layer.k8s.GetPods(namespace, labelSelector)
 		if err != nil {
 			log.Errorf("Error fetching Pods per namespace %s: %s", namespace, err)
 			errChan <- err
@@ -622,15 +627,8 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 	// Deployments are always fetched
 	go func() {
 		defer wg.Done()
-
-		// Check if namespace is cached
-		// Namespace access is checked in the upper caller
 		var err error
-		if IsNamespaceCached(namespace) {
-			dep, err = kialiCache.GetDeployments(namespace)
-		} else {
-			dep, err = layer.k8s.GetDeployments(namespace)
-		}
+		dep, err = layer.k8s.GetDeployments(namespace)
 		if err != nil {
 			log.Errorf("Error fetching Deployments per namespace %s: %s", namespace, err)
 			errChan <- err
@@ -640,15 +638,8 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 	// ReplicaSets are always fetched
 	go func() {
 		defer wg.Done()
-
-		// Check if namespace is cached
-		// Namespace access is checked in the upper caller
 		var err error
-		if IsNamespaceCached(namespace) {
-			repset, err = kialiCache.GetReplicaSets(namespace)
-		} else {
-			repset, err = layer.k8s.GetReplicaSets(namespace)
-		}
+		repset, err = layer.k8s.GetReplicaSets(namespace)
 		if err != nil {
 			log.Errorf("Error fetching ReplicaSets per namespace %s: %s", namespace, err)
 			errChan <- err
@@ -689,11 +680,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 
 		var err error
 		if isWorkloadIncluded(kubernetes.StatefulSetType) {
-			if IsNamespaceCached(namespace) {
-				fulset, err = kialiCache.GetStatefulSets(namespace)
-			} else {
-				fulset, err = layer.k8s.GetStatefulSets(namespace)
-			}
+			fulset, err = layer.k8s.GetStatefulSets(namespace)
 			if err != nil {
 				log.Errorf("Error fetching StatefulSets per namespace %s: %s", namespace, err)
 				errChan <- err
@@ -735,11 +722,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 
 		var err error
 		if isWorkloadIncluded(kubernetes.DaemonSetType) {
-			if IsNamespaceCached(namespace) {
-				daeset, err = kialiCache.GetDaemonSets(namespace)
-			} else {
-				daeset, err = layer.k8s.GetDaemonSets(namespace)
-			}
+			daeset, err = layer.k8s.GetDaemonSets(namespace)
 			if err != nil {
 				log.Errorf("Error fetching DaemonSets per namespace %s: %s", namespace, err)
 			}
@@ -1185,15 +1168,8 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 	// Pods are always fetched for all workload types
 	go func() {
 		defer wg.Done()
-
-		// Check if namespace is cached
-		// Namespace access is checked in the upper call
 		var err error
-		if IsNamespaceCached(criteria.Namespace) {
-			pods, err = kialiCache.GetPods(criteria.Namespace, "")
-		} else {
-			pods, err = layer.k8s.GetPods(criteria.Namespace, "")
-		}
+		pods, err = layer.k8s.GetPods(criteria.Namespace, "")
 		if err != nil {
 			log.Errorf("Error fetching Pods per namespace %s: %s", criteria.Namespace, err)
 			errChan <- err
@@ -1203,19 +1179,12 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 	// fetch as Deployment when workloadType is Deployment or unspecified
 	go func() {
 		defer wg.Done()
+		var err error
 
 		if criteria.WorkloadType != "" && criteria.WorkloadType != kubernetes.DeploymentType {
 			return
 		}
-
-		// Check if namespace is cached
-		// Namespace access is checked in the upper call
-		var err error
-		if IsNamespaceCached(criteria.Namespace) {
-			dep, err = kialiCache.GetDeployment(criteria.Namespace, criteria.WorkloadName)
-		} else {
-			dep, err = layer.k8s.GetDeployment(criteria.Namespace, criteria.WorkloadName)
-		}
+		dep, err = layer.k8s.GetDeployment(criteria.Namespace, criteria.WorkloadName)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				dep = nil
@@ -1233,15 +1202,8 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 		if criteria.WorkloadType != "" && criteria.WorkloadType != kubernetes.ReplicaSetType && knownWorkloadType {
 			return
 		}
-
-		// Check if namespace is cached
-		// Namespace access is checked in the upper call
 		var err error
-		if IsNamespaceCached(criteria.Namespace) {
-			repset, err = kialiCache.GetReplicaSets(criteria.Namespace)
-		} else {
-			repset, err = layer.k8s.GetReplicaSets(criteria.Namespace)
-		}
+		repset, err = layer.k8s.GetReplicaSets(criteria.Namespace)
 		if err != nil {
 			log.Errorf("Error fetching ReplicaSets per namespace %s: %s", criteria.Namespace, err)
 			errChan <- err
@@ -1293,11 +1255,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 
 		var err error
 		if isWorkloadIncluded(kubernetes.StatefulSetType) {
-			if IsNamespaceCached(criteria.Namespace) {
-				fulset, err = kialiCache.GetStatefulSet(criteria.Namespace, criteria.WorkloadName)
-			} else {
-				fulset, err = layer.k8s.GetStatefulSet(criteria.Namespace, criteria.WorkloadName)
-			}
+			fulset, err = layer.k8s.GetStatefulSet(criteria.Namespace, criteria.WorkloadName)
 			if err != nil {
 				fulset = nil
 			}
@@ -1350,11 +1308,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 
 		var err error
 		if isWorkloadIncluded(kubernetes.DaemonSetType) {
-			if IsNamespaceCached(criteria.Namespace) {
-				ds, err = kialiCache.GetDaemonSet(criteria.Namespace, criteria.WorkloadName)
-			} else {
-				ds, err = layer.k8s.GetDaemonSet(criteria.Namespace, criteria.WorkloadName)
-			}
+			ds, err = layer.k8s.GetDaemonSet(criteria.Namespace, criteria.WorkloadName)
 			if err != nil {
 				ds = nil
 			}
@@ -1733,10 +1687,10 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 	return wl, kubernetes.NewNotFound(criteria.WorkloadName, "Kiali", "Workload")
 }
 
-func updateWorkload(layer *Layer, namespace string, workloadName string, workloadType string, jsonPatch string) error {
+func (in *WorkloadService) updateWorkload(namespace string, workloadName string, workloadType string, jsonPatch string) error {
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := layer.Namespace.GetNamespace(context.TODO(), namespace); err != nil {
+	if _, err := in.businessLayer.Namespace.GetNamespace(context.TODO(), namespace); err != nil {
 		return err
 	}
 
@@ -1776,7 +1730,7 @@ func updateWorkload(layer *Layer, namespace string, workloadName string, workloa
 			defer wg.Done()
 			var err error
 			if isWorkloadIncluded(wkType) {
-				err = layer.k8s.UpdateWorkload(namespace, workloadName, wkType, jsonPatch)
+				err = in.k8s.UpdateWorkload(namespace, workloadName, wkType, jsonPatch)
 			}
 			if err != nil {
 				if !errors.IsNotFound(err) {
@@ -1844,7 +1798,7 @@ func (in *WorkloadService) GetWorkloadAppName(ctx context.Context, namespace, wo
 		return "", err
 	}
 
-	appLabelName := config.Get().IstioLabels.AppLabelName
+	appLabelName := in.config.IstioLabels.AppLabelName
 	app := wkd.Labels[appLabelName]
 	return app, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -284,6 +284,7 @@ type KubernetesConfig struct {
 	// Cache uses watchers to sync with the backend, after a CacheDuration watchers are closed and re-opened
 	CacheDuration int `yaml:"cache_duration,omitempty"`
 	// Enable cache for kubernetes and istio resources
+	// TODO: Remove once all services are migrated to use the cache.
 	CacheEnabled bool `yaml:"cache_enabled,omitempty"`
 	// Kiali can cache VirtualService,DestinationRule,Gateway and ServiceEntry Istio resources if they are present
 	// on this list of Istio types. Other Istio types are not yet supported.

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -179,11 +179,6 @@ func NewKialiCache(namespaceSeedList ...string) (KialiCache, error) {
 
 	cacheNamespacesRegexps := make([]regexp.Regexp, len(cacheNamespaces))
 	for i, ns := range cacheNamespaces {
-		// '**' is a special character for selecting all namespaces
-		// but needs to be converted to an actual regexp.
-		if ns == "**" {
-			ns = ".*"
-		}
 		cacheNamespacesRegexps[i] = *regexp.MustCompile(strings.TrimSpace(ns))
 	}
 

--- a/kubernetes/cache/cachingclient.go
+++ b/kubernetes/cache/cachingclient.go
@@ -1,0 +1,111 @@
+package cache
+
+import (
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+// CachingClient is a wrapper around a ClientInterface that adds caching.
+// If the object is cached then it is read from the cache. Not all object
+// types are cached. When an object is created, updated, or deleted, then
+// the cache is refreshed and updated.
+type CachingClient struct {
+	cache KialiCache
+	kubernetes.ClientInterface
+}
+
+// NewCachingClient creates a new CachingClient out of a cache and a client.
+func NewCachingClient(cache KialiCache, client kubernetes.ClientInterface) *CachingClient {
+	return &CachingClient{
+		cache:           cache,
+		ClientInterface: client,
+	}
+}
+
+// TODO: Remove conditionals for cache once cache is fully mandatory.
+
+func (cc *CachingClient) GetConfigMap(namespace, name string) (*core_v1.ConfigMap, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetConfigMap(namespace, name)
+	}
+	return cc.ClientInterface.GetConfigMap(namespace, name)
+}
+
+func (cc *CachingClient) GetDaemonSet(namespace string, name string) (*apps_v1.DaemonSet, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetDaemonSet(namespace, name)
+	}
+	return cc.ClientInterface.GetDaemonSet(namespace, name)
+}
+
+func (cc *CachingClient) GetDaemonSets(namespace string) ([]apps_v1.DaemonSet, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetDaemonSets(namespace)
+	}
+	return cc.ClientInterface.GetDaemonSets(namespace)
+}
+
+func (cc *CachingClient) GetDeployment(namespace string, name string) (*apps_v1.Deployment, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetDeployment(namespace, name)
+	}
+	return cc.ClientInterface.GetDeployment(namespace, name)
+}
+
+func (cc *CachingClient) GetDeployments(namespace string) ([]apps_v1.Deployment, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetDeployments(namespace)
+	}
+	return cc.ClientInterface.GetDeployments(namespace)
+}
+
+func (cc *CachingClient) GetEndpoints(namespace string, name string) (*core_v1.Endpoints, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetEndpoints(namespace, name)
+	}
+	return cc.ClientInterface.GetEndpoints(namespace, name)
+}
+
+func (cc *CachingClient) GetPods(namespace, labelSelector string) ([]core_v1.Pod, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetPods(namespace, labelSelector)
+	}
+	return cc.ClientInterface.GetPods(namespace, labelSelector)
+}
+
+func (cc *CachingClient) GetReplicaSets(namespace string) ([]apps_v1.ReplicaSet, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetReplicaSets(namespace)
+	}
+	return cc.ClientInterface.GetReplicaSets(namespace)
+}
+
+func (cc *CachingClient) GetService(namespace string, name string) (*core_v1.Service, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetService(namespace, name)
+	}
+	return cc.ClientInterface.GetService(namespace, name)
+}
+
+func (cc *CachingClient) GetServices(namespace string, selectorLabels map[string]string) ([]core_v1.Service, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetServices(namespace, selectorLabels)
+	}
+	return cc.ClientInterface.GetServices(namespace, selectorLabels)
+}
+
+func (cc *CachingClient) GetStatefulSet(namespace string, name string) (*apps_v1.StatefulSet, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetStatefulSet(namespace, name)
+	}
+	return cc.ClientInterface.GetStatefulSet(namespace, name)
+}
+
+func (cc *CachingClient) GetStatefulSets(namespace string) ([]apps_v1.StatefulSet, error) {
+	if cc.cache.CheckNamespace(namespace) {
+		return cc.cache.GetStatefulSets(namespace)
+	}
+	return cc.ClientInterface.GetStatefulSets(namespace)
+}

--- a/kubernetes/cache/istio_test.go
+++ b/kubernetes/cache/istio_test.go
@@ -8,10 +8,10 @@ import (
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
 func TestGetSidecar(t *testing.T) {
@@ -107,7 +107,7 @@ func TestGetNonCachedResource(t *testing.T) {
 			Name: "sidecar", Namespace: "test", Labels: map[string]string{"app": "bookinfo", "version": "v1"},
 		},
 	}
-	kialiCache := newTestKialiCache(nil, []runtime.Object{sidecar}, nil)
+	kialiCache := newTestKialiCache(kubetest.NewFakeK8sClient(sidecar))
 	kialiCache.cacheIstioTypes = nil
 	_, err := kialiCache.GetVirtualServices("testing-ns", "app=bookinfo")
 	assert.Error(err)
@@ -122,7 +122,7 @@ func TestGetAndListReturnKindInfo(t *testing.T) {
 			Name: "vs", Namespace: "test",
 		},
 	}
-	kialiCache := newTestKialiCache(nil, []runtime.Object{vs}, nil)
+	kialiCache := newTestKialiCache(kubetest.NewFakeK8sClient(vs))
 	kialiCache.cacheIstioTypes = map[string]bool{
 		kubernetes.PluralType[kubernetes.VirtualServices]: true,
 	}

--- a/kubernetes/cache/kubernetes_test.go
+++ b/kubernetes/cache/kubernetes_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apps_v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
 // Other parts of the codebase assume that this kind field is present so it's important
@@ -20,7 +21,7 @@ func TestKubeGetAndListReturnKindInfo(t *testing.T) {
 			Name: "deployment", Namespace: "test",
 		},
 	}
-	kialiCache := newTestKialiCache([]runtime.Object{d}, nil, nil)
+	kialiCache := newTestKialiCache(kubetest.NewFakeK8sClient(d))
 	kialiCache.Refresh("test")
 
 	deploymentFromCache, err := kialiCache.GetDeployment("test", "deployment")
@@ -32,4 +33,35 @@ func TestKubeGetAndListReturnKindInfo(t *testing.T) {
 	for _, deployment := range deploymentListFromCache {
 		assert.Equal(kubernetes.DeploymentType, deployment.Kind)
 	}
+}
+
+// Tests that when a refresh happens, the new cache must fully load before the
+// new object is returned.
+func TestConcurrentAccessDuringRefresh(t *testing.T) {
+	require := require.New(t)
+	d := &apps_v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "deployment", Namespace: "test",
+		},
+	}
+
+	kialiCache := newTestKialiCache(kubetest.NewFakeK8sClient(d))
+	// Prime the pump with a first Refresh.
+	kialiCache.Refresh("test")
+
+	stop := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_, err := kialiCache.GetDeployment(d.Namespace, d.Name)
+				require.NoError(err)
+			}
+		}
+	}()
+
+	kialiCache.Refresh("test")
+	close(stop)
 }

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -51,7 +51,7 @@ type K8SClient struct {
 	ClientInterface
 	token          string
 	k8s            kube.Interface
-	istioClientset *istio.Clientset
+	istioClientset istio.Interface
 	// Used in REST queries after bump to client-go v0.20.x
 	ctx context.Context
 	// isOpenShift private variable will check if kiali is deployed under an OpenShift cluster or not
@@ -90,7 +90,7 @@ func UseRemoteCreds(remoteSecret *RemoteSecret) (*rest.Config, error) {
 
 	serverParse := strings.Split(remoteSecret.Clusters[0].Cluster.Server, ":")
 	if len(serverParse) != 3 && len(serverParse) != 2 {
-		return nil, errors.New("Invalid remote API server URL")
+		return nil, errors.New("invalid remote API server URL")
 	}
 	host := strings.TrimPrefix(serverParse[1], "//")
 
@@ -100,7 +100,7 @@ func UseRemoteCreds(remoteSecret *RemoteSecret) (*rest.Config, error) {
 	}
 
 	if !strings.EqualFold(serverParse[0], "https") {
-		return nil, errors.New("Only HTTPS protocol is allowed in remote API server URL")
+		return nil, errors.New("only HTTPS protocol is allowed in remote API server URL")
 	}
 
 	// There's no need to add the BearerToken because it's ignored later on
@@ -173,4 +173,13 @@ func NewClientFromConfig(config *rest.Config) (*K8SClient, error) {
 
 	client.ctx = context.Background()
 	return &client, nil
+}
+
+// NewClient is just used for testing purposes.
+func NewClient(kubeClient kube.Interface, istioClient istio.Interface, gatewayapiClient gatewayapiclient.Interface) *K8SClient {
+	return &K8SClient{
+		istioClientset: istioClient,
+		k8s:            kubeClient,
+		gatewayapi:     gatewayapiClient,
+	}
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -442,7 +442,7 @@ func (in *K8SClient) getPodPortForwarder(namespace, name, portMap string) (httpu
 
 	// Create a Port Forwarder
 	restInterface := in.k8s.CoreV1().RESTClient()
-	return httputil.NewPortForwarder(&restInterface, clientConfig,
+	return httputil.NewPortForwarder(restInterface, clientConfig,
 		namespace, name, "localhost", portMap, writer)
 }
 

--- a/kubernetes/kubetest/fake.go
+++ b/kubernetes/kubetest/fake.go
@@ -1,0 +1,173 @@
+package kubetest
+
+import (
+	"context"
+
+	osapps_v1 "github.com/openshift/api/apps/v1"
+	osproject_v1 "github.com/openshift/api/project/v1"
+	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	istio "istio.io/client-go/pkg/clientset/versioned"
+	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
+	istioscheme "istio.io/client-go/pkg/clientset/versioned/scheme"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	gatewayapifake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+	gatewayapischeme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
+
+	kialikube "github.com/kiali/kiali/kubernetes"
+)
+
+func isIstioResource(obj runtime.Object) bool {
+	_, _, err := istioscheme.Scheme.ObjectKinds(obj)
+	return err == nil
+}
+
+func isKubeResource(obj runtime.Object) bool {
+	_, _, err := kubescheme.Scheme.ObjectKinds(obj)
+	return err == nil
+}
+
+func isGatewayAPIResource(obj runtime.Object) bool {
+	_, _, err := gatewayapischeme.Scheme.ObjectKinds(obj)
+	return err == nil
+}
+
+func isOpenShiftResource(obj runtime.Object) bool {
+	// We don't use openshift's client-go package where the scheme is located
+	// so just manually checking a few types that Kiali uses here. Not all the
+	// types are covered.
+	switch obj.(type) {
+	case *osapps_v1.DeploymentConfig, *osproject_v1.Project:
+		return true
+	}
+
+	return false
+}
+
+func NewFakeK8sClient(objects ...runtime.Object) *FakeK8sClient {
+	// NOTE: The kube fake client object tracker guesses the resource name based on the Kind.
+	// For a plural resource, it will convert the kind to lowercase and add an "ies" to the end.
+	// In the case of objects like "Gateway" where the plural is actually "Gateways", the conversion
+	// is wrong. The guessing of the resource name only happens with tracker.Add inside of NewSimpleClientset.
+	// If we create the object after creating the clientset, then the tracker will use the correct resource name.
+	var (
+		kubeObjects       []runtime.Object
+		istioObjects      []runtime.Object
+		gatewayapiObjects []runtime.Object
+		istioGateways     []*networking_v1beta1.Gateway
+		deploymentConfigs = make(map[string][]osapps_v1.DeploymentConfig)
+		projects          = []osproject_v1.Project{}
+	)
+
+	for _, obj := range objects {
+		o := obj
+		switch {
+		case isKubeResource(o):
+			kubeObjects = append(kubeObjects, o)
+		case isIstioResource(o):
+			if gw, ok := o.(*networking_v1beta1.Gateway); ok {
+				istioGateways = append(istioGateways, gw)
+			} else {
+				istioObjects = append(istioObjects, o)
+			}
+		case isGatewayAPIResource(o):
+			gatewayapiObjects = append(gatewayapiObjects, o)
+		case isOpenShiftResource(o):
+			if dc, ok := o.(*osapps_v1.DeploymentConfig); ok {
+				if _, exists := deploymentConfigs[dc.Namespace]; !exists {
+					deploymentConfigs[dc.Namespace] = []osapps_v1.DeploymentConfig{}
+				}
+				deploymentConfigs[dc.Namespace] = append(deploymentConfigs[dc.Namespace], *dc)
+			} else if proj, ok := o.(*osproject_v1.Project); ok {
+				projects = append(projects, *proj)
+			}
+		}
+	}
+
+	kubeClient := kubefake.NewSimpleClientset(kubeObjects...)
+	istioClient := istiofake.NewSimpleClientset(istioObjects...)
+	gatewayAPIClient := gatewayapifake.NewSimpleClientset(gatewayapiObjects...)
+
+	// These are created separately because the fake clientset guesses the resource name based on the Kind.
+	for _, gw := range istioGateways {
+		if _, err := istioClient.NetworkingV1beta1().Gateways(gw.Namespace).Create(context.TODO(), gw, metav1.CreateOptions{}); err != nil {
+			panic(err)
+		}
+	}
+
+	return &FakeK8sClient{
+		ClientInterface:   kialikube.NewClient(kubeClient, istioClient, gatewayAPIClient),
+		deploymentConfigs: deploymentConfigs,
+		projects:          projects,
+		KubeClientset:     kubeClient,
+		IstioClientset:    istioClient,
+	}
+}
+
+// FakeK8sClient is an implementation of the kiali Kubernetes client interface used for tests.
+type FakeK8sClient struct {
+	OpenShift         bool
+	GatewayAPIEnabled bool
+	kialikube.ClientInterface
+	// Keeping track of the openshift objects separately since we don't use the openshift client-go
+	// and there's no underlying fake clientset.
+	// This is a map of namespace: []objects e.g. DeploymentConfig: []DeploymentConfig.
+	deploymentConfigs map[string][]osapps_v1.DeploymentConfig
+	projects          []osproject_v1.Project
+	// Underlying kubernetes clientset.
+	KubeClientset kubernetes.Interface
+	// Underlying istio clientset.
+	IstioClientset istio.Interface
+}
+
+func (c *FakeK8sClient) IsOpenShift() bool  { return c.OpenShift }
+func (c *FakeK8sClient) IsGatewayAPI() bool { return c.GatewayAPIEnabled }
+
+// The openshift resources are stubbed out because Kiali talks directly to the
+// kube api for these instead of using the openshift client-go.
+func (c *FakeK8sClient) GetProject(name string) (*osproject_v1.Project, error) {
+	for _, p := range c.projects {
+		if p.Name == name {
+			return &p, nil
+		}
+	}
+	return nil, kubeerrors.NewNotFound(osproject_v1.Resource("project"), name)
+}
+
+// The openshift resources are stubbed out because Kiali talks directly to the
+// kube api for these instead of using the openshift client-go.
+func (c *FakeK8sClient) GetProjects(labelSelector string) ([]osproject_v1.Project, error) {
+	return c.projects, nil
+}
+
+func (c *FakeK8sClient) GetDeploymentConfig(namespace string, name string) (*osapps_v1.DeploymentConfig, error) {
+	for _, dc := range c.deploymentConfigs[namespace] {
+		if dc.Name == name {
+			return &dc, nil
+		}
+	}
+	return nil, kubeerrors.NewNotFound(osapps_v1.Resource("deploymentconfig"), name)
+}
+
+func (c *FakeK8sClient) GetDeploymentConfigs(namespace string) ([]osapps_v1.DeploymentConfig, error) {
+	// No namespace specified means return all.
+	if namespace == "" {
+		var all []osapps_v1.DeploymentConfig
+		for _, dcs := range c.deploymentConfigs {
+			all = append(all, dcs...)
+		}
+		return all, nil
+	}
+
+	if dcs, ok := c.deploymentConfigs[namespace]; ok {
+		return dcs, nil
+	}
+
+	return nil, nil
+}
+
+var _ kialikube.ClientInterface = &FakeK8sClient{}

--- a/kubernetes/kubetest/fake.go
+++ b/kubernetes/kubetest/fake.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	gatewayapi "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 	gatewayapifake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 	gatewayapischeme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 
@@ -122,6 +123,8 @@ type FakeK8sClient struct {
 	KubeClientset kubernetes.Interface
 	// Underlying istio clientset.
 	IstioClientset istio.Interface
+	// Underlying gateway api clientset.
+	GatewayAPIClientset gatewayapi.Interface
 }
 
 func (c *FakeK8sClient) IsOpenShift() bool  { return c.OpenShift }

--- a/util/httputil/port_forwarder.go
+++ b/util/httputil/port_forwarder.go
@@ -50,11 +50,11 @@ func (f forwarder) Stop() {
 	Pool.FreePort(f.localPort)
 }
 
-func NewPortForwarder(client *rest.Interface, clientConfig *rest.Config, namespace, pod, address, portMap string, writer io.Writer) (PortForwarder, error) {
+func NewPortForwarder(client rest.Interface, clientConfig *rest.Config, namespace, pod, address, portMap string, writer io.Writer) (PortForwarder, error) {
 	stopCh := make(chan struct{})
 	readyCh := make(chan struct{})
 
-	forwarderUrl := (*client).Post().
+	forwarderUrl := client.Post().
 		Namespace(namespace).
 		Resource("pods").
 		Name(pod).


### PR DESCRIPTION
Relates to #5599. Splitting out the changes into multiple PRs to make the more reviewable.

This PR also fixes some race conditions present in the cache.