### PR TITLE
Fix header in overview page for large names

### DIFF
--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -118,7 +118,7 @@ const emptyStateStyle = style({
 });
 
 const cardNamespaceNameNormalStyle = style({
-  display: 'inline-block',
+  display: 'table-footer-group',
   verticalAlign: 'middle'
 });
 
@@ -128,9 +128,9 @@ const cardNamespaceNameNormalStyle = style({
 const NS_LONG = 20;
 
 const cardNamespaceNameLongStyle = style({
-  display: 'inline-block',
-  maxWidth: 'calc(100% - 75px)',
   overflow: 'hidden',
+  display: 'block',
+  maxWidth: 'calc(100% - 75px)',
   textOverflow: 'ellipsis',
   verticalAlign: 'middle',
   whiteSpace: 'nowrap'
@@ -950,7 +950,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
                         }
                       >
                         <CardHeader>
-                          <CardHeaderMain>
+                          <CardHeaderMain style={{ width: '85%' }}>
                             <Title headingLevel="h5" size={TitleSizes.lg}>
                               <span
                                 className={isLongNs ? cardNamespaceNameLongStyle : cardNamespaceNameNormalStyle}
@@ -988,7 +988,9 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
                               </span>
                             </Title>
                           </CardHeaderMain>
-                          <CardActions>{namespaceActions[i]}</CardActions>
+                          <CardActions style={{ width: '15%', textAlign: 'right', display: 'block' }}>
+                            {namespaceActions[i]}
+                          </CardActions>
                         </CardHeader>
                         <CardBody>
                           {isMultiCluster() && ns.cluster && (


### PR DESCRIPTION
I have tested with Chrome and Firefox, but probably it would worth a try with other screen / browser versions, ...

![image](https://github.com/kiali/kiali/assets/49480155/c7e665bd-1439-4883-a3cb-366df9919351)

![image](https://github.com/kiali/kiali/assets/49480155/a591dfac-e4a0-43dc-9ac5-e0038bc2499c)

Fixes #6133 