### PR TITLE
Use cluster param when it is available

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -244,7 +244,7 @@ func (in *AppService) GetAppDetails(ctx context.Context, criteria AppCriteria) (
 	defer end()
 
 	appInstance := &models.App{Namespace: models.Namespace{Name: criteria.Namespace}, Name: criteria.AppName, Health: models.EmptyAppHealth(), Cluster: criteria.Cluster}
-	ns, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, criteria.Namespace, criteria.Cluster)
+	ns, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, criteria.Namespace, criteria.Cluster)
 	if err != nil {
 		return *appInstance, err
 	}
@@ -347,7 +347,7 @@ func (in *AppService) fetchNamespaceApps(ctx context.Context, namespace string, 
 
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return nil, err
 	}
 

--- a/business/health.go
+++ b/business/health.go
@@ -203,7 +203,7 @@ func (in *HealthService) GetNamespaceServiceHealth(ctx context.Context, criteria
 		return nil, fmt.Errorf("Cluster [%s] is not found or is not accessible for Kiali", cluster)
 	}
 
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return nil, err
 	}
 
@@ -279,7 +279,7 @@ func (in *HealthService) GetNamespaceWorkloadHealth(ctx context.Context, criteri
 		return nil, fmt.Errorf("Cluster [%s] is not found or is not accessible for Kiali", cluster)
 	}
 
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return nil, err
 	}
 

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -344,7 +344,7 @@ func (in *IstioConfigService) getIstioConfigListForCluster(ctx context.Context, 
 	if !criteria.AllNamespaces {
 		// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 		// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-		if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, criteria.Namespace, cluster); err != nil {
+		if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, criteria.Namespace, cluster); err != nil {
 			return models.IstioConfigList{}, err
 		}
 	} else {
@@ -595,7 +595,7 @@ func (in *IstioConfigService) GetIstioConfigDetails(ctx context.Context, cluster
 	}
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return istioConfigDetail, err
 	}
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -49,7 +49,7 @@ func (in *IstioValidationsService) GetValidations(ctx context.Context, cluster, 
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
 	if namespace != "" {
-		if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+		if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 			return nil, err
 		}
 	}
@@ -184,7 +184,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err = in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err = in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return nil, istioReferences, err
 	}
 
@@ -350,7 +350,7 @@ func (in *IstioValidationsService) fetchServices(ctx context.Context, rValue *mo
 func (in *IstioValidationsService) fetchAllWorkloads(ctx context.Context, rValue *map[string]models.WorkloadList, cluster string, namespaces *models.Namespaces, errChan chan error, wg *sync.WaitGroup) {
 	defer wg.Done()
 	if len(errChan) == 0 {
-		nss, err := in.businessLayer.Namespace.GetNamespacesForCluster(ctx, cluster)
+		nss, err := in.businessLayer.Namespace.GetClusterNamespaces(ctx, cluster)
 		if err != nil {
 			errChan <- err
 			return

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -116,6 +116,7 @@ func (in *MeshService) discoverKiali(ctx context.Context, clusterName string, r 
 	client, ok := in.kialiSAClients[clusterName]
 	if !ok {
 		log.Warningf("Discovery for Kiali instances in cluster [%s] failed. Unable to find SA client for cluster [%s]", clusterName, clusterName)
+
 		return nil
 	}
 

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -506,13 +506,6 @@ func (in *NamespaceService) isIncludedNamespace(namespace string) bool {
 	return false
 }
 
-// GetNamespace returns the definition of the specified namespace.
-// TODO: Multicluster: We are going to need something else to identify the namespace, the cluster (OR Return a list/array/map)
-func (in *NamespaceService) GetNamespace(ctx context.Context, namespace string) (*models.Namespace, error) {
-	// TODO: Wrapper for MC while other services are not updated to propagate the cluster
-	return in.GetNamespaceByCluster(ctx, namespace, "")
-}
-
 // GetNamespaceClusters is a convenience routine that filters GetNamespaces for a particular namespace
 func (in *NamespaceService) GetNamespaceClusters(ctx context.Context, namespace string) ([]models.Namespace, error) {
 	namespaces, err := in.GetNamespaces(ctx)
@@ -531,7 +524,6 @@ func (in *NamespaceService) GetNamespaceClusters(ctx context.Context, namespace 
 }
 
 // GetNamespace returns the definition of the specified namespace.
-// TODO: Multicluster: We are going to need something else to identify the namespace, the cluster (OR Return a list/array/map)
 func (in *NamespaceService) GetNamespaceByCluster(ctx context.Context, namespace string, cluster string) (*models.Namespace, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetNamespaceByCluster",

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -315,6 +315,8 @@ func (in *NamespaceService) getNamespacesByCluster(cluster string) ([]models.Nam
 				}
 				namespaces = models.CastProjectCollection(filteredProjects, cluster)
 			}
+		} else {
+			return nil, err2
 		}
 	} else {
 		// if the accessible namespaces define a distinct list of namespaces, use only those.

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -392,8 +392,8 @@ func (in *NamespaceService) getNamespacesByCluster(cluster string) ([]models.Nam
 	return namespaces, nil
 }
 
-// GetNamespacesForCluster is just a convenience routine that filters GetNamespaces for a particular cluster
-func (in *NamespaceService) GetNamespacesForCluster(ctx context.Context, cluster string) ([]models.Namespace, error) {
+// GetClusterNamespaces is just a convenience routine that filters GetNamespaces for a particular cluster
+func (in *NamespaceService) GetClusterNamespaces(ctx context.Context, cluster string) ([]models.Namespace, error) {
 	tokenNamespaces, err := in.GetNamespaces(ctx)
 	if err != nil {
 		return nil, err
@@ -523,10 +523,10 @@ func (in *NamespaceService) GetNamespaceClusters(ctx context.Context, namespace 
 	return result, nil
 }
 
-// GetNamespace returns the definition of the specified namespace.
-func (in *NamespaceService) GetNamespaceByCluster(ctx context.Context, namespace string, cluster string) (*models.Namespace, error) {
+// GetClusterNamespace returns the definition of the specified namespace.
+func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace string, cluster string) (*models.Namespace, error) {
 	var end observability.EndFunc
-	ctx, end = observability.StartSpan(ctx, "GetNamespaceByCluster",
+	ctx, end = observability.StartSpan(ctx, "GetClusterNamespace",
 		observability.Attribute("package", "business"),
 		observability.Attribute("namespace", namespace),
 		observability.Attribute("cluster", cluster),
@@ -593,7 +593,7 @@ func (in *NamespaceService) UpdateNamespace(ctx context.Context, namespace strin
 	defer end()
 
 	// A first check to run the accessible/excluded logic and not run the Update operation on filtered namespaces
-	_, err := in.GetNamespaceByCluster(ctx, namespace, cluster)
+	_, err := in.GetClusterNamespace(ctx, namespace, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -608,7 +608,7 @@ func (in *NamespaceService) UpdateNamespace(ctx context.Context, namespace strin
 	in.kialiCache.RefreshTokenNamespaces()
 
 	// Call GetNamespace to update the caching
-	return in.GetNamespaceByCluster(ctx, namespace, cluster)
+	return in.GetClusterNamespace(ctx, namespace, cluster)
 }
 
 func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelector string, forwardedError error) ([]core_v1.Namespace, error) {

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -75,7 +75,7 @@ func NewNamespaceService(userClients map[string]kubernetes.ClientInterface, kial
 // Returns a list of the given namespaces / projects
 func (in *NamespaceService) GetClusterList() []string {
 	var clusterList []string
-	for cluster, _ := range in.userClients {
+	for cluster := range in.userClients {
 		clusterList = append(clusterList, cluster)
 	}
 	return clusterList
@@ -284,7 +284,7 @@ func (in *NamespaceService) getNamespacesByCluster(cluster string) ([]models.Nam
 
 	labelSelectorInclude := configObject.API.Namespaces.LabelSelectorInclude
 
-	namespaces := []models.Namespace{}
+	var namespaces []models.Namespace
 	_, queryAllNamespaces := in.isAccessibleNamespaces["**"]
 	// If we are running in OpenShift, we will use the project names since these are the list of accessible namespaces
 	if in.hasProjects {

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -532,6 +532,9 @@ func (in *NamespaceService) GetNamespaceByCluster(ctx context.Context, namespace
 		observability.Attribute("cluster", cluster),
 	)
 	defer end()
+	if cluster == "" {
+		log.Infof("*** Get Namespace for cluster: %s ", cluster)
+	}
 
 	var err error
 

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -72,7 +72,7 @@ func NewNamespaceService(userClients map[string]kubernetes.ClientInterface, kial
 	}
 }
 
-// Returns a list of the given namespaces / projects
+// GetClusterList Returns a list of cluster names based on the user clients
 func (in *NamespaceService) GetClusterList() []string {
 	var clusterList []string
 	for cluster := range in.userClients {

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -73,6 +73,15 @@ func NewNamespaceService(userClients map[string]kubernetes.ClientInterface, kial
 }
 
 // Returns a list of the given namespaces / projects
+func (in *NamespaceService) GetClusterList() []string {
+	var clusterList []string
+	for cluster, _ := range in.userClients {
+		clusterList = append(clusterList, cluster)
+	}
+	return clusterList
+}
+
+// Returns a list of the given namespaces / projects
 func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespace, error) {
 	var end observability.EndFunc
 	_, end = observability.StartSpan(ctx, "GetNamespaces",

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -524,6 +524,7 @@ func (in *NamespaceService) GetNamespaceClusters(ctx context.Context, namespace 
 }
 
 // GetNamespace returns the definition of the specified namespace.
+// TODO: When cluster is "" it returns the first occurrence
 func (in *NamespaceService) GetNamespaceByCluster(ctx context.Context, namespace string, cluster string) (*models.Namespace, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetNamespaceByCluster",
@@ -532,9 +533,6 @@ func (in *NamespaceService) GetNamespaceByCluster(ctx context.Context, namespace
 		observability.Attribute("cluster", cluster),
 	)
 	defer end()
-	if cluster == "" {
-		log.Infof("*** Get Namespace for cluster: %s ", cluster)
-	}
 
 	var err error
 

--- a/business/namespaces_test.go
+++ b/business/namespaces_test.go
@@ -74,7 +74,7 @@ func TestGetNamespace(t *testing.T) {
 
 	nsservice := setupNamespaceService(t, k8s, conf)
 
-	ns, _ := nsservice.GetNamespace(context.TODO(), "bookinfo")
+	ns, _ := nsservice.GetNamespaceByCluster(context.TODO(), "bookinfo", config.Get().KubernetesConfig.ClusterName)
 
 	assert.NotNil(t, ns)
 	assert.Equal(t, ns.Name, "bookinfo")
@@ -92,7 +92,7 @@ func TestGetNamespaceWithError(t *testing.T) {
 
 	nsservice := setupNamespaceService(t, k8s, conf)
 
-	ns2, err := nsservice.GetNamespace(context.TODO(), "fakeNS")
+	ns2, err := nsservice.GetNamespaceByCluster(context.TODO(), "fakeNS", config.Get().KubernetesConfig.ClusterName)
 
 	assert.NotNil(t, err)
 	assert.Nil(t, ns2)
@@ -143,13 +143,10 @@ func TestMultiClusterGetNamespace(t *testing.T) {
 
 	nsservice := NewNamespaceService(clients, clients, cache, *conf)
 
-	_, err := nsservice.GetNamespace(context.TODO(), "bookinfo")
+	ns, err := nsservice.GetNamespaceByCluster(context.TODO(), "bookinfo", conf.KubernetesConfig.ClusterName)
 	require.NoError(err)
-	// TODO: It is indeterminite which cluster will be returned first.
-	// GetNamespace should probably always return the home cluster to
-	// keep backward compatability and anything new should use
-	// GetNamespaceByCluster.
-	// assert.Equal(conf.KubernetesConfig.ClusterName, ns.Cluster)
+
+	assert.Equal(t, conf.KubernetesConfig.ClusterName, ns.Cluster)
 }
 
 func TestMultiClusterGetNamespaces(t *testing.T) {

--- a/business/namespaces_test.go
+++ b/business/namespaces_test.go
@@ -74,7 +74,7 @@ func TestGetNamespace(t *testing.T) {
 
 	nsservice := setupNamespaceService(t, k8s, conf)
 
-	ns, _ := nsservice.GetNamespaceByCluster(context.TODO(), "bookinfo", config.Get().KubernetesConfig.ClusterName)
+	ns, _ := nsservice.GetClusterNamespace(context.TODO(), "bookinfo", config.Get().KubernetesConfig.ClusterName)
 
 	assert.NotNil(t, ns)
 	assert.Equal(t, ns.Name, "bookinfo")
@@ -92,7 +92,7 @@ func TestGetNamespaceWithError(t *testing.T) {
 
 	nsservice := setupNamespaceService(t, k8s, conf)
 
-	ns2, err := nsservice.GetNamespaceByCluster(context.TODO(), "fakeNS", config.Get().KubernetesConfig.ClusterName)
+	ns2, err := nsservice.GetClusterNamespace(context.TODO(), "fakeNS", config.Get().KubernetesConfig.ClusterName)
 
 	assert.NotNil(t, err)
 	assert.Nil(t, ns2)
@@ -143,7 +143,7 @@ func TestMultiClusterGetNamespace(t *testing.T) {
 
 	nsservice := NewNamespaceService(clients, clients, cache, *conf)
 
-	ns, err := nsservice.GetNamespaceByCluster(context.TODO(), "bookinfo", conf.KubernetesConfig.ClusterName)
+	ns, err := nsservice.GetClusterNamespace(context.TODO(), "bookinfo", conf.KubernetesConfig.ClusterName)
 	require.NoError(err)
 
 	assert.Equal(t, conf.KubernetesConfig.ClusterName, ns.Cluster)
@@ -217,7 +217,7 @@ func TestGetNamespacesCached(t *testing.T) {
 
 	require.Len(namespaces, 4)
 
-	namespace, err := nsservice.GetNamespaceByCluster(context.TODO(), "gamma", "west")
+	namespace, err := nsservice.GetClusterNamespace(context.TODO(), "gamma", "west")
 	require.NoError(err)
 
 	assert.Equal("west", namespace.Cluster)
@@ -259,7 +259,7 @@ func TestGetNamespacesForbiddenCached(t *testing.T) {
 
 	nsservice := NewNamespaceService(clients, clients, cache, *conf)
 	// Try to get the bookinfo namespace from the home cluster.
-	_, err := nsservice.GetNamespaceByCluster(context.TODO(), "bookinfo", "east")
+	_, err := nsservice.GetClusterNamespace(context.TODO(), "bookinfo", "east")
 	require.Error(err)
 }
 

--- a/business/services.go
+++ b/business/services.go
@@ -70,7 +70,7 @@ func (in *SvcService) GetServiceList(ctx context.Context, criteria ServiceCriter
 			continue
 		}
 
-		if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, criteria.Namespace, cluster); err != nil {
+		if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, criteria.Namespace, cluster); err != nil {
 			// We want to throw an error if we're single vs. multi cluster to be backward compatible
 			// TODO: Probably need this in a few other places as well. It'd be nice to have a
 			// centralized check for this in the config instead of this hacky one.
@@ -474,7 +474,7 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return nil, err
 	}
 
@@ -717,7 +717,7 @@ func (in *SvcService) UpdateService(ctx context.Context, cluster, namespace, ser
 	// Identify controller and apply patch to workload
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(context.TODO(), namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(context.TODO(), namespace, cluster); err != nil {
 		return nil, err
 	}
 
@@ -749,7 +749,7 @@ func (in *SvcService) GetService(ctx context.Context, cluster, namespace, servic
 
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return models.Service{}, err
 	}
 
@@ -815,7 +815,7 @@ func (in *SvcService) GetServiceAppName(ctx context.Context, cluster, namespace,
 
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return "", err
 	}
 

--- a/business/tls.go
+++ b/business/tls.go
@@ -119,7 +119,7 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace, cl
 }
 
 func (in *TLSService) getNamespaces(ctx context.Context, cluster string) ([]string, error) {
-	nss, nssErr := in.businessLayer.Namespace.GetNamespacesForCluster(ctx, cluster)
+	nss, nssErr := in.businessLayer.Namespace.GetClusterNamespaces(ctx, cluster)
 	if nssErr != nil {
 		return nil, nssErr
 	}

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -338,7 +338,7 @@ func (in *WorkloadService) GetWorkload(ctx context.Context, criteria WorkloadCri
 	)
 	defer end()
 
-	ns, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, criteria.Namespace, criteria.Cluster)
+	ns, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, criteria.Namespace, criteria.Cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -633,7 +633,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return nil, err
 	}
 
@@ -1194,7 +1194,7 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, criteria.Namespace, criteria.Cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, criteria.Namespace, criteria.Cluster); err != nil {
 		return nil, err
 	}
 
@@ -1836,7 +1836,7 @@ func (in *WorkloadService) listWaypointWorkloadsForNamespace(ctx context.Context
 func (in *WorkloadService) updateWorkload(ctx context.Context, cluster string, namespace string, workloadName string, workloadType string, jsonPatch string, patchType string) error {
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespaceByCluster(ctx, namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return err
 	}
 

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -60,12 +61,12 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 
 	if criteria.IncludeHealth {
 		// When the cluster is not specified, we need to get it. If there are more than one, the home cluster will be used
-		clusters := business.Namespace.GetNamespaceClusters(p.Namespace)
+		clusters, _ := business.Namespace.GetNamespaceClusters(context.TODO(), p.Namespace)
 		if len(clusters) == 0 {
 			handleErrorResponse(w, err, "Error looking for cluster: "+err.Error())
 			return
 		}
-		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, clusters[0])
+		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, clusters[0].Cluster)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -49,7 +49,7 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 	p.extract(r)
 
 	criteria := business.AppCriteria{Namespace: p.Namespace, IncludeIstioResources: p.IncludeIstioResources,
-		IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval, QueryTime: p.QueryTime}
+		IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval, QueryTime: p.QueryTime, Cluster: p.ClusterName}
 
 	// Get business layer
 	business, err := getBusiness(r)
@@ -59,7 +59,7 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if criteria.IncludeHealth {
-		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime)
+		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, p.ClusterName)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -63,7 +63,8 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 		// When the cluster is not specified, we need to get it. If there are more than one, the home cluster will be used
 		clusters, _ := business.Namespace.GetNamespaceClusters(context.TODO(), p.Namespace)
 		if len(clusters) == 0 {
-			handleErrorResponse(w, err, "Error looking for cluster: "+err.Error())
+                        err = fmt.Errorf("No clusters found for namespace  [%s], p.Namespace)
+			handleErrorResponse(w, err, err.Error())
 			return
 		}
 		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, clusters[0].Cluster)

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/gorilla/mux"
 
@@ -63,20 +62,14 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 	if criteria.IncludeHealth {
 		// When the cluster is not specified, we need to get it. If there are more than one,
 		// get the one for which the namespace creation time is oldest
-		clusters, _ := business.Namespace.GetNamespaceClusters(r.Context(), p.Namespace)
-		if len(clusters) == 0 {
+		namespaces, _ := business.Namespace.GetNamespaceClusters(r.Context(), p.Namespace)
+		if len(namespaces) == 0 {
 			err = fmt.Errorf("No clusters found for namespace  [%s]", p.Namespace)
 			handleErrorResponse(w, err, err.Error())
 			return
 		}
-		var cluster string
-		var creationTimestamp time.Time
-		for i, cl := range clusters {
-			if i == 0 || cl.CreationTimestamp.Before(creationTimestamp) {
-				cluster = cl.Cluster
-			}
-		}
-		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, cluster)
+		ns := GetOldestNamespace(namespaces)
+		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, ns.Cluster)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -64,7 +65,7 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 		// get the one for which the namespace creation time is oldest
 		clusters, _ := business.Namespace.GetNamespaceClusters(r.Context(), p.Namespace)
 		if len(clusters) == 0 {
-                        err = fmt.Errorf("No clusters found for namespace  [%s], p.Namespace)
+			err = fmt.Errorf("No clusters found for namespace  [%s]", p.Namespace)
 			handleErrorResponse(w, err, err.Error())
 			return
 		}

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -41,7 +41,18 @@ func TestAppMetricsDefault(t *testing.T) {
 	now := time.Now()
 	delta := 15 * time.Second
 	var gaugeSentinel uint32
-
+	/*
+		ns := []core_v1.Namespace{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "ns",
+					Namespace: "Namespace",
+					Labels:    map[string]string{"app": "ns"},
+				},
+			},
+		}
+		k8s.On("GetNamespaces", "").Return(ns, nil)
+	*/
 	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
 		query := args[1].(string)
 		assert.IsType(t, prom_v1.Range{}, args[2])
@@ -91,7 +102,18 @@ func TestAppMetricsWithParams(t *testing.T) {
 	q.Add("filters[]", "request_count")
 	q.Add("filters[]", "request_size")
 	req.URL.RawQuery = q.Encode()
-
+	/*
+		ns := []core_v1.Namespace{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "ns",
+					Namespace: "Namespace",
+					Labels:    map[string]string{"app": "ns"},
+				},
+			},
+		}
+		k8s.On("GetNamespaces", "").Return(ns, nil)
+	*/
 	queryTime := time.Unix(1523364075, 0)
 	delta := 2 * time.Second
 	var histogramSentinel, gaugeSentinel uint32
@@ -156,6 +178,20 @@ func TestAppMetricsInaccessibleNamespace(t *testing.T) {
 
 	url := ts.URL + "/api/namespaces/my_namespace/apps/my_app/metrics"
 
+	/*
+		var nsNil *core_v1.Namespace
+		ns := []core_v1.Namespace{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "my_namespace",
+					Namespace: "Namespace",
+					Labels:    map[string]string{"app": "my_namespace"},
+				},
+			},
+		}
+		k8s.On("GetNamespaces", "").Return(ns, nil)
+		k8s.On("GetNamespace", "my_namespace").Return(nsNil, errors.New("no privileges"))
+	*/
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -176,7 +212,11 @@ func setupAppMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.Pr
 		t.Fatal(err)
 	}
 	prom.Inject(xapi)
-
+	/*
+		k8s.On("IsOpenShift").Return(false)
+		k8s.On("IsGatewayAPI").Return(false)
+		k8s.On("GetNamespace", "ns").Return(&core_v1.Namespace{}, nil)
+	*/
 	k8s := &clientNoPrivileges{kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}})}
 	/*
 		k8s.On("IsOpenShift").Return(false)

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -41,18 +41,7 @@ func TestAppMetricsDefault(t *testing.T) {
 	now := time.Now()
 	delta := 15 * time.Second
 	var gaugeSentinel uint32
-	/*
-		ns := []core_v1.Namespace{
-			{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Name:      "ns",
-					Namespace: "Namespace",
-					Labels:    map[string]string{"app": "ns"},
-				},
-			},
-		}
-		k8s.On("GetNamespaces", "").Return(ns, nil)
-	*/
+
 	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
 		query := args[1].(string)
 		assert.IsType(t, prom_v1.Range{}, args[2])
@@ -102,18 +91,7 @@ func TestAppMetricsWithParams(t *testing.T) {
 	q.Add("filters[]", "request_count")
 	q.Add("filters[]", "request_size")
 	req.URL.RawQuery = q.Encode()
-	/*
-		ns := []core_v1.Namespace{
-			{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Name:      "ns",
-					Namespace: "Namespace",
-					Labels:    map[string]string{"app": "ns"},
-				},
-			},
-		}
-		k8s.On("GetNamespaces", "").Return(ns, nil)
-	*/
+
 	queryTime := time.Unix(1523364075, 0)
 	delta := 2 * time.Second
 	var histogramSentinel, gaugeSentinel uint32
@@ -178,20 +156,6 @@ func TestAppMetricsInaccessibleNamespace(t *testing.T) {
 
 	url := ts.URL + "/api/namespaces/my_namespace/apps/my_app/metrics"
 
-	/*
-		var nsNil *core_v1.Namespace
-		ns := []core_v1.Namespace{
-			{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Name:      "my_namespace",
-					Namespace: "Namespace",
-					Labels:    map[string]string{"app": "my_namespace"},
-				},
-			},
-		}
-		k8s.On("GetNamespaces", "").Return(ns, nil)
-		k8s.On("GetNamespace", "my_namespace").Return(nsNil, errors.New("no privileges"))
-	*/
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -212,18 +176,7 @@ func setupAppMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.Pr
 		t.Fatal(err)
 	}
 	prom.Inject(xapi)
-	/*
-		k8s.On("IsOpenShift").Return(false)
-		k8s.On("IsGatewayAPI").Return(false)
-		k8s.On("GetNamespace", "ns").Return(&core_v1.Namespace{}, nil)
-	*/
 	k8s := &clientNoPrivileges{kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}})}
-	/*
-		k8s.On("IsOpenShift").Return(false)
-		k8s.On("IsGatewayAPI").Return(false)
-		k8s.On("GetNamespace", "ns").Return(&core_v1.Namespace{}, nil)
-		k8s.On("GetNamespaces", "").Return([]core_v1.Namespace{}, nil)
-	*/
 	mr := mux.NewRouter()
 
 	authInfo := &api.AuthInfo{Token: "test"}

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -178,7 +178,12 @@ func setupAppMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.Pr
 	prom.Inject(xapi)
 
 	k8s := &clientNoPrivileges{kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}})}
-
+	/*
+		k8s.On("IsOpenShift").Return(false)
+		k8s.On("IsGatewayAPI").Return(false)
+		k8s.On("GetNamespace", "ns").Return(&core_v1.Namespace{}, nil)
+		k8s.On("GetNamespaces", "").Return([]core_v1.Namespace{}, nil)
+	*/
 	mr := mux.NewRouter()
 
 	authInfo := &api.AuthInfo{Token: "test"}

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -117,14 +117,15 @@ func AppDashboard(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	app := vars["app"]
+	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, namespace)
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, namespace, cluster)
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
 	}
 
-	params := models.IstioMetricsQuery{Cluster: clusterNameFromQuery(r.URL.Query()), Namespace: namespace, App: app}
+	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, App: app}
 	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
@@ -149,7 +150,7 @@ func ServiceDashboard(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 	cluster := clusterNameFromQuery(queryParams)
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, namespace)
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, namespace, cluster)
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -195,14 +196,15 @@ func WorkloadDashboard(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	workload := vars["workload"]
+	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, namespace)
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, namespace, cluster)
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
 	}
 
-	params := models.IstioMetricsQuery{Cluster: clusterNameFromQuery(r.URL.Query()), Namespace: namespace, Workload: workload}
+	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, Workload: workload}
 	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -119,7 +119,7 @@ func AppDashboard(w http.ResponseWriter, r *http.Request) {
 	app := vars["app"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, namespace, cluster)
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, models.Namespace{Name: namespace, Cluster: cluster})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -150,7 +150,7 @@ func ServiceDashboard(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 	cluster := clusterNameFromQuery(queryParams)
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, namespace, cluster)
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, models.Namespace{Name: namespace, Cluster: cluster})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -198,7 +198,7 @@ func WorkloadDashboard(w http.ResponseWriter, r *http.Request) {
 	workload := vars["workload"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, namespace, cluster)
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, defaultPromClientSupplier, models.Namespace{Name: namespace, Cluster: cluster})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -33,7 +33,7 @@ func CustomDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check namespace access
-	info, err := layer.Namespace.GetNamespaceByCluster(r.Context(), namespace, cluster)
+	info, err := layer.Namespace.GetClusterNamespace(r.Context(), namespace, cluster)
 	if err != nil {
 		RespondWithError(w, http.StatusForbidden, "Cannot access namespace data: "+err.Error())
 		return

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -32,7 +32,7 @@ func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Adjust rate interval
-	rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime)
+	rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime, p.ClusterName)
 	if err != nil {
 		handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 		return
@@ -124,8 +124,8 @@ func (p *namespaceHealthParams) extract(r *http.Request) (bool, string) {
 	return true, ""
 }
 
-func adjustRateInterval(ctx context.Context, business *business.Layer, namespace, rateInterval string, queryTime time.Time) (string, error) {
-	namespaceInfo, err := business.Namespace.GetNamespace(ctx, namespace)
+func adjustRateInterval(ctx context.Context, business *business.Layer, namespace, rateInterval string, queryTime time.Time, cluster string) (string, error) {
+	namespaceInfo, err := business.Namespace.GetNamespaceByCluster(ctx, namespace, cluster)
 	if err != nil {
 		return "", err
 	}

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -126,7 +126,7 @@ func (p *namespaceHealthParams) extract(r *http.Request) (bool, string) {
 
 func adjustRateInterval(ctx context.Context, business *business.Layer, namespace, rateInterval string, queryTime time.Time, cluster string) (string, error) {
 
-	namespaceInfo, err := business.Namespace.GetNamespaceByCluster(ctx, namespace, cluster)
+	namespaceInfo, err := business.Namespace.GetClusterNamespace(ctx, namespace, cluster)
 	if err != nil {
 		return "", err
 	}

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -125,6 +125,7 @@ func (p *namespaceHealthParams) extract(r *http.Request) (bool, string) {
 }
 
 func adjustRateInterval(ctx context.Context, business *business.Layer, namespace, rateInterval string, queryTime time.Time, cluster string) (string, error) {
+
 	namespaceInfo, err := business.Namespace.GetNamespaceByCluster(ctx, namespace, cluster)
 	if err != nil {
 		return "", err

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -68,7 +68,7 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if allNamespaces && len(nss) == 0 {
-		loadedNamespaces, _ := business.Namespace.GetNamespacesForCluster(r.Context(), cluster)
+		loadedNamespaces, _ := business.Namespace.GetClusterNamespaces(r.Context(), cluster)
 		for _, ns := range loadedNamespaces {
 			nss = append(nss, ns.Name)
 		}

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -43,6 +43,11 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClie
 		log.Errorf("Error getting namespace clusters %s", errNs.Error())
 	}
 
+	if len(namespaces) == 0 {
+		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
+		return
+	}
+
 	//TODO: Namespace is used to check permissions, this is checking just in one of them
 	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
 	if metricsService == nil {
@@ -85,6 +90,11 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
 	if errNs != nil {
 		log.Errorf("Error getting namespace clusters %s", errNs.Error())
+	}
+
+	if len(namespaces) == 0 {
+		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
+		return
 	}
 
 	// TODO: Namespace is used to check permissions, this is checking just in one of them
@@ -132,6 +142,11 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 		log.Errorf("Error getting namespace clusters %s", errNs.Error())
 	}
 
+	if len(namespaces) == 0 {
+		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
+		return
+	}
+
 	// TODO: Namespace is used to check permissions, this is checking just in one of them
 	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
 	if metricsService == nil {
@@ -174,6 +189,11 @@ func getAggregateMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
 	if errNs != nil {
 		log.Errorf("Error getting namespace clusters %s", errNs.Error())
+	}
+
+	if len(namespaces) == 0 {
+		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
+		return
 	}
 
 	// TODO: Namespace is used to check permissions, this is checking just in one of them
@@ -226,6 +246,11 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
 	if errNs != nil {
 		log.Errorf("Error getting namespace clusters %s", errNs.Error())
+	}
+
+	if len(namespaces) == 0 {
+		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
+		return
 	}
 
 	// TODO: Namespace is used to check permissions, this is checking just in one of them

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -66,7 +66,7 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 	workload := vars["workload"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	// TODO: Namespace is used to check permissions, this is checking just in one of them
+	//TODO: Namespace is used to check permissions, this is checking just in one of them
 	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
 
 	if metricsService == nil {
@@ -101,7 +101,7 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 	service := vars["service"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	// TODO: Namespace is used to check permissions, this is checking just in one of them
+	//TODO: Namespace is used to check permissions, this is checking just in one of them
 	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
@@ -135,7 +135,7 @@ func getAggregateMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	aggregate := vars["aggregate"]
 	aggregateValue := vars["aggregateValue"]
 
-	// TODO: Namespace is used to check permissions, this is checking just in one of them
+	//TODO: Namespace is used to check permissions, this is checking just in one of them
 	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
@@ -176,8 +176,8 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	cluster := clusterNameFromQuery(r.URL.Query())
-	
-	// TODO: Namespace is used to check permissions, this is checking just in one of them
+
+	//TODO: Namespace is used to check permissions, this is checking just in one of them
 	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
 	if metricsService == nil {
 		// any returned value nil means error & response already written

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -361,24 +361,23 @@ func MetricsStats(w http.ResponseWriter, r *http.Request) {
 
 func prepareStatsQueries(w http.ResponseWriter, r *http.Request, rawQ []models.MetricsStatsQuery, promSupplier promClientSupplier) (*business.MetricsService, []models.MetricsStatsQuery, *util.Errors) {
 	// Get unique namespaces list
-	var namespaces []string
-	var cluster string
+	var namespaces []models.Namespace
 	for _, q := range rawQ {
 		found := false
 		for _, ns := range namespaces {
-			if ns == q.Target.Namespace {
+			if ns.Name == q.Target.Namespace {
 				found = true
-				cluster = q.Target.Cluster
 				break
 			}
 		}
 		if !found {
-			namespaces = append(namespaces, q.Target.Namespace)
+			newNs := models.Namespace{Name: q.Target.Namespace, Cluster: q.Target.Cluster}
+			namespaces = append(namespaces, newNs)
 		}
 	}
 
 	// Create the metrics service, along with namespaces information for adjustements
-	metricsService, nsInfos := createMetricsServiceForNamespaces(w, r, promSupplier, namespaces, cluster)
+	metricsService, nsInfos := createMetricsServiceForNamespaces(w, r, promSupplier, namespaces)
 
 	// Keep only valid queries (fill errors if needed) and adjust queryTime / interval
 	var errors util.Errors

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -172,7 +172,7 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	cluster := clusterNameFromQuery(r.URL.Query())
-	
+
 	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
 	if metricsService == nil {
 		// any returned value nil means error & response already written

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -32,14 +32,15 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClie
 	app := vars["app"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
 	}
 
 	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, App: app}
-	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
+	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
+	err := extractIstioMetricsQueryParams(r, &params, oldestNs)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
@@ -65,15 +66,15 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 	workload := vars["workload"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
-
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
 	}
+	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
 
 	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, Workload: workload}
-	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
+	err := extractIstioMetricsQueryParams(r, &params, oldestNs)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
@@ -99,14 +100,15 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 	service := vars["service"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
 	}
+	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
 
 	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, Service: service}
-	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
+	err := extractIstioMetricsQueryParams(r, &params, oldestNs)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
@@ -132,14 +134,15 @@ func getAggregateMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	aggregate := vars["aggregate"]
 	aggregateValue := vars["aggregateValue"]
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
 	}
+	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
 
 	params := models.IstioMetricsQuery{Namespace: namespace, Aggregate: aggregate, AggregateValue: aggregateValue}
-	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
+	err := extractIstioMetricsQueryParams(r, &params, oldestNs)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
@@ -173,15 +176,16 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	namespace := vars["namespace"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
 	}
+	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
 
 	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace}
 
-	err := extractIstioMetricsQueryParams(r, &params, namespaceInfo)
+	err := extractIstioMetricsQueryParams(r, &params, oldestNs)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,7 +33,18 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClie
 	app := vars["app"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespace, cluster)
+	layer, errBs := getBusiness(r)
+	if errBs != nil {
+		log.Errorf("Error getting business %s", errBs.Error())
+	}
+
+	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
+	if errNs != nil {
+		log.Errorf("Error getting namespace clusters %s", errNs.Error())
+	}
+
+	// TODO: Namespace is used to check permissions, this is checking just in one of them 
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -65,7 +77,19 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 	workload := vars["workload"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespace, cluster)
+	layer, errBs := getBusiness(r)
+	if errBs != nil {
+		log.Errorf("Error getting business %s", errBs.Error())
+	}
+
+	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
+	if errNs != nil {
+		log.Errorf("Error getting namespace clusters %s", errNs.Error())
+	}
+
+	// TODO: Namespace is used to check permissions, this is checking just in one of them
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
+
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -98,7 +122,18 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 	service := vars["service"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespace, cluster)
+	layer, errBs := getBusiness(r)
+	if errBs != nil {
+		log.Errorf("Error getting business %s", errBs.Error())
+	}
+
+	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
+	if errNs != nil {
+		log.Errorf("Error getting namespace clusters %s", errNs.Error())
+	}
+
+	// TODO: Namespace is used to check permissions, this is checking just in one of them
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -130,9 +165,19 @@ func getAggregateMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	namespace := vars["namespace"]
 	aggregate := vars["aggregate"]
 	aggregateValue := vars["aggregateValue"]
-	cluster := clusterNameFromQuery(r.URL.Query())
 
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespace, cluster)
+	layer, errBs := getBusiness(r)
+	if errBs != nil {
+		log.Errorf("Error getting business %s", errBs.Error())
+	}
+
+	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
+	if errNs != nil {
+		log.Errorf("Error getting namespace clusters %s", errNs.Error())
+	}
+
+	// TODO: Namespace is used to check permissions, this is checking just in one of them
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -172,7 +217,19 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	cluster := clusterNameFromQuery(r.URL.Query())
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespace, "")
+
+	layer, errBs := getBusiness(r)
+	if errBs != nil {
+		log.Errorf("Error getting business %s", errBs.Error())
+	}
+
+	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
+	if errNs != nil {
+		log.Errorf("Error getting namespace clusters %s", errNs.Error())
+	}
+
+	// TODO: Namespace is used to check permissions, this is checking just in one of them
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,23 +32,8 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClie
 	app := vars["app"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	layer, errBs := getBusiness(r)
-	if errBs != nil {
-		log.Errorf("Error getting business %s", errBs.Error())
-	}
-
-	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
-	if errNs != nil {
-		log.Errorf("Error getting namespace clusters %s", errNs.Error())
-	}
-
-	if len(namespaces) == 0 {
-		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
-		return
-	}
-
 	//TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -82,23 +66,8 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 	workload := vars["workload"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	layer, errBs := getBusiness(r)
-	if errBs != nil {
-		log.Errorf("Error getting business %s", errBs.Error())
-	}
-
-	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
-	if errNs != nil {
-		log.Errorf("Error getting namespace clusters %s", errNs.Error())
-	}
-
-	if len(namespaces) == 0 {
-		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
-		return
-	}
-
 	// TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
 
 	if metricsService == nil {
 		// any returned value nil means error & response already written
@@ -132,23 +101,8 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 	service := vars["service"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	layer, errBs := getBusiness(r)
-	if errBs != nil {
-		log.Errorf("Error getting business %s", errBs.Error())
-	}
-
-	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
-	if errNs != nil {
-		log.Errorf("Error getting namespace clusters %s", errNs.Error())
-	}
-
-	if len(namespaces) == 0 {
-		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
-		return
-	}
-
 	// TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -181,23 +135,8 @@ func getAggregateMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	aggregate := vars["aggregate"]
 	aggregateValue := vars["aggregateValue"]
 
-	layer, errBs := getBusiness(r)
-	if errBs != nil {
-		log.Errorf("Error getting business %s", errBs.Error())
-	}
-
-	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
-	if errNs != nil {
-		log.Errorf("Error getting namespace clusters %s", errNs.Error())
-	}
-
-	if len(namespaces) == 0 {
-		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
-		return
-	}
-
 	// TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -237,24 +176,9 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	cluster := clusterNameFromQuery(r.URL.Query())
-
-	layer, errBs := getBusiness(r)
-	if errBs != nil {
-		log.Errorf("Error getting business %s", errBs.Error())
-	}
-
-	namespaces, errNs := layer.Namespace.GetNamespaceClusters(context.TODO(), namespace)
-	if errNs != nil {
-		log.Errorf("Error getting namespace clusters %s", errNs.Error())
-	}
-
-	if len(namespaces) == 0 {
-		RespondWithError(w, http.StatusBadRequest, "No namespaces matching the request")
-		return
-	}
-
+	
 	// TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
+	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -43,7 +43,7 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClie
 		log.Errorf("Error getting namespace clusters %s", errNs.Error())
 	}
 
-	// TODO: Namespace is used to check permissions, this is checking just in one of them 
+	//TODO: Namespace is used to check permissions, this is checking just in one of them
 	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, namespaces[0])
 	if metricsService == nil {
 		// any returned value nil means error & response already written

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -32,8 +32,7 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClie
 	app := vars["app"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	//TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -66,8 +65,7 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 	workload := vars["workload"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	//TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
 
 	if metricsService == nil {
 		// any returned value nil means error & response already written
@@ -101,8 +99,7 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 	service := vars["service"]
 	cluster := clusterNameFromQuery(r.URL.Query())
 
-	//TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -135,8 +132,7 @@ func getAggregateMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	aggregate := vars["aggregate"]
 	aggregateValue := vars["aggregateValue"]
 
-	//TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return
@@ -176,9 +172,8 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	cluster := clusterNameFromQuery(r.URL.Query())
-
-	//TODO: Namespace is used to check permissions, this is checking just in one of them
-	metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, promSupplier, models.Namespace{Name: namespace, Cluster: ""})
+	
+	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, models.Namespace{Name: namespace})
 	if metricsService == nil {
 		// any returned value nil means error & response already written
 		return

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -39,7 +39,7 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClie
 	}
 
 	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, App: app}
-	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
+	oldestNs := GetOldestNamespace(namespaceInfo)
 	err := extractIstioMetricsQueryParams(r, &params, oldestNs)
 	if err != nil {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
@@ -71,7 +71,7 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 		// any returned value nil means error & response already written
 		return
 	}
-	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
+	oldestNs := GetOldestNamespace(namespaceInfo)
 
 	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, Workload: workload}
 	err := extractIstioMetricsQueryParams(r, &params, oldestNs)
@@ -105,7 +105,7 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 		// any returned value nil means error & response already written
 		return
 	}
-	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
+	oldestNs := GetOldestNamespace(namespaceInfo)
 
 	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, Service: service}
 	err := extractIstioMetricsQueryParams(r, &params, oldestNs)
@@ -139,7 +139,7 @@ func getAggregateMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 		// any returned value nil means error & response already written
 		return
 	}
-	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
+	oldestNs := GetOldestNamespace(namespaceInfo)
 
 	params := models.IstioMetricsQuery{Namespace: namespace, Aggregate: aggregate, AggregateValue: aggregateValue}
 	err := extractIstioMetricsQueryParams(r, &params, oldestNs)
@@ -181,7 +181,7 @@ func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 		// any returned value nil means error & response already written
 		return
 	}
-	oldestNs := GetNsWithOldestCreationDate(namespaceInfo)
+	oldestNs := GetOldestNamespace(namespaceInfo)
 
 	params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace}
 

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -67,7 +67,7 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 	cluster := clusterNameFromQuery(r.URL.Query())
 
 	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
-	if metricsService == nil {
+	if metricsService == nil || namespaceInfo == nil {
 		// any returned value nil means error & response already written
 		return
 	}

--- a/handlers/metrics_test.go
+++ b/handlers/metrics_test.go
@@ -246,6 +246,7 @@ func TestAggregateMetricsInaccessibleNamespace(t *testing.T) {
 	ts, _ := setupAggregateMetricsEndpoint(t)
 
 	k := kubetest.NewFakeK8sClient(&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}})
+
 	business.SetupBusinessLayer(t, &noPrivClient{k}, *config.Get())
 
 	url := ts.URL + "/api/namespaces/my_namespace/aggregates/my_aggregate/my_aggregate_value/metrics"

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -59,7 +59,7 @@ func NamespaceValidationSummary(w http.ResponseWriter, r *http.Request) {
 		istioConfigValidationResults, errValidations = business.Validations.GetValidations(r.Context(), cluster, namespace, "", "")
 	} else {
 		for _, cl := range clusters {
-			_, errNs := business.Namespace.GetNamespaceByCluster(r.Context(), namespace, cl.Name)
+			_, errNs := business.Namespace.GetClusterNamespace(r.Context(), namespace, cl.Name)
 			if errNs == nil {
 				clusterIstioConfigValidationResults, _ := business.Validations.GetValidations(r.Context(), cl.Name, namespace, "", "")
 				istioConfigValidationResults = istioConfigValidationResults.MergeValidations(clusterIstioConfigValidationResults)
@@ -96,7 +96,7 @@ func ConfigValidationSummary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(nss) == 0 {
-		loadedNamespaces, _ := business.Namespace.GetNamespacesForCluster(r.Context(), cluster)
+		loadedNamespaces, _ := business.Namespace.GetClusterNamespaces(r.Context(), cluster)
 		for _, ns := range loadedNamespaces {
 			nss = append(nss, ns.Name)
 		}

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strconv"
@@ -65,12 +66,12 @@ func ServiceList(w http.ResponseWriter, r *http.Request) {
 
 	if criteria.IncludeHealth {
 		// When the cluster is not specified, we need to get it. If there are more than one, get the first one
-		clusters := business.Namespace.GetNamespaceClusters(p.Namespace)
+		clusters, _ := business.Namespace.GetNamespaceClusters(context.TODO(), p.Namespace)
 		if len(clusters) == 0 {
 			handleErrorResponse(w, err, "Error looking for cluster: "+err.Error())
 			return
 		}
-		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, clusters[0])
+		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, clusters[0].Cluster)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -69,6 +70,7 @@ func ServiceList(w http.ResponseWriter, r *http.Request) {
 		// get the one for which the namespace creation time is oldest
 		clusters, _ := business.Namespace.GetNamespaceClusters(r.Context(), p.Namespace)
 		if len(clusters) == 0 {
+			err = fmt.Errorf("No clusters found for namespace  [%s]", p.Namespace)
 			handleErrorResponse(w, err, "Error looking for cluster: "+err.Error())
 			return
 		}

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -1,11 +1,11 @@
 package handlers
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -65,13 +65,21 @@ func ServiceList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if criteria.IncludeHealth {
-		// When the cluster is not specified, we need to get it. If there are more than one, get the first one
-		clusters, _ := business.Namespace.GetNamespaceClusters(context.TODO(), p.Namespace)
+		// When the cluster is not specified, we need to get it. If there are more than one,
+		// get the one for which the namespace creation time is oldest
+		clusters, _ := business.Namespace.GetNamespaceClusters(r.Context(), p.Namespace)
 		if len(clusters) == 0 {
 			handleErrorResponse(w, err, "Error looking for cluster: "+err.Error())
 			return
 		}
-		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, clusters[0].Cluster)
+		var cluster string
+		var creationTimestamp time.Time
+		for i, cl := range clusters {
+			if i == 0 || cl.CreationTimestamp.Before(creationTimestamp) {
+				cluster = cl.Cluster
+			}
+		}
+		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, cluster)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -53,7 +53,9 @@ func ServiceList(w http.ResponseWriter, r *http.Request) {
 	p := serviceListParams{}
 	p.extract(r)
 
-	criteria := business.ServiceCriteria{Namespace: p.Namespace, IncludeHealth: p.IncludeHealth, IncludeIstioResources: p.IncludeIstioResources, IncludeOnlyDefinitions: p.IncludeOnlyDefinitions, RateInterval: "", QueryTime: p.QueryTime}
+	criteria := business.ServiceCriteria{Namespace: p.Namespace, IncludeHealth: p.IncludeHealth,
+		IncludeIstioResources: p.IncludeIstioResources, IncludeOnlyDefinitions: p.IncludeOnlyDefinitions, RateInterval: "", QueryTime: p.QueryTime,
+		Cluster: p.ClusterName}
 
 	// Get business layer
 	business, err := getBusiness(r)
@@ -63,7 +65,7 @@ func ServiceList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if criteria.IncludeHealth {
-		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime)
+		rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime, p.ClusterName)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return
@@ -108,7 +110,7 @@ func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 	namespace := params["namespace"]
 	service := params["service"]
 	queryTime := util.Clock.Now()
-	rateInterval, err = adjustRateInterval(r.Context(), business, namespace, rateInterval, queryTime)
+	rateInterval, err = adjustRateInterval(r.Context(), business, namespace, rateInterval, queryTime, cluster)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return
@@ -171,7 +173,7 @@ func ServiceUpdate(w http.ResponseWriter, r *http.Request) {
 	namespace := params["namespace"]
 	service := params["service"]
 	queryTime := util.Clock.Now()
-	rateInterval, err = adjustRateInterval(r.Context(), business, namespace, rateInterval, queryTime)
+	rateInterval, err = adjustRateInterval(r.Context(), business, namespace, rateInterval, queryTime, cluster)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Adjust rate interval error: "+err.Error())
 		return

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -14,6 +14,7 @@ import (
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -328,7 +329,9 @@ func TestServiceMetricsInaccessibleNamespace(t *testing.T) {
 func setupServiceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.PromAPIMock) {
 	conf := config.NewConfig()
 	config.Set(conf)
-	k := kubetest.NewFakeK8sClient(&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}})
+	k := kubetest.NewFakeK8sClient(&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "my_namespace"}},
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}})
 	k.OpenShift = true
 
 	xapi := new(prometheustest.PromAPIMock)

--- a/handlers/tls.go
+++ b/handlers/tls.go
@@ -44,7 +44,7 @@ func MeshTls(w http.ResponseWriter, r *http.Request) {
 	cluster := clusterNameFromQuery(r.URL.Query())
 
 	// Get all the namespaces
-	namespaces, err := business.Namespace.GetNamespacesForCluster(ctx, cluster)
+	namespaces, err := business.Namespace.GetClusterNamespaces(ctx, cluster)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -26,6 +26,51 @@ func checkNamespaceAccess(ctx context.Context, nsServ business.NamespaceService,
 	return nsServ.GetNamespaceByCluster(ctx, namespace, cluster)
 }
 
+// Create Metrics Service for a single namespace and no cluster parameter. It will check permissions for all the clusters, and return the service
+// if it has permissions at least one of the clusters
+func createMetricsServiceForNamespaceMC(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, ns models.Namespace) (*business.MetricsService, *models.Namespace) {
+	layer, err := getBusiness(r)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return nil, nil
+	}
+	prom, err := promSupplier()
+	if err != nil {
+		log.Error(err)
+		RespondWithError(w, http.StatusServiceUnavailable, "Prometheus client error: "+err.Error())
+		return nil, nil
+	}
+	var nsInfo nsInfoError
+
+	nsLists, err := layer.Namespace.GetNamespaceClusters(r.Context(), ns.Name)
+	if err != nil || len(nsLists) == 0 {
+		log.Infof("No clusters found.")
+		// TWe cant find the cluster list, we asume it is local
+		nsLists = make([]models.Namespace, 1)
+		nsLists[0] = models.Namespace{Cluster: config.Get().KubernetesConfig.ClusterName, Name: ns.Name}
+	}
+
+	for _, nsCluster := range nsLists {
+		nsNoErrors := len(nsLists)
+		info, err := checkNamespaceAccess(r.Context(), layer.Namespace, nsCluster.Name, nsCluster.Cluster)
+		nsInfo = nsInfoError{info: info, err: err}
+		if err != nil {
+			nsNoErrors--
+		}
+		// At least, one ns with permissions
+		if nsNoErrors > 0 {
+			nsInfo = nsInfoError{info: info, err: nil}
+		}
+	}
+	metrics := business.NewMetricsService(prom)
+	if nsInfo.err != nil {
+		RespondWithError(w, http.StatusForbidden, "Cannot access namespace data: "+nsInfo.err.Error())
+		return nil, nil
+	}
+
+	return metrics, nsInfo.info
+}
+
 func createMetricsServiceForNamespace(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, ns models.Namespace) (*business.MetricsService, *models.Namespace) {
 
 	metrics, infoMap := createMetricsServiceForNamespaces(w, r, promSupplier, []models.Namespace{ns})

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -65,9 +65,9 @@ func createMetricsServiceForNamespaceMC(w http.ResponseWriter, r *http.Request, 
 	return metrics, nsInfo
 }
 
-// Get namespespace with oldest creation time
-// Used to choose between one namespace from all the clusters and use the creation timestamp for the metrics service
-func GetNsWithOldestCreationDate(namespaces []models.Namespace) *models.Namespace {
+// GetOldestNamespace is a convenience function that takes a list of Namespaces and returns the
+// Namespace with the oldest CreationTimestamp.  In a tie, preference is towards the head of the list.
+func GetOldestNamespace(namespaces []models.Namespace) *models.Namespace {
 	var oldestNamespace *models.Namespace
 	for i, ns := range namespaces {
 		if i == 0 || ns.CreationTimestamp.Before(oldestNamespace.CreationTimestamp) {

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -26,8 +26,8 @@ func checkNamespaceAccess(ctx context.Context, nsServ business.NamespaceService,
 	return nsServ.GetClusterNamespace(ctx, namespace, cluster)
 }
 
-// Create Metrics Service for a single namespace and no cluster parameter. It will check permissions for all the clusters, and return the service
-// if it has permissions at least one of the clusters
+// createMetricsServiceForNamespaceMC is used when the service will query across all clusters for the namespace.
+// It will return an error if the user does not have access to the namespace on all of the clusters.
 func createMetricsServiceForNamespaceMC(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, ns models.Namespace) (*business.MetricsService, *models.Namespace) {
 	layer, err := getBusiness(r)
 	if err != nil {

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -28,7 +28,7 @@ func checkNamespaceAccess(ctx context.Context, nsServ business.NamespaceService,
 
 // createMetricsServiceForNamespaceMC is used when the service will query across all clusters for the namespace.
 // It will return an error if the user does not have access to the namespace on all of the clusters.
-func createMetricsServiceForNamespaceMC(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, ns models.Namespace) (*business.MetricsService, *models.Namespace) {
+func createMetricsServiceForNamespaceMC(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, nsName string) (*business.MetricsService, *models.Namespace) {
 	layer, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -26,10 +26,10 @@ func checkNamespaceAccess(ctx context.Context, nsServ business.NamespaceService,
 	return nsServ.GetNamespaceByCluster(ctx, namespace, cluster)
 }
 
-func createMetricsServiceForNamespace(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, namespace string, cluster string) (*business.MetricsService, *models.Namespace) {
-	ns := models.Namespace{Name: namespace, Cluster: cluster}
+func createMetricsServiceForNamespace(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, ns models.Namespace) (*business.MetricsService, *models.Namespace) {
+
 	metrics, infoMap := createMetricsServiceForNamespaces(w, r, promSupplier, []models.Namespace{ns})
-	if result, ok := infoMap[namespace]; ok {
+	if result, ok := infoMap[ns.Name]; ok {
 		if result.err != nil {
 			RespondWithError(w, http.StatusForbidden, "Cannot access namespace data: "+result.err.Error())
 			return nil, nil

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -23,7 +23,7 @@ const defaultPatchType = "merge"
 var defaultPromClientSupplier = prometheus.NewClient
 
 func checkNamespaceAccess(ctx context.Context, nsServ business.NamespaceService, namespace string) (*models.Namespace, error) {
-	return nsServ.GetNamespace(ctx, namespace)
+	return nsServ.GetNamespaceByCluster(ctx, namespace, "")
 }
 
 func createMetricsServiceForNamespace(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, namespace string) (*business.MetricsService, *models.Namespace) {

--- a/handlers/utils_test.go
+++ b/handlers/utils_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"errors"
-	"github.com/kiali/kiali/models"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -19,6 +18,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
 )

--- a/handlers/utils_test.go
+++ b/handlers/utils_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"github.com/kiali/kiali/models"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -71,7 +72,7 @@ func TestCreateMetricsServiceForNamespace(t *testing.T) {
 	req = req.WithContext(authentication.SetAuthInfoContext(req.Context(), &api.AuthInfo{Token: "test"}))
 
 	w := httptest.NewRecorder()
-	srv, info := createMetricsServiceForNamespace(w, req, prom, "ns1")
+	srv, info := createMetricsServiceForNamespace(w, req, prom, "ns1", config.Get().KubernetesConfig.ClusterName)
 
 	assert.NotNil(srv)
 	assert.NotNil(info)
@@ -87,7 +88,7 @@ func TestCreateMetricsServiceForNamespaceForbidden(t *testing.T) {
 	req = req.WithContext(authentication.SetAuthInfoContext(req.Context(), &api.AuthInfo{Token: "test"}))
 
 	w := httptest.NewRecorder()
-	srv, info := createMetricsServiceForNamespace(w, req, prom, "nsNil")
+	srv, info := createMetricsServiceForNamespace(w, req, prom, "nsNil", config.Get().KubernetesConfig.ClusterName)
 
 	assert.Nil(srv)
 	assert.Nil(info)
@@ -102,7 +103,7 @@ func TestCreateMetricsServiceForSeveralNamespaces(t *testing.T) {
 	req = req.WithContext(authentication.SetAuthInfoContext(req.Context(), &api.AuthInfo{Token: "test"}))
 
 	w := httptest.NewRecorder()
-	srv, info := createMetricsServiceForNamespaces(w, req, prom, []string{"ns1", "ns2", "nsNil"})
+	srv, info := createMetricsServiceForNamespaces(w, req, prom, []models.Namespace{{Name: "ns1"}, {Name: "ns2"}, {Name: "nsNil"}})
 
 	assert.NotNil(srv)
 	assert.Len(info, 3)

--- a/handlers/utils_test.go
+++ b/handlers/utils_test.go
@@ -72,7 +72,7 @@ func TestCreateMetricsServiceForNamespace(t *testing.T) {
 	req = req.WithContext(authentication.SetAuthInfoContext(req.Context(), &api.AuthInfo{Token: "test"}))
 
 	w := httptest.NewRecorder()
-	srv, info := createMetricsServiceForNamespace(w, req, prom, "ns1", config.Get().KubernetesConfig.ClusterName)
+	srv, info := createMetricsServiceForNamespace(w, req, prom, models.Namespace{Name: "ns1", Cluster: config.Get().KubernetesConfig.ClusterName})
 
 	assert.NotNil(srv)
 	assert.NotNil(info)
@@ -88,7 +88,7 @@ func TestCreateMetricsServiceForNamespaceForbidden(t *testing.T) {
 	req = req.WithContext(authentication.SetAuthInfoContext(req.Context(), &api.AuthInfo{Token: "test"}))
 
 	w := httptest.NewRecorder()
-	srv, info := createMetricsServiceForNamespace(w, req, prom, "nsNil", config.Get().KubernetesConfig.ClusterName)
+	srv, info := createMetricsServiceForNamespace(w, req, prom, models.Namespace{Name: "nsNil", Cluster: config.Get().KubernetesConfig.ClusterName})
 
 	assert.Nil(srv)
 	assert.Nil(info)

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -70,12 +71,12 @@ func WorkloadList(w http.ResponseWriter, r *http.Request) {
 
 	if criteria.IncludeHealth {
 		// When the cluster is not specified, we need to get it. If there are more than one, get the first one
-		clusters := businessLayer.Namespace.GetNamespaceClusters(p.Namespace)
+		clusters, _ := businessLayer.Namespace.GetNamespaceClusters(context.TODO(), p.Namespace)
 		if len(clusters) == 0 {
 			handleErrorResponse(w, err, "Error looking for cluster: "+err.Error())
 			return
 		}
-		rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime, clusters[0])
+		rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime, clusters[0].Cluster)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -74,6 +74,7 @@ func WorkloadList(w http.ResponseWriter, r *http.Request) {
 		// get the one for which the namespace creation time is oldest
 		clusters, _ := businessLayer.Namespace.GetNamespaceClusters(r.Context(), p.Namespace)
 		if len(clusters) == 0 {
+			err = fmt.Errorf("No clusters found for namespace  [%s]", p.Namespace)
 			handleErrorResponse(w, err, "Error looking for cluster: "+err.Error())
 			return
 		}

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -58,7 +58,8 @@ func WorkloadList(w http.ResponseWriter, r *http.Request) {
 	p := workloadParams{}
 	p.extract(r)
 
-	criteria := business.WorkloadCriteria{Namespace: p.Namespace, IncludeHealth: p.IncludeHealth, IncludeIstioResources: p.IncludeIstioResources, RateInterval: p.RateInterval, QueryTime: p.QueryTime}
+	criteria := business.WorkloadCriteria{Namespace: p.Namespace, IncludeHealth: p.IncludeHealth,
+		IncludeIstioResources: p.IncludeIstioResources, RateInterval: p.RateInterval, QueryTime: p.QueryTime, Cluster: p.ClusterName}
 
 	// Get business layer
 	businessLayer, err := getBusiness(r)
@@ -68,7 +69,7 @@ func WorkloadList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if criteria.IncludeHealth {
-		rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime)
+		rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime, p.ClusterName)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -77,7 +77,6 @@ func WorkloadList(w http.ResponseWriter, r *http.Request) {
 		}
 		rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime, clusters[0])
 		if err != nil {
-			log.Errorf("error %s", err.Error())
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return
 		}

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -1,12 +1,12 @@
 package handlers
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -70,13 +70,22 @@ func WorkloadList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if criteria.IncludeHealth {
-		// When the cluster is not specified, we need to get it. If there are more than one, get the first one
-		clusters, _ := businessLayer.Namespace.GetNamespaceClusters(context.TODO(), p.Namespace)
+		// When the cluster is not specified, we need to get it. If there are more than one,
+		// get the one for which the namespace creation time is oldest
+		clusters, _ := businessLayer.Namespace.GetNamespaceClusters(r.Context(), p.Namespace)
 		if len(clusters) == 0 {
 			handleErrorResponse(w, err, "Error looking for cluster: "+err.Error())
 			return
 		}
-		rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime, clusters[0].Cluster)
+		var cluster string
+		var creationTimestamp time.Time
+		for i, cl := range clusters {
+			if i == 0 || cl.CreationTimestamp.Before(creationTimestamp) {
+				cluster = cl.Cluster
+			}
+		}
+
+		rateInterval, err := adjustRateInterval(r.Context(), businessLayer, p.Namespace, p.RateInterval, p.QueryTime, cluster)
 		if err != nil {
 			handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 			return

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -286,7 +286,8 @@ func TestWorkloadMetricsBadRateFunc(t *testing.T) {
 
 func TestWorkloadMetricsInaccessibleNamespace(t *testing.T) {
 	ts, _ := setupWorkloadMetricsEndpoint(t)
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}})
+	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "my_namespace"}})
 	business.SetupBusinessLayer(t, &nsForbidden{k8s, "my_namespace"}, *config.Get())
 
 	url := ts.URL + "/api/namespaces/my_namespace/workloads/my_workload/metrics"

--- a/kubernetes/kubetest/mock_kubernetes.go
+++ b/kubernetes/kubetest/mock_kubernetes.go
@@ -75,6 +75,16 @@ func (o *K8SClientMock) GetNamespaces(labelSelector string) ([]core_v1.Namespace
 	return args.Get(0).([]core_v1.Namespace), args.Error(1)
 }
 
+func (o *K8SClientMock) GetNamespaceClusters(namespace string) ([]core_v1.Namespace, error) {
+	args := o.Called(namespace)
+	return args.Get(0).([]core_v1.Namespace), args.Error(1)
+}
+
+func (o *K8SClientMock) GetNamespacesByCluster(namespace string) ([]core_v1.Namespace, error) {
+	args := o.Called(namespace)
+	return args.Get(0).([]core_v1.Namespace), args.Error(1)
+}
+
 func (o *K8SClientMock) GetPods(namespace, labelSelector string) ([]core_v1.Pod, error) {
 	args := o.Called(namespace, labelSelector)
 	return args.Get(0).([]core_v1.Pod), args.Error(1)


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6333

There was some calls to getNamespace that didn't include the cluster parameter. But in a multicluster environment, a namespace with the same name can exist in different clusters, which can result in more than one namespace. getNamespace mehod was returning just one namespace, the first namespace found, which is a behavior non deterministic. 

This behavior was changed to use, when we want a namespace and we don't know the cluster (So we can expect to have more than one) GetNamespaceClusters, implemented as part as https://github.com/kiali/kiali/pull/6336/files.

The majority of the calls include the cluster parameter. Some metrics calls doesn't include it, because in the right panel summary for the graphs, we want the metrics for the namespaces for all the clusters, see https://github.com/kiali/kiali/pull/6131#pullrequestreview-1429313391