### PR TITLE
Do not use result from GetNamespaceByCluster

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -238,12 +238,13 @@ func (in *AppService) GetAppDetails(ctx context.Context, criteria AppCriteria) (
 	)
 	defer end()
 
-	appInstance := &models.App{Namespace: models.Namespace{Name: criteria.Namespace}, Name: criteria.AppName, Health: models.EmptyAppHealth(), Cluster: criteria.Cluster}
+	appInstance := &models.App{Namespace: models.Namespace{Name: criteria.Namespace, Cluster: criteria.Cluster}, Name: criteria.AppName, Health: models.EmptyAppHealth(), Cluster: criteria.Cluster}
 	ns, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, criteria.Namespace, criteria.Cluster)
 	if err != nil {
 		return *appInstance, err
 	}
-	appInstance.Namespace = *ns
+	// @TODO GetNamespaceByCluster is returning empty namespace for single cluster
+	//appInstance.Namespace = *ns
 
 	namespaceApps, err := in.fetchNamespaceApps(ctx, criteria.Namespace, criteria.Cluster, criteria.AppName)
 	if err != nil {

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -518,6 +518,7 @@ func (in *NamespaceService) GetNamespace(ctx context.Context, namespace string) 
 
 // GetNamespace returns the definition of the specified namespace.
 // TODO: Multicluster: We are going to need something else to identify the namespace, the cluster (OR Return a list/array/map)
+// TODO: It returns empty Namespace for single cluster
 func (in *NamespaceService) GetNamespaceByCluster(ctx context.Context, namespace string, cluster string) (*models.Namespace, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetNamespace",


### PR DESCRIPTION
Post merge fix for App Details multicluster support https://github.com/kiali/kiali/pull/6088

The issue was that in single cluster mode the App Details page was not loading correctly. As the response.Namespace was empty.
GetNamespaceByCluster returns empty Namespace object. Skip using that result.

Need to be regression tested AppDetails page on Single and Multicluster.

