### PR TITLE
Virtual list type does not depend on url value

### DIFF
--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -280,7 +280,6 @@ const istio: Resource = {
 };
 
 const conf = {
-  headerTable: true,
   applications: applications,
   workloads: workloads,
   overview: namespaces,

--- a/frontend/src/pages/AppList/AppListPage.tsx
+++ b/frontend/src/pages/AppList/AppListPage.tsx
@@ -139,7 +139,7 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
           />
         </div>
         <RenderContent>
-          <VirtualList rows={this.state.listItems} hiddenColumns={hiddenColumns}>
+          <VirtualList rows={this.state.listItems} hiddenColumns={hiddenColumns} type="applications">
             <StatefulFilters
               initialFilters={AppListFilters.availableFilters}
               initialToggles={this.initialToggles}

--- a/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/frontend/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -210,7 +210,7 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
           />
         </div>
         <RenderContent>
-          <VirtualList rows={this.state.listItems} hiddenColumns={hiddenColumns}>
+          <VirtualList rows={this.state.listItems} hiddenColumns={hiddenColumns} type="istio">
             <StatefulFilters
               initialFilters={IstioConfigListFilters.availableFilters}
               initialToggles={this.props.istioAPIEnabled ? this.initialToggles : undefined}

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -925,6 +925,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
                 statefulProps={this.sFOverviewToolbar}
                 actions={namespaceActions}
                 hiddenColumns={hiddenColumns}
+                type="overview"
               />
             ) : (
               <Grid>

--- a/frontend/src/pages/ServiceList/ServiceListPage.tsx
+++ b/frontend/src/pages/ServiceList/ServiceListPage.tsx
@@ -185,7 +185,7 @@ class ServiceListPageComponent extends FilterComponent.Component<
           />
         </div>
         <RenderContent>
-          <VirtualList rows={this.state.listItems} hiddenColumns={hiddenColumns}>
+          <VirtualList rows={this.state.listItems} hiddenColumns={hiddenColumns} type="services">
             <StatefulFilters
               initialFilters={ServiceListFilters.availableFilters}
               initialToggles={this.initialToggles}

--- a/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -176,7 +176,7 @@ class WorkloadListPageComponent extends FilterComponent.Component<
           />
         </div>
         <RenderContent>
-          <VirtualList rows={this.state.listItems} hiddenColumns={hiddenColumns}>
+          <VirtualList rows={this.state.listItems} hiddenColumns={hiddenColumns} type="workloads">
             <StatefulFilters
               initialFilters={WorkloadListFilters.availableFilters}
               initialToggles={this.initialToggles}


### PR DESCRIPTION
** Describe the change **

Virtual list type is not a dynamic value, so it does not need to depend on url value. To make it compatible with OSSMC plugin, type is converted to React input property.

** Issue reference **

Closes #6262 