### PR TITLE
[OSSM-3538] removed duplicate scenario names

### DIFF
--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -15,11 +15,11 @@ Feature: Kiali App Details page
     Then user sees details information for app
 
   @app-details-page
-  Scenario: See minigraph for details app.
+  Scenario: See app minigraph for details app.
     Then user sees a minigraph
 
   @app-details-page
-  Scenario: See Traffic information
+  Scenario: See app Traffic information
     Then user sees inbound and outbound traffic information
 
   @app-details-page
@@ -37,7 +37,7 @@ Feature: Kiali App Details page
     Then user sees trace details
 
   @app-details-page
-  Scenario: See span info after selecting a span
+  Scenario: See trace info after selecting a span
     And user sees trace information
     When user selects a trace
     Then user sees span details

--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -37,7 +37,7 @@ Feature: Kiali App Details page
     Then user sees trace details
 
   @app-details-page
-  Scenario: See trace info after selecting a span
+  Scenario: See span info after selecting app span
     And user sees trace information
     When user selects a trace
     Then user sees span details

--- a/frontend/cypress/integration/featureFiles/graph_display.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display.feature
@@ -103,7 +103,7 @@ Scenario: Enable Traffic Rate edge labels
 
 # edge label variable must match edge data name
 @graph-page-display
-Scenario: Disable Traffic Distribution edge labels
+Scenario: Disable Traffic Rate edge labels
   When user "disables" "trafficRate" edge labels
   Then user sees "trafficRate" edge label option is closed
 
@@ -183,7 +183,7 @@ Scenario: User disables animation
   Then "traffic animation" option "does not appear" in the graph
 
 @graph-page-display
-Scenario: User resets to factory default
+Scenario: User resets to factory default setting
   When user resets to factory default
   And user opens display menu
   Then the display menu opens

--- a/frontend/cypress/integration/featureFiles/graph_toolbar.feature
+++ b/frontend/cypress/integration/featureFiles/graph_toolbar.feature
@@ -103,6 +103,6 @@ Scenario: graph type versioned app
   Then user sees a "versionedApp" graph
 
 @graph-page-toolbar
-Scenario: graph type service
+Scenario: graph type workload
   When user selects "WORKLOAD" graph type
   Then user sees a "workload" graph

--- a/frontend/cypress/integration/featureFiles/istio_config_editor.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_editor.feature
@@ -8,7 +8,7 @@ Feature: Kiali Istio Config editor page
     And user is at the "istio" page
     And user selects the "bookinfo" namespace
 
-  Scenario: Filter Istio Config objects by Valid configuration
+  Scenario: Verify editor loads correctly
     When the user filters by "Config" for "Valid"
     And user sees "bookinfo-gateway"
     And user sees "bookinfo"

--- a/frontend/cypress/integration/featureFiles/istio_config_editor.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_editor.feature
@@ -8,7 +8,7 @@ Feature: Kiali Istio Config editor page
     And user is at the "istio" page
     And user selects the "bookinfo" namespace
 
-  Scenario: Verify editor loads correctly
+  Scenario: Filter Istio Config editor objects by Valid configuration
     When the user filters by "Config" for "Valid"
     And user sees "bookinfo-gateway"
     And user sees "bookinfo"

--- a/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
@@ -28,12 +28,12 @@ Feature: Kiali Istio Config page
     When multiple filters are chosen
     Then multiple filters are active
 
-  Scenario: Filter should be deletable 
+  Scenario: Filter AuthorizationPolicy should be deletable 
     When a type filter "AuthorizationPolicy" is applied  
     And user clicks the cross next to the "AuthorizationPolicy" 
     Then the filter is no longer active 
 
-  Scenario: Deleting all filters at once
+  Scenario: Deleting all filters at once in config
     When a type filter "AuthorizationPolicy" is applied
     And user clicks on "Clear all filters"
     Then the filter is no longer active 
@@ -42,7 +42,7 @@ Feature: Kiali Istio Config page
     When user chooses 4 type filters
     Then he can only see 3 right away
     
-  Scenario: Show the view of all chosen filters
+  Scenario: Show the view of all type filters
     When user chooses 4 type filters
     And clicks on the button next to them
     Then he can see the remaining filter

--- a/frontend/cypress/integration/featureFiles/istio_config_validation_filters.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_validation_filters.feature
@@ -15,7 +15,7 @@ Feature: Kiali Istio Config page
     Then user can see the Filter by Config Validation dropdown
     And the dropdown contains all of the filters 
 
-  Scenario: Single filter should be usable 
+  Scenario: Single validation filter should be usable 
     When a validation filter is chosen from the dropdown
     Then the filter is applied and visible
 
@@ -29,16 +29,16 @@ Feature: Kiali Istio Config page
     And user clicks on "Clear all filters"
     Then the filter is no longer active 
 
-  Scenario: When 4 or more filters are chosen, only 3 are visible right away
+  Scenario: When 4 or more filters are chosen, only 3 are visible
     When user chooses 4 validation filters
     Then he can only see 3 right away
     
-  Scenario: Show the view of all chosen filters
+  Scenario: Show the view of all validation filters
     When user chooses 4 validation filters
     And clicks on the button next to them
     Then he can see the remaining filter
 
-  Scenario: Hide the menu of all chosen filters 
+  Scenario: Hide the menu of all chosen filters for valdiation
     When user chooses 4 validation filters
     And makes them all visible
     When user clicks on "Show Less"

--- a/frontend/cypress/integration/featureFiles/kiali_cookie.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_cookie.feature
@@ -7,13 +7,8 @@ Feature: Kiali login cookie
     Given user is at administrator perspective
   
   @smoke  
-  Scenario: Open Kaili home page
+  Scenario: Console is visible after login
     And user visits base url
     Then user see console in URL
   
-  @smoke
-  Scenario: Open Kaili home page2
-    And user visits base url
-    Then user see console in URL
-
   

--- a/frontend/cypress/integration/featureFiles/kiali_homepage.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_homepage.feature
@@ -3,6 +3,6 @@ Feature: Kiali login
   I want to login to Kiali and see landing page
 
   @smoke  
-  Scenario: Kaili is present in the page title
+  Scenario: Kiali is present in the page title
     Given I open Kiali URL
     Then I see "Kiali" in the title

--- a/frontend/cypress/integration/featureFiles/kiali_homepage.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_homepage.feature
@@ -3,6 +3,6 @@ Feature: Kiali login
   I want to login to Kiali and see landing page
 
   @smoke  
-  Scenario: Open Kaili home page
+  Scenario: Kaili is present in the page title
     Given I open Kiali URL
     Then I see "Kiali" in the title

--- a/frontend/cypress/integration/featureFiles/kiali_login.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_login.feature
@@ -6,7 +6,7 @@ Feature: Kiali login
     Given user opens base url
     And user clicks my_htpasswd_provider
 
-  Scenario: Open Kaili home page
+  Scenario: Verify console URL
     And user fill in username and password
     Then user see console in URL
 

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -22,11 +22,11 @@ Feature: Kiali Service Details page
     Then sd::user sees Istio Config
 
   @service-details-page
-  Scenario: See minigraph for details app.
+  Scenario: See service minigraph for details app.
     Then sd::user sees a minigraph
 
   @service-details-page
-  Scenario: See Traffic information
+  Scenario: See service Traffic information
     Then sd::user sees inbound and outbound traffic information
 
   @service-details-page

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -55,7 +55,7 @@ Feature: Kiali Service Details page
     Then user sees trace details
 
   @service-details-page
-  Scenario: See span info after selecting a span
+  Scenario: See span info after selecting service span
     And user sees trace information
     When user selects a trace
     Then user sees span details

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -7,7 +7,7 @@ Feature: Kiali Services page
     And user is at the "services" page
 
   @services-page
-  Scenario: See a table with correct info
+  Scenario: See services table with correct info
     When user selects the "bookinfo" namespace
     Then user sees a table with headings
       | Health | Name | Namespace | Labels | Configuration | Details |

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -7,7 +7,7 @@ Feature: Kiali Workloads page
     And user is at the "workloads" page
 
   @workloads-page
-  Scenario: See a table with correct info
+  Scenario: See workloads table with correct info
     When user selects the "bookinfo" namespace
     Then user sees a table with headings
       | Health | Name | Namespace | Type | Labels | Details |


### PR DESCRIPTION
Polarion cannot process generated XML files from Cypress due to duplicate names of scenarios. This change removes all duplicate scenario names. Functionality was not changed. 