### PR TITLE
Remove cluster param from workload graph API url

### DIFF
--- a/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -87,7 +87,7 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
   getItemPage = () => {
     let path = `/namespaces/${this.state.namespace}/${this.state.pathItem}/${this.state.item}`;
     if (this.state.cluster) {
-      path += `?cluster=${this.state.cluster}`;
+      path += `?clusterName=${this.state.cluster}`;
     }
     return path;
   };

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -596,9 +596,6 @@ export const getNodeGraphElements = (node: NodeParamsType, params: any) => {
         {}
       );
     case NodeType.WORKLOAD:
-      if (node.cluster) {
-        params['clusterName'] = node.cluster;
-      }
       return newRequest<GraphDefinition>(
         HTTP_VERBS.GET,
         urls.workloadGraphElements(node.namespace.name, node.workload),

--- a/frontend/src/services/GraphDataSource.ts
+++ b/frontend/src/services/GraphDataSource.ts
@@ -268,7 +268,7 @@ export class GraphDataSource {
     });
 
     if (fetchParams.node?.cluster) {
-      restParams.cluster = fetchParams.node.cluster;
+      restParams.clusterName = fetchParams.node.cluster;
     }
 
     this._isLoading = true;


### PR DESCRIPTION
** Describe the change **

Remove cluster param from the workload graph API url. 

Besides, I have found a cluster param reference in BreadCrumbView component (renamed to clusterName).

** Issue reference **

Fixes #6328 

** Testing PR **

1. Select any workload.
2. Go to graph API request URL (Network section of Chrome developer tools)
3. Check that only cluster param does not appear (only clusterName)

![image](https://github.com/kiali/kiali/assets/122779323/c46baed0-2074-4af1-8f0f-44a8d813480e)
