### PR TITLE
Fix apps cypress failures in downstream CI

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -44,7 +44,7 @@ And('user sees span details', () => {
     .eq(1) // take 1st  row
     .find('td')
     .eq(4) // take 5th cell (kebab)
-    .should('be.visible')
+    .should('be.visible');
 });
 
 When('I fetch the list of applications', function () {
@@ -85,11 +85,11 @@ And('user sees Details information for Apps', () => {
   });
 });
 
-And('user only sees the apps with the {string} name in the {string} namespace', (name:string,ns:string) => {
-  let count:number;
-  cy.request('GET', `/api/namespaces/${ns}/apps`).should((response) =>{
-    count = response.body.applications.filter((item) => item.name.includes(name)).length;
-  }); 
+And('user only sees the apps with the {string} name in the {string} namespace', (name: string, ns: string) => {
+  let count: number;
+  cy.request('GET', `/api/namespaces/${ns}/apps`).should(response => {
+    count = response.body.applications.filter(item => item.name.includes(name)).length;
+  });
   cy.get('tbody').within(() => {
     cy.contains('No apps found').should('not.exist');
     cy.get('tr').should('have.length', count);
@@ -114,4 +114,15 @@ Then('the health status of the application should be {string}', function (health
 
 Then('user cannot see any apps in the table', () => {
   cy.get('h5').contains('No applications found').should('exist');
+});
+
+Then('user may only see {string}', (sees: string) => {
+  cy.get('tbody').within(() => {
+    cy.get('tr').should('have.length', 1);
+    cy.contains('tr', sees).then($el => {
+      if (!$el.length) {
+        cy.get('h5').contains('No applications found');
+      }
+    });
+  });
 });

--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -3,14 +3,12 @@ import { And, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 When('user clicks in the {string} Istio config actions', (action: string) => {
   cy.get('button[data-test="config-actions-dropdown"]')
     .should('be.visible')
-    .and('be.enabled')
     .click()
     .get('#loading_kiali_spinner')
     .should('not.exist');
 
   cy.get('a[data-test="create_' + action + '"]')
     .should('be.visible')
-    .and('be.enabled')
     .click()
     .get('#loading_kiali_spinner')
     .should('not.exist');
@@ -21,7 +19,7 @@ And('user sees the {string} config wizard', (title: string) => {
 });
 
 And('user adds listener', () => {
-  cy.get('button[name="addListener"]').should('be.visible').and('be.enabled').click();
+  cy.get('button[name="addListener"]').should('be.visible').click();
 });
 
 And('user types {string} in the {string} input', (value: string, id: string) => {
@@ -39,7 +37,7 @@ And('user checks validation of the hostname {string} input', (id: string) => {
 });
 
 And('user adds a server to a server list', () => {
-  cy.get('[aria-label="Server List"]').find('button').should('be.visible').and('be.enabled').click();
+  cy.get('[aria-label="Server List"]').find('button').should('be.visible').click();
 });
 
 And('the {string} input should display a warning', (id: string) => {
@@ -51,7 +49,7 @@ And('the {string} input should not display a warning', (id: string) => {
 });
 
 And('user creates the istio config', () => {
-  cy.get('button[data-test="create"]').should('be.visible').and('be.enabled').click();
+  cy.get('button[data-test="create"]').should('be.visible').click();
   it('spinner should disappear', { retries: 3 }, () => {
     cy.get('#loading_kiali_spinner').should('not.exist');
   });
@@ -62,11 +60,11 @@ And('user chooses {string} mode from the {string} select', (option: string, id: 
 });
 
 And('the {string} message should be displayed', (message: string) => {
-  cy.get('main').contains(message).should('be.visible').and('be.enabled');
+  cy.get('main').contains(message).should('be.visible');
 });
 
 And('user opens the {string} submenu', (title: string) => {
-  cy.get('button').contains(title).should('be.visible').and('be.enabled').click();
+  cy.get('button').contains(title).should('be.visible').should('be.enabled').click();
 });
 
 Then('the {string} {string} should be listed in {string} namespace', function (
@@ -82,7 +80,7 @@ Then('the preview button should be disabled', () => {
 });
 
 Then('an error message {string} is displayed', (message: string) => {
-  cy.get('h4').contains(message).should('be.visible').and('be.enabled');
+  cy.get('h4').contains(message).should('be.visible');
 });
 
 Then('the {string} input should be empty', (id: string) => {

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -16,12 +16,12 @@ Feature: Kiali Apps List page
     And user sees Namespace information for Apps
     And user sees Labels information for Apps
     And user sees Details information for Apps
-  
+
   @apps-page
   Scenario: Filter Apps by Istio Name
     When the user filters by "App Name" for "productpage"
     Then user only sees "productpage"
-  
+
   @apps-page
   Scenario: Filter Apps by Istio Sidecar
     When the user filters by "Istio Sidecar" for "Present"
@@ -34,7 +34,7 @@ Feature: Kiali Apps List page
   @apps-page
   Scenario: Filter workloads table by Istio Sidecar not being present
     When the user filters by "Istio Sidecar" for "Not Present"
-    Then user cannot see any apps in the table
+    Then user may only see "kiali-traffic-generator"
 
   @apps-page
   Scenario: Filter Apps by Istio Type
@@ -46,7 +46,7 @@ Feature: Kiali Apps List page
     When the user filters by "Health" for "Healthy"
     Then user only sees healthy apps
 
-  @apps-page 
+  @apps-page
   Scenario: Filter Applications table by Label
     When the user filters by "Label" for "app=reviews"
     Then user sees "reviews"


### PR DESCRIPTION
- make apps test happy even if bookinfo has the traffic generator app
- remove the 'be.enabled' tests in most places, it's not happy in CI.
