### PR TITLE
Test objects cleanup related to the Istio Config Wizard

### DIFF
--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -20,6 +20,21 @@ When('viewing the detail for {string}', (object: string) => {
   cy.get('a').contains(object).should('be.visible').click();
 });
 
+When ('k8sgateway {string} is not created',(name:string) =>{
+  cy.exec(`kubectl delete gateways.gateway.networking.k8s.io ${name} -n bookinfo`, { failOnNonZeroExit: false });
+  ensureKialiFinishedLoading();
+});
+
+When ('gateway {string} is not created',(name:string) =>{
+  cy.exec(`kubectl delete gateway.networking.istio.io ${name} -n bookinfo`, { failOnNonZeroExit: false });
+  ensureKialiFinishedLoading();
+});
+
+When ('service {string} is not created',(name:string) =>{
+  cy.exec(`kubectl delete serviceEntries ${name} -n bookinfo`, { failOnNonZeroExit: false });
+  ensureKialiFinishedLoading();
+});
+
 And('user sees the {string} config wizard', (title: string) => {
   cy.get('h1').should('contain.text', title);
 });

--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -20,17 +20,18 @@ When('viewing the detail for {string}', (object: string) => {
   cy.get('a').contains(object).should('be.visible').click();
 });
 
-When ('k8sgateway {string} is not created',(name:string) =>{
+
+When ('user deletes k8sgateway named {string} and the resource is no longer available',(name:string) =>{
   cy.exec(`kubectl delete gateways.gateway.networking.k8s.io ${name} -n bookinfo`, { failOnNonZeroExit: false });
   ensureKialiFinishedLoading();
 });
 
-When ('gateway {string} is not created',(name:string) =>{
+When ('user deletes gateway named {string} and the resource is no longer available',(name:string) =>{
   cy.exec(`kubectl delete gateway.networking.istio.io ${name} -n bookinfo`, { failOnNonZeroExit: false });
   ensureKialiFinishedLoading();
 });
 
-When ('service {string} is not created',(name:string) =>{
+When ('user deletes service named {string} and the resource is no longer available',(name:string) =>{
   cy.exec(`kubectl delete serviceEntries ${name} -n bookinfo`, { failOnNonZeroExit: false });
   ensureKialiFinishedLoading();
 });
@@ -96,6 +97,10 @@ And('choosing to delete it', () => {
   cy.get('#actions').should('be.visible').click();
   cy.get('#actions').contains('Delete').should('be.visible').click();
   cy.get('#pf-modal-part-2').find('button').contains('Delete').should('be.visible').click();
+});
+
+And('user closes the success notification',()=>{
+  cy.get('[aria-label="Close Success alert: alert: Istio Gateway created"]').click();
 });
 
 Then('the {string} {string} should be listed in {string} namespace', function (

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -13,7 +13,8 @@ Feature: Kiali Istio Config page
   @gateway-api
   @wizard-istio-config
   Scenario: Create a K8s Gateway scenario
-    When user clicks in the "K8sGateway" Istio config actions
+    When k8sgateway "k8sapigateway" is not created
+    And user clicks in the "K8sGateway" Istio config actions
     And user sees the "Create K8sGateway" config wizard
     And user adds listener
     And user types "k8sapigateway" in the "name" input
@@ -43,7 +44,8 @@ Feature: Kiali Istio Config page
 
   @wizard-istio-config
   Scenario: Create a Gateway scenario
-    When user clicks in the "Gateway" Istio config actions
+    When gateway "mygateway" is not created
+    And user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
     And user types "mygateway" in the "name" input
     And user adds a server to a server list
@@ -123,7 +125,8 @@ Feature: Kiali Istio Config page
 
   @wizard-istio-config
   Scenario: Create a Gateway with TLS 
-    When user clicks in the "Gateway" Istio config actions
+    When gateway "mygatewaywithtls" is not created
+    And user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
     And user types "mygatewaywithtls" in the "name" input
     And user adds a server to a server list
@@ -161,7 +164,8 @@ Feature: Kiali Istio Config page
 
   @wizard-istio-config
   Scenario: Create a ServiceEntry without ports specified 
-    When user clicks in the "ServiceEntry" Istio config actions
+    When service "myservice" is not created
+    And user clicks in the "ServiceEntry" Istio config actions
     And user sees the "Create ServiceEntry" config wizard
     And user types "myservice" in the "name" input
     And user types "website.com,website2.com" in the "hosts" input
@@ -187,7 +191,8 @@ Feature: Kiali Istio Config page
 
   @wizard-istio-config
   Scenario: Create a ServiceEntry with ports specified 
-    When user clicks in the "ServiceEntry" Istio config actions
+    When service "myservice2" is not created
+    And user clicks in the "ServiceEntry" Istio config actions
     And user sees the "Create ServiceEntry" config wizard
     And user types "myservice2" in the "name" input
     And user types "website.com,website2.com" in the "hosts" input
@@ -220,7 +225,8 @@ Feature: Kiali Istio Config page
   @gateway-api
   @wizard-istio-config
   Scenario: Create multiple K8s Gateways with colliding hostnames and port combinations and check for a reference
-    When user clicks in the "K8sGateway" Istio config actions
+    When k8sgateway "gatewayapi-1" is not created
+    And user clicks in the "K8sGateway" Istio config actions
     And user sees the "Create K8sGateway" config wizard
     And user adds listener
     And user types "gatewayapi-1" in the "name" input

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -13,7 +13,7 @@ Feature: Kiali Istio Config page
   @gateway-api
   @wizard-istio-config
   Scenario: Create a K8s Gateway scenario
-    When k8sgateway "k8sapigateway" is not created
+    When user deletes k8sgateway named "k8sapigateway" and the resource is no longer available
     And user clicks in the "K8sGateway" Istio config actions
     And user sees the "Create K8sGateway" config wizard
     And user adds listener
@@ -43,8 +43,8 @@ Feature: Kiali Istio Config page
     And the preview button should be disabled
 
   @wizard-istio-config
-  Scenario: Create a Gateway scenario
-    When gateway "mygateway" is not created
+  Scenario: Create a Gateway scenario and check that Gateway with the same name cannot be created
+    When user deletes gateway named "mygateway" and the resource is no longer available
     And user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
     And user types "mygateway" in the "name" input
@@ -56,6 +56,17 @@ Feature: Kiali Istio Config page
     And user previews the configuration
     And user creates the istio config
     Then the "Gateway" "mygateway" should be listed in "bookinfo" namespace
+    And user closes the success notification
+    And user clicks in the "Gateway" Istio config actions
+    And user sees the "Create Gateway" config wizard
+    And user types "mygateway" in the "name" input
+    And user adds a server to a server list
+    And user types "website.com" in the "hosts0" input
+    And user types "8080" in the "addPortNumber0" input
+    And user types "foobar" in the "addPortName0" input
+    And user previews the configuration
+    And user creates the istio config
+    Then an error message "Could not create Istio Gateway objects." is displayed
 
   @wizard-istio-config
   Scenario: Try to create a Gateway with negative port number
@@ -93,18 +104,6 @@ Feature: Kiali Istio Config page
     Then the preview button should be disabled
     And the "addPortNumber0" input should display a warning
 
-  @wizard-istio-config
-  Scenario: Create a Gateway with duplicate name 
-    When user clicks in the "Gateway" Istio config actions
-    And user sees the "Create Gateway" config wizard
-    And user types "mygateway" in the "name" input
-    And user adds a server to a server list
-    And user types "website.com" in the "hosts0" input
-    And user types "8080" in the "addPortNumber0" input
-    And user types "foobar" in the "addPortName0" input
-    And user previews the configuration
-    And user creates the istio config
-    Then an error message "Could not create Istio Gateway objects." is displayed
 
   @wizard-istio-config
   Scenario: Try to create a Gateway without filling the inputs related to TLS 
@@ -125,7 +124,7 @@ Feature: Kiali Istio Config page
 
   @wizard-istio-config
   Scenario: Create a Gateway with TLS 
-    When gateway "mygatewaywithtls" is not created
+    When user deletes gateway named "mygatewaywithtls" and the resource is no longer available
     And user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
     And user types "mygatewaywithtls" in the "name" input
@@ -164,7 +163,7 @@ Feature: Kiali Istio Config page
 
   @wizard-istio-config
   Scenario: Create a ServiceEntry without ports specified 
-    When service "myservice" is not created
+    When user deletes service named "myservice" and the resource is no longer available
     And user clicks in the "ServiceEntry" Istio config actions
     And user sees the "Create ServiceEntry" config wizard
     And user types "myservice" in the "name" input
@@ -191,7 +190,7 @@ Feature: Kiali Istio Config page
 
   @wizard-istio-config
   Scenario: Create a ServiceEntry with ports specified 
-    When service "myservice2" is not created
+    When user deletes service named "myservice2" and the resource is no longer available
     And user clicks in the "ServiceEntry" Istio config actions
     And user sees the "Create ServiceEntry" config wizard
     And user types "myservice2" in the "name" input
@@ -224,8 +223,9 @@ Feature: Kiali Istio Config page
 
   @gateway-api
   @wizard-istio-config
-  Scenario: Create multiple K8s Gateways with colliding hostnames and port combinations and check for a reference
-    When k8sgateway "gatewayapi-1" is not created
+  Scenario: Create multiple K8s Gateways with colliding hostnames and port combinations and check for a reference. Then delete one of them and the reference should be gone.
+    When user deletes k8sgateway named "gatewayapi-1" and the resource is no longer available
+    And user deletes k8sgateway named "gatewayapi-2" and the resource is no longer available
     And user clicks in the "K8sGateway" Istio config actions
     And user sees the "Create K8sGateway" config wizard
     And user adds listener
@@ -254,12 +254,8 @@ Feature: Kiali Istio Config page
     And the "K8sGateway" "gatewayapi-2" should be listed in "bookinfo" namespace
     When viewing the detail for "gatewayapi-1"
     Then "gatewayapi-2" should be referenced
-
-
-  @gateway-api
-  @wizard-istio-config
-  Scenario: Delete one of the K8s Gateways and check that the reference is removed
-    When viewing the detail for "gatewayapi-2"
+    When user is at the "istio" page
+    And viewing the detail for "gatewayapi-2"
     And choosing to delete it 
     Then the "K8sGateway" "gatewayapi-2" should not be listed in "bookinfo" namespace
     When viewing the detail for "gatewayapi-1"


### PR DESCRIPTION
Fixes #6073.

I added one step before all affected tests to delete the object. 

I also merged the dependent scenarios together. Do we want it this way or is there a more suitable way? The gherkins are huge. @ScriptingShrimp 