### PR TITLE
Include cluster in health appender request key

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -521,9 +521,10 @@ func (in *NamespaceService) GetNamespace(ctx context.Context, namespace string) 
 // TODO: Multicluster: We are going to need something else to identify the namespace, the cluster (OR Return a list/array/map)
 func (in *NamespaceService) GetNamespaceByCluster(ctx context.Context, namespace string, cluster string) (*models.Namespace, error) {
 	var end observability.EndFunc
-	ctx, end = observability.StartSpan(ctx, "GetNamespace",
+	ctx, end = observability.StartSpan(ctx, "GetNamespaceByCluster",
 		observability.Attribute("package", "business"),
 		observability.Attribute("namespace", namespace),
+		observability.Attribute("cluster", cluster),
 	)
 	defer end()
 

--- a/business/testing.go
+++ b/business/testing.go
@@ -70,3 +70,9 @@ func NewTestingCache(t *testing.T, k8s kubernetes.ClientInterface, conf config.C
 	cf := kubetest.NewK8SClientFactoryMock(k8s)
 	return newTestingCache(t, cf, conf)
 }
+
+// NewTestingCacheWithFactory allows you to pass in a custom client factory. Good for testing multicluster.
+func NewTestingCacheWithFactory(t *testing.T, cf kubernetes.ClientFactory, conf config.Config) cache.KialiCache {
+	t.Helper()
+	return newTestingCache(t, cf, conf)
+}


### PR DESCRIPTION
Key did not include cluster and when multiple namespaces exist across clusters the request was being overwritten.

Fixes #6185 