### PR TITLE
Change log level to debug in openid auth controller

### DIFF
--- a/business/authentication/openid_auth_controller.go
+++ b/business/authentication/openid_auth_controller.go
@@ -300,7 +300,7 @@ func (c OpenIdAuthController) authenticateWithAuthorizationCodeFlow(r *http.Requ
 
 	if flow.Error != nil {
 		if err, ok := flow.Error.(*badOidcRequest); ok {
-			log.Errorf("Not handling OpenId code flow authentication: %s", err.Detail)
+			log.Debugf("Not handling OpenId code flow authentication: %s", err.Detail)
 			fallbackHandler.ServeHTTP(w, r)
 		} else {
 			if flow.ShouldTerminateSession {


### PR DESCRIPTION
openid authentication was raising an error message even when the authentication is successful. The message is useful for diagnose purposes just in case the authentication failed, so changing the message log level to debug. 