### PR TITLE
Add grpc-web to portProtocols in istio.go

### DIFF
--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -76,7 +76,7 @@ const (
 
 var (
 	portNameMatcher = regexp.MustCompile(`^[\-].*`)
-	portProtocols   = [...]string{"grpc", "http", "http2", "https", "mongo", "redis", "tcp", "tls", "udp", "mysql"}
+	portProtocols   = [...]string{"grpc", "grpc-web", "http", "http2", "https", "mongo", "redis", "tcp", "tls", "udp", "mysql"}
 )
 
 type IstioClientInterface interface {


### PR DESCRIPTION
** Describe the change **

Add grpc-web to portProtocols in istio.go

Refer to https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

** Issue reference **

* If this is a fix for a GH-issue, please link it here