### PR TITLE
Skip loading istio configs from registry for remote clusters.

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -200,7 +200,8 @@ func (in *IstioConfigService) GetIstioConfigListPerCluster(ctx context.Context, 
 	}
 
 	// Use the Istio Registry when AllNamespaces is present
-	if criteria.AllNamespaces && in.config.ExternalServices.Istio.IstioAPIEnabled {
+	// TODO use Istio Registry for Home cluster only now
+	if criteria.AllNamespaces && in.config.ExternalServices.Istio.IstioAPIEnabled && cluster == config.Get().KubernetesConfig.ClusterName {
 		registryCriteria := RegistryCriteria{
 			AllNamespaces: true,
 		}

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -277,6 +277,11 @@ func (in *IstioConfigService) GetIstioConfigListPerCluster(ctx context.Context, 
 		return istioConfigList, fmt.Errorf("K8s Client [%s] is not found or is not accessible for Kiali", cluster)
 	}
 
+	if cluster != config.Get().KubernetesConfig.ClusterName && !kubeCache.Client().IsIstioAPI() {
+		log.Infof("Cluster [%s] does not have Istio API installed", cluster)
+		return istioConfigList, nil
+	}
+
 	if !criteria.AllNamespaces {
 		// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 		// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -199,18 +199,9 @@ func (in *IstioConfigService) GetIstioConfigListPerCluster(ctx context.Context, 
 		RequestAuthentications: []*security_v1beta1.RequestAuthentication{},
 	}
 
-	kubeCache := in.kialiCache.GetKubeCaches()[cluster]
-	if kubeCache == nil {
-		return istioConfigList, fmt.Errorf("K8s Cache [%s] is not found or is not accessible for Kiali", cluster)
-	}
-	userClient := in.userClients[cluster]
-	if userClient == nil {
-		return istioConfigList, fmt.Errorf("K8s Client [%s] is not found or is not accessible for Kiali", cluster)
-	}
-
 	// Use the Istio Registry when AllNamespaces is present
 	// TODO use Istio Registry for Home cluster only now
-	if criteria.AllNamespaces && kubeCache.Client().IsIstioAPI() && cluster == config.Get().KubernetesConfig.ClusterName {
+	if criteria.AllNamespaces && in.config.ExternalServices.Istio.IstioAPIEnabled && cluster == config.Get().KubernetesConfig.ClusterName {
 		registryCriteria := RegistryCriteria{
 			AllNamespaces: true,
 		}
@@ -276,6 +267,14 @@ func (in *IstioConfigService) GetIstioConfigListPerCluster(ctx context.Context, 
 		}
 
 		return istioConfigList, nil
+	}
+	kubeCache := in.kialiCache.GetKubeCaches()[cluster]
+	if kubeCache == nil {
+		return istioConfigList, fmt.Errorf("K8s Cache [%s] is not found or is not accessible for Kiali", cluster)
+	}
+	userClient := in.userClients[cluster]
+	if userClient == nil {
+		return istioConfigList, fmt.Errorf("K8s Client [%s] is not found or is not accessible for Kiali", cluster)
 	}
 
 	if cluster != config.Get().KubernetesConfig.ClusterName && !kubeCache.Client().IsIstioAPI() {

--- a/frontend/src/hooks/services.ts
+++ b/frontend/src/hooks/services.ts
@@ -31,7 +31,7 @@ export function useServiceDetail(
     setIsLoading(true); // Mark as loading
     let getDetailPromise = API.getServiceDetail(namespace, serviceName, false, cluster, duration);
     let getGwPromise = API.getAllIstioConfigs([], ['gateways'], false, '', '', cluster);
-    let getPeerAuthsPromise = API.getIstioConfig(namespace, ['peerauthentications'], false, '', '');
+    let getPeerAuthsPromise = API.getIstioConfig(namespace, ['peerauthentications'], false, '', '', cluster);
 
     const allPromise = new CancelablePromise(Promise.all([getDetailPromise, getGwPromise, getPeerAuthsPromise]));
     allPromise.promise

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -96,7 +96,14 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
     });
     const workloadSelector = wkLabels.join(',');
 
-    API.getIstioConfig(this.props.namespace, workloadIstioResources, true, '', workloadSelector)
+    API.getIstioConfig(
+      this.props.namespace,
+      workloadIstioResources,
+      true,
+      '',
+      workloadSelector,
+      this.props.workload.cluster
+    )
       .then(results => {
         this.setState({ workloadIstioConfig: results.data });
       })

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -181,7 +181,8 @@ export const getIstioConfig = (
   objects: string[],
   validate: boolean,
   labelSelector: string,
-  workloadSelector: string
+  workloadSelector: string,
+  cluster?: string
 ): Promise<Response<IstioConfigList>> => {
   const params: any = objects && objects.length > 0 ? { objects: objects.join(',') } : {};
   if (validate) {
@@ -192,6 +193,9 @@ export const getIstioConfig = (
   }
   if (workloadSelector) {
     params.workloadSelector = workloadSelector;
+  }
+  if (cluster) {
+    params.cluster = cluster;
   }
   return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
 };


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/6063

Skipping Registry usage for now for remote clusters because still the home cluster istiod is called when loading from registry.

Now the configs are not duplicated between clusters.
Tested also in primary remote mode when Istio CRDs are installed (https://raw.githubusercontent.com/istio/istio/master/manifests/charts/base/crds/crd-all.gen.yaml)

![Screenshot from 2023-05-09 17-16-35](https://github.com/kiali/kiali/assets/604313/8d9de347-8bec-4c3c-ad5a-6a4caf0de8be)
