### PR TITLE
Add unique listener per GW

### DIFF
--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -329,6 +329,11 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "More than one K8s Gateway for the same address and type combination",
 		Severity: WarningSeverity,
 	},
+	"k8sgateways.unique.listener": {
+		Code:     "KIA1503",
+		Message:  "Each listener must have a unique combination of Hostname, Port, and Protocol",
+		Severity: ErrorSeverity,
+	},
 }
 
 func Build(checkId string, path string) IstioCheck {


### PR DESCRIPTION
Fixes #5710 

It is currently no possible to create a k8s gw with no listeners: 
`
error: error validating "/home/jcordoba/dev/deployments/k8sgwwrong.yaml": error validating data: ValidationError(Gateway.spec): missing required field "listeners" in io.k8s.networking.gateway.v1beta1.Gateway.spec; if you choose to ignore these errors, turn validation off with --validate=false`

So, no extra validation was done in this PR. 