### PR TITLE
RBAC-related fixes

### DIFF
--- a/handlers/proxy_status.go
+++ b/handlers/proxy_status.go
@@ -4,13 +4,21 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	kiali_business "github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/kubernetes"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 func ConfigDump(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
 	// Get business layer
-	business, err := getBusiness(r)
+	kialiToken, err := kubernetes.GetKialiToken()
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error (kiali token): "+err.Error())
+	}
+
+	business, err := kiali_business.Get(&api.AuthInfo{Token: kialiToken})
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return
@@ -32,7 +40,12 @@ func ConfigDumpResourceEntries(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
 	// Get business layer
-	business, err := getBusiness(r)
+	kialiToken, err := kubernetes.GetKialiToken()
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, "Services initialization error (kiali token): "+err.Error())
+	}
+
+	business, err := kiali_business.Get(&api.AuthInfo{Token: kialiToken})
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 		return

--- a/handlers/proxy_status.go
+++ b/handlers/proxy_status.go
@@ -4,9 +4,10 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"k8s.io/client-go/tools/clientcmd/api"
+
 	kiali_business "github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/kubernetes"
-	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 func ConfigDump(w http.ResponseWriter, r *http.Request) {

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -289,7 +289,7 @@ func (in *K8SClient) GetRegistryServices() ([]*RegistryService, error) {
 	} else {
 		debugStatus, err := in.getIstiodDebugStatus(registryzPath)
 		if err != nil {
-			log.Errorf("Failed to call Istiod endpoint %s error: %s", registryzPath, err)
+			log.Tracef("Failed to call Istiod endpoint %s error: %s", registryzPath, err)
 			return nil, err
 		}
 		result = debugStatus
@@ -312,7 +312,7 @@ func (in *K8SClient) GetRegistryEndpoints() ([]*RegistryEndpoint, error) {
 	} else {
 		debugStatus, err := in.getIstiodDebugStatus(endpointzPath)
 		if err != nil {
-			log.Errorf("Failed to call Istiod endpoint %s error: %s", endpointzPath, err)
+			log.Tracef("Failed to call Istiod endpoint %s error: %s", endpointzPath, err)
 			return nil, err
 		}
 		result = debugStatus
@@ -335,7 +335,7 @@ func (in *K8SClient) GetRegistryConfiguration() (*RegistryConfiguration, error) 
 	} else {
 		debugStatus, err := in.getIstiodDebugStatus(configzPath)
 		if err != nil {
-			log.Errorf("Failed to call Istiod endpoint %s error: %s", configzPath, err)
+			log.Tracef("Failed to call Istiod endpoint %s error: %s", configzPath, err)
 			return nil, err
 		}
 		result = debugStatus


### PR DESCRIPTION
I'm not sure if this is fair. I'm anyway suggesting these.

This is doing two fixes:
* In istio.go some messages are moved from ERR level to TRACE level. Apparently, when these funcs fail because of the user not having enough privileges, Kiali will retry using its ServiceAccount. So, these messages are not that useful unless something weird happened.
* In proxy_status.go config dumps are now retrieved using the Kiali ServiceAccount rather than the token of the logged-in user. This is for the "Envoy" tab of Workloads to work properly if the user has "less" privileges.

Related #5720
