### PR TITLE
Honor configured timeout for calls to tracing API

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -194,6 +194,7 @@ type TracingConfig struct {
 	IsCore               bool              `yaml:"is_core,omitempty"`
 	NamespaceSelector    bool              `yaml:"namespace_selector"`
 	QueryScope           map[string]string `yaml:"query_scope,omitempty"`
+	QueryTimeout         int               `yaml:"query_timeout,omitempty"`
 	URL                  string            `yaml:"url"`
 	UseGRPC              bool              `yaml:"use_grpc"`
 	WhiteListIstioSystem []string          `yaml:"whitelist_istio_system"`
@@ -609,6 +610,7 @@ func NewConfig() (c *Config) {
 				IsCore:               false,
 				NamespaceSelector:    true,
 				QueryScope:           map[string]string{},
+				QueryTimeout:         5,
 				URL:                  "",
 				UseGRPC:              true,
 				WhiteListIstioSystem: []string{"jaeger-query", "istio-ingressgateway"},

--- a/frontend/src/components/JaegerIntegration/TracesDisplayOptions.tsx
+++ b/frontend/src/components/JaegerIntegration/TracesDisplayOptions.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { Checkbox, Dropdown, DropdownToggle, Radio, Tooltip } from '@patternfly/react-core';
-import { InfoAltIcon } from '@patternfly/react-icons';
-
-import { itemStyleWithoutInfo, menuStyle, titleStyle } from 'styles/DropdownStyles';
+import { Checkbox, Dropdown, DropdownToggle, Radio, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { infoStyle, itemStyleWithoutInfo, menuStyle, titleStyle } from 'styles/DropdownStyles';
 import { HistoryManager, URLParam } from 'app/History';
+import { KialiIcon } from 'config/KialiIcon';
 
 export interface QuerySettings {
   percentile?: string;
@@ -103,17 +102,26 @@ export class TracesDisplayOptions extends React.Component<Props, State> {
   private getPopoverContent() {
     return (
       <div id="traces-display-menu" className={menuStyle}>
-        <Tooltip
-          content={`
-          These percentiles are computed from metrics. To refresh them, reload the page.
-          The filter applies on span durations.
-          Thus, the filtered traces are the ones where at least one span for the service satisfies the duration criteria.
-        `}
-        >
-          <div className={titleStyle}>
-            Filter by percentile <InfoAltIcon />
-          </div>
-        </Tooltip>
+        <div style={{ marginTop: '10px' }}>
+          <span className={titleStyle} style={{ position: 'relative', bottom: '3px', paddingRight: 0 }}>
+            Filter by percentile
+          </span>
+          <Tooltip
+            key="tooltip_filter_by_percentile"
+            position={TooltipPosition.right}
+            content={
+              <div style={{ textAlign: 'left' }}>
+                <div>
+                  These percentiles are computed from metrics. To refresh them, reload the page. The filter applies on
+                  span durations. Thus, the filtered traces are the ones where at least one span for the service
+                  satisfies the duration criteria.
+                </div>
+              </div>
+            }
+          >
+            <KialiIcon.Info className={infoStyle} />
+          </Tooltip>
+        </div>
         {percentilesOptions.map(item => {
           let label = item.labelText;
           if (this.computedPercentiles) {
@@ -150,7 +158,27 @@ export class TracesDisplayOptions extends React.Component<Props, State> {
             />
           </label>
         </div>
-        <div className={titleStyle}>Limit per query</div>
+        <div style={{ marginTop: '10px' }}>
+          <span className={titleStyle} style={{ position: 'relative', bottom: '3px', paddingRight: 0 }}>
+            Limit per query
+          </span>
+          <Tooltip
+            key="tooltip_limit_per_query"
+            position={TooltipPosition.right}
+            content={
+              <div style={{ textAlign: 'left' }}>
+                <div>
+                  This limits the number of app-level traces that will be fetched. Because an app may be comprised of
+                  several workload versions not every trace trace may apply to a particular workload. It may be
+                  necessary to increase the limit to get the desired number of workload traces. In some cases the same
+                  can be true of service traces.
+                </div>
+              </div>
+            }
+          >
+            <KialiIcon.Info className={infoStyle} />
+          </Tooltip>
+        </div>
         {[20, 100, 500, 1000].map(limit => (
           <div key={'limit-' + limit}>
             <label key={'limit-' + limit} className={itemStyleWithoutInfo}>

--- a/jaeger/client.go
+++ b/jaeger/client.go
@@ -103,7 +103,7 @@ func NewClient(token string) (*Client, error) {
 		} else {
 			// Legacy HTTP client
 			log.Tracef("Using legacy HTTP client for Jaeger: url=%v, auth.type=%s", u, auth.Type)
-			timeout := time.Duration(5000 * time.Millisecond)
+			timeout := time.Duration(config.Get().ExternalServices.Tracing.QueryTimeout) * time.Second
 			transport, err := httputil.CreateTransport(&auth, &http.Transport{}, timeout, nil)
 			if err != nil {
 				return nil, err
@@ -131,7 +131,7 @@ func (in *Client) GetAppTraces(namespace, app string, q models.TracingQuery) (*J
 			SearchDepth:  int32(q.Limit),
 		},
 	}
-	ctx, cancel := context.WithTimeout(in.ctx, 4*time.Second)
+	ctx, cancel := context.WithTimeout(in.ctx, time.Duration(config.Get().ExternalServices.Tracing.QueryTimeout)*time.Second)
 	defer cancel()
 
 	stream, err := in.grpcClient.FindTraces(ctx, findTracesRQ)


### PR DESCRIPTION
- Do not inflate the query limit for workload and service trace queries, it is misleading on the client and can cause unexpected timeout.
- Add info tooltip in Traces Display dropdown to better explain query limit
  - fix tooltip styling and position for the existing menu

Part-of  https://github.com/kiali/kiali/issues/5751

**OPERATOR PR**: https://github.com/kiali/kiali-operator/pull/610
