### PR TITLE
[Cypress] Istio Config page wizard coverage

### DIFF
--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -2,7 +2,7 @@ import { After, And, Given, Then, When } from '@badeball/cypress-cucumber-prepro
 import { getColWithRowText } from './table';
 import { ensureKialiFinishedLoading } from "./transition";
 
-When('user clicks in the {string} Istio config actions', (action) => {
+When('user clicks in the {string} Istio config actions', (action:string) => {
   cy.get('button[data-test="config-actions-dropdown"]')
       .click()
       .get('#loading_kiali_spinner')
@@ -14,7 +14,7 @@ When('user clicks in the {string} Istio config actions', (action) => {
       .should('not.exist');
 });
 
-And('user sees the {string} config wizard', (title) => {
+And('user sees the {string} config wizard', (title:string) => {
   cy.get('h1').should('contain.text', title);
 });
 
@@ -22,20 +22,20 @@ And('user adds listener', () => {
   cy.get('button[name="addListener"]').click()
 });
 
-And('user types {string} in the name input', (name) => {
-  cy.get('input[id="name"]').type(name);
+And('user types {string} in the {string} input', (value:string, id:string) => {
+  cy.get(`input[id="${id}"]`).type(value);
 });
 
-And('user types {string} in the add listener name input', (name) => {
-  cy.get('input[id="addName0"]').type(name);
+And('user adds a server to a server list', () => {
+  cy.get('[aria-label="Server List"]').find('button').click();
 });
 
-And('user types {string} in the add hostname input', (host) => {
-  cy.get('input[id="addHostname0"]').type(host);
+And('the {string} input should display a warning', (id:string)=>{
+  cy.get(`input[id="${id}"]`).invoke('attr', 'aria-invalid').should('eq', 'true');
 });
 
-And('user types {string} in the add port input', (port) => {
-  cy.get('input[id="addPort0"]').type(port);
+And('the {string} input should not display a warning', (id:string)=>{
+  cy.get(`input[id="${id}"]`).invoke('attr', 'aria-invalid').should('eq', 'false');
 });
 
 And('user creates the istio config', () => {
@@ -47,6 +47,31 @@ And('user creates the istio config', () => {
   });
 });
 
-Then('the K8sGateway {string} should be listed in {string} namespace', function(name, namespace: string) {
-  cy.get(`[data-test=VirtualItem_Ns${namespace}_k8sgateway_${name}] svg`).should('exist');
+And('user chooses {string} mode from the {string} select',(option:string, id:string) => {
+  cy.get(`select[id="${id}"]`).select(option);
+});
+
+And('the {string} message should be displayed',(message:string)=> {
+  cy.get('main').contains(message).should('be.visible');
+});
+
+And('user opens the {string} submenu',(title:string)=>{
+  cy.get('button').contains(title).click();
+});
+
+Then('the {string} {string} should be listed in {string} namespace', function(type:string, name:string, namespace: string) {
+  cy.get(`[data-test=VirtualItem_Ns${namespace}_${type.toLowerCase()}_${name}] svg`).should('exist');
+});
+
+Then('the preview button should be disabled', () =>{
+  cy.get('[data-test="preview"').should('be.disabled');
+});
+
+
+Then('an error message {string} is displayed', (message:string) =>{
+  cy.get('h4').contains(message).should("be.visible");
+});
+
+Then('the {string} input should be empty', (id:string) => {
+  cy.get(`input[id="${id}"]`).should('be.empty');
 });

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -12,13 +12,204 @@ Feature: Kiali Istio Config page
 
   @wizard-istio-config
   Scenario: Create a K8s Gateway scenario
-    And user clicks in the "K8sGateway" Istio config actions
+    When user clicks in the "K8sGateway" Istio config actions
     And user sees the "Create K8sGateway" config wizard
     And user adds listener
-    And user types "k8sapigateway" in the name input
-    And user types "listener" in the add listener name input
-    And user types "website.com" in the add hostname input
-    And user types "8080" in the add port input
+    And user types "k8sapigateway" in the "name" input
+    And user types "listener" in the "addName0" input
+    And user types "website.com" in the "addHostname0" input
+    And user types "8080" in the "addPort0" input
     And user previews the configuration
     And user creates the istio config
-    Then the K8sGateway "k8sapigateway" should be listed in "bookinfo" namespace
+    Then the "K8sGateway" "k8sapigateway" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway with no name 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    Then the "name" input should be empty
+    And the "name" input should display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway with invalid name 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "!@#$%^*()_+" in the "name" input
+    Then the "name" input should display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Create a Gateway scenario
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway" in the "name" input
+    And user adds a server to a server list
+    Then the preview button should be disabled
+    And user types "website.com" in the "hosts0" input
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user previews the configuration
+    And user creates the istio config
+    Then the "Gateway" "mygateway" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway with negative port number
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway2" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "-8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    Then the preview button should be disabled
+    And the "addPortNumber0" input should display a warning
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway with invalid port number
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway2" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "65536" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    Then the preview button should be disabled
+    And the "addPortNumber0" input should display a warning
+
+  @wizard-istio-config
+  Scenario: Try to insert letters in the port field
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway2" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "lorem ipsum" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    Then the preview button should be disabled
+    And the "addPortNumber0" input should display a warning
+
+  @wizard-istio-config
+  Scenario: Create a Gateway with duplicate name 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user previews the configuration
+    And user creates the istio config
+    Then an error message "Could not create Istio Gateway objects." is displayed
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway without filling the inputs related to TLS 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygatewaywithtls" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user chooses "TLS" mode from the "addPortProtocol0" select
+    And user chooses "SIMPLE" mode from the "addTlsMode" select
+    Then the "server-certificate" input should be empty
+    And the "server-certificate" input should display a warning
+    And the "private-key" input should be empty
+    And the "private-key" input should display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Create a Gateway with TLS 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygatewaywithtls" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user chooses "TLS" mode from the "addPortProtocol0" select
+    And user chooses "SIMPLE" mode from the "addTlsMode" select
+    And user types "foo" in the "server-certificate" input
+    And user types "bar" in the "private-key" input
+    And user previews the configuration
+    And user creates the istio config
+    Then the "Gateway" "mygatewaywithtls" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create a ServiceEntry with empty fields
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    Then the "name" input should be empty
+    And the "name" input should display a warning
+    And the "hosts" input should be empty
+    And the "hosts" input should display a warning
+    And the "ServiceEntry has no Ports defined" message should be displayed
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Try to create a ServiceEntry with invalid name and host specified
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "%%%%$#&*&" in the "name" input
+    And user types "website.com," in the "hosts" input
+    And the "name" input should display a warning
+    And the "hosts" input should display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Create a ServiceEntry without ports specified 
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "myservice" in the "name" input
+    And user types "website.com,website2.com" in the "hosts" input
+    And the "ServiceEntry has no Ports defined" message should be displayed
+    And user previews the configuration
+    And user creates the istio config
+    Then the "ServiceEntry" "myservice" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create a ServiceEntry with empty ports specified 
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "myservice" in the "name" input
+    And user types "website.com" in the "hosts" input
+    And user opens the "Add Port" submenu
+    Then the "addPortNumber0" input should be empty
+    And the "addPortNumber0" input should display a warning
+    And the "addPortName0" input should be empty
+    And the "addPortName0" input should display a warning
+    And the "addTargetPort0" input should be empty
+    And the "addTargetPort0" input should not display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Create a ServiceEntry with ports specified 
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "myservice2" in the "name" input
+    And user types "website.com,website2.com" in the "hosts" input
+    And user opens the "Add Port" submenu
+    Then the "addPortNumber0" input should be empty
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user types "8080" in the "addTargetPort0" input
+    And user previews the configuration
+    And user creates the istio config
+    Then the "ServiceEntry" "myservice2" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create duplicate port specifications on a ServiceEntry
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "myservice2" in the "name" input
+    And user types "website.com,website2.com" in the "hosts" input
+    And user opens the "Add Port" submenu
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user types "8080" in the "addTargetPort0" input  
+    And user opens the "Add Port" submenu
+    And user types "8080" in the "addPortNumber1" input
+    And user types "foobar" in the "addPortName1" input
+    And user types "8080" in the "addTargetPort1" input
+    Then the preview button should be disabled


### PR DESCRIPTION
Tests related to the #5811 issue. This suite increases coverage of the wizard menu for the ServiceEntries and Gateways in the Istio config section of Kiali. The tests cover creation of said objects, tests of the text fields for valid and invalid values and also tests that object of same name cannot be created twice. Currently not sure if I should implement a teardown of some sort to clean the created objects after the suite is completed.