### PR TITLE
Remove routing properties from Kiali pages

### DIFF
--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -2,7 +2,6 @@ import * as Cy from 'cytoscape';
 import * as React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { RouteComponentProps } from 'react-router-dom';
 import FlexView from 'react-flexview';
 import { style } from 'typestyle';
 import history from '../../app/History';
@@ -83,7 +82,7 @@ import connectRefresh from '../../components/Refresh/connectRefresh';
 import { triggerRefresh } from '../../hooks/refresh';
 
 // GraphURLPathProps holds path variable values.  Currently all path variables are relevant only to a node graph
-type GraphURLPathProps = {
+export type GraphURLPathProps = {
   aggregate: string;
   aggregateValue: string;
   app: string;
@@ -144,7 +143,7 @@ type ReduxProps = {
   istioAPIEnabled: boolean;
 };
 
-export type GraphPageProps = RouteComponentProps<Partial<GraphURLPathProps>> &
+export type GraphPageProps = Partial<GraphURLPathProps> &
   ReduxProps & {
     lastRefreshAt: TimeInMilliseconds;
   };
@@ -245,18 +244,18 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
   private focusSelector?: string;
   private graphDataSource: GraphDataSource;
 
-  static getNodeParamsFromProps(props: RouteComponentProps<Partial<GraphURLPathProps>>): NodeParamsType | undefined {
-    const aggregate = props.match.params.aggregate;
+  static getNodeParamsFromProps(props: Partial<GraphURLPathProps>): NodeParamsType | undefined {
+    const aggregate = props.aggregate;
     const aggregateOk = aggregate && aggregate !== UNKNOWN;
-    const aggregateValue = props.match.params.aggregateValue;
+    const aggregateValue = props.aggregateValue;
     const aggregateValueOk = aggregateValue && aggregateValue !== UNKNOWN;
-    const app = props.match.params.app;
+    const app = props.app;
     const appOk = app && app !== UNKNOWN;
-    const namespace = props.match.params.namespace;
+    const namespace = props.namespace;
     const namespaceOk = namespace && namespace !== UNKNOWN;
-    const service = props.match.params.service;
+    const service = props.service;
     const serviceOk = service && service !== UNKNOWN;
-    const workload = props.match.params.workload;
+    const workload = props.workload;
     const workloadOk = workload && workload !== UNKNOWN;
     if (!aggregateOk && !aggregateValueOk && !appOk && !namespaceOk && !serviceOk && !workloadOk) {
       // @ts-ignore
@@ -270,7 +269,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
       version = '';
     } else if (appOk || workloadOk) {
       nodeType = appOk ? NodeType.APP : NodeType.WORKLOAD;
-      version = props.match.params.version;
+      version = props.version;
     } else {
       nodeType = NodeType.SERVICE;
       version = '';

--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -54,7 +54,6 @@ import RequestAuthenticationForm, {
 } from './RequestAuthenticationForm';
 import { isValidK8SName } from '../../helpers/ValidationHelpers';
 import DefaultSecondaryMasthead from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
-import { RouteComponentProps } from 'react-router-dom';
 import { PFColors } from '../../components/Pf/PfColors';
 import ServiceEntryForm, {
   initServiceEntry,
@@ -70,7 +69,8 @@ export interface IstioConfigNewPageId {
   objectType: string;
 }
 
-type Props = RouteComponentProps<IstioConfigNewPageId> & {
+type Props = {
+  istioConfigNewPageId: IstioConfigNewPageId;
   activeNamespaces: Namespace[];
 };
 
@@ -160,8 +160,8 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   canCreate = (namespace: string): boolean => {
     return (
       this.state.istioPermissions[namespace] &&
-      this.props.match.params.objectType.length > 0 &&
-      this.state.istioPermissions[namespace][DIC[this.props.match.params.objectType]].create
+      this.props.istioConfigNewPageId.objectType.length > 0 &&
+      this.state.istioPermissions[namespace][DIC[this.props.istioConfigNewPageId.objectType]].create
     );
   };
 
@@ -208,26 +208,33 @@ class IstioConfigNewPage extends React.Component<Props, State> {
 
     this.promises
       .registerAll(
-        'Create ' + DIC[this.props.match.params.objectType],
+        'Create ' + DIC[this.props.istioConfigNewPageId.objectType],
         jsonIstioObjects.map(o =>
-          API.createIstioConfigDetail(o.namespace, DIC[this.props.match.params.objectType], o.json)
+          API.createIstioConfigDetail(o.namespace, DIC[this.props.istioConfigNewPageId.objectType], o.json)
         )
       )
       .then(results => {
         if (results.length > 0) {
-          AlertUtils.add('Istio ' + this.props.match.params.objectType + ' created', 'default', MessageType.SUCCESS);
+          AlertUtils.add(
+            'Istio ' + this.props.istioConfigNewPageId.objectType + ' created',
+            'default',
+            MessageType.SUCCESS
+          );
         }
         this.backToList();
       })
       .catch(error => {
-        AlertUtils.addError('Could not create Istio ' + this.props.match.params.objectType + ' objects.', error);
+        AlertUtils.addError(
+          'Could not create Istio ' + this.props.istioConfigNewPageId.objectType + ' objects.',
+          error
+        );
       });
   };
 
   showPreview = () => {
     const items: ConfigPreviewItem[] = [];
     this.props.activeNamespaces.forEach(ns => {
-      switch (this.props.match.params.objectType) {
+      switch (this.props.istioConfigNewPageId.objectType) {
         case AUTHORIZACION_POLICY:
           items.push({
             title: 'Authorization Policy',
@@ -291,7 +298,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   };
 
   isIstioFormValid = (): boolean => {
-    switch (this.props.match.params.objectType) {
+    switch (this.props.istioConfigNewPageId.objectType) {
       case AUTHORIZACION_POLICY:
         return isAuthorizationPolicyStateValid(this.state.authorizationPolicy);
       case GATEWAY:
@@ -396,7 +403,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
               label="Name"
               isRequired={true}
               fieldId="name"
-              helperTextInvalid={'A valid ' + this.props.match.params.objectType + ' name is required'}
+              helperTextInvalid={'A valid ' + this.props.istioConfigNewPageId.objectType + ' name is required'}
               validated={isValid(isNameValid)}
             >
               <TextInput
@@ -410,34 +417,34 @@ class IstioConfigNewPage extends React.Component<Props, State> {
                 validated={isValid(isNameValid)}
               />
             </FormGroup>
-            {this.props.match.params.objectType === AUTHORIZACION_POLICY && (
+            {this.props.istioConfigNewPageId.objectType === AUTHORIZACION_POLICY && (
               <AuthorizationPolicyForm
                 authorizationPolicy={this.state.authorizationPolicy}
                 onChange={this.onChangeAuthorizationPolicy}
               />
             )}
-            {this.props.match.params.objectType === GATEWAY && (
+            {this.props.istioConfigNewPageId.objectType === GATEWAY && (
               <GatewayForm gateway={this.state.gateway} onChange={this.onChangeGateway} />
             )}
-            {this.props.match.params.objectType === K8SGATEWAY && (
+            {this.props.istioConfigNewPageId.objectType === K8SGATEWAY && (
               <K8sGatewayForm k8sGateway={this.state.k8sGateway} onChange={this.onChangeK8sGateway} />
             )}
-            {this.props.match.params.objectType === PEER_AUTHENTICATION && (
+            {this.props.istioConfigNewPageId.objectType === PEER_AUTHENTICATION && (
               <PeerAuthenticationForm
                 peerAuthentication={this.state.peerAuthentication}
                 onChange={this.onChangePeerAuthentication}
               />
             )}
-            {this.props.match.params.objectType === REQUEST_AUTHENTICATION && (
+            {this.props.istioConfigNewPageId.objectType === REQUEST_AUTHENTICATION && (
               <RequestAuthenticationForm
                 requestAuthentication={this.state.requestAuthentication}
                 onChange={this.onChangeRequestAuthentication}
               />
             )}
-            {this.props.match.params.objectType === SERVICE_ENTRY && (
+            {this.props.istioConfigNewPageId.objectType === SERVICE_ENTRY && (
               <ServiceEntryForm serviceEntry={this.state.serviceEntry} onChange={this.onChangeServiceEntry} />
             )}
-            {this.props.match.params.objectType === SIDECAR && (
+            {this.props.istioConfigNewPageId.objectType === SIDECAR && (
               <SidecarForm sidecar={this.state.sidecar} onChange={this.onChangeSidecar} />
             )}
             <ActionGroup>
@@ -481,6 +488,6 @@ const mapStateToProps = (state: KialiAppState) => {
   };
 };
 
-const IstioConfigNewPageContainer = connect(mapStateToProps, null)(IstioConfigNewPage);
+const IstioConfigNewPageContainer = connect(mapStateToProps)(IstioConfigNewPage);
 
 export default IstioConfigNewPageContainer;

--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -65,12 +65,8 @@ import ServiceEntryForm, {
 import { ConfigPreviewItem, IstioConfigPreview } from 'components/IstioConfigPreview/IstioConfigPreview';
 import { isValid } from 'utils/Common';
 
-export interface IstioConfigNewPageId {
-  objectType: string;
-}
-
 type Props = {
-  istioConfigNewPageId: IstioConfigNewPageId;
+  objectType: string;
   activeNamespaces: Namespace[];
 };
 
@@ -160,8 +156,8 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   canCreate = (namespace: string): boolean => {
     return (
       this.state.istioPermissions[namespace] &&
-      this.props.istioConfigNewPageId.objectType.length > 0 &&
-      this.state.istioPermissions[namespace][DIC[this.props.istioConfigNewPageId.objectType]].create
+      this.props.objectType.length > 0 &&
+      this.state.istioPermissions[namespace][DIC[this.props.objectType]].create
     );
   };
 
@@ -208,33 +204,24 @@ class IstioConfigNewPage extends React.Component<Props, State> {
 
     this.promises
       .registerAll(
-        'Create ' + DIC[this.props.istioConfigNewPageId.objectType],
-        jsonIstioObjects.map(o =>
-          API.createIstioConfigDetail(o.namespace, DIC[this.props.istioConfigNewPageId.objectType], o.json)
-        )
+        'Create ' + DIC[this.props.objectType],
+        jsonIstioObjects.map(o => API.createIstioConfigDetail(o.namespace, DIC[this.props.objectType], o.json))
       )
       .then(results => {
         if (results.length > 0) {
-          AlertUtils.add(
-            'Istio ' + this.props.istioConfigNewPageId.objectType + ' created',
-            'default',
-            MessageType.SUCCESS
-          );
+          AlertUtils.add('Istio ' + this.props.objectType + ' created', 'default', MessageType.SUCCESS);
         }
         this.backToList();
       })
       .catch(error => {
-        AlertUtils.addError(
-          'Could not create Istio ' + this.props.istioConfigNewPageId.objectType + ' objects.',
-          error
-        );
+        AlertUtils.addError('Could not create Istio ' + this.props.objectType + ' objects.', error);
       });
   };
 
   showPreview = () => {
     const items: ConfigPreviewItem[] = [];
     this.props.activeNamespaces.forEach(ns => {
-      switch (this.props.istioConfigNewPageId.objectType) {
+      switch (this.props.objectType) {
         case AUTHORIZACION_POLICY:
           items.push({
             title: 'Authorization Policy',
@@ -298,7 +285,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   };
 
   isIstioFormValid = (): boolean => {
-    switch (this.props.istioConfigNewPageId.objectType) {
+    switch (this.props.objectType) {
       case AUTHORIZACION_POLICY:
         return isAuthorizationPolicyStateValid(this.state.authorizationPolicy);
       case GATEWAY:
@@ -403,7 +390,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
               label="Name"
               isRequired={true}
               fieldId="name"
-              helperTextInvalid={'A valid ' + this.props.istioConfigNewPageId.objectType + ' name is required'}
+              helperTextInvalid={'A valid ' + this.props.objectType + ' name is required'}
               validated={isValid(isNameValid)}
             >
               <TextInput
@@ -417,34 +404,34 @@ class IstioConfigNewPage extends React.Component<Props, State> {
                 validated={isValid(isNameValid)}
               />
             </FormGroup>
-            {this.props.istioConfigNewPageId.objectType === AUTHORIZACION_POLICY && (
+            {this.props.objectType === AUTHORIZACION_POLICY && (
               <AuthorizationPolicyForm
                 authorizationPolicy={this.state.authorizationPolicy}
                 onChange={this.onChangeAuthorizationPolicy}
               />
             )}
-            {this.props.istioConfigNewPageId.objectType === GATEWAY && (
+            {this.props.objectType === GATEWAY && (
               <GatewayForm gateway={this.state.gateway} onChange={this.onChangeGateway} />
             )}
-            {this.props.istioConfigNewPageId.objectType === K8SGATEWAY && (
+            {this.props.objectType === K8SGATEWAY && (
               <K8sGatewayForm k8sGateway={this.state.k8sGateway} onChange={this.onChangeK8sGateway} />
             )}
-            {this.props.istioConfigNewPageId.objectType === PEER_AUTHENTICATION && (
+            {this.props.objectType === PEER_AUTHENTICATION && (
               <PeerAuthenticationForm
                 peerAuthentication={this.state.peerAuthentication}
                 onChange={this.onChangePeerAuthentication}
               />
             )}
-            {this.props.istioConfigNewPageId.objectType === REQUEST_AUTHENTICATION && (
+            {this.props.objectType === REQUEST_AUTHENTICATION && (
               <RequestAuthenticationForm
                 requestAuthentication={this.state.requestAuthentication}
                 onChange={this.onChangeRequestAuthentication}
               />
             )}
-            {this.props.istioConfigNewPageId.objectType === SERVICE_ENTRY && (
+            {this.props.objectType === SERVICE_ENTRY && (
               <ServiceEntryForm serviceEntry={this.state.serviceEntry} onChange={this.onChangeServiceEntry} />
             )}
-            {this.props.istioConfigNewPageId.objectType === SIDECAR && (
+            {this.props.objectType === SIDECAR && (
               <SidecarForm sidecar={this.state.sidecar} onChange={this.onChangeSidecar} />
             )}
             <ActionGroup>

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,17 +1,18 @@
+import { MenuItem, Path } from './types/Routes';
+import { Paths } from './config';
 import WorkloadListPage from './pages/WorkloadList/WorkloadListPage';
 import ServiceListPage from './pages/ServiceList/ServiceListPage';
 import IstioConfigPage from './pages/IstioConfigList/IstioConfigListPage';
-import IstioConfigDetailsPage from './pages/IstioConfigDetails/IstioConfigDetailsPage';
-import WorkloadDetailsPage from './pages/WorkloadDetails/WorkloadDetailsPage';
 import AppListPage from './pages/AppList/AppListPage';
-import AppDetailsPage from './pages/AppDetails/AppDetailsPage';
-import OverviewPageContainer from './pages/Overview/OverviewPage';
-import { MenuItem, Path } from './types/Routes';
-import GraphPageContainer from './pages/Graph/GraphPage';
-import { Paths } from './config';
-import ServiceDetailsPageContainer from './pages/ServiceDetails/ServiceDetailsPage';
-import IstioConfigNewPageContainer from './pages/IstioConfigNew/IstioConfigNewPage';
+import OverviewPage from './pages/Overview/OverviewPage';
+import GraphPage from 'pages/Graph/GraphPage';
 import MeshPage from 'pages/Mesh/MeshPage';
+import GraphRoute from 'routes/GraphRoute';
+import ServiceDetailsRoute from 'routes/ServiceDetailsRoute';
+import WorkloadDetailsRoute from 'routes/WorkloadDetailsRoute';
+import AppDetailsRoute from 'routes/AppDetailsRoute';
+import IstioConfigDetailsRoute from 'routes/IstioConfigDetailsRoute';
+import IstioConfigNewRoute from 'routes/IstioConfigNewRoute';
 
 /**
  * Return array of objects that describe vertical menu
@@ -63,39 +64,39 @@ const defaultRoute = '/overview';
 const pathRoutes: Path[] = [
   {
     path: '/overview',
-    component: OverviewPageContainer
+    component: OverviewPage
   },
   {
     path: '/graph/node/namespaces/:namespace/' + Paths.AGGREGATES + '/:aggregate/:aggregateValue',
-    component: GraphPageContainer
+    component: GraphRoute
   },
   {
     path: '/graph/node/namespaces/:namespace/' + Paths.APPLICATIONS + '/:app/versions/:version',
-    component: GraphPageContainer
+    component: GraphRoute
   },
   {
     path: '/graph/node/namespaces/:namespace/' + Paths.APPLICATIONS + '/:app',
-    component: GraphPageContainer
+    component: GraphRoute
   },
   {
     path: '/graph/node/namespaces/:namespace/' + Paths.SERVICES + '/:service',
-    component: GraphPageContainer
+    component: GraphRoute
   },
   {
     path: '/graph/node/namespaces/:namespace/' + Paths.WORKLOADS + '/:workload',
-    component: GraphPageContainer
+    component: GraphRoute
   },
   {
     path: '/graph/namespaces',
-    component: GraphPageContainer
+    component: GraphPage
   },
   {
     path: '/namespaces/:namespace/' + Paths.SERVICES + '/:service',
-    component: ServiceDetailsPageContainer
+    component: ServiceDetailsRoute
   },
   {
     path: '/namespaces/:namespace/' + Paths.ISTIO + '/:objectType/:object',
-    component: IstioConfigDetailsPage
+    component: IstioConfigDetailsRoute
   },
   {
     path: '/' + Paths.SERVICES,
@@ -107,7 +108,7 @@ const pathRoutes: Path[] = [
   },
   {
     path: '/namespaces/:namespace/' + Paths.APPLICATIONS + '/:app',
-    component: AppDetailsPage
+    component: AppDetailsRoute
   },
   {
     path: '/' + Paths.WORKLOADS,
@@ -115,11 +116,11 @@ const pathRoutes: Path[] = [
   },
   {
     path: '/namespaces/:namespace/' + Paths.WORKLOADS + '/:workload',
-    component: WorkloadDetailsPage
+    component: WorkloadDetailsRoute
   },
   {
     path: '/' + Paths.ISTIO + '/new/:objectType',
-    component: IstioConfigNewPageContainer
+    component: IstioConfigNewRoute
   },
   {
     path: '/' + Paths.ISTIO,

--- a/frontend/src/routes/AppDetailsRoute.tsx
+++ b/frontend/src/routes/AppDetailsRoute.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+import { AppId } from 'types/App';
+import AppDetailsPage from 'pages/AppDetails/AppDetailsPage';
+
+const AppDetailsRoute = () => {
+  const appId = useParams<AppId>();
+
+  return <AppDetailsPage appId={appId}></AppDetailsPage>;
+};
+
+export default AppDetailsRoute;

--- a/frontend/src/routes/GraphRoute.tsx
+++ b/frontend/src/routes/GraphRoute.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+import GraphPage, { GraphURLPathProps } from 'pages/Graph/GraphPage';
+
+const GraphRoute = () => {
+  const { aggregate, aggregateValue, app, namespace, service, version, workload } = useParams<GraphURLPathProps>();
+
+  return (
+    <GraphPage
+      aggregate={aggregate}
+      aggregateValue={aggregateValue}
+      app={app}
+      namespace={namespace}
+      service={service}
+      version={version}
+      workload={workload}
+    ></GraphPage>
+  );
+};
+
+export default GraphRoute;

--- a/frontend/src/routes/IstioConfigDetailsRoute.tsx
+++ b/frontend/src/routes/IstioConfigDetailsRoute.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+import { IstioConfigId } from 'types/IstioConfigDetails';
+import IstioConfigDetailsPage from 'pages/IstioConfigDetails/IstioConfigDetailsPage';
+
+const IstioConfigDetailsRoute = () => {
+  const istioConfigId = useParams<IstioConfigId>();
+
+  return <IstioConfigDetailsPage istioConfigId={istioConfigId}></IstioConfigDetailsPage>;
+};
+
+export default IstioConfigDetailsRoute;

--- a/frontend/src/routes/IstioConfigNewRoute.tsx
+++ b/frontend/src/routes/IstioConfigNewRoute.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+import IstioConfigNewPage, { IstioConfigNewPageId } from 'pages/IstioConfigNew/IstioConfigNewPage';
+
+const IstioConfigNewRoute = () => {
+  const istioConfigNewPageId = useParams<IstioConfigNewPageId>();
+
+  return <IstioConfigNewPage istioConfigNewPageId={istioConfigNewPageId}></IstioConfigNewPage>;
+};
+
+export default IstioConfigNewRoute;

--- a/frontend/src/routes/IstioConfigNewRoute.tsx
+++ b/frontend/src/routes/IstioConfigNewRoute.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useParams } from 'react-router';
-import IstioConfigNewPage, { IstioConfigNewPageId } from 'pages/IstioConfigNew/IstioConfigNewPage';
+import IstioConfigNewPage from 'pages/IstioConfigNew/IstioConfigNewPage';
 
 const IstioConfigNewRoute = () => {
-  const istioConfigNewPageId = useParams<IstioConfigNewPageId>();
+  const objectType = useParams<string>();
 
-  return <IstioConfigNewPage istioConfigNewPageId={istioConfigNewPageId}></IstioConfigNewPage>;
+  return <IstioConfigNewPage objectType={objectType}></IstioConfigNewPage>;
 };
 
 export default IstioConfigNewRoute;

--- a/frontend/src/routes/IstioConfigNewRoute.tsx
+++ b/frontend/src/routes/IstioConfigNewRoute.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router';
 import IstioConfigNewPage from 'pages/IstioConfigNew/IstioConfigNewPage';
 
 const IstioConfigNewRoute = () => {
-  const objectType = useParams<string>();
+  const { objectType } = useParams<{ objectType: string }>();
 
   return <IstioConfigNewPage objectType={objectType}></IstioConfigNewPage>;
 };

--- a/frontend/src/routes/ServiceDetailsRoute.tsx
+++ b/frontend/src/routes/ServiceDetailsRoute.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+import ServiceId from 'types/ServiceId';
+import ServiceDetailsPage from 'pages/ServiceDetails/ServiceDetailsPage';
+
+const ServiceDetailsRoute = () => {
+  const serviceId = useParams<ServiceId>();
+
+  return <ServiceDetailsPage serviceId={serviceId}></ServiceDetailsPage>;
+};
+
+export default ServiceDetailsRoute;

--- a/frontend/src/routes/WorkloadDetailsRoute.tsx
+++ b/frontend/src/routes/WorkloadDetailsRoute.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+import { WorkloadId } from 'types/Workload';
+import WorkloadDetailsPage from 'pages/WorkloadDetails/WorkloadDetailsPage';
+
+const WorkloadDetailsRoute = () => {
+  const workloadId = useParams<WorkloadId>();
+
+  return <WorkloadDetailsPage workloadId={workloadId}></WorkloadDetailsPage>;
+};
+
+export default WorkloadDetailsRoute;


### PR DESCRIPTION
** Describe the change **

Remove routing properties from Kiali pages to be able to use them without react-router. Route wrappers have been created to extract routing properties and add to Kiali pages as React input properties

** Issue reference **

Closes #6263 