### PR TITLE
Adjust scroll for Workload Pod Logs

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -714,7 +714,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
                   <div style={{ paddingTop: '10px', paddingLeft: '10px' }}>{NoLogsFoundMessage}</div>
                 )}
                 containerStyle={{ overflow: 'initial !important' }}
-                style={{ overflow: 'auto' }}
+                style={{ overflowX: 'auto', overflowY: 'auto' }}
               />
             )}
           </AutoSizer>

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -714,7 +714,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
                   <div style={{ paddingTop: '10px', paddingLeft: '10px' }}>{NoLogsFoundMessage}</div>
                 )}
                 containerStyle={{ overflow: 'initial !important' }}
-                style={{ overflow: 'scroll' }}
+                style={{ overflow: 'auto' }}
               />
             )}
           </AutoSizer>

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -714,6 +714,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
                   <div style={{ paddingTop: '10px', paddingLeft: '10px' }}>{NoLogsFoundMessage}</div>
                 )}
                 containerStyle={{ overflow: 'initial !important' }}
+                style={{ overflow: 'scroll' }}
               />
             )}
           </AutoSizer>


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/5989 

I was able to reproduce this issue in Firefox (111.0.1), but not in Chrome (112.0.5615.49). 
Firefox view: 

![image](https://user-images.githubusercontent.com/49480155/233370404-6ef3ee58-a0a3-4640-a558-45c6ad662707.png)

Chrome: 

![image](https://user-images.githubusercontent.com/49480155/233370481-88974489-fa2e-4fcf-a60c-2fb23d6f7dee.png)

I've tried to use the Grid (https://github.com/bvaughn/react-virtualized/blob/master/docs/Grid.md) instead of the List, but I had the same issue in Firefox. 

The Container style has the following: 

`overflow: auto`

An for firefox: 

`overflow: hidden auto`

Setting the overflow to auto seems to do the trick: 

![image](https://user-images.githubusercontent.com/49480155/233372154-120e7a40-42e2-4a6a-9baa-fa6c22c9b5b0.png)
