### PR TITLE
get config list by namespace when not all namespaces are accessible

### DIFF
--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -54,7 +54,7 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cluster := clusterNameFromQuery(query)
-	if cluster != config.Get().KubernetesConfig.ClusterName || config.Get().ExternalServices.Istio.IstioAPIEnabled == false {
+	if cluster != config.Get().KubernetesConfig.ClusterName || !config.Get().ExternalServices.Istio.IstioAPIEnabled {
 		// @TODO do not include validations from other clusters yet
 		includeValidations = false
 	}
@@ -146,7 +146,7 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cluster := clusterNameFromQuery(query)
-	if cluster != config.Get().KubernetesConfig.ClusterName || config.Get().ExternalServices.Istio.IstioAPIEnabled == false {
+	if cluster != config.Get().KubernetesConfig.ClusterName || !config.Get().ExternalServices.Istio.IstioAPIEnabled {
 		// @TODO do not include validations from other clusters yet
 		includeValidations = false
 	}

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -54,7 +54,7 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cluster := clusterNameFromQuery(query)
-	if cluster != config.Get().KubernetesConfig.ClusterName {
+	if cluster != config.Get().KubernetesConfig.ClusterName || config.Get().ExternalServices.Istio.IstioAPIEnabled == false {
 		// @TODO do not include validations from other clusters yet
 		includeValidations = false
 	}
@@ -95,7 +95,20 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 		}(namespace, &istioConfigValidations, &err)
 	}
 
-	istioConfig, err := business.IstioConfig.GetIstioConfigListPerCluster(r.Context(), criteria, cluster)
+	istioConfig := models.IstioConfigList{}
+
+	// This can result on an error, so filter here
+	if criteria.AllNamespaces && !config.Get().AllNamespacesAccessible() {
+		criteria.AllNamespaces = false
+		for _, ns := range nss {
+			criteria.Namespace = ns
+			istioConfigNs, _ := business.IstioConfig.GetIstioConfigListPerCluster(r.Context(), criteria, cluster)
+			istioConfig = istioConfig.MergeConfigs(istioConfigNs)
+		}
+	} else {
+		istioConfig, err = business.IstioConfig.GetIstioConfigListPerCluster(r.Context(), criteria, cluster)
+	}
+
 	if includeValidations {
 		// Add validation results to the IstioConfigList once they're available (previously done in the UI layer)
 		wg.Wait()
@@ -133,7 +146,7 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cluster := clusterNameFromQuery(query)
-	if cluster != config.Get().KubernetesConfig.ClusterName {
+	if cluster != config.Get().KubernetesConfig.ClusterName || config.Get().ExternalServices.Istio.IstioAPIEnabled == false {
 		// @TODO do not include validations from other clusters yet
 		includeValidations = false
 	}

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -315,3 +315,26 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 	}
 	return &filtered
 }
+
+// Merge two config lists. To get configs from different namespaces
+func (configList IstioConfigList) MergeConfigs(ns IstioConfigList) IstioConfigList {
+
+	configList.DestinationRules = append(configList.DestinationRules, ns.DestinationRules...)
+	configList.EnvoyFilters = append(configList.EnvoyFilters, ns.EnvoyFilters...)
+	configList.Gateways = append(configList.Gateways, ns.Gateways...)
+	configList.AuthorizationPolicies = append(configList.AuthorizationPolicies, ns.AuthorizationPolicies...)
+	configList.K8sGateways = append(configList.K8sGateways, ns.K8sGateways...)
+	configList.K8sHTTPRoutes = append(configList.K8sHTTPRoutes, ns.K8sHTTPRoutes...)
+	configList.PeerAuthentications = append(configList.PeerAuthentications, ns.PeerAuthentications...)
+	configList.RequestAuthentications = append(configList.RequestAuthentications, ns.RequestAuthentications...)
+	configList.ServiceEntries = append(configList.ServiceEntries, ns.ServiceEntries...)
+	configList.Sidecars = append(configList.Sidecars, ns.Sidecars...)
+	configList.Telemetries = append(configList.Telemetries, ns.Telemetries...)
+	configList.VirtualServices = append(configList.VirtualServices, ns.VirtualServices...)
+	configList.WasmPlugins = append(configList.WasmPlugins, ns.WasmPlugins...)
+	configList.WorkloadEntries = append(configList.WorkloadEntries, ns.WorkloadEntries...)
+	configList.WorkloadGroups = append(configList.WorkloadGroups, ns.WorkloadGroups...)
+	configList.Namespace = Namespace{}
+
+	return configList
+}

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/integration/utils"
 	"github.com/kiali/kiali/tools/cmd"
@@ -191,4 +192,10 @@ func getConfigDetails(namespace, name, configType string, skipReferences bool, a
 	})
 	assert.Nil(pollErr)
 	return config, nil
+}
+
+func getConfigForNamespace(namespace, name, configType string) (*models.IstioConfigDetails, error) {
+	config, _, err := utils.IstioConfigDetails(namespace, name, configType)
+	log.Debugf("Config response returned: %+v", config)
+	return config, err
 }

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/tests/integration/utils"
 )
@@ -70,7 +71,7 @@ func TestNoIstiod(t *testing.T) {
 	t.Run("ServicesListNoRegistryServices", servicesListNoRegistryServices)
 	t.Run("NoProxyStatus", noProxyStatus)
 	t.Run("istioStatus", istioStatus)
-	//t.Run("emptyValidations", emptyValidations)
+	t.Run("emptyValidations", emptyValidations)
 }
 
 func servicesListNoRegistryServices(t *testing.T) {
@@ -125,7 +126,6 @@ func noProxyStatus(t *testing.T) {
 	}
 }
 
-/*
 func emptyValidations(t *testing.T) {
 	name := "bookinfo-gateway"
 	assert := assert.New(t)
@@ -139,10 +139,9 @@ func emptyValidations(t *testing.T) {
 	assert.NotNil(config.Gateway)
 	assert.Equal(name, config.Gateway.Name)
 	assert.Equal(utils.BOOKINFO, config.Gateway.Namespace)
-	assert.Equal(len(config.IstioValidation.Checks), 0)
-	assert.Equal(len(config.IstioValidation.References), 0)
+	assert.Nil(config.IstioValidation)
+	assert.Nil(config.IstioReferences)
 }
-*/
 
 func istioStatus(t *testing.T) {
 	assert := assert.New(t)

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kiali/kiali/kubernetes"
+	k8s "github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/tests/integration/utils"
 )
@@ -130,11 +130,11 @@ func emptyValidations(t *testing.T) {
 	name := "bookinfo-gateway"
 	assert := assert.New(t)
 
-	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.Gateways, true, assert)
+	config, err := getConfigDetails(utils.BOOKINFO, name, k8s.Gateways, true, assert)
 
 	assert.Nil(err)
 	assert.NotNil(config)
-	assert.Equal(kubernetes.Gateways, config.ObjectType)
+	assert.Equal(k8s.Gateways, config.ObjectType)
 	assert.Equal(utils.BOOKINFO, config.Namespace.Name)
 	assert.NotNil(config.Gateway)
 	assert.Equal(name, config.Gateway.Name)

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -130,7 +130,7 @@ func emptyValidations(t *testing.T) {
 	name := "bookinfo-gateway"
 	assert := assert.New(t)
 
-	config, err := getConfigDetails(utils.BOOKINFO, name, k8s.Gateways, true, assert)
+	config, err := getConfigForNamespace(utils.BOOKINFO, name, k8s.Gateways)
 
 	assert.Nil(err)
 	assert.NotNil(config)


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6196

Validations test in no_istiod can be uncommented now. 
The behavior will keeps the same - validations not available, Istio configs available. 
