### PR TITLE
[OSSM-3496]Adding a Dockerfile for integration tests to be used with OpenShiftCI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+_output
+operator
+hack
+deploy
+frontend/node_modules

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,0 +1,29 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV GOPATH=/go
+ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH
+
+# install required packages and prepare go dirs
+WORKDIR /bin
+RUN microdnf install --nodocs tar gzip make \
+    && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
+    && tar -xf oc.tar.gz \
+    && rm -f oc.tar.gz \
+    && curl -Lo ./golang.tar.gz https://go.dev/dl/go1.20.2.linux-amd64.tar.gz \
+    && tar -xf golang.tar.gz -C /usr/local \
+    && rm -f golang.tar.gz \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir -p "$GOPATH/src/kiali" "$GOPATH/bin"
+
+COPY . $GOPATH/src/kiali
+
+WORKDIR "$GOPATH/src/kiali"
+
+# install packages now so we don't have to do it every time we start the container
+# Set required permissions for OpenShift usage
+RUN go mod download \
+    && chgrp -R 0 $GOPATH \
+    && chmod -R g=u $GOPATH
+
+CMD ["/bin/bash", "-c", "tests/integration/run-tests.sh"]

--- a/tests/integration/run-tests.sh
+++ b/tests/integration/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+oc login --token=${TOKEN} --server=${OCP_API_URL} --insecure-skip-tls-verify
+make test-integration -e URL=${KIALI_ROUTE}
+cat tests/integration/junit-rest-report.xml


### PR DESCRIPTION
Image produced by this Dockerfile will be used by the interop pipeline in OpenShift CI.
We can add targets for building and pushing to the makefile later. This is just to test integration with openShiftCI.