### PR TITLE
Remove @webcomponents/custom-elements package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -103,6 +103,8 @@
     "visibilityjs": "2.0.2"
   },
   "devDependencies": {
+    "@badeball/cypress-cucumber-preprocessor": "^12.2.0",
+    "@cypress/browserify-preprocessor": "3.0.2",
     "@types/cytoscape": "3.14.0",
     "@types/enzyme": "3.10.5",
     "@types/jest": "23.3.10",
@@ -115,8 +117,6 @@
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.7",
     "axios-mock-adapter": "1.16.0",
     "cypress": "^10.7.0",
-    "@badeball/cypress-cucumber-preprocessor": "^12.2.0",
-    "@cypress/browserify-preprocessor": "3.0.2",
     "cypress-multi-reporters": "^1.6.0",
     "cypress-react-selector": "^2.3.17",
     "enzyme": "3.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,6 @@
     "@patternfly/react-styles": "4.48.5",
     "@patternfly/react-table": "4.67.5",
     "@patternfly/react-tokens": "4.50.5",
-    "@webcomponents/custom-elements": "1.2.4",
     "axios": "0.21.4",
     "bootstrap-slider-without-jquery": "10.0.0",
     "cy-node-html-label": "2.0.0",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,4 +1,3 @@
-import './polyfills';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import App from './app/App';

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -1,3 +1,0 @@
-// Polyfills window.customElements; currently required for Firefox ESR
-// It can be removed once is supported
-import '@webcomponents/custom-elements';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3613,11 +3613,6 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@webcomponents/custom-elements@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.2.4.tgz#7074543155396114617722724d6f6cb7b3800a14"
-  integrity sha512-WiTlgz6/kuwajYIcgyq64rSlCtb2AvbxwwrExP3wr6rKbJ72I3hi/sb4KdGUumfC+isDn2F0btZGk4MnWpyO1Q==
-
 "@wojtekmaj/enzyme-adapter-react-17@^0.6.7":
   version "0.6.7"
   resolved "https://registry.yarnpkg.com/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.6.7.tgz#7784bd32f518b186218cebb26c98c852676f30b0"


### PR DESCRIPTION
** Describe the change **
The '@webcomponents/custom-elements' package has been removed from the 'package.json' file since Firefox ESR supports it natively.

** Issue reference **
this issue reference to https://github.com/kiali/kiali/issues/5805