### PR TITLE
Fix integration test failure

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -108,10 +108,11 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 	}()
 
 	// Combine namespace data
+	conf := config.Get()
 	for resultCh := range resultsCh {
 		if resultCh.err != nil {
 			// Return failure if we are in single cluster
-			if resultCh.cluster == kubernetes.HomeClusterName && len(in.userClients) == 1 {
+			if resultCh.cluster == conf.KubernetesConfig.ClusterName && len(in.userClients) == 1 {
 				log.Errorf("Error fetching Applications for local cluster %s: %s", resultCh.cluster, resultCh.err)
 				return models.AppList{}, resultCh.err
 			} else {

--- a/business/authentication/openid_auth_controller_test.go
+++ b/business/authentication/openid_auth_controller_test.go
@@ -41,10 +41,10 @@ func TestOpenIdAuthControllerRejectsImplicitFlow(t *testing.T) {
 	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
 	util.Clock = util.ClockMock{Time: clockTime}
 
-	cfg := config.NewConfig()
-	cfg.LoginToken.SigningKey = "kiali67890123456"
-	cfg.LoginToken.ExpirationSeconds = 1
-	config.Set(cfg)
+	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.LoginToken.ExpirationSeconds = 1
+	config.Set(conf)
 
 	// Returning some namespace when a cluster API call is made should have the result of
 	// a successful authentication.
@@ -68,7 +68,7 @@ func TestOpenIdAuthControllerRejectsImplicitFlow(t *testing.T) {
 			return nil, errors.New("unexpected token")
 		}
 		k8sclients := make(map[string]kubernetes.ClientInterface)
-		k8sclients[kubernetes.HomeClusterName] = k8s
+		k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 		return business.NewWithBackends(k8sclients, k8sclients, nil, nil), nil
 	})
 
@@ -122,13 +122,13 @@ func TestOpenIdAuthControllerAuthenticatesCorrectlyWithAuthorizationCodeFlow(t *
 	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
 	util.Clock = util.ClockMock{Time: clockTime}
 
-	cfg := config.NewConfig()
-	cfg.Server.WebRoot = "/kiali-test"
-	cfg.LoginToken.SigningKey = "kiali67890123456"
-	cfg.LoginToken.ExpirationSeconds = 1
-	cfg.Auth.OpenId.IssuerUri = testServer.URL
-	cfg.Auth.OpenId.ClientId = "kiali-client"
-	config.Set(cfg)
+	conf := config.NewConfig()
+	conf.Server.WebRoot = "/kiali-test"
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.LoginToken.ExpirationSeconds = 1
+	conf.Auth.OpenId.IssuerUri = testServer.URL
+	conf.Auth.OpenId.ClientId = "kiali-client"
+	config.Set(conf)
 
 	// Returning some namespace when a cluster API call is made should have the result of
 	// a successful authentication.
@@ -153,7 +153,7 @@ func TestOpenIdAuthControllerAuthenticatesCorrectlyWithAuthorizationCodeFlow(t *
 			return nil, errors.New("unexpected token")
 		}
 		k8sclients := make(map[string]kubernetes.ClientInterface)
-		k8sclients[kubernetes.HomeClusterName] = k8s
+		k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 		return business.NewWithBackends(k8sclients, k8sclients, nil, nil), nil
 	})
 

--- a/business/authentication/token_auth_controller_test.go
+++ b/business/authentication/token_auth_controller_test.go
@@ -47,9 +47,9 @@ func TestTokenAuthControllerRejectsUserWithoutPrivilegesInAnyNamespace(t *testin
 	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
 	util.Clock = util.ClockMock{Time: clockTime}
 
-	cfg := config.NewConfig()
-	cfg.LoginToken.SigningKey = "kiali67890123456"
-	config.Set(cfg)
+	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	config.Set(conf)
 
 	// Returning no namespace when a cluster API call is made should have the result of
 	// a rejected authentication.
@@ -62,7 +62,7 @@ func TestTokenAuthControllerRejectsUserWithoutPrivilegesInAnyNamespace(t *testin
 
 	controller := NewTokenAuthController(CookieSessionPersistor{}, func(authInfo *api.AuthInfo) (*business.Layer, error) {
 		k8sclients := make(map[string]kubernetes.ClientInterface)
-		k8sclients[kubernetes.HomeClusterName] = k8s
+		k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 		return business.NewWithBackends(k8sclients, k8sclients, nil, nil), nil
 	})
 
@@ -84,9 +84,9 @@ func TestTokenAuthControllerRejectsInvalidToken(t *testing.T) {
 	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
 	util.Clock = util.ClockMock{Time: clockTime}
 
-	cfg := config.NewConfig()
-	cfg.LoginToken.SigningKey = "kiali67890123456"
-	config.Set(cfg)
+	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	config.Set(conf)
 
 	// Returning a forbidden error when a cluster API call is made should have the result of
 	// a rejected authentication.
@@ -106,7 +106,7 @@ func TestTokenAuthControllerRejectsInvalidToken(t *testing.T) {
 
 	controller := NewTokenAuthController(CookieSessionPersistor{}, func(authInfo *api.AuthInfo) (*business.Layer, error) {
 		k8sclients := make(map[string]kubernetes.ClientInterface)
-		k8sclients[kubernetes.HomeClusterName] = k8s
+		k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 		return business.NewWithBackends(k8sclients, k8sclients, nil, nil), nil
 	})
 
@@ -129,7 +129,7 @@ func TestTokenAuthControllerRejectsEmptyToken(t *testing.T) {
 
 	controller := NewTokenAuthController(CookieSessionPersistor{}, func(authInfo *api.AuthInfo) (*business.Layer, error) {
 		k8sclients := make(map[string]kubernetes.ClientInterface)
-		k8sclients[kubernetes.HomeClusterName] = new(kubetest.K8SClientMock)
+		k8sclients[config.Get().KubernetesConfig.ClusterName] = new(kubetest.K8SClientMock)
 		return business.NewWithBackends(k8sclients, k8sclients, nil, nil), nil
 	})
 
@@ -161,7 +161,7 @@ func TestTokenAuthControllerValidatesSessionCorrectly(t *testing.T) {
 
 	controller := NewTokenAuthController(CookieSessionPersistor{}, func(authInfo *api.AuthInfo) (*business.Layer, error) {
 		k8sclients := make(map[string]kubernetes.ClientInterface)
-		k8sclients[kubernetes.HomeClusterName] = k8s
+		k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
 		return business.NewWithBackends(k8sclients, k8sclients, nil, nil), nil
 	})
 
@@ -181,7 +181,7 @@ func TestTokenAuthControllerValidatesSessionWithoutActiveSession(t *testing.T) {
 	k8s := kubetest.NewK8SClientMock()
 	controller := NewTokenAuthController(CookieSessionPersistor{}, func(authInfo *api.AuthInfo) (*business.Layer, error) {
 		k8sclients := make(map[string]kubernetes.ClientInterface)
-		k8sclients[kubernetes.HomeClusterName] = k8s
+		k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
 		return business.NewWithBackends(k8sclients, k8sclients, nil, nil), nil
 	})
 
@@ -213,7 +213,7 @@ func TestTokenAuthControllerValidatesSessionForUserWithMissingPrivileges(t *test
 
 	controller := NewTokenAuthController(CookieSessionPersistor{}, func(authInfo *api.AuthInfo) (*business.Layer, error) {
 		k8sclients := make(map[string]kubernetes.ClientInterface)
-		k8sclients[kubernetes.HomeClusterName] = k8s
+		k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
 		return business.NewWithBackends(k8sclients, k8sclients, nil, nil), nil
 	})
 
@@ -228,10 +228,10 @@ func createValidSession() (*httptest.ResponseRecorder, *UserSessionData, error) 
 	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
 	util.Clock = util.ClockMock{Time: clockTime}
 
-	cfg := config.NewConfig()
-	cfg.LoginToken.SigningKey = "kiali67890123456"
-	cfg.LoginToken.ExpirationSeconds = 1
-	config.Set(cfg)
+	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.LoginToken.ExpirationSeconds = 1
+	config.Set(conf)
 
 	// Returning some namespace when a cluster API call is made should have the result of
 	// a successful authentication.
@@ -246,7 +246,7 @@ func createValidSession() (*httptest.ResponseRecorder, *UserSessionData, error) 
 
 	controller := NewTokenAuthController(CookieSessionPersistor{}, func(authInfo *api.AuthInfo) (*business.Layer, error) {
 		k8sclients := make(map[string]kubernetes.ClientInterface)
-		k8sclients[kubernetes.HomeClusterName] = k8s
+		k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 		return business.NewWithBackends(k8sclients, k8sclients, nil, nil), nil
 	})
 

--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -140,6 +140,8 @@ func parsePortAndHostnames(serverDef *api_networking_v1beta1.Server) []Host {
 // findMatch uses a linear search with regexp to check for matching gateway host + port combinations. If this becomes a bottleneck for performance, replace with a graph or trie algorithm.
 func (m MultiMatchChecker) findMatch(host Host, selector string) (bool, []Host) {
 	duplicates := make([]Host, 0)
+	conf := config.Get()
+
 	for groupSelector, hostGroup := range m.existingList {
 		if groupSelector != selector {
 			continue
@@ -151,7 +153,7 @@ func (m MultiMatchChecker) findMatch(host Host, selector string) (bool, []Host) 
 				if h.Port == host.Port {
 					// wildcardMatches will always match unless SkipWildcardGatewayHosts is set 'true'
 					if host.Hostname == wildCardMatch || h.Hostname == wildCardMatch {
-						if !config.Get().KialiFeatureFlags.Validations.SkipWildcardGatewayHosts {
+						if !conf.KialiFeatureFlags.Validations.SkipWildcardGatewayHosts {
 							duplicates = append(duplicates, host)
 							duplicates = append(duplicates, h)
 						}

--- a/business/health.go
+++ b/business/health.go
@@ -125,7 +125,6 @@ func (in *HealthService) GetNamespaceAppHealth(ctx context.Context, criteria Nam
 		observability.Attribute("package", "business"),
 		observability.Attribute("cluster", criteria.Cluster),
 		observability.Attribute("namespace", criteria.Namespace),
-		observability.Attribute("cluster", criteria.Cluster),
 		observability.Attribute("rateInterval", criteria.RateInterval),
 		observability.Attribute("queryTime", criteria.QueryTime),
 	)

--- a/business/health_test.go
+++ b/business/health_test.go
@@ -267,7 +267,7 @@ func TestGetNamespaceAppHealthWithoutIstio(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	hs := NewWithBackends(clients, clients, prom, nil).Health
 	criteria := NamespaceHealthCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "ns", RateInterval: "1m", QueryTime: time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
 
@@ -294,7 +294,7 @@ func TestGetNamespaceServiceHealthWithNA(t *testing.T) {
 	)
 	k8s.OpenShift = true
 	prom := new(prometheustest.PromClientMock)
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
 
 	prom.On("GetNamespaceServicesRequestRates", "tutorial", conf.KubernetesConfig.ClusterName, mock.AnythingOfType("string"), mock.AnythingOfType("time.Time")).Return(serviceRates, nil)
 
@@ -302,7 +302,7 @@ func TestGetNamespaceServiceHealthWithNA(t *testing.T) {
 	clients[conf.KubernetesConfig.ClusterName] = k8s
 	hs := HealthService{prom: prom, businessLayer: NewWithBackends(clients, clients, prom, nil), userClients: clients}
 
-	criteria := NamespaceHealthCriteria{Namespace: "tutorial", RateInterval: "1m", QueryTime: time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
+	criteria := NamespaceHealthCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "tutorial", RateInterval: "1m", QueryTime: time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
 	health, err := hs.GetNamespaceServiceHealth(context.TODO(), criteria)
 
 	assert.Nil(err)
@@ -353,7 +353,7 @@ func TestGetNamespaceServicesHealthMultiCluster(t *testing.T) {
 
 	hs := HealthService{prom: prom, businessLayer: layer, userClients: clients}
 
-	criteria := NamespaceHealthCriteria{Namespace: "tutorial", RateInterval: "1m", QueryTime: time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
+	criteria := NamespaceHealthCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "tutorial", RateInterval: "1m", QueryTime: time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC), IncludeMetrics: true}
 
 	servicesHealth, err := hs.GetNamespaceServiceHealth(context.TODO(), criteria)
 

--- a/business/istio_certs_test.go
+++ b/business/istio_certs_test.go
@@ -25,7 +25,7 @@ func TestCertificatesInformationIndicatorsDisabled(t *testing.T) {
 	k8s.On("IsGatewayAPI").Return(false)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 
 	layer := NewWithBackends(clients, clients, nil, nil)
 	ics := layer.IstioCerts
@@ -74,7 +74,7 @@ V/InYncUvcXt0M4JJSUJi/u6VBKSYYDIHt3mk9Le2qlMQuHkOQ1ZcuEOM2CU/KtO
 	k8s.On("GetSecret", conf.IstioNamespace, "istio-ca-secret").Return(&secret, nil)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	layer := NewWithBackends(clients, clients, nil, nil)
 	ics := layer.IstioCerts
 
@@ -132,7 +132,7 @@ V/InYncUvcXt0M4JJSUJi/u6VBKSYYDIHt3mk9Le2qlMQuHkOQ1ZcuEOM2CU/KtO
 	k8s.On("GetSecret", conf.IstioNamespace, "istio-ca-secret").Return(&secret, forbiddenError)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	layer := NewWithBackends(clients, clients, nil, nil)
 	ics := layer.IstioCerts
 
@@ -194,7 +194,7 @@ cdLzuNyDoeWOHU7mx52TuTwj3eObtQM+hlI=
 	k8s.On("GetSecret", conf.IstioNamespace, "cacerts").Return(&secret, nil)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	layer := NewWithBackends(clients, clients, nil, nil)
 	ics := layer.IstioCerts
 
@@ -334,7 +334,7 @@ iMXzPzS/OeYyKQ==
 	k8s.On("GetSecret", conf.IstioNamespace, "dns.example2-service-account").Return(&example2secret, nil)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	layer := NewWithBackends(clients, clients, nil, nil)
 	ics := layer.IstioCerts
 
@@ -421,7 +421,7 @@ iMXzPzS/OeYyKQ==
 	k8s.On("GetSecret", conf.IstioNamespace, "dns.example2-service-account").Return(&core_v1.Secret{}, kubernetes.NewNotFound("cacerts", "v1", "Secret"))
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	layer := NewWithBackends(clients, clients, nil, nil)
 	ics := layer.IstioCerts
 

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -181,32 +181,33 @@ func TestGetIstioConfigDetails(t *testing.T) {
 	assert := assert.New(t)
 
 	configService := mockGetIstioConfigDetails(t)
+	conf := config.Get()
 
-	istioConfigDetails, err := configService.GetIstioConfigDetails(context.TODO(), kubernetes.HomeClusterName, "test", "gateways", "gw-1")
+	istioConfigDetails, err := configService.GetIstioConfigDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "test", "gateways", "gw-1")
 	assert.Equal("gw-1", istioConfigDetails.Gateway.Name)
 	assert.True(istioConfigDetails.Permissions.Update)
 	assert.False(istioConfigDetails.Permissions.Delete)
 	assert.Nil(err)
 
-	istioConfigDetails, err = configService.GetIstioConfigDetails(context.TODO(), kubernetes.HomeClusterName, "test", "virtualservices", "reviews")
+	istioConfigDetails, err = configService.GetIstioConfigDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "test", "virtualservices", "reviews")
 	assert.Equal("reviews", istioConfigDetails.VirtualService.Name)
 	assert.Equal("VirtualService", istioConfigDetails.VirtualService.Kind)
 	assert.Equal("networking.istio.io/v1beta1", istioConfigDetails.VirtualService.APIVersion)
 	assert.Nil(err)
 
-	istioConfigDetails, err = configService.GetIstioConfigDetails(context.TODO(), kubernetes.HomeClusterName, "test", "destinationrules", "reviews-dr")
+	istioConfigDetails, err = configService.GetIstioConfigDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "test", "destinationrules", "reviews-dr")
 	assert.Equal("reviews-dr", istioConfigDetails.DestinationRule.Name)
 	assert.Equal("DestinationRule", istioConfigDetails.DestinationRule.Kind)
 	assert.Equal("networking.istio.io/v1beta1", istioConfigDetails.DestinationRule.APIVersion)
 	assert.Nil(err)
 
-	istioConfigDetails, err = configService.GetIstioConfigDetails(context.TODO(), kubernetes.HomeClusterName, "test", "serviceentries", "googleapis")
+	istioConfigDetails, err = configService.GetIstioConfigDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "test", "serviceentries", "googleapis")
 	assert.Equal("googleapis", istioConfigDetails.ServiceEntry.Name)
 	assert.Equal("ServiceEntry", istioConfigDetails.ServiceEntry.Kind)
 	assert.Equal("networking.istio.io/v1beta1", istioConfigDetails.ServiceEntry.APIVersion)
 	assert.Nil(err)
 
-	istioConfigDetails, err = configService.GetIstioConfigDetails(context.TODO(), kubernetes.HomeClusterName, "test", "rules-bad", "stdio")
+	istioConfigDetails, err = configService.GetIstioConfigDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "test", "rules-bad", "stdio")
 	assert.Error(err)
 }
 
@@ -215,7 +216,7 @@ func TestCheckMulticlusterPermissions(t *testing.T) {
 
 	configService := mockGetIstioConfigDetailsMulticluster(t)
 
-	istioConfigDetails, err := configService.GetIstioConfigDetails(context.TODO(), kubernetes.HomeClusterName, "test", "gateways", "gw-1")
+	istioConfigDetails, err := configService.GetIstioConfigDetails(context.TODO(), config.Get().KubernetesConfig.ClusterName, "test", "gateways", "gw-1")
 	assert.Equal("gw-1", istioConfigDetails.Gateway.Name)
 	assert.True(istioConfigDetails.Permissions.Update)
 	assert.False(istioConfigDetails.Permissions.Delete)
@@ -250,7 +251,7 @@ func mockGetIstioConfigList(t *testing.T) IstioConfigService {
 	cache := SetupBusinessLayer(t, k8s, *config.NewConfig())
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
 	return IstioConfigService{userClients: k8sclients, kialiCache: cache, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
 }
 
@@ -432,7 +433,7 @@ func mockGetIstioConfigDetails(t *testing.T) IstioConfigService {
 	cache := SetupBusinessLayer(t, k8s, *conf)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = &fakeAccessReview{k8s}
+	k8sclients[conf.KubernetesConfig.ClusterName] = &fakeAccessReview{k8s}
 	return IstioConfigService{userClients: k8sclients, kialiCache: cache, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
 }
 
@@ -452,7 +453,7 @@ func mockGetIstioConfigDetailsMulticluster(t *testing.T) IstioConfigService {
 	cache := SetupBusinessLayer(t, k8s, *conf)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = &fakeAccessReview{k8s}
+	k8sclients[conf.KubernetesConfig.ClusterName] = &fakeAccessReview{k8s}
 	k8sclients["east"] = &fakeAccessReview{k8s}
 	return IstioConfigService{userClients: k8sclients, kialiCache: cache, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
 }
@@ -521,12 +522,13 @@ func TestDeleteIstioConfigDetails(t *testing.T) {
 	assert := assert.New(t)
 	k8s := kubetest.NewFakeK8sClient(data.CreateEmptyVirtualService("reviews-to-delete", "test", []string{"reviews"}))
 	cache := SetupBusinessLayer(t, k8s, *config.NewConfig())
+	conf := config.Get()
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	configService := IstioConfigService{userClients: k8sclients, kialiCache: cache}
 
-	err := configService.DeleteIstioConfigDetail(kubernetes.HomeClusterName, "test", "virtualservices", "reviews-to-delete")
+	err := configService.DeleteIstioConfigDetail(conf.KubernetesConfig.ClusterName, "test", "virtualservices", "reviews-to-delete")
 	assert.Nil(err)
 }
 
@@ -534,12 +536,13 @@ func TestUpdateIstioConfigDetails(t *testing.T) {
 	assert := assert.New(t)
 	k8s := kubetest.NewFakeK8sClient(data.CreateEmptyVirtualService("reviews-to-update", "test", []string{"reviews"}))
 	cache := SetupBusinessLayer(t, k8s, *config.NewConfig())
+	conf := config.Get()
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	configService := IstioConfigService{userClients: k8sclients, kialiCache: cache}
 
-	updatedVirtualService, err := configService.UpdateIstioConfigDetail(kubernetes.HomeClusterName, "test", "virtualservices", "reviews-to-update", "{}")
+	updatedVirtualService, err := configService.UpdateIstioConfigDetail(conf.KubernetesConfig.ClusterName, "test", "virtualservices", "reviews-to-update", "{}")
 	assert.Equal("test", updatedVirtualService.Namespace.Name)
 	assert.Equal("virtualservices", updatedVirtualService.ObjectType)
 	assert.Equal("reviews-to-update", updatedVirtualService.VirtualService.Name)
@@ -550,12 +553,13 @@ func TestCreateIstioConfigDetails(t *testing.T) {
 	assert := assert.New(t)
 	k8s := kubetest.NewFakeK8sClient()
 	cache := SetupBusinessLayer(t, k8s, *config.NewConfig())
+	conf := config.Get()
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	configService := IstioConfigService{userClients: k8sclients, kialiCache: cache}
 
-	createVirtualService, err := configService.CreateIstioConfigDetail(kubernetes.HomeClusterName, "test", "virtualservices", []byte("{}"))
+	createVirtualService, err := configService.CreateIstioConfigDetail(conf.KubernetesConfig.ClusterName, "test", "virtualservices", []byte("{}"))
 	assert.Equal("test", createVirtualService.Namespace.Name)
 	assert.Equal("virtualservices", createVirtualService.ObjectType)
 	// Name is now encoded in the payload of the virtualservice so, it modifies this test

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -195,7 +195,7 @@ func TestGrafanaWorking(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
@@ -233,7 +233,7 @@ func TestGrafanaDisabled(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
@@ -285,7 +285,7 @@ func TestGrafanaNotWorking(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
@@ -316,7 +316,7 @@ func TestFailingTracingService(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockFailingJaeger).IstioStatus
 	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
@@ -342,7 +342,7 @@ func TestOverriddenUrls(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
@@ -372,7 +372,7 @@ func TestCustomDashboardsMainPrometheus(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
@@ -397,7 +397,7 @@ func TestNoIstioComponentFoundError(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 	_, error := iss.GetStatus(context.TODO())
@@ -424,7 +424,7 @@ func TestDefaults(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 
 	icsl, err := iss.GetStatus(context.TODO())
@@ -458,8 +458,8 @@ func TestNonDefaults(t *testing.T) {
 
 	k8s, grafanaCalls, promCalls := mockAddOnsCalls(t, objects, true, false)
 
-	c := config.Get()
-	c.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
+	conf := config.Get()
+	conf.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
 		Enabled: true,
 		Components: []config.ComponentStatus{
 			{AppLabel: "istiod", IsCore: false},
@@ -467,13 +467,13 @@ func TestNonDefaults(t *testing.T) {
 			{AppLabel: "istio-ingressgateway", IsCore: false},
 		},
 	}
-	config.Set(c)
+	config.Set(conf)
 
 	// Set global cache var
-	SetupBusinessLayer(t, k8s, *c)
+	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 
 	icsl, error := iss.GetStatus(context.TODO())
@@ -504,9 +504,9 @@ func TestIstiodNotReady(t *testing.T) {
 
 	k8s, grafanaCalls, promCalls := mockAddOnsCalls(t, objects, false, false)
 
-	c := config.Get()
-	c.IstioLabels.AppLabelName = "app.kubernetes.io/name"
-	c.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
+	conf := config.Get()
+	conf.IstioLabels.AppLabelName = "app.kubernetes.io/name"
+	conf.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
 		Enabled: true,
 		Components: []config.ComponentStatus{
 			{AppLabel: "istiod", IsCore: true},
@@ -514,13 +514,13 @@ func TestIstiodNotReady(t *testing.T) {
 			{AppLabel: "istio-ingressgateway", IsCore: false},
 		},
 	}
-	config.Set(c)
+	config.Set(conf)
 
 	// Set global cache var
-	SetupBusinessLayer(t, k8s, *c)
+	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 
 	icsl, error := iss.GetStatus(context.TODO())
@@ -566,9 +566,9 @@ func TestIstiodUnreachable(t *testing.T) {
 
 	k8s = &fakeIstiodConnecter{k8s, istioStatus}
 
-	c := config.Get()
-	c.IstioLabels.AppLabelName = "app.kubernetes.io/name"
-	c.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
+	conf := config.Get()
+	conf.IstioLabels.AppLabelName = "app.kubernetes.io/name"
+	conf.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
 		Enabled: true,
 		Components: []config.ComponentStatus{
 			{AppLabel: "istiod", IsCore: true},
@@ -576,13 +576,13 @@ func TestIstiodUnreachable(t *testing.T) {
 			{AppLabel: "istio-ingressgateway", IsCore: false},
 		},
 	}
-	config.Set(c)
+	config.Set(conf)
 
 	// Set global cache var
-	SetupBusinessLayer(t, k8s, *c)
+	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 
 	icsl, error := iss.GetStatus(context.TODO())
@@ -621,9 +621,9 @@ func TestCustomizedAppLabel(t *testing.T) {
 
 	k8s, grafanaCalls, promCalls := mockAddOnsCalls(t, objects, true, false)
 
-	c := config.Get()
-	c.IstioLabels.AppLabelName = "app.kubernetes.io/name"
-	c.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
+	conf := config.Get()
+	conf.IstioLabels.AppLabelName = "app.kubernetes.io/name"
+	conf.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
 		Enabled: true,
 		Components: []config.ComponentStatus{
 			{AppLabel: "istiod", IsCore: false},
@@ -631,13 +631,13 @@ func TestCustomizedAppLabel(t *testing.T) {
 			{AppLabel: "istio-ingressgateway", IsCore: false},
 		},
 	}
-	config.Set(c)
+	config.Set(conf)
 
 	// Set global cache var
-	SetupBusinessLayer(t, k8s, *c)
+	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 
 	icsl, error := iss.GetStatus(context.TODO())
@@ -672,9 +672,9 @@ func TestDaemonSetComponentHealthy(t *testing.T) {
 
 	k8s, grafanaCalls, promCalls := mockAddOnsCalls(t, objects, true, false)
 
-	c := config.Get()
-	c.IstioLabels.AppLabelName = "app.kubernetes.io/name"
-	c.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
+	conf := config.Get()
+	conf.IstioLabels.AppLabelName = "app.kubernetes.io/name"
+	conf.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
 		Enabled: true,
 		Components: []config.ComponentStatus{
 			{AppLabel: "istiod", IsCore: false},
@@ -682,13 +682,13 @@ func TestDaemonSetComponentHealthy(t *testing.T) {
 			{AppLabel: "istio-ingressgateway", IsCore: false},
 		},
 	}
-	config.Set(c)
+	config.Set(conf)
 
 	// Set global cache var
-	SetupBusinessLayer(t, k8s, *c)
+	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 
 	icsl, error := iss.GetStatus(context.TODO())
@@ -719,9 +719,9 @@ func TestDaemonSetComponentUnhealthy(t *testing.T) {
 
 	k8s, grafanaCalls, promCalls := mockAddOnsCalls(t, objects, true, false)
 
-	c := config.Get()
-	c.IstioLabels.AppLabelName = "app.kubernetes.io/name"
-	c.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
+	conf := config.Get()
+	conf.IstioLabels.AppLabelName = "app.kubernetes.io/name"
+	conf.ExternalServices.Istio.ComponentStatuses = config.ComponentStatuses{
 		Enabled: true,
 		Components: []config.ComponentStatus{
 			{AppLabel: "istiod", IsCore: false},
@@ -729,13 +729,13 @@ func TestDaemonSetComponentUnhealthy(t *testing.T) {
 			{AppLabel: "istio-ingressgateway", IsCore: false},
 		},
 	}
-	config.Set(c)
+	config.Set(conf)
 
 	// Set global cache var
-	SetupBusinessLayer(t, k8s, *c)
+	SetupBusinessLayer(t, k8s, *conf)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	iss := NewWithBackends(clients, clients, nil, mockJaeger).IstioStatus
 
 	icsl, error := iss.GetStatus(context.TODO())

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -51,7 +50,7 @@ func TestGetValidationsPerf(t *testing.T) {
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", fakePods())
 
 	now := time.Now()
-	validations, err := vs.GetValidations(context.TODO(), kubernetes.HomeClusterName, "test", "", "")
+	validations, err := vs.GetValidations(context.TODO(), conf.KubernetesConfig.ClusterName, "test", "", "")
 	require.NoError(err)
 	log.Debugf("Validation Performance test took %f seconds for %d namespaces", time.Since(now).Seconds(), numNs)
 	assert.NotEmpty(validations)

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -30,7 +30,7 @@ func TestGetNamespaceValidations(t *testing.T) {
 	vs := mockCombinedValidationService(t, fakeIstioConfigList(),
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", fakePods())
 
-	validations, err := vs.GetValidations(context.TODO(), kubernetes.HomeClusterName, "test", "", "")
+	validations, err := vs.GetValidations(context.TODO(), conf.KubernetesConfig.ClusterName, "test", "", "")
 	require.NoError(err)
 	assert.NotEmpty(validations)
 	assert.True(validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}].Valid)
@@ -44,7 +44,7 @@ func TestGetAllValidations(t *testing.T) {
 	vs := mockCombinedValidationService(t, fakeIstioConfigList(),
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", fakePods())
 
-	validations, _ := vs.GetValidations(context.TODO(), kubernetes.HomeClusterName, "", "", "")
+	validations, _ := vs.GetValidations(context.TODO(), conf.KubernetesConfig.ClusterName, "", "", "")
 	assert.NotEmpty(validations)
 	assert.True(validations[models.IstioValidationKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}].Valid)
 }
@@ -57,7 +57,7 @@ func TestGetIstioObjectValidations(t *testing.T) {
 	vs := mockCombinedValidationService(t, fakeIstioConfigList(),
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", fakePods())
 
-	validations, _, _ := vs.GetIstioObjectValidations(context.TODO(), kubernetes.HomeClusterName, "test", "virtualservices", "product-vs")
+	validations, _, _ := vs.GetIstioObjectValidations(context.TODO(), conf.KubernetesConfig.ClusterName, "test", "virtualservices", "product-vs")
 
 	assert.NotEmpty(validations)
 }
@@ -68,7 +68,7 @@ func TestGatewayValidation(t *testing.T) {
 	config.Set(conf)
 
 	v := mockMultiNamespaceGatewaysValidationService(t)
-	validations, _, _ := v.GetIstioObjectValidations(context.TODO(), kubernetes.HomeClusterName, "test", "gateways", "first")
+	validations, _, _ := v.GetIstioObjectValidations(context.TODO(), conf.KubernetesConfig.ClusterName, "test", "gateways", "first")
 	assert.NotEmpty(validations)
 }
 
@@ -114,7 +114,7 @@ func TestGetVSReferences(t *testing.T) {
 
 	vs := mockCombinedValidationService(t, fakeIstioConfigList(), []string{}, "test", fakePods())
 
-	_, referencesMap, err := vs.GetIstioObjectValidations(context.TODO(), kubernetes.HomeClusterName, "test", kubernetes.VirtualServices, "product-vs")
+	_, referencesMap, err := vs.GetIstioObjectValidations(context.TODO(), conf.KubernetesConfig.ClusterName, "test", kubernetes.VirtualServices, "product-vs")
 	references := referencesMap[models.IstioReferenceKey{ObjectType: "virtualservice", Namespace: "test", Name: "product-vs"}]
 
 	// Check Service references
@@ -135,7 +135,7 @@ func TestGetVSReferencesNotExisting(t *testing.T) {
 
 	vs := mockCombinedValidationService(t, fakeEmptyIstioConfigList(), []string{}, "test", fakePods())
 
-	_, referencesMap, err := vs.GetIstioObjectValidations(context.TODO(), kubernetes.HomeClusterName, "wrong", "virtualservices", "wrong")
+	_, referencesMap, err := vs.GetIstioObjectValidations(context.TODO(), conf.KubernetesConfig.ClusterName, "wrong", "virtualservices", "wrong")
 	references := referencesMap[models.IstioReferenceKey{ObjectType: "wrong", Namespace: "wrong", Name: "product-vs"}]
 
 	assert.Nil(err)
@@ -174,7 +174,7 @@ func mockMultiNamespaceGatewaysValidationService(t *testing.T) IstioValidationsS
 	})
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
 	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
 }
 
@@ -224,7 +224,7 @@ func mockCombinedValidationService(t *testing.T, istioConfigList *models.IstioCo
 	})
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
 	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
 }
 
@@ -235,7 +235,7 @@ func mockEmptyValidationService() IstioValidationsService {
 	k8s.On("IsGatewayAPI").Return(false)
 	k8s.On("IsMaistraApi").Return(false)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
 	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
 }
 

--- a/business/layer.go
+++ b/business/layer.go
@@ -50,9 +50,11 @@ var (
 
 // sets the global kiali cache var.
 func initKialiCache() {
+	conf := config.Get()
+
 	if excludedWorkloads == nil {
 		excludedWorkloads = make(map[string]bool)
-		for _, w := range config.Get().KubernetesConfig.ExcludeWorkloads {
+		for _, w := range conf.KubernetesConfig.ExcludeWorkloads {
 			excludedWorkloads[w] = true
 		}
 	}
@@ -65,7 +67,7 @@ func initKialiCache() {
 	clientFactory = userClient
 
 	// TODO: Remove conditonal once cache is fully mandatory.
-	if config.Get().KubernetesConfig.CacheEnabled {
+	if conf.KubernetesConfig.CacheEnabled {
 		log.Infof("Initializing Kiali Cache")
 
 		// Initial list of namespaces to seed the cache with.
@@ -73,7 +75,7 @@ func initKialiCache() {
 		// For a cluster-scoped cache, all namespaces are accessible.
 		// TODO: This is leaking cluster-scoped vs. namespace-scoped in a way.
 		var namespaceSeedList []string
-		if !config.Get().AllNamespacesAccessible() {
+		if !conf.AllNamespacesAccessible() {
 			SAClients := clientFactory.GetSAClients()
 			// Special case when using the SA as the user, to fetch all the namespaces initially
 			initNamespaceService := NewNamespaceService(SAClients, SAClients)
@@ -162,7 +164,9 @@ func SetWithBackends(cf kubernetes.ClientFactory, prom prometheus.ClientInterfac
 // It should be the user client based on the logged in user's token.
 func NewWithBackends(userClients map[string]kubernetes.ClientInterface, kialiSAClients map[string]kubernetes.ClientInterface, prom prometheus.ClientInterface, jaegerClient JaegerLoader) *Layer {
 	temporaryLayer := &Layer{}
-	homeClusterName := config.Get().KubernetesConfig.ClusterName
+	conf := config.Get()
+
+	homeClusterName := conf.KubernetesConfig.ClusterName
 	// TODO: Modify the k8s argument to other services to pass the whole k8s map if needed
 	temporaryLayer.App = AppService{prom: prom, userClients: userClients, businessLayer: temporaryLayer}
 	temporaryLayer.Health = HealthService{prom: prom, businessLayer: temporaryLayer, userClients: userClients}

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -24,8 +24,7 @@ import (
 )
 
 const (
-	DefaultClusterID = "Kubernetes"
-	AllowAny         = "ALLOW_ANY"
+	AllowAny = "ALLOW_ANY"
 )
 
 // MeshService is a support service for retrieving data about the mesh environment

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -26,7 +26,7 @@ import (
 // Setup Mesh cache to avoid duplicate mesh_test.go logic into other business/*_test.go
 func setupGlobalMeshConfig() {
 	SetKialiControlPlaneCluster(&Cluster{
-		Name: DefaultClusterID,
+		Name: config.DefaultClusterID,
 	})
 }
 
@@ -227,7 +227,7 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 	}
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	layer := NewWithBackends(clients, clients, nil, nil)
 	meshSvc := layer.Mesh
 	meshSvc.newRemoteClient = newRemoteClient
@@ -297,7 +297,7 @@ func TestIsMeshConfiguredIsCached(t *testing.T) {
 	k8s.On("GetConfigMap", "foo", "bar").Return(&istioConfigMapMock, nil)
 
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	// Create a MeshService and invoke IsMeshConfigured
 	layer := NewWithBackends(clients, clients, nil, nil)
 	meshSvc := layer.Mesh
@@ -312,7 +312,7 @@ func TestIsMeshConfiguredIsCached(t *testing.T) {
 	k8s.On("IsGatewayAPI").Return(false)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	layer = NewWithBackends(k8sclients, k8sclients, nil, nil)
 	meshSvc = layer.Mesh
 	result, err = meshSvc.IsMeshConfigured()
@@ -400,7 +400,7 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 
 	// Create a MeshService and invoke IsMeshConfigured
 	clients := make(map[string]kubernetes.ClientInterface)
-	clients[kubernetes.HomeClusterName] = k8s
+	clients[conf.KubernetesConfig.ClusterName] = k8s
 	clients["KialiCluster"] = k8s
 	layer := NewWithBackends(clients, clients, nil, nil)
 	meshSvc := layer.Mesh
@@ -417,7 +417,7 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 	k8s.On("IsGatewayAPI").Return(false)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	layer = NewWithBackends(k8sclients, k8sclients, nil, nil)
 	meshSvc = layer.Mesh
 	result, err = meshSvc.ResolveKialiControlPlaneCluster(nil)
@@ -445,7 +445,7 @@ func TestCanaryUpgradeNotConfigured(t *testing.T) {
 
 	// Create a MeshService and invoke IsMeshConfigured
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	layer := NewWithBackends(k8sclients, k8sclients, nil, nil)
 	meshSvc := layer.Mesh
 
@@ -485,7 +485,7 @@ func TestCanaryUpgradeConfigured(t *testing.T) {
 
 	// Create a MeshService and invoke IsMeshConfigured
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	layer := NewWithBackends(k8sclients, k8sclients, nil, nil)
 	meshSvc := layer.Mesh
 

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -564,8 +564,16 @@ func (in *NamespaceService) GetNamespaceByCluster(ctx context.Context, namespace
 			if err2 != nil {
 				return nil, err2
 			}
+		} else {
+			if _, ok := in.userClients[cluster]; !ok {
+				return nil, fmt.Errorf("OCP Cluster [%s] is not found or is not accessible for Kiali", cluster)
+			}
+			project, errC := in.userClients[cluster].GetProject(namespace)
+			if errC != nil {
+				return nil, errC
+			}
+			result = models.CastProject(*project, cluster)
 		}
-
 	} else {
 		// TODO: MC
 		var ns *core_v1.Namespace

--- a/business/namespaces_test.go
+++ b/business/namespaces_test.go
@@ -24,7 +24,7 @@ func setupNamespaceService(k8s kubernetes.ClientInterface, conf *config.Config) 
 	config.Set(conf)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	return NewNamespaceService(k8sclients, k8sclients)
 }
 
@@ -112,7 +112,7 @@ func TestUpdateNamespaces(t *testing.T) {
 
 	nsservice := setupNamespaceService(k8s, conf)
 
-	ns, err := nsservice.UpdateNamespace(context.TODO(), "bookinfo", `{"metadata": {"labels": {"new": "label"}}}`, kubernetes.HomeClusterName)
+	ns, err := nsservice.UpdateNamespace(context.TODO(), "bookinfo", `{"metadata": {"labels": {"new": "label"}}}`, conf.KubernetesConfig.ClusterName)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, ns)
@@ -152,7 +152,7 @@ func TestMultiClusterGetNamespace(t *testing.T) {
 	// GetNamespace should probably always return the home cluster to
 	// keep backward compatability and anything new should use
 	// GetNamespaceByCluster.
-	// assert.Equal(kubernetes.HomeClusterName, ns.Cluster)
+	// assert.Equal(conf.KubernetesConfig.ClusterName, ns.Cluster)
 }
 
 func TestMultiClusterGetNamespaces(t *testing.T) {

--- a/business/services.go
+++ b/business/services.go
@@ -382,7 +382,7 @@ func (in *SvcService) getClusterId() string {
 	//        ]
 	//      }
 	//    }
-	clusterId := config.DefaultClusterID
+	clusterId := config.Get().KubernetesConfig.ClusterName
 	// Protection on tests
 	if in.businessLayer != nil {
 		if cluster, err := in.businessLayer.Mesh.ResolveKialiControlPlaneCluster(nil); err == nil {

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -66,7 +66,7 @@ func TestParseRegistryServices(t *testing.T) {
 	k8s.On("IsGatewayAPI").Return(false)
 	setupGlobalMeshConfig()
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	svc := NewWithBackends(k8sclients, k8sclients, nil, nil).Svc
 
 	servicesz := "../tests/data/registry/services-registryz.json"
@@ -131,7 +131,7 @@ func TestGetServiceListFromMultipleClusters(t *testing.T) {
 
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
-		kubernetes.HomeClusterName: kubetest.NewFakeK8sClient(
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
 			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),
@@ -152,7 +152,7 @@ func TestGetServiceListFromMultipleClusters(t *testing.T) {
 	sort.Slice(svcs.Services, func(i, j int) bool {
 		return svcs.Services[i].Name < svcs.Services[j].Name
 	})
-	assert.Equal(svcs.Services[0].Cluster, kubernetes.HomeClusterName)
+	assert.Equal(svcs.Services[0].Cluster, conf.KubernetesConfig.ClusterName)
 	assert.Equal(svcs.Services[1].Cluster, "west")
 }
 
@@ -166,7 +166,7 @@ func TestMultiClusterGetService(t *testing.T) {
 
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
-		kubernetes.HomeClusterName: kubetest.NewFakeK8sClient(
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
 			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),
@@ -185,7 +185,7 @@ func TestMultiClusterGetService(t *testing.T) {
 
 	assert.Equal(s.Name, "ratings-west-cluster")
 
-	s, err = svc.GetService(context.TODO(), kubernetes.HomeClusterName, "bookinfo", "ratings-home-cluster")
+	s, err = svc.GetService(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-home-cluster")
 	require.NoError(err)
 
 	assert.Equal(s.Name, "ratings-home-cluster")
@@ -201,7 +201,7 @@ func TestMultiClusterServiceUpdate(t *testing.T) {
 
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
-		kubernetes.HomeClusterName: kubetest.NewFakeK8sClient(
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
 			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),
@@ -228,7 +228,7 @@ func TestMultiClusterServiceUpdate(t *testing.T) {
 	require.NoError(err)
 	assert.Contains(s.Annotations, "test")
 
-	s, err = svc.GetService(context.TODO(), kubernetes.HomeClusterName, "bookinfo", "ratings-home-cluster")
+	s, err = svc.GetService(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-home-cluster")
 	require.NoError(err)
 	assert.NotContains(s.Annotations, "test")
 }
@@ -243,7 +243,7 @@ func TestMultiClusterGetServiceDetails(t *testing.T) {
 
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
-		kubernetes.HomeClusterName: kubetest.NewFakeK8sClient(
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
 			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),
@@ -278,7 +278,7 @@ func TestMultiClusterGetServiceAppName(t *testing.T) {
 
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
-		kubernetes.HomeClusterName: kubetest.NewFakeK8sClient(
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
 			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),

--- a/business/tls.go
+++ b/business/tls.go
@@ -44,13 +44,15 @@ func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, namespaces []strin
 		IncludePeerAuthentications: true,
 		Cluster:                    cluster,
 	}
+	conf := config.Get()
 
-	istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigListPerCluster(ctx, criteria, cluster)
+	// @TODO hardcoded HomeClusterName
+	istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigListPerCluster(ctx, criteria, conf.KubernetesConfig.ClusterName)
 	if err != nil {
 		return models.MTLSStatus{}, err
 	}
 
-	pas := kubernetes.FilterPeerAuthenticationByNamespace(config.Get().ExternalServices.Istio.RootNamespace, istioConfigList.PeerAuthentications)
+	pas := kubernetes.FilterPeerAuthenticationByNamespace(conf.ExternalServices.Istio.RootNamespace, istioConfigList.PeerAuthentications)
 	drs := kubernetes.FilterDestinationRulesByNamespaces(namespaces, istioConfigList.DestinationRules)
 
 	mtlsStatus := mtls.MtlsStatus{

--- a/business/tls.go
+++ b/business/tls.go
@@ -47,7 +47,7 @@ func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, namespaces []strin
 	conf := config.Get()
 
 	// @TODO hardcoded HomeClusterName
-	istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigListPerCluster(ctx, criteria, conf.KubernetesConfig.ClusterName)
+	istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigListPerCluster(ctx, criteria, cluster)
 	if err != nil {
 		return models.MTLSStatus{}, err
 	}

--- a/business/tls_perf_test.go
+++ b/business/tls_perf_test.go
@@ -90,10 +90,10 @@ func testPerfScenario(exStatus string, nss []core_v1.Namespace, drs []*networkin
 
 	kialiCache = cache.FakeTlsKialiCache("token", nsNames, ps, drs)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	TLSService := TLSService{userClients: k8sclients, kialiCache: kialiCache, enabledAutoMtls: &autoMtls, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
 	for _, ns := range nss {
-		status, err := (TLSService).NamespaceWidemTLSStatus(context.TODO(), ns.Name, config.Get().KubernetesConfig.ClusterName)
+		status, err := (TLSService).NamespaceWidemTLSStatus(context.TODO(), ns.Name, conf.KubernetesConfig.ClusterName)
 		assert.NoError(err)
 		assert.Equal(exStatus, status.Status)
 	}

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -42,7 +42,7 @@ func TestMeshStatusEnabled(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, false, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, conf.KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -69,7 +69,7 @@ func TestMeshStatusEnabledAutoMtls(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, true, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, conf.KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -97,7 +97,7 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, false, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, conf.KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -126,7 +126,7 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, false, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, conf.KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -155,7 +155,7 @@ func TestMeshStatusDisabled(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	TLSService := getTLSService(k8s, false, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, conf.KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -180,7 +180,7 @@ func TestMeshStatusNotEnabledAutoMtls(t *testing.T) {
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	SetWithBackends(mockClientFactory, nil)
 	TLSService := getTLSService(k8s, true, ns, pa, dr)
-	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, config.Get().KubernetesConfig.ClusterName)
+	status, err := TLSService.MeshWidemTLSStatus(context.TODO(), ns, conf.KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -312,11 +312,12 @@ func TestNamespaceHasDestinationRuleEnabledDifferentNs(t *testing.T) {
 	SetWithBackends(mockClientFactory, nil)
 
 	autoMtls := false
+	conf := config.Get()
 	kialiCache = cache.FakeTlsKialiCache("token", nss, ps, drs)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	TLSService := TLSService{userClients: k8sclients, kialiCache: kialiCache, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil), enabledAutoMtls: &autoMtls}
-	status, err := TLSService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo", config.Get().KubernetesConfig.ClusterName)
+	status, err := TLSService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo", conf.KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 
@@ -350,9 +351,9 @@ func testNamespaceScenario(exStatus string, drs []*networking_v1beta1.Destinatio
 
 	kialiCache = cache.FakeTlsKialiCache("token", nss, ps, drs)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	TLSService := &TLSService{userClients: k8sclients, kialiCache: kialiCache, enabledAutoMtls: &autoMtls, businessLayer: NewWithBackends(k8sclients, k8sclients, nil, nil)}
-	status, err := TLSService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo", config.Get().KubernetesConfig.ClusterName)
+	status, err := TLSService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo", conf.KubernetesConfig.ClusterName)
 
 	cleanTestGlobals()
 

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -68,7 +68,7 @@ func TestGetWorkloadListFromDeployments(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 	svc := setupWorkloadService(k8s, config.NewConfig())
 
-	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false, Cluster: kubernetes.HomeClusterName}
+	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false, Cluster: conf.KubernetesConfig.ClusterName}
 	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
@@ -412,7 +412,7 @@ func TestGetWorkloadFromDeployment(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *config.NewConfig())
 	svc := setupWorkloadService(k8s, conf)
 
-	criteria := WorkloadCriteria{Namespace: "Namespace", WorkloadName: "details-v1", WorkloadType: "", IncludeServices: false}
+	criteria := WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", WorkloadName: "details-v1", WorkloadType: "", IncludeServices: false}
 	workload, err := svc.GetWorkload(context.TODO(), criteria)
 	require.NoError(err)
 
@@ -448,7 +448,7 @@ func TestGetWorkloadWithInvalidWorkloadType(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *config.NewConfig())
 	svc := setupWorkloadService(k8s, conf)
 
-	criteria := WorkloadCriteria{Namespace: "Namespace", WorkloadName: "details-v1", WorkloadType: "invalid", IncludeServices: false}
+	criteria := WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", WorkloadName: "details-v1", WorkloadType: "invalid", IncludeServices: false}
 	workload, err := svc.GetWorkload(context.TODO(), criteria)
 	require.NoError(err)
 
@@ -483,14 +483,14 @@ func TestGetWorkloadFromPods(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *config.NewConfig())
 	svc := setupWorkloadService(k8s, conf)
 
-	criteria := WorkloadCriteria{Namespace: "Namespace", WorkloadName: "custom-controller", WorkloadType: "", IncludeServices: false}
+	criteria := WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", WorkloadName: "custom-controller", WorkloadType: "", IncludeServices: false}
 	workload, err := svc.GetWorkload(context.TODO(), criteria)
 	require.Error(err)
 
 	// custom controller is not a workload type, only its replica set(s)
 	assert.Equal((*models.Workload)(nil), workload)
 
-	criteria = WorkloadCriteria{Namespace: "Namespace", WorkloadName: "custom-controller-RS-123", WorkloadType: "", IncludeServices: false}
+	criteria = WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", WorkloadName: "custom-controller-RS-123", WorkloadType: "", IncludeServices: false}
 	workload, err = svc.GetWorkload(context.TODO(), criteria)
 	require.NoError(err)
 
@@ -735,7 +735,7 @@ func TestDuplicatedControllers(t *testing.T) {
 	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
-	criteria = WorkloadCriteria{Namespace: "Namespace", WorkloadName: "duplicated-v1", WorkloadType: "", IncludeServices: false}
+	criteria = WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", WorkloadName: "duplicated-v1", WorkloadType: "", IncludeServices: false}
 	workload, err := svc.GetWorkload(context.TODO(), criteria)
 
 	require.NoError(err)
@@ -783,7 +783,7 @@ func TestGetWorkloadListFromGenericPodController(t *testing.T) {
 	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
-	criteria = WorkloadCriteria{Namespace: "Namespace", WorkloadName: owner.Name, WorkloadType: "", IncludeServices: false}
+	criteria = WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", WorkloadName: owner.Name, WorkloadType: "", IncludeServices: false}
 	workload, err := svc.GetWorkload(context.TODO(), criteria)
 
 	require.NoError(err)

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,10 @@ const (
 	DashboardsDiscoveryAuto    = "auto"
 )
 
+const (
+	DefaultClusterID = "Kubernetes"
+)
+
 // FeatureName is the enum type used for named features that can be disabled via KialiFeatureFlags.DisabledFeatures
 type FeatureName string
 
@@ -717,7 +721,7 @@ func NewConfig() (c *Config) {
 			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup", "WasmPlugin", "Telemetry", "K8sGateway", "K8sHTTPRoute"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
-			ClusterName:                 "",
+			ClusterName:                 DefaultClusterID,
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},
 			QPS:                         175,
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ const (
 )
 
 const (
+	// DefaultClusterID is generally not for use outside of test-code. In general you should use config.Get().KubernetesConfig.ClusterName
 	DefaultClusterID = "Kubernetes"
 )
 
@@ -721,7 +722,7 @@ func NewConfig() (c *Config) {
 			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup", "WasmPlugin", "Telemetry", "K8sGateway", "K8sHTTPRoute"},
 			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
-			ClusterName:                 DefaultClusterID,
+			ClusterName:                 "", // leave this unset as a flag that we need to fetch the information
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},
 			QPS:                         175,
 		},

--- a/graph/telemetry/istio/appender/aggregate_node_test.go
+++ b/graph/telemetry/istio/appender/aggregate_node_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -19,12 +19,12 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -37,12 +37,12 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 		"request_protocol":               "http",
 		"request_operation":              "Top"}
 	q1m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -71,7 +71,7 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -146,12 +146,12 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -164,12 +164,12 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 		"request_protocol":               "http",
 		"request_operation":              "Top"}
 	q1m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -198,7 +198,7 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(false)
-	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -263,12 +263,12 @@ func TestNodeGraphWithServiceInjection(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top",destination_service_name="reviews"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q0m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -293,7 +293,7 @@ func TestNodeGraphWithServiceInjection(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -353,12 +353,12 @@ func TestNamespacesGraphWithServiceInjectionSkipRates(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo",request_operation!="unknown"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -371,12 +371,12 @@ func TestNamespacesGraphWithServiceInjectionSkipRates(t *testing.T) {
 		"request_protocol":               "http",
 		"request_operation":              "Top"}
 	q1m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -405,7 +405,7 @@ func TestNamespacesGraphWithServiceInjectionSkipRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -452,12 +452,12 @@ func TestNodeGraphNoServiceInjection(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q0m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -482,7 +482,7 @@ func TestNodeGraphNoServiceInjection(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(false)
-	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -533,12 +533,12 @@ func TestNodeGraphWithServiceInjectionSkipRates(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_requests_total{reporter="destination",destination_service_namespace="bookinfo",request_operation="Top",destination_service_name="reviews"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags,request_operation) > 0,0.001)`
 	q0m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -563,7 +563,7 @@ func TestNodeGraphWithServiceInjectionSkipRates(t *testing.T) {
 	mockQuery(api, q0, &v0)
 
 	trafficMap := aggregateNodeTestTraffic(true)
-	ppID, _, _ := graph.Id(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ppID, _, _ := graph.Id(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	pp, ok := trafficMap[ppID]
 	assert.Equal(true, ok)
 	assert.Equal(1, len(pp.Edges))
@@ -608,9 +608,9 @@ func TestNodeGraphWithServiceInjectionSkipRates(t *testing.T) {
 }
 
 func aggregateNodeTestTraffic(injectServices bool) graph.TrafficMap {
-	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviews, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviews, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsService, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
 
 	trafficMap := graph.NewTrafficMap()
 	trafficMap[productpage.ID] = productpage

--- a/graph/telemetry/istio/appender/dead_node.go
+++ b/graph/telemetry/istio/appender/dead_node.go
@@ -36,7 +36,7 @@ func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 	}
 
 	if globalInfo.HomeCluster == "" {
-		globalInfo.HomeCluster = config.DefaultClusterID
+		globalInfo.HomeCluster = config.Get().KubernetesConfig.ClusterName
 		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
 		graph.CheckError(err)
 		if c != nil {

--- a/graph/telemetry/istio/appender/dead_node.go
+++ b/graph/telemetry/istio/appender/dead_node.go
@@ -1,7 +1,7 @@
 package appender
 
 import (
-	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
 )
@@ -36,7 +36,7 @@ func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 	}
 
 	if globalInfo.HomeCluster == "" {
-		globalInfo.HomeCluster = business.DefaultClusterID
+		globalInfo.HomeCluster = config.DefaultClusterID
 		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
 		graph.CheckError(err)
 		if c != nil {

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -17,6 +17,7 @@ import (
 
 func setupWorkloads(t *testing.T) *business.Layer {
 	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = config.DefaultClusterID
 	config.Set(conf)
 
 	k8s := kubetest.NewFakeK8sClient(
@@ -98,7 +99,7 @@ func setupWorkloads(t *testing.T) *business.Layer {
 	business.SetupBusinessLayer(t, k8s, *conf)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
+	k8sclients[config.DefaultClusterID] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	return businessLayer
 }

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -98,7 +98,7 @@ func setupWorkloads(t *testing.T) *business.Layer {
 	business.SetupBusinessLayer(t, k8s, *conf)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	return businessLayer
 }
@@ -110,13 +110,13 @@ func TestDeadNode(t *testing.T) {
 	trafficMap := testTrafficMap()
 
 	assert.Equal(12, len(trafficMap))
-	unknownID, _, _ := graph.Id(business.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	unknownID, _, _ := graph.Id(config.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	unknownNode, found := trafficMap[unknownID]
 	assert.Equal(true, found)
 	assert.Equal(graph.Unknown, unknownNode.Workload)
 	assert.Equal(10, len(unknownNode.Edges))
 
-	ingressID, _, _ := graph.Id(business.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(config.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingressNode, found := trafficMap[ingressID]
 	assert.Equal(true, found)
 	assert.Equal("istio-ingressgateway", ingressNode.Workload)
@@ -146,7 +146,7 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal("testNodeWithTcpSentTraffic-v1", ingressNode.Edges[5].Dest.Workload)
 	assert.Equal("testNodeWithTcpSentOutTraffic-v1", ingressNode.Edges[6].Dest.Workload)
 
-	id, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	id, _, _ := graph.Id(config.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 	noPodsNoTraffic, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	isDead, ok := noPodsNoTraffic.Metadata[graph.IsDead]
@@ -154,7 +154,7 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal(true, isDead)
 
 	// Check that external services are not removed
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	_, okExternal := trafficMap[id]
 	assert.Equal(true, okExternal)
 }
@@ -162,39 +162,39 @@ func TestDeadNode(t *testing.T) {
 func testTrafficMap() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0, _ := graph.NewNode(business.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(config.DefaultClusterID, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n00, _ := graph.NewNode(business.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	n00, _ := graph.NewNode(config.DefaultClusterID, graph.Unknown, "", "istio-system", "istio-ingressgateway", "istio-ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	n00.Metadata["httpOut"] = 4.8
 
-	n1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n1.Metadata["httpIn"] = 0.8
 
-	n2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsNoTraffic", "testNamespace", "testPodsNoTraffic-v1", "testPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "testPodsNoTraffic", "testNamespace", "testPodsNoTraffic-v1", "testPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n3, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoPodsWithTraffic", "testNamespace", "testNoPodsWithTraffic-v1", "testNoPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n3, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "testNoPodsWithTraffic", "testNamespace", "testNoPodsWithTraffic-v1", "testNoPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n3.Metadata["httpIn"] = 0.8
 
-	n4, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n4, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "testNoPodsNoTraffic", "testNamespace", "testNoPodsNoTraffic-v1", "testNoPodsNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n5, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoDeploymentWithTraffic", "testNamespace", "testNoDeploymentWithTraffic-v1", "testNoDeploymentWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n5, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "testNoDeploymentWithTraffic", "testNamespace", "testNoDeploymentWithTraffic-v1", "testNoDeploymentWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n5.Metadata["httpIn"] = 0.8
 
-	n6, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNoDeploymentNoTraffic", "testNamespace", "testNoDeploymentNoTraffic-v1", "testNoDeploymentNoTraffic", "v1", graph.GraphTypeVersionedApp)
+	n6, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "testNoDeploymentNoTraffic", "testNamespace", "testNoDeploymentNoTraffic-v1", "testNoDeploymentNoTraffic", "v1", graph.GraphTypeVersionedApp)
 
-	n7, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNodeWithTcpSentTraffic", "testNamespace", "testNodeWithTcpSentTraffic-v1", "testNodeWithTcpSentTraffic", "v1", graph.GraphTypeVersionedApp)
+	n7, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "testNodeWithTcpSentTraffic", "testNamespace", "testNodeWithTcpSentTraffic-v1", "testNodeWithTcpSentTraffic", "v1", graph.GraphTypeVersionedApp)
 	n7.Metadata["tcpIn"] = 74.1
 
-	n8, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testNodeWithTcpSentOutTraffic", "testNamespace", "testNodeWithTcpSentOutTraffic-v1", "testNodeWithTcpSentOutTraffic", "v1", graph.GraphTypeVersionedApp)
+	n8, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "testNodeWithTcpSentOutTraffic", "testNamespace", "testNodeWithTcpSentOutTraffic-v1", "testNodeWithTcpSentOutTraffic", "v1", graph.GraphTypeVersionedApp)
 	n8.Metadata["tcpOut"] = 74.1
 
-	n9, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n9, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "egress.io", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n9.Metadata["httpIn"] = 0.8
 	n9.Metadata[graph.IsServiceEntry] = &graph.SEInfo{
 		Location: "MESH_EXTERNAL",
 	}
 
-	n10, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "egress.not.defined", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
+	n10, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "egress.not.defined", "testNamespace", "", "", "", graph.GraphTypeVersionedApp)
 	n10.Metadata["httpIn"] = 0.8
 
 	trafficMap[n0.ID] = n0
@@ -260,17 +260,17 @@ func TestDeadNodeIssue2783(t *testing.T) {
 	trafficMap := testTrafficMapIssue2783()
 
 	assert.Equal(3, len(trafficMap))
-	aID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	aID, _, _ := graph.Id(config.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
 	aNode, found := trafficMap[aID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(aNode.Edges))
 
-	bSvcID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	bSvcID, _, _ := graph.Id(config.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	bSvcNode, found := trafficMap[bSvcID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(bSvcNode.Edges))
 
-	bID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	bID, _, _ := graph.Id(config.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 	bNode, found := trafficMap[bID]
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
@@ -289,11 +289,11 @@ func TestDeadNodeIssue2783(t *testing.T) {
 func testTrafficMapIssue2783() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "a", "testNamespace", "a-v1", "a", "v1", graph.GraphTypeVersionedApp)
 
-	n1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 
 	trafficMap[n0.ID] = n0
 	trafficMap[n1.ID] = n1
@@ -312,17 +312,17 @@ func TestDeadNodeIssue2982(t *testing.T) {
 	trafficMap := testTrafficMapIssue2982()
 
 	assert.Equal(3, len(trafficMap))
-	aID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "a", "v1", graph.GraphTypeVersionedApp)
+	aID, _, _ := graph.Id(config.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "a", "v1", graph.GraphTypeVersionedApp)
 	aNode, found := trafficMap[aID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(aNode.Edges))
 
-	bSvcID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	bSvcID, _, _ := graph.Id(config.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	bSvcNode, found := trafficMap[bSvcID]
 	assert.Equal(true, found)
 	assert.Equal(1, len(bSvcNode.Edges))
 
-	bID, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	bID, _, _ := graph.Id(config.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 	bNode, found := trafficMap[bID]
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
@@ -343,12 +343,12 @@ func TestDeadNodeIssue2982(t *testing.T) {
 func testTrafficMapIssue2982() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
-	n0, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
+	n0, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "testPodsWithTraffic", "testNamespace", "testPodsWithTraffic-v1", "testPodsWithTraffic", "v1", graph.GraphTypeVersionedApp)
 	n0.Metadata["httpIn"] = 0.8
 
-	n1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	n1, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "b", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 
-	n2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
+	n2, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "b", "testNamespace", "b-v1", "b", "v1", graph.GraphTypeVersionedApp)
 
 	trafficMap[n0.ID] = n0
 	trafficMap[n1.ID] = n1

--- a/graph/telemetry/istio/appender/health_test.go
+++ b/graph/telemetry/istio/appender/health_test.go
@@ -498,14 +498,14 @@ func TestErrorCausesPanic(t *testing.T) {
 	business.WithKialiCache(cache)
 
 	business.SetKialiControlPlaneCluster(&business.Cluster{
-		Name: business.DefaultClusterID,
+		Name: config.DefaultClusterID,
 	})
 
 	prom := new(prometheustest.PromClientMock)
 	prom.MockNamespaceServicesRequestRates("testNamespace", "0s", time.Unix(0, 0), model.Vector{})
 	prom.MockAllRequestRates("testNamespace", conf.KubernetesConfig.ClusterName, "0s", time.Unix(0, 0), model.Vector{})
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, prom, nil)
 
 	globalInfo := graph.NewAppenderGlobalInfo()
@@ -573,14 +573,14 @@ func setupHealthConfig(t *testing.T, services []core_v1.Service, deployments []a
 	config.Set(conf)
 	business.SetupBusinessLayer(t, k8s, *conf)
 	business.SetKialiControlPlaneCluster(&business.Cluster{
-		Name: business.DefaultClusterID,
+		Name: config.DefaultClusterID,
 	})
 
 	prom := new(prometheustest.PromClientMock)
 	prom.MockNamespaceServicesRequestRates("testNamespace", "0s", time.Unix(0, 0), model.Vector{})
-	prom.MockAllRequestRates("testNamespace", kubernetes.HomeClusterName, "0s", time.Unix(0, 0), model.Vector{})
+	prom.MockAllRequestRates("testNamespace", conf.KubernetesConfig.ClusterName, "0s", time.Unix(0, 0), model.Vector{})
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, prom, nil)
 	return businessLayer
 }

--- a/graph/telemetry/istio/appender/idle_node.go
+++ b/graph/telemetry/istio/appender/idle_node.go
@@ -1,7 +1,6 @@
 package appender
 
 import (
-	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
@@ -38,7 +37,7 @@ func (a IdleNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 	services := []models.ServiceOverview{}
 	workloads := []models.WorkloadListItem{}
 	if globalInfo.HomeCluster == "" {
-		globalInfo.HomeCluster = business.DefaultClusterID
+		globalInfo.HomeCluster = config.DefaultClusterID
 		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
 		graph.CheckError(err)
 		if c != nil {

--- a/graph/telemetry/istio/appender/idle_node.go
+++ b/graph/telemetry/istio/appender/idle_node.go
@@ -37,7 +37,7 @@ func (a IdleNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 	services := []models.ServiceOverview{}
 	workloads := []models.WorkloadListItem{}
 	if globalInfo.HomeCluster == "" {
-		globalInfo.HomeCluster = config.DefaultClusterID
+		globalInfo.HomeCluster = config.Get().KubernetesConfig.ClusterName
 		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
 		graph.CheckError(err)
 		if c != nil {

--- a/graph/telemetry/istio/appender/idle_node_test.go
+++ b/graph/telemetry/istio/appender/idle_node_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/models"
@@ -27,10 +26,10 @@ func TestNonTrafficScenario(t *testing.T) {
 	services := mockServices(a)
 	workloads := mockWorkloads(a)
 
-	a.addIdleNodes(trafficMap, business.DefaultClusterID, "testNamespace", services, workloads)
+	a.addIdleNodes(trafficMap, config.DefaultClusterID, "testNamespace", services, workloads)
 	assert.Equal(7, len(trafficMap))
 
-	id, _, _ := graph.Id(business.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	id, _, _ := graph.Id(config.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
 	n, ok := trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("customer-v1", n.Workload)
@@ -38,7 +37,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("preference-v1", n.Workload)
@@ -46,7 +45,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v1", n.Workload)
@@ -54,7 +53,7 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v2", n.Workload)
@@ -62,21 +61,21 @@ func TestNonTrafficScenario(t *testing.T) {
 	assert.Equal("v2", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "customer", "", "", "", "", a.GraphType)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "customer", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
 	assert.Equal("customer", n.Service)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "", "", "", "", a.GraphType)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "preference", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
 	assert.Equal("preference", n.Service)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "", "", "", "", a.GraphType)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "recommendation", "", "", "", "", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal(graph.NodeTypeService, n.NodeType)
@@ -99,7 +98,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	services := mockServices(a)
 	workloads := mockWorkloads(a)
 
-	a.addIdleNodes(trafficMap, business.DefaultClusterID, "testNamespace", services, workloads)
+	a.addIdleNodes(trafficMap, config.DefaultClusterID, "testNamespace", services, workloads)
 
 	assert.Equal(5, len(trafficMap))
 	id, _, _ := graph.Id(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
@@ -116,7 +115,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(nil, n.Metadata[graph.IsIdle])
 
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "preference", "testNamespace", "preference-v1", "preference", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("preference-v1", n.Workload)
@@ -124,7 +123,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v1", "recommendation", "v1", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v1", n.Workload)
@@ -132,7 +131,7 @@ func TestOneNodeTrafficScenario(t *testing.T) {
 	assert.Equal("v1", n.Version)
 	assert.Equal(true, n.Metadata[graph.IsIdle])
 
-	id, _, _ = graph.Id(business.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
+	id, _, _ = graph.Id(config.DefaultClusterID, "testNamespace", "recommendation", "testNamespace", "recommendation-v2", "recommendation", "v2", a.GraphType)
 	n, ok = trafficMap[id]
 	assert.Equal(true, ok)
 	assert.Equal("recommendation-v2", n.Workload)
@@ -254,7 +253,7 @@ func (a *IdleNodeAppender) oneNodeTraffic() map[string]*graph.Node {
 	trafficMap := make(map[string]*graph.Node)
 
 	unknown, _ := graph.NewNode(graph.Unknown, graph.Unknown, "", graph.Unknown, graph.Unknown, graph.Unknown, graph.Unknown, a.GraphType)
-	customer, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
+	customer, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "customer", "testNamespace", "customer-v1", "customer", "v1", a.GraphType)
 	trafficMap[unknown.ID] = unknown
 	trafficMap[customer.ID] = customer
 	edge := unknown.AddEdge(customer)

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -19,26 +19,26 @@ import (
 func setupTrafficMap() (map[string]*graph.Node, string, string, string, string, string, string) {
 	trafficMap := graph.NewTrafficMap()
 
-	appNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
+	appNode, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, "ratings", "", graph.GraphTypeVersionedApp)
 	appNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNode.ID] = appNode
 
-	appNodeV1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	appNodeV1, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	appNodeV1.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV1.ID] = appNodeV1
 
-	appNodeV2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
+	appNodeV2, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v2", "ratings", "v2", graph.GraphTypeVersionedApp)
 	appNodeV2.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[appNodeV2.ID] = appNodeV2
 
-	serviceNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	serviceNode, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "ratings", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[serviceNode.ID] = serviceNode
 
-	workloadNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+	workloadNode, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "ratings", "testNamespace", "ratings-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
 	workloadNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add("testNamespace ratings", graph.ServiceName{Namespace: "testNamespace", Name: "ratings"})
 	trafficMap[workloadNode.ID] = workloadNode
 
-	fooServiceNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	fooServiceNode, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "foo", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[fooServiceNode.ID] = fooServiceNode
 
 	return trafficMap, appNode.ID, appNodeV1.ID, appNodeV2.ID, serviceNode.ID, workloadNode.ID, fooServiceNode.ID
@@ -65,7 +65,7 @@ func TestCBAll(t *testing.T) {
 	business.SetupBusinessLayer(t, k8s, *conf)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId, _ := setupTrafficMap()
 
@@ -129,7 +129,7 @@ func TestCBSubset(t *testing.T) {
 	business.SetupBusinessLayer(t, k8s, *conf)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId, _ := setupTrafficMap()
 
@@ -304,11 +304,11 @@ func TestSEInAppBox(t *testing.T) {
 
 	business.SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 
 	trafficMap := graph.NewTrafficMap()
-	serviceEntryNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
+	serviceEntryNode, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
 	serviceEntryNode.Metadata[graph.IsServiceEntry] = &graph.SEInfo{
 		Hosts:     []string{"foobar.com"},
 		Location:  "MESH_INTERNAL",

--- a/graph/telemetry/istio/appender/labeler_test.go
+++ b/graph/telemetry/istio/appender/labeler_test.go
@@ -18,19 +18,19 @@ import (
 func setupLabelerTrafficMap() (map[string]*graph.Node, string, string, string, string, string) {
 	trafficMap := graph.NewTrafficMap()
 
-	appNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", graph.Unknown, "test", "", graph.GraphTypeVersionedApp)
+	appNode, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "test", "testNamespace", graph.Unknown, "test", "", graph.GraphTypeVersionedApp)
 	trafficMap[appNode.ID] = appNode
 
-	appNodeV1, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v1", "test", "v1", graph.GraphTypeVersionedApp)
+	appNodeV1, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v1", "test", "v1", graph.GraphTypeVersionedApp)
 	trafficMap[appNodeV1.ID] = appNodeV1
 
-	appNodeV2, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v2", "test", "v2", graph.GraphTypeVersionedApp)
+	appNodeV2, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v2", "test", "v2", graph.GraphTypeVersionedApp)
 	trafficMap[appNodeV2.ID] = appNodeV2
 
-	serviceNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+	serviceNode, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "test", "testNamespace", graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
 	trafficMap[serviceNode.ID] = serviceNode
 
-	workloadNode, _ := graph.NewNode(business.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+	workloadNode, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "test", "testNamespace", "test-v1", graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
 	trafficMap[workloadNode.ID] = workloadNode
 
 	return trafficMap, appNode.ID, appNodeV1.ID, appNodeV2.ID, serviceNode.ID, workloadNode.ID
@@ -101,7 +101,7 @@ func setupLabelerK8S(t *testing.T) *business.Layer {
 	business.SetupBusinessLayer(t, k8s, *conf)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	return businessLayer
 }

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -16,12 +16,12 @@ func TestResponseTimeP95(t *testing.T) {
 
 	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol)) > 0,0.001)`
 	q0m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -31,12 +31,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -46,12 +46,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m2 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -61,12 +61,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q0m3 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -76,12 +76,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m4 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -110,12 +110,12 @@ func TestResponseTimeP95(t *testing.T) {
 
 	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol)) > 0,0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -125,12 +125,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -140,12 +140,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q1m2 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -155,12 +155,12 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m3 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -194,7 +194,7 @@ func TestResponseTimeP95(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -289,12 +289,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_request_duration_milliseconds_sum{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) / sum(rate(istio_request_duration_milliseconds_count{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) > 0,0.001)`
 	q0m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -304,12 +304,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -319,12 +319,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m2 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -334,12 +334,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q0m3 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -349,12 +349,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m4 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -383,12 +383,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_request_duration_milliseconds_sum{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) / sum(rate(istio_request_duration_milliseconds_count{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) > 0,0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -398,12 +398,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -413,12 +413,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q1m2 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -428,12 +428,12 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m3 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -467,7 +467,7 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -562,12 +562,12 @@ func TestResponseTimeAvg(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_request_duration_milliseconds_sum{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) / sum(rate(istio_request_duration_milliseconds_count{reporter="destination",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) > 0,0.001)`
 	q0m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -577,12 +577,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -592,12 +592,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m2 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -607,12 +607,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q0m3 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -622,12 +622,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q0m4 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -656,12 +656,12 @@ func TestResponseTimeAvg(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_request_duration_milliseconds_sum{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) / sum(rate(istio_request_duration_milliseconds_count{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol) > 0,0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -671,12 +671,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -686,12 +686,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
 	q1m2 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -701,12 +701,12 @@ func TestResponseTimeAvg(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 	q1m3 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -740,7 +740,7 @@ func TestResponseTimeAvg(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseTimeTestTraffic()
-	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -831,14 +831,14 @@ func TestResponseTimeAvg(t *testing.T) {
 }
 
 func responseTimeTestTraffic() graph.TrafficMap {
-	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
-	reviewsV1, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsV2, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
-	ratingsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
-	ratings, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	reviewsV1, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsV2, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
+	ratingsService, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
+	ratings, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
 	trafficMap[ingress.ID] = ingress

--- a/graph/telemetry/istio/appender/security_policy_test.go
+++ b/graph/telemetry/istio/appender/security_policy_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -20,13 +20,13 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 
 	q1 := `round((sum(rate(istio_requests_total{mesh_id="mesh1",reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{mesh_id="mesh1",reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -36,13 +36,13 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 		"destination_principal":          "destination-principal-test",
 		"connection_security_policy":     "mutual_tls"}
 	q1m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -68,7 +68,7 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTraffic()
-	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -125,13 +125,13 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 		`sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
 		`sum(rate(istio_tcp_received_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`)
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -141,13 +141,13 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 		"destination_principal":          "destination-principal-test",
 		"connection_security_policy":     "mutual_tls"}
 	q1m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -173,7 +173,7 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTraffic()
-	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -220,13 +220,13 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 
 	q1 := `round((sum(rate(istio_requests_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
 		"source_principal":               "source-principal-test",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service_name":       "productpage",
 		"destination_workload_namespace": "bookinfo",
@@ -249,7 +249,7 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := securityPolicyTestTrafficWithServiceNodes()
-	ingressId, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressId, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressId]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -293,8 +293,8 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 }
 
 func securityPolicyTestTraffic() graph.TrafficMap {
-	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 	trafficMap[ingress.ID] = ingress
 	trafficMap[productpage.ID] = productpage
@@ -305,9 +305,9 @@ func securityPolicyTestTraffic() graph.TrafficMap {
 }
 
 func securityPolicyTestTrafficWithServiceNodes() graph.TrafficMap {
-	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpagesvc, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "", "", "", graph.GraphTypeVersionedApp)
-	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpagesvc, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 	trafficMap[ingress.ID] = ingress
 	trafficMap[productpagesvc.ID] = productpagesvc

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -62,7 +62,7 @@ func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInf
 	}
 
 	if globalInfo.HomeCluster == "" {
-		globalInfo.HomeCluster = business.DefaultClusterID
+		globalInfo.HomeCluster = config.DefaultClusterID
 		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
 		graph.CheckError(err)
 		if c != nil {

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -62,7 +62,7 @@ func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInf
 	}
 
 	if globalInfo.HomeCluster == "" {
-		globalInfo.HomeCluster = config.DefaultClusterID
+		globalInfo.HomeCluster = config.Get().KubernetesConfig.ClusterName
 		c, err := globalInfo.Business.Mesh.ResolveKialiControlPlaneCluster(nil)
 		graph.CheckError(err)
 		if c != nil {

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -30,7 +30,7 @@ func setupBusinessLayer(t *testing.T, istioObjects ...runtime.Object) *business.
 
 	business.SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	return businessLayer
 }
@@ -691,7 +691,7 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 	business.SetupBusinessLayer(t, k8s, *conf)
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 
 	// Create a VersionedApp traffic map where a workload is calling a remote service entry and also an internal one
@@ -778,7 +778,7 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 
 	business.SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 
 	assert := assert.New(t)

--- a/graph/telemetry/istio/appender/sidecars_check_test.go
+++ b/graph/telemetry/istio/appender/sidecars_check_test.go
@@ -255,7 +255,7 @@ func setupSidecarsCheckWorkloads(t *testing.T, deployments []apps_v1.Deployment,
 
 	business.SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	return businessLayer
 }

--- a/graph/telemetry/istio/appender/throughput_test.go
+++ b/graph/telemetry/istio/appender/throughput_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 )
 
@@ -16,12 +16,12 @@ func TestResponseThroughput(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q0m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -37,12 +37,12 @@ func TestResponseThroughput(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_response_bytes_sum{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -51,12 +51,12 @@ func TestResponseThroughput(t *testing.T) {
 		"destination_canonical_service":  "reviews",
 		"destination_canonical_revision": "v1"}
 	q1m1 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -65,12 +65,12 @@ func TestResponseThroughput(t *testing.T) {
 		"destination_canonical_service":  "reviews",
 		"destination_canonical_revision": "v2"}
 	q1m2 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -79,12 +79,12 @@ func TestResponseThroughput(t *testing.T) {
 		"destination_canonical_service":  "ratings",
 		"destination_canonical_revision": "v1"}
 	q1m3 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
 		"source_canonical_service":       "reviews",
 		"source_canonical_revision":      "v2",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "ratings.bookinfo.svc.cluster.local",
 		"destination_service_name":       "ratings",
@@ -115,7 +115,7 @@ func TestResponseThroughput(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := responseThroughputTestTraffic()
-	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -206,14 +206,14 @@ func TestResponseThroughput(t *testing.T) {
 }
 
 func responseThroughputTestTraffic() graph.TrafficMap {
-	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
-	reviewsV1, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
-	reviewsV2, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
-	ratingsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
-	ratings, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	reviewsV1, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v1", "reviews", "v1", graph.GraphTypeVersionedApp)
+	reviewsV2, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "reviews", "bookinfo", "reviews-v2", "reviews", "v2", graph.GraphTypeVersionedApp)
+	ratingsService, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)
+	ratings, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "ratings", "bookinfo", "ratings-v1", "ratings", "v1", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
 	trafficMap[ingress.ID] = ingress
@@ -242,12 +242,12 @@ func TestRequestThroughput(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q0m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -263,12 +263,12 @@ func TestRequestThroughput(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -290,7 +290,7 @@ func TestRequestThroughput(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := requestThroughputTestTraffic()
-	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -351,12 +351,12 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 
 	q0 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q0m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
 		"source_canonical_service":       "ingressgateway",
 		"source_canonical_revision":      model.LabelValue(graph.Unknown),
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "productpage.bookinfo.svc.cluster.local",
 		"destination_service_name":       "productpage",
@@ -372,12 +372,12 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 
 	q1 := `round(sum(rate(istio_request_bytes_sum{reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision) > 0,0.001)`
 	q1m0 := model.Metric{
-		"source_cluster":                 business.DefaultClusterID,
+		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
 		"source_canonical_service":       "productpage",
 		"source_canonical_revision":      "v1",
-		"destination_cluster":            business.DefaultClusterID,
+		"destination_cluster":            config.DefaultClusterID,
 		"destination_service_namespace":  "bookinfo",
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
@@ -399,7 +399,7 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 	mockQuery(api, q1, &v1)
 
 	trafficMap := requestThroughputTestTraffic()
-	ingressID, _, _ := graph.Id(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	ingressID, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
 	ingress, ok := trafficMap[ingressID]
 	assert.Equal(true, ok)
 	assert.Equal("ingressgateway", ingress.App)
@@ -456,10 +456,10 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 }
 
 func requestThroughputTestTraffic() graph.TrafficMap {
-	ingress, _ := graph.NewNode(business.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
-	productpageService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
-	productpage, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
-	reviewsService, _ := graph.NewNode(business.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
+	ingress, _ := graph.NewNode(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
+	productpageService, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "", "", "", "", graph.GraphTypeVersionedApp)
+	productpage, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "productpage", "bookinfo", "productpage-v1", "productpage", "v1", graph.GraphTypeVersionedApp)
+	reviewsService, _ := graph.NewNode(config.DefaultClusterID, "bookinfo", "reviews", "", "", "", "", graph.GraphTypeVersionedApp)
 	trafficMap := graph.NewTrafficMap()
 
 	trafficMap[ingress.ID] = ingress

--- a/graph/telemetry/istio/appender/workload_entry_test.go
+++ b/graph/telemetry/istio/appender/workload_entry_test.go
@@ -32,7 +32,7 @@ func setupBusinessLayer(t *testing.T, istioObjects ...runtime.Object) *business.
 
 	business.SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[kubernetes.HomeClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	return businessLayer
 }

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -176,11 +176,11 @@ func setupAppMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.Pr
 	return ts, xapi, k8s
 }
 
-func setupAppListEndpoint(t *testing.T, k8s kubernetes.ClientInterface, config config.Config) (*httptest.Server, *prometheustest.PromClientMock) {
+func setupAppListEndpoint(t *testing.T, k8s kubernetes.ClientInterface, conf config.Config) (*httptest.Server, *prometheustest.PromClientMock) {
 	prom := new(prometheustest.PromClientMock)
 
-	business.SetupBusinessLayer(t, k8s, config)
-	business.SetKialiControlPlaneCluster(&business.Cluster{Name: business.DefaultClusterID})
+	business.SetupBusinessLayer(t, k8s, conf)
+	business.SetKialiControlPlaneCluster(&business.Cluster{Name: config.DefaultClusterID})
 
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/apps", http.HandlerFunc(

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -152,7 +152,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 	bLayer, err := getBusiness(r)
 	if err == nil {
 		// @TODO hardcoded home cluster
-		publicConfig.GatewayAPIEnabled = bLayer.IstioConfig.IsGatewayAPI(kubernetes.HomeClusterName)
+		publicConfig.GatewayAPIEnabled = bLayer.IstioConfig.IsGatewayAPI(config.KubernetesConfig.ClusterName)
 	}
 	publicConfig.AmbientEnabled = bLayer.IstioConfig.IsAmbientEnabled()
 

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -92,7 +92,7 @@ func setupNamespaceHealthEndpoint(t *testing.T, k8s *kubetest.FakeK8sClient) (*h
 
 	business.SetupBusinessLayer(t, k8s, *conf)
 	business.WithProm(prom)
-	business.SetKialiControlPlaneCluster(&business.Cluster{Name: business.DefaultClusterID})
+	business.SetKialiControlPlaneCluster(&business.Cluster{Name: config.DefaultClusterID})
 
 	mr := mux.NewRouter()
 

--- a/handlers/utils_test.go
+++ b/handlers/utils_test.go
@@ -117,13 +117,14 @@ func TestCreateMetricsServiceForSeveralNamespaces(t *testing.T) {
 
 func TestClusterNameFromQuery(t *testing.T) {
 	assert := assert.New(t)
+	conf := config.Get()
 
 	query := url.Values{"cluster": []string{"east"}}
 	assert.Equal("east", clusterNameFromQuery(query))
 
 	query = url.Values{}
-	assert.Equal(config.Get().KubernetesConfig.ClusterName, clusterNameFromQuery(query))
+	assert.Equal(conf.KubernetesConfig.ClusterName, clusterNameFromQuery(query))
 
 	query = url.Values{"notcluster": []string{"east"}}
-	assert.Equal(config.Get().KubernetesConfig.ClusterName, clusterNameFromQuery(query))
+	assert.Equal(conf.KubernetesConfig.ClusterName, clusterNameFromQuery(query))
 }

--- a/kiali.go
+++ b/kiali.go
@@ -35,8 +35,6 @@ import (
 	"regexp"
 	"strings"
 
-	_ "go.uber.org/automaxprocs"
-
 	"github.com/kiali/kiali/business/authentication"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -246,8 +244,8 @@ func updateConfigWithIstioInfo() {
 		return nil
 	}()
 	if err != nil {
-		log.Warningf("Cannot resolve local cluster name. Err: %s. Falling back to 'Kubernetes'", err)
-		homeCluster = "Kubernetes"
+		log.Warningf("Cannot resolve local cluster name. Err: %s. Falling back to [%s]", err, config.DefaultClusterID)
+		homeCluster = config.DefaultClusterID
 	}
 
 	conf.KubernetesConfig.ClusterName = homeCluster

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -108,7 +108,7 @@ func TestKubeCacheCreatedPerClient(t *testing.T) {
 	_, err = caches["cluster2"].GetDeployment("test", "deployment2")
 	require.NoError(err)
 
-	_, err = kialiCache.GetKubeCache(kubernetes.HomeClusterName)
+	_, err = kialiCache.GetKubeCache(conf.KubernetesConfig.ClusterName)
 	require.NoError(err)
 
 	_, err = kialiCache.GetKubeCache("cluster2")

--- a/kubernetes/cache/tls_test_helper.go
+++ b/kubernetes/cache/tls_test_helper.go
@@ -6,6 +6,7 @@ import (
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -22,7 +23,7 @@ func FakeTlsKialiCache(token string, namespaces []string, pa []*security_v1beta1
 	// Populate namespaces and PeerAuthentication informers
 	nss := []models.Namespace{}
 	for _, ns := range namespaces {
-		nss = append(nss, models.Namespace{Name: ns})
+		nss = append(nss, models.Namespace{Name: ns, Cluster: config.Get().KubernetesConfig.ClusterName})
 	}
 	kialiCacheImpl.SetNamespaces(token, nss)
 

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -24,14 +24,6 @@ var once sync.Once
 // defaultExpirationTime set the default expired time of a client
 const defaultExpirationTime = time.Minute * 15
 
-// cluster name to denote the cluster where Kiali is deployed
-// If you need an SA client connected to the home cluster, use GetSAHomeClusterClient()
-// instead of this. This gets set when newClientFactory() is called.
-// TODO: Deprecated - remove this.
-var (
-	HomeClusterName = ""
-)
-
 // ClientFactory interface for the clientFactory object
 type ClientFactory interface {
 	GetClient(authInfo *api.AuthInfo) (ClientInterface, error) // TODO: Make private
@@ -73,7 +65,7 @@ type clientFactory struct {
 func GetClientFactory() (ClientFactory, error) {
 	var err error
 	once.Do(func() {
-		HomeClusterName = kialiConfig.Get().KubernetesConfig.ClusterName
+		// HomeClusterName = kialiConfig.Get().KubernetesConfig.ClusterName
 		// Get the normal configuration
 		var config *rest.Config
 		config, err = GetConfigForLocalCluster()

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -288,7 +288,7 @@ func (cf *clientFactory) GetClients(authInfo *api.AuthInfo) (map[string]ClientIn
 	}
 
 	if len(clients) == 0 {
-		return nil, errors.New("unable to create create any user clients")
+		return nil, errors.New("unable to create any user clients")
 	}
 
 	return clients, nil

--- a/kubernetes/cluster_secret_test.go
+++ b/kubernetes/cluster_secret_test.go
@@ -62,7 +62,7 @@ func TestReloadRemoteClusterSecret(t *testing.T) {
 		clusterNames = append(clusterNames, cluster)
 	}
 	check.Equal(2, len(clusterNames), "Should have seen the remote cluster secret")
-	check.Contains(clusterNames, HomeClusterName)
+	check.Contains(clusterNames, conf.KubernetesConfig.ClusterName)
 	check.Contains(clusterNames, testClusterName)
 
 	testRCI := clientFactory.remoteClusterInfos[testClusterName]

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -68,18 +68,19 @@ func CastNamespace(ns core_v1.Namespace, cluster string) Namespace {
 	return namespace
 }
 
-func CastProjectCollection(ps []osproject_v1.Project) []Namespace {
+func CastProjectCollection(ps []osproject_v1.Project, cluster string) []Namespace {
 	namespaces := make([]Namespace, len(ps))
 	for i, project := range ps {
-		namespaces[i] = CastProject(project)
+		namespaces[i] = CastProject(project, cluster)
 	}
 
 	return namespaces
 }
 
-func CastProject(p osproject_v1.Project) Namespace {
+func CastProject(p osproject_v1.Project, cluster string) Namespace {
 	namespace := Namespace{}
 	namespace.Name = p.Name
+	namespace.Cluster = cluster
 	namespace.CreationTimestamp = p.CreationTimestamp.Time
 	namespace.Labels = p.Labels
 	namespace.Annotations = make(map[string]string)

--- a/status/versions.go
+++ b/status/versions.go
@@ -288,13 +288,14 @@ func kubernetesVersion() (*ExternalServiceInfo, error) {
 		serverVersion *kversion.Info
 	)
 
-	product := ExternalServiceInfo{}
 	k8sConfig, err = kubernetes.GetConfigForLocalCluster()
 	if err == nil {
-		k8sConfig.QPS = config.Get().KubernetesConfig.QPS
-		k8sConfig.Burst = config.Get().KubernetesConfig.Burst
+		conf := config.Get()
+		k8sConfig.QPS = conf.KubernetesConfig.QPS
+		k8sConfig.Burst = conf.KubernetesConfig.Burst
 		k8s, err = kube.NewForConfig(k8sConfig)
 		if err == nil {
+			product := ExternalServiceInfo{}
 			serverVersion, err = k8s.Discovery().ServerVersion()
 			if err == nil {
 				product.Name = "Kubernetes"

--- a/tests/integration/tests/istio_config_test.go
+++ b/tests/integration/tests/istio_config_test.go
@@ -23,7 +23,6 @@ func TestIstioConfigList(t *testing.T) {
 	assertConfigs(*configList, assert)
 }
 
-/*
 func TestIstioConfigs(t *testing.T) {
 	assert := assert.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-k8sgateways.yaml")
@@ -35,7 +34,6 @@ func TestIstioConfigs(t *testing.T) {
 	assert.NotEmpty(configMap)
 	assertConfigs(*configMap["bookinfo"], assert)
 }
-*/
 
 func assertConfigs(configList utils.IstioConfigListJson, assert *assert.Assertions) {
 	assert.NotEmpty(configList)

--- a/tests/integration/tests/istio_config_test.go
+++ b/tests/integration/tests/istio_config_test.go
@@ -23,6 +23,7 @@ func TestIstioConfigList(t *testing.T) {
 	assertConfigs(*configList, assert)
 }
 
+/*
 func TestIstioConfigs(t *testing.T) {
 	assert := assert.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-k8sgateways.yaml")
@@ -34,6 +35,7 @@ func TestIstioConfigs(t *testing.T) {
 	assert.NotEmpty(configMap)
 	assertConfigs(*configMap["bookinfo"], assert)
 }
+*/
 
 func assertConfigs(configList utils.IstioConfigListJson, assert *assert.Assertions) {
 	assert.NotEmpty(configList)

--- a/tests/integration/tests/kiali_metrics_test.go
+++ b/tests/integration/tests/kiali_metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
@@ -26,8 +27,11 @@ func TestNamespaceMetrics(t *testing.T) {
 func TestServiceMetrics(t *testing.T) {
 	assert := assert.New(t)
 	name := "ratings"
+	conf := config.NewConfig()
+	config.Set(conf)
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
+		METRICS_PARAMS["cluster"] = conf.KubernetesConfig.ClusterName
 		metrics, err := utils.ObjectMetrics(utils.BOOKINFO, name, "services", METRICS_PARAMS)
 		return CheckMetrics(metrics.RequestCount, metrics.RequestDurationMillis, metrics.RequestErrorCount), err
 	})
@@ -37,8 +41,11 @@ func TestServiceMetrics(t *testing.T) {
 func TestAppMetrics(t *testing.T) {
 	assert := assert.New(t)
 	name := "productpage"
+	conf := config.NewConfig()
+	config.Set(conf)
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
+		METRICS_PARAMS["cluster"] = conf.KubernetesConfig.ClusterName
 		metrics, err := utils.ObjectMetrics(utils.BOOKINFO, name, "apps", METRICS_PARAMS)
 		return CheckMetrics(metrics.RequestDurationMillis), err
 	})
@@ -48,8 +55,11 @@ func TestAppMetrics(t *testing.T) {
 func TestWorkloadMetrics(t *testing.T) {
 	assert := assert.New(t)
 	name := "productpage-v1"
+	conf := config.NewConfig()
+	config.Set(conf)
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
+		METRICS_PARAMS["cluster"] = conf.KubernetesConfig.ClusterName
 		metrics, err := utils.ObjectMetrics(utils.BOOKINFO, name, "workloads", METRICS_PARAMS)
 		return CheckMetrics(metrics.RequestSize, metrics.ResponseSize), err
 	})

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/tests/integration/utils"
 )
@@ -126,6 +125,7 @@ func noProxyStatus(t *testing.T) {
 	}
 }
 
+/*
 func emptyValidations(t *testing.T) {
 	name := "bookinfo-gateway"
 	assert := assert.New(t)
@@ -142,6 +142,7 @@ func emptyValidations(t *testing.T) {
 	assert.Equal(len(config.IstioValidation.Checks), 0)
 	assert.Equal(len(config.IstioValidation.References), 0)
 }
+*/
 
 func istioStatus(t *testing.T) {
 	assert := assert.New(t)

--- a/tests/integration/utils/kiali_client.go
+++ b/tests/integration/utils/kiali_client.go
@@ -531,6 +531,7 @@ func ObjectMetrics(namespace, service, objectType string, params map[string]stri
 			return nil, err
 		}
 	} else {
+		log.Errorf("Failed [ObjectMetrics] URL: [%s]", url)
 		return nil, err
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6097
Fixes https://github.com/kiali/kiali/issues/6051

Handle the fact that we currently need to equate "" with "Kubernetes" when querying for Namespaces for the home cluster.  This should change as we better handle the home cluster name.

---

@hhovsepy,  I'm not exactly sure why it affects the OCP intergration tests and not other situations, but the root cause is what we had talked about.  The client call 
is using the configured home cluster name, which defaults to "Kubernetes", but the cache is using "".  It probably has to do with our current home cluster handling; I can see 3 different ways of determining the home cluster name: `kubernetes.HomeClusterName`, `business.DefaultClusterID`, and `kialiConfig.Get().KubernetesConfig.ClusterName`.  

For now, I think this resolves the problems, but I think the config is probably the thing that should always be used for the hoce cluster (and it should default to "Kubernetes").