### PR TITLE
Multicluster - Cluster badge and cluster name in details pages 

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -284,6 +284,8 @@ func (in *AppService) GetAppDetails(ctx context.Context, criteria AppCriteria) (
 		}
 	}
 
+	(*appInstance).Cluster = appDetails.cluster
+
 	return *appInstance, nil
 }
 

--- a/frontend/src/pages/AppDetails/AppDescription.tsx
+++ b/frontend/src/pages/AppDetails/AppDescription.tsx
@@ -34,8 +34,8 @@ class AppDescription extends React.Component<AppDescriptionProps> {
     }
     return this.props.app ? (
       <Card id={'AppDescriptionCard'} data-test="app-description-card">
-        <CardHeader>
-          <Title headingLevel="h5" size={TitleSizes.lg} style={{ position: 'relative', width: '100%' }}>
+        <CardHeader style={{ display: 'table' }}>
+          <Title headingLevel="h5" size={TitleSizes.lg}>
             <div key="service-icon" className={iconStyle}>
               <PFBadge badge={PFBadges.App} position={TooltipPosition.top} />
             </div>
@@ -43,16 +43,12 @@ class AppDescription extends React.Component<AppDescriptionProps> {
             <span className={healthIconStyle}>
               <HealthIndicator id={this.props.app.name} health={this.props.health} />
             </span>
-            {this.props.app.cluster && (
-              <div
-                key="cluster-icon"
-                className={iconStyle}
-                style={{ position: 'absolute', display: 'inline', right: 0 }}
-              >
-                <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {this.props.app.cluster}
-              </div>
-            )}
           </Title>
+          {this.props.app.cluster && (
+            <div key="cluster-icon" style={{ paddingBottom: '10px' }}>
+              <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {this.props.app.cluster}
+            </div>
+          )}
         </CardHeader>
         <CardBody>
           <Labels

--- a/frontend/src/pages/AppDetails/AppDescription.tsx
+++ b/frontend/src/pages/AppDetails/AppDescription.tsx
@@ -35,7 +35,7 @@ class AppDescription extends React.Component<AppDescriptionProps> {
     return this.props.app ? (
       <Card id={'AppDescriptionCard'} data-test="app-description-card">
         <CardHeader>
-          <Title headingLevel="h5" size={TitleSizes.lg}>
+          <Title headingLevel="h5" size={TitleSizes.lg} style={{ position: 'relative', width: '100%' }}>
             <div key="service-icon" className={iconStyle}>
               <PFBadge badge={PFBadges.App} position={TooltipPosition.top} />
             </div>
@@ -43,12 +43,16 @@ class AppDescription extends React.Component<AppDescriptionProps> {
             <span className={healthIconStyle}>
               <HealthIndicator id={this.props.app.name} health={this.props.health} />
             </span>
+            {this.props.app.cluster && (
+              <div
+                key="cluster-icon"
+                className={iconStyle}
+                style={{ position: 'absolute', display: 'inline', right: 0 }}
+              >
+                <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {this.props.app.cluster}
+              </div>
+            )}
           </Title>
-          {this.props.app.cluster && (
-            <div key="cluster-icon" className={iconStyle}>
-              <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {this.props.app.cluster}
-            </div>
-          )}
         </CardHeader>
         <CardBody>
           <Labels

--- a/frontend/src/pages/AppDetails/AppDescription.tsx
+++ b/frontend/src/pages/AppDetails/AppDescription.tsx
@@ -44,6 +44,11 @@ class AppDescription extends React.Component<AppDescriptionProps> {
               <HealthIndicator id={this.props.app.name} health={this.props.health} />
             </span>
           </Title>
+          {this.props.app.cluster && (
+            <div key="cluster-icon" className={iconStyle}>
+              <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {this.props.app.cluster}
+            </div>
+          )}
         </CardHeader>
         <CardBody>
           <Labels

--- a/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -153,8 +153,8 @@ class ServiceDescription extends React.Component<ServiceInfoDescriptionProps, St
     }
     return (
       <Card id={'ServiceDescriptionCard'}>
-        <CardHeader>
-          <Title headingLevel="h5" size={TitleSizes.lg} style={{ position: 'relative', width: '100%' }}>
+        <CardHeader style={{ display: 'table' }}>
+          <Title headingLevel="h5" size={TitleSizes.lg}>
             <div key="service-icon" className={iconStyle}>
               <PFBadge badge={serviceBadge} position={TooltipPosition.top} />
             </div>
@@ -171,17 +171,12 @@ class ServiceDescription extends React.Component<ServiceInfoDescriptionProps, St
                 health={this.props.serviceDetails ? this.props.serviceDetails.health : undefined}
               />
             </span>
-            {this.props.serviceDetails?.cluster && (
-              <div
-                key="cluster-icon"
-                className={iconStyle}
-                style={{ position: 'absolute', display: 'inline', right: 0 }}
-              >
-                <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} />{' '}
-                {this.props.serviceDetails.cluster}
-              </div>
-            )}
           </Title>
+          {this.props.serviceDetails?.cluster && (
+            <div key="cluster-icon" className={iconStyle}>
+              <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {this.props.serviceDetails.cluster}
+            </div>
+          )}
         </CardHeader>
         <CardBody>
           {this.props.serviceDetails && showServiceLabels && (

--- a/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -154,7 +154,7 @@ class ServiceDescription extends React.Component<ServiceInfoDescriptionProps, St
     return (
       <Card id={'ServiceDescriptionCard'}>
         <CardHeader>
-          <Title headingLevel="h5" size={TitleSizes.lg}>
+          <Title headingLevel="h5" size={TitleSizes.lg} style={{ position: 'relative', width: '100%' }}>
             <div key="service-icon" className={iconStyle}>
               <PFBadge badge={serviceBadge} position={TooltipPosition.top} />
             </div>
@@ -171,6 +171,16 @@ class ServiceDescription extends React.Component<ServiceInfoDescriptionProps, St
                 health={this.props.serviceDetails ? this.props.serviceDetails.health : undefined}
               />
             </span>
+            {this.props.serviceDetails?.cluster && (
+              <div
+                key="cluster-icon"
+                className={iconStyle}
+                style={{ position: 'absolute', display: 'inline', right: 0 }}
+              >
+                <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} />{' '}
+                {this.props.serviceDetails.cluster}
+              </div>
+            )}
           </Title>
         </CardHeader>
         <CardBody>

--- a/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -124,8 +124,8 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
 
     return workload ? (
       <Card id={'WorkloadDescriptionCard'} data-test="workload-description-card">
-        <CardHeader>
-          <Title headingLevel="h5" size={TitleSizes.lg} style={{ position: 'relative', width: '100%' }}>
+        <CardHeader style={{ display: 'table' }}>
+          <Title headingLevel="h5" size={TitleSizes.lg}>
             <div key="service-icon" className={iconStyle}>
               <PFBadge badge={PFBadges.Workload} position={TooltipPosition.top} />
             </div>
@@ -178,16 +178,12 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
                   tooltip={true}
                 />
               )}
-            {this.props.workload?.cluster && (
-              <div
-                key="cluster-icon"
-                className={iconStyle}
-                style={{ position: 'absolute', display: 'inline', right: 0 }}
-              >
-                <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {this.props.workload.cluster}
-              </div>
-            )}
           </Title>
+          {this.props.workload?.cluster && (
+            <div key="cluster-icon" className={iconStyle}>
+              <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {this.props.workload.cluster}
+            </div>
+          )}
         </CardHeader>
         <CardBody>
           {workload.labels && (

--- a/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -125,7 +125,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
     return workload ? (
       <Card id={'WorkloadDescriptionCard'} data-test="workload-description-card">
         <CardHeader>
-          <Title headingLevel="h5" size={TitleSizes.lg}>
+          <Title headingLevel="h5" size={TitleSizes.lg} style={{ position: 'relative', width: '100%' }}>
             <div key="service-icon" className={iconStyle}>
               <PFBadge badge={PFBadges.Workload} position={TooltipPosition.top} />
             </div>
@@ -178,6 +178,15 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
                   tooltip={true}
                 />
               )}
+            {this.props.workload?.cluster && (
+              <div
+                key="cluster-icon"
+                className={iconStyle}
+                style={{ position: 'absolute', display: 'inline', right: 0 }}
+              >
+                <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {this.props.workload.cluster}
+              </div>
+            )}
           </Title>
         </CardHeader>
         <CardBody>

--- a/frontend/src/types/App.ts
+++ b/frontend/src/types/App.ts
@@ -18,6 +18,7 @@ export interface AppWorkload {
 
 export interface App {
   namespace: Namespace;
+  cluster: string;
   name: string;
   workloads: AppWorkload[];
   serviceNames: string[];

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -79,6 +79,7 @@ export interface ServiceDetailsInfo {
   namespaceMTLS?: TLSStatus;
   validations: Validations;
   additionalDetails: AdditionalItem[];
+  cluster?: string;
 }
 
 export function getServiceDetailsUpdateLabel(serviceDetails: ServiceDetailsInfo | null) {

--- a/models/app.go
+++ b/models/app.go
@@ -83,6 +83,11 @@ type App struct {
 	// example: reviews
 	Name string `json:"name"`
 
+	// Cluster of the application
+	// required: false
+	// example: east
+	Cluster string `json:"cluster"`
+
 	// Workloads for a given application
 	// required: true
 	Workloads []WorkloadItem `json:"workloads"`


### PR DESCRIPTION
At the moment I have kept just the "C", but it can changed easily. 

![image](https://user-images.githubusercontent.com/49480155/235187362-b22fefeb-7aab-4ee7-83b6-2066a82b8025.png)

Moved the cluster name to the header bottom to have space for larger cluster names. 

Fixes #6059 