### PR TITLE
XML reporting upgrade + get istio shell script fix

### DIFF
--- a/frontend/reporter-config.json
+++ b/frontend/reporter-config.json
@@ -1,6 +1,8 @@
 {
   "reporterEnabled": "spec, mocha-junit-reporter",
   "mochaJunitReporterReporterOptions": {
-    "mochaFile": "cypress/results/results-[hash].xml"
+    "mochaFile": "cypress/results/results-[hash].xml",
+    "testCaseSwitchClassnameAndName": true,
+    "jenkinsMode": true
   }
 }

--- a/hack/istio/download-istio.sh
+++ b/hack/istio/download-istio.sh
@@ -89,7 +89,7 @@ if [ ! -d "./istio-${VERSION_WE_WANT}" ]; then
   echo "Cannot find Istio ${VERSION_WE_WANT} - will download it now..."
   if [ -z "${DEV_ISTIO_VERSION}" ]; then
     export ISTIO_VERSION
-    curl -L --retry 4 --retry-delay 5 https://git.io/getLatestIstio | sh -
+    curl -L --retry 4 --retry-delay 5 https://istio.io/downloadIstio | sh -
   else
     # See https://github.com/istio/istio/wiki/Dev%20Builds
     curl -L https://gcsweb.istio.io/gcs/istio-build/dev/${VERSION_WE_WANT}/istio-${VERSION_WE_WANT}-linux-amd64.tar.gz | tar xvfz -


### PR DESCRIPTION
We need to extend XML reporting for polarion. Following changes are related only to XML reports from Cypress. This setting is tested locally.

Also small fix recommended by @jmazzitelli in shell script to download the istio from correct URL.