### PR TITLE
Prevent crash scenario in namespace management

### DIFF
--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -70,7 +70,7 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if allNamespaces && len(nss) == 0 {
-		loadedNamespaces, _ := business.Namespace.GetNamespacesByCluster(cluster)
+		loadedNamespaces, _ := business.Namespace.GetNamespacesForCluster(r.Context(), cluster)
 		for _, ns := range loadedNamespaces {
 			nss = append(nss, ns.Name)
 		}


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6084

Prevent scenario where a token's namespaces cache can be set to the unfiltered namespaces for a single cluster.

I think this problem emerged gradually, due to a couple of things.

1) We introduced business.namespaces.go#GetNamespacesByCluster()

This method supports GetNamespaces() and is called for each cluster such that the parent can get the cross-cluster list.  I think there were two problems here.  First, it was declared public but really should have been private because it really should only be consumed by GetNamespaces to be launched as a gofunc.  Second, and more importantly, it sets the token's namespace cache to the partial, unfiltered list of namespaces for one cluster.  I'm pretty sure this was just a mistake.  Although unnecessary it's mainly harmless unless this routine is called from outside of GetNamespaces(), which is expecting to be, and should be, the only setter of the cache (I think).

Note that this method was made private by Nick along the way, but still maintained the cache setting.

2) We made it public again and called it from outside of GetNamespaces()

This was the danger scenario.  When called from outside of GetNamespaces the token's cache can get set to the unfiltered set of namespaces for just one cluster.  Given unlucky timing that wrong set of namespaces can then be provided to callers of GetNamespaces.

The PR again makes this method private, removes the unnecessary and dangerous cache setting, and offers a new public method for getting the namespaces of a single cluster.

I'm asking for a lot of reviewers because I'm not originally familiar with this code.


