### PR TITLE
Remote cluster - Istio Configs Editable

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1405,11 +1405,6 @@ func getPermissionsApi(ctx context.Context, k8s kubernetes.ClientInterface, clus
 		log.Debug("View only mode configured, skipping RBAC checks")
 		return canCreate, canPatch, canDelete
 	}
-	// Disable writes for remote clusters
-	if cluster != conf.KubernetesConfig.ClusterName {
-		log.Debug("Writes disabled for remote clusters")
-		return canCreate, canPatch, canDelete
-	}
 
 	/*
 		Kiali only uses create,patch,delete as WRITE permissions

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -227,7 +227,7 @@ func TestCheckMulticlusterPermissions(t *testing.T) {
 
 	istioConfigDetailsRemote, err := configService.GetIstioConfigDetails(context.TODO(), "east", "test", "gateways", "gw-1")
 	assert.Equal("gw-1", istioConfigDetailsRemote.Gateway.Name)
-	assert.False(istioConfigDetailsRemote.Permissions.Update)
+	assert.True(istioConfigDetailsRemote.Permissions.Update)
 	assert.False(istioConfigDetailsRemote.Permissions.Delete)
 	assert.Nil(err)
 }

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -335,10 +335,19 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
         const pa = this.state.previews!.pa;
         // Gateway is only created when user has explicit selected this option
         if (gw) {
-          promises.push(API.createIstioConfigDetail(this.props.namespace, 'gateways', JSON.stringify(gw)));
+          promises.push(
+            API.createIstioConfigDetail(this.props.namespace, 'gateways', JSON.stringify(gw), this.props.cluster)
+          );
         }
         if (k8sgateway) {
-          promises.push(API.createIstioConfigDetail(this.props.namespace, 'k8sgateways', JSON.stringify(k8sgateway)));
+          promises.push(
+            API.createIstioConfigDetail(
+              this.props.namespace,
+              'k8sgateways',
+              JSON.stringify(k8sgateway),
+              this.props.cluster
+            )
+          );
         }
 
         if (this.props.update) {
@@ -348,13 +357,20 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
                 this.props.namespace,
                 'destinationrules',
                 dr.metadata.name,
-                JSON.stringify(dr)
+                JSON.stringify(dr),
+                this.props.cluster
               )
             );
           }
           if (vs) {
             promises.push(
-              API.updateIstioConfigDetail(this.props.namespace, 'virtualservices', vs.metadata.name, JSON.stringify(vs))
+              API.updateIstioConfigDetail(
+                this.props.namespace,
+                'virtualservices',
+                vs.metadata.name,
+                JSON.stringify(vs),
+                this.props.cluster
+              )
             );
           }
           if (k8shttproute) {
@@ -363,7 +379,8 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
                 this.props.namespace,
                 'k8shttproutes',
                 k8shttproute.metadata.name,
-                JSON.stringify(k8shttproute)
+                JSON.stringify(k8shttproute),
+                this.props.cluster
               )
             );
           }
@@ -374,19 +391,45 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
           // Note that Gateways are not updated from the Wizard, only the VS hosts/gateways sections are updated
         } else {
           if (dr) {
-            promises.push(API.createIstioConfigDetail(this.props.namespace, 'destinationrules', JSON.stringify(dr)));
+            promises.push(
+              API.createIstioConfigDetail(
+                this.props.namespace,
+                'destinationrules',
+                JSON.stringify(dr),
+                this.props.cluster
+              )
+            );
           }
           if (vs) {
-            promises.push(API.createIstioConfigDetail(this.props.namespace, 'virtualservices', JSON.stringify(vs)));
+            promises.push(
+              API.createIstioConfigDetail(
+                this.props.namespace,
+                'virtualservices',
+                JSON.stringify(vs),
+                this.props.cluster
+              )
+            );
           }
           if (k8shttproute) {
             promises.push(
-              API.createIstioConfigDetail(this.props.namespace, 'k8shttproutes', JSON.stringify(k8shttproute))
+              API.createIstioConfigDetail(
+                this.props.namespace,
+                'k8shttproutes',
+                JSON.stringify(k8shttproute),
+                this.props.cluster
+              )
             );
           }
 
           if (pa) {
-            promises.push(API.createIstioConfigDetail(this.props.namespace, 'peerauthentications', JSON.stringify(pa)));
+            promises.push(
+              API.createIstioConfigDetail(
+                this.props.namespace,
+                'peerauthentications',
+                JSON.stringify(pa),
+                this.props.cluster
+              )
+            );
           }
         }
         break;
@@ -427,14 +470,29 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
   ): void => {
     if (pa) {
       if (this.state.trafficPolicy.peerAuthnSelector.addPeerAuthnModified) {
-        promises.push(API.createIstioConfigDetail(this.props.namespace, 'peerauthentications', JSON.stringify(pa)));
+        promises.push(
+          API.createIstioConfigDetail(
+            this.props.namespace,
+            'peerauthentications',
+            JSON.stringify(pa),
+            this.props.cluster
+          )
+        );
       } else {
         promises.push(
-          API.updateIstioConfigDetail(this.props.namespace, 'peerauthentications', dr.metadata.name, JSON.stringify(pa))
+          API.updateIstioConfigDetail(
+            this.props.namespace,
+            'peerauthentications',
+            dr.metadata.name,
+            JSON.stringify(pa),
+            this.props.cluster
+          )
         );
       }
     } else if (this.state.trafficPolicy.peerAuthnSelector.addPeerAuthnModified) {
-      promises.push(API.deleteIstioConfigDetail(this.props.namespace, 'peerauthentications', dr.metadata.name));
+      promises.push(
+        API.deleteIstioConfigDetail(this.props.namespace, 'peerauthentications', dr.metadata.name, this.props.cluster)
+      );
     }
   };
 

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -40,6 +40,7 @@ type ReduxProps = {
 
 type Props = ReduxProps & {
   namespace: string;
+  cluster?: string;
   serviceName: string;
   show: boolean;
   readOnly: boolean;
@@ -165,7 +166,8 @@ class ServiceWizardDropdownComponent extends React.Component<Props, State> {
     deleteServiceTrafficRouting(
       this.props.virtualServices,
       DestinationRuleC.fromDrArray(this.props.destinationRules),
-      this.props.k8sHTTPRoutes
+      this.props.k8sHTTPRoutes,
+      this.props.cluster
     )
       .then(_results => {
         this.setState({
@@ -207,7 +209,7 @@ class ServiceWizardDropdownComponent extends React.Component<Props, State> {
 
   onChangeAnnotations = (annotations: { [key: string]: string }) => {
     const jsonInjectionPatch = buildAnnotationPatch(annotations);
-    API.updateService(this.props.namespace, this.props.serviceName, jsonInjectionPatch, 'json')
+    API.updateService(this.props.namespace, this.props.serviceName, jsonInjectionPatch, 'json', this.props.cluster)
       .then(_ => {
         AlertUtils.add('Service ' + this.props.serviceName + ' updated', 'default', MessageType.SUCCESS);
         this.setState(
@@ -268,6 +270,7 @@ class ServiceWizardDropdownComponent extends React.Component<Props, State> {
           type={this.state.wizardType}
           update={this.state.updateWizard}
           namespace={this.props.namespace}
+          cluster={this.props.cluster}
           serviceName={this.props.serviceName}
           workloads={validWorkloads}
           subServices={this.props.subServices}

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -104,6 +104,7 @@ export type ServiceWizardProps = {
   type: string;
   update: boolean;
   namespace: string;
+  cluster?: string;
   serviceName: string;
   servicePort?: number;
   tlsStatus?: TLSStatus;
@@ -2053,10 +2054,12 @@ export const buildWorkloadInjectionPatch = (workloadType: string, enable: boolea
 };
 
 export const buildAnnotationPatch = (annotations: { [key: string]: string }): string => {
-  const patch = [{
-    "op": "replace",
-    "path": "/metadata/annotations",    
-    "value": annotations
-  }];  
+  const patch = [
+    {
+      op: 'replace',
+      path: '/metadata/annotations',
+      value: annotations
+    }
+  ];
   return JSON.stringify(patch);
 };

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -256,7 +256,8 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
     API.deleteIstioConfigDetail(
       this.props.match.params.namespace,
       this.props.match.params.objectType,
-      this.props.match.params.object
+      this.props.match.params.object,
+      this.state.cluster
     )
       .then(() => this.backToList())
       .catch(error => {
@@ -273,7 +274,8 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
         this.props.match.params.namespace,
         this.props.match.params.objectType,
         this.props.match.params.object,
-        jsonPatch
+        jsonPatch,
+        this.state.cluster
       )
         .then(() => {
           const targetMessage =

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -506,14 +506,15 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
   }
 
   fetchValidationResultForCluster(namespaces: NamespaceInfo[], cluster: string) {
-    return Promise.all([API.getConfigValidations(cluster), API.getAllIstioConfigs([], [], false, '', '')])
+    return Promise.all([API.getConfigValidations(cluster), API.getAllIstioConfigs([], [], false, '', '', cluster)])
       .then(results => {
         namespaces.forEach(nsInfo => {
           if (nsInfo.cluster && nsInfo.cluster === cluster && results[0].data[nsInfo.cluster]) {
             nsInfo.validations = results[0].data[nsInfo.cluster][nsInfo.name];
           }
-          // TODO: cluster param here when remote cluster config creation supported
-          nsInfo.istioConfig = results[1].data[nsInfo.name];
+          if (nsInfo.cluster && nsInfo.cluster === cluster) {
+            nsInfo.istioConfig = results[1].data[nsInfo.name];
+          }
         });
       })
       .catch(err => this.handleAxiosError('Could not fetch validations status', err));

--- a/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
+++ b/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
@@ -252,7 +252,11 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
     const aps = items.filter(i => i.type === 'authorizationPolicy')[0];
     const sds = items.filter(i => i.type === 'sidecar')[0];
     this.setState(
-      { authorizationPolicies: aps.items as AuthorizationPolicy[], sidecars: sds.items as Sidecar[], loaded: false },
+      {
+        authorizationPolicies: aps ? (aps.items as AuthorizationPolicy[]) : [],
+        sidecars: sds ? (sds.items as Sidecar[]) : [],
+        loaded: false
+      },
       () => this.fetchPermission(true, false)
     );
   };

--- a/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
+++ b/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
@@ -165,6 +165,7 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
   onAddRemoveTrafficPolicies = (): void => {
     const op = this.props.opTarget;
     const ns = this.props.nsTarget;
+    const cluster = this.props.nsInfo?.cluster;
     const duration = this.props.duration;
     const apsP = this.state.authorizationPolicies;
     const sdsP = this.state.sidecars;
@@ -173,8 +174,8 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
         .registerAll(
           'trafficPoliciesDelete',
           apsP
-            .map(ap => API.deleteIstioConfigDetail(ns, 'authorizationpolicies', ap.metadata.name))
-            .concat(sdsP.map(sc => API.deleteIstioConfigDetail(ns, 'sidecars', sc.metadata.name)))
+            .map(ap => API.deleteIstioConfigDetail(ns, 'authorizationpolicies', ap.metadata.name, cluster))
+            .concat(sdsP.map(sc => API.deleteIstioConfigDetail(ns, 'sidecars', sc.metadata.name, cluster)))
         )
         .then(_ => {
           //Error here
@@ -200,7 +201,8 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
     duration: DurationInSeconds,
     aps: AuthorizationPolicy[],
     sds: Sidecar[],
-    op: string = 'create'
+    op: string = 'create',
+    cluster?: string
   ) => {
     const graphDataSource = new GraphDataSource();
     graphDataSource.on('fetchSuccess', () => {
@@ -208,8 +210,8 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
         .registerAll(
           'trafficPoliciesCreate',
           aps
-            .map(ap => API.createIstioConfigDetail(ns, 'authorizationpolicies', JSON.stringify(ap)))
-            .concat(sds.map(sc => API.createIstioConfigDetail(ns, 'sidecars', JSON.stringify(sc))))
+            .map(ap => API.createIstioConfigDetail(ns, 'authorizationpolicies', JSON.stringify(ap), cluster))
+            .concat(sds.map(sc => API.createIstioConfigDetail(ns, 'sidecars', JSON.stringify(sc), cluster)))
         )
         .then(results => {
           if (results.length > 0) {

--- a/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
+++ b/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
@@ -180,7 +180,7 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
         .then(_ => {
           //Error here
           if (op !== 'delete') {
-            this.createTrafficPolicies(ns, duration, apsP, sdsP, op);
+            this.createTrafficPolicies(ns, duration, apsP, sdsP, op, cluster);
           } else {
             AlertUtils.add('Traffic policies ' + op + 'd for ' + ns + ' namespace.', 'default', MessageType.SUCCESS);
             this.props.load();
@@ -192,7 +192,7 @@ export default class OverviewTrafficPolicies extends React.Component<OverviewTra
           }
         });
     } else {
-      this.createTrafficPolicies(ns, duration, apsP, sdsP);
+      this.createTrafficPolicies(ns, duration, apsP, sdsP, op, cluster);
     }
   };
 

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -242,6 +242,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
     const actionsToolbar = this.state.serviceDetails ? (
       <ServiceWizardDropdown
         namespace={this.props.match.params.namespace}
+        cluster={this.state.cluster ? this.state.cluster : ''}
         serviceName={this.state.serviceDetails.service.name}
         annotations={this.state.serviceDetails.service.annotations}
         show={false}

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -811,13 +811,15 @@ export const getClusters = () => {
 export function deleteServiceTrafficRouting(
   virtualServices: VirtualService[],
   destinationRules: DestinationRuleC[],
-  k8sHTTPRouteList: K8sHTTPRoute[]
+  k8sHTTPRouteList: K8sHTTPRoute[],
+  cluster?: string
 ): Promise<any>;
 export function deleteServiceTrafficRouting(serviceDetail: ServiceDetailsInfo): Promise<any>;
 export function deleteServiceTrafficRouting(
   vsOrSvc: VirtualService[] | ServiceDetailsInfo,
   destinationRules?: DestinationRuleC[],
-  k8sHTTPRouteList?: K8sHTTPRoute[]
+  k8sHTTPRouteList?: K8sHTTPRoute[],
+  cluster?: string
 ): Promise<any> {
   let vsList: VirtualService[];
   let drList: DestinationRuleC[];
@@ -835,19 +837,25 @@ export function deleteServiceTrafficRouting(
   }
 
   vsList.forEach(vs => {
-    deletePromises.push(deleteIstioConfigDetail(vs.metadata.namespace || '', 'virtualservices', vs.metadata.name));
+    deletePromises.push(
+      deleteIstioConfigDetail(vs.metadata.namespace || '', 'virtualservices', vs.metadata.name, cluster)
+    );
   });
 
   routeList.forEach(k8sr => {
-    deletePromises.push(deleteIstioConfigDetail(k8sr.metadata.namespace || '', 'k8shttproutes', k8sr.metadata.name));
+    deletePromises.push(
+      deleteIstioConfigDetail(k8sr.metadata.namespace || '', 'k8shttproutes', k8sr.metadata.name, cluster)
+    );
   });
 
   drList.forEach(dr => {
-    deletePromises.push(deleteIstioConfigDetail(dr.metadata.namespace || '', 'destinationrules', dr.metadata.name));
+    deletePromises.push(
+      deleteIstioConfigDetail(dr.metadata.namespace || '', 'destinationrules', dr.metadata.name, cluster)
+    );
 
     const paName = dr.hasPeerAuthentication();
     if (!!paName) {
-      deletePromises.push(deleteIstioConfigDetail(dr.metadata.namespace || '', 'peerauthentications', paName));
+      deletePromises.push(deleteIstioConfigDetail(dr.metadata.namespace || '', 'peerauthentications', paName, cluster));
     }
   });
 

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -254,25 +254,39 @@ export const getIstioConfigDetail = (
   );
 };
 
-export const deleteIstioConfigDetail = (namespace: string, objectType: string, object: string) => {
-  return newRequest<string>(HTTP_VERBS.DELETE, urls.istioConfigDelete(namespace, objectType, object), {}, {});
+export const deleteIstioConfigDetail = (namespace: string, objectType: string, object: string, cluster?: string) => {
+  const queryParams: any = {};
+  if (cluster) {
+    queryParams.cluster = cluster;
+  }
+  return newRequest<string>(HTTP_VERBS.DELETE, urls.istioConfigDelete(namespace, objectType, object), queryParams, {});
 };
 
 export const updateIstioConfigDetail = (
   namespace: string,
   objectType: string,
   object: string,
-  jsonPatch: string
+  jsonPatch: string,
+  cluster?: string
 ): Promise<Response<string>> => {
-  return newRequest(HTTP_VERBS.PATCH, urls.istioConfigUpdate(namespace, objectType, object), {}, jsonPatch);
+  const queryParams: any = {};
+  if (cluster) {
+    queryParams.cluster = cluster;
+  }
+  return newRequest(HTTP_VERBS.PATCH, urls.istioConfigUpdate(namespace, objectType, object), queryParams, jsonPatch);
 };
 
 export const createIstioConfigDetail = (
   namespace: string,
   objectType: string,
-  json: string
+  json: string,
+  cluster?: string
 ): Promise<Response<string>> => {
-  return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), {}, json);
+  const queryParams: any = {};
+  if (cluster) {
+    queryParams.cluster = cluster;
+  }
+  return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), queryParams, json);
 };
 
 export const getConfigValidations = (cluster?: string) => {


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/6239

Remote clusters Istio Configs can be edited in 3 places now:
1. Config Details YAML editor. Edit and Delete.
2. Overview Page Namespace card. Create, Update, Delete traffic policies.
3. Service Details page Traffic Wizard. Crete, Update, Delete traffic.

![Screenshot from 2023-06-09 19-33-00](https://github.com/kiali/kiali/assets/604313/8469050e-c289-46d3-9d20-00ca1f9b091b)
![Screenshot from 2023-06-09 19-32-43](https://github.com/kiali/kiali/assets/604313/5ca60ecb-42f0-450a-bae9-56b4318cc7f4)
![Screenshot from 2023-06-09 19-32-12](https://github.com/kiali/kiali/assets/604313/6b7b9d49-f5f1-4ec2-9fb0-14c37983f588)

TODO: Istio Config creation wizard is a separate epic.