### PR TITLE
Update Kiali to build with Go 1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.19
+GO_VERSION_KIALI = 1.19.5
 GO_TEST_FLAGS ?=
 
 # Identifies the Kiali container image that will be built.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.18.7
+GO_VERSION_KIALI = 1.19
 GO_TEST_FLAGS ?=
 
 # Identifies the Kiali container image that will be built.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.19.5
+GO_VERSION_KIALI = 1.19.4
 GO_TEST_FLAGS ?=
 
 # Identifies the Kiali container image that will be built.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiali/kiali
 
-go 1.18
+go 1.19
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
** Describe the change **
This change updates the Kiali codebase to use Go 1.19 instead of Go 1.18 as the build environment. The reason for this change is that Go 1.18 is considered deprecated and is no longer receiving patches, making it less stable and compatible than more recent versions of the Go language.

_explanation of what it does_
This pull request updates the Kiali codebase to build with Go 1.19 instead of Go 1.18. Go 1.18 is should be considered as deprecated and no longer receives patches, so updating to a newer and maintained version will ensure stability and compatibility for Kiali.

Changes:
- Update the build scripts to specify Go 1.19 as the target version.
- Test the build process and application functionality with Go 1.19.
- have tested these changes on multiple platforms and confirmed that Kiali builds and works as expected with Go 1.19.

** Issue reference **
this issue is reference to https://github.com/kiali/kiali/issues/5799
