### PR TITLE
[hack] support dev images in mc script

### DIFF
--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -14,7 +14,11 @@ if [ "${KIALI_ENABLED}" != "true" ]; then
   echo "Will not install kiali"
   return 0
 else
-  echo "Installing Kiali in the two clusters"
+  if [ "${SINGLE_KIALI}" == "true" ]; then
+    echo "Installing Kiali in a single cluster."
+  else
+    echo "Installing Kiali in the two clusters"
+  fi
 fi
 
 if ! which helm; then
@@ -26,30 +30,46 @@ deploy_kiali() {
   local helm_args=""
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     helm_args="--disable-openapi-validation"
+    if [ "${KIALI_USE_DEV_IMAGE}" == "true" ]; then
+      echo "'--kiali-use-dev-image true' is only supported with minikube today - will not install Kiali"
+      return 1
+    fi
   fi
 
-  local web_fqdn="${1}"
-  local web_schema="${2}"
+  local cluster_name="${1}"
+  local web_fqdn="${2}"
+  local web_schema="${3}"
   [ ! -z "${web_fqdn}" ] && helm_args="--set server.web_fqdn=${web_fqdn} ${helm_args}"
   [ ! -z "${web_schema}" ] && helm_args="--set server.web_schema=${web_schema} ${helm_args}"
 
-  MINIKUBE_IP_DASHED=$(minikube ip -p "${CLUSTER1_NAME}" | sed 's/\./-/g')
-  KUBE_HOSTNAME="keycloak-${MINIKUBE_IP_DASHED}.nip.io"
+  local minikube_ip=$(minikube ip -p "${cluster_name}")
+  local minikube_ip_dashed=$(minikube ip -p "${cluster_name}" | sed 's/\./-/g')
+  local kube_hostname="keycloak-${minikube_ip_dashed}.nip.io"
+
+  if [ "${KIALI_USE_DEV_IMAGE}" == "true" ]; then
+    local image_to_tag="quay.io/kiali/kiali:dev"
+    local image_to_push="${minikube_ip}:5000/kiali/kiali:dev"
+    echo "Tagging the dev image [${image_to_tag}] -> [${image_to_push}]..."
+    ${DORP} tag ${image_to_tag} ${image_to_push}
+    echo "Pushing the dev image [${image_to_push}] to the cluster [${cluster_name}]..."
+    ${DORP} push --tls-verify=false ${image_to_push}
+    helm_args="--set deployment.image_name=localhost:5000/kiali/kiali --set deployment.image_version=dev ${helm_args}"
+  fi
 
   # These need to exist prior to installing Kiali.
   # Create secret with the oidc secret
-  kubectl create configmap kiali-cabundle --from-file="openid-server-ca.crt=${KEYCLOAK_CERTS_DIR}/root-ca.pem" -n "${ISTIO_NAMESPACE}"
-  kubectl create secret generic kiali --from-literal="oidc-secret=kube-client-secret" -n istio-system
+  ${CLIENT_EXE} create configmap kiali-cabundle --from-file="openid-server-ca.crt=${KEYCLOAK_CERTS_DIR}/root-ca.pem" -n "${ISTIO_NAMESPACE}"
+  ${CLIENT_EXE} create secret generic kiali --from-literal="oidc-secret=kube-client-secret" -n istio-system
+  ${CLIENT_EXE} create clusterrolebinding kiali-user-viewer --clusterrole=kiali-viewer --user=oidc:kiali
 
-  kubectl create clusterrolebinding kiali-user-viewer --clusterrole=kiali-viewer --user=oidc:kiali
-
+  # use the latest published server helm chart (if using dev images, it is up to the user to make sure this chart works with the dev image)
   helm upgrade --install                 \
     ${helm_args}                         \
     --namespace ${ISTIO_NAMESPACE}       \
     --set kubernetes_config.cache_enabled="false" \
     --set auth.strategy="openid"      \
     --set auth.openid.client_id="kube"      \
-    --set auth.openid.issuer_uri="https://${KUBE_HOSTNAME}/realms/kube" \
+    --set auth.openid.issuer_uri="https://${kube_hostname}/realms/kube" \
     --set deployment.ingress.enabled="true" \
     --repo https://kiali.org/helm-charts \
     kiali-server                         \
@@ -58,11 +78,11 @@ deploy_kiali() {
 
 echo "==== DEPLOY KIALI TO CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
 switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
-deploy_kiali "${KIALI1_WEB_FQDN}" "${KIALI1_WEB_SCHEMA}"
+deploy_kiali "${CLUSTER1_NAME}" "${KIALI1_WEB_FQDN}" "${KIALI1_WEB_SCHEMA}"
 
 if [ "${SINGLE_KIALI}" != "true" ]
 then
   echo "==== DEPLOY KIALI TO CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
   switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
-  deploy_kiali "${KIALI2_WEB_FQDN}" "${KIALI2_WEB_SCHEMA}"
+  deploy_kiali "${CLUSTER2_NAME}" "${KIALI2_WEB_FQDN}" "${KIALI2_WEB_SCHEMA}"
 fi

--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -49,7 +49,7 @@ CLIENT_EXE_NAME="kubectl"
 ISTIO_DIR=""
 
 # If the scripts need image registry client, this is it (docker or podman)
-DORP="${DORP:-docker}"
+DORP="${DORP:-podman}"
 
 # The namespace where Istio will be found - this namespace must be the same on both clusters
 ISTIO_NAMESPACE="istio-system"
@@ -94,8 +94,11 @@ CLUSTER2_USER="kiali"
 CLUSTER2_PASS="kiali"
 
 # Should Kiali be installed? This installs the last release of Kiali via the kiali-server helm chart.
-# If you want another verison or your own dev build, you must disable this and install what you want manually.
+# If you want another version, you must disable this and install what you want manually.
 KIALI_ENABLED="true"
+
+# When installing Kiali, this will determine if a released image is used or if a local dev image is to be pushed and used.
+KIALI_USE_DEV_IMAGE="false"
 
 # Should Bookinfo demo be installed? If so, where?
 BOOKINFO_ENABLED="true"
@@ -195,6 +198,11 @@ while [[ $# -gt 0 ]]; do
       KIALI_ENABLED="$2"
       shift;shift
       ;;
+    -kudi|--kiali-use-dev-image)
+      [ "${2:-}" != "true" -a "${2:-}" != "false" ] && echo "--kiali-use-dev-image must be 'true' or 'false'" && exit 1
+      KIALI_USE_DEV_IMAGE="$2"
+      shift;shift
+      ;;
     -k1wf|--kiali1-web-fqdn)
       KIALI1_WEB_FQDN="$2"
       shift;shift
@@ -283,6 +291,11 @@ Valid command line arguments:
   -ke|--kiali-enabled <bool>: If "true" the latest release of Kiali will be installed in both clusters. If you want
                               a different version of Kiali installed, you must set this to "false" and install it yourself.
                               (Default: true)
+  -kudi|--kiali-use-dev-image: If "true" the local dev image of Kiali will be pushed and used in the Kiali deployment.
+                               The local dev image must be tagged as "quay.io/kiali/kiali:dev" prior to running this script;
+                               that will be the image pushed to the clusters. You can "make container-build-kiali" to build it.
+                               Will be ignored if --kiali-enabled is 'false'. (Default: false)
+                               CURRENTLY ONLY SUPPORTED WITH MINIKUBE!
   -k1wf|--kiali1-web-fqdn <fqdn>: If specified, this will be the #1 Kaili setting for spec.server.web_fqdn.
   -k1ws|--kiali1-web-schema <schema>: If specified, this will be the #1 Kaili setting for spec.server.web_schema.
   -k2wf|--kiali2-web-fqdn <fqdn>: If specified, this will be the #2 Kaili setting for spec.server.web_fqdn.
@@ -443,6 +456,7 @@ export BOOKINFO_ENABLED \
        ISTIO_NAMESPACE \
        ISTIO_TAG \
        KIALI_ENABLED \
+       KIALI_USE_DEV_IMAGE \
        MANAGE_KIND \
        MANAGE_MINIKUBE \
        MANUAL_MESH_NETWORK_CONFIG \
@@ -475,6 +489,7 @@ ISTIO_DIR=$ISTIO_DIR
 ISTIO_NAMESPACE=$ISTIO_NAMESPACE
 ISTIO_TAG=$ISTIO_TAG
 KIALI_ENABLED=$KIALI_ENABLED
+KIALI_USE_DEV_IMAGE=$KIALI_USE_DEV_IMAGE
 KIALI1_WEB_FQDN=$KIALI1_WEB_FQDN
 KIALI1_WEB_SCHEMA=$KIALI1_WEB_SCHEMA
 KIALI2_WEB_FQDN=$KIALI2_WEB_FQDN

--- a/hack/istio/multicluster/start-minikube.sh
+++ b/hack/istio/multicluster/start-minikube.sh
@@ -107,7 +107,7 @@ echo "==== START MINIKUBE FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT
 start_minikube "${CLUSTER1_NAME}" "70-84" "--extra-config=apiserver.oidc-issuer-url=https://${KUBE_HOSTNAME}/realms/kube --extra-config=apiserver.oidc-ca-file=${MINIKUBE_KEYCLOAK_CERTS_DIR}/root-ca.pem --extra-config=apiserver.oidc-client-id=kube --extra-config=apiserver.oidc-groups-claim=groups --extra-config=apiserver.oidc-username-prefix=oidc: --extra-config=apiserver.oidc-groups-prefix=oidc: --extra-config=apiserver.oidc-username-claim=preferred_username"
 
 # Wait for ingress to become ready before deploying keycloak since keycloak relies on it.
-kubectl rollout status deployment/ingress-nginx-controller -n ingress-nginx
+${CLIENT_EXE} rollout status deployment/ingress-nginx-controller -n ingress-nginx
 
 helm upgrade --install --wait --timeout 15m \
   --namespace keycloak --create-namespace \
@@ -136,12 +136,12 @@ postgresql:
 EOF
 
 # create secret used by keycloak ingress
-kubectl create secret tls -n keycloak keycloak.kind.cluster-tls \
+${CLIENT_EXE} create secret tls -n keycloak keycloak.kind.cluster-tls \
   --cert="${KEYCLOAK_CERTS_DIR}"/cert.pem \
   --key="${KEYCLOAK_CERTS_DIR}"/key.pem
 
 # Give the ingress some time to be ready
-# kubectl wait ingress/keycloak -n keycloak --context east --for=jsonpath='{.status.loadBalancer.ingress[*].hostname}'=localhost
+# ${CLIENT_EXE} wait ingress/keycloak -n keycloak --context east --for=jsonpath='{.status.loadBalancer.ingress[*].hostname}'=localhost
 sleep 20
 
 # Get a token from keycloak to use the admin api


### PR DESCRIPTION
be able to build your own kiali dev image and have that be used in the MC set up.

See the `--kiali-use-dev-image` option. You need to make sure you build a dev image on your local box (`make build build-ui`) and then ensure its container is built and tagged as `quay.io/kiali/kiali:dev` (which is the default, anytime you do `make container-build` or `make cluster-push` this happens, you can even just do `make container-build-kiali` to just build the server image).