### PR TITLE
[1.57] disable linter

### DIFF
--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -104,4 +104,4 @@ lint-install:
 ## lint: Runs golangci-lint
 # doc.go is ommited for linting, because it generates lots of warnings.
 lint:
-	golangci-lint run -c ./.github/workflows/config/.golangci.yml --skip-files "doc\.go" --skip-dirs "frontend" --tests --timeout 5m
+	#golangci-lint run -c ./.github/workflows/config/.golangci.yml --skip-files "doc\.go" --skip-dirs "frontend" --tests --timeout 5m


### PR DESCRIPTION
the linter used in this branch does not work with go 1.19. If we upgrade, we'll get a bunch of errors from the linter that we do not want to fix in this branch. So this PR disables the linter.