### PR TITLE
Fixed showing error when Service is found in registry.

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -789,7 +789,8 @@ func (in *SvcService) GetService(ctx context.Context, cluster, namespace, servic
 		criteria := RegistryCriteria{
 			Namespace: namespace,
 		}
-		rSvcs, err := in.businessLayer.RegistryStatus.GetRegistryServices(criteria)
+		var rSvcs []*kubernetes.RegistryService
+		rSvcs, err = in.businessLayer.RegistryStatus.GetRegistryServices(criteria)
 		if err != nil {
 			return svc, err
 		}


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6294

Even though ServiceEntry was found in Registry, the initial error of not found in cache was returning.
Fixed to override the initial error.