### PR TITLE
[v1.57] An attempt to fix timing issue resulting in missing side car

### DIFF
--- a/hack/istio/install-error-rates-demo.sh
+++ b/hack/istio/install-error-rates-demo.sh
@@ -22,6 +22,8 @@ spec:
 EOM
 
   if [ "${ENABLE_INJECTION}" == "true" ]; then
+    # let's wait for smmr to be Ready before enabling sidecar injection
+    ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
     for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
     do
       echo "Enabling sidecar injection for deployment: ${d}"

--- a/hack/istio/install-fraud-detection-demo.sh
+++ b/hack/istio/install-fraud-detection-demo.sh
@@ -22,6 +22,8 @@ spec:
 EOM
 
   if [ "${ENABLE_INJECTION}" == "true" ]; then
+    # let's wait for smmr to be Ready before enabling sidecar injection
+    ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
     for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
     do
       echo "Enabling sidecar injection for deployment: ${d}"

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -28,6 +28,8 @@ spec:
     name: "$(${CLIENT_EXE} get smcp -n ${ISTIO_NAMESPACE} -o jsonpath='{.items[0].metadata.name}' )"
 EOM
 
+  # let's wait for smmr to be Ready before enabling sidecar injection
+  ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
   # enable sidecar injection
   for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
   do

--- a/hack/istio/install-travel-agency-demo.sh
+++ b/hack/istio/install-travel-agency-demo.sh
@@ -22,6 +22,8 @@ spec:
 EOM
 
   if [ "${ENABLE_INJECTION}" == "true" ]; then
+    # let's wait for smmr to be Ready before enabling sidecar injection
+    ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
     for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
     do
       echo "Enabling sidecar injection for deployment: ${d}"


### PR DESCRIPTION
Adding waiting for smmr being ready before enabling side car injection so the pods are restarted to pick up a side car. We already have this in master.

