### PR TITLE
Use cluster parameter for permissions check

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1232,7 +1232,7 @@ func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, nam
 	k8s, ok := in.userClients[cluster]
 	if !ok {
 		log.Errorf("Cluster %s doesn't exist ", cluster)
-		cluster = in.config.KubernetesConfig.ClusterName
+		return nil
 	}
 
 	if len(namespaces) > 0 {

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -625,3 +625,9 @@ func (in *MeshService) CanaryUpgradeStatus() (*models.CanaryUpgradeStatus, error
 
 	return status, nil
 }
+
+// Checks if a cluster exist
+func (in *MeshService) IsValidCluster(cluster string) bool {
+	_, exists := in.layer.k8sClients[cluster]
+	return exists
+}

--- a/business/services.go
+++ b/business/services.go
@@ -633,7 +633,7 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 			errChan <- fmt.Errorf("client not found for cluster: %s", cluster)
 			return
 		}
-		vsCreate, vsUpdate, vsDelete = getPermissions(context.TODO(), userClient, namespace, kubernetes.VirtualServices)
+		vsCreate, vsUpdate, vsDelete = getPermissions(context.TODO(), userClient, cluster, namespace, kubernetes.VirtualServices)
 	}()
 
 	wg.Wait()

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -151,6 +151,7 @@ type State = {
   showTrafficPoliciesModal: boolean;
   kind: string;
   nsTarget: string;
+  clusterTarget?: string;
   opTarget: string;
   grafanaLinks: ExternalLink[];
   istiodResourceThresholds: IstiodResourceThresholds;
@@ -188,6 +189,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       showTrafficPoliciesModal: false,
       kind: '',
       nsTarget: '',
+      clusterTarget: '',
       opTarget: '',
       grafanaLinks: [],
       istiodResourceThresholds: { memory: 0, cpu: 0 },
@@ -684,7 +686,13 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           isSeparator: false,
           title: 'Enable Auto Injection',
           action: (ns: string) =>
-            this.setState({ showTrafficPoliciesModal: true, nsTarget: ns, opTarget: 'enable', kind: 'injection' })
+            this.setState({
+              showTrafficPoliciesModal: true,
+              nsTarget: ns,
+              opTarget: 'enable',
+              kind: 'injection',
+              clusterTarget: nsInfo.cluster
+            })
         };
         const disableAction = {
           'data-test': `disable-${nsInfo.name}-namespace-sidecar-injection`,
@@ -692,7 +700,13 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           isSeparator: false,
           title: 'Disable Auto Injection',
           action: (ns: string) =>
-            this.setState({ showTrafficPoliciesModal: true, nsTarget: ns, opTarget: 'disable', kind: 'injection' })
+            this.setState({
+              showTrafficPoliciesModal: true,
+              nsTarget: ns,
+              opTarget: 'disable',
+              kind: 'injection',
+              clusterTarget: nsInfo.cluster
+            })
         };
         const removeAction = {
           'data-test': `remove-${nsInfo.name}-namespace-sidecar-injection`,
@@ -700,7 +714,13 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           isSeparator: false,
           title: 'Remove Auto Injection',
           action: (ns: string) =>
-            this.setState({ showTrafficPoliciesModal: true, nsTarget: ns, opTarget: 'remove', kind: 'injection' })
+            this.setState({
+              showTrafficPoliciesModal: true,
+              nsTarget: ns,
+              opTarget: 'remove',
+              kind: 'injection',
+              clusterTarget: nsInfo.cluster
+            })
         };
         if (
           nsInfo.labels &&
@@ -736,14 +756,26 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           isSeparator: false,
           title: 'Upgrade to ' + serverConfig.istioCanaryRevision.upgrade + ' revision',
           action: (ns: string) =>
-            this.setState({ opTarget: 'upgrade', kind: 'canary', nsTarget: ns, showTrafficPoliciesModal: true })
+            this.setState({
+              opTarget: 'upgrade',
+              kind: 'canary',
+              nsTarget: ns,
+              showTrafficPoliciesModal: true,
+              clusterTarget: nsInfo.cluster
+            })
         };
         const downgradeAction = {
           isGroup: false,
           isSeparator: false,
           title: 'Downgrade to ' + serverConfig.istioCanaryRevision.current + ' revision',
           action: (ns: string) =>
-            this.setState({ opTarget: 'current', kind: 'canary', nsTarget: ns, showTrafficPoliciesModal: true })
+            this.setState({
+              opTarget: 'current',
+              kind: 'canary',
+              nsTarget: ns,
+              showTrafficPoliciesModal: true,
+              clusterTarget: nsInfo.cluster
+            })
         };
         if (
           nsInfo.labels &&
@@ -771,6 +803,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           this.setState({
             opTarget: aps.length === 0 ? 'create' : 'update',
             nsTarget: ns,
+            clusterTarget: nsInfo.cluster,
             showTrafficPoliciesModal: true,
             kind: 'policy'
           });
@@ -781,7 +814,13 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
         isSeparator: false,
         title: 'Delete Traffic Policies',
         action: (ns: string) =>
-          this.setState({ opTarget: 'delete', nsTarget: ns, showTrafficPoliciesModal: true, kind: 'policy' })
+          this.setState({
+            opTarget: 'delete',
+            nsTarget: ns,
+            showTrafficPoliciesModal: true,
+            kind: 'policy',
+            clusterTarget: nsInfo.cluster
+          })
       };
       if (this.props.istioAPIEnabled) {
         namespaceActions.push({
@@ -821,6 +860,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     this.setState({
       showTrafficPoliciesModal: false,
       nsTarget: '',
+      clusterTarget: '',
       opTarget: '',
       kind: ''
     });
@@ -893,7 +933,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
                           ? lg
                           : md
                       }
-                      key={'CardItem_' + ns.name}
+                      key={'CardItem_' + ns.name + ns.cluster}
                       style={{ margin: '0px 5px 0 5px' }}
                     >
                       <Card
@@ -1047,7 +1087,11 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           kind={this.state.kind}
           hideConfirmModal={this.hideTrafficManagement}
           nsTarget={this.state.nsTarget}
-          nsInfo={this.state.namespaces.filter(ns => ns.name === this.state.nsTarget)[0]}
+          nsInfo={
+            this.state.namespaces.filter(
+              ns => ns.name === this.state.nsTarget && ns.cluster === this.state.clusterTarget
+            )[0]
+          }
           duration={this.props.duration}
           load={this.load}
         />

--- a/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
+++ b/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
@@ -96,15 +96,17 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
     confirmationModal: boolean = false,
     loaded: boolean = this.props.opTarget === 'update' || this.props.opTarget === 'create'
   ) => {
-    this.promises.register('namespacepermissions', API.getIstioPermissions([this.props.nsTarget])).then(result => {
-      const permission = result.data[this.props.nsTarget][AUTHORIZATION_POLICIES];
-      const disableOp = !(permission.create && permission.update && permission.delete);
-      this.setState({
-        confirmationModal,
-        disableOp,
-        loaded
+    this.promises
+      .register('namespacepermissions', API.getIstioPermissions([this.props.nsTarget], this.props.nsInfo.cluster))
+      .then(result => {
+        const permission = result.data[this.props.nsTarget][AUTHORIZATION_POLICIES];
+        const disableOp = !(permission.create && permission.update && permission.delete);
+        this.setState({
+          confirmationModal,
+          disableOp,
+          loaded
+        });
       });
-    });
   };
 
   generateTrafficPolicies = () => {
@@ -138,7 +140,7 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
       this.props.opTarget === 'remove',
       null
     );
-    API.updateNamespace(this.props.nsTarget, jsonPatch)
+    API.updateNamespace(this.props.nsTarget, jsonPatch, this.props.nsInfo.cluster)
       .then(_ => {
         AlertUtils.add('Namespace ' + this.props.nsTarget + ' updated', 'default', MessageType.SUCCESS);
         this.props.load();
@@ -150,7 +152,7 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
 
   onUpgradeDowngradeIstio = (): void => {
     const jsonPatch = buildNamespaceInjectionPatch(false, false, this.state.canaryVersion);
-    API.updateNamespace(this.props.nsTarget, jsonPatch)
+    API.updateNamespace(this.props.nsTarget, jsonPatch, this.props.nsInfo.cluster)
       .then(_ => {
         AlertUtils.add('Namespace ' + this.props.nsTarget + ' updated', 'default', MessageType.SUCCESS);
         this.props.load();

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -164,8 +164,8 @@ export const getNamespaceValidations = (namespace: string) => {
   return newRequest<ValidationStatus>(HTTP_VERBS.GET, urls.namespaceValidations(namespace), {}, {});
 };
 
-export const updateNamespace = (namespace: string, jsonPatch: string): Promise<Response<string>> => {
-  return newRequest(HTTP_VERBS.PATCH, urls.namespace(namespace), {}, jsonPatch);
+export const updateNamespace = (namespace: string, jsonPatch: string, cluster?: string): Promise<Response<string>> => {
+  return newRequest(HTTP_VERBS.PATCH, urls.namespace(namespace), { cluster: cluster }, jsonPatch);
 };
 
 export const getIstioConfig = (
@@ -720,8 +720,13 @@ export const getWorkloadSpans = (namespace: string, workload: string, params: Tr
   return newRequest<Span[]>(HTTP_VERBS.GET, urls.workloadSpans(namespace, workload), params, {});
 };
 
-export const getIstioPermissions = (namespaces: string[]) => {
-  return newRequest<IstioPermissions>(HTTP_VERBS.GET, urls.istioPermissions, { namespaces: namespaces.join(',') }, {});
+export const getIstioPermissions = (namespaces: string[], cluster?: string) => {
+  const queryParams: any = {};
+  queryParams.namespaces = namespaces.join(',');
+  if (cluster) {
+    queryParams.cluster = cluster;
+  }
+  return newRequest<IstioPermissions>(HTTP_VERBS.GET, urls.istioPermissions, queryParams, {});
 };
 
 export const getMetricsStats = (queries: MetricsStatsQuery[]) => {

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -337,6 +337,7 @@ func IstioConfigPermissions(w http.ResponseWriter, r *http.Request) {
 	// query params
 	params := r.URL.Query()
 	namespaces := params.Get("namespaces") // csl of namespaces
+	cluster := params.Get("cluster")
 
 	business, err := getBusiness(r)
 	if err != nil {
@@ -346,7 +347,7 @@ func IstioConfigPermissions(w http.ResponseWriter, r *http.Request) {
 	istioConfigPermissions := models.IstioConfigPermissions{}
 	if len(namespaces) > 0 {
 		ns := strings.Split(namespaces, ",")
-		istioConfigPermissions = business.IstioConfig.GetIstioConfigPermissions(r.Context(), ns)
+		istioConfigPermissions = business.IstioConfig.GetIstioConfigPermissions(r.Context(), ns, cluster)
 	}
 	RespondWithJSON(w, http.StatusOK, istioConfigPermissions)
 }

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -1,13 +1,13 @@
 package handlers
 
 import (
-	"github.com/kiali/kiali/config"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/gorilla/mux"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 )
@@ -38,12 +36,7 @@ func NamespaceValidationSummary(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 
-	cluster := ""
-	if query.Get("cluster") != "" {
-		cluster = query.Get("cluster")
-	} else {
-		cluster = kubernetes.HomeClusterName
-	}
+	cluster := clusterNameFromQuery(query)
 
 	business, err := getBusiness(r)
 	if err != nil {
@@ -73,12 +66,7 @@ func ConfigValidationSummary(w http.ResponseWriter, r *http.Request) {
 	if len(namespaces) > 0 {
 		nss = strings.Split(namespaces, ",")
 	}
-	cluster := ""
-	if params.Has("cluster") && params.Get("cluster") != "" {
-		cluster = params.Get("cluster")
-	} else {
-		cluster = kubernetes.HomeClusterName
-	}
+	cluster := clusterNameFromQuery(params)
 
 	business, err := getBusiness(r)
 	if err != nil {
@@ -117,12 +105,7 @@ func NamespaceUpdate(w http.ResponseWriter, r *http.Request) {
 	jsonPatch := string(body)
 
 	query := r.URL.Query()
-	cluster := ""
-	if query.Get("cluster") != "" {
-		cluster = query.Get("cluster")
-	} else {
-		cluster = config.Get().KubernetesConfig.ClusterName
-	}
+	cluster := clusterNameFromQuery(query)
 
 	ns, err := business.Namespace.UpdateNamespace(r.Context(), namespace, jsonPatch, cluster)
 	if err != nil {

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/kiali/kiali/config"
 	"io"
 	"net/http"
 	"strings"
@@ -115,10 +116,12 @@ func NamespaceUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	jsonPatch := string(body)
 
-	// TODO: Multicluster: Add query parameter
-	cluster := params["cluster"]
-	if cluster == "" {
-		cluster = kubernetes.HomeClusterName
+	query := r.URL.Query()
+	cluster := ""
+	if query.Get("cluster") != "" {
+		cluster = query.Get("cluster")
+	} else {
+		cluster = config.Get().KubernetesConfig.ClusterName
 	}
 
 	ns, err := business.Namespace.UpdateNamespace(r.Context(), namespace, jsonPatch, cluster)


### PR DESCRIPTION
- Use the k8s client from the user to check for permissions 
- For Alpha support, writes will be disabled in remote clusters
- Use the cluster to validate permissions

Fixes #5765

How to test: Update namespaces (Enable/disable Auto injection), Create traffic policies, should be possible for the local cluster (If the user has permissions) but not for the remote clusters. 