### PR TITLE
Empty ServiceEntry Ports disables Preview button fix (Backport to 1.65)

### DIFF
--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -165,9 +165,7 @@ Feature: Kiali Istio Config page
     And user types "myservice" in the "name" input
     And user types "website.com,website2.com" in the "hosts" input
     And the "ServiceEntry has no Ports defined" message should be displayed
-    And user previews the configuration
-    And user creates the istio config
-    Then the "ServiceEntry" "myservice" should be listed in "bookinfo" namespace
+    And the preview button should be disabled
 
   @wizard-istio-config
   Scenario: Try to create a ServiceEntry with empty ports specified

--- a/frontend/src/pages/IstioConfigNew/ServiceEntryForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/ServiceEntryForm.tsx
@@ -101,7 +101,12 @@ const noDuplicatePortNames = (name: string, index: number, ports: FormPort[]) =>
 };
 
 export const isServiceEntryValid = (se: ServiceEntryState): boolean => {
-  return se.validHosts && se.serviceEntry.ports !== undefined && isValidPort(se.formPorts);
+  return (
+    se.validHosts &&
+    se.serviceEntry.ports !== undefined &&
+    se.serviceEntry.ports.length !== 0 &&
+    isValidPort(se.formPorts)
+  );
 };
 
 const isValidName = (name: string): boolean => {


### PR DESCRIPTION
Backport of #6292, because the same failure has appeared on our downstream pipeline