### PR TITLE
Fix panic in istiod resource thresholds

### DIFF
--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -7,16 +7,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/models"
 )
 
 // Setup Mesh cache to avoid duplicate mesh_test.go logic into other business/*_test.go
@@ -243,7 +246,7 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 func createTestRemoteClusterSecretFile(t *testing.T, parentDir string, name string, content string) {
 	childDir := fmt.Sprintf("%s/%s", parentDir, name)
 	filename := fmt.Sprintf("%s/%s", childDir, name)
-	if err := os.MkdirAll(childDir, 0777); err != nil {
+	if err := os.MkdirAll(childDir, 0o777); err != nil {
 		t.Fatalf("Failed to create tmp remote cluster secret dir [%v]: %v", childDir, err)
 	}
 	f, err := os.Create(filename)
@@ -486,5 +489,183 @@ func TestCanaryUpgradeConfigured(t *testing.T) {
 	check.Equal(1, len(canaryUpgradeStatus.MigratedNamespaces))
 	check.Contains(canaryUpgradeStatus.PendingNamespaces, "travel-portal")
 	check.Equal(1, len(canaryUpgradeStatus.PendingNamespaces))
+}
 
+func TestIstiodResourceThresholds(t *testing.T) {
+	config.Set(config.NewConfig())
+
+	testCases := map[string]struct {
+		istiodConatiner core_v1.Container
+		istiodMeta      v1.ObjectMeta
+		expected        *models.IstiodThresholds
+		expectedErr     error
+	}{
+		"istiod with no limits": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			istiodConatiner: core_v1.Container{
+				Name: "istiod",
+			},
+			expected: &models.IstiodThresholds{
+				CPU:    0,
+				Memory: 0,
+			},
+		},
+		"istiod with limits": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			istiodConatiner: core_v1.Container{
+				Name: "istiod",
+				Resources: core_v1.ResourceRequirements{
+					Limits: core_v1.ResourceList{
+						core_v1.ResourceCPU:    resource.MustParse("1000m"),
+						core_v1.ResourceMemory: resource.MustParse("1G"),
+					},
+				},
+			},
+			expected: &models.IstiodThresholds{
+				CPU:    1,
+				Memory: 1000,
+			},
+		},
+		"istiod with binary limits": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			istiodConatiner: core_v1.Container{
+				Name: "istiod",
+				Resources: core_v1.ResourceRequirements{
+					Limits: core_v1.ResourceList{
+						core_v1.ResourceCPU:    resource.MustParse("14m"),
+						core_v1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			expected: &models.IstiodThresholds{
+				CPU: 0.014,
+				// Rounded
+				Memory: 1074,
+			},
+		},
+		"istiod with cpu numeral": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			istiodConatiner: core_v1.Container{
+				Name: "istiod",
+				Resources: core_v1.ResourceRequirements{
+					Limits: core_v1.ResourceList{
+						core_v1.ResourceCPU: resource.MustParse("1.5"),
+					},
+				},
+			},
+			expected: &models.IstiodThresholds{
+				CPU: 1.5,
+			},
+		},
+		"istiod with only cpu limits": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			istiodConatiner: core_v1.Container{
+				Name: "istiod",
+				Resources: core_v1.ResourceRequirements{
+					Limits: core_v1.ResourceList{
+						core_v1.ResourceCPU: resource.MustParse("1000m"),
+					},
+				},
+			},
+			expected: &models.IstiodThresholds{
+				CPU: 1,
+			},
+		},
+		"istiod with only memory limits": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			istiodConatiner: core_v1.Container{
+				Name: "istiod",
+				Resources: core_v1.ResourceRequirements{
+					Limits: core_v1.ResourceList{
+						core_v1.ResourceMemory: resource.MustParse("1G"),
+					},
+				},
+			},
+			expected: &models.IstiodThresholds{
+				Memory: 1000,
+			},
+		},
+		"istiod with different name": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod-rev-1",
+				Namespace: "istio-system",
+			},
+			istiodConatiner: core_v1.Container{
+				Name: "istiod",
+				Resources: core_v1.ResourceRequirements{
+					Limits: core_v1.ResourceList{
+						core_v1.ResourceMemory: resource.MustParse("1G"),
+					},
+				},
+			},
+			expectedErr: fmt.Errorf("istiod deployment not found"),
+		},
+		"istiod in a different namespace": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system-2",
+			},
+			istiodConatiner: core_v1.Container{
+				Name: "istiod",
+				Resources: core_v1.ResourceRequirements{
+					Limits: core_v1.ResourceList{
+						core_v1.ResourceMemory: resource.MustParse("1G"),
+					},
+				},
+			},
+			expectedErr: fmt.Errorf("istiod deployment not found"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			istiodDeployment := &apps_v1.Deployment{
+				ObjectMeta: testCase.istiodMeta,
+				Spec: apps_v1.DeploymentSpec{
+					Template: core_v1.PodTemplateSpec{
+						Spec: core_v1.PodSpec{
+							Containers: []core_v1.Container{
+								testCase.istiodConatiner,
+							},
+						},
+					},
+				},
+			}
+			k8s := kubetest.NewFakeK8sClient(
+				&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+				istiodDeployment,
+			)
+
+			ms := MeshService{k8s: k8s}
+			actual, err := ms.IstiodResourceThresholds()
+
+			if testCase.expectedErr != nil {
+				require.Error(err)
+				// End the test early if we expect an error.
+				return
+			}
+
+			require.NoError(err)
+			require.Equal(testCase.expected, actual)
+		})
+	}
 }

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -633,6 +633,27 @@ func TestIstiodResourceThresholds(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("istiod deployment not found"),
 		},
+		"Missing limits": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			istiodConatiner: core_v1.Container{
+				Name:      "istiod",
+				Resources: core_v1.ResourceRequirements{},
+			},
+			expected: &models.IstiodThresholds{},
+		},
+		"Missing resources": {
+			istiodMeta: v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			istiodConatiner: core_v1.Container{
+				Name: "istiod",
+			},
+			expected: &models.IstiodThresholds{},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
Check for nil before accessing limits. Return error when deployment not found. Report binary resources correctly. Add tests.

Fixes #5742

