### PR TITLE
update compatibility matrix for istio 1.17

### DIFF
--- a/config/version-compatibility-matrix.yaml
+++ b/config/version-compatibility-matrix.yaml
@@ -1,9 +1,12 @@
 # The Compatible Version Matrix between upstream Istio and Kiali
 - meshName: "Istio"
   versionRange:
+    - meshVersion: "1.17"
+      kialiMinimumVersion: "1.63.1"
+      kialiMaximumVersion: ""
     - meshVersion: "1.16"
       kialiMinimumVersion: "1.59.1"
-      kialiMaximumVersion: ""
+      kialiMaximumVersion: "1.63.0"
     - meshVersion: "1.15"
       kialiMinimumVersion: "1.55.0"
       kialiMaximumVersion: "1.59.0"

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -285,6 +285,18 @@ func TestMeshVersionCompatible(t *testing.T) {
 	versionsToTest := []versionsToTestStruct{
 		{
 			name:        "Istio",
+			version:     "1.63.1",
+			meshVersion: "1.17",
+			supported:   true,
+		},
+		{
+			name:        "Istio",
+			version:     "1.63.0",
+			meshVersion: "1.17",
+			supported:   false,
+		},
+		{
+			name:        "Istio",
 			version:     "1.59.1",
 			meshVersion: "1.16",
 			supported:   true,


### PR DESCRIPTION
part of https://github.com/kiali/kiali/issues/5773

We need to backport this to 1.63 branch - that is this PR: https://github.com/kiali/kiali/pull/5775