### PR TITLE
Bookinfo gherkin annotations for upcoming hook

### DIFF
--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -9,39 +9,3 @@ Before({tags: '@gateway-api'}, async function () {
     }
   })
 });
-
-Before({tags: '@bookinfo-app'}, async function () {
-  cy.exec(`kubectl get pods -n bookinfo -o=custom-columns=NAME:.metadata.name,Status:.status.phase --no-headers=true --sort-by='.metadata.name' |
-    grep -E -w '(reviews-v(1|2|3))|ratings-v1|details|productpage-v1|kiali-traffic-generator' |
-    awk -F ' ' '{print $2}' |
-    grep Running | 
-    wc -l`,{failOnNonZeroExit: false}).then((result) => {
-    cy.log(result.stdout);
-    if (result.stdout == "7" && result.code == 0){
-      cy.log("Bookinfo demo app is up and running.");
-    } 
-    else{
-      cy.log("Bookinfo demo app is either broken or not present. Installing now.").log("Removing old bookinfo installations.");
-      // is the suite running on openshift?
-      cy.exec('kubectl api-versions | grep --quiet "route.openshift.io";', {failOnNonZeroExit:false}).then((result) =>{
-        if (result.code == 0){
-          cy.exec('../hack/istio/install-bookinfo-demo.sh --delete-bookinfo true').then(()=>{
-            cy.exec('../hack/istio/install-bookinfo-demo.sh -tg -in istio-system -a amd64').then(() =>{
-              cy.exec(`kubectl patch kiali kiali -n kiali-operator --type=json '-p=[{"op": "add", "path": "/spec/deployment/accessible_namespaces/0", "value":"bookinfo"}]'`).then(()=>{
-                cy.exec(`kubectl wait --for=condition=Successful kiali/kiali --timeout=120s -n kiali-operator;` +
-                    `kubectl wait --for=condition=Ready pods --all -n bookinfo --timeout 60s || true;` +
-                    `kubectl wait --for=condition=Ready pods --all -n bookinfo --timeout 60s;` +
-                    `sleep 80;`,{timeout:400*1000});
-              });
-            })
-          })
-        }
-        else{
-          cy.exec('../hack/istio/install-bookinfo-demo.sh --delete-bookinfo true -c kubectl').then(()=>{
-            cy.exec('../hack/istio/install-bookinfo-demo.sh -c kubectl -tg -in istio-system -a amd64');
-          })
-        }
-      })
-    }
-  })
-});

--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -9,3 +9,39 @@ Before({tags: '@gateway-api'}, async function () {
     }
   })
 });
+
+Before({tags: '@bookinfo-app'}, async function () {
+  cy.exec(`kubectl get pods -n bookinfo -o=custom-columns=NAME:.metadata.name,Status:.status.phase --no-headers=true --sort-by='.metadata.name' |
+    grep -E -w '(reviews-v(1|2|3))|ratings-v1|details|productpage-v1|kiali-traffic-generator' |
+    awk -F ' ' '{print $2}' |
+    grep Running | 
+    wc -l`,{failOnNonZeroExit: false}).then((result) => {
+    cy.log(result.stdout);
+    if (result.stdout == "7" && result.code == 0){
+      cy.log("Bookinfo demo app is up and running.");
+    } 
+    else{
+      cy.log("Bookinfo demo app is either broken or not present. Installing now.").log("Removing old bookinfo installations.");
+      // is the suite running on openshift?
+      cy.exec('kubectl api-versions | grep --quiet "route.openshift.io";', {failOnNonZeroExit:false}).then((result) =>{
+        if (result.code == 0){
+          cy.exec('../hack/istio/install-bookinfo-demo.sh --delete-bookinfo true').then(()=>{
+            cy.exec('../hack/istio/install-bookinfo-demo.sh -tg -in istio-system -a amd64').then(() =>{
+              cy.exec(`kubectl patch kiali kiali -n kiali-operator --type=json '-p=[{"op": "add", "path": "/spec/deployment/accessible_namespaces/0", "value":"bookinfo"}]'`).then(()=>{
+                cy.exec(`kubectl wait --for=condition=Successful kiali/kiali --timeout=120s -n kiali-operator;` +
+                    `kubectl wait --for=condition=Ready pods --all -n bookinfo --timeout 60s || true;` +
+                    `kubectl wait --for=condition=Ready pods --all -n bookinfo --timeout 60s;` +
+                    `sleep 80;`,{timeout:400*1000});
+              });
+            })
+          })
+        }
+        else{
+          cy.exec('../hack/istio/install-bookinfo-demo.sh --delete-bookinfo true -c kubectl').then(()=>{
+            cy.exec('../hack/istio/install-bookinfo-demo.sh -c kubectl -tg -in istio-system -a amd64');
+          })
+        }
+      })
+    }
+  })
+});

--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -9,34 +9,41 @@ Feature: Kiali App Details page
   Background:
     Given user is at administrator perspective
     And user is at the details page for the "app" "bookinfo/details"
-  
+
   @app-details-page
+  @bookinfo-app
   Scenario: See details for app.
     Then user sees details information for app
 
   @app-details-page
+  @bookinfo-app
   Scenario: See app minigraph for details app.
     Then user sees a minigraph
 
   @app-details-page
+  @bookinfo-app
   Scenario: See app Traffic information
     Then user sees inbound and outbound traffic information
 
   @app-details-page
+  @bookinfo-app
   Scenario: See Inbound Metrics
     Then user sees inbound metrics information
 
   @app-details-page
+  @bookinfo-app
   Scenario: See Outbound Metrics
     Then user sees outbound metrics information
 
   @app-details-page
+  @bookinfo-app
   Scenario: See tracing info after selecting a trace
     And user sees trace information
     When user selects a trace
     Then user sees trace details
 
   @app-details-page
+  @bookinfo-app
   Scenario: See span info after selecting app span
     And user sees trace information
     When user selects a trace

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -9,6 +9,7 @@ Feature: Kiali Apps List page
     And user selects the "bookinfo" namespace
 
   @apps-page
+  @bookinfo-app
   Scenario: See all Apps objects in the bookinfo namespace.
     Then user sees all the Apps in the bookinfo namespace
     And user sees Health information for Apps
@@ -18,10 +19,12 @@ Feature: Kiali Apps List page
     And user sees Details information for Apps
 
   @apps-page
+  @bookinfo-app
   Scenario: See all Apps toggles
     Then user sees all the Apps toggles
 
   @apps-page
+  @bookinfo-app
   Scenario: Toggle Apps health toggle
     When user "unchecks" toggle "health"
     Then the "Health" column "disappears"
@@ -29,11 +32,13 @@ Feature: Kiali Apps List page
     Then the "Health" column "appears"
 
   @apps-page
+  @bookinfo-app
   Scenario: Filter Apps by Istio Name
     When the user filters by "App Name" for "productpage"
     Then user only sees "productpage"
 
   @apps-page
+  @bookinfo-app
   Scenario: Filter Apps by Istio Sidecar
     When the user filters by "Istio Sidecar" for "Present"
     Then user sees "productpage"
@@ -43,27 +48,32 @@ Feature: Kiali Apps List page
     And user sees "kiali-traffic-generator"
 
   @apps-page
+  @bookinfo-app
   Scenario: Filter workloads table by Istio Sidecar not being present
     When the user filters by "Istio Sidecar" for "Not Present"
     Then user may only see "kiali-traffic-generator"
 
   @apps-page
+  @bookinfo-app
   Scenario: Filter Apps by Istio Type
     When the user filters by "Istio Type" for "VirtualService"
     Then user only sees "productpage"
 
   @apps-page
+  @bookinfo-app
   Scenario: Filter Apps by Health
     When the user filters by "Health" for "Healthy"
     Then user only sees healthy apps
 
   @apps-page
+  @bookinfo-app
   Scenario: Filter Applications table by Label
     When the user filters by "Label" for "app=reviews"
     Then user sees "reviews"
     And user only sees the apps with the "reviews" name in the "bookinfo" namespace
 
   @apps-page
+  @bookinfo-app
   Scenario: The healthy status of a logical mesh application is reported in the list of applications
     Given a healthy application in the cluster
     When I fetch the list of applications
@@ -71,6 +81,7 @@ Feature: Kiali Apps List page
     Then the application should be listed as "healthy"
 
   @apps-page
+  @bookinfo-app
   Scenario: The idle status of a logical mesh application is reported in the list of applications
     Given an idle application in the cluster
     When I fetch the list of applications
@@ -79,6 +90,7 @@ Feature: Kiali Apps List page
     And the health status of the application should be "Not Ready"
 
   @apps-page
+  @bookinfo-app
   Scenario: The failing status of a logical mesh application is reported in the list of applications
     Given a failing application in the mesh
     When I fetch the list of applications
@@ -87,6 +99,7 @@ Feature: Kiali Apps List page
     And the health status of the application should be "Failure"
 
   @apps-page
+  @bookinfo-app
   Scenario: The degraded status of a logical mesh application is reported in the list of applications
     Given a degraded application in the mesh
     When I fetch the list of applications

--- a/frontend/cypress/integration/featureFiles/graph_context_menu.feature
+++ b/frontend/cypress/integration/featureFiles/graph_context_menu.feature
@@ -6,6 +6,7 @@ Feature: Kiali Graph page - Context menu actions
     Given user is at administrator perspective
 
   @graph-page-context
+  @bookinfo-app
   Scenario: Actions in context menu for service node with existing traffic routing
     When user graphs "bookinfo" namespaces
     And user opens the context menu of the "productpage" service node
@@ -13,6 +14,7 @@ Feature: Kiali Graph page - Context menu actions
     Then user should see the confirmation dialog to delete all traffic routing
 
   @graph-page-context
+  @bookinfo-app
   Scenario Outline: Ability to launch <action> wizard from graph context menu
     When user graphs "bookinfo" namespaces
     And user opens the context menu of the "reviews" service node

--- a/frontend/cypress/integration/featureFiles/graph_display.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display.feature
@@ -123,6 +123,7 @@ Scenario: User enables idle edges
   Then idle edges "appear" in the graph
 
 @graph-page-display
+@bookinfo-app
 Scenario: User enables idle nodes
   When user "enables" "idle nodes" option
   Then idle nodes "appear" in the graph

--- a/frontend/cypress/integration/featureFiles/graph_side_panel.feature
+++ b/frontend/cypress/integration/featureFiles/graph_side_panel.feature
@@ -6,6 +6,7 @@ Feature: Kiali Graph page - Side panel menu actions
     Given user is at administrator perspective
 
   @graph-page-context
+  @bookinfo-app
   Scenario: Actions in kebab menu of the side panel for a service node with existing traffic routing
     When user graphs "bookinfo" namespaces
     And user clicks the "productpage" service node
@@ -14,6 +15,7 @@ Feature: Kiali Graph page - Side panel menu actions
     Then user should see the confirmation dialog to delete all traffic routing
 
   @graph-page-context
+  @bookinfo-app
   Scenario Outline: Ability to launch <action> wizard from graph side panel
     When user graphs "bookinfo" namespaces
     And user clicks the "reviews" service node

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -10,6 +10,7 @@ Feature: Kiali Istio Config page
     And user is at the "istio" list page
     And user selects the "bookinfo" namespace
 
+  @bookinfo-app
   Scenario: See all Istio Config objects in the bookinfo namespace.
     Then user sees all the Istio Config objects in the bookinfo namespace
     And user sees Name information for Istio objects
@@ -17,51 +18,64 @@ Feature: Kiali Istio Config page
     And user sees Type information for Istio objects
     And user sees Configuration information for Istio objects
 
+  @bookinfo-app
   Scenario: See all Istio Config toggles
     Then user sees all the Istio Config toggles
 
+  @bookinfo-app
   Scenario: Toggle Istio Config configuration toggle
     When user "unchecks" toggle "configuration"
     Then the "Configuration" column "disappears"
     When user "checks" toggle "configuration"
     Then the "Configuration" column "appears"
 
+  @bookinfo-app
   Scenario: Filter Istio Config objects by Istio Name
     When the user filters by "Istio Name" for "bookinfo-gateway"
     Then user only sees "bookinfo-gateway"
 
+  @bookinfo-app
   Scenario: Filter Istio Config objects by Istio Type
     When the user filters by "Istio Type" for "Gateway"
     Then only "Gateways" are visible in the "bookinfo" namespace
 
+  @bookinfo-app
   Scenario: Filter Istio Config objects by Valid configuration
     When the user filters by "Config" for "Valid"
     Then user sees "bookinfo-gateway"
     And user sees "bookinfo"
 
+  @bookinfo-app
   Scenario: Ability to create an AuthorizationPolicy object
     Then the user can create a "AuthorizationPolicy" Istio object
 
+  @bookinfo-app
   Scenario: Ability to create a Gateway object
     Then the user can create a "Gateway" Istio object
 
   @gateway-api
+  @bookinfo-app
   Scenario: Ability to create a K8sGateway object
     Then the user can create a "K8sGateway" K8s Istio object
 
+  @bookinfo-app
   Scenario: Ability to create a PeerAuthentication object
     Then the user can create a "PeerAuthentication" Istio object
 
+  @bookinfo-app
   Scenario: Ability to create a RequestAuthentication object
     Then the user can create a "RequestAuthentication" Istio object
 
+  @bookinfo-app
   Scenario: Ability to create a ServiceEntry object
     Then the user can create a "ServiceEntry" Istio object
 
+  @bookinfo-app
   Scenario: Ability to create a Sidecar object
     Then the user can create a "Sidecar" Istio object
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0101 validation
     Given a "foo" AuthorizationPolicy in the "bookinfo" namespace
     And the AuthorizationPolicy has a from-source rule for "bar" namespace
@@ -70,6 +84,7 @@ Feature: Kiali Istio Config page
     Then the AuthorizationPolicy should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0102 validation
     Given a "foo" AuthorizationPolicy in the "bookinfo" namespace
     And the AuthorizationPolicy has a to-operation rule with "non-fully-qualified-grpc" method
@@ -78,6 +93,7 @@ Feature: Kiali Istio Config page
     Then the AuthorizationPolicy should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0104 validation
     Given a "foo" AuthorizationPolicy in the "bookinfo" namespace
     And the AuthorizationPolicy has a to-operation rule with "missing.hostname" host
@@ -86,6 +102,7 @@ Feature: Kiali Istio Config page
     Then the AuthorizationPolicy should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0106 validation
     Given a "foo" AuthorizationPolicy in the "bookinfo" namespace
     And the AuthorizationPolicy has a from-source rule for "cluster.local/ns/bookinfo/sa/sleep" principal
@@ -94,6 +111,7 @@ Feature: Kiali Istio Config page
     Then the AuthorizationPolicy should have a "danger"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0201 validation
     Given a "foo" DestinationRule in the "sleep" namespace for "sleep" host
     And the DestinationRule has a "mysubset" subset for "version=v1" labels
@@ -105,6 +123,7 @@ Feature: Kiali Istio Config page
     And the "bar" "DestinationRule" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0202 validation
     Given a "foo" DestinationRule in the "sleep" namespace for "nonexistent" host
     When the user refreshes the list page
@@ -112,6 +131,7 @@ Feature: Kiali Istio Config page
     Then the "foo" "DestinationRule" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0203 validation
     Given a "foo" DestinationRule in the "sleep" namespace for "sleep" host
     And the DestinationRule has a "v1" subset for "version=v1" labels
@@ -120,6 +140,7 @@ Feature: Kiali Istio Config page
     Then the "foo" "DestinationRule" of the "sleep" namespace should have a "danger"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0207 validation
     Given a "disable-mtls" DestinationRule in the "sleep" namespace for "*.sleep.svc.cluster.local" host
     And the DestinationRule disables mTLS
@@ -129,6 +150,7 @@ Feature: Kiali Istio Config page
     Then the "disable-mtls" "DestinationRule" of the "sleep" namespace should have a "danger"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0208 validation
     Given a "disable-mtls" DestinationRule in the "sleep" namespace for "*.sleep.svc.cluster.local" host
     And the DestinationRule disables mTLS
@@ -138,6 +160,7 @@ Feature: Kiali Istio Config page
     Then the "disable-mtls" "DestinationRule" of the "sleep" namespace should have a "danger"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0209 validation
     Given a "foo" DestinationRule in the "sleep" namespace for "*.sleep.svc.cluster.local" host
     And the DestinationRule has a "v1" subset for "" labels
@@ -145,6 +168,7 @@ Feature: Kiali Istio Config page
     Then the "foo" "DestinationRule" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0301 validation
     Given there is a "foo" Gateway on "bookinfo" namespace for "productpage.local" hosts on HTTP port 80 with "app=productpage" labels selector
     And there is a "foo" Gateway on "sleep" namespace for "productpage.local" hosts on HTTP port 80 with "app=productpage" labels selector
@@ -153,12 +177,14 @@ Feature: Kiali Istio Config page
     And the "foo" "Gateway" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0302 validation
     Given there is a "foo" Gateway on "sleep" namespace for "foo.local" hosts on HTTP port 80 with "app=foo" labels selector
     When user selects the "sleep" namespace
     Then the "foo" "Gateway" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0505 validation
     Given a "enable-mtls" DestinationRule in the "sleep" namespace for "*.sleep.svc.cluster.local" host
     And the DestinationRule enables mTLS
@@ -168,6 +194,7 @@ Feature: Kiali Istio Config page
     Then the "default" "PeerAuthentication" of the "sleep" namespace should have a "danger"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA0506 validation
     Given a "enable-mtls" DestinationRule in the "sleep" namespace for "*.local" host
     And the DestinationRule enables mTLS
@@ -177,6 +204,7 @@ Feature: Kiali Istio Config page
     Then the "default" "PeerAuthentication" of the "istio-system" namespace should have a "danger"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA1004 validation
     Given there is a "foo" Sidecar resource in the "sleep" namespace that captures egress traffic for hosts "sleep/foo.sleep.svc.cluster.local"
     And the Sidecar is applied to workloads with "app=sleep" labels
@@ -184,6 +212,7 @@ Feature: Kiali Istio Config page
     Then the "foo" "Sidecar" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA1006 validation
     Given there is a "default" Sidecar resource in the "istio-system" namespace that captures egress traffic for hosts "default/sleep.sleep.svc.cluster.local"
     And the Sidecar is applied to workloads with "app=grafana" labels
@@ -191,12 +220,14 @@ Feature: Kiali Istio Config page
     Then the "default" "Sidecar" of the "istio-system" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA1101 validation
     Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "foo"
     When user selects the "sleep" namespace
     Then the "foo" "VirtualService" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA1102 validation
     Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep"
     And the VirtualService applies to "sleep" hosts
@@ -205,6 +236,7 @@ Feature: Kiali Istio Config page
     Then the "foo" "VirtualService" of the "sleep" namespace should have a "danger"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA1104 validation
     Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep"
     And the route of the VirtualService has weight 10
@@ -212,6 +244,7 @@ Feature: Kiali Istio Config page
     Then the "foo" "VirtualService" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA1105 validation
     Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep" and subset "v1"
     And the route of the VirtualService has weight 50
@@ -222,6 +255,7 @@ Feature: Kiali Istio Config page
     Then the "foo" "VirtualService" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA1106 validation
     Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep"
     And the VirtualService applies to "sleep" hosts
@@ -232,6 +266,7 @@ Feature: Kiali Istio Config page
     And the "bar" "VirtualService" of the "sleep" namespace should have a "warning"
 
   @crd-validation
+  @bookinfo-app
   Scenario: KIA1107 validation
     Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep" and subset "v1"
     When user selects the "sleep" namespace

--- a/frontend/cypress/integration/featureFiles/istio_config_editor.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_editor.feature
@@ -8,6 +8,7 @@ Feature: Kiali Istio Config editor page
     And user is at the "istio" page
     And user selects the "bookinfo" namespace
 
+  @bookinfo-app
   Scenario: Filter Istio Config editor objects by Valid configuration
     When the user filters by "Config" for "Valid"
     And user sees "bookinfo-gateway"

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -78,6 +78,7 @@ Feature: Kiali Overview page
     Then user sees the "alpha" namespace with "outbound" traffic "10m"
 
   @overview-page
+  @bookinfo-app
   Scenario: The healthy status of a logical mesh application is reported in the overview of a namespace
     Given a healthy application in the cluster
     When I fetch the overview of the cluster

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -8,6 +8,7 @@ Feature: Kiali Service Details page
     And user is at the details page for the "service" "bookinfo/productpage"
 
   @service-details-page
+  @bookinfo-app
   Scenario: See details for productpage
     Then sd::user sees a list with content "Overview"
     Then sd::user sees a list with content "Traffic"
@@ -16,20 +17,24 @@ Feature: Kiali Service Details page
     Then sd::user sees the actions button
 
   @service-details-page
+  @bookinfo-app
   Scenario: See details for service
     Then sd::user sees "productpage" details information for service "v1"
     Then sd::user sees Network card
     Then sd::user sees Istio Config
 
   @service-details-page
+  @bookinfo-app
   Scenario: See service minigraph for details app.
     Then sd::user sees a minigraph
 
   @service-details-page
+  @bookinfo-app
   Scenario: See service Traffic information
     Then sd::user sees inbound and outbound traffic information
 
   @service-details-page
+  @bookinfo-app
   Scenario: See Inbound Metrics for productspage service details
     Then sd::user sees "Request volume" graph
     Then sd::user sees "Request duration" graph
@@ -45,22 +50,26 @@ Feature: Kiali Service Details page
     Then sd::user sees "TCP sent" graph
 
   @service-details-page
+  @bookinfo-app
   Scenario: See Graph data for productspage service details Inbound Metrics graphs
     Then sd::user does not see No data message in the "Request volume" graph
 
   @service-details-page
+  @bookinfo-app
   Scenario: See graph traces for productspage service details
     And user sees trace information
     When user selects a trace
     Then user sees trace details
 
   @service-details-page
+  @bookinfo-app
   Scenario: See span info after selecting service span
     And user sees trace information
     When user selects a trace
     Then user sees span details
 
   @service-details-page
+  @bookinfo-app
   Scenario: Verify that the Graph type dropdown is disabled when changing to Show node graph
     When user sees a minigraph
     And user chooses the "Show node graph" option

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -7,6 +7,7 @@ Feature: Kiali Services page
     And user is at the "services" list page
 
   @services-page
+  @bookinfo-app
   Scenario: See services table with correct info
     When user selects the "bookinfo" namespace
     Then user sees a table with headings
@@ -33,6 +34,7 @@ Feature: Kiali Services page
     Then the "Configuration" column "appears"
 
   @services-page
+  @bookinfo-app
   Scenario: Filter services table by Service Name
     When user selects the "bookinfo" namespace
     And user selects filter "Service Name"
@@ -41,6 +43,7 @@ Feature: Kiali Services page
     And table length should be 1
 
   @services-page
+  @bookinfo-app
   Scenario: Filter services table by Service Type
     When user selects the "bookinfo" namespace
     And user selects filter "Service Type"
@@ -48,6 +51,7 @@ Feature: Kiali Services page
     Then user sees "nothing" in the table
 
   @services-page
+  @bookinfo-app
   Scenario: Filter services table by sidecar
     When user selects the "bookinfo" namespace
     And user selects filter "Istio Sidecar"
@@ -55,6 +59,7 @@ Feature: Kiali Services page
     Then user sees "something" in the table
 
   @services-page
+  @bookinfo-app
   Scenario: Filter services table by Istio Type
     When user selects the "bookinfo" namespace
     And user selects filter "Istio Type"
@@ -63,6 +68,7 @@ Feature: Kiali Services page
     And table length should be 1
 
   @services-page
+  @bookinfo-app
   Scenario: Filter services table by health
     When user selects the "bookinfo" namespace
     And user selects filter "Health"
@@ -71,6 +77,7 @@ Feature: Kiali Services page
     And user should only see healthy services in the table
 
   @services-page
+  @bookinfo-app
   Scenario: Filter services table by label
     When user selects the "bookinfo" namespace
     And user selects filter "Label"
@@ -79,6 +86,7 @@ Feature: Kiali Services page
     And table length should be 1
 
   @services-page
+  @bookinfo-app
   Scenario: Filter services table by label click
     When user selects the "bookinfo" namespace
     And user clicks "app=productpage" label
@@ -86,6 +94,7 @@ Feature: Kiali Services page
     And table length should be 1
 
   @services-page
+  @bookinfo-app
   Scenario: Filter and unfilter services table by label click
     When user selects the "bookinfo" namespace
     And user clicks "app=productpage" label
@@ -93,6 +102,7 @@ Feature: Kiali Services page
     Then table length should exceed 1
 
   @services-page
+  @bookinfo-app
   Scenario: The healthy status of a service is reported in the list of services
     Given a service in the cluster with a healthy amount of traffic
     When user selects the "bookinfo" namespace

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -12,6 +12,7 @@ Feature: Kiali Istio Config page
 
   @gateway-api
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Create a K8s Gateway scenario
     When user deletes k8sgateway named "k8sapigateway" and the resource is no longer available
     And user clicks in the "K8sGateway" Istio config actions
@@ -27,6 +28,7 @@ Feature: Kiali Istio Config page
     Then the "K8sGateway" "k8sapigateway" should be listed in "bookinfo" namespace
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to create a Gateway with no name 
     When user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
@@ -35,6 +37,7 @@ Feature: Kiali Istio Config page
     And the preview button should be disabled
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to create a Gateway with invalid name 
     When user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
@@ -43,6 +46,7 @@ Feature: Kiali Istio Config page
     And the preview button should be disabled
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Create a Gateway scenario and check that Gateway with the same name cannot be created
     When user deletes gateway named "mygateway" and the resource is no longer available
     And user clicks in the "Gateway" Istio config actions
@@ -69,6 +73,7 @@ Feature: Kiali Istio Config page
     Then an error message "Could not create Istio Gateway objects." is displayed
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to create a Gateway with negative port number
     When user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
@@ -81,6 +86,7 @@ Feature: Kiali Istio Config page
     And the "addPortNumber0" input should display a warning
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to create a Gateway with invalid port number
     When user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
@@ -93,6 +99,7 @@ Feature: Kiali Istio Config page
     And the "addPortNumber0" input should display a warning
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to insert letters in the port field
     When user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
@@ -106,6 +113,7 @@ Feature: Kiali Istio Config page
 
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to create a Gateway without filling the inputs related to TLS 
     When user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
@@ -123,6 +131,7 @@ Feature: Kiali Istio Config page
     And the preview button should be disabled
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Create a Gateway with TLS 
     When user deletes gateway named "mygatewaywithtls" and the resource is no longer available
     And user clicks in the "Gateway" Istio config actions
@@ -141,6 +150,7 @@ Feature: Kiali Istio Config page
     Then the "Gateway" "mygatewaywithtls" should be listed in "bookinfo" namespace
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to create a ServiceEntry with empty fields
     When user clicks in the "ServiceEntry" Istio config actions
     And user sees the "Create ServiceEntry" config wizard
@@ -152,6 +162,7 @@ Feature: Kiali Istio Config page
     And the preview button should be disabled
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to create a ServiceEntry with invalid name and host specified
     When user clicks in the "ServiceEntry" Istio config actions
     And user sees the "Create ServiceEntry" config wizard
@@ -162,6 +173,7 @@ Feature: Kiali Istio Config page
     And the preview button should be disabled
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Create a ServiceEntry without ports specified 
     When user deletes service named "myservice" and the resource is no longer available
     And user clicks in the "ServiceEntry" Istio config actions
@@ -174,6 +186,7 @@ Feature: Kiali Istio Config page
     Then the "ServiceEntry" "myservice" should be listed in "bookinfo" namespace
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to create a ServiceEntry with empty ports specified 
     When user clicks in the "ServiceEntry" Istio config actions
     And user sees the "Create ServiceEntry" config wizard
@@ -189,6 +202,7 @@ Feature: Kiali Istio Config page
     And the preview button should be disabled
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Create a ServiceEntry with ports specified 
     When user deletes service named "myservice2" and the resource is no longer available
     And user clicks in the "ServiceEntry" Istio config actions
@@ -205,6 +219,7 @@ Feature: Kiali Istio Config page
     Then the "ServiceEntry" "myservice2" should be listed in "bookinfo" namespace
 
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Try to create duplicate port specifications on a ServiceEntry
     When user clicks in the "ServiceEntry" Istio config actions
     And user sees the "Create ServiceEntry" config wizard
@@ -223,6 +238,7 @@ Feature: Kiali Istio Config page
 
   @gateway-api
   @wizard-istio-config
+  @bookinfo-app
   Scenario: Create multiple K8s Gateways with colliding hostnames and port combinations and check for a reference. Then delete one of them and the reference should be gone.
     When user deletes k8sgateway named "gatewayapi-1" and the resource is no longer available
     And user deletes k8sgateway named "gatewayapi-2" and the resource is no longer available

--- a/frontend/cypress/integration/featureFiles/wizard_k8sgw_api_routing.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_k8sgw_api_routing.feature
@@ -7,6 +7,7 @@ Feature: Service Details Wizard: K8s Gateway API Routing
 
   @gateway-api
   @wizard-k8s-routing
+  @bookinfo-app
   Scenario: Create a K8s Gateway API Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
     And user clicks in the "K8s Gateway API Routing" actions
@@ -29,6 +30,7 @@ Feature: Service Details Wizard: K8s Gateway API Routing
 
   @gateway-api
   @wizard-k8s-routing
+  @bookinfo-app
   Scenario: See a HTTPRoute generated
     When user clicks in the "Istio Config" table "HTTP" badge "reviews" name row link
     Then user sees the "kind: HTTPRoute" regex in the editor
@@ -36,6 +38,7 @@ Feature: Service Details Wizard: K8s Gateway API Routing
 
   @gateway-api
   @wizard-k8s-routing
+  @bookinfo-app
   Scenario: Update a K8s Gateway API Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
     And user clicks in the "K8s Gateway API Routing" actions
@@ -50,12 +53,14 @@ Feature: Service Details Wizard: K8s Gateway API Routing
 
   @gateway-api
   @wizard-k8s-routing
+  @bookinfo-app
   Scenario: See a K8s Gateway generated with warning
     When user clicks in the "Istio Config" table "G" badge "reviews-gateway" name row link
     Then user sees the "kind: Gateway" regex in the editor
 
   @gateway-api
   ## @wizard-k8s-routing
+  @bookinfo-app
   Scenario: Delete the K8s Gateway Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
     And user clicks in the "Delete Traffic Routing" actions

--- a/frontend/cypress/integration/featureFiles/wizard_request_routing.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_request_routing.feature
@@ -6,6 +6,7 @@ Feature: Service Details Wizard: Request Routing
     Given user is at administrator perspective
 
   @wizard-request-routing
+  @bookinfo-app
   Scenario: Create a Request Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
     And user clicks in the "Request Routing" actions
@@ -29,6 +30,7 @@ Feature: Service Details Wizard: Request Routing
     Then user sees the "Istio Config" table with 2 rows
 
   @wizard-request-routing
+  @bookinfo-app
   Scenario: See a DestinationRule generated
     When user clicks in the "Istio Config" table "DR" badge "reviews" name row link
     Then user sees the "kind: DestinationRule" regex in the editor
@@ -39,6 +41,7 @@ Feature: Service Details Wizard: Request Routing
     And user sees the "bookinfo" "reviews" "virtualservice" reference
 
   @wizard-request-routing
+  @bookinfo-app
   Scenario: See a VirtualService generated
     When user clicks in the "bookinfo" "reviews" "virtualservice" reference
     Then user sees the "kind: VirtualService" regex in the editor
@@ -47,6 +50,7 @@ Feature: Service Details Wizard: Request Routing
     And user sees the "end-user:[\n ]*exact: jason" regex in the editor
 
   @wizard-request-routing
+  @bookinfo-app
   Scenario: Update a Request Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
     And user clicks in the "Request Routing" actions
@@ -60,12 +64,14 @@ Feature: Service Details Wizard: Request Routing
     Then user sees the "Istio Config" table with 3 rows
 
   @wizard-request-routing
+  @bookinfo-app
   Scenario: See a Gateway generated with warning
     When user clicks in the "Istio Config" table "G" badge "reviews-gateway" name row link
     Then user sees the "kind: Gateway" regex in the editor
     And user sees warning icon in ACE editor
 
   ## @wizard-request-routing
+  @bookinfo-app
   Scenario: Delete the Request Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
     And user clicks in the "Delete Traffic Routing" actions

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -7,6 +7,7 @@ Feature: Workload logs tab
   Background:
     Given user is at administrator perspective
 
+  @bookinfo-app
   Scenario: The logs tab should show the logs of a pod
     Given I am on the "productpage-v1" workload detail page of the "bookinfo" namespace
     When I go to the Logs tab of the workload detail page
@@ -16,26 +17,31 @@ Feature: Workload logs tab
     And the "productpage" container should be checked
     And I should see some "productpage-v1" pod selected in the pod selector
 
+  @bookinfo-app
   Scenario: The log pane of the logs tab should only show the lines with the requested text
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace
     When I type "DEBUG" on the Show text field
     Then the log pane should only show log lines containing "DEBUG"
 
+  @bookinfo-app
   Scenario: The log pane of the logs tab should hide the lines with the requested text
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace
     When I type "DEBUG" on the Hide text field
     Then the log pane should only show log lines not containing "DEBUG"
 
+  @bookinfo-app
   Scenario: The log pane of the logs tab should limit the number of log lines that are fetched
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace
     When I choose to show 100 lines of logs
     Then the log pane should show at most 100 lines of logs of each selected container
 
+  @bookinfo-app
   Scenario: The log pane of the logs tab should only show logs for the selected container
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace
     When I select only the "productpage" container
     Then the log pane should only show logs for the "productpage" container
 
+  @bookinfo-app
   Scenario: The log pane of the logs tab should show spans
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace
     When I enable visualization of spans

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -7,6 +7,7 @@ Feature: Kiali Workloads page
     And user is at the "workloads" list page
 
   @workloads-page
+  @bookinfo-app
   Scenario: See workloads table with correct info
     When user selects the "bookinfo" namespace
     Then user sees a table with headings
@@ -21,10 +22,12 @@ Feature: Kiali Workloads page
     And the "Details" column on the "details-v1" row is empty
 
   @workloads-page
+  @bookinfo-app
   Scenario: See all Workloads toggles
     Then user sees all the Apps toggles
 
   @workloads-page
+  @bookinfo-app
   Scenario: Toggle Workloads health toggle
     When user "unchecks" toggle "health"
     Then the "Health" column "disappears"
@@ -32,6 +35,7 @@ Feature: Kiali Workloads page
     Then the "Health" column "appears"
 
   @workloads-page
+  @bookinfo-app
   Scenario: Filter workloads table by Workloads Name
     When user selects the "bookinfo" namespace
     And user selects filter "Workload Name"
@@ -40,6 +44,7 @@ Feature: Kiali Workloads page
     And table length should be 1
 
   @workloads-page
+  @bookinfo-app
   Scenario: Filter workloads table by Workloads Type
     When user selects the "bookinfo" namespace
     And user selects filter "Workload Type"
@@ -47,6 +52,7 @@ Feature: Kiali Workloads page
     Then user sees "no workloads" in workloads table
 
   @workloads-page
+  @bookinfo-app
   Scenario: Filter workloads table by sidecar
     When user selects the "bookinfo" namespace
     And user selects filter "Istio Sidecar"
@@ -54,6 +60,7 @@ Feature: Kiali Workloads page
     Then user sees "workloads" in workloads table
 
   @workloads-page
+  @bookinfo-app
   Scenario: Filter workloads table by Istio Type
     When user selects the "bookinfo" namespace
     And user selects filter "Istio Type"
@@ -61,6 +68,7 @@ Feature: Kiali Workloads page
     Then user sees "no workloads" in workloads table
 
   @workloads-page
+  @bookinfo-app
   Scenario: Filter workloads table by health
     When user selects the "bookinfo" namespace
     And user selects filter "Health"
@@ -69,6 +77,7 @@ Feature: Kiali Workloads page
     And user should only see healthy workloads in workloads table
 
   @workloads-page
+  @bookinfo-app
   Scenario: Filter workloads table by App Label
     When user selects the "bookinfo" namespace
     And user selects filter "App Label"
@@ -77,6 +86,7 @@ Feature: Kiali Workloads page
     And user should only see workloads with the "app" label
 
   @workloads-page
+  @bookinfo-app
   Scenario: Filter workloads table by Version Label
     When user selects the "bookinfo" namespace
     And user selects filter "Version Label"
@@ -85,6 +95,7 @@ Feature: Kiali Workloads page
     And user should only see workloads with the "version" label
 
   @workloads-page
+  @bookinfo-app
   Scenario: Filter workloads table by label
     When user selects the "bookinfo" namespace
     And user selects filter "Label"
@@ -93,6 +104,7 @@ Feature: Kiali Workloads page
     And table length should be 1
 
   @workloads-page
+  @bookinfo-app
   Scenario: The healthy status of a workload is reported in the list of workloads
     Given a healthy workload in the cluster
     When user selects the "bookinfo" namespace

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -9,32 +9,39 @@ Feature: Kiali Workload Details page
     And user is at the details page for the "workload" "bookinfo/details-v1"
 
   @workload-details
+  @bookinfo-app
   Scenario: See details for workload
     Then user sees details information for workload
 
   @workload-details
+  @bookinfo-app
   Scenario: See minigraph for workload.
     Then user sees a minigraph
 
   @workload-details
+  @bookinfo-app
   Scenario: See workload traffic information
     Then user sees workload inbound and outbound traffic information
 
   @workload-details
+  @bookinfo-app
   Scenario: See workload Inbound Metrics
     Then user sees workload inbound metrics information
 
   @workload-details
+  @bookinfo-app
   Scenario: See workload Outbound Metrics
     Then user sees workload outbound metrics information
 
   @workload-details
+  @bookinfo-app
   Scenario: See workload tracing info after selecting a trace
     And user sees trace information
     When user selects a trace
     Then user sees trace details
 
   @workload-details
+  @bookinfo-app
   Scenario: See workload span info after selecting a span
     And user sees trace information
     When user selects a trace
@@ -42,30 +49,36 @@ Feature: Kiali Workload Details page
     And user can filter spans by workload
 
   @workload-details
+  @bookinfo-app
   Scenario: See Envoy clusters configuration for a workload
     When the user filters by "Port" with value "9080" on the "Clusters" tab
     Then the user sees clusters expected information
 
   @workload-details
+  @bookinfo-app
   Scenario: See Envoy listeners configuration for a workload
     When the user filters by "Destination" with value "Route: 9090" on the "Listeners" tab
     Then the user sees listeners expected information
 
   @workload-details
+  @bookinfo-app
   Scenario: See Envoy routes configuration for a workload
     When the user filters by "Domains" with value "details" on the "Routes" tab
     Then the user sees routes expected information
 
   @workload-details
+  @bookinfo-app
   Scenario: See Envoy bootstrap configuration for a workload
     When the user looks for the bootstrap tab
     Then the user sees bootstrap expected information
 
   @workload-details
+  @bookinfo-app
   Scenario: See Envoy config configuration for a workload
     When the user looks for the config tab
     Then the user sees bootstrap expected information
 
   @workload-details
+  @bookinfo-app
   Scenario: See Envoy metrics for a workload
     Then the user sees the metrics tab


### PR DESCRIPTION
This is related to the OSSM-4049 ticket. 

In order to make more robust setup, we want Cypress to detect if certain demoapps are installed before related tests. For example, if the test uses bookinfo, then all of the 6 bookinfo pods and traffic generator must be installed. If they are not or if they are malformed at some way (for example missing pod), then Cypress installs the specific demo app via the hack scripts. 

To test this:
- Deploy Kiali without the bookinfo demo app
- Run any Cypres feature file, which has the `@bookino-app` tag.
- Bookinfo demo app should be installed prior to the first test and all tests related to bookinfo from that FeatureFile should pass
- This should work both for the OCP and non-OCP.

(Drafting this with bookinfo app only. I will turn it into a regular PR once I add other demos as well. 