### PR TITLE
Added back validation message on workload list and details pages.

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -18,6 +18,7 @@ import { hasMissingAuthPolicy } from 'utils/IstioConfigUtils';
 import DetailDescriptionContainer from '../../components/Details/DetailDescription';
 import { isGateway, isWaypoint } from '../../helpers/LabelFilterHelper';
 import AmbientLabel from '../../components/Ambient/AmbientLabel';
+import { validationKey } from '../../types/IstioConfigList';
 
 type WorkloadDescriptionProps = {
   workload?: Workload;
@@ -160,14 +161,18 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
                 waypoint={this.props.workload.waypointWorkloads?.length > 0 ? true : false}
               />
             )}
-            {this.props.workload && hasMissingAuthPolicy(this.props.workload.name, this.props.workload.validations) && (
-              <MissingAuthPolicy
-                namespace={this.props.namespace}
-                tooltip={true}
-                style={{ marginLeft: '10px' }}
-                text={''}
-              />
-            )}
+            {this.props.workload &&
+              hasMissingAuthPolicy(
+                validationKey(this.props.workload.name, this.props.namespace),
+                this.props.workload.validations
+              ) && (
+                <MissingAuthPolicy
+                  namespace={this.props.namespace}
+                  tooltip={true}
+                  style={{ marginLeft: '10px' }}
+                  text={''}
+                />
+              )}
             {this.props.workload &&
               (!this.props.workload.appLabel || !this.props.workload.versionLabel) &&
               !isWaypoint(this.props.workload.labels) && (

--- a/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -23,6 +23,7 @@ import { hasMissingAuthPolicy } from 'utils/IstioConfigUtils';
 import { WorkloadHealth } from '../../types/Health';
 import RefreshNotifier from '../../components/Refresh/RefreshNotifier';
 import { isMultiCluster } from 'config';
+import { validationKey } from '../../types/IstioConfigList';
 
 type WorkloadListPageState = FilterComponent.State<WorkloadListItem>;
 
@@ -114,7 +115,10 @@ class WorkloadListPageComponent extends FilterComponent.Component<
         }),
         labels: deployment.labels,
         istioReferences: sortIstioReferences(deployment.istioReferences, true),
-        notCoveredAuthPolicy: hasMissingAuthPolicy(deployment.name, data.validations)
+        notCoveredAuthPolicy: hasMissingAuthPolicy(
+          validationKey(deployment.name, data.namespace.name),
+          data.validations
+        )
       }));
     }
     return [];

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -200,7 +200,7 @@ export const hasMissingAuthPolicy = (workloadName: string, validations: Validati
     const workloadValidation = validations['workload'][workloadName];
 
     workloadValidation.checks.forEach((check: ObjectCheck) => {
-      if (check.code === 'KIA1201') {
+      if (check.code === 'KIA1301') {
         hasMissingAP = true;
       }
     });

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -265,7 +265,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"serviceentries.workloadentries.addressmatch": {
-		Code:     "KIA1301",
+		Code:     "KIA1201",
 		Message:  "Missing one or more addresses from matching WorkloadEntries",
 		Severity: WarningSeverity,
 	},
@@ -320,7 +320,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"workload.authorizationpolicy.needstobecovered": {
-		Code:     "KIA1201",
+		Code:     "KIA1301",
 		Message:  "This workload is not covered by any authorization policy",
 		Severity: WarningSeverity,
 	},

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -265,7 +265,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"serviceentries.workloadentries.addressmatch": {
-		Code:     "KIA1201",
+		Code:     "KIA1301",
 		Message:  "Missing one or more addresses from matching WorkloadEntries",
 		Severity: WarningSeverity,
 	},
@@ -320,7 +320,7 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"workload.authorizationpolicy.needstobecovered": {
-		Code:     "KIA1301",
+		Code:     "KIA1201",
 		Message:  "This workload is not covered by any authorization policy",
 		Severity: WarningSeverity,
 	},


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6020
Operator PR: https://github.com/kiali/kiali-operator/pull/647
Helm PR https://github.com/kiali/helm-charts/pull/210

Original feature PR: https://github.com/kiali/kiali/pull/4409

Validation warning "KIA1301" will be by default ignored instead of KIA1201 which was set by typo (or by mistake).
And when not ignored, it will be shown in Workload List and Details pages:
![Screenshot from 2023-05-17 20-03-55](https://github.com/kiali/kiali/assets/604313/4c81a0b6-3e28-4f40-af70-805c24c85822)
![Screenshot from 2023-05-17 20-03-27](https://github.com/kiali/kiali/assets/604313/58d4d51f-5c82-43a6-bcae-45dc69c69b4a)
