### PR TITLE
Add kube cluster name to Kiali config

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -161,26 +161,27 @@ func SetWithBackends(cf kubernetes.ClientFactory, prom prometheus.ClientInterfac
 // It should be the user client based on the logged in user's token.
 func NewWithBackends(userClients map[string]kubernetes.ClientInterface, kialiSAClients map[string]kubernetes.ClientInterface, prom prometheus.ClientInterface, jaegerClient JaegerLoader) *Layer {
 	temporaryLayer := &Layer{}
+	homeClusterName := config.Get().KubernetesConfig.ClusterName
 	// TODO: Modify the k8s argument to other services to pass the whole k8s map if needed
 	temporaryLayer.App = AppService{prom: prom, userClients: userClients, businessLayer: temporaryLayer}
 	temporaryLayer.Health = HealthService{prom: prom, businessLayer: temporaryLayer}
-	temporaryLayer.IstioConfig = IstioConfigService{k8s: userClients[kubernetes.HomeClusterName], cache: kialiCache, businessLayer: temporaryLayer}
-	temporaryLayer.IstioStatus = IstioStatusService{k8s: userClients[kubernetes.HomeClusterName], businessLayer: temporaryLayer}
-	temporaryLayer.IstioCerts = IstioCertsService{k8s: userClients[kubernetes.HomeClusterName], businessLayer: temporaryLayer}
+	temporaryLayer.IstioConfig = IstioConfigService{k8s: userClients[homeClusterName], cache: kialiCache, businessLayer: temporaryLayer}
+	temporaryLayer.IstioStatus = IstioStatusService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
+	temporaryLayer.IstioCerts = IstioCertsService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
 	temporaryLayer.Jaeger = JaegerService{loader: jaegerClient, businessLayer: temporaryLayer}
 	temporaryLayer.k8sClients = userClients
-	temporaryLayer.Mesh = NewMeshService(userClients[kubernetes.HomeClusterName], temporaryLayer, nil)
+	temporaryLayer.Mesh = NewMeshService(userClients[homeClusterName], temporaryLayer, nil)
 	temporaryLayer.Namespace = NewNamespaceService(userClients, kialiSAClients)
-	temporaryLayer.OpenshiftOAuth = OpenshiftOAuthService{k8s: userClients[kubernetes.HomeClusterName]}
-	temporaryLayer.ProxyStatus = ProxyStatusService{k8s: userClients[kubernetes.HomeClusterName], businessLayer: temporaryLayer}
+	temporaryLayer.OpenshiftOAuth = OpenshiftOAuthService{k8s: userClients[homeClusterName]}
+	temporaryLayer.ProxyStatus = ProxyStatusService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
 	// Out of order because it relies on ProxyStatus
-	temporaryLayer.ProxyLogging = ProxyLoggingService{k8s: userClients[kubernetes.HomeClusterName], proxyStatus: &temporaryLayer.ProxyStatus}
-	temporaryLayer.RegistryStatus = RegistryStatusService{k8s: userClients[kubernetes.HomeClusterName], businessLayer: temporaryLayer}
-	temporaryLayer.TLS = TLSService{k8s: userClients[kubernetes.HomeClusterName], businessLayer: temporaryLayer}
+	temporaryLayer.ProxyLogging = ProxyLoggingService{k8s: userClients[homeClusterName], proxyStatus: &temporaryLayer.ProxyStatus}
+	temporaryLayer.RegistryStatus = RegistryStatusService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
+	temporaryLayer.TLS = TLSService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
 	temporaryLayer.Svc = SvcService{config: *config.Get(), kialiCache: kialiCache, businessLayer: temporaryLayer, prom: prom, userClients: userClients}
-	temporaryLayer.TokenReview = NewTokenReview(userClients[kubernetes.HomeClusterName])
-	temporaryLayer.Validations = IstioValidationsService{k8s: userClients[kubernetes.HomeClusterName], businessLayer: temporaryLayer}
-	temporaryLayer.Workload = *NewWorkloadService(userClients[kubernetes.HomeClusterName], prom, kialiCache, temporaryLayer, config.Get())
+	temporaryLayer.TokenReview = NewTokenReview(userClients[homeClusterName])
+	temporaryLayer.Validations = IstioValidationsService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
+	temporaryLayer.Workload = *NewWorkloadService(userClients[homeClusterName], prom, kialiCache, temporaryLayer, config.Get())
 
 	return temporaryLayer
 }

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -335,7 +335,12 @@ func findKialiInNamespace(ctx context.Context, namespace string, clusterName str
 				services = kubernetes.FilterServicesByLabels(selector, tmpSvc)
 			}
 		} else {
-			services, getSvcErr = layer.k8sClients[clusterName].GetServicesByLabels(kialiNs.Name, "app.kubernetes.io/part-of=kiali")
+			k8s, ok := layer.k8sClients[clusterName]
+			if !ok {
+				log.Warningf("Discovery for Kiali instances in cluster [%s] failed: k8s client not found", clusterName)
+				return
+			}
+			services, getSvcErr = k8s.GetServicesByLabels(kialiNs.Name, "app.kubernetes.io/part-of=kiali")
 		}
 		if getSvcErr != nil && !errors.IsNotFound(getSvcErr) {
 			log.Warningf("Discovery for Kiali instances in cluster [%s] failed when finding the service in [%s] namespace: %s", clusterName, namespace, getSvcErr.Error())

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 
 	"github.com/kiali/kiali/config"
@@ -190,7 +191,7 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 	var nilDeployment *apps_v1.Deployment
 	k8s.On("IsOpenShift").Return(false)
 	k8s.On("IsGatewayAPI").Return(false)
-	k8s.On("GetDeployment", conf.IstioNamespace, "istiod").Return(nilDeployment, nil)
+	k8s.On("GetDeployment", conf.IstioNamespace, "istiod").Return(nilDeployment, errors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "deployments"}, "istiod"))
 
 	newRemoteClient := func(config *rest.Config) (kubernetes.ClientInterface, error) {
 		remoteClient := new(kubetest.K8SClientMock)

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -34,13 +34,13 @@ func TestServiceListParsing(t *testing.T) {
 		&s1,
 		&s2,
 	}
-	k8s := kubetest.NewFakeK8sClient(objects...)
 	conf := config.NewConfig()
 	config.Set(conf)
+	k8s := kubetest.NewFakeK8sClient(objects...)
 	setupGlobalMeshConfig()
 	SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	svc := NewWithBackends(k8sclients, k8sclients, nil, nil).Svc
 
 	criteria := ServiceCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}

--- a/config/config.go
+++ b/config/config.go
@@ -715,7 +715,7 @@ func NewConfig() (c *Config) {
 			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup", "WasmPlugin", "Telemetry", "K8sGateway", "K8sHTTPRoute"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
-			ClusterName:                 "Kubernetes",
+			ClusterName:                 "",
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},
 			QPS:                         175,
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -71,8 +71,10 @@ func (fn FeatureName) IsValid() error {
 }
 
 // Global configuration for the application.
-var configuration Config
-var rwMutex sync.RWMutex
+var (
+	configuration Config
+	rwMutex       sync.RWMutex
+)
 
 // Defines where the files are located that contain the secrets content
 var overrideSecretsDir = "/kiali-override-secrets"
@@ -295,6 +297,9 @@ type KubernetesConfig struct {
 	// Kiali cache list of namespaces per user, this is typically short lived cache compared with the duration of the
 	// namespace cache defined by previous CacheDuration parameter
 	CacheTokenNamespaceDuration int `yaml:"cache_token_namespace_duration,omitempty"`
+	// ClusterName is the name of the kubernetes cluster that Kiali is running in.
+	// If empty, then it will default to 'Kubernetes'.
+	ClusterName string `yaml:"cluster_name,omitempty"`
 	// List of controllers that won't be used for Workload calculation
 	// Kiali queries Deployment,ReplicaSet,ReplicationController,DeploymentConfig,StatefulSet,Job and CronJob controllers
 	// Deployment and ReplicaSet will be always queried, but ReplicationController,DeploymentConfig,StatefulSet,Job and CronJobs
@@ -710,6 +715,7 @@ func NewConfig() (c *Config) {
 			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup", "WasmPlugin", "Telemetry", "K8sGateway", "K8sHTTPRoute"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
+			ClusterName:                 "Kubernetes",
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},
 			QPS:                         175,
 		},

--- a/kiali_test.go
+++ b/kiali_test.go
@@ -5,14 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	apps_v1 "k8s.io/api/apps/v1"
-	core_v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/util"
 )
 
@@ -94,70 +87,4 @@ func TestValidateAuthStrategy(t *testing.T) {
 			t.Errorf("Auth Strategy validation should have failed [%v]", conf.Auth.Strategy)
 		}
 	}
-}
-
-func TestGetClusterInfoFromIstiod(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-
-	conf := config.NewConfig()
-	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
-		&apps_v1.Deployment{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name:      "istiod",
-				Namespace: "istio-system",
-			},
-			Spec: apps_v1.DeploymentSpec{
-				Template: core_v1.PodTemplateSpec{
-					Spec: core_v1.PodSpec{
-						Containers: []core_v1.Container{
-							{
-								Name: "istiod",
-								Env: []core_v1.EnvVar{
-									{
-										Name:  "CLUSTER_ID",
-										Value: "east",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	)
-	clusterID, err := getClusterInfoFromIstiod(*conf, k8s)
-	require.NoError(err)
-
-	assert.Equal("east", clusterID)
-}
-
-func TestGetClusterInfoFromIstiodFails(t *testing.T) {
-	require := require.New(t)
-
-	conf := config.NewConfig()
-	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
-		&apps_v1.Deployment{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name:      "istiod",
-				Namespace: "istio-system",
-			},
-			Spec: apps_v1.DeploymentSpec{
-				Template: core_v1.PodTemplateSpec{
-					Spec: core_v1.PodSpec{
-						Containers: []core_v1.Container{
-							{
-								Name: "istiod",
-								Env:  []core_v1.EnvVar{},
-							},
-						},
-					},
-				},
-			},
-		},
-	)
-	_, err := getClusterInfoFromIstiod(*conf, k8s)
-	require.Error(err)
 }

--- a/kiali_test.go
+++ b/kiali_test.go
@@ -5,7 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/util"
 )
 
@@ -87,4 +94,70 @@ func TestValidateAuthStrategy(t *testing.T) {
 			t.Errorf("Auth Strategy validation should have failed [%v]", conf.Auth.Strategy)
 		}
 	}
+}
+
+func TestGetClusterInfoFromIstiod(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	conf := config.NewConfig()
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		&apps_v1.Deployment{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			Spec: apps_v1.DeploymentSpec{
+				Template: core_v1.PodTemplateSpec{
+					Spec: core_v1.PodSpec{
+						Containers: []core_v1.Container{
+							{
+								Name: "istiod",
+								Env: []core_v1.EnvVar{
+									{
+										Name:  "CLUSTER_ID",
+										Value: "east",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	clusterID, err := getClusterInfoFromIstiod(*conf, k8s)
+	require.NoError(err)
+
+	assert.Equal("east", clusterID)
+}
+
+func TestGetClusterInfoFromIstiodFails(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		&apps_v1.Deployment{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			Spec: apps_v1.DeploymentSpec{
+				Template: core_v1.PodTemplateSpec{
+					Spec: core_v1.PodSpec{
+						Containers: []core_v1.Container{
+							{
+								Name: "istiod",
+								Env:  []core_v1.EnvVar{},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	_, err := getClusterInfoFromIstiod(*conf, k8s)
+	require.Error(err)
 }

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -86,13 +86,15 @@ func NewKialiCache(clientFactory kubernetes.ClientFactory, cfg config.Config, na
 	for cluster, client := range clientFactory.GetSAClients() {
 		cache, err := NewKubeCache(client, cfg, NewRegistryHandler(kialiCacheImpl.RefreshRegistryStatus), namespaceSeedList...)
 		if err != nil {
-			log.Errorf("[Kiali Cache] Error creating kube cache for cluster: %s. Err: %v", cluster, err)
+			log.Errorf("[Kiali Cache] Error creating kube cache for cluster: [%s]. Err: %v", cluster, err)
 			return nil, err
 		}
+		log.Infof("[Kiali Cache] Kube cache is active for cluster: [%s] and namespaces: %v", cluster, namespaceSeedList)
+
 		kialiCacheImpl.kubeCache[cluster] = cache
 
 		// TODO: Treat all clusters the same way.
-		if homeClient := clientFactory.GetSAHomeClusterClient(); homeClient != nil && homeClient.GetClusterInfo().Name == cluster {
+		if cluster == cfg.KubernetesConfig.ClusterName {
 			kialiCacheImpl.KubeCache = cache
 		}
 	}

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -89,7 +89,6 @@ func TestKubeCacheCreatedPerClient(t *testing.T) {
 	deploymentCluster2 := &apps_v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deployment2", Namespace: "test"}}
 	client := kubetest.NewFakeK8sClient(ns, deploymentCluster1)
 	client2 := kubetest.NewFakeK8sClient(ns, deploymentCluster2)
-	client2.Cluster.Name = "cluster2"
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clientFactory.SetClients(map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: client,

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -32,12 +32,13 @@ func (f *fakeKubeCache) getClient() kubernetes.ClientInterface {
 
 func TestClientUpdatedWhenSAClientChanges(t *testing.T) {
 	require := require.New(t)
-	config := config.NewConfig()
+	conf := config.NewConfig()
+	config.Set(conf)
 
 	client := kubetest.NewFakeK8sClient()
 	client.Token = "current-token"
 	clientFactory := kubetest.NewK8SClientFactoryMock(client)
-	k8sCache, err := NewKubeCache(client, *config, emptyHandler)
+	k8sCache, err := NewKubeCache(client, *conf, emptyHandler)
 	require.NoError(err)
 
 	kubeCache := &fakeKubeCache{kubeCache: k8sCache}
@@ -55,7 +56,7 @@ func TestClientUpdatedWhenSAClientChanges(t *testing.T) {
 	// Update the client. This should trigger a cache refresh.
 	newClient := kubetest.NewFakeK8sClient()
 	newClient.Token = "new-token"
-	clientFactory.SetClients(map[string]kubernetes.ClientInterface{kubernetes.HomeClusterName: newClient})
+	clientFactory.SetClients(map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: newClient})
 
 	require.Eventually(
 		func() bool { return kubeCache.getClient() != client },
@@ -67,39 +68,42 @@ func TestClientUpdatedWhenSAClientChanges(t *testing.T) {
 
 func TestNoHomeClusterReturnsError(t *testing.T) {
 	require := require.New(t)
-	config := config.NewConfig()
+	conf := config.NewConfig()
+	config.Set(conf)
 
 	client := kubetest.NewFakeK8sClient()
 	clientFactory := kubetest.NewK8SClientFactoryMock(client)
 	clientFactory.SetClients(map[string]kubernetes.ClientInterface{"nothomecluster": client})
 
-	_, err := NewKialiCache(clientFactory, *config)
+	_, err := NewKialiCache(clientFactory, *conf)
 	require.Error(err, "no home cluster should return an error")
 }
 
 func TestKubeCacheCreatedPerClient(t *testing.T) {
 	require := require.New(t)
-	config := config.NewConfig()
+	conf := config.NewConfig()
+	config.Set(conf)
 
 	ns := &core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
 	deploymentCluster1 := &apps_v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deployment1", Namespace: "test"}}
 	deploymentCluster2 := &apps_v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deployment2", Namespace: "test"}}
 	client := kubetest.NewFakeK8sClient(ns, deploymentCluster1)
 	client2 := kubetest.NewFakeK8sClient(ns, deploymentCluster2)
+	client2.Cluster.Name = "cluster2"
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clientFactory.SetClients(map[string]kubernetes.ClientInterface{
-		kubernetes.HomeClusterName: client,
-		"cluster2":                 client2,
+		conf.KubernetesConfig.ClusterName: client,
+		"cluster2":                        client2,
 	})
 
-	kialiCache, err := NewKialiCache(clientFactory, *config)
+	kialiCache, err := NewKialiCache(clientFactory, *conf)
 	require.NoError(err)
 	defer kialiCache.Stop()
 
 	caches := kialiCache.GetKubeCaches()
 	require.Equal(2, len(caches))
 
-	_, err = caches[kubernetes.HomeClusterName].GetDeployment("test", "deployment1")
+	_, err = caches[conf.KubernetesConfig.ClusterName].GetDeployment("test", "deployment1")
 	require.NoError(err)
 
 	_, err = caches["cluster2"].GetDeployment("test", "deployment2")

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -203,7 +203,7 @@ func NewKubeCache(kialiClient kubernetes.ClientInterface, cfg config.Config, ref
 		}
 	}
 
-	log.Infof("[Kiali Cache] Kube cache is active for namespaces %v", cacheNamespaces)
+	log.Infof("[Kiali Cache] Kube cache is active for cluster: %s and namespaces: %v", kialiClient.GetClusterInfo().Name, cacheNamespaces)
 
 	return c, nil
 }

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -203,8 +203,6 @@ func NewKubeCache(kialiClient kubernetes.ClientInterface, cfg config.Config, ref
 		}
 	}
 
-	log.Infof("[Kiali Cache] Kube cache is active for cluster: %s and namespaces: %v", kialiClient.GetClusterInfo().Name, cacheNamespaces)
-
 	return c, nil
 }
 

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -21,16 +21,6 @@ import (
 	"github.com/kiali/kiali/util/httputil"
 )
 
-// ClusterInfo holds some metadata about the cluster the client is connected to.
-type ClusterInfo struct {
-	// Name specifies the CLUSTER_ID as known by the Control Plane.
-	// The cluster name *should always* match what Istio thinks the cluster name is.
-	// For the home cluster, this name could come from the istio configuration at 'values.global.multiCluster.clusterName'.
-	// For remote clusters, the name comes from the name field in the remote cluster secret.
-	// Names need to be unique across all clusters in the mesh.
-	Name string
-}
-
 // RemoteSecretData is used to identify the remote cluster Kiali will connect to as its "local cluster".
 // This is to support installing Kiali in the control plane, but observing only the data plane in the remote cluster.
 // Experimental feature. See: https://github.com/kiali/kiali/issues/3002
@@ -47,7 +37,6 @@ type PodLogs struct {
 
 // ClientInterface for mocks (only mocked function are necessary here)
 type ClientInterface interface {
-	GetClusterInfo() ClusterInfo
 	GetServerVersion() (*version.Info, error)
 	GetToken() string
 	GetAuthInfo() *api.AuthInfo
@@ -63,7 +52,6 @@ type ClientInterface interface {
 // It hides the way it queries each API
 type K8SClient struct {
 	ClientInterface
-	cluster        ClusterInfo
 	token          string
 	k8s            kube.Interface
 	istioClientset istio.Interface
@@ -80,11 +68,6 @@ type K8SClient struct {
 
 	// Separated out for testing purposes
 	getPodPortForwarderFunc func(namespace, name, portMap string) (httputil.PortForwarder, error)
-}
-
-// GetClusterInfo returns the cluster info
-func (client *K8SClient) GetClusterInfo() ClusterInfo {
-	return client.cluster
 }
 
 // GetToken returns the BearerToken used from the config

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -21,6 +21,16 @@ import (
 	"github.com/kiali/kiali/util/httputil"
 )
 
+// ClusterInfo holds some metadata about the cluster the client is connected to.
+type ClusterInfo struct {
+	// Name specifies the CLUSTER_ID as known by the Control Plane.
+	// The cluster name *should always* match what Istio thinks the cluster name is.
+	// For the home cluster, this name could come from the istio configuration at 'values.global.multiCluster.clusterName'.
+	// For remote clusters, the name comes from the name field in the remote cluster secret.
+	// Names need to be unique across all clusters in the mesh.
+	Name string
+}
+
 // RemoteSecretData is used to identify the remote cluster Kiali will connect to as its "local cluster".
 // This is to support installing Kiali in the control plane, but observing only the data plane in the remote cluster.
 // Experimental feature. See: https://github.com/kiali/kiali/issues/3002
@@ -37,13 +47,13 @@ type PodLogs struct {
 
 // ClientInterface for mocks (only mocked function are necessary here)
 type ClientInterface interface {
+	GetClusterInfo() ClusterInfo
 	GetServerVersion() (*version.Info, error)
 	GetToken() string
 	GetAuthInfo() *api.AuthInfo
 	IsOpenShift() bool
 	IsGatewayAPI() bool
 	IsIstioAPI() bool
-	GetClusterNames() []string
 	K8SClientInterface
 	IstioClientInterface
 	OSClientInterface
@@ -53,6 +63,7 @@ type ClientInterface interface {
 // It hides the way it queries each API
 type K8SClient struct {
 	ClientInterface
+	cluster        ClusterInfo
 	token          string
 	k8s            kube.Interface
 	istioClientset istio.Interface
@@ -69,6 +80,11 @@ type K8SClient struct {
 
 	// Separated out for testing purposes
 	getPodPortForwarderFunc func(namespace, name, portMap string) (httputil.PortForwarder, error)
+}
+
+// GetClusterInfo returns the cluster info
+func (client *K8SClient) GetClusterInfo() ClusterInfo {
+	return client.cluster
 }
 
 // GetToken returns the BearerToken used from the config

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -28,7 +28,10 @@ const defaultExpirationTime = time.Minute * 15
 // If you need an SA client connected to the home cluster, use GetSAHomeClusterClient()
 // instead of this. This gets set when newClientFactory() is called.
 // TODO: Deprecated - remove this.
-var HomeClusterName = "Kubernetes"
+var (
+	HomeClusterName     = "Kubernetes"
+	homeClusterNameLock = sync.RWMutex{}
+)
 
 // ClientFactory interface for the clientFactory object
 type ClientFactory interface {
@@ -95,7 +98,9 @@ func GetClientFactory() (ClientFactory, error) {
 // Mock friendly for testing purposes
 func newClientFactory(restConfig *rest.Config) (*clientFactory, error) {
 	homeCluster := kialiConfig.Get().KubernetesConfig.ClusterName
+	homeClusterNameLock.Lock()
 	HomeClusterName = homeCluster
+	homeClusterNameLock.Unlock()
 	f := &clientFactory{
 		baseRestConfig:  restConfig,
 		clientEntries:   make(map[string]map[string]ClientInterface),

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -18,11 +18,17 @@ import (
 // the cached factory - only one is ever created; once created it is cached here
 var factory *clientFactory
 
+// Ensures only one factory is created
+var once sync.Once
+
 // defaultExpirationTime set the default expired time of a client
 const defaultExpirationTime = time.Minute * 15
 
 // cluster name to denote the cluster where Kiali is deployed
-const HomeClusterName = "_kiali_home"
+// If you need an SA client connected to the home cluster, use GetSAHomeClusterClient()
+// instead of this. This gets set when newClientFactory() is called.
+// TODO: Deprecated - remove this.
+var HomeClusterName = "Kubernetes"
 
 // ClientFactory interface for the clientFactory object
 type ClientFactory interface {
@@ -31,23 +37,31 @@ type ClientFactory interface {
 	GetSAClient(cluster string) ClientInterface
 	GetSAClients() map[string]ClientInterface
 	GetSAHomeClusterClient() ClientInterface
-	GetClusterNames() []string
 }
 
 // clientFactory used to generate per users clients
 type clientFactory struct {
-	// remoteClusterInfos contains information on all remote clusters taken from the remote cluster secrets, keyed on cluster name.
-	remoteClusterInfos map[string]RemoteClusterInfo
 	// baseRestConfig contains some of the base rest config to be used for all clients.
 	// Not all of the data in this base config is used - some will be overridden per client like token and host info.
 	baseRestConfig *rest.Config
+
 	// clientEntries contain user clients that are used to authenticate as logged in users.
 	// Keyed by hash code generated from auth data.
 	clientEntries map[string]map[string]ClientInterface // By token by cluster
+
+	// Name of the home cluster. This is the cluster where Kiali is deployed which is usually the
+	// "in cluster" config. This name comes from the istio cluster id.
+	homeCluster string
+
 	// mutex for when accessing the stored clients
 	mutex sync.RWMutex
+
 	// when a client is expired, a signal with its tokenHash will be sent to recycleChan
 	recycleChan chan string
+
+	// remoteClusterInfos contains information on all remote clusters taken from the remote cluster secrets, keyed on cluster name.
+	remoteClusterInfos map[string]RemoteClusterInfo
+
 	// maps cluster name to a kiali client for that cluster. The kiali client uses the
 	// kiali service account to access the cluster API.
 	saClientEntries map[string]ClientInterface
@@ -55,11 +69,13 @@ type clientFactory struct {
 
 // GetClientFactory returns the client factory. Creates a new one if necessary
 func GetClientFactory() (ClientFactory, error) {
-	if factory == nil {
+	var err error
+	once.Do(func() {
 		// Get the normal configuration
-		config, err := GetConfigForLocalCluster()
+		var config *rest.Config
+		config, err = GetConfigForLocalCluster()
 		if err != nil {
-			return nil, err
+			return
 		}
 
 		// Create a new config based on what was gathered above but don't specify the bearer token to use
@@ -70,24 +86,22 @@ func GetClientFactory() (ClientFactory, error) {
 			Burst:           config.Burst,
 		}
 
-		cf, err := newClientFactory(&baseConfig)
-		if err != nil {
-			return nil, err
-		}
-
-		factory = cf
-	}
-	return factory, nil
+		factory, err = newClientFactory(&baseConfig)
+	})
+	return factory, err
 }
 
 // newClientFactory allows for specifying the config and expiry duration
 // Mock friendly for testing purposes
 func newClientFactory(restConfig *rest.Config) (*clientFactory, error) {
+	homeCluster := kialiConfig.Get().KubernetesConfig.ClusterName
+	HomeClusterName = homeCluster
 	f := &clientFactory{
 		baseRestConfig:  restConfig,
 		clientEntries:   make(map[string]map[string]ClientInterface),
 		recycleChan:     make(chan string),
 		saClientEntries: make(map[string]ClientInterface),
+		homeCluster:     homeCluster,
 	}
 	// after creating a client factory
 	// background goroutines will be watching the clients` expiration
@@ -105,12 +119,13 @@ func newClientFactory(restConfig *rest.Config) (*clientFactory, error) {
 	// Note that this means each remote cluster secret token must be given the proper permissions
 	// in that remote cluster for Kiali to do its work. i.e. logging into a remote cluster with the
 	// remote cluster secret token must be given the same permissions as the local cluster Kiali SA.
-	// TODO: should we use a real cluster name instead of the special HomeClusterName value?
 	homeClient, err := f.newSAClient(nil)
 	if err != nil {
 		return nil, err
 	}
-	f.saClientEntries[HomeClusterName] = homeClient
+	homeClient.cluster.Name = f.homeCluster
+
+	f.saClientEntries[f.homeCluster] = homeClient
 
 	for _, clusterInfo := range remoteClusterInfos {
 		client, err := f.newSAClient(&clusterInfo)
@@ -124,7 +139,6 @@ func newClientFactory(restConfig *rest.Config) (*clientFactory, error) {
 }
 
 // newClient creates a new ClientInterface based on a users k8s token
-// TODO: this probably needs a clusterName parameter and the server-side API info needs to be obtained from a remoteClusterInfo
 func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.Duration, cluster string) (ClientInterface, error) {
 	config := *cf.baseRestConfig
 
@@ -148,7 +162,7 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 		var kialiToken string
 		var err error
 
-		if cluster == HomeClusterName {
+		if cluster == cf.homeCluster {
 			kialiToken, err = GetKialiTokenForHomeCluster()
 		} else {
 			kialiToken, err = cf.GetSAClient(cluster).GetToken(), nil
@@ -187,7 +201,7 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 	var newClient ClientInterface
 	var err error
 
-	if cluster == HomeClusterName {
+	if cluster == cf.homeCluster {
 		newClient, err = NewClientFromConfig(&config)
 		if err != nil {
 			log.Errorf("Error creating client for cluster %s: %s", cluster, err.Error())
@@ -206,7 +220,8 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 			} else {
 				remoteConfig, err2 = GetConfigWithTokenForRemoteCluster(clusterInfo[cluster].Cluster,
 					RemoteSecretUser{
-						Name: authInfo.Username, User: RemoteSecretUserToken{Token: authInfo.Token}})
+						Name: authInfo.Username, User: RemoteSecretUserToken{Token: authInfo.Token},
+					})
 			}
 
 			if err2 != nil {
@@ -236,7 +251,6 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 
 // newSAClient returns a new client for the given cluster. If clusterInfo is nil then a client for the local cluster is returned.
 func (cf *clientFactory) newSAClient(clusterInfo *RemoteClusterInfo) (*K8SClient, error) {
-
 	// if no cluster info is provided, we are being asked to create a new client for the home cluster
 	if clusterInfo == nil {
 		config := *cf.baseRestConfig
@@ -266,26 +280,26 @@ func (cf *clientFactory) GetSAClients() map[string]ClientInterface {
 
 // getClient returns a client for the specified token. Creating one if necessary.
 func (cf *clientFactory) GetClient(authInfo *api.AuthInfo) (ClientInterface, error) {
-	return cf.getRecycleClient(authInfo, defaultExpirationTime, HomeClusterName)
+	return cf.getRecycleClient(authInfo, defaultExpirationTime, cf.homeCluster)
 }
 
 // getClient returns a client for the specified token. Creating one if necessary.
 func (cf *clientFactory) GetClients(authInfo *api.AuthInfo) (map[string]ClientInterface, error) {
 	clients := make(map[string]ClientInterface)
-	for _, cluster := range cf.GetClusterNames() {
+	// Try to create a user client for each cluster there's a kiali service account configured.
+	for cluster := range cf.saClientEntries {
 		ci, err := cf.getRecycleClient(authInfo, defaultExpirationTime, cluster)
-		if err == nil {
-			clients[cluster] = ci
-		} else {
-			log.Errorf("Error returning client %s", err)
+		if err != nil {
+			log.Errorf("Error returning user client for cluster: %s. Err: %s", cluster, err)
 		}
-	}
-	if len(clients) > 0 {
-		return clients, nil
-	} else {
-		return nil, errors.New("Error getting clients")
+		clients[cluster] = ci
 	}
 
+	if len(clients) == 0 {
+		return nil, errors.New("unable to create create any user clients")
+	}
+
+	return clients, nil
 }
 
 // getRecycleClient returns a client for the specified token with expirationTime. Creating one if necessary.
@@ -404,7 +418,7 @@ func (cf *clientFactory) refreshClientIfTokenChanged(cluster string) error {
 	var refreshTheClient bool // will be true if the client needs to be refreshed
 	var rci *RemoteClusterInfo
 
-	if cluster == HomeClusterName {
+	if cluster == cf.homeCluster {
 		// LOCAL CLUSTER
 		if newTokenToCheck, err := GetKialiTokenForHomeCluster(); err != nil {
 			return err
@@ -451,19 +465,5 @@ func (cf *clientFactory) refreshClientIfTokenChanged(cluster string) error {
 
 // KialiSAHomeClusterClient returns the Kiali service account client for the cluster where Kiali is running.
 func (cf *clientFactory) GetSAHomeClusterClient() ClientInterface {
-	return cf.GetSAClient(HomeClusterName)
-}
-
-// GetClusterNames returns all the known cluster names - this includes all remotes as well as the home cluster name.
-func (cf *clientFactory) GetClusterNames() []string {
-	cf.mutex.RLock()
-	defer cf.mutex.RUnlock()
-
-	clusterNames := make([]string, 0, 1+len(cf.remoteClusterInfos))
-	clusterNames = append(clusterNames, HomeClusterName)
-	for clusterName := range cf.remoteClusterInfos {
-		clusterNames = append(clusterNames, clusterName)
-	}
-
-	return clusterNames
+	return cf.GetSAClient(cf.homeCluster)
 }

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -120,13 +120,11 @@ func newClientFactory(restConfig *rest.Config) (*clientFactory, error) {
 	// Note that this means each remote cluster secret token must be given the proper permissions
 	// in that remote cluster for Kiali to do its work. i.e. logging into a remote cluster with the
 	// remote cluster secret token must be given the same permissions as the local cluster Kiali SA.
-	// TODO: Support remote secret.
 	homeClient, err := f.newSAClient(nil)
 	if err != nil {
 		return nil, err
 	}
 
-	homeClient.cluster.Name = f.homeCluster
 	f.saClientEntries[f.homeCluster] = homeClient
 
 	for _, clusterInfo := range remoteClusterInfos {

--- a/kubernetes/cluster_secret_test.go
+++ b/kubernetes/cluster_secret_test.go
@@ -57,7 +57,10 @@ func TestReloadRemoteClusterSecret(t *testing.T) {
 	check.Nil(err)
 	check.NotNil(clientFactory)
 
-	clusterNames := clientFactory.GetClusterNames()
+	var clusterNames []string
+	for cluster := range clientFactory.saClientEntries {
+		clusterNames = append(clusterNames, cluster)
+	}
 	check.Equal(2, len(clusterNames), "Should have seen the remote cluster secret")
 	check.Contains(clusterNames, HomeClusterName)
 	check.Contains(clusterNames, testClusterName)
@@ -80,7 +83,7 @@ func TestReloadRemoteClusterSecret(t *testing.T) {
 func createTestRemoteClusterSecretFile(t *testing.T, parentDir string, name string, content string) {
 	childDir := fmt.Sprintf("%s/%s", parentDir, name)
 	filename := fmt.Sprintf("%s/%s", childDir, name)
-	if err := os.MkdirAll(childDir, 0777); err != nil {
+	if err := os.MkdirAll(childDir, 0o777); err != nil {
 		t.Fatalf("Failed to create tmp remote cluster secret dir [%v]: %v", childDir, err)
 	}
 	f, err := os.Create(filename)

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -850,8 +850,8 @@ func DestinationRuleHasMTLSEnabled(destinationRule *networking_v1beta1.Destinati
 	return false, ""
 }
 
-// getClusterInfoFromIstiod tttempts to resolve the cluster name of the "home" cluster where kiali is running from the Istio deployment.
-// Assumes that the istiod deployment is in the same cluster as the kiali pod.
+// ClusterInfoFromIstiod attempts to resolve the cluster info of the "home" cluster where kiali is running
+// by inspecting the istiod deployment. Assumes that the istiod deployment is in the same cluster as the kiali pod.
 func ClusterInfoFromIstiod(conf config.Config, k8s ClientInterface) (string, bool, error) {
 	// The "cluster_id" is set in an environment variable of
 	// the "istiod" deployment. Let's try to fetch it.

--- a/kubernetes/istio_internal_test.go
+++ b/kubernetes/istio_internal_test.go
@@ -1,0 +1,550 @@
+package kubernetes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	api_security_v1beta1 "istio.io/api/security/v1beta1"
+	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/util/httputil"
+)
+
+// Because config.Config is a global variable, we need to reset it after each test.
+// This func will reset the config back to its previous value.
+func setConfig(t *testing.T, newConfig config.Config) {
+	t.Helper()
+	previousConfig := *config.Get()
+	t.Cleanup(func() {
+		config.Set(&previousConfig)
+	})
+	config.Set(&newConfig)
+}
+
+// The port pool is a global variable so we need to reset it between tests.
+func setPortPool(t *testing.T, addr string) {
+	t.Helper()
+	addrPieces := strings.Split(addr, ":")
+	port, err := strconv.Atoi(addrPieces[len(addrPieces)-1])
+	if err != nil {
+		t.Fatalf("Error parsing port from address: %s", err)
+	}
+
+	oldRange := httputil.Pool.PortRangeInit
+	oldBusyPort := httputil.Pool.LastBusyPort
+	oldSize := httputil.Pool.PortRangeSize
+	t.Cleanup(func() {
+		httputil.Pool.PortRangeInit = oldRange
+		httputil.Pool.LastBusyPort = oldBusyPort
+		httputil.Pool.PortRangeSize = oldSize
+	})
+	httputil.Pool.PortRangeInit = port
+	httputil.Pool.LastBusyPort = port - 1
+	httputil.Pool.PortRangeSize = 1
+}
+
+type fakePortForwarder struct{}
+
+func (f *fakePortForwarder) Start() error { return nil }
+func (f *fakePortForwarder) Stop()        {}
+
+func istiodTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var file string
+		switch r.URL.Path {
+		case "/debug/configz":
+			file = "../tests/data/registry/registry-configz.json"
+		case "/debug/endpointz":
+			file = "../tests/data/registry/registry-endpointz.json"
+		case "/debug/registryz":
+			file = "../tests/data/registry/registry-registryz.json"
+		case "/debug/syncz":
+			file = "../tests/data/registry/registry-syncz.json"
+		case "/ready":
+			w.WriteHeader(http.StatusOK)
+			return
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Fatalf("Unexpected request path: %s", r.URL.Path)
+			return
+		}
+		if _, err := w.Write(ReadFile(t, file)); err != nil {
+			t.Fatalf("Error writing response: %s", err)
+		}
+	}))
+	t.Cleanup(testServer.Close)
+	return testServer
+}
+
+func runningIstiodPod() *core_v1.Pod {
+	return &core_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "istiod-123",
+			Namespace: "istio-system",
+			Labels: map[string]string{
+				"app": "istiod",
+			},
+		},
+		Status: core_v1.PodStatus{
+			Phase: core_v1.PodRunning,
+		},
+	}
+}
+
+func TestFilterByHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert.True(t, FilterByHost("reviews", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews-bad", "bookinfo", "reviews", "bookinfo"))
+
+	assert.True(t, FilterByHost("reviews.bookinfo", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews-bad.bookinfo", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews.bookinfo-bad", "bookinfo-bad", "reviews", "bookinfo"))
+
+	assert.True(t, FilterByHost("reviews.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews-bad.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews.bookinfo-bad.svc.cluster.local", "bookinfo-bad", "reviews", "bookinfo"))
+}
+
+func TestFQDNHostname(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert.True(t, FilterByHost("reviews.bookinfo.svc", "bookinfo", "reviews", "bookinfo"))
+	assert.True(t, FilterByHost("reviews.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
+
+	assert.False(t, FilterByHost("reviews.foo.svc", "foo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("reviews.foo.svc.cluster.local", "foo", "reviews", "bookinfo"))
+
+	assert.False(t, FilterByHost("ratings.bookinfo.svc", "bookinfo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("ratings.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
+
+	assert.False(t, FilterByHost("ratings.foo.svc", "foo", "reviews", "bookinfo"))
+	assert.False(t, FilterByHost("ratings.foo.svc.cluster.local", "foo", "reviews", "bookinfo"))
+}
+
+func TestExactProtocolNameMatcher(t *testing.T) {
+	// http, http2, grpc, mongo, or redis
+	assert.True(t, MatchPortNameRule("http", "http"))
+	assert.True(t, MatchPortNameRule("http", "HTTP"))
+	assert.True(t, MatchPortNameRule("grpc", "grpc"))
+	assert.True(t, MatchPortNameRule("http2", "http2"))
+}
+
+func TestTCPAndUDPMatcher(t *testing.T) {
+	assert.True(t, MatchPortNameRule("tcp", "TCP"))
+	assert.True(t, MatchPortNameRule("tcp", "tcp"))
+	assert.True(t, MatchPortNameRule("udp", "UDP"))
+	assert.True(t, MatchPortNameRule("udp", "udp"))
+
+	assert.True(t, MatchPortNameRule("tcp-any", "UDP"))
+	assert.True(t, MatchPortNameRule("udp-any", "TCP"))
+
+	assert.True(t, MatchPortNameRule("doesnotmatter", "UDP"))
+	assert.True(t, MatchPortNameRule("everythingisvalid", "TCP"))
+}
+
+func TestValidProtocolNameMatcher(t *testing.T) {
+	assert.True(t, MatchPortNameRule("http-name", "http"))
+	assert.True(t, MatchPortNameRule("http2-name", "http2"))
+}
+
+func TestInvalidProtocolNameMatcher(t *testing.T) {
+	assert.False(t, MatchPortNameRule("http2-name", "http"))
+	assert.False(t, MatchPortNameRule("http-name", "http2"))
+
+	assert.False(t, MatchPortNameRule("httpname", "http"))
+	assert.False(t, MatchPortNameRule("name", "http"))
+}
+
+func TestValidPortNameMatcher(t *testing.T) {
+	assert.True(t, MatchPortNameWithValidProtocols("http-name"))
+	assert.True(t, MatchPortNameWithValidProtocols("http2-name"))
+}
+
+func TestInvalidPortNameMatcher(t *testing.T) {
+	assert.False(t, MatchPortNameWithValidProtocols("httpname"))
+	assert.False(t, MatchPortNameWithValidProtocols("name"))
+}
+
+func TestValidPortAppProtocolMatcher(t *testing.T) {
+	s1 := "http"
+	s2 := "mysql"
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s1))
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s2))
+}
+
+func TestInvalidPortAppProtocolMatcher(t *testing.T) {
+	s1 := "httpname"
+	s2 := "name"
+	s3 := "http-name"
+	s4 := ""
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s1))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s2))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s3))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s4))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(nil))
+}
+
+func TestPolicyHasMtlsEnabledStructMode(t *testing.T) {
+	policy := createPeerAuthn("default", "bookinfo", nil)
+
+	enabled, mode := PeerAuthnHasMTLSEnabled(policy)
+	assert.False(t, enabled)
+	assert.Equal(t, "", mode)
+}
+
+func TestPolicyHasMTLSEnabledStrictMode(t *testing.T) {
+	policy := createPeerAuthn("default", "bookinfo", createMtls("STRICT"))
+
+	enabled, mode := PeerAuthnHasMTLSEnabled(policy)
+	assert.True(t, enabled)
+	assert.Equal(t, "STRICT", mode)
+}
+
+func TestPolicyHasMTLSEnabledStructMtls(t *testing.T) {
+	policy := createPeerAuthn("default", "bookinfo", createMtls("STRICT"))
+
+	enabled, mode := PeerAuthnHasMTLSEnabled(policy)
+	assert.True(t, enabled)
+	assert.Equal(t, "STRICT", mode)
+}
+
+func TestPolicyHasMTLSEnabledPermissiveMode(t *testing.T) {
+	policy := createPeerAuthn("default", "bookinfo", createMtls("PERMISSIVE"))
+
+	enabled, mode := PeerAuthnHasMTLSEnabled(policy)
+	assert.True(t, enabled)
+	assert.Equal(t, "PERMISSIVE", mode)
+}
+
+func createMtls(mode string) *api_security_v1beta1.PeerAuthentication_MutualTLS {
+	mtls := &api_security_v1beta1.PeerAuthentication_MutualTLS{}
+	mtls.Mode = api_security_v1beta1.PeerAuthentication_MutualTLS_Mode(api_security_v1beta1.PeerAuthentication_MutualTLS_Mode_value[mode])
+	return mtls
+}
+
+func createPeerAuthn(name, namespace string, mtls *api_security_v1beta1.PeerAuthentication_MutualTLS) *security_v1beta1.PeerAuthentication {
+	pa := &security_v1beta1.PeerAuthentication{}
+	pa.Name = name
+	pa.Namespace = namespace
+	pa.Spec.Mtls = mtls
+	return pa
+}
+
+func TestParseRegistryConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	configz := "../tests/data/registry/registry-configz.json"
+	bRegistryz, err := os.ReadFile(configz)
+	assert.NoError(err)
+
+	rConfig := map[string][]byte{
+		"istiod1": bRegistryz,
+	}
+	registry, err2 := ParseRegistryConfig(rConfig)
+	assert.NoError(err2)
+	assert.NotNil(registry)
+
+	assert.Equal(2, len(registry.DestinationRules))
+	assert.Equal(12, len(registry.EnvoyFilters))
+	assert.Equal(1, len(registry.Gateways))
+	assert.Equal(1, len(registry.Gateways))
+	assert.Equal(11, len(registry.Sidecars))
+	assert.Equal(3, len(registry.VirtualServices))
+	assert.Equal(12, len(registry.AuthorizationPolicies))
+}
+
+func TestParseRegistryEndpoints(t *testing.T) {
+	assert := assert.New(t)
+
+	endpointz := "../tests/data/registry/registry-endpointz.json"
+	bEndpointz, err := os.ReadFile(endpointz)
+	assert.NoError(err)
+
+	rEndpoints := map[string][]byte{
+		"istiod1": bEndpointz,
+	}
+
+	registry, err2 := ParseRegistryEndpoints(rEndpoints)
+	assert.NoError(err2)
+	assert.NotNil(registry)
+
+	assert.Equal(101, len(registry))
+	assert.Equal("*.msn.com:http-port", registry[0].Service)
+}
+
+func TestRegistryServices(t *testing.T) {
+	assert := assert.New(t)
+
+	registryz := "../tests/data/registry/registry-registryz.json"
+	bRegistryz, err := os.ReadFile(registryz)
+	assert.NoError(err)
+
+	rRegistry := map[string][]byte{
+		"istiod1": bRegistryz,
+	}
+
+	registry, err2 := ParseRegistryServices(rRegistry)
+	assert.NoError(err2)
+	assert.NotNil(registry)
+
+	assert.Equal(79, len(registry))
+	assert.Equal("*.msn.com", registry[0].Attributes.Name)
+}
+
+func TestGetRegistryConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := istiodTestServer(t)
+	setPortPool(t, testServer.URL)
+
+	k8sClient := &K8SClient{
+		k8s: fake.NewSimpleClientset(runningIstiodPod()),
+		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
+			return &fakePortForwarder{}, nil
+		},
+	}
+
+	_, err := k8sClient.GetRegistryConfiguration()
+	assert.NoError(err)
+}
+
+func TestGetRegistryConfigExternal(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := istiodTestServer(t)
+
+	conf := config.Get()
+	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
+		IstiodURL: testServer.URL,
+	}
+	setConfig(t, *conf)
+
+	k8sClient := &K8SClient{}
+	_, err := k8sClient.GetRegistryConfiguration()
+	assert.NoError(err)
+}
+
+func TestGetRegistryConfigExternalBadResponse(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(testServer.Close)
+
+	conf := config.Get()
+	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
+		IstiodURL: testServer.URL,
+	}
+	setConfig(t, *conf)
+
+	k8sClient := &K8SClient{}
+	_, err := k8sClient.GetRegistryConfiguration()
+	assert.Error(err)
+}
+
+func TestGetRegistryEndpoints(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := istiodTestServer(t)
+	setPortPool(t, testServer.URL)
+
+	k8sClient := &K8SClient{
+		k8s: fake.NewSimpleClientset(runningIstiodPod()),
+		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
+			return &fakePortForwarder{}, nil
+		},
+	}
+
+	_, err := k8sClient.GetRegistryEndpoints()
+	assert.NoError(err)
+}
+
+func TestGetRegistryEndpointsExternal(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := istiodTestServer(t)
+
+	conf := config.Get()
+	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
+		IstiodURL: testServer.URL,
+	}
+	setConfig(t, *conf)
+
+	k8sClient := &K8SClient{}
+	_, err := k8sClient.GetRegistryEndpoints()
+	assert.NoError(err)
+}
+
+func TestGetRegistryEndpointsExternalBadResponse(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(testServer.Close)
+
+	conf := config.Get()
+	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
+		IstiodURL: testServer.URL,
+	}
+	setConfig(t, *conf)
+
+	k8sClient := &K8SClient{}
+	_, err := k8sClient.GetRegistryEndpoints()
+	assert.Error(err)
+}
+
+func TestGetRegistryServices(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := istiodTestServer(t)
+	setPortPool(t, testServer.URL)
+
+	k8sClient := &K8SClient{
+		k8s: fake.NewSimpleClientset(runningIstiodPod()),
+		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
+			return &fakePortForwarder{}, nil
+		},
+	}
+
+	_, err := k8sClient.GetRegistryServices()
+	assert.NoError(err)
+}
+
+func TestGetRegistryServicesExternal(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := istiodTestServer(t)
+
+	conf := config.Get()
+	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
+		IstiodURL: testServer.URL,
+	}
+	setConfig(t, *conf)
+
+	k8sClient := &K8SClient{}
+	_, err := k8sClient.GetRegistryServices()
+	assert.NoError(err)
+}
+
+func TestGetRegistryServicesExternalBadResponse(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(testServer.Close)
+
+	conf := config.Get()
+	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
+		IstiodURL: testServer.URL,
+	}
+	setConfig(t, *conf)
+
+	k8sClient := &K8SClient{}
+	_, err := k8sClient.GetRegistryServices()
+	assert.Error(err)
+}
+
+func TestGetProxyStatus(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := istiodTestServer(t)
+	setPortPool(t, testServer.URL)
+
+	k8sClient := &K8SClient{
+		k8s: fake.NewSimpleClientset(runningIstiodPod()),
+		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
+			return &fakePortForwarder{}, nil
+		},
+	}
+
+	_, err := k8sClient.GetProxyStatus()
+	assert.NoError(err)
+}
+
+func TestGetProxyStatusExternal(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := istiodTestServer(t)
+
+	conf := config.Get()
+	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
+		IstiodURL: testServer.URL,
+	}
+	setConfig(t, *conf)
+
+	k8sClient := &K8SClient{}
+	_, err := k8sClient.GetProxyStatus()
+	assert.NoError(err)
+}
+
+func TestGetProxyStatusExternalBadResponse(t *testing.T) {
+	assert := assert.New(t)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(testServer.Close)
+
+	conf := config.Get()
+	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
+		IstiodURL: testServer.URL,
+	}
+	setConfig(t, *conf)
+
+	k8sClient := &K8SClient{}
+	_, err := k8sClient.GetProxyStatus()
+	assert.Error(err)
+}
+
+func TestCanConnectToIstiodUnreachable(t *testing.T) {
+	assert := assert.New(t)
+	k8sClient := &K8SClient{
+		k8s: fake.NewSimpleClientset(runningIstiodPod()),
+		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
+			return &fakePortForwarder{}, nil
+		},
+	}
+
+	status, err := k8sClient.CanConnectToIstiod()
+	assert.NoError(err)
+
+	assert.Len(status, 1)
+	assert.Equal(ComponentUnreachable, status[0].Status)
+}
+
+func TestCanConnectToIstiodReachable(t *testing.T) {
+	assert := assert.New(t)
+	k8sClient := &K8SClient{
+		k8s: fake.NewSimpleClientset(runningIstiodPod()),
+		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
+			return &fakePortForwarder{}, nil
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(ts.Close)
+
+	setPortPool(t, ts.URL)
+
+	status, err := k8sClient.CanConnectToIstiod()
+	assert.NoError(err)
+
+	assert.Len(status, 1)
+}

--- a/kubernetes/istio_test.go
+++ b/kubernetes/istio_test.go
@@ -1,550 +1,86 @@
-package kubernetes
+package kubernetes_test
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	api_security_v1beta1 "istio.io/api/security/v1beta1"
-	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+	"github.com/stretchr/testify/require"
+	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/util/httputil"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
-// Because config.Config is a global variable, we need to reset it after each test.
-// This func will reset the config back to its previous value.
-func setConfig(t *testing.T, newConfig config.Config) {
-	t.Helper()
-	previousConfig := *config.Get()
-	t.Cleanup(func() {
-		config.Set(&previousConfig)
-	})
-	config.Set(&newConfig)
-}
+func TestGetClusterInfoFromIstiod(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 
-// The port pool is a global variable so we need to reset it between tests.
-func setPortPool(t *testing.T, addr string) {
-	t.Helper()
-	addrPieces := strings.Split(addr, ":")
-	port, err := strconv.Atoi(addrPieces[len(addrPieces)-1])
-	if err != nil {
-		t.Fatalf("Error parsing port from address: %s", err)
-	}
-
-	oldRange := httputil.Pool.PortRangeInit
-	oldBusyPort := httputil.Pool.LastBusyPort
-	oldSize := httputil.Pool.PortRangeSize
-	t.Cleanup(func() {
-		httputil.Pool.PortRangeInit = oldRange
-		httputil.Pool.LastBusyPort = oldBusyPort
-		httputil.Pool.PortRangeSize = oldSize
-	})
-	httputil.Pool.PortRangeInit = port
-	httputil.Pool.LastBusyPort = port - 1
-	httputil.Pool.PortRangeSize = 1
-}
-
-type fakePortForwarder struct{}
-
-func (f *fakePortForwarder) Start() error { return nil }
-func (f *fakePortForwarder) Stop()        {}
-
-func istiodTestServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var file string
-		switch r.URL.Path {
-		case "/debug/configz":
-			file = "../tests/data/registry/registry-configz.json"
-		case "/debug/endpointz":
-			file = "../tests/data/registry/registry-endpointz.json"
-		case "/debug/registryz":
-			file = "../tests/data/registry/registry-registryz.json"
-		case "/debug/syncz":
-			file = "../tests/data/registry/registry-syncz.json"
-		case "/ready":
-			w.WriteHeader(http.StatusOK)
-			return
-		default:
-			w.WriteHeader(http.StatusInternalServerError)
-			t.Fatalf("Unexpected request path: %s", r.URL.Path)
-			return
-		}
-		if _, err := w.Write(ReadFile(t, file)); err != nil {
-			t.Fatalf("Error writing response: %s", err)
-		}
-	}))
-	t.Cleanup(testServer.Close)
-	return testServer
-}
-
-func runningIstiodPod() *core_v1.Pod {
-	return &core_v1.Pod{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      "istiod-123",
-			Namespace: "istio-system",
-			Labels: map[string]string{
-				"app": "istiod",
+	conf := config.NewConfig()
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		&apps_v1.Deployment{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			Spec: apps_v1.DeploymentSpec{
+				Template: core_v1.PodTemplateSpec{
+					Spec: core_v1.PodSpec{
+						Containers: []core_v1.Container{
+							{
+								Name: "istiod",
+								Env: []core_v1.EnvVar{
+									{
+										Name:  "CLUSTER_ID",
+										Value: "east",
+									},
+									{
+										Name:  "PILOT_SCOPE_GATEWAY_TO_NAMESPACE",
+										Value: "true",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
-		Status: core_v1.PodStatus{
-			Phase: core_v1.PodRunning,
-		},
-	}
+	)
+	clusterID, pilotScope, err := kubernetes.ClusterInfoFromIstiod(*conf, k8s)
+	require.NoError(err)
+
+	assert.Equal("east", clusterID)
+	assert.True(pilotScope)
 }
 
-func TestFilterByHost(t *testing.T) {
+func TestGetClusterInfoFromIstiodFails(t *testing.T) {
+	require := require.New(t)
+
 	conf := config.NewConfig()
-	config.Set(conf)
-
-	assert.True(t, FilterByHost("reviews", "bookinfo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews-bad", "bookinfo", "reviews", "bookinfo"))
-
-	assert.True(t, FilterByHost("reviews.bookinfo", "bookinfo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews-bad.bookinfo", "bookinfo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews.bookinfo-bad", "bookinfo-bad", "reviews", "bookinfo"))
-
-	assert.True(t, FilterByHost("reviews.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews-bad.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews.bookinfo-bad.svc.cluster.local", "bookinfo-bad", "reviews", "bookinfo"))
-}
-
-func TestFQDNHostname(t *testing.T) {
-	conf := config.NewConfig()
-	config.Set(conf)
-
-	assert.True(t, FilterByHost("reviews.bookinfo.svc", "bookinfo", "reviews", "bookinfo"))
-	assert.True(t, FilterByHost("reviews.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
-
-	assert.False(t, FilterByHost("reviews.foo.svc", "foo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("reviews.foo.svc.cluster.local", "foo", "reviews", "bookinfo"))
-
-	assert.False(t, FilterByHost("ratings.bookinfo.svc", "bookinfo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("ratings.bookinfo.svc.cluster.local", "bookinfo", "reviews", "bookinfo"))
-
-	assert.False(t, FilterByHost("ratings.foo.svc", "foo", "reviews", "bookinfo"))
-	assert.False(t, FilterByHost("ratings.foo.svc.cluster.local", "foo", "reviews", "bookinfo"))
-}
-
-func TestExactProtocolNameMatcher(t *testing.T) {
-	// http, http2, grpc, mongo, or redis
-	assert.True(t, MatchPortNameRule("http", "http"))
-	assert.True(t, MatchPortNameRule("http", "HTTP"))
-	assert.True(t, MatchPortNameRule("grpc", "grpc"))
-	assert.True(t, MatchPortNameRule("http2", "http2"))
-}
-
-func TestTCPAndUDPMatcher(t *testing.T) {
-	assert.True(t, MatchPortNameRule("tcp", "TCP"))
-	assert.True(t, MatchPortNameRule("tcp", "tcp"))
-	assert.True(t, MatchPortNameRule("udp", "UDP"))
-	assert.True(t, MatchPortNameRule("udp", "udp"))
-
-	assert.True(t, MatchPortNameRule("tcp-any", "UDP"))
-	assert.True(t, MatchPortNameRule("udp-any", "TCP"))
-
-	assert.True(t, MatchPortNameRule("doesnotmatter", "UDP"))
-	assert.True(t, MatchPortNameRule("everythingisvalid", "TCP"))
-}
-
-func TestValidProtocolNameMatcher(t *testing.T) {
-	assert.True(t, MatchPortNameRule("http-name", "http"))
-	assert.True(t, MatchPortNameRule("http2-name", "http2"))
-}
-
-func TestInvalidProtocolNameMatcher(t *testing.T) {
-	assert.False(t, MatchPortNameRule("http2-name", "http"))
-	assert.False(t, MatchPortNameRule("http-name", "http2"))
-
-	assert.False(t, MatchPortNameRule("httpname", "http"))
-	assert.False(t, MatchPortNameRule("name", "http"))
-}
-
-func TestValidPortNameMatcher(t *testing.T) {
-	assert.True(t, MatchPortNameWithValidProtocols("http-name"))
-	assert.True(t, MatchPortNameWithValidProtocols("http2-name"))
-}
-
-func TestInvalidPortNameMatcher(t *testing.T) {
-	assert.False(t, MatchPortNameWithValidProtocols("httpname"))
-	assert.False(t, MatchPortNameWithValidProtocols("name"))
-}
-
-func TestValidPortAppProtocolMatcher(t *testing.T) {
-	s1 := "http"
-	s2 := "mysql"
-	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s1))
-	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s2))
-}
-
-func TestInvalidPortAppProtocolMatcher(t *testing.T) {
-	s1 := "httpname"
-	s2 := "name"
-	s3 := "http-name"
-	s4 := ""
-	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s1))
-	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s2))
-	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s3))
-	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s4))
-	assert.False(t, MatchPortAppProtocolWithValidProtocols(nil))
-}
-
-func TestPolicyHasMtlsEnabledStructMode(t *testing.T) {
-	policy := createPeerAuthn("default", "bookinfo", nil)
-
-	enabled, mode := PeerAuthnHasMTLSEnabled(policy)
-	assert.False(t, enabled)
-	assert.Equal(t, "", mode)
-}
-
-func TestPolicyHasMTLSEnabledStrictMode(t *testing.T) {
-	policy := createPeerAuthn("default", "bookinfo", createMtls("STRICT"))
-
-	enabled, mode := PeerAuthnHasMTLSEnabled(policy)
-	assert.True(t, enabled)
-	assert.Equal(t, "STRICT", mode)
-}
-
-func TestPolicyHasMTLSEnabledStructMtls(t *testing.T) {
-	policy := createPeerAuthn("default", "bookinfo", createMtls("STRICT"))
-
-	enabled, mode := PeerAuthnHasMTLSEnabled(policy)
-	assert.True(t, enabled)
-	assert.Equal(t, "STRICT", mode)
-}
-
-func TestPolicyHasMTLSEnabledPermissiveMode(t *testing.T) {
-	policy := createPeerAuthn("default", "bookinfo", createMtls("PERMISSIVE"))
-
-	enabled, mode := PeerAuthnHasMTLSEnabled(policy)
-	assert.True(t, enabled)
-	assert.Equal(t, "PERMISSIVE", mode)
-}
-
-func createMtls(mode string) *api_security_v1beta1.PeerAuthentication_MutualTLS {
-	mtls := &api_security_v1beta1.PeerAuthentication_MutualTLS{}
-	mtls.Mode = api_security_v1beta1.PeerAuthentication_MutualTLS_Mode(api_security_v1beta1.PeerAuthentication_MutualTLS_Mode_value[mode])
-	return mtls
-}
-
-func createPeerAuthn(name, namespace string, mtls *api_security_v1beta1.PeerAuthentication_MutualTLS) *security_v1beta1.PeerAuthentication {
-	pa := &security_v1beta1.PeerAuthentication{}
-	pa.Name = name
-	pa.Namespace = namespace
-	pa.Spec.Mtls = mtls
-	return pa
-}
-
-func TestParseRegistryConfig(t *testing.T) {
-	assert := assert.New(t)
-
-	configz := "../tests/data/registry/registry-configz.json"
-	bRegistryz, err := os.ReadFile(configz)
-	assert.NoError(err)
-
-	rConfig := map[string][]byte{
-		"istiod1": bRegistryz,
-	}
-	registry, err2 := ParseRegistryConfig(rConfig)
-	assert.NoError(err2)
-	assert.NotNil(registry)
-
-	assert.Equal(2, len(registry.DestinationRules))
-	assert.Equal(12, len(registry.EnvoyFilters))
-	assert.Equal(1, len(registry.Gateways))
-	assert.Equal(1, len(registry.Gateways))
-	assert.Equal(11, len(registry.Sidecars))
-	assert.Equal(3, len(registry.VirtualServices))
-	assert.Equal(12, len(registry.AuthorizationPolicies))
-}
-
-func TestParseRegistryEndpoints(t *testing.T) {
-	assert := assert.New(t)
-
-	endpointz := "../tests/data/registry/registry-endpointz.json"
-	bEndpointz, err := os.ReadFile(endpointz)
-	assert.NoError(err)
-
-	rEndpoints := map[string][]byte{
-		"istiod1": bEndpointz,
-	}
-
-	registry, err2 := ParseRegistryEndpoints(rEndpoints)
-	assert.NoError(err2)
-	assert.NotNil(registry)
-
-	assert.Equal(101, len(registry))
-	assert.Equal("*.msn.com:http-port", registry[0].Service)
-}
-
-func TestRegistryServices(t *testing.T) {
-	assert := assert.New(t)
-
-	registryz := "../tests/data/registry/registry-registryz.json"
-	bRegistryz, err := os.ReadFile(registryz)
-	assert.NoError(err)
-
-	rRegistry := map[string][]byte{
-		"istiod1": bRegistryz,
-	}
-
-	registry, err2 := ParseRegistryServices(rRegistry)
-	assert.NoError(err2)
-	assert.NotNil(registry)
-
-	assert.Equal(79, len(registry))
-	assert.Equal("*.msn.com", registry[0].Attributes.Name)
-}
-
-func TestGetRegistryConfig(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := istiodTestServer(t)
-	setPortPool(t, testServer.URL)
-
-	k8sClient := &K8SClient{
-		k8s: fake.NewSimpleClientset(runningIstiodPod()),
-		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
-			return &fakePortForwarder{}, nil
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		&apps_v1.Deployment{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "istiod",
+				Namespace: "istio-system",
+			},
+			Spec: apps_v1.DeploymentSpec{
+				Template: core_v1.PodTemplateSpec{
+					Spec: core_v1.PodSpec{
+						Containers: []core_v1.Container{
+							{
+								Name: "istiod",
+								Env:  []core_v1.EnvVar{},
+							},
+						},
+					},
+				},
+			},
 		},
-	}
-
-	_, err := k8sClient.GetRegistryConfiguration()
-	assert.NoError(err)
-}
-
-func TestGetRegistryConfigExternal(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := istiodTestServer(t)
-
-	conf := config.Get()
-	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
-		IstiodURL: testServer.URL,
-	}
-	setConfig(t, *conf)
-
-	k8sClient := &K8SClient{}
-	_, err := k8sClient.GetRegistryConfiguration()
-	assert.NoError(err)
-}
-
-func TestGetRegistryConfigExternalBadResponse(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	t.Cleanup(testServer.Close)
-
-	conf := config.Get()
-	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
-		IstiodURL: testServer.URL,
-	}
-	setConfig(t, *conf)
-
-	k8sClient := &K8SClient{}
-	_, err := k8sClient.GetRegistryConfiguration()
-	assert.Error(err)
-}
-
-func TestGetRegistryEndpoints(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := istiodTestServer(t)
-	setPortPool(t, testServer.URL)
-
-	k8sClient := &K8SClient{
-		k8s: fake.NewSimpleClientset(runningIstiodPod()),
-		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
-			return &fakePortForwarder{}, nil
-		},
-	}
-
-	_, err := k8sClient.GetRegistryEndpoints()
-	assert.NoError(err)
-}
-
-func TestGetRegistryEndpointsExternal(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := istiodTestServer(t)
-
-	conf := config.Get()
-	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
-		IstiodURL: testServer.URL,
-	}
-	setConfig(t, *conf)
-
-	k8sClient := &K8SClient{}
-	_, err := k8sClient.GetRegistryEndpoints()
-	assert.NoError(err)
-}
-
-func TestGetRegistryEndpointsExternalBadResponse(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	t.Cleanup(testServer.Close)
-
-	conf := config.Get()
-	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
-		IstiodURL: testServer.URL,
-	}
-	setConfig(t, *conf)
-
-	k8sClient := &K8SClient{}
-	_, err := k8sClient.GetRegistryEndpoints()
-	assert.Error(err)
-}
-
-func TestGetRegistryServices(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := istiodTestServer(t)
-	setPortPool(t, testServer.URL)
-
-	k8sClient := &K8SClient{
-		k8s: fake.NewSimpleClientset(runningIstiodPod()),
-		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
-			return &fakePortForwarder{}, nil
-		},
-	}
-
-	_, err := k8sClient.GetRegistryServices()
-	assert.NoError(err)
-}
-
-func TestGetRegistryServicesExternal(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := istiodTestServer(t)
-
-	conf := config.Get()
-	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
-		IstiodURL: testServer.URL,
-	}
-	setConfig(t, *conf)
-
-	k8sClient := &K8SClient{}
-	_, err := k8sClient.GetRegistryServices()
-	assert.NoError(err)
-}
-
-func TestGetRegistryServicesExternalBadResponse(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	t.Cleanup(testServer.Close)
-
-	conf := config.Get()
-	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
-		IstiodURL: testServer.URL,
-	}
-	setConfig(t, *conf)
-
-	k8sClient := &K8SClient{}
-	_, err := k8sClient.GetRegistryServices()
-	assert.Error(err)
-}
-
-func TestGetProxyStatus(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := istiodTestServer(t)
-	setPortPool(t, testServer.URL)
-
-	k8sClient := &K8SClient{
-		k8s: fake.NewSimpleClientset(runningIstiodPod()),
-		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
-			return &fakePortForwarder{}, nil
-		},
-	}
-
-	_, err := k8sClient.GetProxyStatus()
-	assert.NoError(err)
-}
-
-func TestGetProxyStatusExternal(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := istiodTestServer(t)
-
-	conf := config.Get()
-	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
-		IstiodURL: testServer.URL,
-	}
-	setConfig(t, *conf)
-
-	k8sClient := &K8SClient{}
-	_, err := k8sClient.GetProxyStatus()
-	assert.NoError(err)
-}
-
-func TestGetProxyStatusExternalBadResponse(t *testing.T) {
-	assert := assert.New(t)
-
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	t.Cleanup(testServer.Close)
-
-	conf := config.Get()
-	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
-		IstiodURL: testServer.URL,
-	}
-	setConfig(t, *conf)
-
-	k8sClient := &K8SClient{}
-	_, err := k8sClient.GetProxyStatus()
-	assert.Error(err)
-}
-
-func TestCanConnectToIstiodUnreachable(t *testing.T) {
-	assert := assert.New(t)
-	k8sClient := &K8SClient{
-		k8s: fake.NewSimpleClientset(runningIstiodPod()),
-		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
-			return &fakePortForwarder{}, nil
-		},
-	}
-
-	status, err := k8sClient.CanConnectToIstiod()
-	assert.NoError(err)
-
-	assert.Len(status, 1)
-	assert.Equal(ComponentUnreachable, status[0].Status)
-}
-
-func TestCanConnectToIstiodReachable(t *testing.T) {
-	assert := assert.New(t)
-	k8sClient := &K8SClient{
-		k8s: fake.NewSimpleClientset(runningIstiodPod()),
-		getPodPortForwarderFunc: func(namespace, name, portMap string) (httputil.PortForwarder, error) {
-			return &fakePortForwarder{}, nil
-		},
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(ts.Close)
-
-	setPortPool(t, ts.URL)
-
-	status, err := k8sClient.CanConnectToIstiod()
-	assert.NoError(err)
-
-	assert.Len(status, 1)
+	)
+	_, _, err := kubernetes.ClusterInfoFromIstiod(*conf, k8s)
+	require.Error(err)
 }

--- a/kubernetes/kubetest/fake.go
+++ b/kubernetes/kubetest/fake.go
@@ -19,7 +19,6 @@ import (
 	gatewayapifake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 	gatewayapischeme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 
-	"github.com/kiali/kiali/config"
 	kialikube "github.com/kiali/kiali/kubernetes"
 )
 
@@ -106,7 +105,6 @@ func NewFakeK8sClient(objects ...runtime.Object) *FakeK8sClient {
 
 	return &FakeK8sClient{
 		ClientInterface:   kialikube.NewClient(kubeClient, istioClient, gatewayAPIClient),
-		Cluster:           kialikube.ClusterInfo{Name: config.Get().KubernetesConfig.ClusterName},
 		deploymentConfigs: deploymentConfigs,
 		projects:          projects,
 		KubeClientset:     kubeClient,
@@ -134,17 +132,12 @@ type FakeK8sClient struct {
 	GatewayAPIClientset gatewayapi.Interface
 	// Token is the kiali token this client uses.
 	Token string
-	// Cluster is the name of the cluster this client is connected to.
-	// This normally gets set by the client factory but in tests is mocked out
-	// to match the cluster name from the kiali config.
-	Cluster kialikube.ClusterInfo
 }
 
-func (c *FakeK8sClient) IsOpenShift() bool                     { return c.OpenShift }
-func (c *FakeK8sClient) IsGatewayAPI() bool                    { return c.GatewayAPIEnabled }
-func (c *FakeK8sClient) IsIstioAPI() bool                      { return c.IstioAPIEnabled }
-func (c *FakeK8sClient) GetToken() string                      { return c.Token }
-func (c *FakeK8sClient) GetClusterInfo() kialikube.ClusterInfo { return c.Cluster }
+func (c *FakeK8sClient) IsOpenShift() bool  { return c.OpenShift }
+func (c *FakeK8sClient) IsGatewayAPI() bool { return c.GatewayAPIEnabled }
+func (c *FakeK8sClient) IsIstioAPI() bool   { return c.IstioAPIEnabled }
+func (c *FakeK8sClient) GetToken() string   { return c.Token }
 
 // The openshift resources are stubbed out because Kiali talks directly to the
 // kube api for these instead of using the openshift client-go.

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 	gatewayapifake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 )
 
@@ -30,7 +31,7 @@ type K8SClientFactoryMock struct {
 // Constructor
 func NewK8SClientFactoryMock(k8s kubernetes.ClientInterface) *K8SClientFactoryMock {
 	k8sClientFactory := new(K8SClientFactoryMock)
-	k8sClientFactory.Clients = map[string]kubernetes.ClientInterface{kubernetes.HomeClusterName: k8s}
+	k8sClientFactory.Clients = map[string]kubernetes.ClientInterface{config.Get().KubernetesConfig.ClusterName: k8s}
 	return k8sClientFactory
 }
 
@@ -45,7 +46,7 @@ func (o *K8SClientFactoryMock) SetClients(clients map[string]kubernetes.ClientIn
 func (o *K8SClientFactoryMock) GetClient(authInfo *api.AuthInfo) (kubernetes.ClientInterface, error) {
 	o.lock.RLock()
 	defer o.lock.RUnlock()
-	return o.Clients[kubernetes.HomeClusterName], nil
+	return o.Clients[config.Get().KubernetesConfig.ClusterName], nil
 }
 
 // Business Methods
@@ -70,17 +71,7 @@ func (o *K8SClientFactoryMock) GetSAClients() map[string]kubernetes.ClientInterf
 func (o *K8SClientFactoryMock) GetSAHomeClusterClient() kubernetes.ClientInterface {
 	o.lock.RLock()
 	defer o.lock.RUnlock()
-	return o.Clients[kubernetes.HomeClusterName]
-}
-
-func (o *K8SClientFactoryMock) GetClusterNames() []string {
-	o.lock.RLock()
-	defer o.lock.RUnlock()
-	clusterNames := make([]string, 0)
-	for cn := range o.Clients {
-		clusterNames = append(clusterNames, cn)
-	}
-	return clusterNames
+	return o.Clients[config.Get().KubernetesConfig.ClusterName]
 }
 
 /////
@@ -99,7 +90,6 @@ func NewK8SClientMock() *K8SClientMock {
 	k8s.On("IsGatewayAPI").Return(false)
 	k8s.On("IsIstioAPI").Return(true)
 	k8s.On("GetKialiTokenForHomeCluster").Return("")
-	k8s.On("GetClusterNames").Return(kubernetes.HomeClusterName)
 	return k8s
 }
 
@@ -164,9 +154,9 @@ func (o *K8SClientMock) GetToken() string {
 	return args.Get(0).(string)
 }
 
-func (o *K8SClientMock) GetClusterNames() []string {
+func (o *K8SClientMock) GetClusterInfo() kubernetes.ClusterInfo {
 	args := o.Called()
-	return args.Get(0).([]string)
+	return args.Get(0).(kubernetes.ClusterInfo)
 }
 
 // GetAuthInfo returns the AuthInfo struct for the client

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -154,11 +154,6 @@ func (o *K8SClientMock) GetToken() string {
 	return args.Get(0).(string)
 }
 
-func (o *K8SClientMock) GetClusterInfo() kubernetes.ClusterInfo {
-	args := o.Called()
-	return args.Get(0).(kubernetes.ClusterInfo)
-}
-
 // GetAuthInfo returns the AuthInfo struct for the client
 func (o *K8SClientMock) GetAuthInfo() *api.AuthInfo {
 	args := o.Called()


### PR DESCRIPTION
Adds an option to the Kiali config to provide the kube cluster name for the home cluster. Defaults to `Kubernetes`. In the future, Kiali could auto-detect this value from the environment.

Fixes #6001