### PR TITLE
When generating a Service graph don't change user display settings

### DIFF
--- a/frontend/src/reducers/GraphDataState.ts
+++ b/frontend/src/reducers/GraphDataState.ts
@@ -99,14 +99,9 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
         })
       });
     case getType(GraphToolbarActions.setGraphType):
-      const isServiceGraph = action.payload === GraphType.SERVICE;
-      const showOperationNodes = isServiceGraph ? false : state.toolbarState.showOperationNodes;
-      const showServiceNodes = isServiceGraph ? false : state.toolbarState.showServiceNodes;
       return updateState(state, {
         toolbarState: updateState(state.toolbarState, {
-          graphType: action.payload,
-          showOperationNodes: showOperationNodes,
-          showServiceNodes: showServiceNodes
+          graphType: action.payload
         }),
         // TODO: This should be handled in GraphPage.ComponentDidUpdate (Init graph on type change)
         summaryData: INITIAL_GRAPH_STATE.summaryData

--- a/graph/options.go
+++ b/graph/options.go
@@ -173,6 +173,10 @@ func NewOptions(r *net_http.Request) Options {
 	} else if graphType != GraphTypeApp && graphType != GraphTypeService && graphType != GraphTypeVersionedApp && graphType != GraphTypeWorkload {
 		BadRequest(fmt.Sprintf("Invalid graphType [%s]", graphType))
 	}
+	// service graphs do not inject service nodes
+	if graphType == GraphTypeService {
+		injectServiceNodesString = "false"
+	}
 	// app node graphs require an app graph type
 	if app != "" && graphType != GraphTypeApp && graphType != GraphTypeVersionedApp {
 		BadRequest(fmt.Sprintf("Invalid graphType [%s]. This node detail graph supports only graphType app or versionedApp.", graphType))

--- a/graph/telemetry/istio/appender/aggregate_node.go
+++ b/graph/telemetry/istio/appender/aggregate_node.go
@@ -46,6 +46,11 @@ func (a AggregateNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalIn
 		return
 	}
 
+	// Aggregate Nodes are not applicable to Service Graphs
+	if a.GraphType == graph.GraphTypeService {
+		return
+	}
+
 	// Aggregate Nodes are currently supported only on Requests traffic (not TCP or gRPC-message traffic)
 	if a.Rates.Grpc != graph.RateRequests && a.Rates.Http != graph.RateRequests {
 		return


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6098

When generating a Service graph don't change the users' settings for showServiceNodes and showOperationNodes.  The user shouldn't care that those being enabled does not make sense for Service graphs, and shouldn't get surprised by them suddenly getting disabled. Instead, let the backend ignore those settings as needed.
