### PR TITLE
[DNM] Multicluster - Istio Config validations

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -364,7 +364,7 @@ func (in *AppService) fetchNamespaceApps(ctx context.Context, namespace string, 
 			IncludeOnlyDefinitions: true,
 			ServiceSelector:        labels.Set(w.Labels).String(),
 		}
-		ss, err = in.businessLayer.Svc.GetServiceList(ctx, criteria)
+		ss, err = in.businessLayer.Svc.getServiceList(ctx, criteria, cluster)
 		if err != nil {
 			return nil, err
 		}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -377,7 +377,7 @@ func (in *IstioValidationsService) fetchWorkload(ctx context.Context, rValue *ma
 	defer wg.Done()
 	if len(errChan) == 0 {
 		allWorkloads := map[string]models.WorkloadList{}
-		criteria := WorkloadCriteria{WorkloadName: workload, Namespace: namespace, IncludeIstioResources: true, IncludeHealth: false, Cluster: cluster}
+		criteria := WorkloadCriteria{WorkloadName: workload, Namespace: namespace, IncludeIstioResources: false, IncludeHealth: false, Cluster: cluster}
 		workloadList, err := in.businessLayer.Workload.GetWorkloadList(ctx, criteria)
 		if err != nil {
 			select {

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -75,11 +75,12 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 	)
 	defer end()
 
-	if kialiCache != nil && in.homeClusterUserClient != nil {
-		if ns := kialiCache.GetNamespaces(in.homeClusterUserClient.GetToken()); ns != nil {
-			return ns, nil
-		}
-	}
+	// @TODO after opening Config page for particular cluster, the cache is overridden by home cluster namespaces only
+	//if kialiCache != nil && in.homeClusterUserClient != nil {
+	//	if ns := kialiCache.GetNamespaces(in.homeClusterUserClient.GetToken()); ns != nil {
+	//		return ns, nil
+	//	}
+	//}
 
 	configObject := config.Get()
 

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -502,7 +502,7 @@ func (in *NamespaceService) isIncludedNamespace(namespace string) bool {
 // TODO: Multicluster: We are going to need something else to identify the namespace, the cluster (OR Return a list/array/map)
 func (in *NamespaceService) GetNamespace(ctx context.Context, namespace string) (*models.Namespace, error) {
 	// TODO: Wrapper for MC while other services are not updated to propagate the cluster
-	return in.GetNamespaceByCluster(ctx, namespace, "")
+	return in.GetNamespaceByCluster(ctx, namespace, config.Get().KubernetesConfig.ClusterName)
 }
 
 // GetNamespace returns the definition of the specified namespace.

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -310,8 +310,8 @@ func getWorkloadList(namespace string, gi *graph.AppenderGlobalInfo) *models.Wor
 	if workloadList, ok := workloadListMap[namespace]; ok {
 		return workloadList
 	}
-
-	criteria := business.WorkloadCriteria{Namespace: namespace, IncludeIstioResources: false, IncludeHealth: false}
+	// @TODO cluster support in graph
+	criteria := business.WorkloadCriteria{Namespace: namespace, IncludeIstioResources: false, IncludeHealth: false, Cluster: config.Get().KubernetesConfig.ClusterName}
 	workloadList, err := gi.Business.Workload.GetWorkloadList(context.TODO(), criteria)
 	graph.CheckError(err)
 	workloadListMap[namespace] = &workloadList

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -331,7 +331,8 @@ func (a IstioAppender) getIngressGatewayWorkloads(globalInfo *graph.AppenderGlob
 func (a IstioAppender) getIstioComponentWorkloads(component string, globalInfo *graph.AppenderGlobalInfo) map[string][]models.WorkloadListItem {
 	componentWorkloads := make(map[string][]models.WorkloadListItem)
 	for namespace := range a.AccessibleNamespaces {
-		criteria := business.WorkloadCriteria{Namespace: namespace, IncludeIstioResources: false, IncludeHealth: false}
+		// @TODO cluster support in graph
+		criteria := business.WorkloadCriteria{Namespace: namespace, IncludeIstioResources: false, IncludeHealth: false, Cluster: config.Get().KubernetesConfig.ClusterName}
 		wList, err := globalInfo.Business.Workload.GetWorkloadList(context.TODO(), criteria)
 		graph.CheckError(err)
 
@@ -351,7 +352,8 @@ func (a IstioAppender) getIstioComponentWorkloads(component string, globalInfo *
 func (a IstioAppender) getGatewayAPIWorkloads(globalInfo *graph.AppenderGlobalInfo) map[string][]models.WorkloadListItem {
 	managedWorkloads := make(map[string][]models.WorkloadListItem)
 	for namespace := range a.AccessibleNamespaces {
-		criteria := business.WorkloadCriteria{Namespace: namespace, IncludeIstioResources: false, IncludeHealth: false}
+		// @TODO cluster support in graph
+		criteria := business.WorkloadCriteria{Namespace: namespace, IncludeIstioResources: false, IncludeHealth: false, Cluster: config.Get().KubernetesConfig.ClusterName}
 		wList, err := globalInfo.Business.Workload.GetWorkloadList(context.TODO(), criteria)
 		graph.CheckError(err)
 

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -61,7 +61,7 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if criteria.IncludeHealth {
-		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime)
+		rateInterval, err := adjustRateInterval(r.Context(), business, p.Cluster, p.Namespace, p.RateInterval, p.QueryTime)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -32,7 +32,7 @@ func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Adjust rate interval
-	rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime)
+	rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Cluster, p.Namespace, p.RateInterval, p.QueryTime)
 	if err != nil {
 		handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 		return
@@ -124,8 +124,8 @@ func (p *namespaceHealthParams) extract(r *http.Request) (bool, string) {
 	return true, ""
 }
 
-func adjustRateInterval(ctx context.Context, business *business.Layer, namespace, rateInterval string, queryTime time.Time) (string, error) {
-	namespaceInfo, err := business.Namespace.GetNamespace(ctx, namespace)
+func adjustRateInterval(ctx context.Context, business *business.Layer, cluster, namespace, rateInterval string, queryTime time.Time) (string, error) {
+	namespaceInfo, err := business.Namespace.GetNamespaceByCluster(ctx, namespace, cluster)
 	if err != nil {
 		return "", err
 	}

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -55,10 +55,6 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cluster := clusterNameFromQuery(query)
-	if cluster != config.Get().KubernetesConfig.ClusterName {
-		// @TODO do not include validations from other clusters yet
-		includeValidations = false
-	}
 
 	criteria := business.ParseIstioConfigCriteria(namespace, objects, labelSelector, workloadSelector, allNamespaces)
 
@@ -134,10 +130,6 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cluster := clusterNameFromQuery(query)
-	if cluster != config.Get().KubernetesConfig.ClusterName {
-		// @TODO do not include validations from other clusters yet
-		includeValidations = false
-	}
 
 	if !checkObjectType(objectType) {
 		RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+objectType)

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -64,7 +64,7 @@ func ServiceList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if criteria.IncludeHealth {
-		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime)
+		rateInterval, err := adjustRateInterval(r.Context(), business, p.Cluster, p.Namespace, p.RateInterval, p.QueryTime)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return
@@ -111,7 +111,7 @@ func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 	namespace := params["namespace"]
 	service := params["service"]
 	queryTime := util.Clock.Now()
-	rateInterval, err = adjustRateInterval(r.Context(), business, namespace, rateInterval, queryTime)
+	rateInterval, err = adjustRateInterval(r.Context(), business, cluster, namespace, rateInterval, queryTime)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return
@@ -176,7 +176,7 @@ func ServiceUpdate(w http.ResponseWriter, r *http.Request) {
 	namespace := params["namespace"]
 	service := params["service"]
 	queryTime := util.Clock.Now()
-	rateInterval, err = adjustRateInterval(r.Context(), business, namespace, rateInterval, queryTime)
+	rateInterval, err = adjustRateInterval(r.Context(), business, cluster, namespace, rateInterval, queryTime)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Adjust rate interval error: "+err.Error())
 		return

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -68,7 +68,7 @@ func WorkloadList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if criteria.IncludeHealth {
-		rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime)
+		rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Cluster, p.Namespace, p.RateInterval, p.QueryTime)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5967
Subtask: https://github.com/kiali/kiali/issues/6056

Istio config list and details shows validations from remote clusters.

Added missing cluster param in several places, put default values for metrics.

One issue I noticed, when opening config pages, then going to Overview page, there were failures in loading metrics, and not all namespaces are loaded. 
For this I did put 'cluster' param's value to home cluster in some places with TODO as I added more subtasks in https://github.com/kiali/kiali/issues/5618
Also disabled loading namespaces from cache, because it was loading only home cluster cache after some point.