### PR TITLE
Add retries to downloading istio

### DIFF
--- a/hack/istio/download-istio.sh
+++ b/hack/istio/download-istio.sh
@@ -89,7 +89,7 @@ if [ ! -d "./istio-${VERSION_WE_WANT}" ]; then
   echo "Cannot find Istio ${VERSION_WE_WANT} - will download it now..."
   if [ -z "${DEV_ISTIO_VERSION}" ]; then
     export ISTIO_VERSION
-    curl -L https://git.io/getLatestIstio | sh -
+    curl -L --retry 4 --retry-delay 5 https://git.io/getLatestIstio | sh -
   else
     # See https://github.com/istio/istio/wiki/Dev%20Builds
     curl -L https://gcsweb.istio.io/gcs/istio-build/dev/${VERSION_WE_WANT}/istio-${VERSION_WE_WANT}-linux-amd64.tar.gz | tar xvfz -


### PR DESCRIPTION
Some transient errors in CI seem to be caused by failure to download Istio. Adding retries to try and alleviate the issue.

See: https://github.com/kiali/kiali/actions/runs/4504544840/jobs/7929276953 for an example of a failed CI job due to the failure to download Istio.