### PR TITLE
Added grpc-web protocol in supported

### DIFF
--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -76,7 +76,8 @@ const (
 
 var (
 	portNameMatcher = regexp.MustCompile(`^[\-].*`)
-	portProtocols   = [...]string{"grpc", "http", "http2", "https", "mongo", "redis", "tcp", "tls", "udp", "mysql"}
+	// UDP protocol is not proxied, but it is functional. keeping it in protocols list not to cause UI issues.
+	portProtocols = [...]string{"grpc", "grpc-web", "http", "http2", "https", "mongo", "redis", "tcp", "tls", "udp", "mysql"}
 )
 
 type IstioClientInterface interface {

--- a/kubernetes/istio_internal_test.go
+++ b/kubernetes/istio_internal_test.go
@@ -171,6 +171,8 @@ func TestInvalidProtocolNameMatcher(t *testing.T) {
 func TestValidPortNameMatcher(t *testing.T) {
 	assert.True(t, MatchPortNameWithValidProtocols("http-name"))
 	assert.True(t, MatchPortNameWithValidProtocols("http2-name"))
+	assert.True(t, MatchPortNameWithValidProtocols("grpc-net-test"))
+	assert.True(t, MatchPortNameWithValidProtocols("grpc-web-net"))
 }
 
 func TestInvalidPortNameMatcher(t *testing.T) {
@@ -181,8 +183,10 @@ func TestInvalidPortNameMatcher(t *testing.T) {
 func TestValidPortAppProtocolMatcher(t *testing.T) {
 	s1 := "http"
 	s2 := "mysql"
+	s3 := "grpc-web"
 	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s1))
 	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s2))
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s3))
 }
 
 func TestInvalidPortAppProtocolMatcher(t *testing.T) {
@@ -190,10 +194,12 @@ func TestInvalidPortAppProtocolMatcher(t *testing.T) {
 	s2 := "name"
 	s3 := "http-name"
 	s4 := ""
+	s5 := "grpc-web-wrong"
 	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s1))
 	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s2))
 	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s3))
 	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s4))
+	assert.False(t, MatchPortAppProtocolWithValidProtocols(&s5))
 	assert.False(t, MatchPortAppProtocolWithValidProtocols(nil))
 }
 


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6212

Before:
![Screenshot from 2023-05-29 14-59-13](https://github.com/kiali/kiali/assets/604313/a27d895d-b656-4534-a9c2-9e2ff6e53f0e)

After:
![Screenshot from 2023-05-29 15-56-38](https://github.com/kiali/kiali/assets/604313/e5df4205-d987-43ae-af48-3e16e3cf43fb)

For Service:
```
apiVersion: v1
kind: Service
metadata:
  name: ratings-java
  namespace: bookinfo
  labels:
    app: ratings-java
    service: ratings-java
spec:
  ports:
  - name: grpc-name-j
    protocol: TCP
    appProtocol: grpc-web
    port: 8080
    targetPort: 8080
  - name: http-j
    protocol: TCP
    appProtocol: http
    port: 8480
    targetPort: 8480
  - name: http2-j
    protocol: TCP
    appProtocol: grpc
    port: 8380
    targetPort: 8380
``` 