### PR TITLE
[v1.57] We also need hack scripts and 'which' package for bookinfo install

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 _output
 operator
-hack
 deploy
 frontend/node_modules

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -7,7 +7,7 @@ ENV HOME=$GOPATH/src/kiali
 
 # install required packages and prepare go dirs
 WORKDIR /bin
-RUN microdnf install --nodocs tar gzip make \
+RUN microdnf install --nodocs tar gzip make which \
     && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
     && tar -xf oc.tar.gz \
     && rm -f oc.tar.gz \


### PR DESCRIPTION
We will use also hack scripts to install bookinfo via this image. Also 'which' package was missing and it is needed for the bookinfo install script.