### PR TITLE
[Cypress] Fix for test flakes introduced by the presence of the Gateway API

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -85,10 +85,14 @@ And('user sees Details information for Apps', () => {
   });
 });
 
-Then('user only sees {int} apps', (sees: number) => {
+And('user only sees the apps with the {string} name in the {string} namespace', (name:string,ns:string) => {
+  let count:number;
+  cy.request('GET', `/api/namespaces/${ns}/apps`).should((response) =>{
+    count = response.body.applications.filter((item) => item.name.includes(name)).length;
+  }); 
   cy.get('tbody').within(() => {
     cy.contains('No apps found').should('not.exist');
-    cy.get('tr').should('have.length', sees);
+    cy.get('tr').should('have.length', count);
   });
 });
 

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -50,7 +50,7 @@ Feature: Kiali Apps List page
   Scenario: Filter Applications table by Label
     When the user filters by "Label" for "app=reviews"
     Then user sees "reviews"
-    And user only sees 1 apps
+    And user only sees the apps with the "reviews" name in the "bookinfo" namespace
 
   @apps-page
   Scenario: The healthy status of a logical mesh application is reported in the list of applications

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -23,7 +23,7 @@ Feature: Kiali Istio Config page
 
   Scenario: Filter Istio Config objects by Istio Type
     When the user filters by "Istio Type" for "Gateway"
-    Then user only sees "bookinfo-gateway"
+    Then only "Gateways" are visible in the "bookinfo" namespace
 
   Scenario: Filter Istio Config objects by Valid configuration
     When the user filters by "Config" for "Valid"


### PR DESCRIPTION
This PR is related to 2 flaky tests on OCP.
![image](https://user-images.githubusercontent.com/45061792/217527518-b7cf44e1-5234-4269-8c79-656aa207ec1f.png)
![image](https://user-images.githubusercontent.com/45061792/217527657-b4636853-e0ee-4b1c-b97d-8bac7441732d.png)


These tests expected exactly one item to be present after filtering, but there are more items present due to Gateway API being used. Now the tests expect variable number of items.


