### PR TITLE
Disable set log level dropdown in view only mode

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -52,6 +52,7 @@ import {isKiosk} from "../../components/Kiosk/KioskActions";
 import { KioskElement } from "../../components/Kiosk/KioskElement";
 import { TimeDurationModal } from "../../components/Time/TimeDurationModal";
 import TimeDurationIndicatorContainer from "../../components/Time/TimeDurationIndicatorComponent";
+import {serverConfig} from "../../config";
 
 const appContainerColors = [PFColors.White, PFColors.LightGreen400, PFColors.Purple100, PFColors.LightBlue400];
 const proxyContainerColor = PFColors.Gold400;
@@ -603,11 +604,15 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
       <DropdownItem key="toggleTimestamps" onClick={this.toggleShowTimestamps}>
         {`${this.state.showTimestamps ? 'Remove' : 'Show'} Timestamps`}
       </DropdownItem>,
-      <DropdownSeparator key="logLevelSeparator" />,
-      <DropdownGroup label={dropdownGroupLabel} key="setLogLevels">
-        {hasProxyContainer && logDropDowns}
-      </DropdownGroup>
+      <DropdownSeparator key="logLevelSeparator" />
     ];
+
+    if (!serverConfig.deployment.viewOnlyMode) {
+      kebabActions.push( <DropdownGroup label={dropdownGroupLabel} key="setLogLevels">
+        {hasProxyContainer && logDropDowns}
+      </DropdownGroup>);
+
+    }
 
     const logEntries = this.state.entries ? this.filteredEntries(this.state.entries, this.state.showLogValue, this.state.hideLogValue, this.state.useRegex) : [];
     return (

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -48,11 +48,11 @@ import moment from 'moment';
 import { formatDuration } from 'utils/tracing/TracingHelper';
 import { infoStyle } from 'styles/DropdownStyles';
 import { isValid } from 'utils/Common';
-import {isKiosk} from "../../components/Kiosk/KioskActions";
+import { isKiosk } from "../../components/Kiosk/KioskActions";
 import { KioskElement } from "../../components/Kiosk/KioskElement";
 import { TimeDurationModal } from "../../components/Time/TimeDurationModal";
 import TimeDurationIndicatorContainer from "../../components/Time/TimeDurationIndicatorComponent";
-import {serverConfig} from "../../config";
+import { serverConfig } from "../../config";
 
 const appContainerColors = [PFColors.White, PFColors.LightGreen400, PFColors.Purple100, PFColors.LightBlue400];
 const proxyContainerColor = PFColors.Gold400;
@@ -566,6 +566,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
           onClick={() => {
             this.setLogLevel(LogLevel[level]);
           }}
+          isDisabled={serverConfig.deployment.viewOnlyMode}
         >
           {level}
         </DropdownItem>
@@ -603,17 +604,12 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
       </DropdownItem>,
       <DropdownItem key="toggleTimestamps" onClick={this.toggleShowTimestamps}>
         {`${this.state.showTimestamps ? 'Remove' : 'Show'} Timestamps`}
-      </DropdownItem>
-    ];
-
-    if (!serverConfig.deployment.viewOnlyMode) {
-      kebabActions.push(
-        <DropdownSeparator key="logLevelSeparator" />,
-        <DropdownGroup label={dropdownGroupLabel} key="setLogLevels">
+      </DropdownItem>,
+      <DropdownSeparator key="logLevelSeparator" />,
+      <DropdownGroup label={dropdownGroupLabel} key="setLogLevels">
         {hasProxyContainer && logDropDowns}
-      </DropdownGroup>);
-
-    }
+      </DropdownGroup>
+    ];
 
     const logEntries = this.state.entries ? this.filteredEntries(this.state.entries, this.state.showLogValue, this.state.hideLogValue, this.state.useRegex) : [];
     return (

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -603,12 +603,13 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
       </DropdownItem>,
       <DropdownItem key="toggleTimestamps" onClick={this.toggleShowTimestamps}>
         {`${this.state.showTimestamps ? 'Remove' : 'Show'} Timestamps`}
-      </DropdownItem>,
-      <DropdownSeparator key="logLevelSeparator" />
+      </DropdownItem>
     ];
 
     if (!serverConfig.deployment.viewOnlyMode) {
-      kebabActions.push( <DropdownGroup label={dropdownGroupLabel} key="setLogLevels">
+      kebabActions.push(
+        <DropdownSeparator key="logLevelSeparator" />,
+        <DropdownGroup label={dropdownGroupLabel} key="setLogLevels">
         {hasProxyContainer && logDropDowns}
       </DropdownGroup>);
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -585,7 +585,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
                 the log level to 'off' disables the proxy loggers but does <b>not</b> disable access logging. To hide
                 all proxy logging from the logs view, including access logs, un-check the proxy container. <br />
                 <br />
-                This option is disabled for pods with no proxy container.
+                This option is disabled for pods with no proxy container, or in view-only mode.
               </div>
             </div>
           }

--- a/handlers/proxy_logging.go
+++ b/handlers/proxy_logging.go
@@ -14,7 +14,7 @@ import (
 func LoggingUpdate(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
-	if config.Get().Deployment.ViewOnlyMode == true {
+	if config.Get().Deployment.ViewOnlyMode {
 		RespondWithError(w, http.StatusForbidden, "Logs cannot be edited in View only mode")
 		return
 	}

--- a/handlers/proxy_logging.go
+++ b/handlers/proxy_logging.go
@@ -15,7 +15,7 @@ func LoggingUpdate(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
 	if config.Get().Deployment.ViewOnlyMode {
-		RespondWithError(w, http.StatusForbidden, "Logs cannot be edited in View only mode")
+		RespondWithError(w, http.StatusForbidden, "Log level cannot be changed in view-only mode")
 		return
 	}
 

--- a/handlers/proxy_logging.go
+++ b/handlers/proxy_logging.go
@@ -2,13 +2,13 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/kiali/kiali/config"
 	"net/http"
 	"strings"
 
 	"github.com/gorilla/mux"
 
 	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 )
 
 func LoggingUpdate(w http.ResponseWriter, r *http.Request) {

--- a/handlers/proxy_logging.go
+++ b/handlers/proxy_logging.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"github.com/kiali/kiali/config"
 	"net/http"
 	"strings"
 
@@ -12,6 +13,11 @@ import (
 
 func LoggingUpdate(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
+
+	if config.Get().Deployment.ViewOnlyMode == true {
+		RespondWithError(w, http.StatusForbidden, "Logs cannot be edited in View only mode")
+		return
+	}
 
 	// Get business layer
 	businessLayer, err := getBusiness(r)


### PR DESCRIPTION
Fixes #5714 

In view only mode disable the option to set the log level: 

![image](https://user-images.githubusercontent.com/49480155/212625772-2f832143-0e44-420f-acbd-578c3d9e7b88.png)

Note: There is no change in kiosk mode.
