### PR TITLE
Remove SNAPSHOT from chart glob in CI script

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -153,6 +153,7 @@ infomsg "Using helm: $(ls -l ${HELM})"
 infomsg "$(${HELM} version)"
 
 infomsg "Installing kiali server via Helm"
+infomsg "Chart to be installed: $(ls -1 helm-charts/_output/charts/kiali-server-*.tgz)"
 # The grafana and tracing urls need to be set for backend e2e tests
 # but they don't need to be accessible outside the cluster.
 # Need a single dashboard set for grafana.
@@ -174,7 +175,7 @@ ${HELM} install \
   --set health_config.rate[0].tolerance[0].degraded=2 \
   --set health_config.rate[0].tolerance[0].failure=100 \
   kiali-server \
-  helm-charts/_output/charts/kiali-server-*-SNAPSHOT.tgz
+  helm-charts/_output/charts/kiali-server-*.tgz
 
 # Create the citest service account whose token will be used to log into Kiali
 infomsg "Installing the test ServiceAccount with read-write permissions"


### PR DESCRIPTION
Without this patch releases fail to install the kiali helm chart because `SNAPSHOT` is not present when you run the workflow from the patch release.