### PR TITLE
[v1.67] Prevent bad namespaces cache scenario (#6085)

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -264,6 +264,7 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 		}
 	}
 
+	// store only the filtered set of namespaces in cache for the token
 	if kialiCache != nil && in.homeClusterUserClient != nil {
 		// just get the home cluster token because it is assumed tokens are identical across all clusters
 		kialiCache.SetNamespaces(in.homeClusterUserClient.GetToken(), resultns)
@@ -391,14 +392,24 @@ func (in *NamespaceService) getNamespacesByCluster(cluster string) ([]models.Nam
 		}
 	}
 
-	result := namespaces
+	return namespaces, nil
+}
 
-	if kialiCache != nil && in.homeClusterUserClient != nil {
-		// Set namespace by user token
-		kialiCache.SetNamespaces(in.homeClusterUserClient.GetToken(), result)
+// GetNamespacesForCluster is just a convenience routine that filters GetNamespaces for a particular cluster
+func (in *NamespaceService) GetNamespacesForCluster(ctx context.Context, cluster string) ([]models.Namespace, error) {
+	tokenNamespaces, err := in.GetNamespaces(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	return result, nil
+	clusterNamespaces := []models.Namespace{}
+	for _, ns := range tokenNamespaces {
+		if ns.Cluster == cluster {
+			clusterNamespaces = append(clusterNamespaces, ns)
+		}
+	}
+
+	return clusterNamespaces, nil
 }
 
 // addIncludedNamespaces will look at all the namespaces and return all of them that match the Include list.


### PR DESCRIPTION
**Backport** of https://github.com/kiali/kiali/pull/6085

Prevent scenario where a token's namespaces cache can be set to the unfiltered namespaces for a single cluster.

I'm not 100% sure v1.67 suffers from a problem because the call from istio_config is not yet made, but this should ensure the problem does not happen in an unanticipated scenario.

https://github.com/kiali/kiali/issues/6084