### PR TITLE
[1.65]Update demo apps hack scripts to support OSSM cluster wide mode

### DIFF
--- a/hack/istio/functions.sh
+++ b/hack/istio/functions.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# This file contains useful functions which are used in other hack scripts in this dirrectory.
+
+
+# Given a namepace, prepare it for inclusion in Maistra's control plane
+# This means:
+# 1. Create a SMM (this is skipped for the cluster wide mode)
+# 2. Label the member namespace (only for the cluster wide mode)
+# 3. Annotate all of the namespace's Deployments with the sidecar injection annotation if enabled
+prepare_maistra() {
+  local ns="${1}"
+  if $(is_cluster_wide);
+  then
+    echo "Cluster wide mode detected."
+    ${CLIENT_EXE} label namespace ${ns} "istio-injection=enabled" --overwrite
+  else
+    cat <<EOM | ${CLIENT_EXE} apply -f -
+apiVersion: maistra.io/v1
+kind: ServiceMeshMember
+metadata:
+  name: default
+  namespace: ${ns}
+spec:
+  controlPlaneRef:
+    namespace: ${ISTIO_NAMESPACE}
+    name: "$(${CLIENT_EXE} get smcp -n ${ISTIO_NAMESPACE} -o jsonpath='{.items[0].metadata.name}' )"
+EOM
+    # let's wait for smmr to be Ready before enabling sidecar injection
+    ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
+  fi
+
+  if [ "${ENABLE_INJECTION}" == "true" ]; then
+    for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
+    do
+      echo "Enabling sidecar injection for deployment: ${d}"
+      ${CLIENT_EXE} patch ${d} -n ${ns} -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject": "true"}}}}}' --type=merge
+    done
+  fi
+}
+
+
+# Returns 0 if a smcp in given namespaces contains .spec.mode=ClusterWide, 1 otherwise.
+is_cluster_wide() {
+  local mode=$(${CLIENT_EXE} get smcp -n ${ISTIO_NAMESPACE} -o=jsonpath='{.items[0].spec.mode}' 2> /dev/null || true)
+  if [ "${mode}" = "ClusterWide" ]
+    then
+      # 0 = true
+      return 0
+    else
+      # 1 = false
+      return 1
+  fi
+}

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 ##############################################################################
 # install-bookinfo-demo.sh
 #
@@ -12,35 +11,8 @@
 #
 ##############################################################################
 
-# Given a namepace, prepare it for inclusion in Maistra's control plane
-# This means:
-# 1. Create a SMM
-# 2. Annotate all of the namespace's Deployments with the sidecar injection annotation if enabled
-prepare_maistra() {
-  local ns="${1}"
-
-  cat <<EOM | ${CLIENT_EXE} apply -f -
-apiVersion: maistra.io/v1
-kind: ServiceMeshMember
-metadata:
-  name: default
-  namespace: ${ns}
-spec:
-  controlPlaneRef:
-    namespace: ${ISTIO_NAMESPACE}
-    name: "$(${CLIENT_EXE} get smcp -n ${ISTIO_NAMESPACE} -o jsonpath='{.items[0].metadata.name}' )"
-EOM
-
-  if [ "${AUTO_INJECTION}" == "true" ]; then
-    # let's wait for smmr to be Ready before enabling sidecar injection
-    ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
-    for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
-    do
-      echo "Enabling sidecar injection for deployment: ${d}"
-      ${CLIENT_EXE} patch ${d} -n ${ns} -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject": "true"}}}}}' --type=merge
-    done
-  fi
-}
+HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${HACK_SCRIPT_DIR}/functions.sh
 
 # ISTIO_DIR is where the Istio download is installed and thus where the bookinfo demo files are found.
 # CLIENT_EXE_NAME is going to either be "oc" or "kubectl"
@@ -49,7 +21,7 @@ CLIENT_EXE_NAME="oc"
 NAMESPACE="bookinfo"
 ISTIO_NAMESPACE="istio-system"
 RATE=1
-AUTO_INJECTION="true"
+ENABLE_INJECTION="true"
 DELETE_BOOKINFO="false"
 MINIKUBE_PROFILE="minikube"
 ARCH="amd64"
@@ -63,7 +35,7 @@ while [[ $# -gt 0 ]]; do
       shift;shift
       ;;
     -ai|--auto-injection)
-      AUTO_INJECTION="$2"
+      ENABLE_INJECTION="$2"
       shift;shift
       ;;
     -db|--delete-bookinfo)
@@ -269,7 +241,7 @@ users:
 SCC
 fi
 
-if [ "${AUTO_INJECTION}" == "true" ]; then
+if [ "${ENABLE_INJECTION}" == "true" ]; then
   $CLIENT_EXE label namespace ${NAMESPACE} "istio-injection=enabled"
   $CLIENT_EXE apply -n ${NAMESPACE} -f ${BOOKINFO_YAML}
 else
@@ -297,7 +269,7 @@ if [ "${MONGO_ENABLED}" == "true" ]; then
     MONGO_SERVICE_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-s390x.yaml"
   fi
 
-  if [ "${AUTO_INJECTION}" == "true" ]; then
+  if [ "${ENABLE_INJECTION}" == "true" ]; then
     $CLIENT_EXE apply -n ${NAMESPACE} -f ${MONGO_DB_YAML}
     $CLIENT_EXE apply -n ${NAMESPACE} -f ${MONGO_SERVICE_YAML}
   else
@@ -324,7 +296,7 @@ if [ "${MYSQL_ENABLED}" == "true" ]; then
     MYSQL_SERVICE_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-s390x.yaml"
   fi
 
-  if [ "${AUTO_INJECTION}" == "true" ]; then
+  if [ "${ENABLE_INJECTION}" == "true" ]; then
     $CLIENT_EXE apply -n ${NAMESPACE} -f ${MYSQL_DB_YAML}
     $CLIENT_EXE apply -n ${NAMESPACE} -f ${MYSQL_SERVICE_YAML}
   else

--- a/hack/istio/install-error-rates-demo.sh
+++ b/hack/istio/install-error-rates-demo.sh
@@ -2,35 +2,9 @@
 
 # This deploys the error rates demo
 
-# Given a namepace, prepare it for inclusion in Maistra's control plane
-# This means:
-# 1. Create a SMM
-# 2. Annotate all of the namespace's Deployments with the sidecar injection annotation if enabled
-prepare_maistra() {
-  local ns="${1}"
+HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${HACK_SCRIPT_DIR}/functions.sh
 
-  cat <<EOM | ${CLIENT_EXE} apply -f -
-apiVersion: maistra.io/v1
-kind: ServiceMeshMember
-metadata:
-  name: default
-  namespace: ${ns}
-spec:
-  controlPlaneRef:
-    namespace: ${ISTIO_NAMESPACE}
-    name: "$(${CLIENT_EXE} get smcp -n ${ISTIO_NAMESPACE} -o jsonpath='{.items[0].metadata.name}' )"
-EOM
-
-  if [ "${ENABLE_INJECTION}" == "true" ]; then
-    # let's wait for smmr to be Ready before enabling sidecar injection
-    ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
-    for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
-    do
-      echo "Enabling sidecar injection for deployment: ${d}"
-      ${CLIENT_EXE} patch ${d} -n ${ns} -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject": "true"}}}}}' --type=merge
-    done
-  fi
-}
 
 : ${CLIENT_EXE:=oc}
 : ${ARCH:=amd64}

--- a/hack/istio/install-fraud-detection-demo.sh
+++ b/hack/istio/install-fraud-detection-demo.sh
@@ -2,35 +2,8 @@
 
 # This deploys the fraud-detection demo
 
-# Given a namepace, prepare it for inclusion in Maistra's control plane
-# This means:
-# 1. Create a SMM
-# 2. Annotate all of the namespace's Deployments with the sidecar injection annotation if enabled
-prepare_maistra() {
-  local ns="${1}"
-
-  cat <<EOM | ${CLIENT_EXE} apply -f -
-apiVersion: maistra.io/v1
-kind: ServiceMeshMember
-metadata:
-  name: default
-  namespace: ${ns}
-spec:
-  controlPlaneRef:
-    namespace: ${ISTIO_NAMESPACE}
-    name: "$(${CLIENT_EXE} get smcp -n ${ISTIO_NAMESPACE} -o jsonpath='{.items[0].metadata.name}' )"
-EOM
-
-  if [ "${ENABLE_INJECTION}" == "true" ]; then
-    # let's wait for smmr to be Ready before enabling sidecar injection
-    ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
-    for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
-    do
-      echo "Enabling sidecar injection for deployment: ${d}"
-      ${CLIENT_EXE} patch ${d} -n ${ns} -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject": "true"}}}}}' --type=merge
-    done
-  fi
-}
+HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${HACK_SCRIPT_DIR}/functions.sh
 
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMO:=false}

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -8,35 +8,8 @@
 ##############################################################################
 
 set -eu
-  
-# Given a namepace, prepare it for inclusion in Maistra's control plane
-# This means:
-# 1. Create a SMM
-# 2. Annotate all of the namespace's Deployments with the sidecar injection annotation if enabled
-prepare_maistra() {
-  local ns="${1}"
-
-  cat <<EOM | ${CLIENT_EXE} apply -f -
-apiVersion: maistra.io/v1
-kind: ServiceMeshMember
-metadata:
-  name: default
-  namespace: ${ns}
-spec:
-  controlPlaneRef:
-    namespace: ${ISTIO_NAMESPACE}
-    name: "$(${CLIENT_EXE} get smcp -n ${ISTIO_NAMESPACE} -o jsonpath='{.items[0].metadata.name}' )"
-EOM
-
-  # let's wait for smmr to be Ready before enabling sidecar injection
-  ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
-  # enable sidecar injection
-  for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
-  do
-    echo "Enabling sidecar injection for deployment: ${d}"
-    ${CLIENT_EXE} patch ${d} -n ${ns} -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject": "true"}}}}}' --type=merge
-  done
-}
+HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${HACK_SCRIPT_DIR}/functions.sh
 
 install_sleep_app() {
 
@@ -99,6 +72,7 @@ MINIKUBE_PROFILE="minikube"
 : ${CLIENT_EXE:=oc}
 : ${ARCH:=amd64}
 : ${DELETE_DEMOS:=false}
+: ${ENABLE_INJECTION:=true}
 ISTIO_NAMESPACE="istio-system"
 
 while [ $# -gt 0 ]; do

--- a/hack/istio/install-travel-agency-demo.sh
+++ b/hack/istio/install-travel-agency-demo.sh
@@ -2,35 +2,8 @@
 
 # This deploys the travel agency demo
 
-# Given a namepace, prepare it for inclusion in Maistra's control plane
-# This means:
-# 1. Create a SMM
-# 2. Annotate all of the namespace's Deployments with the sidecar injection annotation if enabled
-prepare_maistra() {
-  local ns="${1}"
-
-  cat <<EOM | ${CLIENT_EXE} apply -f -
-apiVersion: maistra.io/v1
-kind: ServiceMeshMember
-metadata:
-  name: default
-  namespace: ${ns}
-spec:
-  controlPlaneRef:
-    namespace: ${ISTIO_NAMESPACE}
-    name: "$(${CLIENT_EXE} get smcp -n ${ISTIO_NAMESPACE} -o jsonpath='{.items[0].metadata.name}' )"
-EOM
-
-  if [ "${ENABLE_INJECTION}" == "true" ]; then
-    # let's wait for smmr to be Ready before enabling sidecar injection
-    ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
-    for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
-    do
-      echo "Enabling sidecar injection for deployment: ${d}"
-      ${CLIENT_EXE} patch ${d} -n ${ns} -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject": "true"}}}}}' --type=merge
-    done
-  fi
-}
+HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${HACK_SCRIPT_DIR}/functions.sh
 
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMO:=false}


### PR DESCRIPTION
Update demo apps hack scripts to support OSSM cluster wide mode OSSM cluster wide mode has a different approach for memeber namespace management. This change is updating demo apps hack scripts to follow that.
Also the prepare_maistra functions has been moved to external script.
