### PR TITLE
Fix issue with IdleNodes detection

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -517,6 +517,23 @@ func (in *NamespaceService) GetNamespace(ctx context.Context, namespace string) 
 	return in.GetNamespaceByCluster(ctx, namespace, "")
 }
 
+// GetNamespaceClusters is a convenience routine that filters GetNamespaces for a particular namespace
+func (in *NamespaceService) GetNamespaceClusters(ctx context.Context, namespace string) ([]models.Namespace, error) {
+	namespaces, err := in.GetNamespaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []models.Namespace{}
+	for _, ns := range namespaces {
+		if ns.Name == namespace {
+			result = append(result, ns)
+		}
+	}
+
+	return result, nil
+}
+
 // GetNamespace returns the definition of the specified namespace.
 // TODO: Multicluster: We are going to need something else to identify the namespace, the cluster (OR Return a list/array/map)
 func (in *NamespaceService) GetNamespaceByCluster(ctx context.Context, namespace string, cluster string) (*models.Namespace, error) {

--- a/graph/telemetry/istio/appender/idle_node.go
+++ b/graph/telemetry/istio/appender/idle_node.go
@@ -38,11 +38,11 @@ func (a IdleNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 	workloadLists := map[string]*models.WorkloadList{}
 
 	if a.GraphType != graph.GraphTypeService {
-		workloadLists = getWorkloadLists(trafficMap, namespaceInfo.Namespace, globalInfo)
+		workloadLists = getWorkloadLists(nil, namespaceInfo.Namespace, globalInfo)
 	}
 
 	if a.GraphType == graph.GraphTypeService || a.InjectServiceNodes {
-		serviceLists = getServiceLists(trafficMap, namespaceInfo.Namespace, globalInfo)
+		serviceLists = getServiceLists(nil, namespaceInfo.Namespace, globalInfo)
 	}
 
 	a.addIdleNodes(trafficMap, namespaceInfo.Namespace, serviceLists, workloadLists)

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -51,7 +51,7 @@ func (a IstioAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *grap
 }
 
 func addBadging(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
-	clusters := getTrafficClusters(trafficMap, namespaceInfo.Namespace)
+	clusters := getTrafficClusters(trafficMap, namespaceInfo.Namespace, globalInfo)
 	destinationRuleLists := map[string]models.IstioConfigList{}
 	virtualServiceLists := map[string]models.IstioConfigList{}
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6331

Fix issue with IdleNodes detection. The multi-cluster changes resulted in only looking at clusters WITH traffic, but for idle nodes we need to look at all clusters for a namespaces, regardless of traffic.

- Adds new NamespaceService.GetNamespaceClusters() utility function

https://github.com/kiali/kiali/issues/6331

Test Note:
To recreate this bug you need to have NO traffic for any services/workloads in the target namespace, for the time period.