### PR TITLE
Added Gateway and Service references in HTTPRoute object details

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -245,6 +245,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 	case kubernetes.K8sHTTPRoutes:
 		httpRouteChecker := checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, Namespaces: namespaces, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{noServiceChecker, httpRouteChecker}
+		referenceChecker = references.K8sHTTPRouteReferences{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, Namespaces: namespaces}
 	default:
 		err = fmt.Errorf("object type not found: %v", objectType)
 	}

--- a/business/references/k8shttproute_references.go
+++ b/business/references/k8shttproute_references.go
@@ -1,0 +1,95 @@
+package references
+
+import (
+	k8s_networking_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type K8sHTTPRouteReferences struct {
+	Namespaces    models.Namespaces
+	K8sHTTPRoutes []*k8s_networking_v1alpha2.HTTPRoute
+}
+
+func (n K8sHTTPRouteReferences) References() models.IstioReferencesMap {
+	result := models.IstioReferencesMap{}
+
+	for _, rt := range n.K8sHTTPRoutes {
+		key := models.IstioReferenceKey{Namespace: rt.Namespace, Name: rt.Name, ObjectType: models.ObjectTypeSingular[kubernetes.K8sHTTPRoutes]}
+		references := &models.IstioReferences{}
+		references.ServiceReferences = n.getServiceReferences(rt)
+		references.ObjectReferences = n.getConfigReferences(rt)
+		result.MergeReferencesMap(models.IstioReferencesMap{key: references})
+	}
+
+	return result
+}
+
+func (n K8sHTTPRouteReferences) getServiceReferences(rt *k8s_networking_v1alpha2.HTTPRoute) []models.ServiceReference {
+	keys := make(map[string]bool)
+	allServices := make([]models.ServiceReference, 0)
+	result := make([]models.ServiceReference, 0)
+
+	for _, httpRoute := range rt.Spec.Rules {
+		for _, ref := range httpRoute.BackendRefs {
+			if ref.Kind == nil || string(*ref.Kind) != "Service" {
+				continue
+			}
+			namespace := rt.Namespace
+			if ref.Namespace != nil && string(*ref.Namespace) != "" {
+				namespace = string(*ref.Namespace)
+			}
+			fqdn := kubernetes.GetHost(string(ref.Name), namespace, n.Namespaces.GetNames())
+			if !fqdn.IsWildcard() {
+				allServices = append(allServices, models.ServiceReference{Name: fqdn.Service, Namespace: fqdn.Namespace})
+			}
+		}
+	}
+
+	// filter unique references
+	for _, sv := range allServices {
+		if !keys[sv.Name+"."+sv.Namespace] {
+			result = append(result, sv)
+			keys[sv.Name+"."+sv.Namespace] = true
+		}
+	}
+	return result
+}
+
+func (n K8sHTTPRouteReferences) getConfigReferences(rt *k8s_networking_v1alpha2.HTTPRoute) []models.IstioReference {
+	keys := make(map[string]bool)
+	result := make([]models.IstioReference, 0)
+	allGateways := getAllK8sGateways(rt)
+	// filter unique references
+	for _, gw := range allGateways {
+		if !keys[gw.Name+"."+gw.Namespace+"/"+gw.ObjectType] {
+			result = append(result, gw)
+			keys[gw.Name+"."+gw.Namespace+"/"+gw.ObjectType] = true
+		}
+	}
+	return result
+}
+
+func getAllK8sGateways(rt *k8s_networking_v1alpha2.HTTPRoute) []models.IstioReference {
+	allGateways := make([]models.IstioReference, 0)
+
+	if len(rt.Spec.ParentRefs) > 0 {
+		for _, parentRef := range rt.Spec.ParentRefs {
+			if string(parentRef.Name) != "" && string(*parentRef.Kind) == kubernetes.K8sActualGatewayType && string(*parentRef.Group) == kubernetes.K8sNetworkingGroupVersionV1Beta1.Group {
+				namespace := rt.Namespace
+				if parentRef.Namespace != nil && string(*parentRef.Namespace) != "" {
+					namespace = string(*parentRef.Namespace)
+				}
+				allGateways = append(allGateways, getK8sGatewayReference(string(parentRef.Name), namespace))
+			}
+		}
+	}
+
+	return allGateways
+}
+
+func getK8sGatewayReference(gateway string, namespace string) models.IstioReference {
+	gw := kubernetes.ParseGatewayAsHost(gateway, namespace)
+	return models.IstioReference{Name: gw.Service, Namespace: gw.Namespace, ObjectType: models.ObjectTypeSingular[kubernetes.K8sGateways]}
+}

--- a/business/references/k8shttproute_references_test.go
+++ b/business/references/k8shttproute_references_test.go
@@ -1,0 +1,58 @@
+package references
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	k8s_networking_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+func prepareTestForK8sHTTPRoute(route *k8s_networking_v1alpha2.HTTPRoute) models.IstioReferences {
+	routeReferences := K8sHTTPRouteReferences{
+		Namespaces: models.Namespaces{
+			{Name: "bookinfo"},
+			{Name: "bookinfo2"},
+			{Name: "bookinfo3"},
+		},
+		K8sHTTPRoutes: []*k8s_networking_v1alpha2.HTTPRoute{route},
+	}
+	return *routeReferences.References()[models.IstioReferenceKey{ObjectType: "k8shttproute", Namespace: route.Namespace, Name: route.Name}]
+}
+
+func TestK8sHTTPRouteReferences(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Setup mocks
+	references := prepareTestForK8sHTTPRoute(data.AddBackendRefToHTTPRoute("reviews2", "bookinfo2", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route1", "bookinfo", "gatewayapi", []string{"bookinfo"}))))
+	assert.NotEmpty(references.ServiceReferences)
+
+	// Check Service references
+	assert.Len(references.ServiceReferences, 2)
+	assert.Equal(references.ServiceReferences[0].Name, "reviews")
+	assert.Equal(references.ServiceReferences[0].Namespace, "bookinfo")
+	assert.Equal(references.ServiceReferences[1].Name, "reviews2")
+	assert.Equal(references.ServiceReferences[1].Namespace, "bookinfo2")
+
+	assert.Len(references.ObjectReferences, 1)
+	// Check Gateway references
+	assert.Equal(references.ObjectReferences[0].Name, "gatewayapi")
+	assert.Equal(references.ObjectReferences[0].Namespace, "bookinfo")
+	assert.Equal(references.ObjectReferences[0].ObjectType, "k8sgateway")
+}
+
+func TestK8sHTTPRouteNoReferences(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Setup mocks
+	references := prepareTestForK8sHTTPRoute(data.CreateEmptyHTTPRoute("route1", "bookinfo", []string{"details"}))
+	assert.Empty(references.ServiceReferences)
+}


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5709

References to K8s Gateways and Services in K8s HTTPRoute object details page.

![Screenshot from 2023-01-12 19-52-50](https://user-images.githubusercontent.com/604313/212154613-4dce6131-116b-4323-9f3b-91714dbb70d1.png)
