### PR TITLE
Fixed not loading of several config objects which are not cached.

### DIFF
--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -96,8 +96,9 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 
 	istioConfig := models.IstioConfigList{}
 
-	// This can result on an error, so filter here
-	if criteria.AllNamespaces && !config.Get().AllNamespacesAccessible() {
+	// This can result on an error when IstioAPI is disabled, so filter here
+	// Even if all namespaces are not accessible, but the IstioAPI is enabled, still use the Istio Registry by AllNamespaces=true
+	if criteria.AllNamespaces && !config.Get().AllNamespacesAccessible() && !config.Get().ExternalServices.Istio.IstioAPIEnabled {
 		criteria.AllNamespaces = false
 		for _, ns := range nss {
 			criteria.Namespace = ns


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6253
Istio objects which are not in a Cache (hence K8s Gateways) were not loaded in a case when accessible_namespaces are not ["**"], this happens after merging a PR https://github.com/kiali/kiali/pull/6204.
The [initial issue](https://github.com/kiali/kiali/issues/6196) was about IstioAPI disabled case.

The fix it to add additional check when IstioAPI is not enabled, only then skip loading configs from registry.