### PR TITLE
Allow history basename to be modified

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -8,7 +8,7 @@ import { GlobalActions } from '../actions/GlobalActions';
 import NavigationContainer from '../components/Nav/Navigation';
 import { persistor, store } from '../store/ConfigStore';
 import AuthenticationControllerContainer from './AuthenticationController';
-import history from './History';
+import { history } from './History';
 import InitializingScreen from './InitializingScreen';
 import StartupInitializer from './StartupInitializer';
 import LoginPageContainer from '../pages/Login/LoginPage';

--- a/frontend/src/app/AuthenticationController.tsx
+++ b/frontend/src/app/AuthenticationController.tsx
@@ -17,7 +17,7 @@ import { setServerConfig, serverConfig, humanDurations } from '../config/ServerC
 import { AuthStrategy } from '../types/Auth';
 import { JaegerInfo } from '../types/JaegerInfo';
 import { LoginActions } from '../actions/LoginActions';
-import history from './History';
+import { history } from './History';
 import { NamespaceActions } from 'actions/NamespaceAction';
 import Namespace from 'types/Namespace';
 import { UserSettingsActions } from 'actions/UserSettingsActions';

--- a/frontend/src/app/History.ts
+++ b/frontend/src/app/History.ts
@@ -2,16 +2,24 @@ import { createBrowserHistory, createMemoryHistory, createHashHistory } from 'hi
 import { toValidDuration } from '../config/ServerConfig';
 import { BoundsInMilliseconds } from 'types/Common';
 
+const createHistory = (baseName: string) => {
+  return process.env.TEST_RUNNER
+    ? createMemoryHistory()
+    : historyMode === 'hash'
+    ? createHashHistory()
+    : createBrowserHistory({ basename: baseName });
+};
+
+export const setHistory = (baseName: string) => {
+  history = createHistory(baseName);
+};
+
 const webRoot = (window as any).WEB_ROOT ? (window as any).WEB_ROOT : undefined;
 const baseName = webRoot && webRoot !== '/' ? webRoot + '/console' : '/console';
 const historyMode = (window as any).HISTORY_MODE ? (window as any).HISTORY_MODE : 'browser';
-const history = process.env.TEST_RUNNER
-  ? createMemoryHistory()
-  : historyMode === 'hash'
-  ? createHashHistory()
-  : createBrowserHistory({ basename: baseName });
+let history = createHistory(baseName);
 
-export default history;
+export { history };
 
 export enum URLParam {
   AGGREGATOR = 'aggregator',

--- a/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -5,7 +5,7 @@ import { style } from 'typestyle';
 import { Spinner, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import history from 'app/History';
+import { history } from 'app/History';
 import { BoxByType, DecoratedGraphNodeData, NodeType } from 'types/Graph';
 import { JaegerInfo } from 'types/JaegerInfo';
 import { durationSelector } from 'store/Selectors';

--- a/frontend/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -8,7 +8,7 @@ import { PeerAuthentication } from '../../types/IstioObjects';
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
 import { Provider } from 'react-redux';
 import { store } from '../../store/ConfigStore';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import { getOptions } from './ContextMenu/NodeContextMenu';
 import { WizardAction, WizardMode } from '../IstioWizards/WizardActions';
 

--- a/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -11,7 +11,7 @@ import {
   KebabToggle,
   ToolbarItem
 } from '@patternfly/react-core';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import GraphDataSource from '../../services/GraphDataSource';
 import { DecoratedGraphElements, EdgeMode, GraphType, NodeType } from '../../types/Graph';
 import CytoscapeGraph, { GraphEdgeTapEvent, GraphNodeTapEvent } from './CytoscapeGraph';

--- a/frontend/src/components/DurationDropdown/DurationDropdown.tsx
+++ b/frontend/src/components/DurationDropdown/DurationDropdown.tsx
@@ -9,7 +9,7 @@ import { bindActionCreators } from 'redux';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
 import { connect } from 'react-redux';
 import { HistoryManager, URLParam } from '../../app/History';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import { TooltipPosition } from '@patternfly/react-core';
 import { isKioskMode } from '../../utils/SearchParamUtils';
 import { kioskDurationAction } from '../Kiosk/KioskActions';

--- a/frontend/src/components/Envoy/EnvoyDetails.tsx
+++ b/frontend/src/components/Envoy/EnvoyDetails.tsx
@@ -34,7 +34,7 @@ import { DashboardRef } from 'types/Runtimes';
 import CustomMetricsContainer from 'components/Metrics/CustomMetrics';
 import { serverConfig } from 'config';
 import { FilterSelected } from 'components/Filters/StatefulFilters';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import {
   tabName as workloadTabName,
   defaultTab as workloadDefaultTab

--- a/frontend/src/components/FilterList/FilterHelper.ts
+++ b/frontend/src/components/FilterList/FilterHelper.ts
@@ -1,5 +1,5 @@
 import { camelCase } from 'lodash';
-import history, { URLParam, HistoryManager } from '../../app/History';
+import { history, URLParam, HistoryManager } from '../../app/History';
 import { config } from '../../config';
 import {
   ActiveFilter,

--- a/frontend/src/components/FilterList/__tests__/ListPagesHelper.test.ts
+++ b/frontend/src/components/FilterList/__tests__/ListPagesHelper.test.ts
@@ -1,4 +1,4 @@
-import history from '../../../app/History';
+import { history } from '../../../app/History';
 import * as FilterHelper from '../FilterHelper';
 import { DEFAULT_LABEL_OPERATION, FilterType } from '../../../types/Filters';
 

--- a/frontend/src/components/Filters/StatefulFilters.tsx
+++ b/frontend/src/components/Filters/StatefulFilters.tsx
@@ -32,7 +32,7 @@ import { style } from 'typestyle';
 import { LabelFilters } from './LabelFilter';
 import { arrayEquals } from 'utils/Common';
 import { labelFilter } from './CommonFilters';
-import history, { HistoryManager } from 'app/History';
+import { history, HistoryManager } from 'app/History';
 import { serverConfig } from 'config';
 
 var classNames = require('classnames');

--- a/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Dropdown, DropdownGroup, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import { serverConfig } from '../../config';
 import { NEW_ISTIO_RESOURCE } from '../../pages/IstioConfigNew/IstioConfigNewPage';
 import { K8SGATEWAY } from '../../pages/IstioConfigNew/K8sGatewayForm';

--- a/frontend/src/components/JaegerIntegration/JaegerResults/JaegerTraceTitle.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/JaegerTraceTitle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { CardActions, CardHeader, CardTitle, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { FormattedTraceInfo, fullIDStyle } from './FormattedTraceInfo';
-import history from 'app/History';
+import { history } from 'app/History';
 import { KialiAppState } from '../../../store/Store';
 import { connect } from 'react-redux';
 import { isParentKiosk, kioskContextMenuAction } from '../../Kiosk/KioskActions';

--- a/frontend/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
@@ -42,7 +42,7 @@ import { Link } from 'react-router-dom';
 import { PFColors } from 'components/Pf/PfColors';
 import responseFlags from 'utils/ResponseFlags';
 import { renderMetricsComparison } from './StatsComparison';
-import history from 'app/History';
+import { history } from 'app/History';
 import { AngleDownIcon, AngleRightIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { isParentKiosk, kioskContextMenuAction } from '../../Kiosk/KioskActions';
 

--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -15,7 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { serverConfig } from '../../config/ServerConfig';
-import history, { URLParam } from '../../app/History';
+import { history, URLParam } from '../../app/History';
 import * as API from '../../services/Api';
 import { KialiAppState } from '../../store/Store';
 import { TimeRange, evalTimeRange, TimeInMilliseconds, isEqualTimeRange } from '../../types/Common';

--- a/frontend/src/components/Metrics/Helper.ts
+++ b/frontend/src/components/Metrics/Helper.ts
@@ -1,7 +1,7 @@
 import { MetricsSettings, LabelsSettings, Quantiles, LabelSettings } from '../MetricsOptions/MetricsSettings';
 import { boundsToDuration, guardTimeRange, TimeRange, DurationInSeconds } from '../../types/Common';
 import { computePrometheusRateParams } from '../../services/Prometheus';
-import history, { URLParam } from '../../app/History';
+import { history, URLParam } from '../../app/History';
 import responseFlags from 'utils/ResponseFlags';
 import { AggregationModel, DashboardModel } from 'types/Dashboards';
 import { AllPromLabelsValues, Metric, PromLabel, SingleLabelValues } from 'types/Metrics';

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -17,7 +17,7 @@ import { MetricsSettings, LabelsSettings } from '../MetricsOptions/MetricsSettin
 import { MetricsSettingsDropdown } from '../MetricsOptions/MetricsSettingsDropdown';
 import MetricsReporter from '../MetricsOptions/MetricsReporter';
 import { TimeDurationModal } from '../Time/TimeDurationModal';
-import history, { URLParam } from 'app/History';
+import { history, URLParam } from 'app/History';
 import { MetricsObjectTypes } from 'types/Metrics';
 import { GrafanaInfo } from 'types/GrafanaInfo';
 import { MessageType } from 'types/MessageCenter';

--- a/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -12,7 +12,7 @@ import {
 import { style } from 'typestyle';
 import isEqual from 'lodash/isEqual';
 
-import history, { URLParam } from '../../app/History';
+import { history, URLParam } from '../../app/History';
 import { MetricsSettings, Quantiles, allQuantiles, LabelsSettings } from './MetricsSettings';
 import {
   mergeLabelFilter,

--- a/frontend/src/components/Nav/Menu.tsx
+++ b/frontend/src/components/Nav/Menu.tsx
@@ -4,7 +4,7 @@ import { matchPath } from 'react-router';
 import { Link } from 'react-router-dom';
 import { Nav, NavList, NavItem } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import { navMenuItems } from '../../routes';
 import { serverConfig } from '../../config';
 

--- a/frontend/src/components/Tab/Tabs.tsx
+++ b/frontend/src/components/Tab/Tabs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TabProps, Tabs } from '@patternfly/react-core';
-import history from '../../app/History';
+import { history } from '../../app/History';
 
 type TabsProps = {
   activeTab: string;

--- a/frontend/src/components/Time/Replay.tsx
+++ b/frontend/src/components/Time/Replay.tsx
@@ -16,7 +16,7 @@ import { serverConfig } from 'config';
 import { PFColors } from 'components/Pf/PfColors';
 import { DateTimePicker } from './DateTimePicker';
 import _ from 'lodash';
-import history, { HistoryManager, URLParam } from 'app/History';
+import { history, HistoryManager, URLParam } from 'app/History';
 
 type ReduxProps = {
   duration: DurationInSeconds;

--- a/frontend/src/components/Time/TimeDurationIndicatorComponent.tsx
+++ b/frontend/src/components/Time/TimeDurationIndicatorComponent.tsx
@@ -8,7 +8,7 @@ import { getName, getRefreshIntervalName } from '../../utils/RateIntervals';
 import { KialiAppState } from '../../store/Store';
 import { durationSelector, refreshIntervalSelector, timeRangeSelector } from '../../store/Selectors';
 import { connect } from 'react-redux';
-import history, { HistoryManager } from '../../app/History';
+import { history, HistoryManager } from '../../app/History';
 import { KialiDispatch } from '../../types/Redux';
 import { bindActionCreators } from 'redux';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';

--- a/frontend/src/components/TrafficList/TrafficListComponent.tsx
+++ b/frontend/src/components/TrafficList/TrafficListComponent.tsx
@@ -8,7 +8,7 @@ import * as FilterComponent from '../FilterList/FilterComponent';
 import { ThresholdStatus, NA } from 'types/Health';
 import { NodeType, hasProtocolTraffic, ProtocolTraffic } from 'types/Graph';
 import { getTrafficHealth } from 'types/ErrorRate';
-import history, { URLParam } from 'app/History';
+import { history, URLParam } from 'app/History';
 import { createIcon } from 'components/Health/Helper';
 import { sortFields } from './FiltersAndSorts';
 import { SortField } from 'types/SortFilters';

--- a/frontend/src/pages/AppDetails/AppInfo.tsx
+++ b/frontend/src/pages/AppDetails/AppInfo.tsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import { meshWideMTLSEnabledSelector } from '../../store/Selectors';
 import { style } from 'typestyle';
 import { GraphEdgeTapEvent } from '../../components/CytoscapeGraph/CytoscapeGraph';
-import history, { URLParam } from '../../app/History';
+import { history, URLParam } from '../../app/History';
 import MiniGraphCardContainer from '../../components/CytoscapeGraph/MiniGraphCard';
 
 type AppInfoProps = {

--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import FlexView from 'react-flexview';
 import { style } from 'typestyle';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import { DurationInSeconds, IntervalInMilliseconds, TimeInMilliseconds, TimeInSeconds } from '../../types/Common';
 import { MessageType } from '../../types/MessageCenter';
 import Namespace from '../../types/Namespace';

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -19,7 +19,7 @@ import { KialiDispatch } from 'types/Redux';
 import { AutoComplete } from 'utils/AutoComplete';
 import { DEGRADED, FAILURE, HEALTHY } from 'types/Health';
 import { GraphFindOptions } from './GraphFindOptions';
-import history, { HistoryManager, URLParam } from '../../../app/History';
+import { history, HistoryManager, URLParam } from '../../../app/History';
 import { isValid } from 'utils/Common';
 
 type ReduxProps = {

--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -23,7 +23,7 @@ import { GraphToolbarActions } from '../../../actions/GraphToolbarActions';
 import { GraphType, NodeParamsType, EdgeLabelMode, SummaryData, TrafficRate, RankMode } from '../../../types/Graph';
 import GraphFindContainer from './GraphFind';
 import GraphSettingsContainer from './GraphSettings';
-import history, { HistoryManager, URLParam } from '../../../app/History';
+import { history, HistoryManager, URLParam } from '../../../app/History';
 import Namespace, { namespacesFromString, namespacesToString } from '../../../types/Namespace';
 import { KialiDispatch } from '../../../types/Redux';
 import { NamespaceActions } from '../../../actions/NamespaceAction';

--- a/frontend/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -6,7 +6,7 @@ import { style } from 'typestyle';
 
 import { KialiAppState } from 'store/Store';
 import { JaegerThunkActions } from 'actions/JaegerThunkActions';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { JaegerTrace } from 'types/JaegerInfo';

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -26,7 +26,7 @@ import IstioActionDropdown from '../../components/IstioActions/IstioActionsDropd
 import { RenderComponentScroll } from '../../components/Nav/Page';
 import './IstioConfigDetailsPage.css';
 import { default as IstioActionButtonsContainer } from '../../components/IstioActions/IstioActionsButtons';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import { Paths } from '../../config';
 import { MessageType } from '../../types/MessageCenter';
 import { getIstioObject, mergeJsonPatch } from '../../utils/IstioConfigUtils';

--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -20,7 +20,7 @@ import { PromisesRegistry } from '../../utils/CancelablePromises';
 import * as API from '../../services/Api';
 import { IstioPermissions } from '../../types/IstioConfigDetails';
 import * as AlertUtils from '../../utils/AlertUtils';
-import history from '../../app/History';
+import { history } from '../../app/History';
 import {
   buildAuthorizationPolicy,
   buildGateway,

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -65,7 +65,7 @@ import { Paths, isMultiCluster, serverConfig } from '../../config';
 import { PFColors } from '../../components/Pf/PfColors';
 import VirtualList from '../../components/VirtualList/VirtualList';
 import { OverviewNamespaceAction, OverviewNamespaceActions } from './OverviewNamespaceActions';
-import history, { HistoryManager, URLParam } from '../../app/History';
+import { history, HistoryManager, URLParam } from '../../app/History';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { MessageType } from '../../types/MessageCenter';
 import { CanaryUpgradeStatus, OutboundTrafficPolicy, ValidationStatus } from '../../types/IstioObjects';

--- a/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -33,7 +33,7 @@ import { KialiAppState } from '../../store/Store';
 import { durationSelector, meshWideMTLSEnabledSelector } from '../../store/Selectors';
 import ServiceNetwork from './ServiceNetwork';
 import { GraphEdgeTapEvent } from '../../components/CytoscapeGraph/CytoscapeGraph';
-import history, { URLParam } from '../../app/History';
+import { history, URLParam } from '../../app/History';
 import MiniGraphCardContainer from '../../components/CytoscapeGraph/MiniGraphCard';
 import IstioConfigCard from '../../components/IstioConfigCard/IstioConfigCard';
 import ServiceWizard from '../../components/IstioWizards/ServiceWizard';

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
 import { meshWideMTLSEnabledSelector } from '../../store/Selectors';
 import WorkloadPods from './WorkloadPods';
 import { GraphEdgeTapEvent } from '../../components/CytoscapeGraph/CytoscapeGraph';
-import history, { URLParam } from '../../app/History';
+import { history, URLParam } from '../../app/History';
 import MiniGraphCardContainer from '../../components/CytoscapeGraph/MiniGraphCard';
 import IstioConfigCard from '../../components/IstioConfigCard/IstioConfigCard';
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -41,7 +41,7 @@ import { timeRangeSelector } from '../../store/Selectors';
 import { PFColors, PFColorVal } from 'components/Pf/PfColors';
 import AccessLogModal from 'components/Envoy/AccessLogModal';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
-import history, { URLParam } from 'app/History';
+import { history, URLParam } from 'app/History';
 import { TracingQuery, Span } from 'types/Tracing';
 import { AxiosResponse } from 'axios';
 import moment from 'moment';


### PR DESCRIPTION
** Describe the change **

Allow history basename to be modified for those pages where basename is different per page (like in OSSMC). There is no impact on Kiali application (setHistory method is not used).

** Issue reference **

Closes #6264 