### PR TITLE
Don't let the graph generation panic on unexpected/corrupt telemetry.

### DIFF
--- a/graph/api/api.go
+++ b/graph/api/api.go
@@ -87,7 +87,7 @@ func graphNodeIstio(ctx context.Context, business *business.Layer, client *prome
 	globalInfo.Business = business
 	globalInfo.Context = ctx
 
-	trafficMap := istio.BuildNodeTrafficMap(o.TelemetryOptions, client, globalInfo)
+	trafficMap, _ := istio.BuildNodeTrafficMap(o.TelemetryOptions, client, globalInfo)
 	code, config = generateGraph(trafficMap, o)
 
 	return code, config

--- a/graph/config/cytoscape/cytoscape_test.go
+++ b/graph/config/cytoscape/cytoscape_test.go
@@ -89,9 +89,9 @@ func TestHasWorkloadEntryAddedToGraph(t *testing.T) {
 
 	traffic := graph.NewTrafficMap()
 
-	n0 := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	n0.Metadata[graph.HasWorkloadEntry] = []graph.WEInfo{{Name: "ratings-v1"}}
-	traffic[n0.ID] = &n0
+	traffic[n0.ID] = n0
 	cytoConfig := NewConfig(traffic, graph.ConfigOptions{})
 
 	cytoNode := cytoConfig.Elements.Nodes[0]
@@ -103,8 +103,8 @@ func TestHasWorkloadEntryEmpty(t *testing.T) {
 
 	traffic := graph.NewTrafficMap()
 
-	n0 := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
-	traffic[n0.ID] = &n0
+	n0, _ := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	traffic[n0.ID] = n0
 	cytoConfig := NewConfig(traffic, graph.ConfigOptions{})
 
 	cytoNode := cytoConfig.Elements.Nodes[0]
@@ -116,13 +116,13 @@ func TestHTTPToTrafficRate(t *testing.T) {
 
 	traffic := graph.NewTrafficMap()
 
-	svc := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "", "ratings", "", graph.GraphTypeVersionedApp)
-	traffic[svc.ID] = &svc
+	svc, _ := graph.NewNode("testCluster", "appNamespace", "ratings", "appNamespace", "", "ratings", "", graph.GraphTypeVersionedApp)
+	traffic[svc.ID] = svc
 
-	v1 := graph.NewNode("testCluster", "appNamespace", "", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
-	traffic[v1.ID] = &v1
+	v1, _ := graph.NewNode("testCluster", "appNamespace", "", "appNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	traffic[v1.ID] = v1
 
-	e := svc.AddEdge(&v1)
+	e := svc.AddEdge(v1)
 	e.Metadata[graph.HTTP.EdgeResponses] = graph.Responses{
 		"200": &graph.ResponseDetail{
 			Flags: graph.ResponseFlags{

--- a/graph/telemetry/istio/appender/aggregate_node.go
+++ b/graph/telemetry/istio/appender/aggregate_node.go
@@ -201,7 +201,7 @@ func (a AggregateNodeAppender) injectAggregates(trafficMap graph.TrafficMap, vec
 		val := float64(s.Value)
 
 		// inject aggregate node between source and destination
-		sourceID, _ := graph.Id(sourceCluster, sourceWlNs, "", sourceWlNs, sourceWl, sourceApp, sourceVer, a.GraphType)
+		sourceID, _, _ := graph.Id(sourceCluster, sourceWlNs, "", sourceWlNs, sourceWl, sourceApp, sourceVer, a.GraphType)
 		sourceNode, sourceFound := trafficMap[sourceID]
 		if !sourceFound {
 			log.Debugf("Expected source [%s] node not found in traffic map. Skipping aggregate injection [%s]", sourceID, aggregate)
@@ -214,9 +214,9 @@ func (a AggregateNodeAppender) injectAggregates(trafficMap graph.TrafficMap, vec
 		// else show the independent aggregation by using the workload/app node as the dest
 		destID := ""
 		if a.InjectServiceNodes {
-			destID, _ = graph.Id(destCluster, destSvcNs, destSvcName, "", "", "", "", a.GraphType) // service
+			destID, _, _ = graph.Id(destCluster, destSvcNs, destSvcName, "", "", "", "", a.GraphType) // service
 		} else {
-			destID, _ = graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType) // wl/app
+			destID, _, _ = graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType) // wl/app
 		}
 		destNode, destFound := trafficMap[destID]
 		if !destFound {

--- a/graph/telemetry/istio/appender/aggregate_node_test.go
+++ b/graph/telemetry/istio/appender/aggregate_node_test.go
@@ -71,7 +71,7 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -198,7 +198,7 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(false)
-	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -293,7 +293,7 @@ func TestNodeGraphWithServiceInjection(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -405,7 +405,7 @@ func TestNamespacesGraphWithServiceInjectionSkipRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -482,7 +482,7 @@ func TestNodeGraphNoServiceInjection(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(false)
-	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -563,7 +563,7 @@ func TestNodeGraphWithServiceInjectionSkipRates(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -608,19 +608,19 @@ func TestNodeGraphWithServiceInjectionSkipRates(t *testing.T) {
 }
 
 func aggregateNodeTestTraffic(injectServices bool) graph.TrafficMap {
-	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviews := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviews, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
 
 	trafficMap := graph.NewTrafficMap()
-	trafficMap[productpage.ID] = &productpage
-	trafficMap[reviews.ID] = &reviews
+	trafficMap[productpage.ID] = productpage
+	trafficMap[reviews.ID] = reviews
 	if injectServices {
-		trafficMap[reviewsService.ID] = &reviewsService
-		productpage.AddEdge(&reviewsService)
-		reviewsService.AddEdge(&reviews)
+		trafficMap[reviewsService.ID] = reviewsService
+		productpage.AddEdge(reviewsService)
+		reviewsService.AddEdge(reviews)
 	} else {
-		productpage.AddEdge(&reviews)
+		productpage.AddEdge(reviews)
 	}
 
 	return trafficMap

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -116,13 +116,13 @@ func TestDeadNode(t *testing.T) {
 	trafficMap := testTrafficMap()
 
 	assert.Equal(12, len(trafficMap))
-	unknownID, _ := graph.Id(business.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ := graph.Id(business.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found := trafficMap[unknownID]
 	assert.Equal(true, found)
 	assert.Equal(graph.Unknown, unknownNode.Workload)
 	assert.Equal(10, len(unknownNode.Edges))
 
-	ingressID, _ := graph.Id(business.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(business.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingressNode, found := trafficMap[ingressID]
 	assert.Equal(true, found)
 	assert.Equal("istio-ingressgateway", ingressNode.Workload)
@@ -152,7 +152,7 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal("testNodeWithTcpSentTraffic-v1", ingressNode.Edges[5].Dest.Workload)
 	assert.Equal("testNodeWithTcpSentOutTraffic-v1", ingressNode.Edges[6].Dest.Workload)
 
-	id, _ := graph.Id(business.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	id, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 	noPodsNoTraffic, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	isDead, ok := noPodsNoTraffic.Metadata[graph.IsDead]
@@ -160,7 +160,7 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal(true, isDead)
 
 	// Check that external services are not removed
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	_, okExternal := trafficMap[id]
 	assert.Equal(true, okExternal)
 }
@@ -168,92 +168,92 @@ func TestDeadNode(t *testing.T) {
 func testTrafficMap() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode(business.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(business.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n00 := graph.NewNode(business.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	n00, _ := graph.NewNode(business.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	n00.Metadata["httpOut"] = 4.8
 
-	n1 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n1.Metadata["httpIn"] = 0.8
 
-	n2 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsNoTraffic", "testNamespace", "testPodsNoTraffic-v1", "testPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsNoTraffic", "testNamespace", "testPodsNoTraffic-v1", "testPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n3 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoPodsWithTraffic", "testNamespace", "testNoPodsWithTraffic-v1", "testNoPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n3, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoPodsWithTraffic", "testNamespace", "testNoPodsWithTraffic-v1", "testNoPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n3.Metadata["httpIn"] = 0.8
 
-	n4 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n4, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n5 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoDeploymentWithTraffic", "testNamespace", "testNoDeploymentWithTraffic-v1", "testNoDeploymentWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n5, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoDeploymentWithTraffic", "testNamespace", "testNoDeploymentWithTraffic-v1", "testNoDeploymentWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n5.Metadata["httpIn"] = 0.8
 
-	n6 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoDeploymentNoTraffic", "testNamespace", "testNoDeploymentNoTraffic-v1", "testNoDeploymentNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n6, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoDeploymentNoTraffic", "testNamespace", "testNoDeploymentNoTraffic-v1", "testNoDeploymentNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n7 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNodeWithTcpSentTraffic", "testNamespace", "testNodeWithTcpSentTraffic-v1", "testNodeWithTcpSentTraffic", "v1", graph.GraphTypeVersionedApp)
+	n7, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNodeWithTcpSentTraffic", "testNamespace", "testNodeWithTcpSentTraffic-v1", "testNodeWithTcpSentTraffic", "v1", graph.GraphTypeVersionedApp)
 	n7.Metadata["tcpIn"] = 74.1
 
-	n8 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNodeWithTcpSentOutTraffic", "testNamespace", "testNodeWithTcpSentOutTraffic-v1", "testNodeWithTcpSentOutTraffic", "v1", graph.GraphTypeVersionedApp)
+	n8, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNodeWithTcpSentOutTraffic", "testNamespace", "testNodeWithTcpSentOutTraffic-v1", "testNodeWithTcpSentOutTraffic", "v1", graph.GraphTypeVersionedApp)
 	n8.Metadata["tcpOut"] = 74.1
 
-	n9 := graph.NewNode(business.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n9, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n9.Metadata["httpIn"] = 0.8
 	n9.Metadata[graph.IsServiceEntry] = &graph.SEInfo{
 		Location: "MESH_EXTERNAL",
 	}
 
-	n10 := graph.NewNode(business.DefaultClusterID, "testNamespace", "egress.not.defined", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n10, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "egress.not.defined", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n10.Metadata["httpIn"] = 0.8
 
-	trafficMap[n0.ID] = &n0
-	trafficMap[n00.ID] = &n00
-	trafficMap[n1.ID] = &n1
-	trafficMap[n2.ID] = &n2
-	trafficMap[n3.ID] = &n3
-	trafficMap[n4.ID] = &n4
-	trafficMap[n5.ID] = &n5
-	trafficMap[n6.ID] = &n6
-	trafficMap[n7.ID] = &n7
-	trafficMap[n8.ID] = &n8
-	trafficMap[n9.ID] = &n9
-	trafficMap[n10.ID] = &n10
+	trafficMap[n0.ID] = n0
+	trafficMap[n00.ID] = n00
+	trafficMap[n1.ID] = n1
+	trafficMap[n2.ID] = n2
+	trafficMap[n3.ID] = n3
+	trafficMap[n4.ID] = n4
+	trafficMap[n5.ID] = n5
+	trafficMap[n6.ID] = n6
+	trafficMap[n7.ID] = n7
+	trafficMap[n8.ID] = n8
+	trafficMap[n9.ID] = n9
+	trafficMap[n10.ID] = n10
 
-	n0.AddEdge(&n1)
-	e := n00.AddEdge(&n1)
+	n0.AddEdge(n1)
+	e := n00.AddEdge(n1)
 	e.Metadata["http"] = 0.8
 
-	n0.AddEdge(&n2)
-	e = n00.AddEdge(&n2)
+	n0.AddEdge(n2)
+	e = n00.AddEdge(n2)
 	e.Metadata["http"] = 0.8
 
-	n0.AddEdge(&n3)
-	e = n00.AddEdge(&n3)
+	n0.AddEdge(n3)
+	e = n00.AddEdge(n3)
 	e.Metadata["http"] = 0.8
 
-	n0.AddEdge(&n4)
-	e = n00.AddEdge(&n4)
+	n0.AddEdge(n4)
+	e = n00.AddEdge(n4)
 	e.Metadata["http"] = 0.0
 
-	n0.AddEdge(&n5)
-	e = n00.AddEdge(&n5)
+	n0.AddEdge(n5)
+	e = n00.AddEdge(n5)
 	e.Metadata["http"] = 0.8
 
-	n0.AddEdge(&n6)
-	e = n00.AddEdge(&n6)
+	n0.AddEdge(n6)
+	e = n00.AddEdge(n6)
 	e.Metadata["http"] = 0.0
 
-	n0.AddEdge(&n7)
-	e = n00.AddEdge(&n7)
+	n0.AddEdge(n7)
+	e = n00.AddEdge(n7)
 	e.Metadata["tcp"] = 74.1
 
-	n0.AddEdge(&n8)
-	e = n00.AddEdge(&n8)
+	n0.AddEdge(n8)
+	e = n00.AddEdge(n8)
 	e.Metadata["tcp"] = 74.1
 
-	n0.AddEdge(&n9)
-	e = n00.AddEdge(&n9)
+	n0.AddEdge(n9)
+	e = n00.AddEdge(n9)
 	e.Metadata["http"] = 0.8
 
-	n0.AddEdge(&n10)
-	e = n00.AddEdge(&n10)
+	n0.AddEdge(n10)
+	e = n00.AddEdge(n10)
 	e.Metadata["http"] = 0.8
 
 	return trafficMap
@@ -266,17 +266,17 @@ func TestDeadNodeIssue2783(t *testing.T) {
 	trafficMap := testTrafficMapIssue2783()
 
 	assert.Equal(3, len(trafficMap))
-	aID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	aID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
 	aNode, found := trafficMap[aID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(aNode.Edges))
 
-	bSvcID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	bSvcID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	bSvcNode, found := trafficMap[bSvcID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(bSvcNode.Edges))
 
-	bID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	bID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 	bNode, found := trafficMap[bID]
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
@@ -295,18 +295,18 @@ func TestDeadNodeIssue2783(t *testing.T) {
 func testTrafficMapIssue2783() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode(business.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
 
-	n1 := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n2 := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 
-	trafficMap[n0.ID] = &n0
-	trafficMap[n1.ID] = &n1
-	trafficMap[n2.ID] = &n2
+	trafficMap[n0.ID] = n0
+	trafficMap[n1.ID] = n1
+	trafficMap[n2.ID] = n2
 
-	n0.AddEdge(&n1)
-	n1.AddEdge(&n2)
+	n0.AddEdge(n1)
+	n1.AddEdge(n2)
 
 	return trafficMap
 }
@@ -318,17 +318,17 @@ func TestDeadNodeIssue2982(t *testing.T) {
 	trafficMap := testTrafficMapIssue2982()
 
 	assert.Equal(3, len(trafficMap))
-	aID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	aID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "a", "v1", graph.GraphTypeVersionedApp)
 	aNode, found := trafficMap[aID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(aNode.Edges))
 
-	bSvcID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	bSvcID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	bSvcNode, found := trafficMap[bSvcID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(bSvcNode.Edges))
 
-	bID, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	bID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 	bNode, found := trafficMap[bID]
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
@@ -349,19 +349,19 @@ func TestDeadNodeIssue2982(t *testing.T) {
 func testTrafficMapIssue2982() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n0.Metadata["httpIn"] = 0.8
 
-	n1 := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n2 := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 
-	trafficMap[n0.ID] = &n0
-	trafficMap[n1.ID] = &n1
-	trafficMap[n2.ID] = &n2
+	trafficMap[n0.ID] = n0
+	trafficMap[n1.ID] = n1
+	trafficMap[n2.ID] = n2
 
-	n0.AddEdge(&n1)
-	n1.AddEdge(&n2)
+	n0.AddEdge(n1)
+	n1.AddEdge(n2)
 
 	return trafficMap
 }

--- a/graph/telemetry/istio/appender/health_test.go
+++ b/graph/telemetry/istio/appender/health_test.go
@@ -442,8 +442,8 @@ func TestIdleNodesHaveHealthData(t *testing.T) {
 
 	config.Set(config.NewConfig())
 	trafficMap := make(graph.TrafficMap)
-	idleNode := graph.NewNode("cluster-default", "testNamespace", "svc", "", "", "", "v1", graph.GraphTypeVersionedApp)
-	trafficMap[idleNode.ID] = &idleNode
+	idleNode, _ := graph.NewNode("cluster-default", "testNamespace", "svc", "", "", "", "v1", graph.GraphTypeVersionedApp)
+	trafficMap[idleNode.ID] = idleNode
 	idleNode.Metadata[graph.IsIdle] = true
 	idleNode.Metadata[graph.IsInaccessible] = true
 	businessLayer := setupHealthConfig(buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))

--- a/graph/telemetry/istio/appender/idle_node.go
+++ b/graph/telemetry/istio/appender/idle_node.go
@@ -70,14 +70,14 @@ func (a IdleNodeAppender) buildIdleNodeTrafficMap(trafficMap graph.TrafficMap, c
 	idleNodeTrafficMap := graph.NewTrafficMap()
 
 	for _, s := range services {
-		id, nodeType := graph.Id(cluster, namespace, s.Name, "", "", "", "", a.GraphType)
+		id, nodeType, _ := graph.Id(cluster, namespace, s.Name, "", "", "", "", a.GraphType)
 		if _, found := trafficMap[id]; !found {
 			if _, found = idleNodeTrafficMap[id]; !found {
 				log.Tracef("Adding idle node for service [%s]", s.Name)
 				node := graph.NewNodeExplicit(id, cluster, namespace, "", "", "", s.Name, nodeType, a.GraphType)
 				// note: we don't know what the protocol really should be, http is most common, it's a dead edge anyway
 				node.Metadata = graph.Metadata{"httpIn": 0.0, "httpOut": 0.0, graph.IsIdle: true}
-				idleNodeTrafficMap[id] = &node
+				idleNodeTrafficMap[id] = node
 			}
 		}
 	}
@@ -95,14 +95,14 @@ func (a IdleNodeAppender) buildIdleNodeTrafficMap(trafficMap graph.TrafficMap, c
 		if v, ok := labels[versionLabel]; ok {
 			version = v
 		}
-		id, nodeType := graph.Id(cluster, "", "", namespace, w.Name, app, version, a.GraphType)
+		id, nodeType, _ := graph.Id(cluster, "", "", namespace, w.Name, app, version, a.GraphType)
 		if _, found := trafficMap[id]; !found {
 			if _, found = idleNodeTrafficMap[id]; !found {
 				log.Tracef("Adding idle node for workload [%s] with labels [%v]", w.Name, labels)
 				node := graph.NewNodeExplicit(id, cluster, namespace, w.Name, app, version, "", nodeType, a.GraphType)
 				// note: we don't know what the protocol really should be, http is most common, it's a dead edge anyway
 				node.Metadata = graph.Metadata{"httpIn": 0.0, "httpOut": 0.0, graph.IsIdle: true}
-				idleNodeTrafficMap[id] = &node
+				idleNodeTrafficMap[id] = node
 			}
 		}
 	}

--- a/graph/telemetry/istio/appender/idle_node_test.go
+++ b/graph/telemetry/istio/appender/idle_node_test.go
@@ -30,7 +30,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	a.addIdleNodes(trafficMap, business.DefaultClusterID, "testNamespace", services, workloads)
 	assert.Equal(7, len(trafficMap))
 
-	id, _ := graph.Id(business.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	id, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
 	n, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("customer-v1", n.Workload)
@@ -38,7 +38,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("preference-v1", n.Workload)
@@ -46,7 +46,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v1", n.Workload)
@@ -54,7 +54,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v2", n.Workload)
@@ -62,21 +62,21 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v2", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "customer", "", "", "", "", a.GraphType)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "customer", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
 	assert.Equal("customer", n.Service)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "", "", "", "", a.GraphType)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
 	assert.Equal("preference", n.Service)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "", "", "", "", a.GraphType)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
@@ -102,7 +102,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	a.addIdleNodes(trafficMap, business.DefaultClusterID, "testNamespace", services, workloads)
 
 	assert.Equal(5, len(trafficMap))
-	id, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	id, _, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
 	unknown, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.Unknown, unknown.Workload)
@@ -116,7 +116,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(nil, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("preference-v1", n.Workload)
@@ -124,7 +124,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v1", n.Workload)
@@ -132,7 +132,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
+	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v2", n.Workload)
@@ -161,7 +161,7 @@ func TestVersionWithNoTrafficScenario(t *testing.T) {
 	a.addIdleNodes(trafficMap, cluster, "testNamespace", services, workloads)
 
 	assert.Equal(5, len(trafficMap))
-	id, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	id, _, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
 	unknown, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.Unknown, unknown.Workload)
@@ -253,11 +253,11 @@ func mockWorkloads(a IdleNodeAppender) []models.WorkloadListItem {
 func (a *IdleNodeAppender) oneNodeTraffic() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	unknown := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
-	customer := graph.NewNode(business.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
-	trafficMap[unknown.ID] = &unknown
-	trafficMap[customer.ID] = &customer
-	edge := unknown.AddEdge(&customer)
+	unknown, _ := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	customer, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	trafficMap[unknown.ID] = unknown
+	trafficMap[customer.ID] = customer
+	edge := unknown.AddEdge(customer)
 	edge.Metadata["httpIn"] = 0.8
 	unknown.Metadata["httpOut"] = 0.8
 	customer.Metadata["httpIn"] = 0.8
@@ -268,28 +268,28 @@ func (a *IdleNodeAppender) oneNodeTraffic() map[string]*graph.Node {
 func (a *IdleNodeAppender) v1Traffic(cluster string) map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	unknown := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
-	customer := graph.NewNode(cluster, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
-	preference := graph.NewNode(cluster, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
-	recommendation := graph.NewNode(cluster, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
-	trafficMap[unknown.ID] = &unknown
-	trafficMap[customer.ID] = &customer
-	trafficMap[preference.ID] = &preference
-	trafficMap[recommendation.ID] = &recommendation
+	unknown, _ := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
+	customer, _ := graph.NewNode(cluster, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	preference, _ := graph.NewNode(cluster, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	recommendation, _ := graph.NewNode(cluster, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	trafficMap[unknown.ID] = unknown
+	trafficMap[customer.ID] = customer
+	trafficMap[preference.ID] = preference
+	trafficMap[recommendation.ID] = recommendation
 
 	// unknown --> customer --> preference --> recommendation
 
-	edge := unknown.AddEdge(&customer)
+	edge := unknown.AddEdge(customer)
 	edge.Metadata["http"] = 0.8
 	unknown.Metadata["httpOut"] = 0.8
 	customer.Metadata["httpIn"] = 0.8
 
-	edge = customer.AddEdge(&preference)
+	edge = customer.AddEdge(preference)
 	edge.Metadata["http"] = 0.8
 	customer.Metadata["httpOut"] = 0.8
 	preference.Metadata["httpIn"] = 0.8
 
-	edge = preference.AddEdge(&recommendation)
+	edge = preference.AddEdge(recommendation)
 	edge.Metadata["http"] = 0.8
 	preference.Metadata["httpOut"] = 0.8
 	recommendation.Metadata["httpIn"] = 0.8

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -20,27 +20,27 @@ import (
 func setupTrafficMap() (map[string]*graph.Node, string, string, string, string, string, string) {
 	trafficMap := graph.NewTrafficMap()
 
-	appNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
+	appNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
 	appNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
-	trafficMap[appNode.ID] = &appNode
+	trafficMap[appNode.ID] = appNode
 
-	appNodeV1 := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	appNodeV1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	appNodeV1.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
-	trafficMap[appNodeV1.ID] = &appNodeV1
+	trafficMap[appNodeV1.ID] = appNodeV1
 
-	appNodeV2 := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
+	appNodeV2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
 	appNodeV2.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
-	trafficMap[appNodeV2.ID] = &appNodeV2
+	trafficMap[appNodeV2.ID] = appNodeV2
 
-	serviceNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
-	trafficMap[serviceNode.ID] = &serviceNode
+	serviceNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	trafficMap[serviceNode.ID] = serviceNode
 
-	workloadNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+	workloadNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
 	workloadNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
-	trafficMap[workloadNode.ID] = &workloadNode
+	trafficMap[workloadNode.ID] = workloadNode
 
-	fooServiceNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
-	trafficMap[fooServiceNode.ID] = &fooServiceNode
+	fooServiceNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	trafficMap[fooServiceNode.ID] = fooServiceNode
 
 	return trafficMap, appNode.ID, appNodeV1.ID, appNodeV2.ID, serviceNode.ID, workloadNode.ID, fooServiceNode.ID
 }
@@ -306,13 +306,13 @@ func TestSEInAppBox(t *testing.T) {
 	businessLayer := business.NewWithBackends(k8s, nil, nil)
 
 	trafficMap := graph.NewTrafficMap()
-	serviceEntryNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
+	serviceEntryNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
 	serviceEntryNode.Metadata[graph.IsServiceEntry] = &graph.SEInfo{
 		Hosts:     []string{"foobar.com"},
 		Location:  "MESH_INTERNAL",
 		Namespace: "testNamespace",
 	}
-	trafficMap[serviceEntryNode.ID] = &serviceEntryNode
+	trafficMap[serviceEntryNode.ID] = serviceEntryNode
 
 	globalInfo := graph.NewAppenderGlobalInfo()
 	globalInfo.Business = businessLayer

--- a/graph/telemetry/istio/appender/labeler_test.go
+++ b/graph/telemetry/istio/appender/labeler_test.go
@@ -21,20 +21,20 @@ import (
 func setupLabelerTrafficMap() (map[string]*graph.Node, string, string, string, string, string) {
 	trafficMap := graph.NewTrafficMap()
 
-	appNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", graph.Unknown, "test", "", graph.GraphTypeVersionedApp)
-	trafficMap[appNode.ID] = &appNode
+	appNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", graph.Unknown, "test", "", graph.GraphTypeVersionedApp)
+	trafficMap[appNode.ID] = appNode
 
-	appNodeV1 := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v1", "test", "v1", graph.GraphTypeVersionedApp)
-	trafficMap[appNodeV1.ID] = &appNodeV1
+	appNodeV1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v1", "test", "v1", graph.GraphTypeVersionedApp)
+	trafficMap[appNodeV1.ID] = appNodeV1
 
-	appNodeV2 := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v2", "test", "v2", graph.GraphTypeVersionedApp)
-	trafficMap[appNodeV2.ID] = &appNodeV2
+	appNodeV2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v2", "test", "v2", graph.GraphTypeVersionedApp)
+	trafficMap[appNodeV2.ID] = appNodeV2
 
-	serviceNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
-	trafficMap[serviceNode.ID] = &serviceNode
+	serviceNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	trafficMap[serviceNode.ID] = serviceNode
 
-	workloadNode := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
-	trafficMap[workloadNode.ID] = &workloadNode
+	workloadNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+	trafficMap[workloadNode.ID] = workloadNode
 
 	return trafficMap, appNode.ID, appNodeV1.ID, appNodeV2.ID, serviceNode.ID, workloadNode.ID
 }

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -194,7 +194,7 @@ func TestResponseTimeP95(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -467,7 +467,7 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -740,7 +740,7 @@ func TestResponseTimeAvg(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -831,33 +831,33 @@ func TestResponseTimeAvg(t *testing.T) {
 }
 
 func responseTimeTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
-	reviewsV1 := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsV2 := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
-	ratingsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
-	ratings := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	reviewsV1, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsV2, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
+	ratingsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
+	ratings, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
-	trafficMap[ingress.ID] = &ingress
-	trafficMap[productpageService.ID] = &productpageService
-	trafficMap[productpage.ID] = &productpage
-	trafficMap[reviewsService.ID] = &reviewsService
-	trafficMap[reviewsV1.ID] = &reviewsV1
-	trafficMap[reviewsV2.ID] = &reviewsV2
-	trafficMap[ratingsService.ID] = &ratingsService
-	trafficMap[ratings.ID] = &ratings
+	trafficMap[ingress.ID] = ingress
+	trafficMap[productpageService.ID] = productpageService
+	trafficMap[productpage.ID] = productpage
+	trafficMap[reviewsService.ID] = reviewsService
+	trafficMap[reviewsV1.ID] = reviewsV1
+	trafficMap[reviewsV2.ID] = reviewsV2
+	trafficMap[ratingsService.ID] = ratingsService
+	trafficMap[ratings.ID] = ratings
 
-	ingress.AddEdge(&productpageService).Metadata[graph.ProtocolKey] = "http"
-	productpageService.AddEdge(&productpage).Metadata[graph.ProtocolKey] = "http"
-	productpage.AddEdge(&reviewsService).Metadata[graph.ProtocolKey] = "http"
-	reviewsService.AddEdge(&reviewsV1).Metadata[graph.ProtocolKey] = "http"
-	reviewsService.AddEdge(&reviewsV2).Metadata[graph.ProtocolKey] = "http"
-	reviewsV1.AddEdge(&ratingsService).Metadata[graph.ProtocolKey] = "http"
-	reviewsV2.AddEdge(&ratingsService).Metadata[graph.ProtocolKey] = "http"
-	ratingsService.AddEdge(&ratings).Metadata[graph.ProtocolKey] = "http"
+	ingress.AddEdge(productpageService).Metadata[graph.ProtocolKey] = "http"
+	productpageService.AddEdge(productpage).Metadata[graph.ProtocolKey] = "http"
+	productpage.AddEdge(reviewsService).Metadata[graph.ProtocolKey] = "http"
+	reviewsService.AddEdge(reviewsV1).Metadata[graph.ProtocolKey] = "http"
+	reviewsService.AddEdge(reviewsV2).Metadata[graph.ProtocolKey] = "http"
+	reviewsV1.AddEdge(ratingsService).Metadata[graph.ProtocolKey] = "http"
+	reviewsV2.AddEdge(ratingsService).Metadata[graph.ProtocolKey] = "http"
+	ratingsService.AddEdge(ratings).Metadata[graph.ProtocolKey] = "http"
 
 	return trafficMap
 }

--- a/graph/telemetry/istio/appender/security_policy_test.go
+++ b/graph/telemetry/istio/appender/security_policy_test.go
@@ -68,7 +68,7 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTraffic()
-	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -173,7 +173,7 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTraffic()
-	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -249,7 +249,7 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTrafficWithServiceNodes()
-	ingressId, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressId, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressId]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -293,28 +293,28 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 }
 
 func securityPolicyTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
-	trafficMap[ingress.ID] = &ingress
-	trafficMap[productpage.ID] = &productpage
+	trafficMap[ingress.ID] = ingress
+	trafficMap[productpage.ID] = productpage
 
-	ingress.AddEdge(&productpage)
+	ingress.AddEdge(productpage)
 
 	return trafficMap
 }
 
 func securityPolicyTestTrafficWithServiceNodes() graph.TrafficMap {
-	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpagesvc := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpagesvc, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
-	trafficMap[ingress.ID] = &ingress
-	trafficMap[productpagesvc.ID] = &productpagesvc
-	trafficMap[productpage.ID] = &productpage
+	trafficMap[ingress.ID] = ingress
+	trafficMap[productpagesvc.ID] = productpagesvc
+	trafficMap[productpage.ID] = productpage
 
-	ingress.AddEdge(&productpagesvc)
-	productpagesvc.AddEdge(&productpage)
+	ingress.AddEdge(productpagesvc)
+	productpagesvc.AddEdge(productpage)
 
 	return trafficMap
 }

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -60,16 +60,16 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
 	// unknownNode
-	n0 := graph.NewNode(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
 	// NotSE serviceNode
-	n1 := graph.NewNode(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// NotSE appNode
-	n2 := graph.NewNode(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 
 	// externalSE host1 serviceNode
-	n3 := graph.NewNode(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n3, _ := graph.NewNode(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n3.Metadata = graph.NewMetadata()
 	destServices := graph.NewDestServicesMetadata()
 	destService := graph.ServiceName{Namespace: n3.Namespace, Name: n3.Service}
@@ -77,7 +77,7 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	n3.Metadata[graph.DestServices] = destServices
 
 	// externalSE host2 serviceNode
-	n4 := graph.NewNode(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n4, _ := graph.NewNode(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n4.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n4.Namespace, Name: n4.Service}
@@ -85,10 +85,10 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	n4.Metadata[graph.DestServices] = destServices
 
 	// non-service-entry (ALLOW_ANY) serviceNode
-	n5 := graph.NewNode(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n5, _ := graph.NewNode(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// internalSE host1 serviceNode
-	n6 := graph.NewNode(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n6, _ := graph.NewNode(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n6.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n6.Namespace, Name: n6.Service}
@@ -96,29 +96,29 @@ func serviceEntriesTrafficMap() map[string]*graph.Node {
 	n6.Metadata[graph.DestServices] = destServices
 
 	// internalSE host2 serviceNode (test prefix)
-	n7 := graph.NewNode(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n7, _ := graph.NewNode(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n7.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n7.Namespace, Name: n7.Service}
 	destServices[destService.Key()] = destService
 	n7.Metadata[graph.DestServices] = destServices
 
-	trafficMap[n0.ID] = &n0
-	trafficMap[n1.ID] = &n1
-	trafficMap[n2.ID] = &n2
-	trafficMap[n3.ID] = &n3
-	trafficMap[n4.ID] = &n4
-	trafficMap[n5.ID] = &n5
-	trafficMap[n6.ID] = &n6
-	trafficMap[n7.ID] = &n7
+	trafficMap[n0.ID] = n0
+	trafficMap[n1.ID] = n1
+	trafficMap[n2.ID] = n2
+	trafficMap[n3.ID] = n3
+	trafficMap[n4.ID] = n4
+	trafficMap[n5.ID] = n5
+	trafficMap[n6.ID] = n6
+	trafficMap[n7.ID] = n7
 
-	n0.AddEdge(&n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n1.AddEdge(&n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n2.AddEdge(&n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n2.AddEdge(&n4).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n2.AddEdge(&n5).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n2.AddEdge(&n6).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n2.AddEdge(&n7).Metadata[graph.ProtocolKey] = graph.TCP.Name
+	n0.AddEdge(n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n1.AddEdge(n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(n4).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(n5).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(n6).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n2.AddEdge(n7).Metadata[graph.ProtocolKey] = graph.TCP.Name
 
 	return trafficMap
 }
@@ -131,49 +131,49 @@ func TestServiceEntry(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -192,25 +192,25 @@ func TestServiceEntry(t *testing.T) {
 
 	assert.Equal(6, len(trafficMap))
 
-	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
@@ -220,13 +220,13 @@ func TestServiceEntry(t *testing.T) {
 	assert.Equal("host2.external.com", externalHosts[1])
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -245,49 +245,49 @@ func TestServiceEntryExportAll(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -306,38 +306,38 @@ func TestServiceEntryExportAll(t *testing.T) {
 
 	assert.Equal(6, len(trafficMap))
 
-	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
 	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -353,49 +353,49 @@ func TestServiceEntryExportNamespaceFound(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -414,38 +414,38 @@ func TestServiceEntryExportNamespaceFound(t *testing.T) {
 
 	assert.Equal(6, len(trafficMap))
 
-	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
 	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -461,49 +461,49 @@ func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -522,38 +522,38 @@ func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
 
 	assert.Equal(6, len(trafficMap))
 
-	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(4, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEServiceEntryNode, found3 := trafficMap[externalSEServiceEntryID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEServiceEntryNode.Edges))
 	assert.Equal("MESH_EXTERNAL", externalSEServiceEntryNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
 	assert.Equal(2, len(externalSEServiceEntryNode.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -569,49 +569,49 @@ func TestServiceEntryExportNamespaceNotFound(t *testing.T) {
 
 	assert.Equal(8, len(trafficMap))
 
-	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ := graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 := trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost1ServiceNode, found3 := trafficMap[externalSEHost1ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(externalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalSEHost2ServiceNode, found4 := trafficMap[externalSEHost2ServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, externalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	externalHostXServiceID, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ := graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found5 := trafficMap[externalHostXServiceID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost1ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost1", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost1ServiceNode, found6 := trafficMap[internalSEHost1ServiceID]
 	assert.Equal(true, found6)
 	assert.Equal(0, len(internalSEHost1ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "internalHost2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEHost2ServiceNode, found7 := trafficMap[internalSEHost2ServiceID]
 	assert.Equal(true, found7)
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
@@ -630,35 +630,35 @@ func TestServiceEntryExportNamespaceNotFound(t *testing.T) {
 
 	assert.Equal(7, len(trafficMap))
 
-	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(1, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(1, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEAppID, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
+	notSEAppID, _, _ = graph.Id(testCluster, "testNamespace", "NotSE", "testNamespace", "NotSE-v1", "NotSE", "v1", graph.GraphTypeVersionedApp)
 	notSEAppNode, found2 = trafficMap[notSEAppID]
 	assert.Equal(true, found2)
 	assert.Equal(5, len(notSEAppNode.Edges))
 	assert.Equal(nil, notSEAppNode.Metadata[graph.IsServiceEntry])
 
-	externalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "externalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	_, found3 = trafficMap[externalSEServiceEntryID]
 	assert.Equal(false, found3)
 
-	externalHostXServiceID, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	externalHostXServiceID, _, _ = graph.Id(testCluster, "testNamespace", "hostX.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	externalHostXServiceNode, found4 = trafficMap[externalHostXServiceID]
 	assert.Equal(true, found4)
 	assert.Equal(0, len(externalHostXServiceNode.Edges))
 	assert.Equal(nil, externalHostXServiceNode.Metadata[graph.IsServiceEntry])
 
-	internalSEServiceEntryID, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	internalSEServiceEntryID, _, _ := graph.Id(testCluster, "testNamespace", "internalSE", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	internalSEServiceEntryNode, found5 := trafficMap[internalSEServiceEntryID]
 	assert.Equal(true, found5)
 	assert.Equal(0, len(internalSEServiceEntryNode.Edges))
@@ -693,16 +693,16 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 	// Create a VersionedApp traffic map where a workload is calling a remote service entry and also an internal one
 	trafficMap := make(map[string]*graph.Node)
 
-	n0 := graph.NewNode(testCluster, "namespace", "source", "namespace", "wk0", "source", "v0", graph.GraphTypeVersionedApp)
-	n1 := graph.NewNode(testCluster, "namespace", "svc1.namespace.global", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
-	n2 := graph.NewNode(testCluster, "namespace", "svc1", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(testCluster, "namespace", "source", "namespace", "wk0", "source", "v0", graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(testCluster, "namespace", "svc1.namespace.global", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(testCluster, "namespace", "svc1", "unknown", "unknown", "unknown", "unknown", graph.GraphTypeVersionedApp)
 
-	trafficMap[n0.ID] = &n0
-	trafficMap[n1.ID] = &n1
-	trafficMap[n2.ID] = &n2
+	trafficMap[n0.ID] = n0
+	trafficMap[n1.ID] = n1
+	trafficMap[n2.ID] = n2
 
-	n0.AddEdge(&n1)
-	n0.AddEdge(&n2)
+	n0.AddEdge(n1)
+	n0.AddEdge(n2)
 
 	// Run the appender
 	globalInfo := graph.NewAppenderGlobalInfo()
@@ -724,7 +724,7 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 	for _, n := range trafficMap {
 		if n.Service == "svc1" {
 			numMatches++
-			assert.Equal(n, &n2)
+			assert.Equal(n, n2)
 		}
 	}
 	assert.Equal(1, numMatches)
@@ -775,13 +775,13 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 	trafficMap := make(map[string]*graph.Node)
 
 	// unknownNode
-	n0 := graph.NewNode(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
 	// NotSE host3 serviceNode
-	n1 := graph.NewNode(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// SE2 host1 serviceNode
-	n2 := graph.NewNode(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n2.Metadata = graph.NewMetadata()
 	destServices := graph.NewDestServicesMetadata()
 	destService := graph.ServiceName{Namespace: n2.Namespace, Name: n2.Service}
@@ -789,43 +789,43 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 	n2.Metadata[graph.DestServices] = destServices
 
 	// SE2 host2 serviceNode
-	n3 := graph.NewNode(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n3, _ := graph.NewNode(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n3.Metadata = graph.NewMetadata()
 	destServices = graph.NewDestServicesMetadata()
 	destService = graph.ServiceName{Namespace: n3.Namespace, Name: n3.Service}
 	destServices[destService.Key()] = destService
 	n3.Metadata[graph.DestServices] = destServices
 
-	trafficMap[n0.ID] = &n0
-	trafficMap[n1.ID] = &n1
-	trafficMap[n2.ID] = &n2
-	trafficMap[n3.ID] = &n3
+	trafficMap[n0.ID] = n0
+	trafficMap[n1.ID] = n1
+	trafficMap[n2.ID] = n2
+	trafficMap[n3.ID] = n3
 
-	n0.AddEdge(&n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n0.AddEdge(&n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n0.AddEdge(&n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 
 	assert.Equal(4, len(trafficMap))
 
-	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(3, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ := graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 := trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(0, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE2Host1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE2Host1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE2Host1ServiceNode, found2 := trafficMap[SE2Host1ServiceID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE2Host1ServiceNode.Edges))
 	assert.Equal(nil, SE2Host1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE2Host2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE2Host2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE2Host2ServiceNode, found3 := trafficMap[SE2Host2ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(SE2Host2ServiceNode.Edges))
@@ -844,19 +844,19 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 
 	assert.Equal(3, len(trafficMap))
 
-	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(2, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEServiceID, _ = graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEServiceID, _, _ = graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEServiceNode, found1 = trafficMap[notSEServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(0, len(notSEServiceNode.Edges))
 	assert.Equal(nil, notSEServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE2ID, _ := graph.Id(testCluster, "testNamespace", "SE2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE2ID, _, _ := graph.Id(testCluster, "testNamespace", "SE2", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE2Node, found2 := trafficMap[SE2ID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE2Node.Edges))
@@ -899,13 +899,13 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 	trafficMap := make(map[string]*graph.Node)
 
 	// unknownNode
-	n0 := graph.NewNode(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
 	// NotSE host3 serviceNode
-	n1 := graph.NewNode(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
 	// SE1 host1 serviceNode
-	n2 := graph.NewNode(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n2.Metadata = graph.NewMetadata()
 	destServices := graph.NewDestServicesMetadata()
 	destService := graph.ServiceName{Namespace: n2.Namespace, Name: n2.Service}
@@ -913,38 +913,38 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 	n2.Metadata[graph.DestServices] = destServices
 
 	// Not SE host2 serviceNode
-	n3 := graph.NewNode(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n3, _ := graph.NewNode(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 
-	trafficMap[n0.ID] = &n0
-	trafficMap[n1.ID] = &n1
-	trafficMap[n2.ID] = &n2
-	trafficMap[n3.ID] = &n3
+	trafficMap[n0.ID] = n0
+	trafficMap[n1.ID] = n1
+	trafficMap[n2.ID] = n2
+	trafficMap[n3.ID] = n3
 
-	n0.AddEdge(&n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n0.AddEdge(&n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n0.AddEdge(&n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 
 	assert.Equal(4, len(trafficMap))
 
-	unknownID, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ := graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 := trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(3, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEHost3ServiceID, _ := graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost3ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEHost3ServiceNode, found1 := trafficMap[notSEHost3ServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(0, len(notSEHost3ServiceNode.Edges))
 	assert.Equal(nil, notSEHost3ServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE1Host1ServiceID, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE1Host1ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host1.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE1Host1ServiceNode, found2 := trafficMap[SE1Host1ServiceID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE1Host1ServiceNode.Edges))
 	assert.Equal(nil, SE1Host1ServiceNode.Metadata[graph.IsServiceEntry])
 
-	notSEHost2ServiceID, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost2ServiceID, _, _ := graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEHost2ServiceNode, found3 := trafficMap[notSEHost2ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(notSEHost2ServiceNode.Edges))
@@ -963,19 +963,19 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 
 	assert.Equal(4, len(trafficMap))
 
-	unknownID, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ = graph.Id(testCluster, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found0 = trafficMap[unknownID]
 	assert.Equal(true, found0)
 	assert.Equal(3, len(unknownNode.Edges))
 	assert.Equal(nil, unknownNode.Metadata[graph.IsServiceEntry])
 
-	notSEHost3ServiceID, _ = graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost3ServiceID, _, _ = graph.Id(testCluster, "testNamespace", "host3.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEHost3ServiceNode, found1 = trafficMap[notSEHost3ServiceID]
 	assert.Equal(true, found1)
 	assert.Equal(0, len(notSEHost3ServiceNode.Edges))
 	assert.Equal(nil, notSEHost3ServiceNode.Metadata[graph.IsServiceEntry])
 
-	SE1ID, _ := graph.Id(testCluster, "otherNamespace", "SE1", "otherNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	SE1ID, _, _ := graph.Id(testCluster, "otherNamespace", "SE1", "otherNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	SE1Node, found2 := trafficMap[SE1ID]
 	assert.Equal(true, found2)
 	assert.Equal(0, len(SE1Node.Edges))
@@ -983,7 +983,7 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 	assert.Equal("otherNamespace", SE1Node.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Namespace)
 	assert.Equal(1, len(SE1Node.Metadata[graph.DestServices].(graph.DestServicesMetadata)))
 
-	notSEHost2ServiceID, _ = graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	notSEHost2ServiceID, _, _ = graph.Id(testCluster, "testNamespace", "host2.external.com", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	notSEHost2ServiceNode, found3 = trafficMap[notSEHost2ServiceID]
 	assert.Equal(true, found3)
 	assert.Equal(0, len(notSEHost2ServiceNode.Edges))
@@ -1022,35 +1022,35 @@ func TestServiceEntryMultipleEdges(t *testing.T) {
 	trafficMap := make(map[string]*graph.Node)
 
 	// appNode for interal service v1
-	v1 := graph.NewNode(testCluster, namespace, seServiceName, namespace, "reviews-v1", app, "v1", graph.GraphTypeVersionedApp)
+	v1, _ := graph.NewNode(testCluster, namespace, seServiceName, namespace, "reviews-v1", app, "v1", graph.GraphTypeVersionedApp)
 	// appNode for interal service v2
-	v2 := graph.NewNode(testCluster, namespace, seServiceName, namespace, "reviews-v2", app, "v2", graph.GraphTypeVersionedApp)
+	v2, _ := graph.NewNode(testCluster, namespace, seServiceName, namespace, "reviews-v2", app, "v2", graph.GraphTypeVersionedApp)
 
 	// reviews serviceNode
-	svc := graph.NewNode(testCluster, namespace, seServiceName, namespace, "", "", "", graph.GraphTypeVersionedApp)
+	svc, _ := graph.NewNode(testCluster, namespace, seServiceName, namespace, "", "", "", graph.GraphTypeVersionedApp)
 
-	trafficMap[svc.ID] = &svc
-	trafficMap[v1.ID] = &v1
-	trafficMap[v2.ID] = &v2
+	trafficMap[svc.ID] = svc
+	trafficMap[v1.ID] = v1
+	trafficMap[v2.ID] = v2
 
-	svc.AddEdge(&v1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	svc.AddEdge(&v2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	svc.AddEdge(v1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	svc.AddEdge(v2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 
 	assert.Equal(3, len(trafficMap))
 
-	seSVCID, _ := graph.Id(testCluster, namespace, seServiceName, namespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCID, _, _ := graph.Id(testCluster, namespace, seServiceName, namespace, "", "", "", graph.GraphTypeVersionedApp)
 	svcNode, svcNodeFound := trafficMap[seSVCID]
 	assert.Equal(true, svcNodeFound)
 	assert.Equal(2, len(svcNode.Edges))
 	assert.Equal(nil, svcNode.Metadata[graph.IsServiceEntry])
 
-	v1ID, _ := graph.Id(testCluster, namespace, seServiceName, namespace, "reviews-v1", app, "v1", graph.GraphTypeVersionedApp)
+	v1ID, _, _ := graph.Id(testCluster, namespace, seServiceName, namespace, "reviews-v1", app, "v1", graph.GraphTypeVersionedApp)
 	v1Node, v1NodeFound := trafficMap[v1ID]
 	assert.Equal(true, v1NodeFound)
 	assert.Equal(0, len(v1Node.Edges))
 	assert.Equal(nil, v1Node.Metadata[graph.IsServiceEntry])
 
-	v2ID, _ := graph.Id(testCluster, namespace, seServiceName, namespace, "reviews-v2", app, "v2", graph.GraphTypeVersionedApp)
+	v2ID, _, _ := graph.Id(testCluster, namespace, seServiceName, namespace, "reviews-v2", app, "v2", graph.GraphTypeVersionedApp)
 	v2Node, v2NodeFound := trafficMap[v2ID]
 	assert.Equal(true, v2NodeFound)
 	assert.Equal(0, len(v2Node.Edges))
@@ -1069,7 +1069,7 @@ func TestServiceEntryMultipleEdges(t *testing.T) {
 
 	assert.Equal(3, len(trafficMap))
 
-	seSVCID, _ = graph.Id(testCluster, namespace, seServiceName, namespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCID, _, _ = graph.Id(testCluster, namespace, seServiceName, namespace, "", "", "", graph.GraphTypeVersionedApp)
 	svcNode, svcNodeFound = trafficMap[seSVCID]
 	assert.Equal(true, svcNodeFound)
 	assert.Equal("MESH_INTERNAL", svcNode.Metadata[graph.IsServiceEntry].(*graph.SEInfo).Location)
@@ -1078,13 +1078,13 @@ func TestServiceEntryMultipleEdges(t *testing.T) {
 	assert.Equal("reviews.testNamespace.svc.cluster.local", internalHosts[1])
 	assert.Equal(2, len(svcNode.Edges))
 
-	v1ID, _ = graph.Id(testCluster, namespace, seServiceName, namespace, "reviews-v1", app, "v1", graph.GraphTypeVersionedApp)
+	v1ID, _, _ = graph.Id(testCluster, namespace, seServiceName, namespace, "reviews-v1", app, "v1", graph.GraphTypeVersionedApp)
 	v1Node, v1NodeFound = trafficMap[v1ID]
 	assert.Equal(true, v1NodeFound)
 	assert.Equal(0, len(v1Node.Edges))
 	assert.Equal(nil, v1Node.Metadata[graph.IsServiceEntry])
 
-	v2ID, _ = graph.Id(testCluster, namespace, seServiceName, namespace, "reviews-v2", app, "v2", graph.GraphTypeVersionedApp)
+	v2ID, _, _ = graph.Id(testCluster, namespace, seServiceName, namespace, "reviews-v2", app, "v2", graph.GraphTypeVersionedApp)
 	v2Node, v2NodeFound = trafficMap[v2ID]
 	assert.Equal(true, v2NodeFound)
 	assert.Equal(0, len(v2Node.Edges))

--- a/graph/telemetry/istio/appender/sidecars_check_test.go
+++ b/graph/telemetry/istio/appender/sidecars_check_test.go
@@ -157,8 +157,8 @@ func TestServicesAreAlwaysValid(t *testing.T) {
 func buildWorkloadTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode(business.DefaultClusterID, "testNamespace", "", "testNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
-	trafficMap[node.ID] = &node
+	node, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "", "testNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+	trafficMap[node.ID] = node
 
 	return trafficMap
 }
@@ -166,8 +166,8 @@ func buildWorkloadTrafficMap() graph.TrafficMap {
 func buildInaccessibleWorkloadTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode(business.DefaultClusterID, "inaccessibleNamespace", "", "inaccessibleNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
-	trafficMap[node.ID] = &node
+	node, _ := graph.NewNode(business.DefaultClusterID, "inaccessibleNamespace", "", "inaccessibleNamespace", "workload-1", graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	trafficMap[node.ID] = node
 
 	return trafficMap
 }
@@ -175,8 +175,8 @@ func buildInaccessibleWorkloadTrafficMap() graph.TrafficMap {
 func buildAppTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode(business.DefaultClusterID, "testNamespace", "", "testNamespace", graph.Unknown, "myTest", graph.Unknown, graph.GraphTypeVersionedApp)
-	trafficMap[node.ID] = &node
+	node, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "", "testNamespace", graph.Unknown, "myTest", graph.Unknown, graph.GraphTypeVersionedApp)
+	trafficMap[node.ID] = node
 
 	return trafficMap
 }
@@ -184,8 +184,8 @@ func buildAppTrafficMap() graph.TrafficMap {
 func buildServiceTrafficMap() graph.TrafficMap {
 	trafficMap := graph.NewTrafficMap()
 
-	node := graph.NewNode(business.DefaultClusterID, "testNamespace", "svc", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
-	trafficMap[node.ID] = &node
+	node, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "svc", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	trafficMap[node.ID] = node
 
 	return trafficMap
 }

--- a/graph/telemetry/istio/appender/throughput_test.go
+++ b/graph/telemetry/istio/appender/throughput_test.go
@@ -115,7 +115,7 @@ func TestResponseThroughput(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseThroughputTestTraffic()
-	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -206,33 +206,33 @@ func TestResponseThroughput(t *testing.T) {
 }
 
 func responseThroughputTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
-	reviewsV1 := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsV2 := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
-	ratingsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
-	ratings := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	reviewsV1, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsV2, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
+	ratingsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
+	ratings, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
-	trafficMap[ingress.ID] = &ingress
-	trafficMap[productpageService.ID] = &productpageService
-	trafficMap[productpage.ID] = &productpage
-	trafficMap[reviewsService.ID] = &reviewsService
-	trafficMap[reviewsV1.ID] = &reviewsV1
-	trafficMap[reviewsV2.ID] = &reviewsV2
-	trafficMap[ratingsService.ID] = &ratingsService
-	trafficMap[ratings.ID] = &ratings
+	trafficMap[ingress.ID] = ingress
+	trafficMap[productpageService.ID] = productpageService
+	trafficMap[productpage.ID] = productpage
+	trafficMap[reviewsService.ID] = reviewsService
+	trafficMap[reviewsV1.ID] = reviewsV1
+	trafficMap[reviewsV2.ID] = reviewsV2
+	trafficMap[ratingsService.ID] = ratingsService
+	trafficMap[ratings.ID] = ratings
 
-	ingress.AddEdge(&productpageService).Metadata[graph.ProtocolKey] = "http"
-	productpageService.AddEdge(&productpage).Metadata[graph.ProtocolKey] = "http"
-	productpage.AddEdge(&reviewsService).Metadata[graph.ProtocolKey] = "http"
-	reviewsService.AddEdge(&reviewsV1).Metadata[graph.ProtocolKey] = "http"
-	reviewsService.AddEdge(&reviewsV2).Metadata[graph.ProtocolKey] = "http"
-	reviewsV1.AddEdge(&ratingsService).Metadata[graph.ProtocolKey] = "http"
-	reviewsV2.AddEdge(&ratingsService).Metadata[graph.ProtocolKey] = "http"
-	ratingsService.AddEdge(&ratings).Metadata[graph.ProtocolKey] = "http"
+	ingress.AddEdge(productpageService).Metadata[graph.ProtocolKey] = "http"
+	productpageService.AddEdge(productpage).Metadata[graph.ProtocolKey] = "http"
+	productpage.AddEdge(reviewsService).Metadata[graph.ProtocolKey] = "http"
+	reviewsService.AddEdge(reviewsV1).Metadata[graph.ProtocolKey] = "http"
+	reviewsService.AddEdge(reviewsV2).Metadata[graph.ProtocolKey] = "http"
+	reviewsV1.AddEdge(ratingsService).Metadata[graph.ProtocolKey] = "http"
+	reviewsV2.AddEdge(ratingsService).Metadata[graph.ProtocolKey] = "http"
+	ratingsService.AddEdge(ratings).Metadata[graph.ProtocolKey] = "http"
 
 	return trafficMap
 }
@@ -290,7 +290,7 @@ func TestRequestThroughput(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := requestThroughputTestTraffic()
-	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -399,7 +399,7 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := requestThroughputTestTraffic()
-	ingressID, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -456,20 +456,20 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 }
 
 func requestThroughputTestTraffic() graph.TrafficMap {
-	ingress := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
-	trafficMap[ingress.ID] = &ingress
-	trafficMap[productpageService.ID] = &productpageService
-	trafficMap[productpage.ID] = &productpage
-	trafficMap[reviewsService.ID] = &reviewsService
+	trafficMap[ingress.ID] = ingress
+	trafficMap[productpageService.ID] = productpageService
+	trafficMap[productpage.ID] = productpage
+	trafficMap[reviewsService.ID] = reviewsService
 
-	ingress.AddEdge(&productpageService).Metadata[graph.ProtocolKey] = "http"
-	productpageService.AddEdge(&productpage).Metadata[graph.ProtocolKey] = "http"
-	productpage.AddEdge(&reviewsService).Metadata[graph.ProtocolKey] = "http"
+	ingress.AddEdge(productpageService).Metadata[graph.ProtocolKey] = "http"
+	productpageService.AddEdge(productpage).Metadata[graph.ProtocolKey] = "http"
+	productpage.AddEdge(reviewsService).Metadata[graph.ProtocolKey] = "http"
 
 	return trafficMap
 }

--- a/graph/telemetry/istio/appender/workload_entry_test.go
+++ b/graph/telemetry/istio/appender/workload_entry_test.go
@@ -63,30 +63,30 @@ func workloadEntriesTrafficMap() map[string]*graph.Node {
 	// 1 service, 3 workloads. v1 and v2 are workload entries. v3 is not a workload entry e.g. a kube deployment.
 
 	// Service node
-	n0 := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
 
 	// v1 Workload
-	n1 := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 
 	// v2 Workload
-	n2 := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 
 	// v3 Workload
-	n3 := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	n3, _ := graph.NewNode(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 
 	// v4 Workload (just to test ignoring of outsider nodes)
-	n4 := graph.NewNode(testCluster, "outsider", "outsider", "outsider", "outsider-v1", "outsider", "v1", graph.GraphTypeVersionedApp)
+	n4, _ := graph.NewNode(testCluster, "outsider", "outsider", "outsider", "outsider-v1", "outsider", "v1", graph.GraphTypeVersionedApp)
 
-	trafficMap[n0.ID] = &n0
-	trafficMap[n1.ID] = &n1
-	trafficMap[n2.ID] = &n2
-	trafficMap[n3.ID] = &n3
-	trafficMap[n4.ID] = &n4
+	trafficMap[n0.ID] = n0
+	trafficMap[n1.ID] = n1
+	trafficMap[n2.ID] = n2
+	trafficMap[n3.ID] = n3
+	trafficMap[n4.ID] = n4
 
-	n0.AddEdge(&n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n0.AddEdge(&n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n0.AddEdge(&n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
-	n0.AddEdge(&n4).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n4).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 	// Need to put some metadata in here to ensure it gets counted as a workload
 
 	return trafficMap
@@ -100,27 +100,27 @@ func TestWorkloadEntry(t *testing.T) {
 
 	assert.Equal(5, len(trafficMap))
 
-	seSVCID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
 	seSVCNode, found := trafficMap[seSVCID]
 	assert.True(found)
 	assert.Equal(4, len(seSVCNode.Edges))
 
-	v1WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	v1WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	v1Node, found := trafficMap[v1WorkloadID]
 	assert.True(found)
 	assert.NotContains(v1Node.Metadata, graph.HasWorkloadEntry)
 
-	v2WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	v2WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	v2Node, found := trafficMap[v2WorkloadID]
 	assert.True(found)
 	assert.NotContains(v2Node.Metadata, graph.HasWorkloadEntry)
 
-	v3WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	v3WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	v3Node, found := trafficMap[v3WorkloadID]
 	assert.True(found)
 	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
 
-	v4WorkloadID, _ := graph.Id(testCluster, "outsider", "outsider", "outsider", "outsider-v1", "outsider", "v1", graph.GraphTypeVersionedApp)
+	v4WorkloadID, _, _ := graph.Id(testCluster, "outsider", "outsider", "outsider", "outsider-v1", "outsider", "v1", graph.GraphTypeVersionedApp)
 	v4Node, found := trafficMap[v4WorkloadID]
 	assert.True(found)
 	assert.NotContains(v4Node.Metadata, graph.HasWorkloadEntry)
@@ -136,17 +136,17 @@ func TestWorkloadEntry(t *testing.T) {
 
 	assert.Equal(5, len(trafficMap))
 
-	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	workloadV1ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	workloadV1Node, found := trafficMap[workloadV1ID]
 	assert.True(found)
 	assert.Equal(workloadV1Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadA"}})
 
-	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	workloadV2ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	workloadV2Node, found := trafficMap[workloadV2ID]
 	assert.True(found)
 	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadB"}})
 
-	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	workloadV3ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	workloadV3Node, found := trafficMap[workloadV3ID]
 	assert.True(found)
 	assert.NotContains(workloadV3Node.Metadata, graph.HasWorkloadEntry)
@@ -176,22 +176,22 @@ func TestWorkloadEntryAppLabelNotMatching(t *testing.T) {
 
 	assert.Equal(5, len(trafficMap))
 
-	seSVCID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
 	seSVCNode, found := trafficMap[seSVCID]
 	assert.True(found)
 	assert.Equal(4, len(seSVCNode.Edges))
 
-	v1WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	v1WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	v1Node, found := trafficMap[v1WorkloadID]
 	assert.True(found)
 	assert.NotContains(v1Node.Metadata, graph.HasWorkloadEntry)
 
-	v2WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	v2WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	v2Node, found := trafficMap[v2WorkloadID]
 	assert.True(found)
 	assert.NotContains(v2Node.Metadata, graph.HasWorkloadEntry)
 
-	v3WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	v3WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	v3Node, found := trafficMap[v3WorkloadID]
 	assert.True(found)
 	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
@@ -207,17 +207,17 @@ func TestWorkloadEntryAppLabelNotMatching(t *testing.T) {
 
 	assert.Equal(5, len(trafficMap))
 
-	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	workloadV1ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	workloadV1Node, found := trafficMap[workloadV1ID]
 	assert.True(found)
 	assert.NotContains(workloadV1Node.Metadata, graph.HasWorkloadEntry)
 
-	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	workloadV2ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	workloadV2Node, found := trafficMap[workloadV2ID]
 	assert.True(found)
 	assert.NotContains(workloadV2Node.Metadata, graph.HasWorkloadEntry)
 
-	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	workloadV3ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	workloadV3Node, found := trafficMap[workloadV3ID]
 	assert.True(found)
 	assert.NotContains(workloadV3Node.Metadata, graph.HasWorkloadEntry)
@@ -255,22 +255,22 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 
 	assert.Equal(5, len(trafficMap))
 
-	seSVCID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
 	seSVCNode, found := trafficMap[seSVCID]
 	assert.True(found)
 	assert.Equal(4, len(seSVCNode.Edges))
 
-	v1WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	v1WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	v1Node, found := trafficMap[v1WorkloadID]
 	assert.True(found)
 	assert.NotContains(v1Node.Metadata, graph.HasWorkloadEntry)
 
-	v2WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	v2WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	v2Node, found := trafficMap[v2WorkloadID]
 	assert.True(found)
 	assert.NotContains(v2Node.Metadata, graph.HasWorkloadEntry)
 
-	v3WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	v3WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	v3Node, found := trafficMap[v3WorkloadID]
 	assert.True(found)
 	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
@@ -286,7 +286,7 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 
 	assert.Equal(5, len(trafficMap))
 
-	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	workloadV1ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	workloadV1Node, found := trafficMap[workloadV1ID]
 	assert.True(found)
 	assert.Equal(
@@ -294,12 +294,12 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 		[]graph.WEInfo{{Name: "workloadV1A"}, {Name: "workloadV1B"}},
 	)
 
-	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	workloadV2ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	workloadV2Node, found := trafficMap[workloadV2ID]
 	assert.True(found)
 	assert.Equal(workloadV2Node.Metadata[graph.HasWorkloadEntry], []graph.WEInfo{{Name: "workloadV2"}})
 
-	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	workloadV3ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	workloadV3Node, found := trafficMap[workloadV3ID]
 	assert.True(found)
 	assert.NotContains(workloadV3Node.Metadata, graph.HasWorkloadEntry)
@@ -313,22 +313,22 @@ func TestWorkloadWithoutWorkloadEntries(t *testing.T) {
 
 	assert.Equal(5, len(trafficMap))
 
-	seSVCID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	seSVCID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
 	seSVCNode, found := trafficMap[seSVCID]
 	assert.True(found)
 	assert.Equal(4, len(seSVCNode.Edges))
 
-	v1WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	v1WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	v1Node, found := trafficMap[v1WorkloadID]
 	assert.True(found)
 	assert.NotContains(v1Node.Metadata, graph.HasWorkloadEntry)
 
-	v2WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	v2WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	v2Node, found := trafficMap[v2WorkloadID]
 	assert.True(found)
 	assert.NotContains(v2Node.Metadata, graph.HasWorkloadEntry)
 
-	v3WorkloadID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	v3WorkloadID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	v3Node, found := trafficMap[v3WorkloadID]
 	assert.True(found)
 	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
@@ -344,17 +344,17 @@ func TestWorkloadWithoutWorkloadEntries(t *testing.T) {
 
 	assert.Equal(5, len(trafficMap))
 
-	workloadV1ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	workloadV1ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v1", appName, "v1", graph.GraphTypeVersionedApp)
 	workloadV1Node, found := trafficMap[workloadV1ID]
 	assert.True(found)
 	assert.NotContains(workloadV1Node.Metadata, graph.HasWorkloadEntry)
 
-	workloadV2ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
+	workloadV2ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v2", appName, "v2", graph.GraphTypeVersionedApp)
 	workloadV2Node, found := trafficMap[workloadV2ID]
 	assert.True(found)
 	assert.NotContains(workloadV2Node.Metadata, graph.HasWorkloadEntry)
 
-	workloadV3ID, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
+	workloadV3ID, _, _ := graph.Id(testCluster, appNamespace, appName, appNamespace, "ratings-v3", appName, "v3", graph.GraphTypeVersionedApp)
 	workloadV3Node, found := trafficMap[workloadV3ID]
 	assert.True(found)
 	assert.NotContains(workloadV3Node.Metadata, graph.HasWorkloadEntry)

--- a/tools/generator/generator.go
+++ b/tools/generator/generator.go
@@ -261,19 +261,19 @@ func addFakeEdgeTraffic(e *graph.Edge, destination string) {
 
 func (g *Generator) newServiceNode(app app) *graph.Node {
 	// It is important to leave app name blank here, otherwise this node will be considered a workload.
-	s := graph.NewNode(app.Cluster, app.Namespace, app.Name, app.Namespace, "", "", "", g.GraphType)
-	return &s
+	s, _ := graph.NewNode(app.Cluster, app.Namespace, app.Name, app.Namespace, "", "", "", g.GraphType)
+	return s
 }
 
 func (g *Generator) newWorkloadNode(app app, version string) *graph.Node {
 	workload := app.Name + "-" + version
-	node := graph.NewNode(app.Cluster, app.Namespace, "", app.Namespace, workload, app.Name, version, g.GraphType)
+	node, _ := graph.NewNode(app.Cluster, app.Namespace, "", app.Namespace, workload, app.Name, version, g.GraphType)
 	if app.IsIngress {
 		node.Metadata[graph.IsRoot] = true
 		node.Metadata[graph.IsIngressGateway] = graph.GatewaysMetadata{node.Workload: []string{"*"}}
 		node.Metadata[graph.IsOutside] = true
 	}
-	return &node
+	return node
 }
 
 func (g *Generator) ensureNamespace(name string) error {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/5890

Don't let the graph generation panic on unexpected/corrupt telemetry.  Instead, add error return values as needed, and use then to skip over the bad telem.  The change here is fairly straightforward but it touches a lot of files, many test files, because the call signatures change for a few commonly used functions in graph generation.
