### PR TITLE
Check if Istio API (CRDs) are defined to cache them

### DIFF
--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -1066,6 +1066,11 @@ func (c *kubeCache) GetVirtualServices(namespace, labelSelector string) ([]*netw
 	// but it won't prevent other routines from reading from the lister.
 	defer c.cacheLock.RUnlock()
 	c.cacheLock.RLock()
+	// Check if informers are started for this type
+	if c.getCacheLister(namespace).virtualServiceLister == nil {
+		// If disabled, return an empty list
+		return []*networking_v1beta1.VirtualService{}, nil
+	}
 	vs, err := c.getCacheLister(namespace).virtualServiceLister.VirtualServices(namespace).List(selector)
 	if err != nil {
 		return nil, err

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -365,70 +365,72 @@ func (c *kubeCache) createIstioInformers(namespace string) istio.SharedInformerF
 	sharedInformers := istio.NewSharedInformerFactoryWithOptions(c.client.Istio(), c.refreshDuration, opts...)
 	lister := c.getCacheLister(namespace)
 
-	if c.CheckIstioResource(kubernetes.AuthorizationPolicies) {
-		lister.authzLister = sharedInformers.Security().V1beta1().AuthorizationPolicies().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Security().V1beta1().AuthorizationPolicies().Informer().HasSynced)
-		sharedInformers.Security().V1beta1().AuthorizationPolicies().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.DestinationRules) {
-		lister.destinationRuleLister = sharedInformers.Networking().V1beta1().DestinationRules().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().DestinationRules().Informer().HasSynced)
-		sharedInformers.Networking().V1beta1().DestinationRules().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.EnvoyFilters) {
-		lister.envoyFilterLister = sharedInformers.Networking().V1alpha3().EnvoyFilters().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1alpha3().EnvoyFilters().Informer().HasSynced)
-		sharedInformers.Networking().V1alpha3().EnvoyFilters().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.Gateways) {
-		lister.gatewayLister = sharedInformers.Networking().V1beta1().Gateways().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().Gateways().Informer().HasSynced)
-		sharedInformers.Networking().V1beta1().Gateways().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.PeerAuthentications) {
-		lister.peerAuthnLister = sharedInformers.Security().V1beta1().PeerAuthentications().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Security().V1beta1().PeerAuthentications().Informer().HasSynced)
-		sharedInformers.Security().V1beta1().PeerAuthentications().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.RequestAuthentications) {
-		lister.requestAuthnLister = sharedInformers.Security().V1beta1().RequestAuthentications().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Security().V1beta1().RequestAuthentications().Informer().HasSynced)
-		sharedInformers.Security().V1beta1().RequestAuthentications().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.ServiceEntries) {
-		lister.serviceEntryLister = sharedInformers.Networking().V1beta1().ServiceEntries().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().ServiceEntries().Informer().HasSynced)
-		sharedInformers.Networking().V1beta1().ServiceEntries().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.Sidecars) {
-		lister.sidecarLister = sharedInformers.Networking().V1beta1().Sidecars().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().Sidecars().Informer().HasSynced)
-		sharedInformers.Networking().V1beta1().Sidecars().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.Telemetries) {
-		lister.telemetryLister = sharedInformers.Telemetry().V1alpha1().Telemetries().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Telemetry().V1alpha1().Telemetries().Informer().HasSynced)
-		sharedInformers.Telemetry().V1alpha1().Telemetries().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.VirtualServices) {
-		lister.virtualServiceLister = sharedInformers.Networking().V1beta1().VirtualServices().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().VirtualServices().Informer().HasSynced)
-		sharedInformers.Networking().V1beta1().VirtualServices().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.WasmPlugins) {
-		lister.wasmPluginLister = sharedInformers.Extensions().V1alpha1().WasmPlugins().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Extensions().V1alpha1().WasmPlugins().Informer().HasSynced)
-		sharedInformers.Extensions().V1alpha1().WasmPlugins().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.WorkloadEntries) {
-		lister.workloadEntryLister = sharedInformers.Networking().V1beta1().WorkloadEntries().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().WorkloadEntries().Informer().HasSynced)
-		sharedInformers.Networking().V1beta1().WorkloadEntries().Informer().AddEventHandler(c.registryRefreshHandler)
-	}
-	if c.CheckIstioResource(kubernetes.WorkloadGroups) {
-		lister.workloadGroupLister = sharedInformers.Networking().V1beta1().WorkloadGroups().Lister()
-		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().WorkloadGroups().Informer().HasSynced)
-		sharedInformers.Networking().V1beta1().WorkloadGroups().Informer().AddEventHandler(c.registryRefreshHandler)
+	if c.client.IsIstioAPI() {
+		if c.CheckIstioResource(kubernetes.AuthorizationPolicies) {
+			lister.authzLister = sharedInformers.Security().V1beta1().AuthorizationPolicies().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Security().V1beta1().AuthorizationPolicies().Informer().HasSynced)
+			sharedInformers.Security().V1beta1().AuthorizationPolicies().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.DestinationRules) {
+			lister.destinationRuleLister = sharedInformers.Networking().V1beta1().DestinationRules().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().DestinationRules().Informer().HasSynced)
+			sharedInformers.Networking().V1beta1().DestinationRules().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.EnvoyFilters) {
+			lister.envoyFilterLister = sharedInformers.Networking().V1alpha3().EnvoyFilters().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1alpha3().EnvoyFilters().Informer().HasSynced)
+			sharedInformers.Networking().V1alpha3().EnvoyFilters().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.Gateways) {
+			lister.gatewayLister = sharedInformers.Networking().V1beta1().Gateways().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().Gateways().Informer().HasSynced)
+			sharedInformers.Networking().V1beta1().Gateways().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.PeerAuthentications) {
+			lister.peerAuthnLister = sharedInformers.Security().V1beta1().PeerAuthentications().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Security().V1beta1().PeerAuthentications().Informer().HasSynced)
+			sharedInformers.Security().V1beta1().PeerAuthentications().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.RequestAuthentications) {
+			lister.requestAuthnLister = sharedInformers.Security().V1beta1().RequestAuthentications().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Security().V1beta1().RequestAuthentications().Informer().HasSynced)
+			sharedInformers.Security().V1beta1().RequestAuthentications().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.ServiceEntries) {
+			lister.serviceEntryLister = sharedInformers.Networking().V1beta1().ServiceEntries().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().ServiceEntries().Informer().HasSynced)
+			sharedInformers.Networking().V1beta1().ServiceEntries().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.Sidecars) {
+			lister.sidecarLister = sharedInformers.Networking().V1beta1().Sidecars().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().Sidecars().Informer().HasSynced)
+			sharedInformers.Networking().V1beta1().Sidecars().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.Telemetries) {
+			lister.telemetryLister = sharedInformers.Telemetry().V1alpha1().Telemetries().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Telemetry().V1alpha1().Telemetries().Informer().HasSynced)
+			sharedInformers.Telemetry().V1alpha1().Telemetries().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.VirtualServices) {
+			lister.virtualServiceLister = sharedInformers.Networking().V1beta1().VirtualServices().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().VirtualServices().Informer().HasSynced)
+			sharedInformers.Networking().V1beta1().VirtualServices().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.WasmPlugins) {
+			lister.wasmPluginLister = sharedInformers.Extensions().V1alpha1().WasmPlugins().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Extensions().V1alpha1().WasmPlugins().Informer().HasSynced)
+			sharedInformers.Extensions().V1alpha1().WasmPlugins().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.WorkloadEntries) {
+			lister.workloadEntryLister = sharedInformers.Networking().V1beta1().WorkloadEntries().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().WorkloadEntries().Informer().HasSynced)
+			sharedInformers.Networking().V1beta1().WorkloadEntries().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
+		if c.CheckIstioResource(kubernetes.WorkloadGroups) {
+			lister.workloadGroupLister = sharedInformers.Networking().V1beta1().WorkloadGroups().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Networking().V1beta1().WorkloadGroups().Informer().HasSynced)
+			sharedInformers.Networking().V1beta1().WorkloadGroups().Informer().AddEventHandler(c.registryRefreshHandler)
+		}
 	}
 
 	return sharedInformers

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -315,7 +315,7 @@ func (c *kubeCache) refresh(namespace string) error {
 
 func (c *kubeCache) CheckIstioResource(resourceType string) bool {
 	_, exist := c.cacheIstioTypes[kubernetes.PluralType[resourceType]]
-	return exist
+	return exist && c.client.IsIstioAPI()
 }
 
 // starter is a small interface around the different informer factories that
@@ -1066,11 +1066,6 @@ func (c *kubeCache) GetVirtualServices(namespace, labelSelector string) ([]*netw
 	// but it won't prevent other routines from reading from the lister.
 	defer c.cacheLock.RUnlock()
 	c.cacheLock.RLock()
-	// Check if informers are started for this type
-	if c.getCacheLister(namespace).virtualServiceLister == nil {
-		// If disabled, return an empty list
-		return []*networking_v1beta1.VirtualService{}, nil
-	}
 	vs, err := c.getCacheLister(namespace).virtualServiceLister.VirtualServices(namespace).List(selector)
 	if err != nil {
 		return nil, err

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -42,6 +42,7 @@ type ClientInterface interface {
 	GetAuthInfo() *api.AuthInfo
 	IsOpenShift() bool
 	IsGatewayAPI() bool
+	IsIstioAPI() bool
 	GetClusterNames() []string
 	K8SClientInterface
 	IstioClientInterface
@@ -64,6 +65,7 @@ type K8SClient struct {
 	// isGatewayAPI private variable will check if K8s Gateway API CRD exists on cluster or not
 	isGatewayAPI *bool
 	gatewayapi   gatewayapiclient.Interface
+	isIstioAPI   *bool
 
 	// Separated out for testing purposes
 	getPodPortForwarderFunc func(namespace, name, portMap string) (httputil.PortForwarder, error)

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -228,6 +228,24 @@ func (in *K8SClient) IsGatewayAPI() bool {
 	return *in.isGatewayAPI
 }
 
+// Is IstioAPI checks whether Istio API is installed or not
+func (in *K8SClient) IsIstioAPI() bool {
+	if in.Istio() == nil {
+		return false
+	}
+	if in.isIstioAPI == nil {
+		isIstioAPI := false
+		_, err := in.k8s.Discovery().RESTClient().Get().AbsPath("/apis/networking.istio.io").Do(in.ctx).Raw()
+		if err == nil {
+			isIstioAPI = true
+		} else if !errors.IsNotFound(err) {
+			log.Warningf("Error checking Istio API configuration: %v", err)
+		}
+		in.isIstioAPI = &isIstioAPI
+	}
+	return *in.isIstioAPI
+}
+
 // GetServices returns a list of services for a given namespace.
 // If selectorLabels is defined the list of services is filtered for those that matches Services selector labels.
 // It returns an error on any problem.

--- a/kubernetes/kubetest/fake.go
+++ b/kubernetes/kubetest/fake.go
@@ -106,6 +106,7 @@ func NewFakeK8sClient(objects ...runtime.Object) *FakeK8sClient {
 		projects:          projects,
 		KubeClientset:     kubeClient,
 		IstioClientset:    istioClient,
+		IstioAPIEnabled:   true,
 	}
 }
 
@@ -113,6 +114,7 @@ func NewFakeK8sClient(objects ...runtime.Object) *FakeK8sClient {
 type FakeK8sClient struct {
 	OpenShift         bool
 	GatewayAPIEnabled bool
+	IstioAPIEnabled   bool
 	kialikube.ClientInterface
 	// Keeping track of the openshift objects separately since we don't use the openshift client-go
 	// and there's no underlying fake clientset.
@@ -131,6 +133,7 @@ type FakeK8sClient struct {
 
 func (c *FakeK8sClient) IsOpenShift() bool  { return c.OpenShift }
 func (c *FakeK8sClient) IsGatewayAPI() bool { return c.GatewayAPIEnabled }
+func (c *FakeK8sClient) IsIstioAPI() bool   { return c.IstioAPIEnabled }
 func (c *FakeK8sClient) GetToken() string   { return c.Token }
 
 // The openshift resources are stubbed out because Kiali talks directly to the

--- a/kubernetes/kubetest/fake.go
+++ b/kubernetes/kubetest/fake.go
@@ -131,11 +131,10 @@ type FakeK8sClient struct {
 	Token string
 }
 
-func (c *FakeK8sClient) IsOpenShift() bool                { return c.OpenShift }
-func (c *FakeK8sClient) IsGatewayAPI() bool               { return c.GatewayAPIEnabled }
-func (c *FakeK8sClient) IsIstioAPI() bool                 { return c.IstioAPIEnabled }
-func (c *FakeK8sClient) GetToken() string                 { return c.Token }
-func (c *FakeK8sClient) SetIstioAPI(istioAPIEnabled bool) { c.IstioAPIEnabled = istioAPIEnabled }
+func (c *FakeK8sClient) IsOpenShift() bool  { return c.OpenShift }
+func (c *FakeK8sClient) IsGatewayAPI() bool { return c.GatewayAPIEnabled }
+func (c *FakeK8sClient) IsIstioAPI() bool   { return c.IstioAPIEnabled }
+func (c *FakeK8sClient) GetToken() string   { return c.Token }
 
 // The openshift resources are stubbed out because Kiali talks directly to the
 // kube api for these instead of using the openshift client-go.

--- a/kubernetes/kubetest/fake.go
+++ b/kubernetes/kubetest/fake.go
@@ -131,10 +131,11 @@ type FakeK8sClient struct {
 	Token string
 }
 
-func (c *FakeK8sClient) IsOpenShift() bool  { return c.OpenShift }
-func (c *FakeK8sClient) IsGatewayAPI() bool { return c.GatewayAPIEnabled }
-func (c *FakeK8sClient) IsIstioAPI() bool   { return c.IstioAPIEnabled }
-func (c *FakeK8sClient) GetToken() string   { return c.Token }
+func (c *FakeK8sClient) IsOpenShift() bool                { return c.OpenShift }
+func (c *FakeK8sClient) IsGatewayAPI() bool               { return c.GatewayAPIEnabled }
+func (c *FakeK8sClient) IsIstioAPI() bool                 { return c.IstioAPIEnabled }
+func (c *FakeK8sClient) GetToken() string                 { return c.Token }
+func (c *FakeK8sClient) SetIstioAPI(istioAPIEnabled bool) { c.IstioAPIEnabled = istioAPIEnabled }
 
 // The openshift resources are stubbed out because Kiali talks directly to the
 // kube api for these instead of using the openshift client-go.

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -84,6 +84,7 @@ func NewK8SClientMock() *K8SClientMock {
 	k8s := new(K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
 	k8s.On("IsGatewayAPI").Return(false)
+	k8s.On("IsIstioAPI").Return(true)
 	k8s.On("GetKialiTokenForHomeCluster").Return("")
 	k8s.On("GetClusterNames").Return(kubernetes.HomeClusterName)
 	return k8s
@@ -126,6 +127,11 @@ func (o *K8SClientMock) IsOpenShift() bool {
 }
 
 func (o *K8SClientMock) IsGatewayAPI() bool {
+	args := o.Called()
+	return args.Get(0).(bool)
+}
+
+func (o *K8SClientMock) IsIstioAPI() bool {
 	args := o.Called()
 	return args.Get(0).(bool)
 }


### PR DESCRIPTION
Resolves #5939.

Similarly to the GatewayAPI logic, this PR adds the same for Istio APIs. This will be necessary for the remote clusters where is not mandatory to have the CRDs installed.

The following is an example of a Primary-Remote setup with Kiali working ok:

![image](https://user-images.githubusercontent.com/1286393/227063337-328c61ae-995e-458e-b3fa-97dffbf2243b.png)
