### PR TITLE
Rename cluster param for clusterMesh

### DIFF
--- a/frontend/src/app/History.ts
+++ b/frontend/src/app/History.ts
@@ -30,7 +30,7 @@ export { history };
 export enum URLParam {
   AGGREGATOR = 'aggregator',
   BY_LABELS = 'bylbl',
-  CLUSTER = 'cluster',
+  CLUSTERMESH = 'clusterMesh',
   DIRECTION = 'direction',
   DISPLAY_MODE = 'displayMode',
   DURATION = 'duration',

--- a/frontend/src/app/History.ts
+++ b/frontend/src/app/History.ts
@@ -30,7 +30,7 @@ export { history };
 export enum URLParam {
   AGGREGATOR = 'aggregator',
   BY_LABELS = 'bylbl',
-  CLUSTERMESH = 'clusterMesh',
+  CLUSTERNAME = 'clusterName',
   DIRECTION = 'direction',
   DISPLAY_MODE = 'displayMode',
   DURATION = 'duration',

--- a/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -57,7 +57,7 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
     let itemName = page !== 'istio' ? match[3] : match[5];
     return {
       namespace: ns,
-      cluster: urlParams.get('clusterMesh') || undefined,
+      cluster: urlParams.get('clusterName') || undefined,
       pathItem: page,
       item: itemName,
       itemName: ItemNames[page],

--- a/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -57,7 +57,7 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
     let itemName = page !== 'istio' ? match[3] : match[5];
     return {
       namespace: ns,
-      cluster: urlParams.get('cluster') || undefined,
+      cluster: urlParams.get('clusterMesh') || undefined,
       pathItem: page,
       item: itemName,
       itemName: ItemNames[page],

--- a/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -373,7 +373,7 @@ const getOptionsFromLinkParams = (linkParams: LinkParams, jaegerInfo?: JaegerInf
   let detailsPageUrl = `/namespaces/${namespace}/${type}/${name}`;
   let concat = '?';
   if (cluster) {
-    detailsPageUrl += '?cluster=' + cluster;
+    detailsPageUrl += '?clusterMesh=' + cluster;
     concat = '&';
   }
 

--- a/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -373,7 +373,7 @@ const getOptionsFromLinkParams = (linkParams: LinkParams, jaegerInfo?: JaegerInf
   let detailsPageUrl = `/namespaces/${namespace}/${type}/${name}`;
   let concat = '?';
   if (cluster) {
-    detailsPageUrl += '?clusterMesh=' + cluster;
+    detailsPageUrl += '?clusterName=' + cluster;
     concat = '&';
   }
 

--- a/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -237,7 +237,7 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
     let href = `/namespaces/${e.namespace}/${resourceType}s/${resource}`;
 
     if (e.cluster) {
-      href = href + '?clusterMesh=' + e.cluster;
+      href = href + '?clusterName=' + e.cluster;
     }
 
     if (isParentKiosk(this.props.kiosk)) {

--- a/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -237,7 +237,7 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
     let href = `/namespaces/${e.namespace}/${resourceType}s/${resource}`;
 
     if (e.cluster) {
-      href = href + '?cluster=' + e.cluster;
+      href = href + '?clusterMesh=' + e.cluster;
     }
 
     if (isParentKiosk(this.props.kiosk)) {

--- a/frontend/src/components/DetailDescription/DetailDescription.tsx
+++ b/frontend/src/components/DetailDescription/DetailDescription.tsx
@@ -61,7 +61,7 @@ class DetailDescriptionComponent extends React.Component<Props> {
   private renderAppItem(namespace: string, appName: string) {
     let href = '/namespaces/' + namespace + '/applications/' + appName;
     if (this.props.cluster) {
-      href = href + '?cluster=' + this.props.cluster;
+      href = href + '?clusterMesh=' + this.props.cluster;
     }
     const link = isParentKiosk(this.props.kiosk) ? (
       <Link
@@ -88,7 +88,7 @@ class DetailDescriptionComponent extends React.Component<Props> {
   private renderServiceItem(namespace: string, serviceName: string) {
     let href = '/namespaces/' + namespace + '/services/' + serviceName;
     if (this.props.cluster) {
-      href = href + '?cluster=' + this.props.cluster;
+      href = href + '?clusterMesh=' + this.props.cluster;
     }
     const link = isParentKiosk(this.props.kiosk) ? (
       <Link
@@ -143,7 +143,7 @@ class DetailDescriptionComponent extends React.Component<Props> {
   private renderWorkloadItem(workload: AppWorkload) {
     let href = '/namespaces/' + this.props.namespace + '/workloads/' + workload.workloadName;
     if (this.props.cluster) {
-      href = href + '?cluster=' + this.props.cluster;
+      href = href + '?clusterMesh=' + this.props.cluster;
     }
     const link = isParentKiosk(this.props.kiosk) ? (
       <Link
@@ -197,7 +197,7 @@ class DetailDescriptionComponent extends React.Component<Props> {
     if (workload) {
       let href = '/namespaces/' + this.props.namespace + '/workloads/' + workload.workloadName;
       if (this.props.cluster) {
-        href = href + '?cluster=' + this.props.cluster;
+        href = href + '?clusterMesh=' + this.props.cluster;
       }
       const link = isParentKiosk(this.props.kiosk) ? (
         <Link

--- a/frontend/src/components/DetailDescription/DetailDescription.tsx
+++ b/frontend/src/components/DetailDescription/DetailDescription.tsx
@@ -61,7 +61,7 @@ class DetailDescriptionComponent extends React.Component<Props> {
   private renderAppItem(namespace: string, appName: string) {
     let href = '/namespaces/' + namespace + '/applications/' + appName;
     if (this.props.cluster) {
-      href = href + '?clusterMesh=' + this.props.cluster;
+      href = href + '?clusterName=' + this.props.cluster;
     }
     const link = isParentKiosk(this.props.kiosk) ? (
       <Link
@@ -88,7 +88,7 @@ class DetailDescriptionComponent extends React.Component<Props> {
   private renderServiceItem(namespace: string, serviceName: string) {
     let href = '/namespaces/' + namespace + '/services/' + serviceName;
     if (this.props.cluster) {
-      href = href + '?clusterMesh=' + this.props.cluster;
+      href = href + '?clusterName=' + this.props.cluster;
     }
     const link = isParentKiosk(this.props.kiosk) ? (
       <Link
@@ -143,7 +143,7 @@ class DetailDescriptionComponent extends React.Component<Props> {
   private renderWorkloadItem(workload: AppWorkload) {
     let href = '/namespaces/' + this.props.namespace + '/workloads/' + workload.workloadName;
     if (this.props.cluster) {
-      href = href + '?clusterMesh=' + this.props.cluster;
+      href = href + '?clusterName=' + this.props.cluster;
     }
     const link = isParentKiosk(this.props.kiosk) ? (
       <Link
@@ -197,7 +197,7 @@ class DetailDescriptionComponent extends React.Component<Props> {
     if (workload) {
       let href = '/namespaces/' + this.props.namespace + '/workloads/' + workload.workloadName;
       if (this.props.cluster) {
-        href = href + '?clusterMesh=' + this.props.cluster;
+        href = href + '?clusterName=' + this.props.cluster;
       }
       const link = isParentKiosk(this.props.kiosk) ? (
         <Link

--- a/frontend/src/components/Link/IstioObjectLink.tsx
+++ b/frontend/src/components/Link/IstioObjectLink.tsx
@@ -45,7 +45,7 @@ export const GetIstioObjectUrl = (
   to = to + '/' + istioType.url + '/' + name;
 
   if (cluster && isMultiCluster()) {
-    to = to + '?cluster=' + cluster;
+    to = to + '?clusterMesh=' + cluster;
   }
 
   if (!!query) {

--- a/frontend/src/components/Link/IstioObjectLink.tsx
+++ b/frontend/src/components/Link/IstioObjectLink.tsx
@@ -45,7 +45,7 @@ export const GetIstioObjectUrl = (
   to = to + '/' + istioType.url + '/' + name;
 
   if (cluster && isMultiCluster()) {
-    to = to + '?clusterMesh=' + cluster;
+    to = to + '?clusterName=' + cluster;
   }
 
   if (!!query) {

--- a/frontend/src/components/Link/ServiceLink.tsx
+++ b/frontend/src/components/Link/ServiceLink.tsx
@@ -18,7 +18,7 @@ export const getServiceURL = (name: string, namespace: string, cluster?: string,
   to = to + '/' + name;
 
   if (cluster && isMultiCluster()) {
-    to = to + '?clusterMesh=' + cluster;
+    to = to + '?clusterName=' + cluster;
   }
 
   if (!!query) {

--- a/frontend/src/components/Link/ServiceLink.tsx
+++ b/frontend/src/components/Link/ServiceLink.tsx
@@ -18,7 +18,7 @@ export const getServiceURL = (name: string, namespace: string, cluster?: string,
   to = to + '/' + name;
 
   if (cluster && isMultiCluster()) {
-    to = to + '?cluster=' + cluster;
+    to = to + '?clusterMesh=' + cluster;
   }
 
   if (!!query) {

--- a/frontend/src/components/Link/WorkloadLink.tsx
+++ b/frontend/src/components/Link/WorkloadLink.tsx
@@ -17,7 +17,7 @@ export const getWorkloadLink = (name: string, namespace: string, cluster?: strin
   to = to + '/' + name;
 
   if (cluster && isMultiCluster()) {
-    to = to + '?cluster=' + cluster;
+    to = to + '?clusterMesh=' + cluster;
   }
 
   if (!!query) {

--- a/frontend/src/components/Link/WorkloadLink.tsx
+++ b/frontend/src/components/Link/WorkloadLink.tsx
@@ -17,7 +17,7 @@ export const getWorkloadLink = (name: string, namespace: string, cluster?: strin
   to = to + '/' + name;
 
   if (cluster && isMultiCluster()) {
-    to = to + '?clusterMesh=' + cluster;
+    to = to + '?clusterName=' + cluster;
   }
 
   if (!!query) {

--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -107,7 +107,7 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
     this.options = this.initOptions(settings);
     // Initialize active filters from URL
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('cluster') || undefined;
+    const cluster = urlParams.get('clusterMesh') || undefined;
     this.state = {
       cluster: cluster,
       isTimeOptionsOpen: false,

--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -107,7 +107,7 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
     this.options = this.initOptions(settings);
     // Initialize active filters from URL
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('clusterMesh') || undefined;
+    const cluster = urlParams.get('clusterName') || undefined;
     this.state = {
       cluster: cluster,
       isTimeOptionsOpen: false,

--- a/frontend/src/components/TrafficList/TrafficListComponent.tsx
+++ b/frontend/src/components/TrafficList/TrafficListComponent.tsx
@@ -355,7 +355,7 @@ class TrafficList extends FilterComponent.Component<
 
     const detail = `/namespaces/${item.node.namespace}/${this.nodeTypeToType(item.node.type, true)}/${
       item.node.name
-    }?cluster=${item.node.cluster}`;
+    }?clusterMesh=${item.node.cluster}`;
 
     const metricsDirection = item.direction === 'inbound' ? 'in_metrics' : 'out_metrics';
     let metrics = `${history.location.pathname}?tab=${metricsDirection}`;

--- a/frontend/src/components/TrafficList/TrafficListComponent.tsx
+++ b/frontend/src/components/TrafficList/TrafficListComponent.tsx
@@ -355,7 +355,7 @@ class TrafficList extends FilterComponent.Component<
 
     const detail = `/namespaces/${item.node.namespace}/${this.nodeTypeToType(item.node.type, true)}/${
       item.node.name
-    }?clusterMesh=${item.node.cluster}`;
+    }?clusterName=${item.node.cluster}`;
 
     const metricsDirection = item.direction === 'inbound' ? 'in_metrics' : 'out_metrics';
     let metrics = `${history.location.pathname}?tab=${metricsDirection}`;

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -44,9 +44,9 @@ const getLink = (item: TResource, config: Resource, query?: string) => {
 
   if (item.cluster && isMultiCluster() && !url.includes('cluster')) {
     if (url.includes('?')) {
-      url = url + '&clusterMesh=' + item.cluster;
+      url = url + '&clusterName=' + item.cluster;
     } else {
-      url = url + '?clusterMesh=' + item.cluster;
+      url = url + '?clusterName=' + item.cluster;
     }
   }
   if (query) {

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -44,9 +44,9 @@ const getLink = (item: TResource, config: Resource, query?: string) => {
 
   if (item.cluster && isMultiCluster() && !url.includes('cluster')) {
     if (url.includes('?')) {
-      url = url + '&cluster=' + item.cluster;
+      url = url + '&clusterMesh=' + item.cluster;
     } else {
-      url = url + '?cluster=' + item.cluster;
+      url = url + '?clusterMesh=' + item.cluster;
     }
   }
   if (query) {

--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -61,7 +61,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
   constructor(props: AppDetailsProps) {
     super(props);
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('clusterMesh') || undefined;
+    const cluster = urlParams.get('clusterName') || undefined;
     this.state = { currentTab: activeTab(tabName, defaultTab), cluster: cluster };
   }
 

--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -61,7 +61,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
   constructor(props: AppDetailsProps) {
     super(props);
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('cluster') || undefined;
+    const cluster = urlParams.get('clusterMesh') || undefined;
     this.state = { currentTab: activeTab(tabName, defaultTab), cluster: cluster };
   }
 

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -103,7 +103,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
   constructor(props: IstioConfigDetailsProps) {
     super(props);
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('cluster') || undefined;
+    const cluster = urlParams.get('clusterMesh') || undefined;
     this.state = {
       cluster: cluster,
       isModified: false,

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -103,7 +103,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
   constructor(props: IstioConfigDetailsProps) {
     super(props);
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('clusterMesh') || undefined;
+    const cluster = urlParams.get('clusterName') || undefined;
     this.state = {
       cluster: cluster,
       isModified: false,

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -422,7 +422,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
     return Promise.all(
       chunk.map(nsInfo => {
         if (nsInfo.cluster) {
-          options.cluster = nsInfo.cluster;
+          options.clusterMesh = nsInfo.cluster;
         }
         return API.getNamespaceMetrics(nsInfo.name, options).then(rs => {
           nsInfo.metrics = rs.data.request_count;

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -422,7 +422,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
     return Promise.all(
       chunk.map(nsInfo => {
         if (nsInfo.cluster) {
-          options.clusterMesh = nsInfo.cluster;
+          options.clusterName = nsInfo.cluster;
         }
         return API.getNamespaceMetrics(nsInfo.name, options).then(rs => {
           nsInfo.metrics = rs.data.request_count;

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -68,7 +68,7 @@ class ServiceDetailsPageComponent extends React.Component<ServiceDetailsProps, S
   constructor(props: ServiceDetailsProps) {
     super(props);
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('cluster') || undefined;
+    const cluster = urlParams.get('clusterMesh') || undefined;
     this.state = {
       // Because null is not the same as undefined and urlParams.get(...) returns null.
       cluster: cluster,

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -68,7 +68,7 @@ class ServiceDetailsPageComponent extends React.Component<ServiceDetailsProps, S
   constructor(props: ServiceDetailsProps) {
     super(props);
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('clusterMesh') || undefined;
+    const cluster = urlParams.get('clusterName') || undefined;
     this.state = {
       // Because null is not the same as undefined and urlParams.get(...) returns null.
       cluster: cluster,

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -66,7 +66,7 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
   constructor(props: WorkloadDetailsPageProps) {
     super(props);
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('clusterMesh') || undefined;
+    const cluster = urlParams.get('clusterName') || undefined;
     this.state = { currentTab: activeTab(tabName, defaultTab), cluster: cluster };
   }
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -66,7 +66,7 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
   constructor(props: WorkloadDetailsPageProps) {
     super(props);
     const urlParams = new URLSearchParams(history.location.search);
-    const cluster = urlParams.get('cluster') || undefined;
+    const cluster = urlParams.get('clusterMesh') || undefined;
     this.state = { currentTab: activeTab(tabName, defaultTab), cluster: cluster };
   }
 

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -158,7 +158,7 @@ export const getNamespaceMetrics = (namespace: string, params: IstioMetricsOptio
 export const getMeshTls = (cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.meshTls(), queryParams, {});
 };
@@ -170,7 +170,7 @@ export const getOutboundTrafficPolicyMode = () => {
 export const getIstioStatus = (cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<ComponentStatus[]>(HTTP_VERBS.GET, urls.istioStatus(), queryParams, {});
 };
@@ -186,7 +186,7 @@ export const getIstiodResourceThresholds = () => {
 export const getNamespaceTls = (namespace: string, cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.namespaceTls(namespace), queryParams, {});
 };
@@ -218,7 +218,7 @@ export const getIstioConfig = (
     params.workloadSelector = workloadSelector;
   }
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
 };
@@ -245,7 +245,7 @@ export const getAllIstioConfigs = (
     params.workloadSelector = workloadSelector;
   }
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest<IstioConfigsMap>(HTTP_VERBS.GET, urls.allIstioConfigs(), params, {});
 };
@@ -259,7 +259,7 @@ export const getIstioConfigDetail = (
 ) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   if (validate) {
     queryParams.validate = true;
@@ -276,7 +276,7 @@ export const getIstioConfigDetail = (
 export const deleteIstioConfigDetail = (namespace: string, objectType: string, object: string, cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<string>(HTTP_VERBS.DELETE, urls.istioConfigDelete(namespace, objectType, object), queryParams, {});
 };
@@ -290,7 +290,7 @@ export const updateIstioConfigDetail = (
 ): Promise<Response<string>> => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest(HTTP_VERBS.PATCH, urls.istioConfigUpdate(namespace, objectType, object), queryParams, jsonPatch);
 };
@@ -303,7 +303,7 @@ export const createIstioConfigDetail = (
 ): Promise<Response<string>> => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), queryParams, json);
 };
@@ -311,7 +311,7 @@ export const createIstioConfigDetail = (
 export const getConfigValidations = (cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<ValidationStatus>(HTTP_VERBS.GET, urls.configValidations(), queryParams, {});
 };
@@ -328,7 +328,7 @@ export const getServiceMetrics = (
 ) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<IstioMetricsMap>(HTTP_VERBS.GET, urls.serviceMetrics(namespace, service), queryParams, {});
 };
@@ -341,7 +341,7 @@ export const getServiceDashboard = (
 ) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<DashboardModel>(HTTP_VERBS.GET, urls.serviceDashboard(namespace, service), queryParams, {});
 };
@@ -363,7 +363,7 @@ export const getAggregateMetrics = (
 export const getApp = (namespace: string, app: string, params?: { [key: string]: string }, cluster?: string) => {
   const queryParams = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<App>(HTTP_VERBS.GET, urls.app(namespace, app), queryParams, {});
 };
@@ -375,7 +375,7 @@ export const getApps = (namespace: string, params: any = {}) => {
 export const getAppMetrics = (namespace: string, app: string, params: IstioMetricsOptions, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<IstioMetricsMap>(HTTP_VERBS.GET, urls.appMetrics(namespace, app), queryParams, {});
 };
@@ -383,7 +383,7 @@ export const getAppMetrics = (namespace: string, app: string, params: IstioMetri
 export const getAppDashboard = (namespace: string, app: string, params: IstioMetricsOptions, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<DashboardModel>(HTTP_VERBS.GET, urls.appDashboard(namespace, app), queryParams, {});
 };
@@ -396,7 +396,7 @@ export const getWorkloadMetrics = (
 ) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<IstioMetricsMap>(HTTP_VERBS.GET, urls.workloadMetrics(namespace, workload), queryParams, {});
 };
@@ -409,7 +409,7 @@ export const getWorkloadDashboard = (
 ) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<DashboardModel>(HTTP_VERBS.GET, urls.workloadDashboard(namespace, workload), queryParams, {});
 };
@@ -434,7 +434,7 @@ export const getNamespaceAppHealth = (
     params.queryTime = String(queryTime);
   }
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest<NamespaceAppHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(response => {
     const ret: NamespaceAppHealth = {};
@@ -465,7 +465,7 @@ export const getNamespaceServiceHealth = (
     params.queryTime = String(queryTime);
   }
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest<NamespaceServiceHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(
     response => {
@@ -498,7 +498,7 @@ export const getNamespaceWorkloadHealth = (
     params.queryTime = String(queryTime);
   }
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest<NamespaceWorkloadHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(
     response => {
@@ -526,7 +526,7 @@ export const getJaegerInfo = () => {
 export const getAppTraces = (namespace: string, app: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<JaegerResponse>(HTTP_VERBS.GET, urls.appTraces(namespace, app), queryParams, {});
 };
@@ -534,7 +534,7 @@ export const getAppTraces = (namespace: string, app: string, params: TracingQuer
 export const getServiceTraces = (namespace: string, service: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<JaegerResponse>(HTTP_VERBS.GET, urls.serviceTraces(namespace, service), queryParams, {});
 };
@@ -542,7 +542,7 @@ export const getServiceTraces = (namespace: string, service: string, params: Tra
 export const getWorkloadTraces = (namespace: string, workload: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<JaegerResponse>(HTTP_VERBS.GET, urls.workloadTraces(namespace, workload), queryParams, {});
 };
@@ -597,7 +597,7 @@ export const getNodeGraphElements = (node: NodeParamsType, params: any) => {
       );
     case NodeType.WORKLOAD:
       if (node.cluster) {
-        params['cluster'] = node.cluster;
+        params['clusterMesh'] = node.cluster;
       }
       return newRequest<GraphDefinition>(
         HTTP_VERBS.GET,
@@ -630,7 +630,7 @@ export const getServiceDetail = (
     params.rateInterval = `${rateInterval}s`;
   }
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest<ServiceDetailsInfo>(HTTP_VERBS.GET, urls.service(namespace, service), params, {}).then(r => {
     const info: ServiceDetailsInfo = r.data;
@@ -653,7 +653,7 @@ export const getWorkloads = (namespace: string, params: { [key: string]: string 
 export const getWorkload = (namespace: string, name: string, params?: { [key: string]: string }, cluster?: string) => {
   const queryParams = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<Workload>(HTTP_VERBS.GET, urls.workload(namespace, name), queryParams, {});
 };
@@ -672,7 +672,7 @@ export const updateWorkload = (
     params.patchType = patchType;
   }
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest(HTTP_VERBS.PATCH, urls.workload(namespace, name), params, jsonPatch);
 };
@@ -689,7 +689,7 @@ export const updateService = (
     params.patchType = patchType;
   }
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest(HTTP_VERBS.PATCH, urls.service(namespace, name), params, jsonPatch);
 };
@@ -722,7 +722,7 @@ export const getPodLogs = (
     params.duration = `${duration}s`;
   }
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   params.isProxy = !!isProxy;
 
@@ -734,7 +734,7 @@ export const setPodEnvoyProxyLogLevel = (namespace: string, name: string, level:
     level: level
   };
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
 
   return newRequest<undefined>(HTTP_VERBS.POST, urls.podEnvoyProxyLogging(namespace, name), params, {});
@@ -743,7 +743,7 @@ export const setPodEnvoyProxyLogLevel = (namespace: string, name: string, level:
 export const getPodEnvoyProxy = (namespace: string, pod: string, cluster?: string) => {
   const params: any = {};
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest<EnvoyProxyDump>(HTTP_VERBS.GET, urls.podEnvoyProxy(namespace, pod), params, {});
 };
@@ -751,7 +751,7 @@ export const getPodEnvoyProxy = (namespace: string, pod: string, cluster?: strin
 export const getPodEnvoyProxyResourceEntries = (namespace: string, pod: string, resource: string, cluster?: string) => {
   const params: any = {};
   if (cluster) {
-    params.cluster = cluster;
+    params.clusterMesh = cluster;
   }
   return newRequest<EnvoyProxyDump>(
     HTTP_VERBS.GET,
@@ -789,7 +789,7 @@ export const getErrorDetail = (error: AxiosError): string => {
 export const getAppSpans = (namespace: string, app: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<Span[]>(HTTP_VERBS.GET, urls.appSpans(namespace, app), queryParams, {});
 };
@@ -797,7 +797,7 @@ export const getAppSpans = (namespace: string, app: string, params: TracingQuery
 export const getServiceSpans = (namespace: string, service: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<Span[]>(HTTP_VERBS.GET, urls.serviceSpans(namespace, service), queryParams, {});
 };
@@ -805,7 +805,7 @@ export const getServiceSpans = (namespace: string, service: string, params: Trac
 export const getWorkloadSpans = (namespace: string, workload: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<Span[]>(HTTP_VERBS.GET, urls.workloadSpans(namespace, workload), queryParams, {});
 };
@@ -814,7 +814,7 @@ export const getIstioPermissions = (namespaces: string[], cluster?: string) => {
   const queryParams: any = {};
   queryParams.namespaces = namespaces.join(',');
   if (cluster) {
-    queryParams.cluster = cluster;
+    queryParams.clusterMesh = cluster;
   }
   return newRequest<IstioPermissions>(HTTP_VERBS.GET, urls.istioPermissions, queryParams, {});
 };

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -158,7 +158,7 @@ export const getNamespaceMetrics = (namespace: string, params: IstioMetricsOptio
 export const getMeshTls = (cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.meshTls(), queryParams, {});
 };
@@ -170,7 +170,7 @@ export const getOutboundTrafficPolicyMode = () => {
 export const getIstioStatus = (cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<ComponentStatus[]>(HTTP_VERBS.GET, urls.istioStatus(), queryParams, {});
 };
@@ -186,7 +186,7 @@ export const getIstiodResourceThresholds = () => {
 export const getNamespaceTls = (namespace: string, cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.namespaceTls(namespace), queryParams, {});
 };
@@ -218,7 +218,7 @@ export const getIstioConfig = (
     params.workloadSelector = workloadSelector;
   }
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
 };
@@ -245,7 +245,7 @@ export const getAllIstioConfigs = (
     params.workloadSelector = workloadSelector;
   }
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest<IstioConfigsMap>(HTTP_VERBS.GET, urls.allIstioConfigs(), params, {});
 };
@@ -259,7 +259,7 @@ export const getIstioConfigDetail = (
 ) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   if (validate) {
     queryParams.validate = true;
@@ -276,7 +276,7 @@ export const getIstioConfigDetail = (
 export const deleteIstioConfigDetail = (namespace: string, objectType: string, object: string, cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<string>(HTTP_VERBS.DELETE, urls.istioConfigDelete(namespace, objectType, object), queryParams, {});
 };
@@ -290,7 +290,7 @@ export const updateIstioConfigDetail = (
 ): Promise<Response<string>> => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest(HTTP_VERBS.PATCH, urls.istioConfigUpdate(namespace, objectType, object), queryParams, jsonPatch);
 };
@@ -303,7 +303,7 @@ export const createIstioConfigDetail = (
 ): Promise<Response<string>> => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), queryParams, json);
 };
@@ -311,7 +311,7 @@ export const createIstioConfigDetail = (
 export const getConfigValidations = (cluster?: string) => {
   const queryParams: any = {};
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<ValidationStatus>(HTTP_VERBS.GET, urls.configValidations(), queryParams, {});
 };
@@ -328,7 +328,7 @@ export const getServiceMetrics = (
 ) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<IstioMetricsMap>(HTTP_VERBS.GET, urls.serviceMetrics(namespace, service), queryParams, {});
 };
@@ -341,7 +341,7 @@ export const getServiceDashboard = (
 ) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<DashboardModel>(HTTP_VERBS.GET, urls.serviceDashboard(namespace, service), queryParams, {});
 };
@@ -363,7 +363,7 @@ export const getAggregateMetrics = (
 export const getApp = (namespace: string, app: string, params?: { [key: string]: string }, cluster?: string) => {
   const queryParams = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<App>(HTTP_VERBS.GET, urls.app(namespace, app), queryParams, {});
 };
@@ -375,7 +375,7 @@ export const getApps = (namespace: string, params: any = {}) => {
 export const getAppMetrics = (namespace: string, app: string, params: IstioMetricsOptions, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<IstioMetricsMap>(HTTP_VERBS.GET, urls.appMetrics(namespace, app), queryParams, {});
 };
@@ -383,7 +383,7 @@ export const getAppMetrics = (namespace: string, app: string, params: IstioMetri
 export const getAppDashboard = (namespace: string, app: string, params: IstioMetricsOptions, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<DashboardModel>(HTTP_VERBS.GET, urls.appDashboard(namespace, app), queryParams, {});
 };
@@ -396,7 +396,7 @@ export const getWorkloadMetrics = (
 ) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<IstioMetricsMap>(HTTP_VERBS.GET, urls.workloadMetrics(namespace, workload), queryParams, {});
 };
@@ -409,7 +409,7 @@ export const getWorkloadDashboard = (
 ) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<DashboardModel>(HTTP_VERBS.GET, urls.workloadDashboard(namespace, workload), queryParams, {});
 };
@@ -434,7 +434,7 @@ export const getNamespaceAppHealth = (
     params.queryTime = String(queryTime);
   }
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest<NamespaceAppHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(response => {
     const ret: NamespaceAppHealth = {};
@@ -465,7 +465,7 @@ export const getNamespaceServiceHealth = (
     params.queryTime = String(queryTime);
   }
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest<NamespaceServiceHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(
     response => {
@@ -498,7 +498,7 @@ export const getNamespaceWorkloadHealth = (
     params.queryTime = String(queryTime);
   }
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest<NamespaceWorkloadHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(
     response => {
@@ -526,7 +526,7 @@ export const getJaegerInfo = () => {
 export const getAppTraces = (namespace: string, app: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<JaegerResponse>(HTTP_VERBS.GET, urls.appTraces(namespace, app), queryParams, {});
 };
@@ -534,7 +534,7 @@ export const getAppTraces = (namespace: string, app: string, params: TracingQuer
 export const getServiceTraces = (namespace: string, service: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<JaegerResponse>(HTTP_VERBS.GET, urls.serviceTraces(namespace, service), queryParams, {});
 };
@@ -542,7 +542,7 @@ export const getServiceTraces = (namespace: string, service: string, params: Tra
 export const getWorkloadTraces = (namespace: string, workload: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<JaegerResponse>(HTTP_VERBS.GET, urls.workloadTraces(namespace, workload), queryParams, {});
 };
@@ -597,7 +597,7 @@ export const getNodeGraphElements = (node: NodeParamsType, params: any) => {
       );
     case NodeType.WORKLOAD:
       if (node.cluster) {
-        params['clusterMesh'] = node.cluster;
+        params['clusterName'] = node.cluster;
       }
       return newRequest<GraphDefinition>(
         HTTP_VERBS.GET,
@@ -630,7 +630,7 @@ export const getServiceDetail = (
     params.rateInterval = `${rateInterval}s`;
   }
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest<ServiceDetailsInfo>(HTTP_VERBS.GET, urls.service(namespace, service), params, {}).then(r => {
     const info: ServiceDetailsInfo = r.data;
@@ -653,7 +653,7 @@ export const getWorkloads = (namespace: string, params: { [key: string]: string 
 export const getWorkload = (namespace: string, name: string, params?: { [key: string]: string }, cluster?: string) => {
   const queryParams = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<Workload>(HTTP_VERBS.GET, urls.workload(namespace, name), queryParams, {});
 };
@@ -672,7 +672,7 @@ export const updateWorkload = (
     params.patchType = patchType;
   }
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest(HTTP_VERBS.PATCH, urls.workload(namespace, name), params, jsonPatch);
 };
@@ -689,7 +689,7 @@ export const updateService = (
     params.patchType = patchType;
   }
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest(HTTP_VERBS.PATCH, urls.service(namespace, name), params, jsonPatch);
 };
@@ -722,7 +722,7 @@ export const getPodLogs = (
     params.duration = `${duration}s`;
   }
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   params.isProxy = !!isProxy;
 
@@ -734,7 +734,7 @@ export const setPodEnvoyProxyLogLevel = (namespace: string, name: string, level:
     level: level
   };
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
 
   return newRequest<undefined>(HTTP_VERBS.POST, urls.podEnvoyProxyLogging(namespace, name), params, {});
@@ -743,7 +743,7 @@ export const setPodEnvoyProxyLogLevel = (namespace: string, name: string, level:
 export const getPodEnvoyProxy = (namespace: string, pod: string, cluster?: string) => {
   const params: any = {};
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest<EnvoyProxyDump>(HTTP_VERBS.GET, urls.podEnvoyProxy(namespace, pod), params, {});
 };
@@ -751,7 +751,7 @@ export const getPodEnvoyProxy = (namespace: string, pod: string, cluster?: strin
 export const getPodEnvoyProxyResourceEntries = (namespace: string, pod: string, resource: string, cluster?: string) => {
   const params: any = {};
   if (cluster) {
-    params.clusterMesh = cluster;
+    params.clusterName = cluster;
   }
   return newRequest<EnvoyProxyDump>(
     HTTP_VERBS.GET,
@@ -789,7 +789,7 @@ export const getErrorDetail = (error: AxiosError): string => {
 export const getAppSpans = (namespace: string, app: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<Span[]>(HTTP_VERBS.GET, urls.appSpans(namespace, app), queryParams, {});
 };
@@ -797,7 +797,7 @@ export const getAppSpans = (namespace: string, app: string, params: TracingQuery
 export const getServiceSpans = (namespace: string, service: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<Span[]>(HTTP_VERBS.GET, urls.serviceSpans(namespace, service), queryParams, {});
 };
@@ -805,7 +805,7 @@ export const getServiceSpans = (namespace: string, service: string, params: Trac
 export const getWorkloadSpans = (namespace: string, workload: string, params: TracingQuery, cluster?: string) => {
   const queryParams: any = { ...params };
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<Span[]>(HTTP_VERBS.GET, urls.workloadSpans(namespace, workload), queryParams, {});
 };
@@ -814,7 +814,7 @@ export const getIstioPermissions = (namespaces: string[], cluster?: string) => {
   const queryParams: any = {};
   queryParams.namespaces = namespaces.join(',');
   if (cluster) {
-    queryParams.clusterMesh = cluster;
+    queryParams.clusterName = cluster;
   }
   return newRequest<IstioPermissions>(HTTP_VERBS.GET, urls.istioPermissions, queryParams, {});
 };

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -27,7 +27,7 @@ export interface IstioMetricsOptions extends MetricsQuery {
   filters?: string[];
   requestProtocol?: string;
   reporter: Reporter;
-  cluster?: string;
+  clusterMesh?: string;
 }
 
 export type Reporter = 'source' | 'destination' | 'both';

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -27,7 +27,7 @@ export interface IstioMetricsOptions extends MetricsQuery {
   filters?: string[];
   requestProtocol?: string;
   reporter: Reporter;
-  clusterMesh?: string;
+  clusterName?: string;
 }
 
 export type Reporter = 'source' | 'destination' | 'both';

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -18,7 +18,7 @@ type appParams struct {
 	//
 	// in: path
 	Namespace   string `json:"namespace"`
-	MeshCluster string `json:"meshCluster"`
+	ClusterMesh string `json:"clusterMesh"`
 	AppName     string `json:"app"`
 	// Optional
 	IncludeHealth         bool `json:"health"`

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -18,7 +18,7 @@ type appParams struct {
 	//
 	// in: path
 	Namespace   string `json:"namespace"`
-	ClusterMesh string `json:"clusterMesh"`
+	ClusterName string `json:"clusterName"`
 	AppName     string `json:"app"`
 	// Optional
 	IncludeHealth         bool `json:"health"`
@@ -30,7 +30,7 @@ func (p *appParams) extract(r *http.Request) {
 	query := r.URL.Query()
 	p.baseExtract(r, vars)
 	p.Namespace = vars["namespace"]
-	p.ClusterMesh = clusterNameFromQuery(query)
+	p.ClusterName = clusterNameFromQuery(query)
 	p.AppName = vars["app"]
 	var err error
 	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))
@@ -83,7 +83,7 @@ func AppDetails(w http.ResponseWriter, r *http.Request) {
 	p.extract(r)
 
 	criteria := business.AppCriteria{Namespace: p.Namespace, AppName: p.AppName, IncludeIstioResources: true, IncludeHealth: p.IncludeHealth,
-		RateInterval: p.RateInterval, QueryTime: p.QueryTime, Cluster: p.ClusterMesh}
+		RateInterval: p.RateInterval, QueryTime: p.QueryTime, Cluster: p.ClusterName}
 
 	// Get business layer
 	business, err := getBusiness(r)

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -17,9 +17,9 @@ type appParams struct {
 	// The target workload
 	//
 	// in: path
-	Namespace string `json:"namespace"`
-	Cluster   string `json:"cluster"`
-	AppName   string `json:"app"`
+	Namespace   string `json:"namespace"`
+	MeshCluster string `json:"meshCluster"`
+	AppName     string `json:"app"`
 	// Optional
 	IncludeHealth         bool `json:"health"`
 	IncludeIstioResources bool `json:"istioResources"`
@@ -30,7 +30,7 @@ func (p *appParams) extract(r *http.Request) {
 	query := r.URL.Query()
 	p.baseExtract(r, vars)
 	p.Namespace = vars["namespace"]
-	p.Cluster = clusterNameFromQuery(query)
+	p.ClusterMesh = clusterNameFromQuery(query)
 	p.AppName = vars["app"]
 	var err error
 	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))
@@ -83,7 +83,7 @@ func AppDetails(w http.ResponseWriter, r *http.Request) {
 	p.extract(r)
 
 	criteria := business.AppCriteria{Namespace: p.Namespace, AppName: p.AppName, IncludeIstioResources: true, IncludeHealth: p.IncludeHealth,
-		RateInterval: p.RateInterval, QueryTime: p.QueryTime, Cluster: p.Cluster}
+		RateInterval: p.RateInterval, QueryTime: p.QueryTime, Cluster: p.ClusterMesh}
 
 	// Get business layer
 	business, err := getBusiness(r)

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -38,7 +38,7 @@ func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	healthCriteria := business.NamespaceHealthCriteria{Namespace: p.Namespace, Cluster: p.ClusterMesh, RateInterval: rateInterval, QueryTime: p.QueryTime, IncludeMetrics: true}
+	healthCriteria := business.NamespaceHealthCriteria{Namespace: p.Namespace, Cluster: p.ClusterName, RateInterval: rateInterval, QueryTime: p.QueryTime, IncludeMetrics: true}
 	switch p.Type {
 	case "app":
 		health, err := businessLayer.Health.GetNamespaceAppHealth(r.Context(), healthCriteria)
@@ -66,7 +66,7 @@ func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 
 type baseHealthParams struct {
 	// Cluster name
-	ClusterMesh string `json:"clusterMesh"`
+	ClusterName string `json:"clusterName"`
 	// The namespace scope
 	//
 	// in: path
@@ -87,7 +87,7 @@ func (p *baseHealthParams) baseExtract(r *http.Request, vars map[string]string) 
 	if rateInterval := queryParams.Get("rateInterval"); rateInterval != "" {
 		p.RateInterval = rateInterval
 	}
-	p.ClusterMesh = clusterNameFromQuery(queryParams)
+	p.ClusterName = clusterNameFromQuery(queryParams)
 	if queryTime := queryParams.Get("queryTime"); queryTime != "" {
 		unix, err := strconv.ParseInt(queryTime, 10, 64)
 		if err == nil {

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -38,7 +38,7 @@ func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	healthCriteria := business.NamespaceHealthCriteria{Namespace: p.Namespace, Cluster: p.Cluster, RateInterval: rateInterval, QueryTime: p.QueryTime, IncludeMetrics: true}
+	healthCriteria := business.NamespaceHealthCriteria{Namespace: p.Namespace, Cluster: p.ClusterMesh, RateInterval: rateInterval, QueryTime: p.QueryTime, IncludeMetrics: true}
 	switch p.Type {
 	case "app":
 		health, err := businessLayer.Health.GetNamespaceAppHealth(r.Context(), healthCriteria)
@@ -66,7 +66,7 @@ func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 
 type baseHealthParams struct {
 	// Cluster name
-	Cluster string `json:"cluster"`
+	ClusterMesh string `json:"clusterMesh"`
 	// The namespace scope
 	//
 	// in: path
@@ -87,7 +87,7 @@ func (p *baseHealthParams) baseExtract(r *http.Request, vars map[string]string) 
 	if rateInterval := queryParams.Get("rateInterval"); rateInterval != "" {
 		p.RateInterval = rateInterval
 	}
-	p.Cluster = clusterNameFromQuery(queryParams)
+	p.ClusterMesh = clusterNameFromQuery(queryParams)
 	if queryTime := queryParams.Get("queryTime"); queryTime != "" {
 		unix, err := strconv.ParseInt(queryTime, 10, 64)
 		if err == nil {

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -92,7 +92,7 @@ func getBusiness(r *http.Request) (*business.Layer, error) {
 // clusterNameFromQuery extracts the cluster name from the query parameters
 // and provides a default value if it's not present.
 func clusterNameFromQuery(queryParams url.Values) string {
-	cluster := queryParams.Get("clusterMesh")
+	cluster := queryParams.Get("clusterName")
 	if cluster == "" {
 		cluster = config.Get().KubernetesConfig.ClusterName
 	}

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -92,7 +92,7 @@ func getBusiness(r *http.Request) (*business.Layer, error) {
 // clusterNameFromQuery extracts the cluster name from the query parameters
 // and provides a default value if it's not present.
 func clusterNameFromQuery(queryParams url.Values) string {
-	cluster := queryParams.Get("cluster")
+	cluster := queryParams.Get("clusterMesh")
 	if cluster == "" {
 		cluster = config.Get().KubernetesConfig.ClusterName
 	}

--- a/handlers/utils_test.go
+++ b/handlers/utils_test.go
@@ -119,7 +119,7 @@ func TestClusterNameFromQuery(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.Get()
 
-	query := url.Values{"cluster": []string{"east"}}
+	query := url.Values{"clusterMesh": []string{"east"}}
 	assert.Equal("east", clusterNameFromQuery(query))
 
 	query = url.Values{}

--- a/handlers/utils_test.go
+++ b/handlers/utils_test.go
@@ -119,7 +119,7 @@ func TestClusterNameFromQuery(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.Get()
 
-	query := url.Values{"clusterMesh": []string{"east"}}
+	query := url.Values{"clusterName": []string{"east"}}
 	assert.Equal("east", clusterNameFromQuery(query))
 
 	query = url.Values{}

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -28,7 +28,7 @@ type workloadParams struct {
 	// in: query
 	WorkloadType string `json:"type"`
 	// Optional
-	Cluster               string `json:"cluster,omitempty"`
+	ClusterMesh           string `json:"clusterMesh,omitempty"`
 	IncludeHealth         bool   `json:"health"`
 	IncludeIstioResources bool   `json:"istioResources"`
 }
@@ -40,7 +40,7 @@ func (p *workloadParams) extract(r *http.Request) {
 	p.Namespace = vars["namespace"]
 	p.WorkloadName = vars["workload"]
 	p.WorkloadType = query.Get("type")
-	p.Cluster = clusterNameFromQuery(query)
+	p.ClusterMesh = clusterNameFromQuery(query)
 
 	var err error
 	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))
@@ -91,7 +91,9 @@ func WorkloadDetails(w http.ResponseWriter, r *http.Request) {
 	p := workloadParams{}
 	p.extract(r)
 
-	criteria := business.WorkloadCriteria{Namespace: p.Namespace, WorkloadName: p.WorkloadName, WorkloadType: p.WorkloadType, IncludeIstioResources: true, IncludeServices: true, IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval, QueryTime: p.QueryTime, Cluster: p.Cluster}
+	criteria := business.WorkloadCriteria{Namespace: p.Namespace, WorkloadName: p.WorkloadName,
+		WorkloadType: p.WorkloadType, IncludeIstioResources: true, IncludeServices: true, IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval,
+		QueryTime: p.QueryTime, Cluster: p.ClusterMesh}
 
 	// Get business layer
 	business, err := getBusiness(r)

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -28,7 +28,7 @@ type workloadParams struct {
 	// in: query
 	WorkloadType string `json:"type"`
 	// Optional
-	ClusterMesh           string `json:"clusterMesh,omitempty"`
+	ClusterName           string `json:"clusterName,omitempty"`
 	IncludeHealth         bool   `json:"health"`
 	IncludeIstioResources bool   `json:"istioResources"`
 }
@@ -40,7 +40,7 @@ func (p *workloadParams) extract(r *http.Request) {
 	p.Namespace = vars["namespace"]
 	p.WorkloadName = vars["workload"]
 	p.WorkloadType = query.Get("type")
-	p.ClusterMesh = clusterNameFromQuery(query)
+	p.ClusterName = clusterNameFromQuery(query)
 
 	var err error
 	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))
@@ -93,7 +93,7 @@ func WorkloadDetails(w http.ResponseWriter, r *http.Request) {
 
 	criteria := business.WorkloadCriteria{Namespace: p.Namespace, WorkloadName: p.WorkloadName,
 		WorkloadType: p.WorkloadType, IncludeIstioResources: true, IncludeServices: true, IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval,
-		QueryTime: p.QueryTime, Cluster: p.ClusterMesh}
+		QueryTime: p.QueryTime, Cluster: p.ClusterName}
 
 	// Get business layer
 	business, err := getBusiness(r)


### PR DESCRIPTION
This is changed just in the parameter, the variable name "cluster" was not renamed. 

I wonder if I should also change it to keep consistency, but still at some point (Like in the queries), clusterMesh should be changed by cluster.

Fixes #6322 