### PR TITLE
Fix validation for K8s gateway hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TARGET_ARCHS ?= amd64 arm64 s390x ppc64le
 
 # Identifies the current build.
 # These will be embedded in the app and displayed when it starts.
-VERSION ?= v1.64.0-SNAPSHOT
+VERSION ?= v1.65.0-SNAPSHOT
 COMMIT_HASH ?= $(shell git rev-parse HEAD)
 
 # The path where the UI project has been git cloned. The UI should

--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -60,7 +60,7 @@ cypress/
 4) Failed tests could mean that:
     * Reuse of step definitions is not suitable or gets broken by different testcase or your modifications
     * We want to refactor broken code and if its heavily used, move it into a custom command file (cypress/support/commands.ts) - i.e. `cy.login()`, `cy.kiali_apply_config()` lives there
-5) Test case execution should be all green, you are ready to commit your test case. You might want verify whole regression run locally - so you did not introduce any braking changes in your PR
+5) Test case execution should be all green, you are ready to commit your test case. You might want verify whole regression run locally - so you did not introduce any breaking changes in your PR
 
 ## Performance Tests
 

--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -2,7 +2,7 @@ import { After, And, Given, Then, When } from '@badeball/cypress-cucumber-prepro
 import { getColWithRowText } from './table';
 import { ensureKialiFinishedLoading } from "./transition";
 
-When('user clicks in the {string} Istio config actions', (action) => {
+When('user clicks in the {string} Istio config actions', (action:string) => {
   cy.get('button[data-test="config-actions-dropdown"]')
       .click()
       .get('#loading_kiali_spinner')
@@ -14,7 +14,7 @@ When('user clicks in the {string} Istio config actions', (action) => {
       .should('not.exist');
 });
 
-And('user sees the {string} config wizard', (title) => {
+And('user sees the {string} config wizard', (title:string) => {
   cy.get('h1').should('contain.text', title);
 });
 
@@ -22,20 +22,20 @@ And('user adds listener', () => {
   cy.get('button[name="addListener"]').click()
 });
 
-And('user types {string} in the name input', (name) => {
-  cy.get('input[id="name"]').type(name);
+And('user types {string} in the {string} input', (value:string, id:string) => {
+  cy.get(`input[id="${id}"]`).type(value);
 });
 
-And('user types {string} in the add listener name input', (name) => {
-  cy.get('input[id="addName0"]').type(name);
+And('user adds a server to a server list', () => {
+  cy.get('[aria-label="Server List"]').find('button').click();
 });
 
-And('user types {string} in the add hostname input', (host) => {
-  cy.get('input[id="addHostname0"]').type(host);
+And('the {string} input should display a warning', (id:string)=>{
+  cy.get(`input[id="${id}"]`).invoke('attr', 'aria-invalid').should('eq', 'true');
 });
 
-And('user types {string} in the add port input', (port) => {
-  cy.get('input[id="addPort0"]').type(port);
+And('the {string} input should not display a warning', (id:string)=>{
+  cy.get(`input[id="${id}"]`).invoke('attr', 'aria-invalid').should('eq', 'false');
 });
 
 And('user creates the istio config', () => {
@@ -47,6 +47,31 @@ And('user creates the istio config', () => {
   });
 });
 
-Then('the K8sGateway {string} should be listed in {string} namespace', function(name, namespace: string) {
-  cy.get(`[data-test=VirtualItem_Ns${namespace}_k8sgateway_${name}] svg`).should('exist');
+And('user chooses {string} mode from the {string} select',(option:string, id:string) => {
+  cy.get(`select[id="${id}"]`).select(option);
+});
+
+And('the {string} message should be displayed',(message:string)=> {
+  cy.get('main').contains(message).should('be.visible');
+});
+
+And('user opens the {string} submenu',(title:string)=>{
+  cy.get('button').contains(title).click();
+});
+
+Then('the {string} {string} should be listed in {string} namespace', function(type:string, name:string, namespace: string) {
+  cy.get(`[data-test=VirtualItem_Ns${namespace}_${type.toLowerCase()}_${name}] svg`).should('exist');
+});
+
+Then('the preview button should be disabled', () =>{
+  cy.get('[data-test="preview"').should('be.disabled');
+});
+
+
+Then('an error message {string} is displayed', (message:string) =>{
+  cy.get('h4').contains(message).should("be.visible");
+});
+
+Then('the {string} input should be empty', (id:string) => {
+  cy.get(`input[id="${id}"]`).should('be.empty');
 });

--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -1,8 +1,6 @@
-import { After, And, Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { getColWithRowText } from './table';
-import { ensureKialiFinishedLoading } from "./transition";
+import { And, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 
-When('user clicks in the {string} Istio config actions', (action:string) => {
+When('user clicks in the {string} Istio config actions', (action: string) => {
   cy.get('button[data-test="config-actions-dropdown"]')
       .click()
       .get('#loading_kiali_spinner')
@@ -14,7 +12,7 @@ When('user clicks in the {string} Istio config actions', (action:string) => {
       .should('not.exist');
 });
 
-And('user sees the {string} config wizard', (title:string) => {
+And('user sees the {string} config wizard', (title: string) => {
   cy.get('h1').should('contain.text', title);
 });
 
@@ -22,19 +20,29 @@ And('user adds listener', () => {
   cy.get('button[name="addListener"]').click()
 });
 
-And('user types {string} in the {string} input', (value:string, id:string) => {
+And('user types {string} in the {string} input', (value: string, id: string) => {
   cy.get(`input[id="${id}"]`).type(value);
+});
+
+And('user checks validation in the hostname {string} input', (id: string) => {
+  cy.inputValidation(id, 'host', false); // hostname must be fqdn
+  cy.inputValidation(id, '1.1.1.1', false); // IPs are not allowed
+  cy.inputValidation(id, 'namespace/host', false); // namespace/dns format is not allowed
+  cy.inputValidation(id, '*.hostname.com', true); // domain name with wildcard prefix is allowed
+  cy.inputValidation(id, '*.hostname.*.com', false); // but not wildcards in the middle
+  cy.inputValidation(id, '*', false); // or just a wildcard
+  cy.inputValidation(id, 'HOST.com', false); // capital letters are not allowed
 });
 
 And('user adds a server to a server list', () => {
   cy.get('[aria-label="Server List"]').find('button').click();
 });
 
-And('the {string} input should display a warning', (id:string)=>{
+And('the {string} input should display a warning', (id: string)=>{
   cy.get(`input[id="${id}"]`).invoke('attr', 'aria-invalid').should('eq', 'true');
 });
 
-And('the {string} input should not display a warning', (id:string)=>{
+And('the {string} input should not display a warning', (id: string)=>{
   cy.get(`input[id="${id}"]`).invoke('attr', 'aria-invalid').should('eq', 'false');
 });
 
@@ -47,19 +55,19 @@ And('user creates the istio config', () => {
   });
 });
 
-And('user chooses {string} mode from the {string} select',(option:string, id:string) => {
+And('user chooses {string} mode from the {string} select',(option: string, id: string) => {
   cy.get(`select[id="${id}"]`).select(option);
 });
 
-And('the {string} message should be displayed',(message:string)=> {
+And('the {string} message should be displayed',(message: string)=> {
   cy.get('main').contains(message).should('be.visible');
 });
 
-And('user opens the {string} submenu',(title:string)=>{
+And('user opens the {string} submenu',(title: string)=>{
   cy.get('button').contains(title).click();
 });
 
-Then('the {string} {string} should be listed in {string} namespace', function(type:string, name:string, namespace: string) {
+Then('the {string} {string} should be listed in {string} namespace', function(type: string, name: string, namespace: string) {
   cy.get(`[data-test=VirtualItem_Ns${namespace}_${type.toLowerCase()}_${name}] svg`).should('exist');
 });
 
@@ -68,10 +76,10 @@ Then('the preview button should be disabled', () =>{
 });
 
 
-Then('an error message {string} is displayed', (message:string) =>{
+Then('an error message {string} is displayed', (message: string) =>{
   cy.get('h4').contains(message).should("be.visible");
 });
 
-Then('the {string} input should be empty', (id:string) => {
+Then('the {string} input should be empty', (id: string) => {
   cy.get(`input[id="${id}"]`).should('be.empty');
 });

--- a/frontend/cypress/integration/common/wizard_request_routing.ts
+++ b/frontend/cypress/integration/common/wizard_request_routing.ts
@@ -1,9 +1,9 @@
-import {And, Before, Given, Then, When} from "@badeball/cypress-cucumber-preprocessor";
+import {And, Before, Given, When} from "@badeball/cypress-cucumber-preprocessor";
 
 const url = "/console";
 
 Before(() => {
-    // Focing to not stop cypress on unexpected errors not related to the tests.
+    // Forcing to not stop cypress on unexpected errors not related to the tests.
     // There are some random failures due timeouts/loadtime/framework that throws some error in the browser.
     // After reviewing the tests failures, those are unrelated to the app, so,
     // it needs this event to not fail the CI action due some "slow" action or similar.
@@ -21,12 +21,12 @@ Before(() => {
     });
 });
 
-Given('user opens the namespace {string} and {string} service details page', (namespace, service) => {
+Given('user opens the namespace {string} and {string} service details page', (namespace: string, service: string) => {
     // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
     cy.visit(url + '/namespaces/' + namespace + '/services/' + service + '?refresh=0');
 });
 
-When('user clicks in the {string} actions', (action) => {
+When('user clicks in the {string} actions', (action: string) => {
     let actionId = '';
     switch (action) {
         case 'Request Routing':
@@ -56,16 +56,16 @@ When('user clicks in the {string} actions', (action) => {
         .should('not.exist');
 });
 
-And('user sees the {string} wizard', (title) => {
+And('user sees the {string} wizard', (title: string) => {
     cy.get('div[aria-label="' + title + '"]');
 });
 
-And('user clicks in the {string} tab', (tab) => {
+And('user clicks in the {string} tab', (tab: string) => {
     cy.get('button[data-test="' + tab +'"]')
         .click();
 });
 
-And('user clicks in the {string} request matching dropdown', (select) => {
+And('user clicks in the {string} request matching dropdown', (select: string) => {
     cy.get('button[data-test="requestmatching-header-toggle"]')
         .click();
 
@@ -73,7 +73,7 @@ And('user clicks in the {string} request matching dropdown', (select) => {
         .click();
 });
 
-And('user clicks in the {string} request filtering dropdown', (select) => {
+And('user clicks in the {string} request filtering dropdown', (select: string) => {
     cy.get('button[data-test="filtering-type-toggle"]')
         .click();
 
@@ -81,17 +81,17 @@ And('user clicks in the {string} request filtering dropdown', (select) => {
         .click();
 });
 
-And('user types {string} in the matching header input', (header) => {
+And('user types {string} in the matching header input', (header: string) => {
     cy.get('input[id="header-name-id"]')
         .type(header);
 });
 
-And('user types {string} in the filtering header input', (header) => {
+And('user types {string} in the filtering header input', (header: string) => {
     cy.get('input[id="filter-header-name-id"]')
         .type(header);
 });
 
-And('user clicks in the {string} match value dropdown', (value) => {
+And('user clicks in the {string} match value dropdown', (value: string) => {
     cy.get('button[data-test="requestmatching-match-toggle"]')
         .click();
 
@@ -99,7 +99,7 @@ And('user clicks in the {string} match value dropdown', (value) => {
         .click();
 });
 
-And('user types {string} in the match value input', (value) => {
+And('user types {string} in the match value input', (value: string) => {
     cy.get('input[id="match-value-id"]')
         .type(value);
 });
@@ -114,7 +114,7 @@ And('user adds a filter', () => {
         .click();
 });
 
-And('user types {string} traffic weight in the {string} workload', (weight, workload) => {
+And('user types {string} traffic weight in the {string} workload', (weight: string, workload: string) => {
     cy.get('input[data-test="input-slider-' + workload + '"]')
         .type(weight);
 });
@@ -124,7 +124,7 @@ And('user adds a route', () => {
         .click();
 });
 
-And('user clicks in {string} matching selected', (match) => {
+And('user clicks in {string} matching selected', (match: string) => {
    cy.get('span[data-test="' + match + '"]')
        .children()
        .first()         // div wrapper
@@ -171,11 +171,11 @@ And('user confirms delete the configuration', () => {
     });
 });
 
-And('user sees the {string} {string} {string} reference', (namespace, name, type) => {
+And('user sees the {string} {string} {string} reference', (namespace: string, name: string, type: string) => {
     cy.get('a[data-test="' + type + '-' + namespace + '-' + name + '"]');
 });
 
-And('user clicks in the {string} {string} {string} reference', (namespace, name, type) => {
+And('user clicks in the {string} {string} {string} reference', (namespace: string, name: string, type: string) => {
     cy.get('a[data-test="' + type + '-' + namespace + '-' + name + '"]')
         .click();
 
@@ -196,14 +196,14 @@ And('user clicks in the {string} {string} {string} reference', (namespace, name,
         .should('include', expectedURl);
 });
 
-And('user sees the {string} regex in the editor', (regexContent) => {
+And('user sees the {string} regex in the editor', (regexContent: string) => {
     const re = new RegExp(regexContent);
     cy.get('.ace_content')
         .invoke('text')
         .should('match', re);
 });
 
-And('user clicks on {string} Advanced Options', (action) => {
+And('user clicks on {string} Advanced Options', (action: string) => {
     cy.get('div[id="' + action.toLowerCase() + '_advanced_options"]').prev()
         .click();
 });

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -17,6 +17,7 @@ Feature: Kiali Istio Config page
     And user adds listener
     And user types "k8sapigateway" in the "name" input
     And user types "listener" in the "addName0" input
+    And user checks validation in the hostname "addHostname0" input
     And user types "website.com" in the "addHostname0" input
     And user types "8080" in the "addPort0" input
     And user previews the configuration

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -12,13 +12,204 @@ Feature: Kiali Istio Config page
 
   @wizard-istio-config
   Scenario: Create a K8s Gateway scenario
-    And user clicks in the "K8sGateway" Istio config actions
+    When user clicks in the "K8sGateway" Istio config actions
     And user sees the "Create K8sGateway" config wizard
     And user adds listener
-    And user types "k8sapigateway" in the name input
-    And user types "listener" in the add listener name input
-    And user types "website.com" in the add hostname input
-    And user types "8080" in the add port input
+    And user types "k8sapigateway" in the "name" input
+    And user types "listener" in the "addName0" input
+    And user types "website.com" in the "addHostname0" input
+    And user types "8080" in the "addPort0" input
     And user previews the configuration
     And user creates the istio config
-    Then the K8sGateway "k8sapigateway" should be listed in "bookinfo" namespace
+    Then the "K8sGateway" "k8sapigateway" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway with no name 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    Then the "name" input should be empty
+    And the "name" input should display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway with invalid name 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "!@#$%^*()_+" in the "name" input
+    Then the "name" input should display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Create a Gateway scenario
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway" in the "name" input
+    And user adds a server to a server list
+    Then the preview button should be disabled
+    And user types "website.com" in the "hosts0" input
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user previews the configuration
+    And user creates the istio config
+    Then the "Gateway" "mygateway" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway with negative port number
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway2" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "-8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    Then the preview button should be disabled
+    And the "addPortNumber0" input should display a warning
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway with invalid port number
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway2" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "65536" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    Then the preview button should be disabled
+    And the "addPortNumber0" input should display a warning
+
+  @wizard-istio-config
+  Scenario: Try to insert letters in the port field
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway2" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "lorem ipsum" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    Then the preview button should be disabled
+    And the "addPortNumber0" input should display a warning
+
+  @wizard-istio-config
+  Scenario: Create a Gateway with duplicate name 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user previews the configuration
+    And user creates the istio config
+    Then an error message "Could not create Istio Gateway objects." is displayed
+
+  @wizard-istio-config
+  Scenario: Try to create a Gateway without filling the inputs related to TLS 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygatewaywithtls" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user chooses "TLS" mode from the "addPortProtocol0" select
+    And user chooses "SIMPLE" mode from the "addTlsMode" select
+    Then the "server-certificate" input should be empty
+    And the "server-certificate" input should display a warning
+    And the "private-key" input should be empty
+    And the "private-key" input should display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Create a Gateway with TLS 
+    When user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygatewaywithtls" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user chooses "TLS" mode from the "addPortProtocol0" select
+    And user chooses "SIMPLE" mode from the "addTlsMode" select
+    And user types "foo" in the "server-certificate" input
+    And user types "bar" in the "private-key" input
+    And user previews the configuration
+    And user creates the istio config
+    Then the "Gateway" "mygatewaywithtls" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create a ServiceEntry with empty fields
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    Then the "name" input should be empty
+    And the "name" input should display a warning
+    And the "hosts" input should be empty
+    And the "hosts" input should display a warning
+    And the "ServiceEntry has no Ports defined" message should be displayed
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Try to create a ServiceEntry with invalid name and host specified
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "%%%%$#&*&" in the "name" input
+    And user types "website.com," in the "hosts" input
+    And the "name" input should display a warning
+    And the "hosts" input should display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Create a ServiceEntry without ports specified 
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "myservice" in the "name" input
+    And user types "website.com,website2.com" in the "hosts" input
+    And the "ServiceEntry has no Ports defined" message should be displayed
+    And user previews the configuration
+    And user creates the istio config
+    Then the "ServiceEntry" "myservice" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create a ServiceEntry with empty ports specified 
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "myservice" in the "name" input
+    And user types "website.com" in the "hosts" input
+    And user opens the "Add Port" submenu
+    Then the "addPortNumber0" input should be empty
+    And the "addPortNumber0" input should display a warning
+    And the "addPortName0" input should be empty
+    And the "addPortName0" input should display a warning
+    And the "addTargetPort0" input should be empty
+    And the "addTargetPort0" input should not display a warning
+    And the preview button should be disabled
+
+  @wizard-istio-config
+  Scenario: Create a ServiceEntry with ports specified 
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "myservice2" in the "name" input
+    And user types "website.com,website2.com" in the "hosts" input
+    And user opens the "Add Port" submenu
+    Then the "addPortNumber0" input should be empty
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user types "8080" in the "addTargetPort0" input
+    And user previews the configuration
+    And user creates the istio config
+    Then the "ServiceEntry" "myservice2" should be listed in "bookinfo" namespace
+
+  @wizard-istio-config
+  Scenario: Try to create duplicate port specifications on a ServiceEntry
+    When user clicks in the "ServiceEntry" Istio config actions
+    And user sees the "Create ServiceEntry" config wizard
+    And user types "myservice2" in the "name" input
+    And user types "website.com,website2.com" in the "hosts" input
+    And user opens the "Add Port" submenu
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user types "8080" in the "addTargetPort0" input  
+    And user opens the "Add Port" submenu
+    And user types "8080" in the "addPortNumber1" input
+    And user types "foobar" in the "addPortName1" input
+    And user types "8080" in the "addTargetPort1" input
+    Then the preview button should be disabled

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -28,9 +28,20 @@ declare namespace Cypress {
   interface Chainable<Subject> {
     /**
      * Custom command to select DOM element by the 'data-test' attribute.
+     * @param selector the DOM element selector
+     * @param args the rest of DOM element args
      * @example cy.getBySel('greeting')
      */
     getBySel(selector: string, ...args: any): Chainable<Subject>;
+
+    /**
+     * Custom command to check text validation for inputs.
+     * @param id the input identifier
+     * @param text the text to validate
+     * @param valid check if the text must be valid or invalid
+     * @example cy.inputValidation('hostname','host',false)
+     */
+    inputValidation(id: string, text: string, valid: boolean): Chainable<Subject>;
 
     /**
      * Login to Kiali with the given username and password.
@@ -203,4 +214,10 @@ Cypress.Commands.add('login', (username: string, password: string) => {
   });
 });
 
-Cypress.Commands.add('getBySel', (selector: string, ...args) => cy.get(`[data-test="${selector}"]`, ...args));
+Cypress.Commands.add('getBySel', (selector: string, ...args: any) => cy.get(`[data-test="${selector}"]`, ...args));
+
+Cypress.Commands.add('inputValidation', (id: string, text: string, valid = true) => {
+  cy.get(`input[id="${id}"]`).type(text);
+  cy.get(`input[id="${id}"]`).should('have.attr', 'aria-invalid', `${!valid}`);
+  cy.get(`input[id="${id}"]`).clear();
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiali/kiali-ui",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
   "keywords": [
     "istio service mesh",

--- a/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
+++ b/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Form, FormGroup, FormSelect, FormSelectOption, Radio, Switch, TextInput } from '@patternfly/react-core';
 import { GATEWAY_TOOLTIP, wizardTooltip } from './WizardHelp';
 import { isValid } from 'utils/Common';
+import { isK8sGatewayHostValid } from '../../utils/IstioConfigUtils';
 
 type Props = {
   serviceName: string;
@@ -47,16 +48,10 @@ class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelectorState>
   }
 
   checkGwHosts = (gwHosts: string): boolean => {
-    const hosts = gwHosts.split(',');
-    for (let i = 0; i < hosts.length; i++) {
-      if (hosts[i] === '*') {
-        continue;
-      }
-      if (!hosts[i].includes('.')) {
-        return false;
-      }
-    }
-    return true;
+    // All k8s gateway hosts must be valid
+    return gwHosts.split(',').every(host => {
+      return isK8sGatewayHostValid(host);
+    });
   };
 
   onFormChange = (component: K8sGatewayForm, value: string) => {
@@ -180,7 +175,7 @@ class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelectorState>
                   fieldId="gwHosts"
                   label="K8s API Gateway Hosts"
                   helperText="One or more hosts exposed by this gateway. Enter one or multiple hosts separated by comma."
-                  helperTextInvalid="K8s API Gateway hosts should be specified using FQDN format or '*.' format."
+                  helperTextInvalid="K8s API Gateway hosts should be specified using FQDN format or '*.' format. IPs are not allowed."
                   validated={isValid(this.state.gwHostsValid)}
                 >
                   <TextInput

--- a/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
+++ b/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { K8sGatewaySelectorState } from './K8sGatewaySelector';
 import { isValid } from 'utils/Common';
-import { isGatewayHostValid } from '../../utils/IstioConfigUtils';
+import { isK8sGatewayHostValid } from '../../utils/IstioConfigUtils';
+
 type Props = {
+  valid: boolean;
   k8sRouteHosts: string[];
   gateway?: K8sGatewaySelectorState;
   onK8sRouteHostsChange: (valid: boolean, k8sRouteHosts: string[]) => void;
@@ -11,13 +13,10 @@ type Props = {
 
 class K8sRouteHosts extends React.Component<Props> {
   isK8sRouteHostsValid = (k8sRouteHosts: string[]): boolean => {
-    k8sRouteHosts.forEach(host => {
-      if (!isGatewayHostValid(host)) {
-        return false;
-      }
-      return true;
+    // All k8s route hosts must be valid
+    return k8sRouteHosts.every(host => {
+      return isK8sGatewayHostValid(host);
     });
-    return true;
   };
 
   render() {
@@ -27,9 +26,11 @@ class K8sRouteHosts extends React.Component<Props> {
         <FormGroup
           label="K8s HTTPRoute Hosts"
           fieldId="advanced-k8sRouteHosts"
-          validated={isValid(this.isK8sRouteHostsValid(this.props.k8sRouteHosts))}
+          validated={isValid(this.props.valid)}
           helperText="The route hosts to which traffic is being sent. Enter one or multiple hosts separated by comma."
-          helperTextInvalid={'IPs are not allowed. A hostname may be prefixed with a wildcard label (*.)'}
+          helperTextInvalid={
+            "K8s Route hosts should be specified using FQDN format or '*.' format. IPs are not allowed."
+          }
         >
           <TextInput
             value={k8sRouteHosts}
@@ -40,6 +41,7 @@ class K8sRouteHosts extends React.Component<Props> {
               const isValid = this.isK8sRouteHostsValid(k8sRouteHosts);
               this.props.onK8sRouteHostsChange(isValid, k8sRouteHosts);
             }}
+            validated={isValid(this.props.valid)}
           />
         </FormGroup>
       </Form>

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -881,6 +881,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
                 <Tab eventKey={0} title={'K8s HTTPRoute Hosts'}>
                   <div style={{ marginTop: '20px' }}>
                     <K8sRouteHosts
+                      valid={this.state.valid.k8sRouteHosts}
                       k8sRouteHosts={this.state.k8sRouteHosts}
                       gateway={this.state.gateway}
                       onK8sRouteHostsChange={this.onK8sRouteHosts}

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isGatewayHostValid } from '../../../utils/IstioConfigUtils';
+import { isK8sGatewayHostValid } from '../../../utils/IstioConfigUtils';
 import { Button, ButtonVariant, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
 import { isValid } from '../../../utils/Common';
 import { TrashIcon } from '@patternfly/react-icons';
@@ -24,7 +24,7 @@ export const isValidName = (name: string) => {
 };
 
 export const isValidHostname = (hostname: string) => {
-  return hostname !== undefined && hostname.length > 0 && isGatewayHostValid(hostname);
+  return hostname !== undefined && hostname.length > 0 && isK8sGatewayHostValid(hostname);
 };
 
 export const isValidPort = (port: string) => {
@@ -37,7 +37,7 @@ export const isValidSelector = (selector: string) => {
 
 class ListenerBuilder extends React.Component<Props> {
   isValidHost = (host: string): boolean => {
-    return isGatewayHostValid(host);
+    return isK8sGatewayHostValid(host);
   };
 
   onAddHostname = (value: string, _) => {

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -65,10 +65,20 @@ export const getIstioObject = (istioObjectDetails?: IstioConfigDetails | IstioCo
   return istioObject;
 };
 
+const k8sHostRegexp = /^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 const nsRegexp = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 const hostRegexp = /(?=^.{4,253}$)(^((?!-)(([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])|\*)\.)+[a-zA-Z]{2,63}$)/;
 const ipRegexp = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))?$/;
 const durationRegexp = /^[\d]+\.?[\d]*(h|m|s|ms)$/;
+
+// Gateway hosts have only dnsName
+export const isK8sGatewayHostValid = (k8sGatewayHost: string): boolean => {
+  if (k8sGatewayHost.length === 0) {
+    return false;
+  }
+
+  return k8sGatewayHost.search(k8sHostRegexp) === 0;
+};
 
 // Gateway hosts have namespace/dnsName with namespace optional
 export const isGatewayHostValid = (gatewayHost: string): boolean => {

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -71,9 +71,14 @@ const hostRegexp = /(?=^.{4,253}$)(^((?!-)(([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])|\*)\.
 const ipRegexp = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))?$/;
 const durationRegexp = /^[\d]+\.?[\d]*(h|m|s|ms)$/;
 
-// Gateway hosts have only dnsName
+// K8s gateway hosts have only dnsName
 export const isK8sGatewayHostValid = (k8sGatewayHost: string): boolean => {
   if (k8sGatewayHost.length < 1 && k8sGatewayHost.length > 253) {
+    return false;
+  }
+
+  // K8s gateway host must be fqdn but not ip address
+  if (k8sGatewayHost.split('.').length < 2 || k8sGatewayHost.search(ipRegexp) === 0) {
     return false;
   }
 

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -73,7 +73,7 @@ const durationRegexp = /^[\d]+\.?[\d]*(h|m|s|ms)$/;
 
 // Gateway hosts have only dnsName
 export const isK8sGatewayHostValid = (k8sGatewayHost: string): boolean => {
-  if (k8sGatewayHost.length === 0) {
+  if (k8sGatewayHost.length < 1 && k8sGatewayHost.length > 253) {
     return false;
   }
 

--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -270,7 +270,7 @@ SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPT_ROOT}
 
 # The default version of the crc tool to be downloaded
-DEFAULT_CRC_DOWNLOAD_VERSION="2.5.1"
+DEFAULT_CRC_DOWNLOAD_VERSION="2.13.1"
 
 # The default version of the crc bundle - this is typically the version included with the CRC download
 DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.10.18"


### PR DESCRIPTION
** Describe the change **

Applies different hostname validations for Istio Gateways and K8s Gateways:
- Istio Gateway hosts have namespace/dnsName with namespace optional (https://istio.io/latest/docs/reference/config/networking/gateway/)
- K8s Gateway hosts have only dnsName (https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.Hostname)

K8s gateway host validations obtained from K8s Gateway API library (shared_types.go):

// Hostname is the fully qualified domain name of a network host. This matches
// the RFC 1123 definition of a hostname with 2 notable exceptions:
//
// 1. IPs are not allowed.
// 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
//    label must appear by itself as the first label.
//
// Hostname can be "precise" which is a domain name without the terminating
// dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
// domain name prefixed with a single wildcard label (e.g. `*.example.com`).
//
// Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
// alphanumeric characters or '-', and must start and end with an alphanumeric
// character. No other punctuation is allowed.
//
// +kubebuilder:validation:MinLength=1
// +kubebuilder:validation:MaxLength=253
// +kubebuilder:validation:Pattern=`^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
type Hostname string

** Issue reference **

Fixes #5802 

** Testing **

Checks that valid hostnames in Istio Gateways are no longer valid in K8s Gateways, like for example:
- \*
- test/test.test
- test/*
- TEST.test