### PR TITLE
Avoid graph generation panic scenario

### DIFF
--- a/graph/types.go
+++ b/graph/types.go
@@ -209,11 +209,12 @@ func Id(cluster, serviceNamespace, service, workloadNamespace, workload, app, ve
 	// handle workload graph nodes (service graphs are initially processed as workload graphs)
 	if graphType == GraphTypeWorkload || graphType == GraphTypeService {
 		// workload graph nodes are type workload or service
-		if !workloadOk && !serviceOk {
-			panic(fmt.Sprintf("Failed ID gen2: cluster=[%s] namespace=[%s] workload=[%s] app=[%s] version=[%s] service=[%s] graphType=[%s]", cluster, namespace, workload, app, version, service, graphType))
-		}
 		if !workloadOk {
-			return fmt.Sprintf("svc_%s_%s_%s", cluster, namespace, service), NodeTypeService
+			if serviceOk {
+				return fmt.Sprintf("svc_%s_%s_%s", cluster, namespace, service), NodeTypeService
+			}
+			// We have seen cases when app is set but workload is unknown and service may be unknown or not set (See #5696)
+			return fmt.Sprintf("svc_%s_%s_%s", cluster, namespace, Unknown), NodeTypeService
 		}
 		return fmt.Sprintf("wl_%s_%s_%v", cluster, namespace, workload), NodeTypeWorkload
 	}


### PR DESCRIPTION
It seems there is a legitimate case (possibly with a newer version of Istio, I'm not sure) where the telemetry may have app set, but not workload or service.  Possibly when the workload is not injected but app/version labeling is still applied to the workload.

In this case, avoid a graph-gen panic when trying to generate a workload graph node, and instead default to an Unknown service node.  Panics don't really help anyone, so anything we can do to avoid that situation is, I think, better.

Closes https://github.com/kiali/kiali/issues/5696
