### PR TITLE
[WIP] Kiali model to support multicluster

### DIFF
--- a/models/app.go
+++ b/models/app.go
@@ -53,6 +53,9 @@ type WorkloadItem struct {
 }
 
 type App struct {
+	// Cluster where the app lives in
+	Cluster string
+
 	// Namespace where the app lives in
 	// required: true
 	// example: bookinfo

--- a/models/app.go
+++ b/models/app.go
@@ -31,6 +31,9 @@ type AppListItem struct {
 
 	// Health
 	Health AppHealth `json:"health,omitempty"`
+
+	// Cluster where the app lives in
+	Cluster string `json:"cluster"`
 }
 
 type WorkloadItem struct {
@@ -50,11 +53,14 @@ type WorkloadItem struct {
 	// List of service accounts involved in this application
 	// required: true
 	ServiceAccountNames []string `json:"serviceAccountNames"`
+
+	// Cluster where the app lives in
+	Cluster string `json:"cluster"`
 }
 
 type App struct {
 	// Cluster where the app lives in
-	Cluster string
+	Cluster string `json:"cluster"`
 
 	// Namespace where the app lives in
 	// required: true

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -36,6 +36,8 @@ type IstioConfigList struct {
 	PeerAuthentications    []*security_v1beta.PeerAuthentication    `json:"peerAuthentications"`
 	RequestAuthentications []*security_v1beta.RequestAuthentication `json:"requestAuthentications"`
 	IstioValidations       IstioValidations                         `json:"validations"`
+
+	Cluster string `json:"cluster"`
 }
 
 type IstioConfigDetails struct {
@@ -63,6 +65,8 @@ type IstioConfigDetails struct {
 	IstioValidation       *IstioValidation    `json:"validation"`
 	IstioReferences       *IstioReferences    `json:"references"`
 	IstioConfigHelpFields []IstioConfigHelp   `json:"help"`
+
+	Cluster string `json:"cluster"`
 }
 
 // IstioConfigHelp represents a help message for a given Istio object type and field

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -15,6 +15,7 @@ type IstioValidationKey struct {
 	ObjectType string `json:"objectType"`
 	Name       string `json:"name"`
 	Namespace  string `json:"namespace"`
+	Cluster    string `json:"cluster"`
 }
 
 // IstioValidationSummary represents the number of errors/warnings of a set of Istio Validations.

--- a/models/istio_validation_test.go
+++ b/models/istio_validation_test.go
@@ -38,7 +38,7 @@ func TestIstioValidationKeyMarshal(t *testing.T) {
 	}
 	b, err := json.Marshal(validationKey)
 	assert.NoError(err)
-	assert.Equal(string(b), `{"objectType":"virtualservice","name":"foo","namespace":""}`)
+	assert.Equal(string(b), `{"objectType":"virtualservice","name":"foo","namespace":"","cluster":""}`)
 }
 
 func TestSummarizeValidations(t *testing.T) {

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -32,6 +32,8 @@ type Namespace struct {
 
 	// Specific annotations used in Kiali
 	Annotations map[string]string `json:"annotations"`
+
+	Cluster string `json:"cluster"`
 }
 
 type Namespaces []Namespace

--- a/models/service.go
+++ b/models/service.go
@@ -52,6 +52,9 @@ type ServiceOverview struct {
 
 	// Health
 	Health ServiceHealth `json:"health,omitempty"`
+
+	// Cluster
+	Cluster string `json:"cluster"`
 }
 
 type ServiceList struct {
@@ -97,6 +100,7 @@ type Service struct {
 	Annotations       map[string]string `json:"annotations"`
 	HealthAnnotations map[string]string `json:"healthAnnotations"`
 	AdditionalDetails []AdditionalItem  `json:"additionalDetails"`
+	Cluster           string            `json:"cluster"`
 }
 
 func (so *ServiceOverview) ParseToService() *Service {

--- a/models/workload.go
+++ b/models/workload.go
@@ -103,6 +103,8 @@ type WorkloadListItem struct {
 
 	// Health
 	Health WorkloadHealth `json:"health,omitempty"`
+
+	Cluster string `json:"cluster"`
 }
 
 type WorkloadOverviews []*WorkloadListItem
@@ -142,6 +144,8 @@ type Workload struct {
 
 	// Health
 	Health WorkloadHealth `json:"health"`
+
+	Cluster string `json:"cluster"`
 }
 
 type Workloads []*Workload
@@ -164,6 +168,7 @@ func (workload *WorkloadListItem) ParseWorkload(w *Workload) {
 	}
 	workload.HealthAnnotations = w.HealthAnnotations
 	workload.IstioReferences = []*IstioValidationKey{}
+	workload.Cluster = w.Cluster
 
 	/** Check the labels app and version required by Istio in template Pods*/
 	_, workload.AppLabel = w.Labels[conf.IstioLabels.AppLabelName]


### PR DESCRIPTION
Resolves #5736 

This PR is draft and the purpose is to have some early reviews on the code.

Note: I added a cluster field to the IstioConfigList but I'm not sure this is needed, or at least I'm not sure if it will have a value different than the Home cluster. This doubt comes because when having just one control plane (as we were discussing on support just this scenario) for example in a primary-remote scenario, the Istio custom resources will be in the cluster where the control plane is installed (Istio does not create the CRDs on remote cluster so we won't expect to find any Istio configurations on them). Finally, in the case of multi primary control planes, we were discussing about having 1 Kiali per control plane, where the Istio configurations will belong to the Home clusters as well (each Kiali will be in a Home cluster where a control plane is also deployed). 