### PR TITLE
Sleep hack script refactor to a separate file

### DIFF
--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+##############################################################################
+# install-sleep-demo.sh
+#
+# Installs the Istio Sleep Sample Demo Application into your cluster
+# (either Kubernetes or OpenShift).
+#
+# See --help for more details on options to this script.
+#
+##############################################################################
+
+HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source ${HACK_SCRIPT_DIR}/functions.sh
+
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+
+# ISTIO_DIR is where the Istio download is installed and thus where the sleep demo files are found.
+# CLIENT_EXE_NAME is going to either be "oc" or "kubectl"
+ISTIO_DIR=
+CLIENT_EXE="oc"
+DELETE_SLEEP="false"
+
+# process command line args
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -ds|--delete-sleep)
+      DELETE_SLEEP="$2"
+      shift;shift
+      ;;
+    -id|--istio-dir)
+      ISTIO_DIR="$2"
+      shift;shift
+      ;;
+    -c|--client-exe)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -ds|--delete-sleep <true|false>: If true, uninstall sleep. If false, install sleep. (default: false).
+  -id|--istio-dir <dir>: Where Istio has already been downloaded. If not found, this script aborts.
+  -c|--client-exe <name>: Cluster client executable name - valid values are "kubectl" or "oc"
+  -h|--help : this message
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+IS_OPENSHIFT="false"
+IS_MAISTRA="false"
+if [[ "${CLIENT_EXE}" = *"oc" ]]; then
+  IS_OPENSHIFT="true"
+  IS_MAISTRA=$([ "$(${CLIENT_EXE} get crd | grep servicemesh | wc -l)" -gt "0" ] && echo "true" || echo "false")
+fi
+
+echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
+echo "IS_MAISTRA=${IS_MAISTRA}"
+
+if [ "${DELETE_SLEEP}" == "true" ]; then
+  set +e
+
+  echo "Deleting the 'sleep' app in the 'sleep' namespace..."
+  ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
+  if [ "${IS_MAISTRA}" == "true" ]; then
+    ${CLIENT_EXE} delete smm default -n "sleep" --ignore-not-found=true
+  fi
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} delete network-attachment-definition istio-cni -n sleep
+    ${CLIENT_EXE} delete scc sleep-scc
+    ${CLIENT_EXE} delete project sleep
+  fi
+  ${CLIENT_EXE} delete namespace sleep
+  exit 0
+
+else
+  echo "Installing the 'sleep' app in the 'sleep' namespace..."
+  if [ "${ISTIO_DIR}" == "" ]; then
+    ISTIO_DIR=$(ls -dt1 ${SCRIPT_DIR}/../../_output/istio-* | head -n1)
+  fi
+
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} get project "sleep" || ${CLIENT_EXE} new-project "sleep"
+  else
+    ${CLIENT_EXE} get ns sleep || ${CLIENT_EXE} create ns sleep
+  fi
+
+  ${CLIENT_EXE} label namespace "sleep" istio-injection=enabled --overwrite=true
+
+  # For OpenShift 4.11, adds default service account in the current ns to use as a user
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:sleep:sleep
+  fi
+
+  if [ "${IS_OPENSHIFT}" == "true" ]; then
+      cat <<NAD | $CLIENT_EXE -n sleep apply -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+NAD
+    cat <<SCC | $CLIENT_EXE apply -n sleep -f -
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: sleep-scc
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- "system:serviceaccount:sleep:default"
+- "system:serviceaccount:sleep:sleep"
+SCC
+  fi
+
+  ${CLIENT_EXE} apply -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
+
+  if [ "${IS_MAISTRA}" == "true" ]; then
+    prepare_maistra "sleep"
+  fi
+
+  sleep 4
+
+  echo "Sleep Demo should be installed and starting up - here are the pods and services"
+  $CLIENT_EXE get services -n sleep
+  $CLIENT_EXE get pods -n sleep
+
+fi

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -11,56 +11,6 @@ set -eu
 HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source ${HACK_SCRIPT_DIR}/functions.sh
 
-install_sleep_app() {
-
-  if [ "${ISTIO_DIR}" == "" ]; then
-    ISTIO_DIR=$(ls -dt1 ${SCRIPT_DIR}/../../_output/istio-* | head -n1)
-  fi
-
-  if [ "${IS_OPENSHIFT}" == "true" ]; then
-    ${CLIENT_EXE} get project "sleep" || ${CLIENT_EXE} new-project "sleep"
-  else
-    ${CLIENT_EXE} get ns sleep || ${CLIENT_EXE} create ns sleep
-  fi
-
-  ${CLIENT_EXE} label namespace "sleep" istio-injection=enabled --overwrite=true
-
-  # For OpenShift 4.11, adds default service account in the current ns to use as a user
-  if [ "${IS_OPENSHIFT}" == "true" ]; then
-    ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:sleep:sleep
-  fi
-
-  if [ "${IS_OPENSHIFT}" == "true" ]; then
-      cat <<NAD | $CLIENT_EXE -n sleep apply -f -
-apiVersion: "k8s.cni.cncf.io/v1"
-kind: NetworkAttachmentDefinition
-metadata:
-  name: istio-cni
-NAD
-    cat <<SCC | $CLIENT_EXE apply -n sleep -f -
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
-metadata:
-  name: sleep-scc
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
-users:
-- "system:serviceaccount:sleep:default"
-- "system:serviceaccount:sleep:sleep"
-SCC
-  fi
-
-  ${CLIENT_EXE} apply -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
-
-  if [ "${IS_MAISTRA}" == "true" ]; then
-    prepare_maistra "sleep"
-  fi
-}
-
 SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 
 # install the Istio release that was last downloaded (that's the -t option to ls)
@@ -155,6 +105,8 @@ if [ "${DELETE_DEMOS}" != "true" ]; then
     "${SCRIPT_DIR}/install-bookinfo-demo.sh" -tg -in ${ISTIO_NAMESPACE} -a ${ARCH}
     echo "Deploying error rates demo ..."
     "${SCRIPT_DIR}/install-error-rates-demo.sh" -in ${ISTIO_NAMESPACE} -a ${ARCH}
+    echo "Deploying sleep demo ..."
+    "${SCRIPT_DIR}/install-sleep-demo.sh" 
 
   else
     echo "Deploying bookinfo demo..."
@@ -162,10 +114,10 @@ if [ "${DELETE_DEMOS}" != "true" ]; then
 
     echo "Deploying error rates demo..."
     "${SCRIPT_DIR}/install-error-rates-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE} -a ${ARCH}
-  fi
 
-  echo "Installing the 'sleep' app in the 'sleep' namespace..."
-  install_sleep_app
+    echo "Deploying sleep demo ..."
+    "${SCRIPT_DIR}/install-sleep-demo.sh" -c kubectl
+  fi
 
   # Some front-end tests have conflicts with the wildcard host in the bookinfo-gateway. Patch it with the host resolved for the traffic generator.
   ISTIO_INGRESS_HOST=$(${CLIENT_EXE} get cm -n bookinfo traffic-generator-config -o jsonpath='{.data.route}' | sed 's|.*//\([^\:]*\).*/.*|\1|')
@@ -180,24 +132,16 @@ else
   # Delete everything - don't abort on error, just keep going and try to delete everything
   set +e
 
-  echo "Deleting the 'sleep' app in the 'sleep' namespace..."
-  ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
-  if [ "${IS_MAISTRA}" == "true" ]; then
-    ${CLIENT_EXE} delete smm default -n "sleep" --ignore-not-found=true
-  fi
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-    ${CLIENT_EXE} delete network-attachment-definition istio-cni -n sleep
-    ${CLIENT_EXE} delete scc sleep-scc
-    ${CLIENT_EXE} delete project sleep
-  fi
-  ${CLIENT_EXE} delete namespace sleep
-
-  if [ "${IS_OPENSHIFT}" == "true" ]; then
+    echo "Deleting sleep demo ..."
+    "${SCRIPT_DIR}/install-sleep-demo.sh" --delete-sleep true
     echo "Deleting bookinfo demo ..."
     "${SCRIPT_DIR}/install-bookinfo-demo.sh" --delete-bookinfo true
     echo "Deleting error rates demo ..."
     "${SCRIPT_DIR}/install-error-rates-demo.sh" --delete true
   else
+    echo "Deleting sleep demo ..."
+    "${SCRIPT_DIR}/install-sleep-demo.sh" --delete-sleep true -c kubectl
     echo "Deleting bookinfo demo..."
     "${SCRIPT_DIR}/install-bookinfo-demo.sh" --delete-bookinfo true -c kubectl
     echo "Deleting error rates demo..."


### PR DESCRIPTION
Due to the upcoming Cypress hooks, I needed to move the installation of the Sleep app into a separate file. This file is now intended to be called from Cypress when Sleep demo app is not detected.

Tested on upstream OCP and it works.