### PR TITLE
Add new option to skip KIA0301 for Gateways with wildcard hosts.

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/intutil"
 )
@@ -148,10 +149,12 @@ func (m MultiMatchChecker) findMatch(host Host, selector string) (bool, []Host) 
 			// only compare hosts that share the target namespace or hosts where at least one of the pair is exported to all namespaces
 			if h.TargetNamespace == targetNamespaceAll || host.TargetNamespace == targetNamespaceAll || h.TargetNamespace == host.TargetNamespace {
 				if h.Port == host.Port {
-					// wildcardMatches will always match
+					// wildcardMatches will always match unless SkipWildcardGatewayHosts is set 'true'
 					if host.Hostname == wildCardMatch || h.Hostname == wildCardMatch {
-						duplicates = append(duplicates, host)
-						duplicates = append(duplicates, h)
+						if !config.Get().KialiFeatureFlags.Validations.SkipWildcardGatewayHosts {
+							duplicates = append(duplicates, host)
+							duplicates = append(duplicates, h)
+						}
 						continue
 					}
 

--- a/config/config.go
+++ b/config/config.go
@@ -418,7 +418,8 @@ type UIDefaults struct {
 
 // Validations defines default settings configured for the Validations subsystem
 type Validations struct {
-	Ignore []string `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+	Ignore                   []string `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+	SkipWildcardGatewayHosts bool     `yaml:"skip_wildcard_gateway_hosts,omitempty"`
 }
 
 // CertificatesInformationIndicators defines configuration to enable the feature and to grant read permissions to a list of secrets


### PR DESCRIPTION
RFE: https://github.com/kiali/kiali/issues/5711

Added new option "skip_wildcard_gateway_hosts" to skip "KIA0301 More than one Gateway for the same host port combination" validation for Gateways with wildcard in hostname.

![Screenshot from 2023-02-23 13-05-02](https://user-images.githubusercontent.com/604313/220900841-359ddcd9-2098-42d2-8a84-4b297e3f9f1b.png)
![Screenshot from 2023-02-23 13-04-45](https://user-images.githubusercontent.com/604313/220900851-d8584d29-223f-4f31-8f5b-8131bf4d3fd9.png)

How to test:
Create 3 Gateways:
1. Hostname: host.com
2. Hostname: *
3. Hostname: host.com
Verify that all 3 Gateways are showing warning and references to each other.
Change "skip_wildcard_gateway_hosts: true"
Verify that Gateway number 2 with wildcard is not in validation warnings and references anymore.