### PR TITLE
Adapt apps_test.go to not rely on turning off the cache

### DIFF
--- a/business/test_util.go
+++ b/business/test_util.go
@@ -893,7 +893,11 @@ func FakeCustomControllerRSSyncedWithPods() []apps_v1.ReplicaSet {
 func FakeServices() []core_v1.Service {
 	return []core_v1.Service{
 		{
-			ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "Namespace"},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "httpbin",
+				Namespace: "Namespace",
+				Labels:    map[string]string{"app": "httpbin"},
+			},
 			Spec: core_v1.ServiceSpec{
 				Selector: map[string]string{"app": "httpbin"},
 			},


### PR DESCRIPTION
The adaptation moves from using mocks to using a fake client. This allows for starting a cache where the underlying client is a fake, making it possible to allow the code to use "caching" as with the real client.

Related #5599
