### PR TITLE
Adding readme for cypress tests in a container

### DIFF
--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -29,6 +29,23 @@ or in headless mode:
 yarn cypress:run
 ```
 
+### Running tests in a container
+You can also run the test suite in a container, using the image `quay.io/kiali/kiali-cypress-tests:latest`.
+System dependencies are bundled in the container but you are still required to install istio + kiali + demo apps in advance.
+
+Use the `-e` option to set the environment variables that affect the execution of the test suite, as described in the previous sections.
+
+
+To run the container:
+```console
+podman run -it \
+  -e CYPRESS_BASE_URL=https://kiali-istio-system.apps.test-cluster.test.com \
+  -e CYPRESS_PASSWD=<password> \
+  -e CYPRESS_USERNAME="kubeadmin" \
+  -e CYPRESS_AUTH_PROVIDER="kube:admin" \
+  quay.io/kiali/kiali-cypress-tests:latest
+```
+
 ## Structure
 
 ```


### PR DESCRIPTION
Adding readme section which describes how to run cypress tests in a container