### PR TITLE
Cypress Kiali Login test fix

### DIFF
--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -19,10 +19,14 @@ Given('user opens base url', () => {
 
 And('user clicks my_htpasswd_provider', () => {
     if (auth_strategy === 'openshift') {
-        cy.log('Log in using auth provider: ' + KUBEADMIN_IDP);
-        cy.contains(KUBEADMIN_IDP)
+        cy.exec("kubectl get user").then((result) => {
+            if (result.stderr != "No resources found"){
+                cy.log('Log in using auth provider: ' + KUBEADMIN_IDP);
+                    cy.contains(KUBEADMIN_IDP)
                     .should('be.visible')
                     .click();
+            }
+        })
     }
 })
 


### PR DESCRIPTION
The test expects buttons with auth providers when on Openshift. When no users are present on the cluster and the only way to log in is using the Kubeadmin, Openshift login page skips the buttons and goes straight to login form. However, the test still expects buttons, which causes it to fail. 

I've added a condition to prevent this from happening.

Thanks @FilipB for discovering this. 