### PR TITLE
Added missing cluster params in Service/App Details pages links

### DIFF
--- a/frontend/src/components/Details/DetailDescription.tsx
+++ b/frontend/src/components/Details/DetailDescription.tsx
@@ -195,7 +195,10 @@ class DetailDescription extends React.Component<Props> {
       }
     }
     if (workload) {
-      const href = '/namespaces/' + this.props.namespace + '/workloads/' + workload.workloadName;
+      let href = '/namespaces/' + this.props.namespace + '/workloads/' + workload.workloadName;
+      if (this.props.cluster) {
+        href = href + '?cluster=' + this.props.cluster;
+      }
       const link = isParentKiosk(this.props.kiosk) ? (
         <Link
           to={''}

--- a/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -196,6 +196,7 @@ class ServiceDescription extends React.Component<ServiceInfoDescriptionProps, St
             apps={apps}
             workloads={workloads}
             health={this.props.serviceDetails?.health}
+            cluster={this.props.serviceDetails?.cluster}
           />
         </CardBody>
       </Card>


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6127

How to test:
App, Workload and Service details page's Overview sections contain cross links, which should contain `cluster` param.