### PR TITLE
Cluster badge on the Overview page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,5 @@
 {
+  "proxy": "http://localhost:20001",
   "name": "@kiali/kiali-ui",
   "version": "1.68.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,4 @@
 {
-  "proxy": "http://localhost:20001",
   "name": "@kiali/kiali-ui",
   "version": "1.68.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -68,7 +68,7 @@ const status: ResourceType<NamespaceInfo> = {
   name: 'Status',
   param: 'h',
   column: 'Status',
-  transforms: [sortable, cellWidth(40)],
+  transforms: [sortable, cellWidth(50)],
   cellTransforms: [textCenter],
   renderer: Renderers.status
 };
@@ -252,7 +252,7 @@ export type Resource = {
 
 const namespaces: Resource = {
   name: 'namespaces',
-  columns: [tlsStatus, nsItem, istioConfiguration, labels, status],
+  columns: [tlsStatus, nsItem, cluster, istioConfiguration, status],
   badge: PFBadges.Namespace
 };
 

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -18,7 +18,7 @@ import { Health } from '../../types/Health';
 import NamespaceInfo from '../../pages/Overview/NamespaceInfo';
 import NamespaceMTLSStatusContainer from '../MTls/NamespaceMTLSStatus';
 import ValidationSummary from '../Validations/ValidationSummary';
-import OverviewCardSparklineCharts from '../../pages/Overview/OverviewCardSparklineCharts';
+import OverviewCardSparklineCharts from '../../pages/Overview/OverviewCardSparklineChartsComponent';
 import { OverviewToolbar } from '../../pages/Overview/OverviewToolbar';
 import { StatefulFilters } from '../Filters/StatefulFilters';
 import IstioObjectLink, { GetIstioObjectUrl, infoStyle } from '../Link/IstioObjectLink';

--- a/frontend/src/pages/Overview/OverviewCardSparklineChartsComponent.tsx
+++ b/frontend/src/pages/Overview/OverviewCardSparklineChartsComponent.tsx
@@ -6,6 +6,12 @@ import { DurationInSeconds } from '../../types/Common';
 import OverviewCardDataPlaneNamespace from './OverviewCardDataPlaneNamespace';
 import OverviewCardControlPlaneNamespace from './OverviewCardControlPlaneNamespace';
 import { IstiodResourceThresholds } from 'types/IstioStatus';
+import { connect } from 'react-redux';
+import { KialiAppState } from 'store/Store';
+
+type ReduxProps = {
+  istioAPIEnabled: boolean;
+};
 
 type Props = {
   name: string;
@@ -15,14 +21,13 @@ type Props = {
   errorMetrics?: Metric[];
   controlPlaneMetrics?: ControlPlaneMetricsMap;
   istiodResourceThresholds?: IstiodResourceThresholds;
-  istioAPIEnabled?: boolean;
 };
 
-class OverviewCardSparklineCharts extends React.Component<Props> {
+class OverviewCardSparklineChartsComponent extends React.Component<Props & ReduxProps> {
   render() {
     return (
       <>
-        {(this.props.name !== serverConfig.istioNamespace || !this.props.istioAPIEnabled) && (
+        {this.props.name !== serverConfig.istioNamespace && (
           <OverviewCardDataPlaneNamespace
             metrics={this.props.metrics}
             errorMetrics={this.props.errorMetrics}
@@ -44,4 +49,9 @@ class OverviewCardSparklineCharts extends React.Component<Props> {
   }
 }
 
+const mapStateToProps = (state: KialiAppState): ReduxProps => ({
+  istioAPIEnabled: state.statusState.istioEnvironment.istioAPIEnabled
+});
+
+const OverviewCardSparklineCharts = connect(mapStateToProps)(OverviewCardSparklineChartsComponent);
 export default OverviewCardSparklineCharts;

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -43,7 +43,7 @@ import NamespaceInfo, { NamespaceStatus } from './NamespaceInfo';
 import NamespaceMTLSStatusContainer from '../../components/MTls/NamespaceMTLSStatus';
 import { RenderComponentScroll } from '../../components/Nav/Page';
 import NamespaceStatuses from './NamespaceStatuses';
-import OverviewCardSparklineCharts from './OverviewCardSparklineCharts';
+import OverviewCardSparklineCharts from './OverviewCardSparklineChartsComponent';
 import OverviewTrafficPolicies from './OverviewTrafficPolicies';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
 import { computePrometheusRateParams } from '../../services/Prometheus';
@@ -82,6 +82,7 @@ import TLSInfo from 'components/Overview/TLSInfo';
 import CanaryUpgradeProgress from './CanaryUpgradeProgress';
 import ControlPlaneVersionBadge from './ControlPlaneVersionBadge';
 import AmbientBadge from '../../components/Ambient/AmbientBadge';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 const gridStyleCompact = style({
   backgroundColor: '#f5f5f5',
@@ -986,6 +987,12 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
                           <CardActions>{namespaceActions[i]}</CardActions>
                         </CardHeader>
                         <CardBody>
+                          {ns.cluster && (
+                            <div style={{ textAlign: 'left', paddingBottom: 3 }}>
+                              <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} />
+                              {ns.cluster}
+                            </div>
+                          )}
                           {ns.name === serverConfig.istioNamespace &&
                             this.state.displayMode === OverviewDisplayMode.EXPAND && (
                               <Grid>
@@ -1147,7 +1154,6 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           errorMetrics={ns.errorMetrics}
           controlPlaneMetrics={ns.controlPlaneMetrics}
           istiodResourceThresholds={this.state.istiodResourceThresholds}
-          istioAPIEnabled={this.props.istioAPIEnabled}
         />
       );
     }

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -61,7 +61,7 @@ import * as Sorts from './Sorts';
 import * as Filters from './Filters';
 import ValidationSummary from '../../components/Validations/ValidationSummary';
 import { DurationInSeconds, IntervalInMilliseconds } from 'types/Common';
-import { Paths, serverConfig } from '../../config';
+import { Paths, isMultiCluster, serverConfig } from '../../config';
 import { PFColors } from '../../components/Pf/PfColors';
 import VirtualList from '../../components/VirtualList/VirtualList';
 import { OverviewNamespaceAction, OverviewNamespaceActions } from './OverviewNamespaceActions';
@@ -987,7 +987,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
                           <CardActions>{namespaceActions[i]}</CardActions>
                         </CardHeader>
                         <CardBody>
-                          {ns.cluster && (
+                          {isMultiCluster() && ns.cluster && (
                             <div style={{ textAlign: 'left', paddingBottom: 3 }}>
                               <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} />
                               {ns.cluster}


### PR DESCRIPTION
Resolves https://github.com/kiali/kiali/issues/5921.

This PR adds the cluster badge to all views. It also fixes a problem in list view that wasn't showing the control plane metrics.

![image](https://user-images.githubusercontent.com/1286393/235826624-a2605b4b-d4ef-4de6-8f75-8c133931eb87.png)
![image](https://user-images.githubusercontent.com/1286393/235826654-f211b386-71b9-4591-a1dc-394feb5af2de.png)
