### PR TITLE
[v1.65] OSSM-4214: Adding a Dockerfile for integration tests to be used with …

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+_output
+operator
+deploy
+frontend/node_modules

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ OPERATOR_CONTAINER_VERSION ?= ${CONTAINER_VERSION}
 OPERATOR_QUAY_NAME ?= quay.io/${OPERATOR_CONTAINER_NAME}
 OPERATOR_QUAY_TAG ?= ${OPERATOR_QUAY_NAME}:${OPERATOR_CONTAINER_VERSION}
 
+# Identifies the Kiali interation tests container image that will be built
+INT_TESTS_CONTAINER_NAME ?= ${IMAGE_ORG}/kiali-int-tests
+INT_TESTS_CONTAINER_VERSION ?= ${CONTAINER_VERSION}
+INT_TESTS_QUAY_NAME ?= quay.io/${INT_TESTS_CONTAINER_NAME}
+INT_TESTS_QUAY_TAG ?= ${INT_TESTS_QUAY_NAME}:${INT_TESTS_CONTAINER_VERSION}
+
 # Where the control plane is
 ISTIO_NAMESPACE ?= istio-system
 # Declares the namespace/project where the objects are to be deployed.

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -34,6 +34,16 @@ else
 container-build: container-build-kiali
 endif
 
+## container-build-int-tests: Build Kiali integration tests container image
+container-build-int-tests:
+ifeq ($(DORP),docker)
+	@echo Building container image for Kiali integration tests using docker
+	docker build --pull -t ${INT_TESTS_QUAY_TAG} -f tests/integration/Dockerfile .
+else
+	@echo Building container image for Kiali integration tests using podman
+	podman build --pull -t ${INT_TESTS_QUAY_TAG} -f tests/integration/Dockerfile .
+endif
+
 ## container-push-kiali-quay: Pushes the Kiali image to quay.
 container-push-kiali-quay:
 ifeq ($(DORP),docker)
@@ -50,6 +60,16 @@ container-push-operator-quay:
 
 ## container-push: Pushes all container images to quay
 container-push: container-push-kiali-quay container-push-operator-quay
+
+## container-push-int-tests-quay: Pushes the Kiali integration tests image to quay.
+container-push-int-tests-quay:
+ifeq ($(DORP),docker)
+	@echo Pushing Kiali integration tests image to ${INT_TESTS_QUAY_TAG} using docker
+	docker push ${INT_TESTS_QUAY_TAG}
+else
+	@echo Pushing Kiali integration tests image to ${INT_TESTS_QUAY_TAG} using podman
+	podman push ${INT_TESTS_QUAY_TAG}
+endif
 
 # Ensure "docker buildx" is available and enabled. For more details, see: https://github.com/docker/buildx/blob/master/README.md
 # This does a few things:

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV GOPATH=/go
+ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH
+# we need to set HOME when running on OCP with random UID, otherwise the home is set to / and any writing there will fail with permission denied
+ENV HOME=$GOPATH/src/kiali
+
+# install required packages and prepare go dirs
+WORKDIR /bin
+RUN microdnf install --nodocs tar gzip make which \
+    && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
+    && tar -xf oc.tar.gz \
+    && rm -f oc.tar.gz \
+    && curl -Lo ./golang.tar.gz https://go.dev/dl/go1.20.2.linux-amd64.tar.gz \
+    && tar -xf golang.tar.gz -C /usr/local \
+    && rm -f golang.tar.gz \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir -p "$GOPATH/src/kiali" "$GOPATH/bin"
+
+COPY . $GOPATH/src/kiali
+
+WORKDIR "$GOPATH/src/kiali"
+
+# install packages now so we don't have to do it every time we start the container
+# Set required permissions for OpenShift usage
+RUN go mod download \
+    && chgrp -R 0 $GOPATH \
+    && chmod -R g=u $GOPATH
+
+CMD ["/bin/bash", "-c", "tests/integration/run-tests.sh"]

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -75,6 +75,23 @@ $ make test-integration -e CLIENT_EXE="kubectl" -e URL="http://localhost:20001/k
 # test results are stored in the "tests/integration/junit-rest-report.xml" file
 ```
 
+## Running tests in a container
+You can also run the test suite in a container, using the image `quay.io/kiali/kiali-int-tests:v1.65`.
+System dependencies are bundled in the container but you are still required to install istio + kiali + bookinfo in advance.
+Following environment variables are expected:
+- `OCP_API_URL` - The URL of the OpenShift API server.
+- `TOKEN` - The OCP API TOKEN.
+
+
+To run the container:
+```console
+podman run -it \
+  -e OCP_API_URL=https://api.test-cluter.test.com:6443 \
+  -e TOKEN=<token> \
+  quay.io/kiali/kiali-int-tests:v1.65
+```
+
+
 ## Run notes
 
 * The Bookinfo namespace is cleaned of pre-existing Circuit Breakers and Virtual Services.

--- a/tests/integration/run-tests.sh
+++ b/tests/integration/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+oc login --token=${TOKEN} --server=${OCP_API_URL} --insecure-skip-tls-verify
+make test-integration -e URL="https://$(oc get route -n istio-system kiali -o 'jsonpath={.spec.host}')"
+cat tests/integration/junit-rest-report.xml


### PR DESCRIPTION
Adding int tests image dockerfile and updating readme. This is needed for interop job to use OSSM 2.4
