### PR TITLE
Fix caching when fetching workloads

### DIFF
--- a/business/health_test.go
+++ b/business/health_test.go
@@ -228,6 +228,7 @@ func TestGetNamespaceAppHealthWithoutIstio(t *testing.T) {
 	k8s := new(kubetest.K8SClientMock)
 	prom := new(prometheustest.PromClientMock)
 	conf := config.NewConfig()
+	conf.KubernetesConfig.CacheEnabled = false
 	config.Set(conf)
 
 	k8s.On("IsOpenShift").Return(true)

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -189,6 +189,10 @@ func TestGrafanaWorking(t *testing.T) {
 	k8s, httpServ, grafanaCalls, promCalls := mockAddOnsCalls(sampleIstioComponent())
 	defer httpServ.Close()
 
+	conf := config.Get()
+	conf.KubernetesConfig.CacheEnabled = false
+	config.Set(conf)
+
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
 	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
@@ -212,6 +216,7 @@ func TestGrafanaDisabled(t *testing.T) {
 	// Disable Grafana
 	conf := config.Get()
 	conf.ExternalServices.Grafana.Enabled = false
+	conf.KubernetesConfig.CacheEnabled = false
 	config.Set(conf)
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
@@ -250,6 +255,7 @@ func TestGrafanaNotWorking(t *testing.T) {
 
 	// Adapt the AddOns URLs to the mock Server
 	conf := addonAddMockUrls(httpServer.URL, config.NewConfig(), false)
+	conf.KubernetesConfig.CacheEnabled = false
 	config.Set(conf)
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
@@ -275,6 +281,10 @@ func TestFailingTracingService(t *testing.T) {
 	k8s, httpServ, grafanaCalls, promCalls := mockAddOnsCalls(sampleIstioComponent())
 	defer httpServ.Close()
 
+	conf := config.Get()
+	conf.KubernetesConfig.CacheEnabled = false
+	config.Set(conf)
+
 	iss := NewWithBackends(k8s, nil, mockFailingJaeger).IstioStatus
 	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
@@ -291,6 +301,10 @@ func TestFailingTracingService(t *testing.T) {
 
 func TestOverriddenUrls(t *testing.T) {
 	assert := assert.New(t)
+
+	conf := config.Get()
+	conf.KubernetesConfig.CacheEnabled = false
+	config.Set(conf)
 
 	dps, ds, pods, idReachable, _ := sampleIstioComponent()
 	k8s, httpServ, grafanaCalls, promCalls := mockAddOnsCalls(dps, ds, pods, idReachable, true)
@@ -820,6 +834,7 @@ func defaultAddOnCalls(grafana, prom *int) map[string]addOnsSetup {
 }
 
 func addonAddMockUrls(baseUrl string, conf *config.Config, overrideUrl bool) *config.Config {
+	conf.KubernetesConfig.CacheEnabled = false
 	conf.ExternalServices.Grafana.Enabled = true
 	conf.ExternalServices.Grafana.InClusterURL = baseUrl + "/grafana/mock"
 	conf.ExternalServices.Grafana.IsCore = false

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -17,7 +17,6 @@ import (
 
 func FakeDeployments() []apps_v1.Deployment {
 	conf := config.NewConfig()
-	config.Set(conf)
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -93,7 +92,7 @@ func FakeDeployments() []apps_v1.Deployment {
 
 func FakeDuplicatedDeployments() []apps_v1.Deployment {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -124,7 +123,7 @@ func FakeDuplicatedDeployments() []apps_v1.Deployment {
 
 func FakeReplicaSets() []apps_v1.ReplicaSet {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -200,7 +199,7 @@ func FakeReplicaSets() []apps_v1.ReplicaSet {
 
 func FakeDuplicatedReplicaSets() []apps_v1.ReplicaSet {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -240,7 +239,7 @@ func FakeReplicationControllers() []core_v1.ReplicationController {
 	conf := config.NewConfig()
 	// Enable ReplicationController, those are not fetched by default
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -317,7 +316,7 @@ func FakeReplicationControllers() []core_v1.ReplicationController {
 func FakeDeploymentConfigs() []osapps_v1.DeploymentConfig {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -394,7 +393,7 @@ func FakeDeploymentConfigs() []osapps_v1.DeploymentConfig {
 func FakeStatefulSets() []apps_v1.StatefulSet {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -468,7 +467,7 @@ func FakeStatefulSets() []apps_v1.StatefulSet {
 func FakeDaemonSets() []apps_v1.DaemonSet {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -544,7 +543,7 @@ func FakeDaemonSets() []apps_v1.DaemonSet {
 
 func FakeDuplicatedStatefulSets() []apps_v1.StatefulSet {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -575,7 +574,7 @@ func FakeDuplicatedStatefulSets() []apps_v1.StatefulSet {
 
 func FakeDepSyncedWithRS() []apps_v1.Deployment {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -607,7 +606,7 @@ func FakeDepSyncedWithRS() []apps_v1.Deployment {
 
 func FakeRSSyncedWithPods() []apps_v1.ReplicaSet {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -645,7 +644,7 @@ func FakeRSSyncedWithPods() []apps_v1.ReplicaSet {
 
 func FakePodsSyncedWithDeployments() []core_v1.Pod {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -680,7 +679,7 @@ func FakePodsSyncedWithDeployments() []core_v1.Pod {
 
 func FakePodSyncedWithDeployments() *core_v1.Pod {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -728,7 +727,7 @@ func FakePodLogsProxy() *kubernetes.PodLogs {
 
 func FakePodsSyncedWithDuplicated() []core_v1.Pod {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -787,7 +786,7 @@ func FakePodsSyncedWithDuplicated() []core_v1.Pod {
 
 func FakePodsNoController() []core_v1.Pod {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -820,7 +819,7 @@ func FakePodsNoController() []core_v1.Pod {
 
 func FakePodsFromCustomController() []core_v1.Pod {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -855,7 +854,7 @@ func FakePodsFromCustomController() []core_v1.Pod {
 
 func FakeCustomControllerRSSyncedWithPods() []apps_v1.ReplicaSet {
 	conf := config.NewConfig()
-	config.Set(conf)
+
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -620,7 +620,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 	go func() {
 		defer wg.Done()
 		var err error
-		pods, err = layer.k8s.GetPods(namespace, labelSelector)
+		pods, err = layer.Workload.k8s.GetPods(namespace, labelSelector)
 		if err != nil {
 			log.Errorf("Error fetching Pods per namespace %s: %s", namespace, err)
 			errChan <- err
@@ -631,7 +631,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 	go func() {
 		defer wg.Done()
 		var err error
-		dep, err = layer.k8s.GetDeployments(namespace)
+		dep, err = layer.Workload.k8s.GetDeployments(namespace)
 		if err != nil {
 			log.Errorf("Error fetching Deployments per namespace %s: %s", namespace, err)
 			errChan <- err
@@ -642,7 +642,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 	go func() {
 		defer wg.Done()
 		var err error
-		repset, err = layer.k8s.GetReplicaSets(namespace)
+		repset, err = layer.Workload.k8s.GetReplicaSets(namespace)
 		if err != nil {
 			log.Errorf("Error fetching ReplicaSets per namespace %s: %s", namespace, err)
 			errChan <- err
@@ -655,7 +655,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 
 		var err error
 		if isWorkloadIncluded(kubernetes.ReplicationControllerType) {
-			repcon, err = layer.k8s.GetReplicationControllers(namespace)
+			repcon, err = layer.Workload.k8s.GetReplicationControllers(namespace)
 			if err != nil {
 				log.Errorf("Error fetching GetReplicationControllers per namespace %s: %s", namespace, err)
 				errChan <- err
@@ -668,8 +668,8 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 		defer wg.Done()
 
 		var err error
-		if layer.k8s.IsOpenShift() && isWorkloadIncluded(kubernetes.DeploymentConfigType) {
-			depcon, err = layer.k8s.GetDeploymentConfigs(namespace)
+		if layer.Workload.k8s.IsOpenShift() && isWorkloadIncluded(kubernetes.DeploymentConfigType) {
+			depcon, err = layer.Workload.k8s.GetDeploymentConfigs(namespace)
 			if err != nil {
 				log.Errorf("Error fetching DeploymentConfigs per namespace %s: %s", namespace, err)
 				errChan <- err
@@ -683,7 +683,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 
 		var err error
 		if isWorkloadIncluded(kubernetes.StatefulSetType) {
-			fulset, err = layer.k8s.GetStatefulSets(namespace)
+			fulset, err = layer.Workload.k8s.GetStatefulSets(namespace)
 			if err != nil {
 				log.Errorf("Error fetching StatefulSets per namespace %s: %s", namespace, err)
 				errChan <- err
@@ -697,7 +697,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 
 		var err error
 		if isWorkloadIncluded(kubernetes.CronJobType) {
-			conjbs, err = layer.k8s.GetCronJobs(namespace)
+			conjbs, err = layer.Workload.k8s.GetCronJobs(namespace)
 			if err != nil {
 				log.Errorf("Error fetching CronJobs per namespace %s: %s", namespace, err)
 				errChan <- err
@@ -711,7 +711,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 
 		var err error
 		if isWorkloadIncluded(kubernetes.JobType) {
-			jbs, err = layer.k8s.GetJobs(namespace)
+			jbs, err = layer.Workload.k8s.GetJobs(namespace)
 			if err != nil {
 				log.Errorf("Error fetching Jobs per namespace %s: %s", namespace, err)
 				errChan <- err
@@ -725,7 +725,7 @@ func fetchWorkloads(ctx context.Context, layer *Layer, namespace string, labelSe
 
 		var err error
 		if isWorkloadIncluded(kubernetes.DaemonSetType) {
-			daeset, err = layer.k8s.GetDaemonSets(namespace)
+			daeset, err = layer.Workload.k8s.GetDaemonSets(namespace)
 			if err != nil {
 				log.Errorf("Error fetching DaemonSets per namespace %s: %s", namespace, err)
 			}
@@ -1168,7 +1168,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 	go func() {
 		defer wg.Done()
 		var err error
-		pods, err = layer.k8s.GetPods(criteria.Namespace, "")
+		pods, err = layer.Workload.k8s.GetPods(criteria.Namespace, "")
 		if err != nil {
 			log.Errorf("Error fetching Pods per namespace %s: %s", criteria.Namespace, err)
 			errChan <- err
@@ -1183,7 +1183,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 		if criteria.WorkloadType != "" && criteria.WorkloadType != kubernetes.DeploymentType {
 			return
 		}
-		dep, err = layer.k8s.GetDeployment(criteria.Namespace, criteria.WorkloadName)
+		dep, err = layer.Workload.k8s.GetDeployment(criteria.Namespace, criteria.WorkloadName)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				dep = nil
@@ -1202,7 +1202,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 			return
 		}
 		var err error
-		repset, err = layer.k8s.GetReplicaSets(criteria.Namespace)
+		repset, err = layer.Workload.k8s.GetReplicaSets(criteria.Namespace)
 		if err != nil {
 			log.Errorf("Error fetching ReplicaSets per namespace %s: %s", criteria.Namespace, err)
 			errChan <- err
@@ -1219,7 +1219,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 
 		var err error
 		if isWorkloadIncluded(kubernetes.ReplicationControllerType) {
-			repcon, err = layer.k8s.GetReplicationControllers(criteria.Namespace)
+			repcon, err = layer.Workload.k8s.GetReplicationControllers(criteria.Namespace)
 			if err != nil {
 				log.Errorf("Error fetching GetReplicationControllers per namespace %s: %s", criteria.Namespace, err)
 				errChan <- err
@@ -1236,8 +1236,8 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 		}
 
 		var err error
-		if layer.k8s.IsOpenShift() && isWorkloadIncluded(kubernetes.DeploymentConfigType) {
-			depcon, err = layer.k8s.GetDeploymentConfig(criteria.Namespace, criteria.WorkloadName)
+		if layer.Workload.k8s.IsOpenShift() && isWorkloadIncluded(kubernetes.DeploymentConfigType) {
+			depcon, err = layer.Workload.k8s.GetDeploymentConfig(criteria.Namespace, criteria.WorkloadName)
 			if err != nil {
 				depcon = nil
 			}
@@ -1254,7 +1254,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 
 		var err error
 		if isWorkloadIncluded(kubernetes.StatefulSetType) {
-			fulset, err = layer.k8s.GetStatefulSet(criteria.Namespace, criteria.WorkloadName)
+			fulset, err = layer.Workload.k8s.GetStatefulSet(criteria.Namespace, criteria.WorkloadName)
 			if err != nil {
 				fulset = nil
 			}
@@ -1271,7 +1271,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 
 		var err error
 		if isWorkloadIncluded(kubernetes.CronJobType) {
-			conjbs, err = layer.k8s.GetCronJobs(criteria.Namespace)
+			conjbs, err = layer.Workload.k8s.GetCronJobs(criteria.Namespace)
 			if err != nil {
 				log.Errorf("Error fetching CronJobs per namespace %s: %s", criteria.Namespace, err)
 				errChan <- err
@@ -1289,7 +1289,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 
 		var err error
 		if isWorkloadIncluded(kubernetes.JobType) {
-			jbs, err = layer.k8s.GetJobs(criteria.Namespace)
+			jbs, err = layer.Workload.k8s.GetJobs(criteria.Namespace)
 			if err != nil {
 				log.Errorf("Error fetching Jobs per namespace %s: %s", criteria.Namespace, err)
 				errChan <- err
@@ -1307,7 +1307,7 @@ func fetchWorkload(ctx context.Context, layer *Layer, criteria WorkloadCriteria)
 
 		var err error
 		if isWorkloadIncluded(kubernetes.DaemonSetType) {
-			ds, err = layer.k8s.GetDaemonSet(criteria.Namespace, criteria.WorkloadName)
+			ds, err = layer.Workload.k8s.GetDaemonSet(criteria.Namespace, criteria.WorkloadName)
 			if err != nil {
 				ds = nil
 			}

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -26,6 +26,7 @@ import (
 
 func setupWorkloadService(k8s kubernetes.ClientInterface, conf *config.Config) WorkloadService {
 	// config needs to be set by other services since those rely on the global.
+	conf.KubernetesConfig.CacheEnabled = false
 	config.Set(conf)
 	prom := new(prometheustest.PromClientMock)
 	return *NewWorkloadService(k8s, prom, nil, NewWithBackends(k8s, prom, nil), conf)

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -21,6 +21,7 @@ import (
 func setupWorkloads() *business.Layer {
 	k8s := kubetest.NewK8SClientMock()
 	conf := config.NewConfig()
+	conf.KubernetesConfig.CacheEnabled = false
 	config.Set(conf)
 
 	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
@@ -86,7 +87,8 @@ func setupWorkloads() *business.Layer {
 					Labels: map[string]string{"app": "testPodsWithTraffic", "version": "v1"},
 				},
 				Status: core_v1.PodStatus{
-					Message: "foo"},
+					Message: "foo",
+				},
 			},
 			{
 				ObjectMeta: meta_v1.ObjectMeta{
@@ -94,14 +96,14 @@ func setupWorkloads() *business.Layer {
 					Labels: map[string]string{"app": "testPodsNoTraffic", "version": "v1"},
 				},
 				Status: core_v1.PodStatus{
-					Message: "foo"},
+					Message: "foo",
+				},
 			},
 		}, nil)
 	k8s.On("GetReplicationControllers", mock.AnythingOfType("string")).Return([]core_v1.ReplicationController{}, nil)
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
 	k8s.On("GetStatefulSets", mock.AnythingOfType("string")).Return([]apps_v1.StatefulSet{}, nil)
 	k8s.On("GetDaemonSets", mock.AnythingOfType("string")).Return([]apps_v1.DaemonSet{}, nil)
-	config.Set(config.NewConfig())
 
 	businessLayer := business.NewWithBackends(k8s, nil, nil)
 	return businessLayer

--- a/graph/telemetry/istio/appender/health_test.go
+++ b/graph/telemetry/istio/appender/health_test.go
@@ -48,7 +48,9 @@ func TestServicesHealthConfigPasses(t *testing.T) {
 }
 
 func TestServicesHealthNoConfigPasses(t *testing.T) {
-	config.Set(config.NewConfig())
+	cfg := config.NewConfig()
+	cfg.KubernetesConfig.CacheEnabled = false
+	config.Set(cfg)
 	trafficMap := buildServiceTrafficMap()
 	businessLayer := setupHealthConfig(buildFakeServicesHealth(""), buildFakeWorkloadDeploymentsHealth(""), buildFakePodsHealth(""))
 
@@ -67,7 +69,9 @@ func TestServicesHealthNoConfigPasses(t *testing.T) {
 }
 
 func TestWorkloadHealthConfigPasses(t *testing.T) {
-	config.Set(config.NewConfig())
+	cfg := config.NewConfig()
+	cfg.KubernetesConfig.CacheEnabled = false
+	config.Set(cfg)
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupHealthConfig(buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
@@ -86,7 +90,9 @@ func TestWorkloadHealthConfigPasses(t *testing.T) {
 }
 
 func TestWorkloadHealthNoConfigPasses(t *testing.T) {
-	config.Set(config.NewConfig())
+	cfg := config.NewConfig()
+	cfg.KubernetesConfig.CacheEnabled = false
+	config.Set(cfg)
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupHealthConfig(buildFakeServicesHealth(""), buildFakeWorkloadDeploymentsHealth(""), buildFakePodsHealth(""))
 
@@ -107,7 +113,9 @@ func TestWorkloadHealthNoConfigPasses(t *testing.T) {
 func TestHealthDataPresent(t *testing.T) {
 	assert := assert.New(t)
 
-	config.Set(config.NewConfig())
+	cfg := config.NewConfig()
+	cfg.KubernetesConfig.CacheEnabled = false
+	config.Set(cfg)
 	svcNodes := buildServiceTrafficMap()
 	appNodes := buildAppTrafficMap()
 	wkNodes := buildWorkloadTrafficMap()
@@ -138,7 +146,6 @@ func TestHealthDataPresent(t *testing.T) {
 func TestHealthDataPresent200SvcWk(t *testing.T) {
 	assert := assert.New(t)
 
-	config.Set(config.NewConfig())
 	svcNodes := buildServiceTrafficMap()
 	appNodes := buildAppTrafficMap()
 	wkNodes := buildWorkloadTrafficMap()
@@ -454,7 +461,9 @@ func TestIdleNodesHaveHealthData(t *testing.T) {
 func TestErrorCausesPanic(t *testing.T) {
 	assert := assert.New(t)
 
-	config.Set(config.NewConfig())
+	conf := config.NewConfig()
+	conf.KubernetesConfig.CacheEnabled = false
+	config.Set(conf)
 	trafficMap := buildAppTrafficMap()
 	k8s := kubetest.NewK8SClientMock()
 	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
@@ -469,7 +478,6 @@ func TestErrorCausesPanic(t *testing.T) {
 	k8s.On("GetDaemonSets", mock.AnythingOfType("string")).Return([]apps_v1.DaemonSet{}, nil)
 	const panicErrMsg = "test error! This should cause a panic"
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{}, fmt.Errorf(panicErrMsg))
-	config.Set(config.NewConfig())
 	business.SetKialiControlPlaneCluster(&business.Cluster{
 		Name: business.DefaultClusterID,
 	})
@@ -533,7 +541,9 @@ func setupHealthConfig(services []core_v1.Service, deployments []apps_v1.Deploym
 	k8s.On("GetStatefulSets", mock.AnythingOfType("string")).Return([]apps_v1.StatefulSet{}, nil)
 	k8s.On("GetDaemonSets", mock.AnythingOfType("string")).Return([]apps_v1.DaemonSet{}, nil)
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return(services, nil)
-	config.Set(config.NewConfig())
+	cfg := config.Get()
+	cfg.KubernetesConfig.CacheEnabled = false
+	config.Set(cfg)
 	business.SetKialiControlPlaneCluster(&business.Cluster{
 		Name: business.DefaultClusterID,
 	})

--- a/graph/telemetry/istio/appender/labeler_test.go
+++ b/graph/telemetry/istio/appender/labeler_test.go
@@ -42,6 +42,7 @@ func setupLabelerTrafficMap() (map[string]*graph.Node, string, string, string, s
 func setupLabelerK8S() *business.Layer {
 	k8s := kubetest.NewK8SClientMock()
 	conf := config.NewConfig()
+	conf.KubernetesConfig.CacheEnabled = false
 	config.Set(conf)
 
 	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
@@ -84,7 +85,8 @@ func setupLabelerK8S() *business.Layer {
 					Labels: graph.LabelsMetadata{"app": "test", "version": "v1", "datacenter": "east"},
 				},
 				Status: core_v1.PodStatus{
-					Message: "foo"},
+					Message: "foo",
+				},
 			},
 			{
 				ObjectMeta: meta_v1.ObjectMeta{
@@ -92,7 +94,8 @@ func setupLabelerK8S() *business.Layer {
 					Labels: graph.LabelsMetadata{"app": "test", "version": "v2", "datacenter": "west"},
 				},
 				Status: core_v1.PodStatus{
-					Message: "foo"},
+					Message: "foo",
+				},
 			},
 		}, nil)
 	k8s.On("GetReplicationControllers", mock.AnythingOfType("string")).Return([]core_v1.ReplicationController{}, nil)
@@ -100,15 +103,14 @@ func setupLabelerK8S() *business.Layer {
 	k8s.On("GetStatefulSets", mock.AnythingOfType("string")).Return([]apps_v1.StatefulSet{}, nil)
 	k8s.On("GetDaemonSets", mock.AnythingOfType("string")).Return([]apps_v1.DaemonSet{}, nil)
 
-	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:   "test",
-			Labels: graph.LabelsMetadata{"app": "test", "datacenter": "east"},
+	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:   "test",
+				Labels: graph.LabelsMetadata{"app": "test", "datacenter": "east"},
+			},
 		},
-	},
 	}, nil)
-
-	config.Set(config.NewConfig())
 
 	businessLayer := business.NewWithBackends(k8s, nil, nil)
 	return businessLayer

--- a/graph/telemetry/istio/appender/sidecars_check_test.go
+++ b/graph/telemetry/istio/appender/sidecars_check_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestWorkloadSidecarsPasses(t *testing.T) {
-	config.Set(config.NewConfig())
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(buildFakeWorkloadDeployments(), buildFakeWorkloadPods())
 
@@ -40,7 +39,6 @@ func TestWorkloadSidecarsPasses(t *testing.T) {
 }
 
 func TestWorkloadWithMissingSidecarsIsFlagged(t *testing.T) {
-	config.Set(config.NewConfig())
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(buildFakeWorkloadDeployments(), buildFakeWorkloadPodsNoSidecar())
 
@@ -61,7 +59,6 @@ func TestWorkloadWithMissingSidecarsIsFlagged(t *testing.T) {
 }
 
 func TestInaccessibleWorkload(t *testing.T) {
-	config.Set(config.NewConfig())
 	trafficMap := buildInaccessibleWorkloadTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(buildFakeWorkloadDeployments(), buildFakeWorkloadPodsNoSidecar())
 
@@ -81,7 +78,6 @@ func TestInaccessibleWorkload(t *testing.T) {
 }
 
 func TestAppNoPodsPasses(t *testing.T) {
-	config.Set(config.NewConfig())
 	trafficMap := buildAppTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads([]apps_v1.Deployment{}, []core_v1.Pod{})
 
@@ -101,7 +97,6 @@ func TestAppNoPodsPasses(t *testing.T) {
 }
 
 func TestAppSidecarsPasses(t *testing.T) {
-	config.Set(config.NewConfig())
 	trafficMap := buildAppTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads([]apps_v1.Deployment{}, buildFakeWorkloadPods())
 
@@ -121,7 +116,6 @@ func TestAppSidecarsPasses(t *testing.T) {
 }
 
 func TestAppWithMissingSidecarsIsFlagged(t *testing.T) {
-	config.Set(config.NewConfig())
 	trafficMap := buildAppTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads([]apps_v1.Deployment{}, buildFakeWorkloadPodsNoSidecar())
 
@@ -252,7 +246,9 @@ func setupSidecarsCheckWorkloads(deployments []apps_v1.Deployment, pods []core_v
 	k8s.On("GetReplicaSets", mock.AnythingOfType("string")).Return([]apps_v1.ReplicaSet{}, nil)
 	k8s.On("GetStatefulSets", mock.AnythingOfType("string")).Return([]apps_v1.StatefulSet{}, nil)
 	k8s.On("GetDaemonSets", mock.AnythingOfType("string")).Return([]apps_v1.DaemonSet{}, nil)
-	config.Set(config.NewConfig())
+	conf := config.NewConfig()
+	conf.KubernetesConfig.CacheEnabled = false
+	config.Set(conf)
 
 	businessLayer := business.NewWithBackends(k8s, nil, nil)
 	return businessLayer

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -50,6 +50,7 @@ func setupWorkloadList() (*httptest.Server, *kubetest.K8SClientMock, *prometheus
 
 func TestWorkloadsEndpoint(t *testing.T) {
 	conf := config.NewConfig()
+	conf.KubernetesConfig.CacheEnabled = false
 	config.Set(conf)
 	ts, k8s, _ := setupWorkloadList()
 	k8s.MockIstio()


### PR DESCRIPTION
The fetchWorkload(s) funcs used the business layer k8s rather than the workload service's k8s. This resulted in the fetchWorkload(s) funcs not using the caching client and causing a perf regression since fetchWorkloads called the API server directly rather than pulling from the kube cache.

Fixes #5743 