### PR TITLE
Workload and App lists are loading Istio configs per cluster.

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -134,7 +134,7 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 		IncludeSidecars:               true,
 		IncludeVirtualServices:        true,
 	}
-	var istioConfigList models.IstioConfigList
+	var istioConfigMap models.IstioConfigMap
 
 	// TODO: MC
 	if criteria.IncludeIstioResources {
@@ -145,7 +145,7 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 		go func(ctx context.Context) {
 			defer wg2.Done()
 			var err2 error
-			istioConfigList, err2 = in.businessLayer.IstioConfig.GetIstioConfigList(ctx, icCriteria)
+			istioConfigMap, err2 = in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, icCriteria)
 			if err2 != nil {
 				log.Errorf("Error fetching Istio Config per namespace %s: %s", criteria.Namespace, err2)
 				errChan <- err2
@@ -166,6 +166,7 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 				IstioSidecar: true,
 				Health:       models.EmptyAppHealth(),
 			}
+			istioConfigList, _ := istioConfigMap[valueApp.cluster]
 			applabels := make(map[string][]string)
 			svcReferences := make([]*models.IstioValidationKey, 0)
 			for _, srv := range valueApp.Services {

--- a/business/apps.go
+++ b/business/apps.go
@@ -166,7 +166,10 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 				IstioSidecar: true,
 				Health:       models.EmptyAppHealth(),
 			}
-			istioConfigList, _ := istioConfigMap[valueApp.cluster]
+			istioConfigList := models.IstioConfigList{}
+			if _, ok := istioConfigMap[valueApp.cluster]; ok {
+				istioConfigList = istioConfigMap[valueApp.cluster]
+			}
 			applabels := make(map[string][]string)
 			svcReferences := make([]*models.IstioValidationKey, 0)
 			for _, srv := range valueApp.Services {

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -242,7 +242,9 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
   render() {
     const workload = this.props.workload;
     const pods = workload?.pods || [];
-    const istioConfigItems = this.state.workloadIstioConfig ? toIstioItems(this.state.workloadIstioConfig, '') : [];
+    const istioConfigItems = this.state.workloadIstioConfig
+      ? toIstioItems(this.state.workloadIstioConfig, workload?.cluster || '')
+      : [];
     // Helper to iterate at same time on workloadIstioConfig resources and validations
     const wkIstioTypes = [
       { field: 'gateways', validation: 'gateway' },

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -38,6 +38,9 @@ type IstioConfigList struct {
 	IstioValidations       IstioValidations                         `json:"validations"`
 }
 
+// IstioConfigMap holds a map of IstioConfigList per cluster
+type IstioConfigMap map[string]IstioConfigList
+
 type IstioConfigDetails struct {
 	Namespace  Namespace `json:"namespace"`
 	ObjectType string    `json:"objectType"`


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6136

App and Workload lists pages are sending request to backend to load items per namespace and for all clusters,
and they require also loading Istio configs per Workload and App to be shown in Details column.
Before: Istio configs were loaded for all clusters, which was causing a mess.
Now: Istio configs are loaded per cluster.

New method 'GetIstioConfigMap' is introduced, this method will replace 'GetIstioConfigList' in further task: https://github.com/kiali/kiali/issues/6052
Loading workload validations is disabled, because it is never used, we have a task for this: https://github.com/kiali/kiali/issues/6020

How to test:
Create a PeerAuth in 'west' cluster, it should not be shown in 'east' clsuter's Workloads and Applications.

```
apiVersion: security.istio.io/v1beta1
kind: PeerAuthentication
metadata:
  name: west
  namespace: bookinfo
spec:
  mtls:
    mode: STRICT
``` 

![Screenshot from 2023-05-15 17-11-18](https://github.com/kiali/kiali/assets/604313/21daa5d6-108a-4f03-b4c4-c2f3a317bbc9)
![Screenshot from 2023-05-15 17-10-52](https://github.com/kiali/kiali/assets/604313/5ba94755-857d-4c85-bf8f-d6ecd8415401)
