### PR TITLE
Poll for proxy status continually rather than fetching lazily

### DIFF
--- a/business/proxy_logging.go
+++ b/business/proxy_logging.go
@@ -1,15 +1,11 @@
 package business
 
 import (
-	"fmt"
-
 	"github.com/kiali/kiali/kubernetes"
 )
 
-var (
-	// ValidProxyLogLevels are the application log levels supported by the envoy admin interface.
-	ValidProxyLogLevels = []string{"off", "trace", "debug", "info", "warning", "error", "critical"}
-)
+// ValidProxyLogLevels are the application log levels supported by the envoy admin interface.
+var ValidProxyLogLevels = []string{"off", "trace", "debug", "info", "warning", "error", "critical"}
 
 // IsValidLogLevel determines if the provided string is a valid proxy log level.
 // This can be called before calling SetLogLevel.
@@ -30,8 +26,9 @@ type ProxyLoggingService struct {
 
 // SetLogLevel sets the pod's proxy log level.
 func (in *ProxyLoggingService) SetLogLevel(namespace, pod, level string) error {
-	if _, err := in.proxyStatus.GetPodProxyStatus(namespace, pod); err != nil {
-		return fmt.Errorf("unable to detect proxy for Pod: %s in Namespace: %s", pod, namespace)
+	// Ensure pod exists
+	if _, err := in.k8s.GetPod(namespace, pod); err != nil {
+		return err
 	}
 	return in.k8s.SetProxyLogLevel(namespace, pod, level)
 }

--- a/business/proxy_status.go
+++ b/business/proxy_status.go
@@ -3,8 +3,6 @@ package business
 import (
 	"context"
 
-	"k8s.io/client-go/tools/clientcmd/api"
-
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -14,45 +12,12 @@ type ProxyStatusService struct {
 	businessLayer *Layer
 }
 
-func (in *ProxyStatusService) GetPodProxyStatus(ns, pod string) (*kubernetes.ProxyStatus, error) {
+func (in *ProxyStatusService) GetPodProxyStatus(ns, pod string) *models.ProxyStatus {
 	if kialiCache == nil {
-		return nil, nil
+		return nil
 	}
 
-	if kialiCache.CheckProxyStatus() {
-		return kialiCache.GetPodProxyStatus(ns, pod), nil
-	}
-
-	var proxyStatus []*kubernetes.ProxyStatus
-	var err error
-
-	if proxyStatus, err = in.k8s.GetProxyStatus(); err != nil {
-		if proxyStatus, err = in.getProxyStatusUsingKialiSA(); err != nil {
-			return nil, err
-		}
-	}
-
-	kialiCache.SetProxyStatus(proxyStatus)
-	return kialiCache.GetPodProxyStatus(ns, pod), nil
-}
-
-func (in *ProxyStatusService) getProxyStatusUsingKialiSA() ([]*kubernetes.ProxyStatus, error) {
-	clientFactory, err := kubernetes.GetClientFactory()
-	if err != nil {
-		return nil, err
-	}
-
-	kialiToken, err := kubernetes.GetKialiToken()
-	if err != nil {
-		return nil, err
-	}
-
-	k8s, err := clientFactory.GetClient(&api.AuthInfo{Token: kialiToken})
-	if err != nil {
-		return nil, err
-	}
-
-	return k8s.GetProxyStatus()
+	return castProxyStatus(kialiCache.GetPodProxyStatus(ns, pod))
 }
 
 func castProxyStatus(ps *kubernetes.ProxyStatus) *models.ProxyStatus {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1133,11 +1133,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 		// Add the Proxy Status to the workload
 		for _, pod := range w.Pods {
 			if pod.HasIstioSidecar() {
-				ps, err := layer.ProxyStatus.GetPodProxyStatus(namespace, pod.Name)
-				if err != nil {
-					log.Warningf("GetPodProxyStatus is failing for [namespace: %s] [pod: %s]: %s ", namespace, pod.Name, err.Error())
-				}
-				pod.ProxyStatus = castProxyStatus(ps)
+				pod.ProxyStatus = layer.ProxyStatus.GetPodProxyStatus(namespace, pod.Name)
 			}
 		}
 
@@ -1718,11 +1714,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 		// Add the Proxy Status to the workload
 		for _, pod := range w.Pods {
 			if pod.HasIstioSidecar() {
-				ps, err := layer.ProxyStatus.GetPodProxyStatus(criteria.Namespace, pod.Name)
-				if err != nil {
-					log.Warningf("GetPodProxyStatus is failing for [namespace: %s] [pod: %s]: %s ", criteria.Namespace, pod.Name, err.Error())
-				}
-				pod.ProxyStatus = castProxyStatus(ps)
+				pod.ProxyStatus = layer.ProxyStatus.GetPodProxyStatus(criteria.Namespace, pod.Name)
 			}
 		}
 

--- a/handlers/proxy_logging_test.go
+++ b/handlers/proxy_logging_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/kiali/kiali/business"
@@ -36,6 +37,8 @@ func setupTestLoggingServer(t *testing.T, namespace, pod string) *httptest.Serve
 	k8s.On("IsOpenShift").Return(false)
 	k8s.On("IsGatewayAPI").Return(false)
 	k8s.On("SetProxyLogLevel").Return(nil)
+	var fakePod *corev1.Pod
+	k8s.On("GetPod", namespace, pod).Return(fakePod, nil)
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	business.SetWithBackends(mockClientFactory, nil)

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"regexp"
 	"strings"
 	"sync"
@@ -117,9 +118,9 @@ type (
 		registryStatusLock     sync.RWMutex
 		registryStatusCreated  *time.Time
 		registryStatus         *kubernetes.RegistryStatus
-		// Stops the background goroutine which refreshes the cache's
-		// service account token.
-		stopCacheChan chan bool
+		// Stops the background goroutines which refreshe the cache's
+		// service account token and poll for istiod's proxy status.
+		stopPolling context.CancelFunc
 
 		clusterCacheLister *cacheLister
 		nsCacheLister      map[string]*cacheLister
@@ -191,11 +192,16 @@ func NewKialiCache(namespaceSeedList ...string) (KialiCache, error) {
 	kialiCacheImpl.istioApi = istioClient.Istio()
 	kialiCacheImpl.gatewayApi = istioClient.GatewayAPI()
 
+	// Cache launches some goroutines in the background to periodically poll some resources.
+	// These are stopped by calling cancel.
+	ctx, cancel := context.WithCancel(context.Background())
+	kialiCacheImpl.stopPolling = cancel
+
 	// Update SA Token
-	kialiCacheImpl.stopCacheChan = kialiCacheImpl.refreshCache(istioConfig)
+	kialiCacheImpl.refreshCache(ctx, istioConfig)
 
 	// Populate cache from Istiod in the background. This routine gets stopped when the cache is stopped.
-	kialiCacheImpl.pollIstiodForProxyStatus()
+	kialiCacheImpl.pollIstiodForProxyStatus(ctx)
 
 	kialiCacheImpl.registryRefreshHandler = NewRegistryHandler(kialiCacheImpl.RefreshRegistryStatus)
 
@@ -341,9 +347,8 @@ func (c *kialiCacheImpl) Refresh(namespace string) {
 
 // refreshCache watches for changes to the cache's service account token
 // and recreates the cache(s) when the token changes.
-func (c *kialiCacheImpl) refreshCache(istioConfig rest.Config) chan bool {
+func (c *kialiCacheImpl) refreshCache(ctx context.Context, istioConfig rest.Config) {
 	ticker := time.NewTicker(60 * time.Second)
-	quit := make(chan bool)
 	go func() {
 		for {
 			select {
@@ -380,14 +385,13 @@ func (c *kialiCacheImpl) refreshCache(istioConfig rest.Config) chan bool {
 						log.Debug("Kiali Cache: Nothing to refresh")
 					}
 				}
-			case <-quit:
+			case <-ctx.Done():
+				log.Debug("[Kiali Cache] Stopping watching for service account token changes")
 				ticker.Stop()
 				return
 			}
 		}
 	}()
-
-	return quit
 }
 
 // Stop will stop either the cluster wide cache or all of the namespace caches.
@@ -402,7 +406,7 @@ func (c *kialiCacheImpl) Stop() {
 			c.stop(namespace)
 		}
 	}
-	close(c.stopCacheChan)
+	c.stopPolling()
 }
 
 func (c *kialiCacheImpl) stop(namespace string) {

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -118,7 +118,7 @@ type (
 		registryStatusLock     sync.RWMutex
 		registryStatusCreated  *time.Time
 		registryStatus         *kubernetes.RegistryStatus
-		// Stops the background goroutines which refreshe the cache's
+		// Stops the background goroutines which refresh the cache's
 		// service account token and poll for istiod's proxy status.
 		stopPolling context.CancelFunc
 

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -25,7 +25,7 @@ func newTestKialiCache(kubeObjects []runtime.Object, istioObjects []runtime.Obje
 		stopClusterScopedChan: make(chan struct{}),
 		stopNSChans:           make(map[string]chan struct{}),
 		nsCacheLister:         make(map[string]*cacheLister),
-		stopCacheChan:         make(chan bool),
+		stopPolling:           func() {},
 	}
 	kialiCache.registryRefreshHandler = NewRegistryHandler(kialiCache.RefreshRegistryStatus)
 	return kialiCache

--- a/kubernetes/cache/proxy_status.go
+++ b/kubernetes/cache/proxy_status.go
@@ -1,31 +1,61 @@
 package cache
 
 import (
+	"context"
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 )
 
-type (
-	ProxyStatusCache interface {
-		CheckProxyStatus() bool
-		GetPodProxyStatus(namespace, pod string) *kubernetes.ProxyStatus
-		SetProxyStatus(proxyStatus []*kubernetes.ProxyStatus)
-		RefreshProxyStatus()
-	}
-)
+type ProxyStatusCache interface {
+	GetPodProxyStatus(namespace, pod string) *kubernetes.ProxyStatus
+}
 
-func (c *kialiCacheImpl) CheckProxyStatus() bool {
-	defer c.proxyStatusLock.RUnlock()
-	c.proxyStatusLock.RLock()
-	if c.proxyStatusCreated == nil {
-		return false
-	}
-	if time.Since(*c.proxyStatusCreated) > c.tokenNamespaceDuration {
-		return false
-	}
-	return true
+// pollIstiodForProxyStatus is a long running goroutine that will periodically poll istiod for proxy status.
+// Polling stops when the stopCacheChan is closed.
+func (c *kialiCacheImpl) pollIstiodForProxyStatus() {
+	log.Debug("[Kiali Cache] Scraping istiod for proxy status")
+	go func() {
+		for {
+			select {
+			case <-c.stopCacheChan:
+				return
+			case <-time.After(c.tokenNamespaceDuration):
+				// Get the proxy status from istiod with some retries.
+				// Wrapping this so we can defer cancel.
+				func() {
+					ctx, cancel := context.WithTimeout(context.Background(), c.tokenNamespaceDuration)
+					defer cancel()
+
+					var (
+						proxyStatus []*kubernetes.ProxyStatus
+						err         error
+					)
+
+					retryErr := wait.PollImmediateUntilWithContext(ctx, time.Second*4, func(ctx context.Context) (bool, error) {
+						log.Trace("Getting proxy status from istiod")
+						proxyStatus, err = c.istioClient.GetProxyStatus()
+						if err != nil {
+							// TODO: Error checking could be done here to determine retry if GetProxyStatus provided that info.
+							return false, nil
+						}
+
+						return true, nil
+					})
+					if retryErr != nil {
+						log.Errorf("Error getting proxy status from istiod: %v", err)
+						return
+					}
+
+					c.setProxyStatus(proxyStatus)
+				}()
+			}
+		}
+	}()
 }
 
 func (c *kialiCacheImpl) GetPodProxyStatus(namespace, pod string) *kubernetes.ProxyStatus {
@@ -39,12 +69,10 @@ func (c *kialiCacheImpl) GetPodProxyStatus(namespace, pod string) *kubernetes.Pr
 	return nil
 }
 
-func (c *kialiCacheImpl) SetProxyStatus(proxyStatus []*kubernetes.ProxyStatus) {
+func (c *kialiCacheImpl) setProxyStatus(proxyStatus []*kubernetes.ProxyStatus) {
 	defer c.proxyStatusLock.Unlock()
 	c.proxyStatusLock.Lock()
 	if len(proxyStatus) > 0 {
-		timeNow := time.Now()
-		c.proxyStatusCreated = &timeNow
 		for _, ps := range proxyStatus {
 			if ps != nil {
 				// Expected format <pod-name>.<namespace>
@@ -65,10 +93,4 @@ func (c *kialiCacheImpl) SetProxyStatus(proxyStatus []*kubernetes.ProxyStatus) {
 			}
 		}
 	}
-}
-
-func (c *kialiCacheImpl) RefreshProxyStatus() {
-	defer c.proxyStatusLock.Unlock()
-	c.proxyStatusLock.Lock()
-	c.proxyStatusNamespaces = make(map[string]map[string]podProxyStatus)
 }


### PR DESCRIPTION
Helps mitigate #5669 by fetching proxy status continually every 10 seconds rather than fetching it only when it's asked for. This will limit the amount of times the proxy status service will attempt to port forward to istiod.