### PR TITLE
fix the config-values-test molecule test when testing with OLM

### DIFF
--- a/hack/ci-minikube-molecule-tests.sh
+++ b/hack/ci-minikube-molecule-tests.sh
@@ -187,9 +187,9 @@ if ! ${minikube_sh} status; then
     echo "Waiting for Kiali CRD to be established."
     ${CLIENT_EXE} wait --for condition=established --timeout=300s crd kialis.kiali.io
 
-    echo "Configuring the Kiali operator to allow ad hoc images and ad hoc namespaces."
+    echo "Configuring the Kiali operator to allow ad hoc images and ad hoc namespaces and security context override."
     operator_namespace="$(${CLIENT_EXE} get deployments --all-namespaces  | grep kiali-operator | cut -d ' ' -f 1)"
-    for env_name in ALLOW_AD_HOC_KIALI_NAMESPACE ALLOW_AD_HOC_KIALI_IMAGE; do
+    for env_name in ALLOW_AD_HOC_KIALI_NAMESPACE ALLOW_AD_HOC_KIALI_IMAGE ALLOW_SECURITY_CONTEXT_OVERRIDE; do
       ${CLIENT_EXE} -n ${operator_namespace} patch $(${CLIENT_EXE} -n ${operator_namespace} get csv -o name | grep kiali) --type=json -p "[{'op':'replace','path':"/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/$(${CLIENT_EXE} -n ${operator_namespace} get $(${CLIENT_EXE} -n ${operator_namespace} get csv -o name | grep kiali) -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[*].name}' | tr ' ' '\n' | cat --number | grep ${env_name} | cut -f 1 | xargs echo -n | cat - <(echo "-1") | bc)/value",'value':"\"true\""}]"
     done
 


### PR DESCRIPTION
This test requires the operator to allow security context override; when installing the operator via OLM we need to enable that feature.

fixes: https://github.com/kiali/kiali/issues/6155
