### PR TITLE
Auto-enable find/hide filters via Kiali CR

### DIFF
--- a/business/metrics_definitions.go
+++ b/business/metrics_definitions.go
@@ -56,12 +56,12 @@ var istioMetrics = []istioMetric{
 	},
 	{
 		kialiName: "tcp_received",
-		istioName: "istio_tcp_received_bytes_total",
+		istioName: "istio_tcp_sent_bytes_total", // Istio telemetry is backwards
 		isHisto:   false,
 	},
 	{
 		kialiName: "tcp_sent",
-		istioName: "istio_tcp_sent_bytes_total",
+		istioName: "istio_tcp_received_bytes_total", // Istio telemetry is backwards
 		isHisto:   false,
 	},
 	{

--- a/business/metrics_definitions.go
+++ b/business/metrics_definitions.go
@@ -56,12 +56,12 @@ var istioMetrics = []istioMetric{
 	},
 	{
 		kialiName: "tcp_received",
-		istioName: "istio_tcp_sent_bytes_total", // Istio telemetry is backwards
+		istioName: "istio_tcp_received_bytes_total",
 		isHisto:   false,
 	},
 	{
 		kialiName: "tcp_sent",
-		istioName: "istio_tcp_received_bytes_total", // Istio telemetry is backwards
+		istioName: "istio_tcp_sent_bytes_total",
 		isHisto:   false,
 	},
 	{

--- a/config/config.go
+++ b/config/config.go
@@ -376,6 +376,7 @@ type DeploymentConfig struct {
 type GraphFindOption struct {
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	Expression  string `yaml:"expression,omitempty" json:"expression,omitempty"`
+	AutoEnable  bool   `yaml:"auto_enable,omitempty" json:"autoEnable,omitempty"`
 }
 
 // GraphSettings affect the graph visualization.

--- a/config/config.go
+++ b/config/config.go
@@ -376,7 +376,7 @@ type DeploymentConfig struct {
 type GraphFindOption struct {
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	Expression  string `yaml:"expression,omitempty" json:"expression,omitempty"`
-	AutoEnable  bool   `yaml:"auto_enable,omitempty" json:"autoEnable,omitempty"`
+	AutoSelect  bool   `yaml:"auto_select,omitempty" json:"autoSelect,omitempty"`
 }
 
 // GraphSettings affect the graph visualization.

--- a/config/config.go
+++ b/config/config.go
@@ -374,9 +374,9 @@ type DeploymentConfig struct {
 
 // GraphFindOption defines a single Graph Find/Hide Option
 type GraphFindOption struct {
+	AutoSelect  bool   `yaml:"auto_select,omitempty" json:"autoSelect,omitempty"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	Expression  string `yaml:"expression,omitempty" json:"expression,omitempty"`
-	AutoSelect  bool   `yaml:"auto_select,omitempty" json:"autoSelect,omitempty"`
 }
 
 // GraphSettings affect the graph visualization.

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -21,6 +21,7 @@ import { DEGRADED, FAILURE, HEALTHY } from 'types/Health';
 import { GraphFindOptions } from './GraphFindOptions';
 import { history, HistoryManager, URLParam } from '../../../app/History';
 import { isValid } from 'utils/Common';
+import { serverConfig } from '../../../config';
 
 type ReduxProps = {
   compressOnHide: boolean;
@@ -162,6 +163,12 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
       }
     } else if (!!findValue) {
       HistoryManager.setParam(URLParam.GRAPH_FIND, findValue);
+    } else {
+      serverConfig.kialiFeatureFlags.uiDefaults.graph.findOptions.forEach(opt => {
+        if (opt.autoEnable == true) {
+          props.setFindValue(opt.expression);
+        }
+      });
     }
     const urlHide = HistoryManager.getParam(URLParam.GRAPH_HIDE, urlParams);
     if (!!urlHide) {
@@ -171,6 +178,12 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
       }
     } else if (!!hideValue) {
       HistoryManager.setParam(URLParam.GRAPH_HIDE, hideValue);
+    } else {
+      serverConfig.kialiFeatureFlags.uiDefaults.graph.hideOptions.forEach(opt => {
+        if (opt.autoEnable == true) {
+          props.setHideValue(opt.expression);
+        }
+      });
     }
 
     this.state = { findInputValue: findValue, hideInputValue: hideValue };

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -164,11 +164,10 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     } else if (!!findValue) {
       HistoryManager.setParam(URLParam.GRAPH_FIND, findValue);
     } else {
-      serverConfig.kialiFeatureFlags.uiDefaults.graph.findOptions.forEach(opt => {
-        if (opt.autoEnable === true) {
-          props.setFindValue(opt.expression);
-        }
-      });
+      const autoSelect = serverConfig.kialiFeatureFlags.uiDefaults.graph.findOptions.find(opt => opt.autoSelect);
+      if (autoSelect) {
+        props.setFindValue(opt.expression);
+      }
     }
     const urlHide = HistoryManager.getParam(URLParam.GRAPH_HIDE, urlParams);
     if (!!urlHide) {

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -166,7 +166,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     } else {
       const autoSelect = serverConfig.kialiFeatureFlags.uiDefaults.graph.findOptions.find(opt => opt.autoSelect);
       if (autoSelect) {
-        props.setFindValue(opt.expression);
+        props.setFindValue(autoSelect.expression);
       }
     }
     const urlHide = HistoryManager.getParam(URLParam.GRAPH_HIDE, urlParams);
@@ -178,11 +178,10 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     } else if (!!hideValue) {
       HistoryManager.setParam(URLParam.GRAPH_HIDE, hideValue);
     } else {
-      serverConfig.kialiFeatureFlags.uiDefaults.graph.hideOptions.forEach(opt => {
-        if (opt.autoEnable === true) {
-          props.setHideValue(opt.expression);
-        }
-      });
+      const autoSelect = serverConfig.kialiFeatureFlags.uiDefaults.graph.hideOptions.find(opt => opt.autoSelect);
+      if (autoSelect) {
+        props.setHideValue(autoSelect.expression);
+      }
     }
 
     this.state = { findInputValue: findValue, hideInputValue: hideValue };

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -165,7 +165,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
       HistoryManager.setParam(URLParam.GRAPH_FIND, findValue);
     } else {
       serverConfig.kialiFeatureFlags.uiDefaults.graph.findOptions.forEach(opt => {
-        if (opt.autoEnable == true) {
+        if (opt.autoEnable === true) {
           props.setFindValue(opt.expression);
         }
       });
@@ -180,7 +180,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
       HistoryManager.setParam(URLParam.GRAPH_HIDE, hideValue);
     } else {
       serverConfig.kialiFeatureFlags.uiDefaults.graph.hideOptions.forEach(opt => {
-        if (opt.autoEnable == true) {
+        if (opt.autoEnable === true) {
           props.setHideValue(opt.expression);
         }
       });

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -20,7 +20,7 @@ interface IstioAnnotations {
 interface GraphFindOption {
   description: string;
   expression: string;
-  autoEnable: boolean;
+  autoSelect: boolean;
 }
 
 interface GraphTraffic {

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -20,6 +20,7 @@ interface IstioAnnotations {
 interface GraphFindOption {
   description: string;
   expression: string;
+  autoEnable: boolean;
 }
 
 interface GraphTraffic {

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -18,9 +18,9 @@ interface IstioAnnotations {
 }
 
 interface GraphFindOption {
+  autoSelect: boolean;
   description: string;
   expression: string;
-  autoSelect: boolean;
 }
 
 interface GraphTraffic {


### PR DESCRIPTION
Fixes #6012

Operator PR: https://github.com/kiali/kiali-operator/pull/665 
kiali.io PR: https://github.com/kiali/kiali.io/pull/671

Example for testing: 

```
  ui_defaults: 
    graph:
      hide_options:
         - description: "Hide unselected namespaces"
           expression: "outside"
         - description: "Hide nodes with no label region"
           expression: "!label:region"
      find_options:
         - description: "name not contains rev"
           expression: "name not contains rev"
         - description: "tcpserver"
           expression: "name = tcpserver"
           auto_enable: true
```

![image](https://github.com/kiali/kiali/assets/49480155/cb35b3de-8f00-4f53-b19f-d325364c9974)
