### PR TITLE
Navigate to the proper subtab for route links in the envoy listener list

### DIFF
--- a/frontend/src/helpers/EnvoyHelpers.tsx
+++ b/frontend/src/helpers/EnvoyHelpers.tsx
@@ -37,7 +37,10 @@ export const routeLink = (
     if (result && result[1]) {
       return (
         <React.Fragment>
-          <Link onClick={handler} to={`/namespaces/${namespace}/workloads/${workload}?tab=envoy&name=${result[1]}`}>
+          <Link
+            onClick={handler}
+            to={`/namespaces/${namespace}/workloads/${workload}?tab=envoy&envoyTab=routes&name=${result[1]}`}
+          >
             {route}
           </Link>
         </React.Fragment>


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/5871

To Test:
1. Navigate to a workload detail (I used hotels-v1 in travel demo)
2. Click `Listeners` Tab
3. Click on a route link in the `Destination` column
4. It should navigate to a filtered route and the `Routes` tab should be highlighted