### PR TITLE
Update the Namespace cache to support multicluster

### DIFF
--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -62,7 +62,7 @@ type kialiCacheImpl struct {
 	kubeCache              map[string]KubeCache
 	refreshDuration        time.Duration
 	tokenLock              sync.RWMutex
-	tokenNamespaces        map[string]namespaceCache
+	tokenNamespaces        map[string]map[string]namespaceCache // By token, by cluster
 	tokenNamespaceDuration time.Duration
 	proxyStatusLock        sync.RWMutex
 	proxyStatusNamespaces  map[string]map[string]podProxyStatus
@@ -78,7 +78,7 @@ func NewKialiCache(clientFactory kubernetes.ClientFactory, cfg config.Config, na
 		kubeCache:                  make(map[string]KubeCache),
 		proxyStatusNamespaces:      make(map[string]map[string]podProxyStatus),
 		refreshDuration:            time.Duration(cfg.KubernetesConfig.CacheDuration) * time.Second,
-		tokenNamespaces:            make(map[string]namespaceCache),
+		tokenNamespaces:            make(map[string]map[string]namespaceCache),
 		tokenNamespaceDuration:     time.Duration(cfg.KubernetesConfig.CacheTokenNamespaceDuration) * time.Second,
 	}
 

--- a/kubernetes/cache/registry_test_helper.go
+++ b/kubernetes/cache/registry_test_helper.go
@@ -25,7 +25,7 @@ func FakeGatewaysKialiCache(gws []*networking_v1beta1.Gateway) KialiCache {
 		panic(fmt.Sprintf("Error creating KialiCache in testing. Err: %v", err))
 	}
 	kialiCacheImpl := kialiCacheImpl{
-		tokenNamespaces: make(map[string]namespaceCache),
+		tokenNamespaces: make(map[string]map[string]namespaceCache),
 		// ~ long duration for unit testing
 		refreshDuration: time.Hour,
 		KubeCache:       cache,
@@ -63,7 +63,7 @@ func FakeServicesKialiCache(rss []*kubernetes.RegistryService,
 		panic(fmt.Sprintf("Error creating KialiCache in testing. Err: %v", err))
 	}
 	kialiCacheImpl := kialiCacheImpl{
-		tokenNamespaces: make(map[string]namespaceCache),
+		tokenNamespaces: make(map[string]map[string]namespaceCache),
 		// ~ long duration for unit testing
 		refreshDuration: time.Hour,
 		KubeCache:       cache,

--- a/kubernetes/cache/tls_test_helper.go
+++ b/kubernetes/cache/tls_test_helper.go
@@ -14,7 +14,7 @@ import (
 // It populates the Namespaces, Informers and Registry information needed
 func FakeTlsKialiCache(token string, namespaces []string, pa []*security_v1beta1.PeerAuthentication, dr []*networking_v1beta1.DestinationRule) KialiCache {
 	kialiCacheImpl := kialiCacheImpl{
-		tokenNamespaces: make(map[string]namespaceCache),
+		tokenNamespaces: make(map[string]map[string]namespaceCache),
 		// ~ long duration for unit testing
 		refreshDuration: time.Hour,
 	}

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -29,6 +29,7 @@ type ClientFactory interface {
 	GetSAClient(cluster string) ClientInterface
 	GetSAHomeClusterClient() ClientInterface
 	GetClusterNames() []string
+	GetHomeClusterName() string
 }
 
 // clientFactory used to generate per users clients
@@ -213,6 +214,11 @@ func (cf *clientFactory) newSAClient(clusterInfo *RemoteClusterInfo) (*K8SClient
 // getClient returns a client for the specified token. Creating one if necessary.
 func (cf *clientFactory) GetClient(authInfo *api.AuthInfo) (ClientInterface, error) {
 	return cf.getRecycleClient(authInfo, defaultExpirationTime)
+}
+
+// getClient returns a client for the specified token. Creating one if necessary.
+func (cf *clientFactory) GetHomeClusterName() string {
+	return HomeClusterName
 }
 
 // getRecycleClient returns a client for the specified token with expirationTime. Creating one if necessary.

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -20,6 +20,13 @@ type Namespace struct {
 	// required: true
 	Name string `json:"name"`
 
+	// The name of the cluster.
+	// Empty when local
+	//
+	// example:  east
+	// required: true
+	Cluster string `json:"cluster"`
+
 	// Creation date of the namespace.
 	// There is no need to export this through the API. So, this is
 	// set to be ignored by JSON package.
@@ -37,18 +44,19 @@ type Namespace struct {
 type Namespaces []Namespace
 type NamespaceNames []string
 
-func CastNamespaceCollection(ns []core_v1.Namespace) []Namespace {
+func CastNamespaceCollection(ns []core_v1.Namespace, cluster string) []Namespace {
 	namespaces := make([]Namespace, len(ns))
 	for i, item := range ns {
-		namespaces[i] = CastNamespace(item)
+		namespaces[i] = CastNamespace(item, cluster)
 	}
 
 	return namespaces
 }
 
-func CastNamespace(ns core_v1.Namespace) Namespace {
+func CastNamespace(ns core_v1.Namespace, cluster string) Namespace {
 	namespace := Namespace{}
 	namespace.Name = ns.Name
+	namespace.Cluster = cluster
 	namespace.CreationTimestamp = ns.CreationTimestamp.Time
 	namespace.Labels = ns.Labels
 	namespace.Annotations = make(map[string]string)


### PR DESCRIPTION
Fixes #5766 

The first approach was to change the cache: 

`tokenNamespaces        map[string]namespaceCache`

For the following: 

`tokenNamespaces        map[string]map[string]namespaceCache // By token, by cluster`

The purpose of this would be to access the information easily of quickly in case we need to reload just one cluster information. And the information will be mixed before returning. 

The other approach it is to just save the information as it was. 

Another change will be to include the cluster inside the namespace model. It can help to filter the information in the GUI: 

`Cluster string json:"cluster"`

Still need to figure out how to return the information in the API. ATM, the API 7namespaces returns: 
`
[{"name":"alpha","cluster":"_kiali_home","labels":{"istio-injection":"enabled","kubernetes.io/metadata.name":"alpha"},"annotations":{}},{"name":"beta","cluster":"_kiali_home","labels":{"istio-injection":"enabled","kubernetes.io/metadata.name":"beta"},"annotations":{}}, ...`

It can merge all the information: 

```
{"name":"NSNAME", 
  "clusters": [ "clustername", "clustername2"],
{labels, annotations}}
```

`{"name":"alpha","clusters":["_kiali_home", "east"],"labels":{"istio-injection":"enabled","kubernetes.io/metadata.name":"alpha", "kubernetes.io/metadata.name":"new_metadata"},"annotations":{}}`

Or be returned by cluster: 

```
{"name":"NSNAME", 
  "clusters": [ {"clustername" : {"abels, annotations"}}]}
```

```
{"name":"alpha",
"clusters":[{"_kiali_home": {"labels":{"istio-injection":"enabled","kubernetes.io/metadata.name":"alpha"},"annotations":{}}}, 
{"east": {"labels":{"istio-injection":"enabled","kubernetes.io/metadata.name":"alpha", "kubernetes.io/metadata.name":"new_metadata"},"annotations":{}}}]
```