### PR TITLE
use discovery selectors to filter namespaces

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -10,6 +10,8 @@ import (
 	osproject_v1 "github.com/openshift/api/project/v1"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -80,6 +82,26 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 	}
 
 	configObject := config.Get()
+
+	// determine what the discoverySelectors are by examining the Istio ConfigMap
+	var discoverySelectors []*meta_v1.LabelSelector
+	if kialiCache != nil {
+		if icm, err := kialiCache.GetConfigMap(configObject.IstioNamespace, configObject.ExternalServices.Istio.ConfigMapName); err == nil {
+			if ic, err2 := kubernetes.GetIstioConfigMap(icm); err2 == nil {
+				discoverySelectors = ic.DiscoverySelectors
+			} else {
+				log.Errorf("Will not process discoverySelectors due to a failure to get the Istio ConfigMap: %v", err2)
+			}
+		} else {
+			log.Errorf("Will not process discoverySelectors due to a failure to parse the Istio ConfigMap: %v", err)
+		}
+	}
+
+	if len(discoverySelectors) > 0 {
+		log.Tracef("Istio discovery selectors: %+v", discoverySelectors)
+	} else {
+		log.Tracef("No Istio discovery selectors defined.")
+	}
 
 	// Let's explain the four different filters along with accessible namespaces (aka AN).
 	//
@@ -169,10 +191,10 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 	for resultCh := range resultsCh {
 		if resultCh.err != nil {
 			if resultCh.cluster == kubernetes.HomeClusterName {
-				log.Errorf("Error fetching Namespaces for local cluster %s: %s", resultCh.cluster, resultCh.err)
+				log.Errorf("Error fetching Namespaces for local cluster [%s]: %s", resultCh.cluster, resultCh.err)
 				return nil, resultCh.err
 			} else {
-				log.Infof("Error fetching Namespaces for cluster %s: %s", resultCh.cluster, resultCh.err)
+				log.Infof("Error fetching Namespaces for cluster [%s]: %s", resultCh.cluster, resultCh.err)
 				continue
 			}
 		}
@@ -180,6 +202,40 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 	}
 
 	resultns := namespaces
+
+	// Filter out those namespaces that do not match discoverySelectors.
+	// Follow the semantics that Istio follows, which is:
+	//   If there is no discoverySelectors section in the config, skip this entirely.
+	//   If there is an empty discoverySelectors section, that means all namespaces are to be used.
+	//   If there are one or more discoverySelectors specified, the filter namespaces based on what they select.
+	if len(discoverySelectors) > 0 {
+		// 1. convert LabelSelectors to Selectors
+		selectors := make([]labels.Selector, 0)
+		for _, selector := range discoverySelectors {
+			ls, err := meta_v1.LabelSelectorAsSelector(selector)
+			if err != nil {
+				return nil, fmt.Errorf("error initializing discovery selectors filter, invalid discovery selector: %v", err)
+			}
+			selectors = append(selectors, ls)
+		}
+
+		// 2. range over all namespaces to get discovery namespaces, notice each selector result is ORed (as per Istio convention)
+		selectedNamespaces := make([]models.Namespace, 0)
+		for _, ns := range resultns {
+			if ns.Name == configObject.IstioNamespace {
+				selectedNamespaces = append(selectedNamespaces, ns) // we always want to return the control plane namespace
+			} else {
+				for _, selector := range selectors {
+					if selector.Matches(labels.Set(ns.Labels)) {
+						selectedNamespaces = append(selectedNamespaces, ns)
+						break
+					}
+				}
+			}
+		}
+		namespaces = selectedNamespaces
+		resultns = namespaces
+	}
 
 	// exclude namespaces that are:
 	// 1. to be filtered out via the exclude list

--- a/config/config.go
+++ b/config/config.go
@@ -541,6 +541,7 @@ func NewConfig() (c *Config) {
 		CustomDashboards: dashboards.GetBuiltInMonitoringDashboards(),
 		Deployment: DeploymentConfig{
 			AccessibleNamespaces: []string{"**"},
+			ClusterWideAccess:    true,
 			InstanceName:         "kiali",
 			Namespace:            "istio-system",
 			ViewOnlyMode:         false,

--- a/config/config.go
+++ b/config/config.go
@@ -361,6 +361,7 @@ type OpenIdConfig struct {
 // DeploymentConfig provides details on how Kiali was deployed.
 type DeploymentConfig struct {
 	AccessibleNamespaces []string `yaml:"accessible_namespaces"`
+	ClusterWideAccess    bool     `yaml:"cluster_wide_access,omitempty"`
 	InstanceName         string   `yaml:"instance_name"`
 	Namespace            string   `yaml:"namespace,omitempty"` // Kiali deployment namespace
 	ViewOnlyMode         bool     `yaml:"view_only_mode,omitempty"`
@@ -791,14 +792,18 @@ func (conf *Config) AddHealthDefault() {
 
 // AllNamespacesAccessible determines if kiali has access to all namespaces.
 // When using the operator, the operator will grant the kiali service account
-// cluster role permissions when '**' is provided as a namespace.
+// cluster role permissions when '**' is provided in the accessible_namespaces
+// or if cluster-wide-access was explicitly requested.
 func (conf *Config) AllNamespacesAccessible() bool {
+	// look for ** in accessible namespaces first, as we have done in the past. This backwards compatible
+	// behavior will help support users who installed the server via the server helm chart.
 	for _, ns := range conf.Deployment.AccessibleNamespaces {
 		if ns == "**" {
 			return true
 		}
 	}
-	return false
+	// it is still possible we are in cluster wide access mode even if accessible namespaces has been restricted
+	return conf.Deployment.ClusterWideAccess
 }
 
 // Get the global Config

--- a/kubernetes/cache/kube_cache_test.go
+++ b/kubernetes/cache/kube_cache_test.go
@@ -107,6 +107,7 @@ func TestRefreshNSScoped(t *testing.T) {
 
 	cfg := config.NewConfig()
 	cfg.Deployment.AccessibleNamespaces = []string{"ns1", "ns2"}
+	cfg.Deployment.ClusterWideAccess = false
 	kialiCache := newTestingKubeCache(t, cfg)
 	kialiCache.nsCacheLister = map[string]*cacheLister{}
 
@@ -129,6 +130,7 @@ func TestCheckNamespaceNotIncluded(t *testing.T) {
 
 	cfg := config.NewConfig()
 	cfg.Deployment.AccessibleNamespaces = []string{"bookinfo"}
+	cfg.Deployment.ClusterWideAccess = false
 	cfg.KubernetesConfig.CacheNamespaces = []string{"bookinfo"}
 	kialiCache := newTestingKubeCache(t, cfg)
 

--- a/kubernetes/cache/tls_test_helper.go
+++ b/kubernetes/cache/tls_test_helper.go
@@ -16,7 +16,8 @@ func FakeTlsKialiCache(token string, namespaces []string, pa []*security_v1beta1
 	kialiCacheImpl := kialiCacheImpl{
 		tokenNamespaces: make(map[string]namespaceCache),
 		// ~ long duration for unit testing
-		refreshDuration: time.Hour,
+		refreshDuration:        time.Hour,
+		tokenNamespaceDuration: time.Hour,
 	}
 	// Populate namespaces and PeerAuthentication informers
 	nss := []models.Namespace{}

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/yaml.v2"
 	api_networking_v1beta1 "istio.io/api/networking/v1beta1"
 	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -23,6 +22,7 @@ import (
 	istio "istio.io/client-go/pkg/clientset/versioned"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
@@ -678,7 +678,7 @@ func GetIstioConfigMap(istioConfig *core_v1.ConfigMap) (*IstioMeshConfig, error)
 		return nil, fmt.Errorf(errMsg, istioConfig)
 	}
 
-	err = yaml.Unmarshal([]byte(meshConfigYaml), &meshConfig)
+	err = k8syaml.Unmarshal([]byte(meshConfigYaml), &meshConfig)
 	if err != nil {
 		log.Warningf("GetIstioConfigMap: Cannot read Istio mesh configuration.")
 		return nil, err

--- a/kubernetes/istio_test.go
+++ b/kubernetes/istio_test.go
@@ -14,6 +14,49 @@ import (
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
+func TestGetIstioConfigMap(t *testing.T) {
+	meshYaml := `
+discoverySelectors:
+- matchLabels:
+    mazzlabel1: mazzvalue1
+    mazzlabel2: mazzvalue2
+- matchExpressions:
+  - key: mazzkey1
+    operator: In
+    values:
+    - mazz1a
+    - mazz1b
+  - key: mazzkey2
+    operator: In
+    values:
+    - mazz2a
+    - mazz2b
+`
+	cm := core_v1.ConfigMap{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "istio",
+		},
+		Data: map[string]string{
+			"mesh": meshYaml,
+		},
+	}
+	// this tests that we can unmarshal the k8s objects successfully (GetIstioConfigMap had to use the k8s yaml marshaller to get it to work)
+	data, err := kubernetes.GetIstioConfigMap(&cm)
+	assert.Nil(t, err, "Should not have got an error")
+	assert.Len(t, data.DiscoverySelectors, 2, "Should have had 2 discovery selectors: %+v", data)
+
+	assert.Len(t, data.DiscoverySelectors[0].MatchExpressions, 0, "First selector should have no matchExpressions: %+v", data)
+	assert.Len(t, data.DiscoverySelectors[1].MatchLabels, 0, "Second selector should have no matchLabels: %+v", data)
+
+	assert.Len(t, data.DiscoverySelectors[0].MatchLabels, 2, "First selector should have matchLabels with 2 labels: %+v", data)
+	assert.Equal(t, "mazzvalue1", data.DiscoverySelectors[0].MatchLabels["mazzlabel1"])
+	assert.Equal(t, "mazzvalue2", data.DiscoverySelectors[0].MatchLabels["mazzlabel2"])
+
+	assert.Len(t, data.DiscoverySelectors[1].MatchExpressions, 2, "Second selector should have 2 matchExpressions: %+v", data)
+	assert.Equal(t, "mazzkey1", data.DiscoverySelectors[1].MatchExpressions[0].Key)
+	assert.Equal(t, "mazzkey2", data.DiscoverySelectors[1].MatchExpressions[1].Key)
+}
+
 func TestGetClusterInfoFromIstiod(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -8,10 +8,10 @@ import (
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
 	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
-	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 const (
@@ -174,8 +174,9 @@ var (
 )
 
 type IstioMeshConfig struct {
-	DisableMixerHttpReports bool  `yaml:"disableMixerHttpReports,omitempty"`
-	EnableAutoMtls          *bool `yaml:"enableAutoMtls,omitempty"`
+	DisableMixerHttpReports bool                    `yaml:"disableMixerHttpReports,omitempty"`
+	DiscoverySelectors      []*metav1.LabelSelector `yaml:"discoverySelectors,omitempty"`
+	EnableAutoMtls          *bool                   `yaml:"enableAutoMtls,omitempty"`
 }
 
 // MTLSDetails is a wrapper to group all Istio objects related to non-local mTLS configurations


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3914

operator PR: https://github.com/kiali/kiali-operator/pull/628

The Istio ConfigMap has discoverySelectors that Kiali will now use to filter namespaces.

If no discoverySelectors are specified, or discoverySelectors is specified as an empty list in the ConfigMap, then Kiali works as before.

If discoverySelectors are specified, then they will filter out any namespaces that do not match. After that filter is performed, Kiali will further exclude namespaces defined in the excludes config settings in the Kiali CR (this works as before).