### PR TITLE
Add missing gettext pkg which is required by install bookinfo script

### DIFF
--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -7,7 +7,7 @@ ENV HOME=$GOPATH/src/kiali
 
 # install required packages and prepare go dirs
 WORKDIR /bin
-RUN microdnf install --nodocs tar gzip make which \
+RUN microdnf install --nodocs tar gzip make which gettext \
     && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
     && tar -xf oc.tar.gz \
     && rm -f oc.tar.gz \


### PR DESCRIPTION
This image is used in the iterop pipeline to install bookinfo. Install bookinfo hack script requires this package.