### PR TITLE
Skip validations for OverviewPage remote cluster's namespaces

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -412,11 +412,13 @@ func (in *IstioValidationsService) fetchIstioConfigList(ctx context.Context, rVa
 		IncludeK8sHTTPRoutes:          true,
 		IncludeK8sGateways:            true,
 	}
-	istioConfigList, err := in.businessLayer.IstioConfig.GetIstioConfigList(ctx, criteria)
+	istioConfigMap, err := in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, criteria)
 	if err != nil {
 		errChan <- err
 		return
 	}
+	istioConfigList := istioConfigMap[criteria.Cluster]
+
 	// Filter VS
 	filteredVSs := in.filterVSExportToNamespaces(namespace, istioConfigList.VirtualServices)
 	rValue.VirtualServices = append(rValue.VirtualServices, filteredVSs...)

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -275,13 +275,12 @@ export const createIstioConfigDetail = (
   return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), {}, json);
 };
 
-export const getConfigValidations = (namespaces: string[]) => {
-  return newRequest<ValidationStatus>(
-    HTTP_VERBS.GET,
-    urls.configValidations(),
-    { namespaces: namespaces.join(',') },
-    {}
-  );
+export const getConfigValidations = (cluster?: string) => {
+  const queryParams: any = {};
+  if (cluster) {
+    queryParams.cluster = cluster;
+  }
+  return newRequest<ValidationStatus>(HTTP_VERBS.GET, urls.configValidations(), queryParams, {});
 };
 
 export const getServices = (namespace: string, params: { [key: string]: string } = {}) => {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -34,8 +34,8 @@ type IstioValidationSummary struct {
 	Warnings int `json:"warnings"`
 }
 
-// ValidationSummaries holds a map of IstioValidationSummary per namespace
-type ValidationSummaries map[string]*IstioValidationSummary
+// ValidationSummaries holds a map of IstioValidationSummary per cluster and namespace
+type ValidationSummaries map[string]map[string]*IstioValidationSummary
 
 // IstioValidations represents a set of IstioValidation grouped by IstioValidationKey.
 type IstioValidations map[IstioValidationKey]*IstioValidation


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6070

Before: 
There was request to backend with a chunks of namespaces, and without cluster params, the namespaces were duplicated. So in Overview page for remote cluster's namespaces it was showing the home cluster validations.

Now:
Single validations and configs request to backend without namespaces param, will return validations and configs by default for home cluster.
Only home cluster's config validations are shown, for remote ones N/A.

TODO: Separate sub-epic for remote cluster's configs validations.

![Screenshot from 2023-06-01 13-26-19](https://github.com/kiali/kiali/assets/604313/f6c259ed-9504-4fa7-9bff-8f8d9150c3be)
