### PR TITLE
Skipping the Gateway API tests when Gateway API is not enabled using Cypress hooks

### DIFF
--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -1,0 +1,11 @@
+import { Before } from '@badeball/cypress-cucumber-preprocessor';
+
+Before({tags: '@gateway-api'}, async function () {
+  cy.exec('kubectl get crd gateways.gateway.networking.k8s.io',{failOnNonZeroExit: false}).then((result) => {
+    if (result.code != 0){
+      cy.log("Gateway API not found. Enabling it now.");
+      cy.exec('kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.5.1" | kubectl apply -f -;')
+      .its('code').should('eq', 0);
+    }
+  })
+});

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -45,6 +45,7 @@ Feature: Kiali Istio Config page
   Scenario: Ability to create a Gateway object
     Then the user can create a "Gateway" Istio object
 
+  @gateway-api
   Scenario: Ability to create a K8sGateway object
     Then the user can create a "K8sGateway" K8s Istio object
 

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -10,6 +10,7 @@ Feature: Kiali Istio Config page
     And user is at the "istio" page
     And user selects the "bookinfo" namespace
 
+  @gateway-api
   @wizard-istio-config
   Scenario: Create a K8s Gateway scenario
     When user clicks in the "K8sGateway" Istio config actions
@@ -215,7 +216,9 @@ Feature: Kiali Istio Config page
     And user types "8080" in the "addTargetPort1" input
     Then the preview button should be disabled
 
-@wizard-istio-config
+
+  @gateway-api
+  @wizard-istio-config
   Scenario: Create multiple K8s Gateways with colliding hostnames and port combinations and check for a reference
     When user clicks in the "K8sGateway" Istio config actions
     And user sees the "Create K8sGateway" config wizard
@@ -247,7 +250,8 @@ Feature: Kiali Istio Config page
     Then "gatewayapi-2" should be referenced
 
 
-@wizard-istio-config
+  @gateway-api
+  @wizard-istio-config
   Scenario: Delete one of the K8s Gateways and check that the reference is removed
     When viewing the detail for "gatewayapi-2"
     And choosing to delete it 

--- a/frontend/cypress/integration/featureFiles/wizard_k8sgw_api_routing.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_k8sgw_api_routing.feature
@@ -5,6 +5,7 @@ Feature: Service Details Wizard: K8s Gateway API Routing
   Background:
     Given user is at administrator perspective
 
+  @gateway-api
   @wizard-k8s-routing
   Scenario: Create a K8s Gateway API Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
@@ -26,12 +27,14 @@ Feature: Service Details Wizard: K8s Gateway API Routing
     And user creates the configuration
     Then user sees the "Istio Config" table with 1 rows
 
+  @gateway-api
   @wizard-k8s-routing
   Scenario: See a HTTPRoute generated
     When user clicks in the "Istio Config" table "HTTP" badge "reviews" name row link
     Then user sees the "kind: HTTPRoute" regex in the editor
     And user sees the "bookinfo" "reviews" "service" reference
 
+  @gateway-api
   @wizard-k8s-routing
   Scenario: Update a K8s Gateway API Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
@@ -45,11 +48,13 @@ Feature: Service Details Wizard: K8s Gateway API Routing
     And user updates the configuration
     Then user sees the "Istio Config" table with 2 rows
 
+  @gateway-api
   @wizard-k8s-routing
   Scenario: See a K8s Gateway generated with warning
     When user clicks in the "Istio Config" table "G" badge "reviews-gateway" name row link
     Then user sees the "kind: Gateway" regex in the editor
 
+  @gateway-api
   ## @wizard-k8s-routing
   Scenario: Delete the K8s Gateway Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page


### PR DESCRIPTION
There has already been some usage of the tags in the gherkin code. However, you can also use Cypress hooks with these to allow for some specific setups or teardowns when needed. This PR is meant to be a PoC of this Cypress feature. 

To demonstrate this:

- setup Kiali without the Gateway API
- run some of the feature files, which contains the `@gateway-api` tag
- you should see those specific tests ~~to be skipped/pending~~ passing instead of running and failing due to the Gateway API not being enabled

This approach might be useful in the future for the multicluster testing or the parallel execution of the Cypress suite. I am also planning to resolve the #6073 issue in a similiar fashion. 

Props to @ScriptingShrimp for guiding me through this.