### PR TITLE
Cluster support for mTLS

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -178,7 +178,7 @@ func NewWithBackends(userClients map[string]kubernetes.ClientInterface, kialiSAC
 	// Out of order because it relies on ProxyStatus
 	temporaryLayer.ProxyLogging = ProxyLoggingService{userClients: userClients, proxyStatus: &temporaryLayer.ProxyStatus}
 	temporaryLayer.RegistryStatus = RegistryStatusService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
-	temporaryLayer.TLS = TLSService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
+	temporaryLayer.TLS = TLSService{userClients: userClients, kialiCache: kialiCache, businessLayer: temporaryLayer}
 	temporaryLayer.Svc = SvcService{config: *config.Get(), kialiCache: kialiCache, businessLayer: temporaryLayer, prom: prom, userClients: userClients}
 	temporaryLayer.TokenReview = NewTokenReview(userClients[homeClusterName])
 	temporaryLayer.Validations = IstioValidationsService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}

--- a/business/services.go
+++ b/business/services.go
@@ -590,7 +590,7 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 	go func(ctx context.Context) {
 		defer wg.Done()
 		var err2 error
-		nsmtls, err2 = in.businessLayer.TLS.NamespaceWidemTLSStatus(ctx, namespace)
+		nsmtls, err2 = in.businessLayer.TLS.NamespaceWidemTLSStatus(ctx, namespace, cluster)
 		if err2 != nil {
 			errChan <- err2
 		}

--- a/business/tls.go
+++ b/business/tls.go
@@ -3,12 +3,12 @@ package business
 import (
 	"context"
 
-	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/observability"
@@ -16,7 +16,8 @@ import (
 )
 
 type TLSService struct {
-	k8s             kubernetes.ClientInterface
+	userClients     map[string]kubernetes.ClientInterface
+	kialiCache      cache.KialiCache
 	businessLayer   *Layer
 	enabledAutoMtls *bool
 }
@@ -28,11 +29,12 @@ const (
 	MTLSDisabled         = "MTLS_DISABLED"
 )
 
-func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, namespaces []string) (models.MTLSStatus, error) {
+func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, namespaces []string, cluster string) (models.MTLSStatus, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "MeshWidemTLSStatus",
 		observability.Attribute("package", "business"),
 		observability.Attribute("namespaces", namespaces),
+		observability.Attribute("cluster", cluster),
 	)
 	defer end()
 
@@ -40,9 +42,10 @@ func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, namespaces []strin
 		AllNamespaces:              true,
 		IncludeDestinationRules:    true,
 		IncludePeerAuthentications: true,
+		Cluster:                    cluster,
 	}
-	// @TODO hardcoded HomeClusterName
-	istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigListPerCluster(ctx, criteria, kubernetes.HomeClusterName)
+
+	istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigListPerCluster(ctx, criteria, cluster)
 	if err != nil {
 		return models.MTLSStatus{}, err
 	}
@@ -53,7 +56,7 @@ func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, namespaces []strin
 	mtlsStatus := mtls.MtlsStatus{
 		PeerAuthentications: pas,
 		DestinationRules:    drs,
-		AutoMtlsEnabled:     in.hasAutoMTLSEnabled(),
+		AutoMtlsEnabled:     in.hasAutoMTLSEnabled(cluster),
 		AllowPermissive:     false,
 	}
 
@@ -69,15 +72,16 @@ func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, namespaces []strin
 	}, nil
 }
 
-func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace string) (models.MTLSStatus, error) {
+func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace, cluster string) (models.MTLSStatus, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "NamespaceWidemTLSStatus",
 		observability.Attribute("package", "business"),
+		observability.Attribute("cluster", cluster),
 		observability.Attribute("namespace", namespace),
 	)
 	defer end()
 
-	nss, err := in.getNamespaces(ctx)
+	nss, err := in.getNamespaces(cluster)
 	if err != nil {
 		return models.MTLSStatus{}, nil
 	}
@@ -86,9 +90,10 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace str
 		AllNamespaces:              true,
 		IncludeDestinationRules:    true,
 		IncludePeerAuthentications: true,
+		Cluster:                    cluster,
 	}
-	// @TODO
-	istioConfigList, err2 := in.businessLayer.IstioConfig.GetIstioConfigListPerCluster(ctx, criteria, kubernetes.HomeClusterName)
+
+	istioConfigList, err2 := in.businessLayer.IstioConfig.GetIstioConfigListPerCluster(ctx, criteria, cluster)
 	if err2 != nil {
 		return models.MTLSStatus{}, err2
 	}
@@ -102,7 +107,7 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace str
 	mtlsStatus := mtls.MtlsStatus{
 		PeerAuthentications: pas,
 		DestinationRules:    drs,
-		AutoMtlsEnabled:     in.hasAutoMTLSEnabled(),
+		AutoMtlsEnabled:     in.hasAutoMTLSEnabled(cluster),
 		AllowPermissive:     false,
 	}
 
@@ -112,43 +117,8 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace str
 	}, nil
 }
 
-// TODO refactor business/istio_validations.go
-func (in *TLSService) GetAllDestinationRules(ctx context.Context, namespaces []string) ([]*networking_v1beta1.DestinationRule, error) {
-	var end observability.EndFunc
-	ctx, end = observability.StartSpan(ctx, "GetAllDestinationRules",
-		observability.Attribute("package", "business"),
-		observability.Attribute("namespaces", namespaces),
-	)
-	defer end()
-
-	criteria := IstioConfigCriteria{
-		AllNamespaces:           true,
-		IncludeDestinationRules: true,
-	}
-
-	istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigListPerCluster(ctx, criteria, kubernetes.HomeClusterName)
-	if err != nil {
-		return nil, err
-	}
-
-	allDestinationRules := make([]*networking_v1beta1.DestinationRule, 0)
-	for _, dr := range istioConfigList.DestinationRules {
-		found := false
-		for _, ns := range namespaces {
-			if dr.Namespace == ns {
-				found = true
-				break
-			}
-		}
-		if found {
-			allDestinationRules = append(allDestinationRules, dr)
-		}
-	}
-	return allDestinationRules, nil
-}
-
-func (in *TLSService) getNamespaces(ctx context.Context) ([]string, error) {
-	nss, nssErr := in.businessLayer.Namespace.GetNamespaces(ctx)
+func (in *TLSService) getNamespaces(cluster string) ([]string, error) {
+	nss, nssErr := in.businessLayer.Namespace.GetNamespacesByCluster(cluster)
 	if nssErr != nil {
 		return nil, nssErr
 	}
@@ -160,18 +130,27 @@ func (in *TLSService) getNamespaces(ctx context.Context) ([]string, error) {
 	return nsNames, nil
 }
 
-func (in *TLSService) hasAutoMTLSEnabled() bool {
+func (in *TLSService) hasAutoMTLSEnabled(cluster string) bool {
 	if in.enabledAutoMtls != nil {
 		return *in.enabledAutoMtls
+	}
+
+	kubeCache := in.kialiCache.GetKubeCaches()[cluster]
+	if kubeCache == nil {
+		return true
+	}
+	userClient := in.userClients[cluster]
+	if userClient == nil {
+		return true
 	}
 
 	cfg := config.Get()
 	var istioConfig *core_v1.ConfigMap
 	var err error
 	if IsNamespaceCached(cfg.IstioNamespace) {
-		istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
+		istioConfig, err = kubeCache.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	} else {
-		istioConfig, err = in.k8s.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
+		istioConfig, err = userClient.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	}
 	if err != nil {
 		return true

--- a/business/tls.go
+++ b/business/tls.go
@@ -81,7 +81,7 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace, cl
 	)
 	defer end()
 
-	nss, err := in.getNamespaces(cluster)
+	nss, err := in.getNamespaces(ctx, cluster)
 	if err != nil {
 		return models.MTLSStatus{}, nil
 	}
@@ -117,8 +117,8 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace, cl
 	}, nil
 }
 
-func (in *TLSService) getNamespaces(cluster string) ([]string, error) {
-	nss, nssErr := in.businessLayer.Namespace.GetNamespacesByCluster(cluster)
+func (in *TLSService) getNamespaces(ctx context.Context, cluster string) ([]string, error) {
+	nss, nssErr := in.businessLayer.Namespace.GetNamespacesForCluster(ctx, cluster)
 	if nssErr != nil {
 		return nil, nssErr
 	}

--- a/business/tls_perf_test.go
+++ b/business/tls_perf_test.go
@@ -90,10 +90,10 @@ func testPerfScenario(exStatus string, nss []core_v1.Namespace, drs []*networkin
 
 	kialiCache = cache.FakeTlsKialiCache("token", nsNames, ps, drs)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
-	TLSService := TLSService{k8s: k8s, enabledAutoMtls: &autoMtls, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
+	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
+	TLSService := TLSService{userClients: k8sclients, kialiCache: kialiCache, enabledAutoMtls: &autoMtls, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
 	for _, ns := range nss {
-		status, err := (TLSService).NamespaceWidemTLSStatus(context.TODO(), ns.Name)
+		status, err := (TLSService).NamespaceWidemTLSStatus(context.TODO(), ns.Name, config.Get().KubernetesConfig.ClusterName)
 		assert.NoError(err)
 		assert.Equal(exStatus, status.Status)
 	}

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -42,7 +42,7 @@ func TestMeshStatusEnabled(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, false, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -69,7 +69,7 @@ func TestMeshStatusEnabledAutoMtls(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, true, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -97,7 +97,7 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, false, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -126,7 +126,7 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, false, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -155,7 +155,7 @@ func TestMeshStatusDisabled(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, false, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -180,7 +180,7 @@ func TestMeshStatusNotEnabledAutoMtls(t *testing.T) {
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	SetWithBackends(mockClientFactory, nil)
 	TLSService := getTLSService(k8s, true, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -314,9 +314,9 @@ func TestNamespaceHasDestinationRuleEnabledDifferentNs(t *testing.T) {
 	autoMtls := false
 	kialiCache = cache.FakeTlsKialiCache("token", nss, ps, drs)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
-	TLSService := TLSService{k8s: k8s, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil), enabledAutoMtls: &autoMtls}
-	status, err := TLSService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo")
+	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
+	TLSService := TLSService{userClients: k8sclients, kialiCache: kialiCache, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil), enabledAutoMtls: &autoMtls}
+	status, err := TLSService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo", config.Get().KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -350,9 +350,9 @@ func testNamespaceScenario(exStatus string, drs []*networking_v1beta1.Destinatio
 
 	kialiCache = cache.FakeTlsKialiCache("token", nss, ps, drs)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
-	TLSService := &TLSService{k8s: k8s, enabledAutoMtls: &autoMtls, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
-	status, err := TLSService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo")
+	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
+	TLSService := &TLSService{userClients: k8sclients, kialiCache: kialiCache, enabledAutoMtls: &autoMtls, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
+	status, err := TLSService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo", config.Get().KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -398,8 +398,8 @@ func fakePeerAuthn(name, namespace string, peers *api_security_v1beta1.PeerAuthe
 func getTLSService(k8s kubernetes.ClientInterface, autoMtls bool, namespaces []string, pa []*security_v1beta1.PeerAuthentication, dr []*networking_v1beta1.DestinationRule) *TLSService {
 	kialiCache = cache.FakeTlsKialiCache("token", namespaces, pa, dr)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
-	return &TLSService{k8s: k8s, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil), enabledAutoMtls: &autoMtls}
+	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
+	return &TLSService{userClients: k8sclients, kialiCache: kialiCache, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil), enabledAutoMtls: &autoMtls}
 }
 
 func fakeStrictMeshPeerAuthentication(name string) []*security_v1beta1.PeerAuthentication {

--- a/frontend/src/components/MTls/MeshMTLSStatus.tsx
+++ b/frontend/src/components/MTls/MeshMTLSStatus.tsx
@@ -84,6 +84,7 @@ class MeshMTLSStatus extends React.Component<Props> {
   }
 
   fetchStatus = () => {
+    // leaving empty cluster param here, home cluster will be used by default
     API.getMeshTls()
       .then(response => {
         return this.props.setMeshTlsStatus(response.data);

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -460,7 +460,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
   fetchTLSChunk(chunk: NamespaceInfo[]) {
     return Promise.all(
       chunk.map(nsInfo => {
-        return API.getNamespaceTls(nsInfo.name).then(rs => ({ status: rs.data, nsInfo: nsInfo }));
+        return API.getNamespaceTls(nsInfo.name, nsInfo.cluster).then(rs => ({ status: rs.data, nsInfo: nsInfo }));
       })
     )
       .then(results => {

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -136,8 +136,12 @@ export const getNamespaceMetrics = (namespace: string, params: IstioMetricsOptio
   return newRequest<Readonly<IstioMetricsMap>>(HTTP_VERBS.GET, urls.namespaceMetrics(namespace), params, {});
 };
 
-export const getMeshTls = () => {
-  return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.meshTls(), {}, {});
+export const getMeshTls = (cluster?: string) => {
+  const queryParams: any = {};
+  if (cluster) {
+    queryParams.cluster = cluster;
+  }
+  return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.meshTls(), queryParams, {});
 };
 
 export const getOutboundTrafficPolicyMode = () => {
@@ -156,8 +160,12 @@ export const getIstiodResourceThresholds = () => {
   return newRequest<IstiodResourceThresholds>(HTTP_VERBS.GET, urls.istiodResourceThresholds(), {}, {});
 };
 
-export const getNamespaceTls = (namespace: string) => {
-  return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.namespaceTls(namespace), {}, {});
+export const getNamespaceTls = (namespace: string, cluster?: string) => {
+  const queryParams: any = {};
+  if (cluster) {
+    queryParams.cluster = cluster;
+  }
+  return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.namespaceTls(namespace), queryParams, {});
 };
 
 export const getNamespaceValidations = (namespace: string) => {

--- a/handlers/tls.go
+++ b/handlers/tls.go
@@ -20,8 +20,9 @@ func NamespaceTls(w http.ResponseWriter, r *http.Request) {
 	}
 
 	namespace := params["namespace"]
+	cluster := clusterNameFromQuery(r.URL.Query())
 
-	status, err := business.TLS.NamespaceWidemTLSStatus(r.Context(), namespace)
+	status, err := business.TLS.NamespaceWidemTLSStatus(r.Context(), namespace, cluster)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())

--- a/handlers/tls.go
+++ b/handlers/tls.go
@@ -20,9 +20,8 @@ func NamespaceTls(w http.ResponseWriter, r *http.Request) {
 	}
 
 	namespace := params["namespace"]
-	cluster := clusterNameFromQuery(r.URL.Query())
 
-	status, err := business.TLS.NamespaceWidemTLSStatus(r.Context(), namespace, cluster)
+	status, err := business.TLS.NamespaceWidemTLSStatus(r.Context(), namespace, clusterNameFromQuery(r.URL.Query()))
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
@@ -42,8 +41,10 @@ func MeshTls(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cluster := clusterNameFromQuery(r.URL.Query())
+
 	// Get all the namespaces
-	namespaces, err := business.Namespace.GetNamespaces(ctx)
+	namespaces, err := business.Namespace.GetNamespacesByCluster(cluster)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
@@ -57,7 +58,7 @@ func MeshTls(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get mtls status given the whole namespaces
-	globalmTLSStatus, err := business.TLS.MeshWidemTLSStatus(ctx, nsNames)
+	globalmTLSStatus, err := business.TLS.MeshWidemTLSStatus(ctx, nsNames, cluster)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())

--- a/handlers/tls.go
+++ b/handlers/tls.go
@@ -44,7 +44,7 @@ func MeshTls(w http.ResponseWriter, r *http.Request) {
 	cluster := clusterNameFromQuery(r.URL.Query())
 
 	// Get all the namespaces
-	namespaces, err := business.Namespace.GetNamespacesByCluster(cluster)
+	namespaces, err := business.Namespace.GetNamespacesForCluster(ctx, cluster)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())


### PR DESCRIPTION
Subtask https://github.com/kiali/kiali/issues/6064

All 'namespace/tls' requests into backend are containing 'cluster' param.
Can be seen in Overview page:
![Screenshot from 2023-05-03 13-18-16](https://user-images.githubusercontent.com/604313/235901672-362a0a89-28ae-4c5e-80cf-29b335b1d27f.png)

mTLS request for the home cluster does not send 'cluster' param and the default home cluster name is chosen backend.

Consider this [logged issue](https://github.com/kiali/kiali/issues/6063) when verifying mTLS for namespace only, as the created PeerAuth will be shown for same named namespaces in all clusters, thus all same named namespaces will be considered as enabled mTLS.