### PR TITLE
Added new check for HTTPRoute backend Ref Service existence.

### DIFF
--- a/business/checkers/k8shttproute_checker.go
+++ b/business/checkers/k8shttproute_checker.go
@@ -11,8 +11,10 @@ import (
 const K8sHTTPRouteCheckerType = "k8shttproute"
 
 type K8sHTTPRouteChecker struct {
-	K8sHTTPRoutes []*k8s_networking_v1alpha2.HTTPRoute
-	K8sGateways   []*k8s_networking_v1alpha2.Gateway
+	K8sHTTPRoutes    []*k8s_networking_v1alpha2.HTTPRoute
+	K8sGateways      []*k8s_networking_v1alpha2.Gateway
+	Namespaces       models.Namespaces
+	RegistryServices []*kubernetes.RegistryService
 }
 
 // Check runs checks for the all namespaces actions as well as for the single namespace validations
@@ -44,6 +46,11 @@ func (in K8sHTTPRouteChecker) runChecks(rt *k8s_networking_v1alpha2.HTTPRoute, g
 		k8shttproutes.NoK8sGatewayChecker{
 			K8sHTTPRoute: rt,
 			GatewayNames: gatewayNames,
+		},
+		k8shttproutes.NoHostChecker{
+			K8sHTTPRoute:     rt,
+			Namespaces:       in.Namespaces,
+			RegistryServices: in.RegistryServices,
 		},
 	}
 

--- a/business/checkers/k8shttproute_checker_test.go
+++ b/business/checkers/k8shttproute_checker_test.go
@@ -16,8 +16,10 @@ func TestNoCrashOnEmptyRoute(t *testing.T) {
 	assert := assert.New(t)
 
 	typeValidations := K8sHTTPRouteChecker{
-		K8sHTTPRoutes: []*k8s_networking_v1alpha2.HTTPRoute{},
-		K8sGateways:   []*k8s_networking_v1alpha2.Gateway{},
+		K8sHTTPRoutes:    []*k8s_networking_v1alpha2.HTTPRoute{},
+		K8sGateways:      []*k8s_networking_v1alpha2.Gateway{},
+		RegistryServices: data.CreateEmptyRegistryServices(),
+		Namespaces:       models.Namespaces{},
 	}.Check()
 
 	assert.Empty(typeValidations)
@@ -43,4 +45,31 @@ func TestWithoutK8sGateway(t *testing.T) {
 	route2 := vals[models.IstioValidationKey{ObjectType: "k8shttproute", Namespace: "bookinfo", Name: "route2"}]
 	assert.False(route2.Valid)
 	assert.NoError(validations.ConfirmIstioCheckMessage("k8shttproutes.nok8sgateway", route2.Checks[0]))
+}
+
+func TestWithoutService(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	assert := assert.New(t)
+
+	registryService1 := data.CreateFakeRegistryServices("other.bookinfo.svc.cluster.local", "bookinfo", "*")
+	registryService2 := data.CreateFakeRegistryServices("details.bookinfo.svc.cluster.local", "bookinfo2", "*")
+
+	vals := K8sHTTPRouteChecker{
+		K8sHTTPRoutes: []*k8s_networking_v1alpha2.HTTPRoute{
+			data.AddBackendRefToHTTPRoute("ratings", data.CreateHTTPRoute("route1", "bookinfo", "gatewayapi", []string{"bookinfo"})),
+			data.AddBackendRefToHTTPRoute("ratings", data.CreateHTTPRoute("route2", "bookinfo2", "gatewayapi2", []string{"bookinfo2"}))},
+		K8sGateways:      []*k8s_networking_v1alpha2.Gateway{data.CreateEmptyK8sGateway("gatewayapi", "bookinfo"), data.CreateEmptyK8sGateway("gatewayapi2", "bookinfo2")},
+		RegistryServices: append(registryService1, registryService2...),
+		Namespaces:       models.Namespaces{models.Namespace{Name: "bookinfo"}, models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo3"}},
+	}.Check()
+
+	assert.NotEmpty(vals)
+
+	route1 := vals[models.IstioValidationKey{ObjectType: "k8shttproute", Namespace: "bookinfo", Name: "route1"}]
+	assert.False(route1.Valid)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8shttproutes.nohost.namenotfound", route1.Checks[0]))
+	route2 := vals[models.IstioValidationKey{ObjectType: "k8shttproute", Namespace: "bookinfo2", Name: "route2"}]
+	assert.False(route2.Valid)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8shttproutes.nohost.namenotfound", route2.Checks[0]))
 }

--- a/business/checkers/k8shttproutes/no_host_checker.go
+++ b/business/checkers/k8shttproutes/no_host_checker.go
@@ -1,0 +1,45 @@
+package k8shttproutes
+
+import (
+	"fmt"
+
+	k8s_networking_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type NoHostChecker struct {
+	Namespaces       models.Namespaces
+	K8sHTTPRoute     *k8s_networking_v1alpha2.HTTPRoute
+	RegistryServices []*kubernetes.RegistryService
+}
+
+func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+	valid := true
+	namespace := n.K8sHTTPRoute.Namespace
+
+	for k, httpRoute := range n.K8sHTTPRoute.Spec.Rules {
+		for i, ref := range httpRoute.BackendRefs {
+			if ref.Kind == nil || string(*ref.Kind) != "Service" {
+				continue
+			}
+			fqdn := kubernetes.GetHost(string(ref.Name), namespace, n.Namespaces.GetNames())
+			if !n.checkDestination(fqdn.String(), namespace) {
+				path := fmt.Sprintf("spec/rules[%d]/backendRefs[%d]/name", k, i)
+				validation := models.Build("k8shttproutes.nohost.namenotfound", path)
+				validations = append(validations, &validation)
+				valid = false
+			}
+		}
+	}
+
+	return validations, valid
+}
+
+func (n NoHostChecker) checkDestination(sHost string, itemNamespace string) bool {
+	// Use RegistryService to check destinations that may not be covered with previous check
+	// i.e. Multi-cluster or Federation validations
+	return kubernetes.HasMatchingRegistryService(itemNamespace, sHost, n.RegistryServices)
+}

--- a/business/checkers/k8shttproutes/no_host_checker_test.go
+++ b/business/checkers/k8shttproutes/no_host_checker_test.go
@@ -1,0 +1,58 @@
+package k8shttproutes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+func TestValidRefHost(t *testing.T) {
+	c := config.Get()
+	c.ExternalServices.Istio.IstioIdentityDomain = "svc.cluster.local"
+	config.Set(c)
+
+	assert := assert.New(t)
+
+	registryService1 := data.CreateFakeRegistryServices("other.bookinfo.svc.cluster.local", "bookinfo", "*")
+	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
+
+	vals, valid := NoHostChecker{
+		RegistryServices: append(registryService1, registryService2...),
+		K8sHTTPRoute:     data.AddBackendRefToHTTPRoute("reviews", data.CreateHTTPRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
+func TestNoValidRefHost(t *testing.T) {
+	c := config.Get()
+	c.ExternalServices.Istio.IstioIdentityDomain = "svc.cluster.local"
+	config.Set(c)
+
+	registryService1 := data.CreateFakeRegistryServices("other.bookinfo.svc.cluster.local", "bookinfo", "*")
+	registryService2 := data.CreateFakeRegistryServices("details.bookinfo.svc.cluster.local", "bookinfo", "*")
+
+	assert := assert.New(t)
+
+	vals, valid := NoHostChecker{
+		RegistryServices: append(registryService1, registryService2...),
+		K8sHTTPRoute:     data.AddBackendRefToHTTPRoute("ratings", data.AddBackendRefToHTTPRoute("reviews", data.CreateHTTPRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"}))),
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 2)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8shttproutes.nohost.namenotfound", vals[0]))
+	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[0].Path)
+
+	assert.Equal(models.ErrorSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8shttproutes.nohost.namenotfound", vals[1]))
+	assert.Equal("spec/rules[1]/backendRefs[0]/name", vals[1].Path)
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -139,7 +139,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(istioConfigList models.I
 		checkers.WorkloadChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.WasmPluginChecker{WasmPlugins: istioConfigList.WasmPlugins, Namespaces: namespaces},
 		checkers.TelemetryChecker{Telemetries: istioConfigList.Telemetries, Namespaces: namespaces},
-		checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways},
+		checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, Namespaces: namespaces, RegistryServices: registryServices},
 	}
 }
 
@@ -239,7 +239,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 	case kubernetes.K8sGateways:
 		// TODO
 	case kubernetes.K8sHTTPRoutes:
-		httpRouteChecker := checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways}
+		httpRouteChecker := checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, Namespaces: namespaces, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{noServiceChecker, httpRouteChecker}
 	default:
 		err = fmt.Errorf("object type not found: %v", objectType)

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -218,6 +218,11 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "No matching workload found for the selector in this namespace",
 		Severity: WarningSeverity,
 	},
+	"k8shttproutes.nohost.namenotfound": {
+		Code:     "KIA1402",
+		Message:  "BackendRef on rule doesn't have a valid service (host not found)",
+		Severity: ErrorSeverity,
+	},
 	"k8shttproutes.nok8sgateway": {
 		Code:     "KIA1401",
 		Message:  "HTTPRoute is pointing to a non-existent K8s gateway",

--- a/tests/data/k8sgateway_data.go
+++ b/tests/data/k8sgateway_data.go
@@ -32,6 +32,22 @@ func AddParentRefToHTTPRoute(name, namespace string, rt *k8s_networking_v1alpha2
 	return rt
 }
 
+func AddBackendRefToHTTPRoute(name string, rt *k8s_networking_v1alpha2.HTTPRoute) *k8s_networking_v1alpha2.HTTPRoute {
+	kind := k8s_networking_v1alpha2.Kind("Service")
+	backendRef := k8s_networking_v1alpha2.HTTPBackendRef{
+		BackendRef: k8s_networking_v1alpha2.BackendRef{
+			BackendObjectReference: k8s_networking_v1alpha2.BackendObjectReference{
+				Kind: &kind,
+				Name: k8s_networking_v1alpha2.ObjectName(name),
+			},
+		},
+	}
+	rule := k8s_networking_v1alpha2.HTTPRouteRule{}
+	rule.BackendRefs = append(rule.BackendRefs, backendRef)
+	rt.Spec.Rules = append(rt.Spec.Rules, rule)
+	return rt
+}
+
 func CreateEmptyK8sGateway(name, namespace string) *k8s_networking_v1alpha2.Gateway {
 	gw := k8s_networking_v1alpha2.Gateway{}
 	gw.Name = name


### PR DESCRIPTION
RFE: https://github.com/kiali/kiali/issues/5501
Added new validation check and message when K8s HTTPRoute is referring to a non existing Service.

![Screenshot from 2023-01-10 15-43-30](https://user-images.githubusercontent.com/604313/211582838-98049c08-b88a-41a0-8301-8d957a08314f.png)
