### PR TITLE
[master] Fix apps CI failure in downstream CI

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -113,10 +113,6 @@ Then('the health status of the application should be {string}', function (health
   checkHealthStatusInTable(this.targetNamespace, null, this.targetApp, healthStatus);
 });
 
-Then('user cannot see any apps in the table', () => {
-  cy.get('h5').contains('No applications found').should('exist');
-});
-
 Then('user sees all the Apps toggles', () => {
   cy.get('[data-test="toggle-health"]').should('be.checked');
   cy.get('[data-test="toggle-istioResources"]').should('be.checked');

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -135,3 +135,16 @@ When('user {string} toggle {string}', function (action: 'checks' | 'unchecks', t
 Then('the {string} column {string}', (col: string, action: 'appears' | 'disappears') => {
   colExists(col, action === 'appears');
 });
+
+Then('user may only see {string}', (sees: string) => {
+  cy.get('tbody').within(() => {
+    cy.get('tr').should('have.length', 1);
+    cy.get('td').then(td => {
+      if (td.length === 1) {
+        cy.get('h5').contains('No applications found');
+      } else {
+        cy.contains('tr', sees);
+      }
+    });
+  });
+});

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -45,7 +45,7 @@ Feature: Kiali Apps List page
   @apps-page
   Scenario: Filter workloads table by Istio Sidecar not being present
     When the user filters by "Istio Sidecar" for "Not Present"
-    Then user cannot see any apps in the table
+    Then user may only see "kiali-traffic-generator"
 
   @apps-page
   Scenario: Filter Apps by Istio Type


### PR DESCRIPTION
make apps test happy even if bookinfo has the traffic generator app

forward-port of ossm-3940 change in v1.65