### PR TITLE
Add Matěj as tester

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -66,6 +66,7 @@ both roles aren't mutually exclusive.
 Current list of testers (alphabetically ordered):
 
 * [FilipB](https://github.com/FilipB)
+* [matejnesuta](https://github.com/matejnesuta)
 * [mattmahoneyrh](https://github.com/mattmahoneyrh)
 * [pbajjuri20](https://github.com/pbajjuri20)
 * [prachiyadav](https://github.com/prachiyadav)


### PR DESCRIPTION
See #5665

Governance mandates that voting should be given withing 7 working days. However, because of holidays most maintainers aren't available and majority won't be possible. So, voting is delayed and starting at the very first working day of January 2023.

People who is available can give their vote in advance.