### PR TITLE
Beautify render error message

### DIFF
--- a/frontend/src/components/Nav/RenderPage.tsx
+++ b/frontend/src/components/Nav/RenderPage.tsx
@@ -5,10 +5,13 @@ import { pathRoutes, defaultRoute } from '../../routes';
 import { Path } from '../../types/Routes';
 import { style } from 'typestyle';
 import { PFColors } from '../Pf/PfColors';
+import { Button, ButtonVariant, EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { KialiIcon } from 'config/KialiIcon';
 
 const containerStyle = style({ marginLeft: 0, marginRight: 0 });
 const containerPadding = style({ padding: '0 20px 0 20px' });
 const containerGray = style({ background: PFColors.Black150 });
+const containerError = style({ height: 'calc(100vh - 76px)' });
 
 class RenderPage extends React.Component<{ isGraph: boolean }> {
   renderPaths(paths: Path[]) {
@@ -21,7 +24,22 @@ class RenderPage extends React.Component<{ isGraph: boolean }> {
     const component = (
       <div className={`${containerStyle} ${this.props.isGraph && containerPadding}`}>
         <SwitchErrorBoundary
-          fallBackComponent={() => <h2>Sorry, there was a problem. Try a refresh or navigate to a different page.</h2>}
+          fallBackComponent={() => (
+            <EmptyState className={containerError} variant="large">
+              <EmptyStateIcon icon={KialiIcon.Error} />
+              <Title headingLevel="h1" size="2xl">
+                Something went wrong
+              </Title>
+              <EmptyStateBody>
+                <p style={{ marginBottom: 'var(--pf-global--spacer--lg)' }}>
+                  Sorry, there was a problem. Try a refresh or navigate to a different page.
+                </p>
+                <Button variant={ButtonVariant.primary} onClick={() => history.back()}>
+                  Return to last page
+                </Button>
+              </EmptyStateBody>
+            </EmptyState>
+          )}
         >
           {this.renderPaths(pathRoutes)}
           <Redirect from="/" to={defaultRoute} />


### PR DESCRIPTION
** Describe the change **

Convert simple render error message to a more visual one (adding error icon and return to last page button).

![image](https://user-images.githubusercontent.com/122779323/221857013-b5574adc-76e4-43ef-95a6-b4f074b8a028.png)


** Issue reference **

Closes #5862 

** Testing **

Just adding `throw new Error()` in componentDidMount() method of any rendered page (e.g., OverviewPage) to cause an intentional error and see the error message.