### PR TITLE
Changes to the multi-primary hack script

### DIFF
--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -73,7 +73,7 @@ SINGLE_KIALI="true"
 
 # If a gateway is required to cross the networks, set this to true and one will be created
 # See: https://istio.io/latest/docs/setup/install/multicluster/multi-primary_multi-network/
-CROSSNETWORK_GATEWAY_REQUIRED="false"
+CROSSNETWORK_GATEWAY_REQUIRED="true"
 
 # Under some conditions, manually configuring the mesh network will be required.
 MANUAL_MESH_NETWORK_CONFIG=""

--- a/hack/istio/multicluster/install-multi-primary.sh
+++ b/hack/istio/multicluster/install-multi-primary.sh
@@ -158,6 +158,12 @@ create_remote_secret "${CLUSTER2_NAME}"
 switch_cluster "${CLUSTER1_CONTEXT}" "${CLUSTER1_USER}" "${CLUSTER1_PASS}"
 printf "%s" "${REMOTE_SECRET}" | ${CLIENT_EXE} apply -f -
 
+# Configure Prometheus federation
+WEST_PROMETHEUS_ADDRESS=$(${CLIENT_EXE} --context=${CLUSTER2_CONTEXT} -n ${ISTIO_NAMESPACE} get svc prometheus -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+sed -i "s/WEST_PROMETHEUS_ADDRESS/$WEST_PROMETHEUS_ADDRESS/g" ${SCRIPT_DIR}/prometheus.yaml
+${CLIENT_EXE} apply -f ${SCRIPT_DIR}/prometheus.yaml -n ${ISTIO_NAMESPACE} --context ${CLUSTER1_CONTEXT} 
+sed -i "s/$WEST_PROMETHEUS_ADDRESS/WEST_PROMETHEUS_ADDRESS/g" ${SCRIPT_DIR}/prometheus.yaml
+
 # Install bookinfo across cluster if enabled
 source ${SCRIPT_DIR}/split-bookinfo.sh
 

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -17,12 +17,6 @@ source ${SCRIPT_DIR}/env.sh $*
 echo "Starting minikube instances"
 source ${SCRIPT_DIR}/start-minikube.sh
 
-# Temporary fix due to https://github.com/kubernetes/minikube/issues/16053
-${CLIENT_EXE} set image --context ${CLUSTER1_CONTEXT} -n metallb-system deployment/controller controller=quay.io/metallb/controller:v0.9.6@sha256:6932cf255dd7f06f550c7f106b9a206be95f847ab8cb77aafac7acd27def0b00
-${CLIENT_EXE} set image --context ${CLUSTER1_CONTEXT} -n metallb-system daemonset/speaker speaker=quay.io/metallb/speaker:v0.9.6@sha256:7a400205b4986acd3d2ff32c29929682b8ff8d830837aff74f787c757176fa9f
-${CLIENT_EXE} set image --context ${CLUSTER2_CONTEXT} -n metallb-system deployment/controller controller=quay.io/metallb/controller:v0.9.6@sha256:6932cf255dd7f06f550c7f106b9a206be95f847ab8cb77aafac7acd27def0b00
-${CLIENT_EXE} set image --context ${CLUSTER2_CONTEXT} -n metallb-system daemonset/speaker speaker=quay.io/metallb/speaker:v0.9.6@sha256:7a400205b4986acd3d2ff32c29929682b8ff8d830837aff74f787c757176fa9f
-
 # Setup the certificates
 source ${SCRIPT_DIR}/setup-ca.sh
 

--- a/hack/istio/multicluster/prometheus.yaml
+++ b/hack/istio/multicluster/prometheus.yaml
@@ -27,7 +27,7 @@ data:
 
       static_configs:
         - targets:
-          - ':9090'
+          - 'WEST_PROMETHEUS_ADDRESS:9090'
           labels:
             cluster: 'west'
     - job_name: prometheus

--- a/hack/istio/multicluster/prometheus.yaml
+++ b/hack/istio/multicluster/prometheus.yaml
@@ -27,7 +27,7 @@ data:
 
       static_configs:
         - targets:
-          - 'WEST_PROMETHEUS_ADDRESS:9090'
+          - ':9090'
           labels:
             cluster: 'west'
     - job_name: prometheus

--- a/hack/istio/multicluster/start-minikube.sh
+++ b/hack/istio/multicluster/start-minikube.sh
@@ -106,6 +106,10 @@ minikube stop -p "${CLUSTER1_NAME}"
 echo "==== START MINIKUBE FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
 start_minikube "${CLUSTER1_NAME}" "70-84" "--extra-config=apiserver.oidc-issuer-url=https://${KUBE_HOSTNAME}/realms/kube --extra-config=apiserver.oidc-ca-file=${MINIKUBE_KEYCLOAK_CERTS_DIR}/root-ca.pem --extra-config=apiserver.oidc-client-id=kube --extra-config=apiserver.oidc-groups-claim=groups --extra-config=apiserver.oidc-username-prefix=oidc: --extra-config=apiserver.oidc-groups-prefix=oidc: --extra-config=apiserver.oidc-username-claim=preferred_username"
 
+# Temporary fix due to https://github.com/kubernetes/minikube/issues/16053
+${CLIENT_EXE} set image --context ${CLUSTER1_NAME} -n metallb-system deployment/controller controller=quay.io/metallb/controller:v0.9.6@sha256:6932cf255dd7f06f550c7f106b9a206be95f847ab8cb77aafac7acd27def0b00
+${CLIENT_EXE} set image --context ${CLUSTER1_NAME} -n metallb-system daemonset/speaker speaker=quay.io/metallb/speaker:v0.9.6@sha256:7a400205b4986acd3d2ff32c29929682b8ff8d830837aff74f787c757176fa9f
+
 # Wait for ingress to become ready before deploying keycloak since keycloak relies on it.
 ${CLIENT_EXE} rollout status deployment/ingress-nginx-controller -n ingress-nginx
 
@@ -176,3 +180,7 @@ done
 minikube stop -p "${CLUSTER2_NAME}"
 echo "==== START MINIKUBE FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
 start_minikube "${CLUSTER2_NAME}" "85-98" "--network=mk-${CLUSTER1_NAME} --extra-config=apiserver.oidc-issuer-url=https://${KUBE_HOSTNAME}/realms/kube --extra-config=apiserver.oidc-ca-file=${MINIKUBE_KEYCLOAK_CERTS_DIR}/root-ca.pem --extra-config=apiserver.oidc-client-id=kube --extra-config=apiserver.oidc-groups-claim=groups --extra-config=apiserver.oidc-username-prefix=oidc: --extra-config=apiserver.oidc-groups-prefix=oidc: --extra-config=apiserver.oidc-username-claim=preferred_username"
+
+# Temporary fix due to https://github.com/kubernetes/minikube/issues/16053
+${CLIENT_EXE} set image --context ${CLUSTER2_NAME} -n metallb-system deployment/controller controller=quay.io/metallb/controller:v0.9.6@sha256:6932cf255dd7f06f550c7f106b9a206be95f847ab8cb77aafac7acd27def0b00
+${CLIENT_EXE} set image --context ${CLUSTER2_NAME} -n metallb-system daemonset/speaker speaker=quay.io/metallb/speaker:v0.9.6@sha256:7a400205b4986acd3d2ff32c29929682b8ff8d830837aff74f787c757176fa9f


### PR DESCRIPTION
This PR adds the workaround for Metallb (needed until the next Minikube release) in the start-minikube script so both hack scripts to install primary-remote and multi-primary can benefit from it.

Also, adds the same logic to federate west's Prometheus into East's.

Finally, the default value for the generation of cross gateways (eastwest-gateway) is default to true as this is needed for proper communication between services across clusters. 