### PR TITLE
Automation of a test procedure related to multiple K8 Gateways with same ports and hosts at the same time

### DIFF
--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -1,4 +1,5 @@
 import { And, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { ensureKialiFinishedLoading } from './transition';
 
 When('user clicks in the {string} Istio config actions', (action: string) => {
   cy.get('button[data-test="config-actions-dropdown"]')
@@ -12,12 +13,23 @@ When('user clicks in the {string} Istio config actions', (action: string) => {
       .should('not.exist');
 });
 
+
+When('viewing the detail for {string}', (object: string) => {
+  ensureKialiFinishedLoading();
+  cy.get('a').contains(object).click();
+});
+
+
 And('user sees the {string} config wizard', (title: string) => {
   cy.get('h1').should('contain.text', title);
 });
 
 And('user adds listener', () => {
   cy.get('button[name="addListener"]').click()
+});
+
+And('user adds a hostname', () => {
+  cy.get('[aria-label="Address List"]').find('button').click();
 });
 
 And('user types {string} in the {string} input', (value: string, id: string) => {
@@ -67,8 +79,18 @@ And('user opens the {string} submenu',(title: string)=>{
   cy.get('button').contains(title).click();
 });
 
+And('choosing to delete it',()=>{
+  cy.get('#actions').click();
+  cy.get('#actions').contains("Delete").click();
+  cy.get('#pf-modal-part-2').find('button').contains("Delete").click();
+});
+
 Then('the {string} {string} should be listed in {string} namespace', function(type: string, name: string, namespace: string) {
   cy.get(`[data-test=VirtualItem_Ns${namespace}_${type.toLowerCase()}_${name}] svg`).should('exist');
+});
+
+Then('the {string} {string} should not be listed in {string} namespace', function(type: string, name: string, namespace: string) {
+  cy.get(`[data-test=VirtualItem_Ns${namespace}_${type.toLowerCase()}_${name}] svg`).should('not.exist');
 });
 
 Then('the preview button should be disabled', () =>{
@@ -82,4 +104,16 @@ Then('an error message {string} is displayed', (message: string) =>{
 
 Then('the {string} input should be empty', (id: string) => {
   cy.get(`input[id="${id}"]`).should('be.empty');
+});
+
+
+Then('{string} should be referenced', (gateway: string) => {
+  ensureKialiFinishedLoading();
+  cy.get('h5').contains("Validation References").should("be.visible");
+  cy.get(`a[data-test="k8sgateway-bookinfo-${gateway}"]`).should("be.visible");
+});
+
+Then('{string} should not be referenced anymore', (gateway: string) => {
+  ensureKialiFinishedLoading();
+  cy.get(`a[data-test="k8sgateway-bookinfo-${gateway}"]`).should("not.exist");
 });

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -214,3 +214,43 @@ Feature: Kiali Istio Config page
     And user types "foobar" in the "addPortName1" input
     And user types "8080" in the "addTargetPort1" input
     Then the preview button should be disabled
+
+@wizard-istio-config
+  Scenario: Create multiple K8s Gateways with colliding hostnames and port combinations and check for a reference
+    When user clicks in the "K8sGateway" Istio config actions
+    And user sees the "Create K8sGateway" config wizard
+    And user adds listener
+    And user types "gatewayapi-1" in the "name" input
+    And user types "default" in the "addName0" input
+    And user types "bookinfo-istio-system.apps.ocp4-kqe1.maistra.upshift.redhat.com" in the "addHostname0" input
+    And user types "80" in the "addPort0" input
+    And user adds a hostname
+    And user chooses "Hostname" mode from the "addType0" select
+    And user types "google.com" in the "addValue0" input
+    And user previews the configuration
+    And user creates the istio config
+    And user clicks in the "K8sGateway" Istio config actions
+    And user sees the "Create K8sGateway" config wizard
+    And user adds listener
+    And user types "gatewayapi-2" in the "name" input
+    And user types "default" in the "addName0" input
+    And user types "bookinfo-istio-system.apps.ocp4-kqe1.maistra.upshift.redhat.com" in the "addHostname0" input
+    And user types "80" in the "addPort0" input
+    And user adds a hostname
+    And user chooses "Hostname" mode from the "addType0" select
+    And user types "google.com" in the "addValue0" input
+    And user previews the configuration
+    And user creates the istio config
+    Then the "K8sGateway" "gatewayapi-1" should be listed in "bookinfo" namespace
+    And the "K8sGateway" "gatewayapi-2" should be listed in "bookinfo" namespace
+    When viewing the detail for "gatewayapi-1"
+    Then "gatewayapi-2" should be referenced
+
+
+@wizard-istio-config
+  Scenario: Delete one of the K8s Gateways and check that the reference is removed
+    When viewing the detail for "gatewayapi-2"
+    And choosing to delete it 
+    Then the "K8sGateway" "gatewayapi-2" should not be listed in "bookinfo" namespace
+    When viewing the detail for "gatewayapi-1"
+    Then "gatewayapi-2" should not be referenced anymore


### PR DESCRIPTION
This PR is an automation for #5868. The PR contains 2 tests. One of them is checking if the validations are present when 2 K8s Gateways with same ports and hosts are created. The other test then deletes one of the gateways and checks that the validations are no longer present. 

Related to #5853.

(works for the upstream OCP, not sure about the CI yet)