### PR TITLE
Control plane metrics improvements

### DIFF
--- a/business/metrics.go
+++ b/business/metrics.go
@@ -262,19 +262,19 @@ func (in *MetricsService) GetControlPlaneMetrics(q models.IstioMetricsQuery, sca
 	}
 	metrics["pilot_proxy_convergence_time"] = append(metrics["pilot_proxy_convergence_time"], converted...)
 
-	metric := in.prom.FetchRateRange("process_cpu_seconds_total", []string{`{app="istiod"}`}, "", &q.RangeQuery)
-	converted, err = models.ConvertMetric("process_cpu_seconds_total", metric, models.ConversionParams{Scale: 1})
+	metric := in.prom.FetchRateRange("container_cpu_usage_seconds_total", []string{`{pod=~"istiod-.*|istio-pilot-.*"}`}, "", &q.RangeQuery)
+	converted, err = models.ConvertMetric("container_cpu_usage_seconds_total", metric, models.ConversionParams{Scale: 1})
 	if err != nil {
 		return nil, err
 	}
-	metrics["process_cpu_seconds_total"] = append(metrics["process_cpu_seconds_total"], converted...)
+	metrics["container_cpu_usage_seconds_total"] = append(metrics["container_cpu_usage_seconds_total"], converted...)
 
 	metric = in.prom.FetchRange("container_memory_working_set_bytes", `{pod=~"istiod-.*|istio-pilot-.*"}`, "", "", &q.RangeQuery)
 	converted, err = models.ConvertMetric("container_memory_working_set_bytes", metric, models.ConversionParams{Scale: 0.000001})
 	if err != nil {
 		return nil, err
 	}
-	metrics["process_virtual_memory_bytes"] = append(metrics["container_memory_working_set_bytes"], converted...)
+	metrics["container_memory_working_set_bytes"] = append(metrics["container_memory_working_set_bytes"], converted...)
 
 	return metrics, nil
 }

--- a/business/metrics.go
+++ b/business/metrics.go
@@ -269,7 +269,7 @@ func (in *MetricsService) GetControlPlaneMetrics(q models.IstioMetricsQuery, sca
 	}
 	metrics["container_cpu_usage_seconds_total"] = append(metrics["container_cpu_usage_seconds_total"], converted...)
 
-	metric = in.prom.FetchRange("container_memory_working_set_bytes", `{pod=~"istiod-.*|istio-pilot-.*"}`, "", "", &q.RangeQuery)
+	metric = in.prom.FetchRange("container_memory_working_set_bytes", `{container="discovery", pod=~"istiod-.*|istio-pilot-.*"}`, "", "", &q.RangeQuery)
 	converted, err = models.ConvertMetric("container_memory_working_set_bytes", metric, models.ConversionParams{Scale: 0.000001})
 	if err != nil {
 		return nil, err

--- a/business/metrics.go
+++ b/business/metrics.go
@@ -269,12 +269,26 @@ func (in *MetricsService) GetControlPlaneMetrics(q models.IstioMetricsQuery, sca
 	}
 	metrics["container_cpu_usage_seconds_total"] = append(metrics["container_cpu_usage_seconds_total"], converted...)
 
+	metric = in.prom.FetchRateRange("process_cpu_seconds_total", []string{`{app="istiod"}`}, "", &q.RangeQuery)
+	converted, err = models.ConvertMetric("process_cpu_seconds_total", metric, models.ConversionParams{Scale: 1})
+	if err != nil {
+		return nil, err
+	}
+	metrics["process_cpu_seconds_total"] = append(metrics["process_cpu_seconds_total"], converted...)
+
 	metric = in.prom.FetchRange("container_memory_working_set_bytes", `{container="discovery", pod=~"istiod-.*|istio-pilot-.*"}`, "", "", &q.RangeQuery)
 	converted, err = models.ConvertMetric("container_memory_working_set_bytes", metric, models.ConversionParams{Scale: 0.000001})
 	if err != nil {
 		return nil, err
 	}
 	metrics["container_memory_working_set_bytes"] = append(metrics["container_memory_working_set_bytes"], converted...)
+
+	metric = in.prom.FetchRange("process_resident_memory_bytes", `{app="istiod"}`, "", "", &q.RangeQuery)
+	converted, err = models.ConvertMetric("process_resident_memory_bytes", metric, models.ConversionParams{Scale: 0.000001})
+	if err != nil {
+		return nil, err
+	}
+	metrics["process_resident_memory_bytes"] = append(metrics["process_resident_memory_bytes"], converted...)
 
 	return metrics, nil
 }

--- a/config/dashboards/dashboards.go
+++ b/config/dashboards/dashboards.go
@@ -54,7 +54,7 @@ const DEFAULT_DASHBOARDS_YAML = `
   - chart:
       name: "CPU ratio"
       spans: 4
-      metricName: "process_cpu_seconds_total"
+      metricName: "container_cpu_usage_seconds_total"
       dataType: "rate"
       aggregations:
       - label: "pod_name"

--- a/config/dashboards/dashboards_config_test.go
+++ b/config/dashboards/dashboards_config_test.go
@@ -78,7 +78,7 @@ func TestGetBuiltInMonitoringDashboards(t *testing.T) {
 	assert.Equal(t, 6, len(d.Items))
 	assert.Equal(t, "CPU ratio", d.Items[0].Chart.Name)
 	assert.Equal(t, 4, d.Items[0].Chart.Spans)
-	assert.Equal(t, "process_cpu_seconds_total", d.Items[0].Chart.MetricName)
+	assert.Equal(t, "container_cpu_usage_seconds_total", d.Items[0].Chart.MetricName)
 	assert.Equal(t, Rate, d.Items[0].Chart.DataType)
 }
 

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -162,6 +162,14 @@ Then(`user sees the {string} namespace with {string} traffic {string}`, (ns, dir
   );
 });
 
+Then('user sees the memory chart', () => {
+  cy.get('div[data-test="memory-chart"]').should('exist');
+});
+
+And('user sees the cpu chart', () => {
+  cy.get('div[data-test="cpu-chart"]').should('exist');
+});
+
 Then('there should be a {string} application indicator in the namespace', function (healthStatus: string) {
   cy.get(
     `[data-test=${this.targetNamespace}-EXPAND] [data-test=overview-app-health] svg[class=icon-${healthStatus}]`

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -122,3 +122,8 @@ Feature: Kiali Overview page
     And user sees the "Control plane" label in the "istio-system" namespace card
     And user sees the "Outbound policy" label in the "istio-system" namespace card
     Then the toggle on the right side of the "istio-system" namespace card exists
+
+  @overview-page
+  Scenario: The control plane metrics should be present
+    Then user sees the memory chart
+    And user sees the cpu chart

--- a/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
+++ b/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
@@ -119,7 +119,7 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
           <Card isPlain>
             <CardBody>
               {showMetrics(memory) && (
-                <Grid style={{ marginBottom: 20 }} hasGutter>
+                <Grid data-test="memory-chart" style={{ marginBottom: 20 }} hasGutter>
                   <GridItem md={2}>
                     <Flex
                       className="pf-u-h-100-on-md"
@@ -165,7 +165,7 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
                 </Grid>
               )}
               {showMetrics(cpu) && (
-                <Grid hasGutter>
+                <Grid data-test="cpu-chart" hasGutter>
                   <GridItem md={2}>
                     <Flex
                       className="pf-u-h-100-on-md"

--- a/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
+++ b/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
@@ -49,14 +49,20 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
     let memoryThresholds: VCLine<RichDataPoint>[] = [];
     let cpuThresholds: VCLine<RichDataPoint>[] = [];
 
+    // The CPU metric can be respresented by a container or a process metric. We need to check which one to use
+    let cpuMetricSource = 'container';
     let cpu = this.props.istiodContainerCpu;
     if (!showMetrics(this.props.istiodContainerCpu)) {
       cpu = this.props.istiodProcessCpu;
+      cpuMetricSource = 'process';
     }
 
+    // The memory metric can be respresented by a container or a process metric. We need to check which one to use
+    let memoryMetricSource = 'process';
     let memory = this.props.istiodContainerMemory;
     if (!showMetrics(this.props.istiodContainerMemory)) {
       memory = this.props.istiodProcessMemory;
+      memoryMetricSource = 'container';
     }
 
     if (showMetrics(memory)) {
@@ -131,7 +137,7 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
                           position={TooltipPosition.right}
                           content={
                             <div style={{ textAlign: 'left' }}>
-                              This values represents the memory of the istiod process
+                              This values represents the memory of the istiod {memoryMetricSource}
                             </div>
                           }
                         >
@@ -176,7 +182,9 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
                         <Tooltip
                           position={TooltipPosition.right}
                           content={
-                            <div style={{ textAlign: 'left' }}>This values represents cpu of the istiod process</div>
+                            <div style={{ textAlign: 'left' }}>
+                              This values represents cpu of the istiod {cpuMetricSource}
+                            </div>
                           }
                         >
                           <KialiIcon.Info className={infoStyle} />

--- a/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
+++ b/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
@@ -20,8 +20,10 @@ export const infoStyle = style({
 
 type ControlPlaneProps = {
   pilotLatency?: Metric[];
-  istiodMemory?: Metric[];
-  istiodCpu?: Metric[];
+  istiodContainerMemory?: Metric[];
+  istiodContainerCpu?: Metric[];
+  istiodProcessMemory?: Metric[];
+  istiodProcessCpu?: Metric[];
   duration: DurationInSeconds;
   istiodResourceThresholds?: IstiodResourceThresholds;
 };
@@ -47,19 +49,26 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
     let memoryThresholds: VCLine<RichDataPoint>[] = [];
     let cpuThresholds: VCLine<RichDataPoint>[] = [];
 
-    if (showMetrics(this.props.istiodMemory)) {
-      if (this.props.istiodMemory && this.props.istiodMemory?.length > 0) {
-        const data = toVCLine(this.props.istiodMemory[0].datapoints, 'Mb', PFColors.Green400);
+    let cpu = this.props.istiodContainerCpu;
+    if (!showMetrics(this.props.istiodContainerCpu)) {
+      cpu = this.props.istiodProcessCpu;
+    }
+
+    let memory = this.props.istiodContainerMemory;
+    if (!showMetrics(this.props.istiodContainerMemory)) {
+      memory = this.props.istiodProcessMemory;
+    }
+
+    if (showMetrics(memory)) {
+      if (memory && memory?.length > 0) {
+        const data = toVCLine(memory[0].datapoints, 'Mb', PFColors.Green400);
 
         if (this.props.istiodResourceThresholds?.memory) {
-          const datapoint0: Datapoint = [
-            this.props.istiodMemory[0].datapoints[0][0],
-            this.props.istiodMemory[0].datapoints[0][1]
-          ];
+          const datapoint0: Datapoint = [memory[0].datapoints[0][0], memory[0].datapoints[0][1]];
           datapoint0[1] = this.props.istiodResourceThresholds?.memory;
           const datapointn: Datapoint = [
-            this.props.istiodMemory[0].datapoints[this.props.istiodMemory[0].datapoints.length - 1][0],
-            this.props.istiodMemory[0].datapoints[this.props.istiodMemory[0].datapoints.length - 1][0]
+            memory[0].datapoints[memory[0].datapoints.length - 1][0],
+            memory[0].datapoints[memory[0].datapoints.length - 1][0]
           ];
           datapointn[1] = this.props.istiodResourceThresholds?.memory;
           const dataThre = toVCLine([datapoint0, datapointn], 'Mb (Threshold)', PFColors.Green300);
@@ -70,19 +79,16 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
       }
     }
 
-    if (showMetrics(this.props.istiodCpu)) {
-      if (this.props.istiodCpu && this.props.istiodCpu?.length > 0) {
-        const data = toVCLine(this.props.istiodCpu[0].datapoints, 'cores', PFColors.Green400);
+    if (showMetrics(cpu)) {
+      if (cpu && cpu?.length > 0) {
+        const data = toVCLine(cpu[0].datapoints, 'cores', PFColors.Green400);
 
         if (this.props.istiodResourceThresholds?.cpu) {
-          const datapoint0: Datapoint = [
-            this.props.istiodCpu[0].datapoints[0][0],
-            this.props.istiodCpu[0].datapoints[0][1]
-          ];
+          const datapoint0: Datapoint = [cpu[0].datapoints[0][0], cpu[0].datapoints[0][1]];
           datapoint0[1] = this.props.istiodResourceThresholds?.cpu;
           const datapointn: Datapoint = [
-            this.props.istiodCpu[0].datapoints[this.props.istiodCpu[0].datapoints.length - 1][0],
-            this.props.istiodCpu[0].datapoints[this.props.istiodCpu[0].datapoints.length - 1][0]
+            cpu[0].datapoints[cpu[0].datapoints.length - 1][0],
+            cpu[0].datapoints[cpu[0].datapoints.length - 1][0]
           ];
           datapointn[1] = this.props.istiodResourceThresholds?.cpu;
           const dataThre = toVCLine([datapoint0, datapointn], 'cores', PFColors.Green300);
@@ -106,7 +112,7 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
         >
           <Card isPlain>
             <CardBody>
-              {showMetrics(this.props.istiodMemory) && (
+              {showMetrics(memory) && (
                 <Grid style={{ marginBottom: 20 }} hasGutter>
                   <GridItem md={2}>
                     <Flex
@@ -152,7 +158,7 @@ class OverviewCardControlPlaneNamespace extends React.Component<ControlPlaneProp
                   </GridItem>
                 </Grid>
               )}
-              {showMetrics(this.props.istiodCpu) && (
+              {showMetrics(cpu) && (
                 <Grid hasGutter>
                   <GridItem md={2}>
                     <Flex

--- a/frontend/src/pages/Overview/OverviewCardSparklineChartsComponent.tsx
+++ b/frontend/src/pages/Overview/OverviewCardSparklineChartsComponent.tsx
@@ -38,8 +38,10 @@ class OverviewCardSparklineChartsComponent extends React.Component<Props & Redux
         {this.props.name === serverConfig.istioNamespace && this.props.istioAPIEnabled && (
           <OverviewCardControlPlaneNamespace
             pilotLatency={this.props.controlPlaneMetrics?.istiod_proxy_time}
-            istiodMemory={this.props.controlPlaneMetrics?.istiod_mem}
-            istiodCpu={this.props.controlPlaneMetrics?.istiod_cpu}
+            istiodContainerMemory={this.props.controlPlaneMetrics?.istiod_container_mem}
+            istiodContainerCpu={this.props.controlPlaneMetrics?.istiod_container_cpu}
+            istiodProcessMemory={this.props.controlPlaneMetrics?.istiod_process_mem}
+            istiodProcessCpu={this.props.controlPlaneMetrics?.istiod_process_cpu}
             duration={this.props.duration}
             istiodResourceThresholds={this.props.istiodResourceThresholds}
           />

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -435,8 +435,10 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           if (nsInfo.name === serverConfig.istioNamespace) {
             nsInfo.controlPlaneMetrics = {
               istiod_proxy_time: rs.data.pilot_proxy_convergence_time,
-              istiod_cpu: rs.data.container_cpu_usage_seconds_total,
-              istiod_mem: rs.data.container_memory_working_set_bytes
+              istiod_container_cpu: rs.data.container_cpu_usage_seconds_total,
+              istiod_container_mem: rs.data.container_memory_working_set_bytes,
+              istiod_process_cpu: rs.data.process_cpu_seconds_total,
+              istiod_process_mem: rs.data.process_resident_memory_bytes
             };
           }
           return nsInfo;

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -435,8 +435,8 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           if (nsInfo.name === serverConfig.istioNamespace) {
             nsInfo.controlPlaneMetrics = {
               istiod_proxy_time: rs.data.pilot_proxy_convergence_time,
-              istiod_cpu: rs.data.process_cpu_seconds_total,
-              istiod_mem: rs.data.process_virtual_memory_bytes
+              istiod_cpu: rs.data.container_cpu_usage_seconds_total,
+              istiod_mem: rs.data.container_memory_working_set_bytes
             };
           }
           return nsInfo;

--- a/frontend/src/types/Metrics.ts
+++ b/frontend/src/types/Metrics.ts
@@ -27,8 +27,8 @@ export type IstioMetricsMap = {
   tcp_received?: Metric[];
   tcp_sent?: Metric[];
   pilot_proxy_convergence_time?: Metric[];
-  process_cpu_seconds_total?: Metric[];
-  process_virtual_memory_bytes?: Metric[];
+  container_cpu_usage_seconds_total?: Metric[];
+  container_memory_working_set_bytes?: Metric[];
 };
 
 export enum MetricsObjectTypes {

--- a/frontend/src/types/Metrics.ts
+++ b/frontend/src/types/Metrics.ts
@@ -10,8 +10,10 @@ export interface Metric {
 
 export type ControlPlaneMetricsMap = {
   istiod_proxy_time?: Metric[];
-  istiod_cpu?: Metric[];
-  istiod_mem?: Metric[];
+  istiod_container_cpu?: Metric[];
+  istiod_container_mem?: Metric[];
+  istiod_process_cpu?: Metric[];
+  istiod_process_mem?: Metric[];
 };
 
 export type IstioMetricsMap = {
@@ -29,6 +31,8 @@ export type IstioMetricsMap = {
   pilot_proxy_convergence_time?: Metric[];
   container_cpu_usage_seconds_total?: Metric[];
   container_memory_working_set_bytes?: Metric[];
+  process_cpu_seconds_total?: Metric[];
+  process_resident_memory_bytes?: Metric[];
 };
 
 export enum MetricsObjectTypes {


### PR DESCRIPTION
Resolves #6177.

Docs PR: https://github.com/kiali/kiali.io/pull/664

This PR adds some logic to fetch the "process" metrics (CPU and memory) if "container" metrics are not available in Prometheus (this is the case for OSSM when it's using it's own Prometheus, which hasn't configured cAdvisor scraping metrics).

Kiali will indicate the source of the metric like:

![image](https://github.com/kiali/kiali/assets/1286393/bf9a5bca-c4be-4352-8f98-230194d3030f)
 