### PR TITLE
Fix accessibleNamespaces typo

### DIFF
--- a/handlers/config.go
+++ b/handlers/config.go
@@ -49,7 +49,7 @@ type DeploymentConfig struct {
 // PublicConfig is a subset of Kiali configuration that can be exposed to clients to
 // help them interact with the system.
 type PublicConfig struct {
-	AccessibleNamespaces []string                    `json:"accesibleNamespaces,omitempty"`
+	AccessibleNamespaces []string                    `json:"accessibleNamespaces,omitempty"`
 	AuthStrategy         string                      `json:"authStrategy,omitempty"`
 	AmbientEnabled       bool                        `json:"ambientEnabled,omitempty"`
 	ClusterInfo          ClusterInfo                 `json:"clusterInfo,omitempty"`


### PR DESCRIPTION
** Describe the change **

Fix accessibleNamespaces typo in handlers/config.go

** Issue reference **

Fixes #6160.

** Test steps **
In any Kiali application page:
Open chrome developer tools and go to Network tab
Search for config API request
Check the accessibleNamespaces field in the response contains two 's' instead of only one.

![image](https://github.com/kiali/kiali/assets/122779323/ed8fb59c-8057-4239-9cae-5eb3f46cd60f)

