### PR TITLE
Fix OCP tests

### DIFF
--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -82,7 +82,7 @@ test-integration-setup:
 ## test-integration: Run Integration test suite
 test-integration: test-integration-setup
 	@echo Running Integration tests
-	cd tests/integration/tests && ${GO} test ${GO_TEST_FLAGS} -v -timeout 15m 2>&1 | go-junit-report > ../junit-rest-report.xml
+	cd tests/integration/tests && ${GO} test ${GO_TEST_FLAGS} -v -timeout 30m 2>&1 | go-junit-report > ../junit-rest-report.xml
 	@echo Test results can be found here: $$(ls -1 ${ROOTDIR}/tests/integration/junit-rest-report.xml)
 
 #

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -82,7 +82,7 @@ test-integration-setup:
 ## test-integration: Run Integration test suite
 test-integration: test-integration-setup
 	@echo Running Integration tests
-	cd tests/integration/tests && ${GO} test ${GO_TEST_FLAGS} -v 2>&1 | go-junit-report > ../junit-rest-report.xml
+	cd tests/integration/tests && ${GO} test ${GO_TEST_FLAGS} -v
 	@echo Test results can be found here: $$(ls -1 ${ROOTDIR}/tests/integration/junit-rest-report.xml)
 
 #

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -82,7 +82,7 @@ test-integration-setup:
 ## test-integration: Run Integration test suite
 test-integration: test-integration-setup
 	@echo Running Integration tests
-	cd tests/integration/tests && ${GO} test ${GO_TEST_FLAGS} -v
+	cd tests/integration/tests && ${GO} test ${GO_TEST_FLAGS} -v -timeout 15m
 	@echo Test results can be found here: $$(ls -1 ${ROOTDIR}/tests/integration/junit-rest-report.xml)
 
 #

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -82,7 +82,7 @@ test-integration-setup:
 ## test-integration: Run Integration test suite
 test-integration: test-integration-setup
 	@echo Running Integration tests
-	cd tests/integration/tests && ${GO} test ${GO_TEST_FLAGS} -v -timeout 15m
+	cd tests/integration/tests && ${GO} test ${GO_TEST_FLAGS} -v -timeout 15m 2>&1 | go-junit-report > ../junit-rest-report.xml
 	@echo Test results can be found here: $$(ls -1 ${ROOTDIR}/tests/integration/junit-rest-report.xml)
 
 #

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	
+
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/tests/integration/utils"
 )

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -1,13 +1,13 @@
 package tests
 
 import (
-	"os/exec"
-	"strconv"
-	"strings"
-	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
+"github.com/stretchr/testify/assert"
+"os/exec"
+"strconv"
+"strings"
+"testing""time"
+
 
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/tests/integration/utils"
@@ -54,19 +54,21 @@ func update_istio_api_enabled(value bool) {
 			waitCmd := ocCommand + " wait --for=condition=ready pod -l app=kiali -n istio-system"
 			out, err4 := exec.Command("bash", "-c", waitCmd).Output()
 
-			log.Debugf("Waiting for condition to met %s", out)
+			log.Debugf("Kiali pod ready after restart %s", out)
+			// We need this because even if the pod is really the application is not responding yet
+			time.Sleep(10 * time.Second)
 
 			if err4 != nil {
 				log.Errorf("Error waiting for pod %s ", err4.Error())
 			}
 		}
 	}
+
 }
 
 func TestNoIstiod(t *testing.T) {
 	defer update_istio_api_enabled(true)
 	update_istio_api_enabled(false)
-	time.Sleep(10 * time.Second)
 	t.Run("ServicesListNoRegistryServices", servicesListNoRegistryServices)
 	t.Run("NoProxyStatus", noProxyStatus)
 	t.Run("istioStatus", istioStatus)

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -2,9 +2,6 @@ package tests
 
 import (
 	"context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -12,7 +9,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/tests/integration/utils"
 )

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -53,7 +53,7 @@ func update_istio_api_enabled(value bool) {
 
 		if err3 == nil {
 			waitCmd2 := ocCommand + " wait --for=condition=delete pod/" + podName + " -n " + kialiNamespace
-            out2, err5 := exec.Command("bash", "-c", waitCmd2).Output()
+			out2, err5 := exec.Command("bash", "-c", waitCmd2).Output()
 
 			if err5 != nil {
 				log.Errorf("Error waiting for pod %s ", err5.Error())

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
-var ocCommand = utils.NewExecCommand()
 const kialiNamespace = "istio-system"
+
+var ocCommand = utils.NewExecCommand()
 
 func update_istio_api_enabled(value bool) {
 	original := !value

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -19,19 +19,19 @@ var ocCommand = utils.NewExecCommand()
 func update_istio_api_enabled(value bool) {
 	original := !value
 
-	cmdGetProp := ocCommand + " get cm kiali -n "+ kialiNamespace +" -o yaml | grep 'istio_api_enabled'"
+	cmdGetProp := ocCommand + " get cm kiali -n " + kialiNamespace + " -o yaml | grep 'istio_api_enabled'"
 	getPropOutput, _ := exec.Command("bash", "-c", cmdGetProp).Output()
 
 	if len(string(getPropOutput)) == 0 {
 		// Is the property is not there, we should add it, instead of replacing
-		cmdReplacecm3 := ocCommand + " get cm kiali -n "+ kialiNamespace +" -o yaml | sed -e 's|root_namespace: "+ kialiNamespace +"|root_namespace: "+ kialiNamespace +"'\r'        istio_api_enabled: " + strconv.FormatBool(value) + "|' | " + ocCommand + " apply -f -"
+		cmdReplacecm3 := ocCommand + " get cm kiali -n " + kialiNamespace + " -o yaml | sed -e 's|root_namespace: " + kialiNamespace + "|root_namespace: " + kialiNamespace + "'\r'        istio_api_enabled: " + strconv.FormatBool(value) + "|' | " + ocCommand + " apply -f -"
 		_, err := exec.Command("bash", "-c", cmdReplacecm3).Output()
 		if err != nil {
 			log.Errorf("Error updating config map: %s", err.Error())
 		}
 
 	} else {
-		cmdReplacecm := ocCommand + " get cm kiali -n "+ kialiNamespace +" -o yaml | sed -e 's|istio_api_enabled: " + strconv.FormatBool(original) + "|istio_api_enabled: " + strconv.FormatBool(value) + "|' | " + ocCommand + " apply -f -"
+		cmdReplacecm := ocCommand + " get cm kiali -n " + kialiNamespace + " -o yaml | sed -e 's|istio_api_enabled: " + strconv.FormatBool(original) + "|istio_api_enabled: " + strconv.FormatBool(value) + "|' | " + ocCommand + " apply -f -"
 		_, err := exec.Command("bash", "-c", cmdReplacecm).Output()
 		if err != nil {
 			log.Errorf("Error updating config map: %s", err.Error())
@@ -40,24 +40,24 @@ func update_istio_api_enabled(value bool) {
 
 	// Restart kiali pod
 	// Get kiali pod name
-	cmdGetPodName := ocCommand + " get pods -o name -n "+ kialiNamespace +" | egrep kiali | sed 's|pod/||'"
+	cmdGetPodName := ocCommand + " get pods -o name -n " + kialiNamespace + " | egrep kiali | sed 's|pod/||'"
 	kialiPodName, err2 := exec.Command("bash", "-c", cmdGetPodName).Output()
 	podName := strings.Replace(string(kialiPodName), "\n", "", -1)
 	log.Debugf("Kiali pod name: %s", podName)
 
 	if err2 == nil {
 		// Restart
-		cmd3 := ocCommand + " delete pod " + podName + " -n "+ kialiNamespace
+		cmd3 := ocCommand + " delete pod " + podName + " -n " + kialiNamespace
 		_, err3 := exec.Command("bash", "-c", cmd3).Output()
 		log.Debugf("Delete pod command: %s", cmd3)
 
 		if err3 == nil {
-			waitCmd2 := ocCommand + " wait --for=condition=delete pod/"+podName+" -n "+ kialiNamespace
+			waitCmd2 := ocCommand + " wait --for=condition=delete pod/"+podName+" -n " + kialiNamespace
             out2, _ := exec.Command("bash", "-c", waitCmd2).Output()
 
 			log.Debugf("Pod terminated %s", out2)
 
-			waitCmd := ocCommand + " wait --for=condition=ready pod -l app=kiali -n "+ kialiNamespace
+			waitCmd := ocCommand + " wait --for=condition=ready pod -l app=kiali -n " + kialiNamespace
 			out, err4 := exec.Command("bash", "-c", waitCmd).Output()
 
 			log.Debugf("Kiali pod ready after restart %s", out)

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -53,7 +53,11 @@ func update_istio_api_enabled(value bool) {
 
 		if err3 == nil {
 			waitCmd2 := ocCommand + " wait --for=condition=delete pod/" + podName + " -n " + kialiNamespace
-            out2, _ := exec.Command("bash", "-c", waitCmd2).Output()
+            out2, err5 := exec.Command("bash", "-c", waitCmd2).Output()
+
+			if err5 != nil {
+				log.Errorf("Error waiting for pod %s ", err5.Error())
+			}
 
 			log.Debugf("Pod terminated %s", out2)
 

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -52,7 +52,7 @@ func update_istio_api_enabled(value bool) {
 		log.Debugf("Delete pod command: %s", cmd3)
 
 		if err3 == nil {
-			waitCmd2 := ocCommand + " wait --for=condition=delete pod/"+podName+" -n " + kialiNamespace
+			waitCmd2 := ocCommand + " wait --for=condition=delete pod/" + podName + " -n " + kialiNamespace
             out2, _ := exec.Command("bash", "-c", waitCmd2).Output()
 
 			log.Debugf("Pod terminated %s", out2)

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -48,7 +48,7 @@ func update_istio_api_enabled(t *testing.T, value bool, kubeClientSet kubernetes
 	}
 
 	// Restart Kiali pod to pick up the new config.
-    require.NoError(restartKialiPod(ctx, kubeClientSet, kialiNamespace, false, podName))
+	require.NoError(restartKialiPod(ctx, kubeClientSet, kialiNamespace, false, podName))
 
 }
 

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -1,13 +1,13 @@
 package tests
 
 import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
 
-"github.com/stretchr/testify/assert"
-"os/exec"
-"strconv"
-"strings"
-"testing""time"
-
+	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/tests/integration/utils"

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -14,23 +13,24 @@ import (
 )
 
 var ocCommand = utils.NewExecCommand()
+const kialiNamespace = "istio-system"
 
 func update_istio_api_enabled(value bool) {
 	original := !value
 
-	cmdGetProp := ocCommand + " get cm kiali -n istio-system -o yaml | grep 'istio_api_enabled'"
+	cmdGetProp := ocCommand + " get cm kiali -n "+ kialiNamespace +" -o yaml | grep 'istio_api_enabled'"
 	getPropOutput, _ := exec.Command("bash", "-c", cmdGetProp).Output()
 
 	if len(string(getPropOutput)) == 0 {
 		// Is the property is not there, we should add it, instead of replacing
-		cmdReplacecm3 := ocCommand + " get cm kiali -n istio-system -o yaml | sed -e 's|root_namespace: istio-system|root_namespace: istio-system'\r'        istio_api_enabled: " + strconv.FormatBool(value) + "|' | " + ocCommand + " apply -f -"
+		cmdReplacecm3 := ocCommand + " get cm kiali -n "+ kialiNamespace +" -o yaml | sed -e 's|root_namespace: "+ kialiNamespace +"|root_namespace: "+ kialiNamespace +"'\r'        istio_api_enabled: " + strconv.FormatBool(value) + "|' | " + ocCommand + " apply -f -"
 		_, err := exec.Command("bash", "-c", cmdReplacecm3).Output()
 		if err != nil {
 			log.Errorf("Error updating config map: %s", err.Error())
 		}
 
 	} else {
-		cmdReplacecm := ocCommand + " get cm kiali -n istio-system -o yaml | sed -e 's|istio_api_enabled: " + strconv.FormatBool(original) + "|istio_api_enabled: " + strconv.FormatBool(value) + "|' | " + ocCommand + " apply -f -"
+		cmdReplacecm := ocCommand + " get cm kiali -n "+ kialiNamespace +" -o yaml | sed -e 's|istio_api_enabled: " + strconv.FormatBool(original) + "|istio_api_enabled: " + strconv.FormatBool(value) + "|' | " + ocCommand + " apply -f -"
 		_, err := exec.Command("bash", "-c", cmdReplacecm).Output()
 		if err != nil {
 			log.Errorf("Error updating config map: %s", err.Error())
@@ -39,24 +39,27 @@ func update_istio_api_enabled(value bool) {
 
 	// Restart kiali pod
 	// Get kiali pod name
-	cmdGetPodName := ocCommand + " get pods -o name -n istio-system | egrep kiali | sed 's|pod/||'"
+	cmdGetPodName := ocCommand + " get pods -o name -n "+ kialiNamespace +" | egrep kiali | sed 's|pod/||'"
 	kialiPodName, err2 := exec.Command("bash", "-c", cmdGetPodName).Output()
 	podName := strings.Replace(string(kialiPodName), "\n", "", -1)
 	log.Debugf("Kiali pod name: %s", podName)
 
 	if err2 == nil {
 		// Restart
-		cmd3 := ocCommand + " delete pod " + podName + " -n istio-system"
+		cmd3 := ocCommand + " delete pod " + podName + " -n "+ kialiNamespace
 		_, err3 := exec.Command("bash", "-c", cmd3).Output()
 		log.Debugf("Delete pod command: %s", cmd3)
 
 		if err3 == nil {
-			waitCmd := ocCommand + " wait --for=condition=ready pod -l app=kiali -n istio-system"
+			waitCmd2 := ocCommand + " wait --for=condition=delete pod/"+podName+" -n "+ kialiNamespace
+            out2, _ := exec.Command("bash", "-c", waitCmd2).Output()
+
+			log.Debugf("Pod terminated %s", out2)
+
+			waitCmd := ocCommand + " wait --for=condition=ready pod -l app=kiali -n "+ kialiNamespace
 			out, err4 := exec.Command("bash", "-c", waitCmd).Output()
 
 			log.Debugf("Kiali pod ready after restart %s", out)
-			// We need this because even if the pod is really the application is not responding yet
-			time.Sleep(10 * time.Second)
 
 			if err4 != nil {
 				log.Errorf("Error waiting for pod %s ", err4.Error())

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -249,7 +249,7 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 
 		for _, pod := range pods.Items {
 			for _, condition := range pod.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "true" && pod.Name != currentKialiPod.Name {
+				if condition.Type == "Ready" && condition.Status == "True" && pod.Name != currentKialiPod.Name {
 					log.Debug("New kiali pod is not ready.")
 					return true, nil
 				}

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -150,7 +150,7 @@ func TestRemoteIstiod(t *testing.T) {
 		require.NoError(err)
 
 		// Restart Kiali pod to pick up the new config.
-		require.NoError(restartKialiPod(ctx, kubeClient, kialiNamespace, kialiCRDExists, currentKialiPod))
+		require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, kialiCRDExists, currentKialiPod))
 		//}
 
 		// Remove service:

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"os/exec"
 	"path"
 	"strings"
 	"testing"
@@ -228,31 +227,38 @@ func TestRemoteIstiod(t *testing.T) {
 
 // Deletes the existing kiali Pod and waits for the new one to be ready.
 func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string) error {
-	// Restart kiali pod
-	// Get kiali pod name
-	cmdGetPodName := ocCommand + " get pods -o name -n istio-system | egrep kiali | sed 's|pod/||'"
-	kialiPodName, err2 := exec.Command("bash", "-c", cmdGetPodName).Output()
-	podName := strings.Replace(string(kialiPodName), "\n", "", -1)
-	log.Debugf("Kiali pod name: %s", podName)
+	log.Debug("Restarting kiali pod")
+	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
+	if err != nil {
+		return err
+	}
+	currentKialiPod := pods.Items[0]
 
-	if err2 == nil {
-		// Restart
-		cmd3 := ocCommand + " delete pod " + podName + " -n istio-system"
-		_, err3 := exec.Command("bash", "-c", cmd3).Output()
-		log.Debugf("Delete pod command: %s", cmd3)
+	err = kubeClient.CoreV1().Pods(namespace).Delete(ctx, currentKialiPod.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
 
-		if err3 == nil {
-			waitCmd := ocCommand + " wait --for=condition=ready pod -l app=kiali -n istio-system"
-			out, err4 := exec.Command("bash", "-c", waitCmd).Output()
+	return wait.PollImmediate(time.Second*10, time.Minute*2, func() (bool, error) {
+		log.Debug("Waiting for kiali to be ready")
+		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
+		if err != nil {
+			return false, err
+		}
 
-			log.Debugf("Kiali pod ready after restart %s", out)
-			// We need this because even if the pod is really the application is not responding yet
-			time.Sleep(10 * time.Second)
-
-			if err4 != nil {
-				log.Errorf("Error waiting for pod %s ", err4.Error())
+		for _, pod := range pods.Items {
+			if pod.Name == currentKialiPod.Name {
+				log.Debug("Old kiali pod still exists.")
+				return false, nil
+			}
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == "Ready" && condition.Status == "False" {
+					log.Debug("New kiali pod is not ready.")
+					return false, nil
+				}
 			}
 		}
-	}
-	return nil
+
+		return true, nil
+	})
 }

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -149,6 +149,7 @@ func TestRemoteIstiod(t *testing.T) {
 
 			// Restart Kiali pod to pick up the new config.
 			require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, kialiCRDExists, currentKialiPod))
+			time.Sleep(10 * time.Second) // Give time for the application to be ready
 		}
 
 		// Remove service:

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -240,7 +240,7 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 		return err
 	}
 
-	return wait.PollImmediate(time.Second*10, time.Minute*2, func() (bool, error) {
+	return wait.PollImmediate(time.Second*5, time.Minute*4, func() (bool, error) {
 		log.Debug("Waiting for kiali to be ready")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
 		if err != nil {

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -240,7 +240,7 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 		return err
 	}
 	time.Sleep(5 * time.Second)
-	return wait.PollImmediate(time.Second*5, time.Minute*2, func() (bool, error) {
+	return wait.PollImmediate(time.Second*5, time.Minute*4, func() (bool, error) {
 		log.Debug("Waiting for kiali to be ready")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
 		if err != nil {

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -239,7 +239,7 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 	if err != nil {
 		return err
 	}
-
+	time.Sleep(5 * time.Second)
 	return wait.PollImmediate(time.Second*5, time.Minute*4, func() (bool, error) {
 		log.Debug("Waiting for kiali to be ready")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -258,7 +258,7 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 				}
 			}
 		}
-
+		time.Sleep(10 * time.Second)
 		return true, nil
 	})
 }

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -118,11 +118,9 @@ func TestRemoteIstiod(t *testing.T) {
 
 		var currentKialiPod string
 		pods, err := kubeClient.CoreV1().Pods(kialiDeploymentNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
-		if err != nil {
-			log.Errorf("Error getting the pods list %s", err)
-		} else {
-			currentKialiPod = pods.Items[0].Name
-		}
+		require.NoError(err)
+		require.Len(pods.Items, 1)
+		currentKialiPod = pods.Items[0].Name
 
 		if kialiCRDExists {
 			undoRegistryPatch := []byte(`[{"op": "remove", "path": "/spec/external_services/istio/registry"}]`)

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -161,9 +161,9 @@ func TestRemoteIstiod(t *testing.T) {
 		require.NoError(err)
 
 		time.Sleep(10 * time.Second)
-		
+
 		// Wait for the configmap to be updated again before exiting.
-		require.NoError(wait.PollImmediate(time.Second*5, time.Minute*2, func() (bool, error) {
+		require.NoError(wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
 			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -192,7 +192,7 @@ func TestRemoteIstiod(t *testing.T) {
 
 		// Need to know when the kiali operator has seen the CR change and finished updating
 		// the configmap. There's no ObservedGeneration on the Kiali CR so just checking the configmap itself.
-		require.NoError(wait.PollImmediate(time.Second*5, time.Minute*2, func() (bool, error) {
+		require.NoError(wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
 			log.Debug("Waiting for kiali configmap to update")
 			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
 			if err != nil {

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"os/exec"
 	"path"
 	"strings"
 	"testing"
@@ -228,67 +227,37 @@ func TestRemoteIstiod(t *testing.T) {
 
 // Deletes the existing kiali Pod and waits for the new one to be ready.
 func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string) error {
-	// Get kiali pod name
-	cmdGetPodName := ocCommand + " get pods -o name -n istio-system | egrep kiali | sed 's|pod/||'"
-	kialiPodName, err2 := exec.Command("bash", "-c", cmdGetPodName).Output()
-	podName := strings.Replace(string(kialiPodName), "\n", "", -1)
-	log.Debugf("Kiali pod name: %s", podName)
-
-	if err2 == nil {
-		// Restart
-		cmd3 := ocCommand + " delete pod " + podName + " -n istio-system"
-		_, err3 := exec.Command("bash", "-c", cmd3).Output()
-		log.Debugf("Delete pod command: %s", cmd3)
-
-		if err3 == nil {
-			waitCmd := ocCommand + " wait --for=condition=ready pod -l app=kiali -n istio-system"
-			out, err4 := exec.Command("bash", "-c", waitCmd).Output()
-
-			log.Debugf("Kiali pod ready after restart %s", out)
-			// We need this because even if the pod is really the application is not responding yet
-			time.Sleep(10 * time.Second)
-
-			if err4 != nil {
-				log.Errorf("Error waiting for pod %s ", err4.Error())
-				return err4
-			}
-		}
+	log.Debug("Restarting kiali pod")
+	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
+	if err != nil {
+		return err
 	}
-	return nil
-	/*
-		log.Debug("Restarting kiali pod")
+	currentKialiPod := pods.Items[0]
+
+	err = kubeClient.CoreV1().Pods(namespace).Delete(ctx, currentKialiPod.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return wait.PollImmediate(time.Second*20, time.Minute*2, func() (bool, error) {
+		log.Debug("Waiting for kiali to be ready")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
 		if err != nil {
-			return err
-		}
-		currentKialiPod := pods.Items[0]
-
-		err = kubeClient.CoreV1().Pods(namespace).Delete(ctx, currentKialiPod.Name, metav1.DeleteOptions{})
-		if err != nil {
-			return err
+			return false, err
 		}
 
-		return wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
-			log.Debug("Waiting for kiali to be ready")
-			pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
-			if err != nil {
-				return false, err
+		for _, pod := range pods.Items {
+			if pod.Name == currentKialiPod.Name {
+				log.Debug("Old kiali pod still exists.")
+				return false, nil
 			}
-
-			for _, pod := range pods.Items {
-				if pod.Name == currentKialiPod.Name {
-					log.Debug("Old kiali pod still exists.")
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == "Ready" && condition.Status == "False" {
+					log.Debug("New kiali pod is not ready.")
 					return false, nil
 				}
-				for _, condition := range pod.Status.Conditions {
-					if condition.Type == "Ready" && condition.Status == "False" {
-						log.Debug("New kiali pod is not ready.")
-						return false, nil
-					}
-				}
 			}
-			return true, nil
-		})
-
-	*/
+		}
+		return true, nil
+	})
 }

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -127,8 +127,9 @@ func TestRemoteIstiod(t *testing.T) {
 
 		if kialiCRDExists {
 			undoRegistryPatch := []byte(`[{"op": "remove", "path": "/spec/external_services/istio/registry"}]`)
-			_, err = dynamicClient.Resource(kialiGVR).Namespace(kialiNamespace).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
-			require.NoError(err)
+			response, err2 := dynamicClient.Resource(kialiGVR).Namespace(kialiNamespace).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
+			log.Info("Response code [ %v ] body", response)
+			require.NoError(err2)
 		} else {
 			// Update the configmap directly by getting the configmap and patching it.
 			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -72,7 +72,7 @@ func TestRemoteIstiod(t *testing.T) {
 	dynamicClient := dynamicClient(t)
 	kialiGVR := schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
 
-	deadline, _ := t.Deadline()
+	deadline := time.Now().Local().Add(15 * time.Minute)
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	// This is used by cleanup so needs to be added to cleanup instead of deferred.
 	t.Cleanup(cancel)

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -72,7 +72,8 @@ func TestRemoteIstiod(t *testing.T) {
 	dynamicClient := dynamicClient(t)
 	kialiGVR := schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
 
-	deadline, _ := t.Deadline()
+	//deadline, _ := t.Deadline()
+	deadline := time.Now().Local().Add(10 * time.Minute)
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	// This is used by cleanup so needs to be added to cleanup instead of deferred.
 	t.Cleanup(cancel)

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -160,8 +160,6 @@ func TestRemoteIstiod(t *testing.T) {
 		_, err = kubeClient.AppsV1().Deployments("istio-system").Update(ctx, istiod, metav1.UpdateOptions{})
 		require.NoError(err)
 
-		time.Sleep(10 * time.Second)
-
 		// Wait for the configmap to be updated again before exiting.
 		require.NoError(wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
 			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -186,6 +186,8 @@ func TestRemoteIstiod(t *testing.T) {
 		}), "Error waiting for kiali configmap to update")
 
 		require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, kialiCRDExists, currentKialiPod))
+
+		time.Sleep(10 * time.Second) // Give time for the application to be ready
 	})
 
 	// Expose the istiod /debug endpoints by adding a proxy to the pod.

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -243,7 +243,7 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 		return err
 	}
 
-	return wait.PollImmediate(time.Second*5, time.Minute*2, func() (bool, error) {
+	return wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
 		log.Debug("Waiting for kiali to be ready")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
 		if err != nil {

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -124,31 +124,31 @@ func TestRemoteIstiod(t *testing.T) {
 		} else {
 			currentKialiPod = pods.Items[0].Name
 		}
+		/*
+			if kialiCRDExists {
+				undoRegistryPatch := []byte(`[{"op": "remove", "path": "/spec/external_services/istio/registry"}]`)
+				response, err2 := dynamicClient.Resource(kialiGVR).Namespace(kialiNamespace).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
+				log.Info("Response code [ %v ] body", response)
+				require.NoError(err2)
+			} else { */
+		// Update the configmap directly by getting the configmap and patching it.
+		cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
+		require.NoError(err)
 
-		if kialiCRDExists {
-			undoRegistryPatch := []byte(`[{"op": "remove", "path": "/spec/external_services/istio/registry"}]`)
-			response, err2 := dynamicClient.Resource(kialiGVR).Namespace(kialiNamespace).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
-			log.Info("Response code [ %v ] body", response)
-			require.NoError(err2)
-		} else {
-			// Update the configmap directly by getting the configmap and patching it.
-			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
-			require.NoError(err)
+		var currentConfig config.Config
+		require.NoError(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &currentConfig))
+		currentConfig.ExternalServices.Istio.Registry = nil
 
-			var currentConfig config.Config
-			require.NoError(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &currentConfig))
-			currentConfig.ExternalServices.Istio.Registry = nil
+		newConfig, err := yaml.Marshal(currentConfig)
+		require.NoError(err)
+		cm.Data["config.yaml"] = string(newConfig)
 
-			newConfig, err := yaml.Marshal(currentConfig)
-			require.NoError(err)
-			cm.Data["config.yaml"] = string(newConfig)
+		_, err = kubeClient.CoreV1().ConfigMaps(kialiNamespace).Update(ctx, cm, metav1.UpdateOptions{})
+		require.NoError(err)
 
-			_, err = kubeClient.CoreV1().ConfigMaps(kialiNamespace).Update(ctx, cm, metav1.UpdateOptions{})
-			require.NoError(err)
-
-			// Restart Kiali pod to pick up the new config.
-			require.NoError(restartKialiPod(ctx, kubeClient, kialiNamespace, kialiCRDExists, currentKialiPod))
-		}
+		// Restart Kiali pod to pick up the new config.
+		require.NoError(restartKialiPod(ctx, kubeClient, kialiNamespace, kialiCRDExists, currentKialiPod))
+		//}
 
 		// Remove service:
 		err = kubeClient.CoreV1().Services("istio-system").Delete(ctx, "istiod-debug", metav1.DeleteOptions{})

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -247,16 +247,14 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 			return false, err
 		}
 
-		podready := false
 		for _, pod := range pods.Items {
 			for _, condition := range pod.Status.Conditions {
 				if condition.Type == "Ready" && condition.Status == "true" && pod.Name != currentKialiPod.Name {
 					log.Debug("New kiali pod is not ready.")
-					podready = true
+					return true, nil
 				}
 			}
 		}
-
-		return podready, nil
+		return false, nil
 	})
 }

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"os/exec"
 	"path"
 	"strings"
 	"testing"
@@ -137,8 +138,6 @@ func TestRemoteIstiod(t *testing.T) {
 
 			// Restart Kiali pod to pick up the new config.
 			require.NoError(restartKialiPod(ctx, kubeClient, kialiNamespace))
-			// Pod is ready but app might not be ready
-			time.Sleep(10 * time.Second)
 		}
 
 		// Remove service:
@@ -221,8 +220,6 @@ func TestRemoteIstiod(t *testing.T) {
 
 	// Restart Kiali pod to pick up the new config.
 	require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace), "Error waiting for kiali deployment to update")
-	// Pod is ready but app might not be ready
-	time.Sleep(10 * time.Second)
 
 	configs, err := utils.IstioConfigs()
 	require.NoError(err)
@@ -231,37 +228,67 @@ func TestRemoteIstiod(t *testing.T) {
 
 // Deletes the existing kiali Pod and waits for the new one to be ready.
 func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string) error {
-	log.Debug("Restarting kiali pod")
-	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
-	if err != nil {
-		return err
-	}
-	currentKialiPod := pods.Items[0]
+	// Get kiali pod name
+	cmdGetPodName := ocCommand + " get pods -o name -n istio-system | egrep kiali | sed 's|pod/||'"
+	kialiPodName, err2 := exec.Command("bash", "-c", cmdGetPodName).Output()
+	podName := strings.Replace(string(kialiPodName), "\n", "", -1)
+	log.Debugf("Kiali pod name: %s", podName)
 
-	err = kubeClient.CoreV1().Pods(namespace).Delete(ctx, currentKialiPod.Name, metav1.DeleteOptions{})
-	if err != nil {
-		return err
-	}
+	if err2 == nil {
+		// Restart
+		cmd3 := ocCommand + " delete pod " + podName + " -n istio-system"
+		_, err3 := exec.Command("bash", "-c", cmd3).Output()
+		log.Debugf("Delete pod command: %s", cmd3)
 
-	return wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
-		log.Debug("Waiting for kiali to be ready")
+		if err3 == nil {
+			waitCmd := ocCommand + " wait --for=condition=ready pod -l app=kiali -n istio-system"
+			out, err4 := exec.Command("bash", "-c", waitCmd).Output()
+
+			log.Debugf("Kiali pod ready after restart %s", out)
+			// We need this because even if the pod is really the application is not responding yet
+			time.Sleep(10 * time.Second)
+
+			if err4 != nil {
+				log.Errorf("Error waiting for pod %s ", err4.Error())
+				return err4
+			}
+		}
+	}
+	return nil
+	/*
+		log.Debug("Restarting kiali pod")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
 		if err != nil {
-			return false, err
+			return err
+		}
+		currentKialiPod := pods.Items[0]
+
+		err = kubeClient.CoreV1().Pods(namespace).Delete(ctx, currentKialiPod.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
 		}
 
-		for _, pod := range pods.Items {
-			if pod.Name == currentKialiPod.Name {
-				log.Debug("Old kiali pod still exists.")
-				return false, nil
+		return wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
+			log.Debug("Waiting for kiali to be ready")
+			pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
+			if err != nil {
+				return false, err
 			}
-			for _, condition := range pod.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "False" {
-					log.Debug("New kiali pod is not ready.")
+
+			for _, pod := range pods.Items {
+				if pod.Name == currentKialiPod.Name {
+					log.Debug("Old kiali pod still exists.")
 					return false, nil
 				}
+				for _, condition := range pod.Status.Conditions {
+					if condition.Type == "Ready" && condition.Status == "False" {
+						log.Debug("New kiali pod is not ready.")
+						return false, nil
+					}
+				}
 			}
-		}
-		return true, nil
-	})
+			return true, nil
+		})
+
+	*/
 }

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -249,12 +249,8 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 
 		podready := false
 		for _, pod := range pods.Items {
-			if pod.Name == currentKialiPod.Name {
-				log.Debug("Old kiali pod still exists.")
-				return false, nil
-			}
 			for _, condition := range pod.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "true" {
+				if condition.Type == "Ready" && condition.Status == "true" && pod.Name != currentKialiPod.Name {
 					log.Debug("New kiali pod is not ready.")
 					podready = true
 				}

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -160,6 +160,8 @@ func TestRemoteIstiod(t *testing.T) {
 		_, err = kubeClient.AppsV1().Deployments("istio-system").Update(ctx, istiod, metav1.UpdateOptions{})
 		require.NoError(err)
 
+		time.Sleep(10 * time.Second)
+		
 		// Wait for the configmap to be updated again before exiting.
 		require.NoError(wait.PollImmediate(time.Second*5, time.Minute*2, func() (bool, error) {
 			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
@@ -181,7 +183,7 @@ func TestRemoteIstiod(t *testing.T) {
 	// Then create a service for the proxy/debug endpoint.
 	require.True(utils.ApplyFile(assetsFolder+"/remote-istiod/istiod-debug-service.yaml", "istio-system"), "Could not create istiod debug service")
 
-	// Now patch kiali to use that remote endpoint.
+	// Now patch kiali to use that remote endpoint.istio/multicluster/install-primary-remote.sh -c kubectl -kudi true -kshc ~/dev/kiali_sources/helm-charts/_output/charts/kiali-server-1.64.0-SNAPSHOT.tgz
 	log.Debug("Patching kiali to use remote istiod")
 	if kialiCRDExists {
 		registryPatch := []byte(`{"spec": {"external_services": {"istio": {"registry": {"istiod_url": "http://istiod-debug.istio-system:9240"}}}}}`)

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -149,7 +149,6 @@ func TestRemoteIstiod(t *testing.T) {
 
 			// Restart Kiali pod to pick up the new config.
 			require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, kialiCRDExists, currentKialiPod))
-			time.Sleep(10 * time.Second) // Give time for the application to be ready
 		}
 
 		// Remove service:
@@ -190,8 +189,6 @@ func TestRemoteIstiod(t *testing.T) {
 		}), "Error waiting for kiali configmap to update")
 
 		require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, kialiCRDExists, currentKialiPod))
-
-		time.Sleep(10 * time.Second) // Give time for the application to be ready
 	})
 
 	// Expose the istiod /debug endpoints by adding a proxy to the pod.

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -72,8 +72,7 @@ func TestRemoteIstiod(t *testing.T) {
 	dynamicClient := dynamicClient(t)
 	kialiGVR := schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
 
-	//deadline, _ := t.Deadline()
-	deadline := time.Now().Local().Add(10 * time.Minute)
+	deadline, _ := t.Deadline()
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	// This is used by cleanup so needs to be added to cleanup instead of deferred.
 	t.Cleanup(cancel)
@@ -127,9 +126,7 @@ func TestRemoteIstiod(t *testing.T) {
 
 		if kialiCRDExists {
 			undoRegistryPatch := []byte(`[{"op": "remove", "path": "/spec/external_services/istio/registry"}]`)
-			response, err2 := dynamicClient.Resource(kialiGVR).Namespace(kialiNamespace).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
-			//response, err2 := dynamicClient.Resource(kialiGVR).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
-			log.Info("Response code [ %v ] body", response)
+			_, err2 := dynamicClient.Resource(kialiGVR).Namespace(kialiNamespace).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
 			require.NoError(err2)
 		} else {
 			// Update the configmap directly by getting the configmap and patching it.
@@ -144,8 +141,8 @@ func TestRemoteIstiod(t *testing.T) {
 			require.NoError(err)
 			cm.Data["config.yaml"] = string(newConfig)
 
-			log.Infof("Kiali namespace: %s ", kialiNamespace)
-			log.Infof("Kiali deployment namespace: %s ", kialiDeploymentNamespace)
+			log.Debugf("Kiali namespace: %s ", kialiNamespace)
+			log.Debugf("Kiali deployment namespace: %s ", kialiDeploymentNamespace)
 
 			_, err = kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Update(ctx, cm, metav1.UpdateOptions{})
 			require.NoError(err)

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -143,7 +143,10 @@ func TestRemoteIstiod(t *testing.T) {
 		require.NoError(err)
 		cm.Data["config.yaml"] = string(newConfig)
 
-		_, err = kubeClient.CoreV1().ConfigMaps(kialiNamespace).Update(ctx, cm, metav1.UpdateOptions{})
+		log.Info("Kiali namespace: %s ", kialiNamespace)
+		log.Info("Kiali deplument namespace: %s ", kialiDeploymentNamespace)
+
+		_, err = kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Update(ctx, cm, metav1.UpdateOptions{})
 		require.NoError(err)
 
 		// Restart Kiali pod to pick up the new config.

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"os/exec"
 	"path"
 	"strings"
 	"testing"
@@ -43,7 +44,7 @@ func dynamicClient(t *testing.T) dynamic.Interface {
 	return client
 }
 
-func createKubeClient(t *testing.T) kubernetes.Interface {
+func kubeClient(t *testing.T) kubernetes.Interface {
 	t.Helper()
 
 	cfg, err := cmd.GetKubeConfig()
@@ -68,7 +69,7 @@ func TestRemoteIstiod(t *testing.T) {
 	proxyPatch, err := kubeyaml.ToJSON(kialiKube.ReadFile(t, proxyPatchPath))
 	require.NoError(err)
 
-	kubeClient := createKubeClient(t)
+	kubeClient := kubeClient(t)
 	dynamicClient := dynamicClient(t)
 	kialiGVR := schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
 
@@ -227,38 +228,31 @@ func TestRemoteIstiod(t *testing.T) {
 
 // Deletes the existing kiali Pod and waits for the new one to be ready.
 func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string) error {
-	log.Debug("Restarting kiali pod")
-	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
-	if err != nil {
-		return err
-	}
-	currentKialiPod := pods.Items[0]
+	// Restart kiali pod
+	// Get kiali pod name
+	cmdGetPodName := ocCommand + " get pods -o name -n istio-system | egrep kiali | sed 's|pod/||'"
+	kialiPodName, err2 := exec.Command("bash", "-c", cmdGetPodName).Output()
+	podName := strings.Replace(string(kialiPodName), "\n", "", -1)
+	log.Debugf("Kiali pod name: %s", podName)
 
-	err = kubeClient.CoreV1().Pods(namespace).Delete(ctx, currentKialiPod.Name, metav1.DeleteOptions{})
-	if err != nil {
-		return err
-	}
+	if err2 == nil {
+		// Restart
+		cmd3 := ocCommand + " delete pod " + podName + " -n istio-system"
+		_, err3 := exec.Command("bash", "-c", cmd3).Output()
+		log.Debugf("Delete pod command: %s", cmd3)
 
-	return wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
-		log.Debug("Waiting for kiali to be ready")
-		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
-		if err != nil {
-			return false, err
-		}
+		if err3 == nil {
+			waitCmd := ocCommand + " wait --for=condition=ready pod -l app=kiali -n istio-system"
+			out, err4 := exec.Command("bash", "-c", waitCmd).Output()
 
-		for _, pod := range pods.Items {
-			if pod.Name == currentKialiPod.Name {
-				log.Debug("Old kiali pod still exists.")
-				return false, nil
-			}
-			for _, condition := range pod.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "False" {
-					log.Debug("New kiali pod is not ready.")
-					return false, nil
-				}
+			log.Debugf("Kiali pod ready after restart %s", out)
+			// We need this because even if the pod is really the application is not responding yet
+			time.Sleep(10 * time.Second)
+
+			if err4 != nil {
+				log.Errorf("Error waiting for pod %s ", err4.Error())
 			}
 		}
-
-		return true, nil
-	})
+	}
+	return nil
 }

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -137,6 +137,8 @@ func TestRemoteIstiod(t *testing.T) {
 
 			// Restart Kiali pod to pick up the new config.
 			require.NoError(restartKialiPod(ctx, kubeClient, kialiNamespace))
+			// Pod is ready but app might not be ready
+			time.Sleep(10 * time.Second)
 		}
 
 		// Remove service:
@@ -169,6 +171,8 @@ func TestRemoteIstiod(t *testing.T) {
 		}), "Error waiting for kiali configmap to update")
 
 		require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace))
+		// Pod is ready but app might not be ready
+		time.Sleep(10 * time.Second)
 	})
 
 	// Expose the istiod /debug endpoints by adding a proxy to the pod.

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -239,7 +239,7 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 		return err
 	}
 
-	return wait.PollImmediate(time.Second*5, time.Minute*2, func() (bool, error) {
+	pollErr := wait.PollImmediate(time.Second*5, time.Minute*2, func() (bool, error) {
 		log.Debug("Waiting for kiali to be ready")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
 		if err != nil {
@@ -258,7 +258,12 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 				}
 			}
 		}
-		time.Sleep(10 * time.Second)
 		return true, nil
 	})
+
+	if pollErr == nil {
+		time.Sleep(10 * time.Second)
+		return nil
+	}
+	return pollErr
 }

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -43,7 +43,7 @@ func dynamicClient(t *testing.T) dynamic.Interface {
 	return client
 }
 
-func kubeClient(t *testing.T) kubernetes.Interface {
+func createKubeClient(t *testing.T) kubernetes.Interface {
 	t.Helper()
 
 	cfg, err := cmd.GetKubeConfig()
@@ -68,7 +68,7 @@ func TestRemoteIstiod(t *testing.T) {
 	proxyPatch, err := kubeyaml.ToJSON(kialiKube.ReadFile(t, proxyPatchPath))
 	require.NoError(err)
 
-	kubeClient := kubeClient(t)
+	kubeClient := createKubeClient(t)
 	dynamicClient := dynamicClient(t)
 	kialiGVR := schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
 
@@ -239,7 +239,7 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 		return err
 	}
 
-	return wait.PollImmediate(time.Second*5, time.Minute*2, func() (bool, error) {
+	return wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
 		log.Debug("Waiting for kiali to be ready")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
 		if err != nil {

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -124,34 +124,34 @@ func TestRemoteIstiod(t *testing.T) {
 		} else {
 			currentKialiPod = pods.Items[0].Name
 		}
+		/*
+			if kialiCRDExists {
+				undoRegistryPatch := []byte(`[{"op": "remove", "path": "/spec/external_services/istio/registry"}]`)
+				response, err2 := dynamicClient.Resource(kialiGVR).Namespace(kialiNamespace).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
+				log.Info("Response code [ %v ] body", response)
+				require.NoError(err2)
+			} else { */
+		// Update the configmap directly by getting the configmap and patching it.
+		cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
+		require.NoError(err)
 
-		if kialiCRDExists {
-			undoRegistryPatch := []byte(`[{"op": "remove", "path": "/spec/external_services/istio/registry"}]`)
-			response, err2 := dynamicClient.Resource(kialiGVR).Namespace(kialiDeploymentNamespace).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
-			log.Info("Response code [ %v ] body", response)
-			require.NoError(err2)
-		} else {
-			// Update the configmap directly by getting the configmap and patching it.
-			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
-			require.NoError(err)
+		var currentConfig config.Config
+		require.NoError(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &currentConfig))
+		currentConfig.ExternalServices.Istio.Registry = nil
 
-			var currentConfig config.Config
-			require.NoError(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &currentConfig))
-			currentConfig.ExternalServices.Istio.Registry = nil
+		newConfig, err := yaml.Marshal(currentConfig)
+		require.NoError(err)
+		cm.Data["config.yaml"] = string(newConfig)
 
-			newConfig, err := yaml.Marshal(currentConfig)
-			require.NoError(err)
-			cm.Data["config.yaml"] = string(newConfig)
+		log.Infof("Kiali namespace: %s ", kialiNamespace)
+		log.Infof("Kiali deployment namespace: %s ", kialiDeploymentNamespace)
 
-			log.Infof("Kiali namespace: %s ", kialiNamespace)
-			log.Infof("Kiali deployment namespace: %s ", kialiDeploymentNamespace)
+		_, err = kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Update(ctx, cm, metav1.UpdateOptions{})
+		require.NoError(err)
 
-			_, err = kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Update(ctx, cm, metav1.UpdateOptions{})
-			require.NoError(err)
-
-			// Restart Kiali pod to pick up the new config.
-			require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, kialiCRDExists, currentKialiPod))
-		}
+		// Restart Kiali pod to pick up the new config.
+		require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, false, currentKialiPod))
+		//}
 
 		// Remove service:
 		err = kubeClient.CoreV1().Services("istio-system").Delete(ctx, "istiod-debug", metav1.DeleteOptions{})

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -161,7 +161,7 @@ func TestRemoteIstiod(t *testing.T) {
 		require.NoError(err)
 
 		// Wait for the configmap to be updated again before exiting.
-		require.NoError(wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
+		require.NoError(wait.PollImmediate(time.Second*20, time.Minute*2, func() (bool, error) {
 			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -190,7 +190,7 @@ func TestRemoteIstiod(t *testing.T) {
 
 		// Need to know when the kiali operator has seen the CR change and finished updating
 		// the configmap. There's no ObservedGeneration on the Kiali CR so just checking the configmap itself.
-		require.NoError(wait.PollImmediate(time.Second*15, time.Minute*2, func() (bool, error) {
+		require.NoError(wait.PollImmediate(time.Second*20, time.Minute*2, func() (bool, error) {
 			log.Debug("Waiting for kiali configmap to update")
 			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
 			if err != nil {

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -169,6 +169,7 @@ func TestRemoteIstiod(t *testing.T) {
 			return !strings.Contains(cm.Data["config.yaml"], "http://istiod-debug.istio-system:9240"), nil
 		}), "Error waiting for kiali configmap to update")
 
+		time.Sleep(10 * time.Second) // Give time to be ready
 		require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace))
 	})
 
@@ -244,6 +245,7 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 		log.Debug("Waiting for kiali to be ready")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
 		if err != nil {
+			log.Error("Error getting the pods list %s", err)
 			return false, err
 		}
 

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -171,8 +171,6 @@ func TestRemoteIstiod(t *testing.T) {
 		}), "Error waiting for kiali configmap to update")
 
 		require.NoError(restartKialiPod(ctx, kubeClient, kialiDeploymentNamespace))
-		// Pod is ready but app might not be ready
-		time.Sleep(10 * time.Second)
 	})
 
 	// Expose the istiod /debug endpoints by adding a proxy to the pod.

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -178,6 +178,7 @@ func TestRemoteIstiod(t *testing.T) {
 			log.Error("Error getting the pods list %s", err)
 		} else {
 			currentKialiPod = pods.Items[0].Name
+			log.Infof("Current Kiali pod %s", currentKialiPod)
 		}
 
 		// Wait for the configmap to be updated again before exiting.
@@ -259,7 +260,7 @@ func TestRemoteIstiod(t *testing.T) {
 
 // Deletes the existing kiali Pod and waits for the new one to be ready.
 func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string, kialiCRDExists bool, currentKialiPod string) error {
-	log.Debug("Restarting kiali pod")
+	log.Debug("Restarting kiali pod %s %s", namespace, currentKialiPod)
 
 	// Restart Kiali pod when kiali CRD does not exist
 	if !kialiCRDExists {
@@ -283,6 +284,8 @@ func restartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 				if condition.Type == "Ready" && condition.Status == "True" && pod.Name != currentKialiPod {
 					log.Debug("New kiali pod is not ready.")
 					return true, nil
+				} else {
+					log.Debug("Condition type %s status %s pod name %s", condition.Type, condition.Status, pod.Name)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6121

There was a couple of failures: 

- **no_istiod**: It is not enough for wait for the pod to be ready, we need to wait to the old pod is terminated. Otherwise, doing a request to the application we receive an error `The application is currently not serving requests at this endpoint. It may not have been started or is still starting.`
-  **remote_istiod**: There was a couple of things: 
   - One of the calls was using wrong namespace (kialiNS vs KialiDeploymentNS)
   - It is safer to don't delete the pod it a Kiali CRD exists - The operator will handle it.  
   - Time out per test has to be increased