### PR TITLE
document how to upgrade the project to a new Go version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -342,6 +342,16 @@ spec:
 
 == Additional Notes
 
+=== Upgrading Go
+
+The Kiali project will periodically upgrade to a newer version of Go. These are the steps that need to be performed in order for the Kiali build to use a different version of Go:
+
+1. In the top link:./Makefile[Makefile], change the value of the variable `GO_VERSION_KIALI` to the new Go version (use a z-stream version: "x.y.z").
+2. Run `go mod edit -go=x.y` where "x" and "y" are the major/minor versions of the Go version being used.
+3. Run `go mod tidy -v`
+4. Run `make clean build build-ui test` to ensure everything builds correctly. If any problems occur, obviously you must fix them.
+5. Commit the changes to your working branch, create a PR, and make sure everything builds and works before merging the PR.
+
 === Running the UI outside the cluster
 
 When developing the http://github.com/kiali/kiali/frontend[Kiali UI] you will find it useful to run it outside of the cluster to make it easier to update the UI code and see the changes without having to re-deploy. The preferred approach for this is to use the _proxy_ feature of React. The process is described https://github.com/kiali/kiali/blob/master/frontend/README.adoc#developing[here]. Alternatively, you can use the `make -e YARN_START_URL=<url> yarn-start` command where `<url>` is to the Kiali backend.


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/5818

This is the new section: https://github.com/kiali/kiali/blob/177125ebcd374b431b5fa7787f44aa5745bbe491/README.adoc#upgrading-go