### PR TITLE
[make] fix olm-operator-create target so it works again.

### DIFF
--- a/make/Makefile.olm.mk
+++ b/make/Makefile.olm.mk
@@ -74,6 +74,7 @@ build-olm-bundle: .prepare-olm-cluster-names .determine-olm-bundle-version
 	  sed -E -i "/.*kiali.*-operator.*/ n; s~(value:)(.*/.*-kiali-.*)~\1 ${CLUSTER_KIALI_INTERNAL_NAME}:${CONTAINER_VERSION}~g" $${csv} ;\
 	  sed -i "s/\$${KIALI_OPERATOR_VERSION}/$${bundle_version_sans_v}/g" $${csv} ;\
 	  sed -i "s/\$${CREATED_AT}/Created-By-Kiali-Makefile/g" $${csv} ;\
+	  sed -i "s|\$${KIALI_OPERATOR_REGISTRY}|${CLUSTER_OPERATOR_INTERNAL_NAME}:${OPERATOR_CONTAINER_VERSION}|g" $${csv} ;\
 	)
 	${DORP} build -f ${OUTDIR}/bundle/bundle.Dockerfile -t ${CLUSTER_OLM_BUNDLE_NAME}:${BUNDLE_VERSION}
 


### PR DESCRIPTION
The CSV was changed last year but we didn't realize it broke the make target to test on OLM. See: https://github.com/kiali/kiali-operator/pull/577