### PR TITLE
No longer read kubernetes_config.cache_enabled config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -286,7 +286,7 @@ type KubernetesConfig struct {
 	CacheDuration int `yaml:"cache_duration,omitempty"`
 	// Enable cache for kubernetes and istio resources
 	// TODO: Remove once all services are migrated to use the cache.
-	CacheEnabled bool `yaml:"cache_enabled,omitempty"`
+	CacheEnabled bool `yaml:"-,omitempty"`
 	// Kiali can cache VirtualService,DestinationRule,Gateway and ServiceEntry Istio resources if they are present
 	// on this list of Istio types. Other Istio types are not yet supported.
 	CacheIstioTypes []string `yaml:"cache_istio_types,omitempty"`


### PR DESCRIPTION
This small change will prevent reading (unmarshalling) the kubernetes_config.cache_enabled configuration from a YAML file (i.e. from a Kubernetes ConfigMap).

This effectively makes it impossible to disable Kiali's kube cache via the usual configuration mechanism. This will allow to write new code under the assumption that the kube cache is always enabled (i.e. no more if/else conditionals around this configuration variable).

The kube cache can still be disabled programmatically. This will allow to gradually update existing code to stop relying on the removed configuration (most notably, unit tests need to be adapted).

Related #5599
