### PR TITLE
Improve graph labels with PF badges instead of parentheses

### DIFF
--- a/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -107,22 +107,14 @@ const contentDefault = style({
   borderRadius: '3px',
   borderWidth: '1px',
   color: NodeTextColor,
-  padding: '3px 5px'
+  padding: '1px 5px'
 });
 
 const contentBox = style({
   backgroundColor: NodeTextBackgroundColorBox,
   color: NodeTextColorBox
 });
-/*
-const contentWithBadges = style({
-  borderBottomLeftRadius: 'unset',
-  borderColor: NodeBadgeBackgroundColor,
-  borderStyle: 'solid',
-  borderTopLeftRadius: 'unset',
-  borderLeft: '0'
-});
-*/
+
 const hostsClass = style({
   $nest: {
     '& div:last-child': {
@@ -403,7 +395,6 @@ export class GraphStyles {
     }
 
     const contentText = content.join('<br/>');
-    //let contentClasses = hasBadges && !noBadge ? `${contentDefault} ${contentWithBadges}` : `${contentDefault}`;
     let contentClasses = `${contentDefault}`;
 
     // The final label...


### PR DESCRIPTION
Closes #6123 
Relates To #5922

In the graph, replace parenthesized label information with properly PF badged content.  This is for when labels add namespace and/or cluster disciminators to ensure label uniqueness.  

To test you need to generate situations where labels would previously use the parenthesized information for namespace/cluster discriminator.  Some ways of doing this:
- multi-cluster
- select multiple namespaces for the graph
- remove namespace and/or cluster boxing

Negative testing may also be useful, to ensure unnecessary badging doesn't now appear.  Different graph types, enable boxing, single namespace, single cluster, etc.