### PR TITLE
Add prefix to generated typestyle classNames

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,7 +97,7 @@
     "screenfull": "5.0.2",
     "tippy.js": "3.4.1",
     "typesafe-actions": "^4.2.1",
-    "typestyle": "2.0.4",
+    "typestyle": "^2.4.0",
     "victory": "36.3.0",
     "visibilityjs": "2.0.2"
   },

--- a/frontend/src/app/InitializingScreen.tsx
+++ b/frontend/src/app/InitializingScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Alert, Button, ButtonVariant } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { isKioskMode } from '../utils/SearchParamUtils';
 
 import kialiTitle from '../assets/img/logo-lightbkg.svg';
@@ -10,7 +10,7 @@ type initializingScreenProps = {
   errorDetails?: string;
 };
 
-const defaultErrorStyle = style({
+const defaultErrorStyle = kialiStyle({
   $nest: {
     '& > textarea': {
       display: 'none'
@@ -21,7 +21,7 @@ const defaultErrorStyle = style({
   }
 });
 
-const expandedErrorStyle = style({
+const expandedErrorStyle = kialiStyle({
   $nest: {
     '& > p:last-of-type': {
       display: 'none'
@@ -34,7 +34,7 @@ const expandedErrorStyle = style({
   }
 });
 
-const centerVerticalHorizontalStyle = style({
+const centerVerticalHorizontalStyle = kialiStyle({
   position: 'relative',
   top: '10em',
   textAlign: 'center',

--- a/frontend/src/components/About/AboutUIModal.tsx
+++ b/frontend/src/components/About/AboutUIModal.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { ExternalServiceInfo, Status, StatusKey } from '../../types/StatusState';
 import { config, kialiLogo } from '../../config';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon } from 'config/KialiIcon';
 
 type AboutUIModalState = {
@@ -25,7 +25,7 @@ type AboutUIModalProps = {
   warningMessages: string[];
 };
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   marginRight: '10px'
 });
 

--- a/frontend/src/components/Charts/ChartWithLegend.tsx
+++ b/frontend/src/components/Charts/ChartWithLegend.tsx
@@ -24,7 +24,7 @@ import { INTERPOLATION_STRATEGY } from './SparklineChart';
 import { KialiIcon } from '../../config/KialiIcon';
 import { Button, ButtonVariant, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import regression from 'regression';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type Props<T extends RichDataPoint, O extends LineInfo> = {
   chartHeight?: number;
@@ -81,12 +81,12 @@ export const MIN_WIDTH = 275;
 export const LEGEND_HEIGHT = 25;
 const FONT_SIZE_LEGEND = 14;
 
-const moreLegendIconStyle = style({
+const moreLegendIconStyle = kialiStyle({
   margin: '0px 5px 2px 10px',
   verticalAlign: '-4px !important'
 });
 
-const noEnoughHeightStyle = style({
+const noEnoughHeightStyle = kialiStyle({
   margin: '0px 0px 0px 0px',
   verticalAlign: '-4px !important'
 });

--- a/frontend/src/components/Charts/KChart.tsx
+++ b/frontend/src/components/Charts/KChart.tsx
@@ -16,7 +16,7 @@ import { Overlay } from 'types/Overlay';
 import { ChartWithLegend, LEGEND_HEIGHT, MIN_HEIGHT, MIN_HEIGHT_YAXIS } from './ChartWithLegend';
 import { BrushHandlers } from './Container';
 import { defaultIconStyle, KialiIcon } from '../../config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type KChartProps<T extends LineInfo> = {
   chart: ChartModel;
@@ -37,12 +37,12 @@ export const maximizeButtonStyle: React.CSSProperties = {
   float: 'right'
 };
 
-const emptyStyle = style({
+const emptyStyle = kialiStyle({
   padding: '0 0 0 0',
   margin: '0 0 0 0'
 });
 
-const kchartStyle = style({
+const kchartStyle = kialiStyle({
   paddingTop: 15,
   paddingLeft: 25,
   paddingRight: 25,

--- a/frontend/src/components/CytoscapeGraph/ContextMenu/EdgeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/ContextMenu/EdgeContextMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { prettyProtocol } from 'types/Graph';
 import { EdgeContextMenuProps } from '../CytoscapeContextMenu';
 import { getTitle } from 'pages/Graph/SummaryPanelCommon';
@@ -7,7 +7,7 @@ import { renderBadgedName } from 'pages/Graph/SummaryLink';
 import { decoratedNodeData } from '../CytoscapeGraphUtils';
 import { EdgeSingular } from 'cytoscape';
 
-const contextMenu = style({
+const contextMenu = kialiStyle({
   fontSize: 'var(--graph-side-panel--font-size)',
   textAlign: 'left'
 });

--- a/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Spinner, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
@@ -32,25 +32,25 @@ type ReduxProps = {
 };
 
 // Note, in the below styles we assign colors to be consistent with PF Dropdown
-const contextMenu = style({
+const contextMenu = kialiStyle({
   fontSize: 'var(--graph-side-panel--font-size)',
   textAlign: 'left'
 });
 
-const contextMenuHeader = style({
+const contextMenuHeader = kialiStyle({
   fontSize: 'var(--graph-side-panel--font-size)',
   marginBottom: '3px',
   textAlign: 'left'
 });
 
-const contextMenuSubTitle = style({
+const contextMenuSubTitle = kialiStyle({
   color: PFColors.Black600,
   fontWeight: 700,
   paddingTop: 2,
   paddingBottom: 4
 });
 
-const contextMenuItem = style({
+const contextMenuItem = kialiStyle({
   textDecoration: 'none',
   $nest: {
     '&:hover': {
@@ -60,7 +60,7 @@ const contextMenuItem = style({
   }
 });
 
-const contextMenuItemLink = style({
+const contextMenuItemLink = kialiStyle({
   color: PFColors.Black900
 });
 

--- a/frontend/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/frontend/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -9,7 +9,7 @@ import {
   TenantIcon,
   TopologyIcon
 } from '@patternfly/react-icons';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { KialiDispatch } from 'types/Redux';
@@ -51,7 +51,7 @@ type CytoscapeToolbarState = {
   allowGrab: boolean;
 };
 
-const activeButtonStyle = style({
+const activeButtonStyle = kialiStyle({
   color: PFColors.Active
 });
 
@@ -61,7 +61,7 @@ const buttonStyle = {
   padding: '2px 6px 4px 6px'
 };
 
-const cyToolbarStyle = style({
+const cyToolbarStyle = kialiStyle({
   width: '20px'
 });
 

--- a/frontend/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
+++ b/frontend/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
@@ -9,7 +9,7 @@ import {
   Title,
   TitleSizes
 } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import * as _ from 'lodash';
 import { Namespace } from '../../types/Namespace';
 import { KialiIcon } from '../../config/KialiIcon';
@@ -27,7 +27,7 @@ type EmptyGraphLayoutProps = {
   toggleIdleNodes: () => void;
 };
 
-const emptyStateStyle = style({
+const emptyStateStyle = kialiStyle({
   height: '98%',
   marginRight: 'auto',
   marginLeft: 'auto',

--- a/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/frontend/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -17,7 +17,7 @@ import { DecoratedGraphElements, EdgeMode, GraphType, NodeType } from '../../typ
 import { CytoscapeGraph, GraphEdgeTapEvent, GraphNodeTapEvent } from './CytoscapeGraph';
 import { GraphUrlParams, makeNodeGraphUrlFromParams } from 'components/Nav/NavUtils';
 import { store } from 'store/ConfigStore';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { toRangeString } from '../Time/Utils';
 import { TimeInMilliseconds } from '../../types/Common';
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
@@ -32,7 +32,7 @@ import { TimeDurationIndicator } from '../Time/TimeDurationIndicator';
 import { KioskElement } from '../Kiosk/KioskElement';
 import { GraphSelectorBuilder } from 'pages/Graph/GraphSelector';
 
-const initGraphContainerStyle = style({ width: '100%', height: '100%' });
+const initGraphContainerStyle = kialiStyle({ width: '100%', height: '100%' });
 
 type ReduxProps = {
   kiosk: string;

--- a/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -1,4 +1,4 @@
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors, PFColorVal, PFColorVals } from '../../../components/Pf/PfColors';
 import { DEGRADED, FAILURE } from '../../../types/Health';
 import {
@@ -23,6 +23,7 @@ import * as Cy from 'cytoscape';
 import { PFBadges } from 'components/Pf/PfBadges';
 import { config } from 'config/Config';
 import { kialiBadge, PFBadgeType } from '../../Pf/PfBadges';
+import { NestedCSSProperties } from 'typestyle/lib/types';
 
 export const HighlightClass = 'mousehighlight';
 export const HoveredClass = 'mousehover';
@@ -90,9 +91,9 @@ type contentType = {
 
 // Puts a little more space between icons when a badge has multiple icons
 const badgeMargin = (existingIcons: string) =>
-  existingIcons === '' ? style({ marginLeft: '1px' }) : style({ marginRight: '2px' });
+  existingIcons === '' ? kialiStyle({ marginLeft: '1px' }) : kialiStyle({ marginRight: '2px' });
 
-const badgesDefault = style({
+const badgesDefault = kialiStyle({
   alignItems: 'center',
   backgroundColor: NodeBadgeBackgroundColor,
   borderTopLeftRadius: '3px',
@@ -102,7 +103,7 @@ const badgesDefault = style({
   padding: '3px 3px'
 });
 
-const contentDefault = style({
+const contentDefault = kialiStyle({
   alignItems: 'center',
   backgroundColor: NodeTextBackgroundColor,
   borderRadius: '3px',
@@ -111,12 +112,12 @@ const contentDefault = style({
   padding: '1px 5px'
 });
 
-const contentBox = style({
+const contentBox = kialiStyle({
   backgroundColor: NodeTextBackgroundColorBox,
   color: NodeTextColorBox
 });
 
-const hostsClass = style({
+const hostsClass = kialiStyle({
   $nest: {
     '& div:last-child': {
       display: 'none'
@@ -127,14 +128,14 @@ const hostsClass = style({
   }
 });
 
-const hostsList = style({
+const hostsList = kialiStyle({
   textAlign: 'initial',
   marginTop: 2,
   paddingTop: 2,
   borderTop: `1px solid ${PFColors.Black600}`
 });
 
-const labelDefault = style({
+const labelDefault = kialiStyle({
   borderRadius: '3px',
   boxShadow: '0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 2px 8px 0 rgba(0, 0, 0, 0.19)',
   display: 'inline-flex',
@@ -144,7 +145,7 @@ const labelDefault = style({
   textAlign: 'center'
 });
 
-const labelBox = style({
+const labelBox = kialiStyle({
   display: 'block',
   marginTop: '13px',
   textAlign: 'left'
@@ -247,7 +248,7 @@ export class GraphStyles {
             badges = `<span class="${NodeIconFaultInjection} ${badgeMargin(badges)}"></span> ${badges}`;
           }
           if (node.hasMirroring) {
-            badges = `<span class="${NodeIconMirroring}  ${badgeMargin(badges)} ${style({
+            badges = `<span class="${NodeIconMirroring}  ${badgeMargin(badges)} ${kialiStyle({
               marginTop: '1px'
             })}"></span> ${badges}`;
           }
@@ -418,7 +419,7 @@ export class GraphStyles {
       newContent.forEach(c => {
         let contentPfBadge = '';
         if (!!c.pfBadge) {
-          const pfBadgeStyle = style(c.pfBadge.style);
+          const pfBadgeStyle = kialiStyle(c.pfBadge.style as NestedCSSProperties);
           contentPfBadge = `<span class="pf-c-badge pf-m-unread ${kialiBadge} ${pfBadgeStyle}" style="${appBoxStyle}">${c.pfBadge.badge}</span>`;
         }
         const contentDiv = `<div class="${contentClasses} ${contentBox}" style="${appBoxStyle} ${contentStyle}">${contentPfBadge}${c.text}</div>`;
@@ -455,7 +456,7 @@ export class GraphStyles {
     newContent.forEach(c => {
       let contentPfBadge = '';
       if (!!c.pfBadge) {
-        const pfBadgeStyle = style(c.pfBadge.style);
+        const pfBadgeStyle = kialiStyle(c.pfBadge.style as NestedCSSProperties);
         contentPfBadge = `<span class="pf-c-badge pf-m-unread ${kialiBadge} ${pfBadgeStyle}" style="${''}">${
           c.pfBadge.badge
         }</span>`;

--- a/frontend/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/frontend/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Title, TitleSizes } from '@patternfly/react-core';
 import { NamespaceDropdown } from '../NamespaceDropdown';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon } from '../../config/KialiIcon';
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
@@ -18,20 +18,20 @@ type Props = ReduxProps & {
   rightToolbar?: JSX.Element;
 };
 
-const mainPadding = style({
+const mainPadding = kialiStyle({
   padding: '10px 20px 10px 20px'
 });
 
-const flexStyle = style({
+const flexStyle = kialiStyle({
   display: 'flex',
   flexWrap: 'wrap'
 });
 
-const rightToolbarStyle = style({
+const rightToolbarStyle = kialiStyle({
   marginLeft: 'auto'
 });
 
-const actionsToolbarStyle = style({
+const actionsToolbarStyle = kialiStyle({
   marginLeft: 'auto',
   paddingTop: '17px'
 });

--- a/frontend/src/components/DetailDescription/DetailDescription.tsx
+++ b/frontend/src/components/DetailDescription/DetailDescription.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { AppWorkload } from '../../types/App';
 import { PopoverPosition, Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Link } from 'react-router-dom';
 import { MissingSidecar } from '../MissingSidecar/MissingSidecar';
 import * as H from '../../types/Health';
@@ -31,13 +31,13 @@ type Props = ReduxProps & {
   waypointWorkloads?: Workload[];
 };
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   margin: '0 0 0 0',
   padding: '0 0 0 0',
   display: 'inline-block'
 });
 
-const resourceListStyle = style({
+const resourceListStyle = kialiStyle({
   margin: '0px 0 11px 0',
   $nest: {
     '& > span': {
@@ -48,11 +48,11 @@ const resourceListStyle = style({
   }
 });
 
-const titleStyle = style({
+const titleStyle = kialiStyle({
   margin: '15px 0 8px 0'
 });
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 4px 2px 10px',
   verticalAlign: '-4px !important'
 });

--- a/frontend/src/components/Envoy/AccessLogModal.tsx
+++ b/frontend/src/components/Envoy/AccessLogModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button, ButtonVariant, Modal, Split, SplitItem } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { AccessLog } from 'types/IstioObjects';
 import { PFColors } from 'components/Pf/PfColors';
 
@@ -11,17 +11,17 @@ export interface AccessLogModalProps {
   onClose?: () => void;
 }
 
-const fieldStyle = style({
+const fieldStyle = kialiStyle({
   color: PFColors.Gold400,
   display: 'inline-block'
 });
 
-const modalStyle = style({
+const modalStyle = kialiStyle({
   height: '70%',
   width: '50%'
 });
 
-const prefaceStyle = style({
+const prefaceStyle = kialiStyle({
   fontFamily: 'monospace',
   fontSize: 'var(--kiali-global--font-size)',
   backgroundColor: PFColors.Black1000,
@@ -34,7 +34,7 @@ const prefaceStyle = style({
   width: 'calc(100% - 15px)'
 });
 
-const splitStyle = style({
+const splitStyle = kialiStyle({
   overflow: 'auto',
   overflowY: 'auto',
   width: '50%'

--- a/frontend/src/components/Envoy/EnvoyDetails.tsx
+++ b/frontend/src/components/Envoy/EnvoyDetails.tsx
@@ -21,7 +21,7 @@ import {
 } from '@patternfly/react-core';
 import { SummaryTableBuilder } from './tables/BaseTable';
 import { Namespace } from 'types/Namespace';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import AceEditor from 'react-ace';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { ToolbarDropdown } from 'components/ToolbarDropdown/ToolbarDropdown';
@@ -46,7 +46,7 @@ require('ace-builds/src-noconflict/ext-searchbox');
 
 const resources: string[] = ['clusters', 'listeners', 'routes', 'bootstrap', 'config', 'metrics'];
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   display: 'inline-block',
   paddingTop: '5px'
 });
@@ -78,7 +78,7 @@ type EnvoyDetailsState = {
   resource: string;
 };
 
-const fullHeightStyle = style({
+const fullHeightStyle = kialiStyle({
   height: '100%'
 });
 

--- a/frontend/src/components/Envoy/tables/BaseTable.tsx
+++ b/frontend/src/components/Envoy/tables/BaseTable.tsx
@@ -11,7 +11,7 @@ import { Namespace } from '../../../types/Namespace';
 import { ToolbarDropdown } from '../../ToolbarDropdown/ToolbarDropdown';
 import { PFBadge, PFBadges } from '../../Pf/PfBadges';
 import { TooltipPosition } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 export interface SummaryTable {
   head: () => ICell[];
@@ -23,7 +23,7 @@ export interface SummaryTable {
   tooltip: () => React.ReactNode;
 }
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   display: 'inline-block'
 });
 
@@ -73,7 +73,7 @@ export function SummaryTableRenderer<T extends SummaryTable>() {
                 label={this.props.pod}
                 options={this.props.pods.sort()}
               />
-              <div className={style({ position: 'fixed', right: '60px' })}>{this.props.writer.tooltip()}</div>
+              <div className={kialiStyle({ position: 'fixed', right: '60px' })}>{this.props.writer.tooltip()}</div>
             </>
           </StatefulFilters>
           <Table

--- a/frontend/src/components/Envoy/tables/ClusterTable.tsx
+++ b/frontend/src/components/Envoy/tables/ClusterTable.tsx
@@ -9,7 +9,7 @@ import { defaultFilter, istioConfigLink, serviceLink } from '../../../helpers/En
 import { Tooltip } from '@patternfly/react-core';
 import { PFColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { isParentKiosk } from '../../Kiosk/KioskActions';
 
 export class ClusterTable implements SummaryTable {
@@ -147,7 +147,7 @@ export class ClusterTable implements SummaryTable {
 
   render_cluster_type = (): React.ReactNode => {
     return (
-      <ul className={style({ textAlign: 'left' })}>
+      <ul className={kialiStyle({ textAlign: 'left' })}>
         <li>
           <b>STATIC</b>: Static is the simplest service discovery type. The configuration explicitly specifies the
           resolved network name (IP address/port, unix domain socket, etc.) of each upstream host.
@@ -188,7 +188,7 @@ export class ClusterTable implements SummaryTable {
         header: {
           info: {
             tooltip: (
-              <ul className={style({ textAlign: 'left' })}>
+              <ul className={kialiStyle({ textAlign: 'left' })}>
                 <li>
                   <b>inbound</b>: The inbound cluster events are the events that come into a node. These cluster events
                   come from another node and enter other nodes.
@@ -225,12 +225,12 @@ export class ClusterTable implements SummaryTable {
     return (
       <Tooltip
         content={
-          <div className={style({ textAlign: 'left' })}>
+          <div className={kialiStyle({ textAlign: 'left' })}>
             Group of logically similar upstream hosts that Envoy connects to. (All the hosts that envoy manage traffic)
           </div>
         }
       >
-        <KialiIcon.Help className={style({ width: '14px', height: '14px', color: PFColors.Blue400 })} />
+        <KialiIcon.Help className={kialiStyle({ width: '14px', height: '14px', color: PFColors.Blue400 })} />
       </Tooltip>
     );
   };

--- a/frontend/src/components/Envoy/tables/ListenerTable.tsx
+++ b/frontend/src/components/Envoy/tables/ListenerTable.tsx
@@ -9,7 +9,7 @@ import { defaultFilter, routeLink } from '../../../helpers/EnvoyHelpers';
 import { Tooltip } from '@patternfly/react-core';
 import { PFColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 export class ListenerTable implements SummaryTable {
   summaries: ListenerSummary[];
@@ -136,7 +136,7 @@ export class ListenerTable implements SummaryTable {
         header: {
           info: {
             tooltip: (
-              <div className={style({ textAlign: 'left' })}>
+              <div className={kialiStyle({ textAlign: 'left' })}>
                 The address that the listener should listen on. In general, the address must be unique, though that is
                 governed by the bind rules of the OS
               </div>
@@ -152,7 +152,7 @@ export class ListenerTable implements SummaryTable {
         header: {
           info: {
             tooltip: (
-              <div className={style({ textAlign: 'left' })}>
+              <div className={kialiStyle({ textAlign: 'left' })}>
                 Original destination listener filter reads the SO_ORIGINAL_DST socket option set when a connection has
                 been redirected by an iptables REDIRECT target, or by an iptables TPROXY target in combination with
                 setting the listener’s transparent option
@@ -182,13 +182,13 @@ export class ListenerTable implements SummaryTable {
     return (
       <Tooltip
         content={
-          <div className={style({ textAlign: 'left' })}>
+          <div className={kialiStyle({ textAlign: 'left' })}>
             Network location that can be connected to by downstream clients (Incomming to envoy). List of
             endpoints:ports that envoy lets traffic
           </div>
         }
       >
-        <KialiIcon.Help className={style({ width: '14px', height: '14px', color: PFColors.Blue400 })} />
+        <KialiIcon.Help className={kialiStyle({ width: '14px', height: '14px', color: PFColors.Blue400 })} />
       </Tooltip>
     );
   };

--- a/frontend/src/components/Envoy/tables/RouteTable.tsx
+++ b/frontend/src/components/Envoy/tables/RouteTable.tsx
@@ -9,7 +9,7 @@ import { defaultFilter, istioConfigLink, serviceLink } from '../../../helpers/En
 import { Tooltip } from '@patternfly/react-core';
 import { PFColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { isParentKiosk } from '../../Kiosk/KioskActions';
 
 export class RouteTable implements SummaryTable {
@@ -111,7 +111,7 @@ export class RouteTable implements SummaryTable {
         header: {
           info: {
             tooltip: (
-              <div className={style({ textAlign: 'left' })}>
+              <div className={kialiStyle({ textAlign: 'left' })}>
                 Envoy will be matched this domain to this virtual host.
               </div>
             )
@@ -124,7 +124,7 @@ export class RouteTable implements SummaryTable {
         header: {
           info: {
             tooltip: (
-              <div className={style({ textAlign: 'left' })}>
+              <div className={kialiStyle({ textAlign: 'left' })}>
                 The match tree to use when resolving route actions for incoming requests
               </div>
             )
@@ -153,12 +153,12 @@ export class RouteTable implements SummaryTable {
     return (
       <Tooltip
         content={
-          <div className={style({ textAlign: 'left' })}>
+          <div className={kialiStyle({ textAlign: 'left' })}>
             Network connection between source a destination that is configured in envoy
           </div>
         }
       >
-        <KialiIcon.Help className={style({ width: '14px', height: '14px', color: PFColors.Blue400 })} />
+        <KialiIcon.Help className={kialiStyle({ width: '14px', height: '14px', color: PFColors.Blue400 })} />
       </Tooltip>
     );
   };

--- a/frontend/src/components/ErrorSection/ErrorSection.tsx
+++ b/frontend/src/components/ErrorSection/ErrorSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { EmptyState, EmptyStateBody, EmptyStateVariant, Title, TitleSizes } from '@patternfly/react-core';
 import { ErrorMsg } from '../../types/ErrorMsg';
 
@@ -7,7 +7,7 @@ interface MessageProps {
   error: ErrorMsg;
 }
 
-const errorSectionStyle = style({
+const errorSectionStyle = kialiStyle({
   height: '80vh'
 });
 

--- a/frontend/src/components/Filters/StatefulFilters.tsx
+++ b/frontend/src/components/Filters/StatefulFilters.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../types/Filters';
 import * as FilterHelper from '../FilterList/FilterHelper';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { LabelFilters } from './LabelFilter';
 import { arrayEquals } from 'utils/Common';
 import { labelFilter } from './CommonFilters';
@@ -37,7 +37,7 @@ import { serverConfig } from 'config';
 
 var classNames = require('classnames');
 
-const toolbarStyle = style({
+const toolbarStyle = kialiStyle({
   padding: 0,
   rowGap: 'var(--pf-global--spacer--md)',
   $nest: {
@@ -47,7 +47,7 @@ const toolbarStyle = style({
   }
 });
 
-const bottomPadding = style({
+const bottomPadding = kialiStyle({
   paddingBottom: 'var(--pf-global--spacer--md)'
 });
 
@@ -137,8 +137,8 @@ export class Toggles {
   };
 }
 
-const dividerStyle = style({ borderRight: '1px solid #d1d1d1;', padding: '10px', display: 'inherit' });
-const paddingStyle = style({ padding: '10px' });
+const dividerStyle = kialiStyle({ borderRight: '1px solid #d1d1d1;', padding: '10px', display: 'inherit' });
+const paddingStyle = kialiStyle({ padding: '10px' });
 
 export class StatefulFilters extends React.Component<StatefulFiltersProps, StatefulFiltersState> {
   private promises = new PromisesRegistry();

--- a/frontend/src/components/Health/HealthDetails.tsx
+++ b/frontend/src/components/Health/HealthDetails.tsx
@@ -5,13 +5,13 @@ import { InfoAltIcon } from '@patternfly/react-icons';
 import './Health.css';
 import { PFColors } from '../Pf/PfColors';
 import { Title, TitleSizes } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 interface Props {
   health: H.Health;
 }
 
-const titleStyle = style({
+const titleStyle = kialiStyle({
   margin: '15px 0 8px 0'
 });
 

--- a/frontend/src/components/HeatMap/HeatMap.tsx
+++ b/frontend/src/components/HeatMap/HeatMap.tsx
@@ -3,7 +3,7 @@
 
 import { PFColors } from 'components/Pf/PfColors';
 import React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 // rgb in [0,255] bounds
 export type Color = { r: number; g: number; b: number };
@@ -31,9 +31,12 @@ const baseStyle = {
   textOverflow: 'clip'
 };
 
-const labelStyle = style(baseStyle);
+const labelStyle = kialiStyle(baseStyle);
 
-const cellStyle = style(baseStyle, { whiteSpace: 'nowrap' });
+const cellStyle = kialiStyle({
+  ...baseStyle,
+  whiteSpace: 'nowrap'
+});
 
 export class HeatMap extends React.Component<Props> {
   static HealthColorMap: ColorMap = [

--- a/frontend/src/components/IstioConfigCard/IstioConfigCard.tsx
+++ b/frontend/src/components/IstioConfigCard/IstioConfigCard.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { ValidationObjectSummary } from '../Validations/ValidationObjectSummary';
 import { IstioTypes } from '../VirtualList/Config';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFBadge } from '../Pf/PfBadges';
 import { IstioObjectLink } from '../Link/IstioObjectLink';
 
@@ -23,7 +23,7 @@ type Props = {
   items: IstioConfigItem[];
 };
 
-const emtpytStyle = style({
+const emtpytStyle = kialiStyle({
   padding: '0 0 0 0',
   margin: '0 0 0 0'
 });

--- a/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
+++ b/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
@@ -21,7 +21,7 @@ import {
   VirtualService
 } from 'types/IstioObjects';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon, defaultIconStyle } from '../../config/KialiIcon';
 import { safeDumpOptions } from '../../types/IstioConfigDetails';
 import { jsYaml } from '../../types/AceValidations';
@@ -203,7 +203,7 @@ export class IstioConfigPreview extends React.Component<Props, State> {
       >
         <Toolbar>
           <ToolbarGroup
-            className={style({
+            className={kialiStyle({
               marginLeft: 'auto'
             })}
           >
@@ -222,7 +222,7 @@ export class IstioConfigPreview extends React.Component<Props, State> {
                   variant={ButtonVariant.link}
                   isInline
                   aria-label="Download"
-                  className={style({ marginLeft: '0.5em' })}
+                  className={kialiStyle({ marginLeft: '0.5em' })}
                   onClick={() => this.downloadTraffic()}
                 >
                   <KialiIcon.Download className={defaultIconStyle} />
@@ -242,7 +242,9 @@ export class IstioConfigPreview extends React.Component<Props, State> {
           </Tabs>
         )}
         {this.props.disableAction && (
-          <div className={style({ color: PFColors.Danger })}>User does not have enough permission for this action.</div>
+          <div className={kialiStyle({ color: PFColors.Danger })}>
+            User does not have enough permission for this action.
+          </div>
         )}
       </Modal>
     );

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilterBuilder.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { ServiceOverview } from '../../../types/ServiceList';
 import { getServicePort } from '../../../types/ServiceInfo';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type Props = {
   filterType: string;
@@ -70,7 +70,7 @@ const allOptions = {
   [RESP_MOD]: [SET, ADD, REMOVE]
 };
 
-const serviceStyle = style({
+const serviceStyle = kialiStyle({
   width: '100%'
 });
 

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sFilters.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Chip } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { FILTERING_SELECTED_TOOLTIP, wizardTooltip } from '../WizardHelp';
 
 type Props = {
@@ -8,12 +8,12 @@ type Props = {
   onRemoveFilter: (filter: string) => void;
 };
 
-const labelContainerStyle = style({
+const labelContainerStyle = kialiStyle({
   marginTop: 20,
   height: 40
 });
 
-const remove = style({
+const remove = kialiStyle({
   cursor: 'not-allowed'
 });
 

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatches.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatches.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Chip } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { MATCHING_SELECTED_TOOLTIP, wizardTooltip } from '../WizardHelp';
 
 type Props = {
@@ -8,12 +8,12 @@ type Props = {
   onRemoveMatch: (match: string) => void;
 };
 
-const labelContainerStyle = style({
+const labelContainerStyle = kialiStyle({
   marginTop: 20,
   height: 40
 });
 
-const remove = style({
+const remove = kialiStyle({
   cursor: 'not-allowed'
 });
 

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRuleBuilder.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button, Tabs, Tab, ButtonVariant } from '@patternfly/react-core';
 import { K8sMatchBuilder } from './K8sMatchBuilder';
 import { K8sMatches } from './K8sMatches';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../Pf/PfColors';
 import { K8sTrafficShifting, K8sRouteBackendRef } from '../K8sTrafficShifting';
 import { ServiceOverview } from '../../../types/ServiceList';
@@ -66,12 +66,12 @@ type State = {
   ruleTabKey: number;
 };
 
-const addRuleStyle = style({
+const addRuleStyle = kialiStyle({
   width: '100%',
   textAlign: 'right'
 });
 
-const validationStyle = style({
+const validationStyle = kialiStyle({
   marginRight: 20,
   color: PFColors.Red100,
   display: 'inline'

--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRules.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sRules.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableHeader, TableBody } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../Pf/PfColors';
 import {
   EmptyState,
@@ -31,12 +31,12 @@ type Props = {
   onMoveRule: (index: number, move: MOVE_TYPE) => void;
 };
 
-const validationStyle = style({
+const validationStyle = kialiStyle({
   marginTop: 15,
   color: PFColors.Red100
 });
 
-const noRulesStyle = style({
+const noRulesStyle = kialiStyle({
   marginTop: 15,
   color: PFColors.Red100,
   textAlign: 'center',

--- a/frontend/src/components/IstioWizards/K8sTrafficShifting.tsx
+++ b/frontend/src/components/IstioWizards/K8sTrafficShifting.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableHeader, TableBody } from '@patternfly/react-table';
 import { Slider } from './Slider/Slider';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Button, ButtonVariant, TooltipPosition } from '@patternfly/react-core';
 import { EqualizerIcon } from '@patternfly/react-icons';
 import { getDefaultBackendRefs } from './WizardActions';
@@ -41,7 +41,7 @@ type State = {
   backendRefs: K8sRouteBackendRef[];
 };
 
-const evenlyButtonStyle = style({
+const evenlyButtonStyle = kialiStyle({
   width: '100%',
   textAlign: 'right'
 });

--- a/frontend/src/components/IstioWizards/RequestRouting/Matches.tsx
+++ b/frontend/src/components/IstioWizards/RequestRouting/Matches.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Chip } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { MATCHING_SELECTED_TOOLTIP, wizardTooltip } from '../WizardHelp';
 
 type Props = {
@@ -8,12 +8,12 @@ type Props = {
   onRemoveMatch: (match: string) => void;
 };
 
-const labelContainerStyle = style({
+const labelContainerStyle = kialiStyle({
   marginTop: 20,
   height: 40
 });
 
-const remove = style({
+const remove = kialiStyle({
   cursor: 'not-allowed'
 });
 

--- a/frontend/src/components/IstioWizards/RequestRouting/RuleBuilder.tsx
+++ b/frontend/src/components/IstioWizards/RequestRouting/RuleBuilder.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button, Tabs, Tab, ButtonVariant } from '@patternfly/react-core';
 import { MatchBuilder } from './MatchBuilder';
 import { Matches } from './Matches';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { WorkloadOverview } from '../../../types/ServiceInfo';
 import { TrafficShifting, WorkloadWeight } from '../TrafficShifting';
 import { FaultInjection, FaultInjectionRoute } from '../FaultInjection';
@@ -46,12 +46,12 @@ type State = {
   ruleTabKey: number;
 };
 
-const addRuleStyle = style({
+const addRuleStyle = kialiStyle({
   width: '100%',
   textAlign: 'right'
 });
 
-const validationStyle = style({
+const validationStyle = kialiStyle({
   marginRight: 20,
   color: PFColors.Red100,
   display: 'inline'

--- a/frontend/src/components/IstioWizards/RequestRouting/Rules.tsx
+++ b/frontend/src/components/IstioWizards/RequestRouting/Rules.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableHeader, TableBody } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../Pf/PfColors';
 import {
   EmptyState,
@@ -35,12 +35,12 @@ type Props = {
   onMoveRule: (index: number, move: MOVE_TYPE) => void;
 };
 
-const validationStyle = style({
+const validationStyle = kialiStyle({
   marginTop: 15,
   color: PFColors.Red100
 });
 
-const noRulesStyle = style({
+const noRulesStyle = kialiStyle({
   marginTop: 15,
   color: PFColors.Red100,
   textAlign: 'center',

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -61,7 +61,7 @@ import {
   PeerAuthenticationMutualTLSMode,
   VirtualService
 } from '../../types/IstioObjects';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { RequestTimeouts, TimeoutRetryRoute } from './RequestTimeouts';
 import { CircuitBreaker, CircuitBreakerState } from './CircuitBreaker';
 import _ from 'lodash';
@@ -151,7 +151,7 @@ const emptyServiceWizardState = (fqdnServiceName: string): ServiceWizardState =>
   };
 };
 
-const advancedOptionsStyle = style({
+const advancedOptionsStyle = kialiStyle({
   marginTop: 10
 });
 

--- a/frontend/src/components/IstioWizards/Slider/Slider.tsx
+++ b/frontend/src/components/IstioWizards/Slider/Slider.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BootstrapSlider } from './BootstrapSlider';
 import { Button, ButtonVariant, InputGroupText, TextInput, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Boundaries } from './Boundaries';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { MinusIcon, PlusIcon, ThumbTackIcon, MigrationIcon } from '@patternfly/react-icons';
 import './styles/default.css';
 
@@ -139,27 +139,27 @@ export class Slider extends React.Component<Props, State> {
       />
     );
 
-    const leftButtonStyle = style({
+    const leftButtonStyle = kialiStyle({
       width: '20px',
       paddingLeft: 0,
       paddingRight: 0,
       marginLeft: 0,
       marginRight: 5
     });
-    const inputStyle = style({
+    const inputStyle = kialiStyle({
       width: '3em',
       textAlign: 'center',
       marginLeft: 0,
       marginRight: 0
     });
-    const rightButtonStyle = style({
+    const rightButtonStyle = kialiStyle({
       width: '20px',
       paddingLeft: 0,
       paddingRight: 0,
       marginLeft: 5,
       marginRight: 5
     });
-    const pinButtonStyle = style({
+    const pinButtonStyle = kialiStyle({
       paddingLeft: 8,
       paddingRight: 8
     });

--- a/frontend/src/components/IstioWizards/TrafficShifting.tsx
+++ b/frontend/src/components/IstioWizards/TrafficShifting.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { cellWidth, ICell, Table, TableHeader, TableBody } from '@patternfly/react-table';
 import { Slider } from './Slider/Slider';
 import { WorkloadOverview } from '../../types/ServiceInfo';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../Pf/PfColors';
 import { Button, ButtonVariant, TooltipPosition } from '@patternfly/react-core';
 import { EqualizerIcon } from '@patternfly/react-icons';
@@ -29,13 +29,13 @@ type State = {
   workloads: WorkloadWeight[];
 };
 
-const validationStyle = style({
+const validationStyle = kialiStyle({
   marginBottom: 10,
   color: PFColors.Red100,
   textAlign: 'right'
 });
 
-const evenlyButtonStyle = style({
+const evenlyButtonStyle = kialiStyle({
   width: '100%',
   textAlign: 'right'
 });

--- a/frontend/src/components/IstioWizards/WizardHelp.tsx
+++ b/frontend/src/components/IstioWizards/WizardHelp.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from '../../config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 0px 2px 10px',
   verticalAlign: '-5px !important'
 });
 
-const importantTooltip = style({
+const importantTooltip = kialiStyle({
   fontWeight: 700
 });
 

--- a/frontend/src/components/JaegerIntegration/JaegerResults/FormattedTraceInfo.ts
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/FormattedTraceInfo.ts
@@ -1,16 +1,16 @@
 import { JaegerTrace } from '../../../types/JaegerInfo';
 import moment from 'moment';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from 'components/Pf/PfColors';
 import { formatDuration, formatRelativeDate, isErrorTag } from 'utils/tracing/TracingHelper';
 
-export const shortIDStyle = style({
+export const shortIDStyle = kialiStyle({
   color: PFColors.Black600,
   padding: 4,
   fontSize: 12
 });
 
-export const fullIDStyle = style({
+export const fullIDStyle = kialiStyle({
   color: PFColors.Black600,
   paddingLeft: 10,
   fontSize: 14

--- a/frontend/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
@@ -35,7 +35,7 @@ import { EnvoySpanInfo, OpenTracingHTTPInfo, OpenTracingTCPInfo, RichSpanData } 
 import { sameSpans } from 'utils/tracing/TracingHelper';
 import { buildQueriesFromSpans } from 'utils/tracing/TraceStats';
 import { getSpanId } from '../../../utils/SearchParamUtils';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { formatDuration, isErrorTag } from 'utils/tracing/TracingHelper';
 import { Link } from 'react-router-dom';
@@ -70,26 +70,26 @@ type SortableCell<T> = ICell & {
   compare?: (a: T, b: T) => number;
 };
 
-const dangerErrorStyle = style({
+const dangerErrorStyle = kialiStyle({
   borderLeft: '3px solid var(--pf-global--danger-color--100)'
 });
 
-const selectedErrorStyle = style({
+const selectedErrorStyle = kialiStyle({
   borderRight: '3px solid var(--pf-global--info-color--100)',
   borderLeft: '3px solid var(--pf-global--danger-color--100)'
 });
 
-const selectedStyle = style({
+const selectedStyle = kialiStyle({
   borderRight: '3px solid var(--pf-global--info-color--100)'
 });
 
-const rowKebabStyle = style({
+const rowKebabStyle = kialiStyle({
   paddingLeft: 0,
   textAlign: 'left',
   whiteSpace: 'nowrap'
 });
 
-const linkStyle = style({
+const linkStyle = kialiStyle({
   fontSize: 14
 });
 

--- a/frontend/src/components/JaegerIntegration/JaegerScatter.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerScatter.tsx
@@ -14,7 +14,7 @@ import { durationSelector } from '../../store/Selectors';
 import { TraceTooltip } from './TraceTooltip';
 import { isErrorTag } from 'utils/tracing/TracingHelper';
 import { averageSpanDuration, buildQueriesFromSpans } from 'utils/tracing/TraceStats';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { MetricsStatsQuery } from 'types/MetricsOptions';
 import { MetricsStatsThunkActions } from 'actions/MetricsStatsThunkActions';
 
@@ -37,14 +37,14 @@ const MAXIMAL_SIZE = 30;
 export type JaegerLineInfo = LineInfo & { trace: JaegerTrace };
 type Datapoint = VCDataPoint & JaegerLineInfo;
 
-const jaegerChartStyle = style({
+const jaegerChartStyle = kialiStyle({
   paddingTop: 15,
   paddingLeft: 25,
   paddingRight: 25,
   paddingBottom: 15
 });
 
-const emptyStyle = style({
+const emptyStyle = kialiStyle({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',

--- a/frontend/src/components/JaegerIntegration/TraceListItem.tsx
+++ b/frontend/src/components/JaegerIntegration/TraceListItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { pluralize, Tooltip } from '@patternfly/react-core';
 
 import { JaegerTrace } from '../../types/JaegerInfo';
@@ -10,12 +10,12 @@ interface Props {
   trace: JaegerTrace;
 }
 
-const parentDivStyle = style({
+const parentDivStyle = kialiStyle({
   fontSize: 'var(--graph-side-panel--font-size)',
   lineHeight: 1.3
 });
 
-const nameStyle = style({
+const nameStyle = kialiStyle({
   display: 'inline-block',
   maxWidth: 175,
   textOverflow: 'ellipsis',
@@ -23,15 +23,15 @@ const nameStyle = style({
   whiteSpace: 'nowrap'
 });
 
-const errorStyle = style({
+const errorStyle = kialiStyle({
   color: PFColors.Danger
 });
 
-const secondaryLeftStyle = style({
+const secondaryLeftStyle = kialiStyle({
   color: PFColors.Black600
 });
 
-const secondaryRightStyle = style({
+const secondaryRightStyle = kialiStyle({
   color: PFColors.Black600,
   float: 'right'
 });

--- a/frontend/src/components/JaegerIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/JaegerIntegration/TraceTooltip.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { pluralize } from '@patternfly/react-core';
 import { ChartCursorFlyout, ChartLabelProps } from '@patternfly/react-charts';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { KialiAppState } from 'store/Store';
 import { averageSpanDuration, reduceMetricsStats, StatsMatrix } from 'utils/tracing/TraceStats';
 import { JaegerLineInfo } from './JaegerScatter';
@@ -18,20 +18,20 @@ const flyoutMargin = 10;
 const innerWidth = flyoutWidth - 2 * flyoutMargin;
 const innerHeight = flyoutHeight - 2 * flyoutMargin;
 
-const tooltipStyle = style({
+const tooltipStyle = kialiStyle({
   color: PFColors.Black100,
   width: innerWidth,
   height: innerHeight
 });
 
-const titleStyle = style({
+const titleStyle = kialiStyle({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis'
 });
 
-const contentStyle = style({ width: '100%', height: '100%' });
-const leftStyle = style({ width: '35%', height: '100%', float: 'left' });
+const contentStyle = kialiStyle({ width: '100%', height: '100%' });
+const leftStyle = kialiStyle({ width: '35%', height: '100%', float: 'left' });
 
 type LabelProps = ChartLabelProps & {
   trace: JaegerTrace;

--- a/frontend/src/components/Label/Label.tsx
+++ b/frontend/src/components/Label/Label.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Label as PfLabel } from '@patternfly/react-core';
 import { canRender } from '../../utils/SafeRender';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 interface Props {
   name: string;
@@ -10,7 +10,7 @@ interface Props {
   value: string;
 }
 
-const labelStyle = style({
+const labelStyle = kialiStyle({
   display: 'block',
   float: 'left',
   fontSize: 'var(--kiali-global--font-size)',

--- a/frontend/src/components/Label/Labels.tsx
+++ b/frontend/src/components/Label/Labels.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Label } from './Label';
 import { Button, ButtonVariant, Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon } from '../../config/KialiIcon';
 
 const SHOW_MORE_TRESHOLD = 2;
@@ -16,17 +16,17 @@ interface State {
   expanded: boolean;
 }
 
-const linkStyle = style({
+const linkStyle = kialiStyle({
   padding: '0 4px 0 4px',
   fontSize: '0.8rem',
   bottom: '2px'
 });
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '4px 4px 2px 5px'
 });
 
-const labelsContainerStyle = style({
+const labelsContainerStyle = kialiStyle({
   overflow: 'hidden'
 });
 

--- a/frontend/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/frontend/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`#Badge render correctly with data should render badge 1`] = `
 <Label
-  className="fahj8d2"
+  className="kiali_fahj8d2"
   isCompact={true}
 >
   app=bookinfo

--- a/frontend/src/components/Label/__tests__/__snapshots__/Labels.test.tsx.snap
+++ b/frontend/src/components/Label/__tests__/__snapshots__/Labels.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`#Labels render correctly with data should render badges with More labels link 1`] = `
 <div
-  className="faowcuh"
+  className="kiali_faowcuh"
 >
   <div
     data-test="app-label-container"
@@ -25,7 +25,7 @@ exports[`#Labels render correctly with data should render badges with More label
     />
   </div>
   <Button
-    className="f1tvybfg"
+    className="kiali_f1tvybfg"
     data-test="label_more"
     key="label_more"
     onClick={[Function]}
@@ -38,7 +38,7 @@ exports[`#Labels render correctly with data should render badges with More label
 
 exports[`#Labels render correctly with data should render badges without More labels link 1`] = `
 <div
-  className="faowcuh"
+  className="kiali_faowcuh"
 >
   <div
     data-test="app-label-container"

--- a/frontend/src/components/Link/IstioObjectLink.tsx
+++ b/frontend/src/components/Link/IstioObjectLink.tsx
@@ -5,12 +5,12 @@ import { IstioTypes } from '../VirtualList/Config';
 import { PFBadge } from 'components/Pf/PfBadges';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from 'config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
 import { isParentKiosk, kioskContextMenuAction } from '../Kiosk/KioskActions';
 
-export const infoStyle = style({
+export const infoStyle = kialiStyle({
   margin: '0px 0px -2px 3px'
 });
 

--- a/frontend/src/components/Logo/Logos.tsx
+++ b/frontend/src/components/Logo/Logos.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 import GrpcIcon from '../../assets/img/grpc-logo.svg';
 import RestIcon from '../../assets/img/rest-logo.svg';
@@ -44,7 +44,7 @@ const apiLogos = {
   graphql: GraphqlIcon
 };
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   marginTop: -2,
   marginRight: 6,
   width: 30

--- a/frontend/src/components/MTls/MeshMTLSStatus.tsx
+++ b/frontend/src/components/MTls/MeshMTLSStatus.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { KialiAppState } from '../../store/Store';
 import { MTLSIconTypes } from './MTLSIcon';
 import { MTLSStatus, emptyDescriptor, StatusDescriptor } from './MTLSStatus';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { meshWideMTLSEnabledSelector, meshWideMTLSStatusSelector, namespaceItemsSelector } from '../../store/Selectors';
 import { connect } from 'react-redux';
 import { MTLSStatuses, TLSStatus } from '../../types/TLSStatus';
@@ -101,7 +101,7 @@ class MeshMTLSStatusComponent extends React.Component<Props> {
   };
 
   iconStyle() {
-    return style({
+    return kialiStyle({
       marginRight: 10,
       marginLeft: 10,
       width: 13

--- a/frontend/src/components/MTls/NamespaceMTLSStatus.tsx
+++ b/frontend/src/components/MTls/NamespaceMTLSStatus.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { MTLSIconTypes } from './MTLSIcon';
 import { MTLSStatus, emptyDescriptor, StatusDescriptor } from './MTLSStatus';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { MTLSStatuses } from '../../types/TLSStatus';
 
 type Props = {
@@ -39,7 +39,7 @@ const statusDescriptors = new Map<string, StatusDescriptor>([
 ]);
 
 // Magic style to align Istio Config icons on top of status overview
-const iconStyle = style({
+const iconStyle = kialiStyle({
   marginTop: -3,
   marginRight: 18,
   marginLeft: 2,

--- a/frontend/src/components/MessageCenter/AlertDrawer.tsx
+++ b/frontend/src/components/MessageCenter/AlertDrawer.tsx
@@ -16,7 +16,7 @@ import { CloseIcon, InfoIcon } from '@patternfly/react-icons';
 import { connect } from 'react-redux';
 import { KialiDispatch } from 'types/Redux';
 import { KialiAppState } from 'store/Store';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { NotificationMessage, NotificationGroup } from '../../types/MessageCenter';
 import { MessageCenterActions } from 'actions/MessageCenterActions';
 import { AlertDrawerGroup } from './AlertDrawerGroup';
@@ -64,24 +64,24 @@ const noNotificationsMessage = (
 );
 
 class AlertDrawerComponent extends React.PureComponent<AlertDrawerProps> {
-  static readonly head = style({
+  static readonly head = kialiStyle({
     paddingBottom: 0
   });
-  static readonly body = style({
+  static readonly body = kialiStyle({
     paddingLeft: 0,
     paddingRight: 0
   });
-  static readonly wrapper = style({
+  static readonly wrapper = kialiStyle({
     overflow: 'auto'
   });
   static readonly wrapperMarginBottom = 10;
-  static readonly groups = style({
+  static readonly groups = kialiStyle({
     paddingTop: 0,
     paddingBottom: 0
   });
 
   render() {
-    const drawer = style({
+    const drawer = kialiStyle({
       position: 'absolute',
       right: '0',
       width: this.props.isExpanded ? '80%' : '30em'

--- a/frontend/src/components/MessageCenter/AlertDrawerGroup.tsx
+++ b/frontend/src/components/MessageCenter/AlertDrawerGroup.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { KialiDispatch } from 'types/Redux';
 import { Card, Button, CardBody, CardFooter, ButtonVariant } from '@patternfly/react-core';
 import { InfoIcon } from '@patternfly/react-icons';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { NotificationGroup } from '../../types/MessageCenter';
 import { MessageCenterThunkActions } from 'actions/MessageCenterThunkActions';
 import { AlertDrawerMessage } from './AlertDrawerMessage';
@@ -26,17 +26,17 @@ const noNotificationsMessage = (
 );
 
 class AlertDrawerGroupComponent extends React.PureComponent<AlertDrawerGroupProps> {
-  static readonly body = style({
+  static readonly body = kialiStyle({
     padding: 0 // note: I don't know why but paddingTop with the additional explicit style prop used below
   });
-  static readonly footer = style({
+  static readonly footer = kialiStyle({
     paddingBottom: 5,
     paddingTop: 5
   });
-  static readonly left = style({
+  static readonly left = kialiStyle({
     float: 'left'
   });
-  static readonly right = style({
+  static readonly right = kialiStyle({
     float: 'right'
   });
 

--- a/frontend/src/components/MessageCenter/AlertDrawerMessage.tsx
+++ b/frontend/src/components/MessageCenter/AlertDrawerMessage.tsx
@@ -5,7 +5,7 @@ import { MessageType, NotificationMessage } from '../../types/MessageCenter';
 import moment from 'moment';
 import { MessageCenterActions } from 'actions/MessageCenterActions';
 import { KialiDispatch } from 'types/Redux';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon } from 'config/KialiIcon';
 
 const getIcon = (type: MessageType) => {
@@ -33,13 +33,13 @@ type AlertDrawerMessageProps = ReduxProps & {
 };
 
 class AlertDrawerMessageComponent extends React.PureComponent<AlertDrawerMessageProps> {
-  static readonly body = style({
+  static readonly body = kialiStyle({
     paddingTop: 0
   });
-  static readonly left = style({
+  static readonly left = kialiStyle({
     float: 'left'
   });
-  static readonly right = style({
+  static readonly right = kialiStyle({
     float: 'right'
   });
 

--- a/frontend/src/components/MessageCenter/MessageCenter.tsx
+++ b/frontend/src/components/MessageCenter/MessageCenter.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { NotificationList } from './NotificationList';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { NotificationMessage, NotificationGroup } from '../../types/MessageCenter';
 import { AlertDrawer } from './AlertDrawer';
 import { KialiAppState } from 'store/Store';
 import { KialiDispatch } from 'types/Redux';
 import { MessageCenterActions } from 'actions/MessageCenterActions';
 
-const notificationStyle = style({
+const notificationStyle = kialiStyle({
   position: 'relative',
   zIndex: 500
 });

--- a/frontend/src/components/MessageCenter/MessageCenterTrigger.tsx
+++ b/frontend/src/components/MessageCenter/MessageCenterTrigger.tsx
@@ -6,7 +6,7 @@ import { KialiAppState } from '../../store/Store';
 import { MessageType, NotificationGroup, NotificationMessage } from '../../types/MessageCenter';
 import { MessageCenterThunkActions } from '../../actions/MessageCenterThunkActions';
 import { KialiIcon } from 'config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type PropsType = {
   newMessagesCount: number;
@@ -16,7 +16,7 @@ type PropsType = {
   toggleSystemErrorsCenter: () => void;
 };
 
-const systemErrorCountStyle = style({
+const systemErrorCountStyle = kialiStyle({
   marginRight: '0.3em',
   paddingTop: '0.1em'
 });
@@ -51,12 +51,12 @@ class MessageCenterTriggerComponent extends React.PureComponent<PropsType, {}> {
   };
 
   private renderMessageCenterBadge = () => {
-    const bell = style({
+    const bell = kialiStyle({
       position: 'relative',
       right: '5px',
       top: '2px'
     });
-    const count = style({
+    const count = kialiStyle({
       position: 'relative',
       top: '2px',
       verticalAlign: '0.125em'

--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -13,7 +13,7 @@ import {
   Title,
   TitleSizes
 } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { serverConfig } from '../../config/ServerConfig';
 import { history, URLParam } from '../../app/History';
 import * as API from '../../services/Api';
@@ -72,12 +72,12 @@ type ReduxProps = {
 
 type Props = ReduxProps & CustomMetricsProps;
 
-const fullHeightStyle = style({
+const fullHeightStyle = kialiStyle({
   height: '100%'
 });
 
 // For some reason checkbox as a ToolbarItem needs to be tweaked
-const toolbarInputStyle = style({
+const toolbarInputStyle = kialiStyle({
   $nest: {
     '& > input': {
       marginTop: '2px'
@@ -85,7 +85,7 @@ const toolbarInputStyle = style({
   }
 });
 
-const emptyStyle = style({
+const emptyStyle = kialiStyle({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux';
 import { KialiDispatch } from 'types/Redux';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { Card, CardBody, Checkbox, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import * as API from 'services/Api';
 import { KialiAppState } from 'store/Store';
 import { TimeRange, evalTimeRange, TimeInMilliseconds, isEqualTimeRange, IntervalInMilliseconds } from 'types/Common';
@@ -67,12 +67,12 @@ type ReduxProps = {
 
 type Props = ReduxProps & IstioMetricsProps;
 
-const fullHeightStyle = style({
+const fullHeightStyle = kialiStyle({
   height: '100%'
 });
 
 // For some reason checkbox as a ToolbarItem needs to be tweaked
-const toolbarInputStyle = style({
+const toolbarInputStyle = kialiStyle({
   $nest: {
     '& > input': {
       marginTop: '2px'

--- a/frontend/src/components/MetricsOptions/MetricsReporter.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsReporter.tsx
@@ -5,7 +5,7 @@ import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import { Reporter, Direction } from '../../types/MetricsOptions';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from '../../config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 interface Props {
   onChanged: (reproter: Reporter) => void;
@@ -13,7 +13,7 @@ interface Props {
   reporter: Reporter;
 }
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 5px 2px 5px',
   verticalAlign: '-5px !important'
 });

--- a/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import isEqual from 'lodash/isEqual';
 
 import { history, URLParam } from '../../app/History';
@@ -40,10 +40,10 @@ type State = MetricsSettings & {
   allSelected: boolean;
 };
 
-const checkboxSelectAllStyle = style({ marginLeft: 10 });
-const secondLevelStyle = style({ marginLeft: 18 });
-const spacerStyle = style({ height: '1em' });
-const titlePaddingStyle = style({ paddingLeft: 0, fontSize: 'small' });
+const checkboxSelectAllStyle = kialiStyle({ marginLeft: 10 });
+const secondLevelStyle = kialiStyle({ marginLeft: 18 });
+const spacerStyle = kialiStyle({ height: '1em' });
+const titlePaddingStyle = kialiStyle({ paddingLeft: 0, fontSize: 'small' });
 
 export class MetricsSettingsDropdown extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -290,7 +290,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
   renderHistogramOptions(): JSX.Element {
     // Prettier removes the parenthesis introducing JSX
     // prettier-ignore
-    const infoStyle = style({
+    const infoStyle = kialiStyle({
       margin: '8px 5px -1px 2px'
     });
 

--- a/frontend/src/components/MissingAuthPolicy/MissingAuthPolicy.tsx
+++ b/frontend/src/components/MissingAuthPolicy/MissingAuthPolicy.tsx
@@ -4,7 +4,7 @@ import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 import { isIstioNamespace } from 'config/ServerConfig';
 import { icons } from 'config';
 import { KialiIcon } from '../../config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type MissingAuthPolicyProps = {
   text: string;
@@ -16,7 +16,7 @@ type MissingAuthPolicyProps = {
   style?: React.CSSProperties;
 };
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 5px 2px 4px',
   verticalAlign: '-5px !important'
 });

--- a/frontend/src/components/MissingLabel/MissingLabel.tsx
+++ b/frontend/src/components/MissingLabel/MissingLabel.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { icons, serverConfig } from '../../config';
 import { KialiIcon } from '../../config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFBadge } from '../Pf/PfBadges';
 
 type MissingLabelProps = {
@@ -12,7 +12,7 @@ type MissingLabelProps = {
   style?: React.CSSProperties;
 };
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 5px 2px 4px',
   verticalAlign: '-5px !important'
 });

--- a/frontend/src/components/MissingSidecar/MissingSidecar.tsx
+++ b/frontend/src/components/MissingSidecar/MissingSidecar.tsx
@@ -4,7 +4,7 @@ import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 import { isIstioNamespace, serverConfig } from 'config/ServerConfig';
 import { icons } from 'config';
 import { KialiIcon } from '../../config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type MissingSidecarProps = {
   'data-test'?: string;
@@ -20,7 +20,7 @@ type MissingSidecarProps = {
   isGateway?: boolean;
 };
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 5px 2px 4px',
   verticalAlign: '-5px !important'
 });

--- a/frontend/src/components/NamespaceDropdown.tsx
+++ b/frontend/src/components/NamespaceDropdown.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { KialiDispatch } from 'types/Redux';
 import _ from 'lodash';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import {
   Button,
   Dropdown,
@@ -47,24 +47,24 @@ type NamespaceDropdownState = {
   selectedNamespaces: Namespace[];
 };
 
-const checkboxBulkStyle = style({
+const checkboxBulkStyle = kialiStyle({
   marginLeft: '0.5em',
   position: 'relative',
   top: 8
 });
 
-const checkboxStyle = style({ marginLeft: '1.0em' });
+const checkboxStyle = kialiStyle({ marginLeft: '1.0em' });
 
-const checkboxLabelStyle = style({ marginLeft: '0.5em' });
+const checkboxLabelStyle = kialiStyle({ marginLeft: '0.5em' });
 
-const headerStyle = style({
+const headerStyle = kialiStyle({
   margin: '0 0.5em 10px 0.5em',
   width: 300
 });
 
 const marginBottom = 20;
 
-const namespaceContainerStyle = style({
+const namespaceContainerStyle = kialiStyle({
   overflow: 'auto'
 });
 

--- a/frontend/src/components/Nav/Navigation.tsx
+++ b/frontend/src/components/Nav/Navigation.tsx
@@ -17,7 +17,7 @@ import {
   ButtonVariant
 } from '@patternfly/react-core';
 import { BarsIcon } from '@patternfly/react-icons';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { MessageCenter } from '../../components/MessageCenter/MessageCenter';
 import { kialiLogo, serverConfig } from '../../config';
 import { KialiAppState } from '../../store/Store';
@@ -37,7 +37,7 @@ type NavigationState = {
   isNavOpenMobile: boolean;
 };
 
-const flexBoxColumnStyle = style({
+const flexBoxColumnStyle = kialiStyle({
   display: 'flex',
   flexDirection: 'column'
 });

--- a/frontend/src/components/Nav/Page/RenderContent.tsx
+++ b/frontend/src/components/Nav/Page/RenderContent.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../Pf/PfColors';
 import { RenderComponentScroll } from './RenderComponentScroll';
 
-const containerPadding = style({ padding: '30px 20px 0 20px' });
-const containerWhite = style({ backgroundColor: PFColors.White });
+const containerPadding = kialiStyle({ padding: '30px 20px 0 20px' });
+const containerWhite = kialiStyle({ backgroundColor: PFColors.White });
 
 export class RenderContent extends React.Component<{ needScroll?: boolean }> {
   render() {

--- a/frontend/src/components/Nav/Page/RenderHeader.tsx
+++ b/frontend/src/components/Nav/Page/RenderHeader.tsx
@@ -1,27 +1,27 @@
 import React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../Pf/PfColors';
 import { BreadcrumbView } from '../../BreadcrumbView/BreadcrumbView';
 import { KialiAppState } from '../../../store/Store';
 import { connect } from 'react-redux';
 import { isKiosk } from '../../Kiosk/KioskActions';
 
-const containerPadding = style({ padding: '0 20px 28px 20px' });
-const containerWhite = style({ backgroundColor: PFColors.White });
+const containerPadding = kialiStyle({ padding: '0 20px 28px 20px' });
+const containerWhite = kialiStyle({ backgroundColor: PFColors.White });
 // This magic style tries to adjust Breadcrumb with Namespace selector
 // to give impression that both components are placed in the same location
-const breadcrumbMargin = style({ padding: '10px 0 4px 0' });
+const breadcrumbMargin = kialiStyle({ padding: '10px 0 4px 0' });
 
-const breadcrumbStyle = style({
+const breadcrumbStyle = kialiStyle({
   display: 'flex',
   flexWrap: 'wrap'
 });
 
-const rightToolbarStyle = style({
+const rightToolbarStyle = kialiStyle({
   marginLeft: 'auto'
 });
 
-const actionsToolbarStyle = style({
+const actionsToolbarStyle = kialiStyle({
   float: 'right',
   backgroundColor: '#fff',
   padding: '0px 20px 22px 5px',

--- a/frontend/src/components/Nav/RenderPage.tsx
+++ b/frontend/src/components/Nav/RenderPage.tsx
@@ -3,15 +3,15 @@ import { Redirect, Route } from 'react-router-dom';
 import { SwitchErrorBoundary } from '../SwitchErrorBoundary/SwitchErrorBoundary';
 import { pathRoutes, defaultRoute } from '../../routes';
 import { Path } from '../../types/Routes';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../Pf/PfColors';
 import { Button, ButtonVariant, EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { KialiIcon } from 'config/KialiIcon';
 
-const containerStyle = style({ marginLeft: 0, marginRight: 0 });
-const containerPadding = style({ padding: '0 20px 0 20px' });
-const containerGray = style({ background: PFColors.Black150 });
-const containerError = style({ height: 'calc(100vh - 76px)' });
+const containerStyle = kialiStyle({ marginLeft: 0, marginRight: 0 });
+const containerPadding = kialiStyle({ padding: '0 20px 0 20px' });
+const containerGray = kialiStyle({ background: PFColors.Black150 });
+const containerError = kialiStyle({ height: 'calc(100vh - 76px)' });
 
 export class RenderPage extends React.Component<{ isGraph: boolean }> {
   renderPaths(paths: Path[]) {

--- a/frontend/src/components/Nav/SecondaryMasthead.tsx
+++ b/frontend/src/components/Nav/SecondaryMasthead.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
-const marginStyle = style({
+const marginStyle = kialiStyle({
   margin: '10px 20px 0 0'
 });
-const secondaryMastheadStyle = style({
+const secondaryMastheadStyle = kialiStyle({
   position: 'sticky',
   zIndex: 10,
   marginLeft: 0,
@@ -13,9 +13,9 @@ const secondaryMastheadStyle = style({
 
 export class SecondaryMasthead extends React.Component<{ title: boolean }> {
   render() {
-    let secondaryMastheadStyleHeight = style({ height: '42px' });
+    let secondaryMastheadStyleHeight = kialiStyle({ height: '42px' });
     if (this.props.title) {
-      secondaryMastheadStyleHeight = style({ height: 'unset' });
+      secondaryMastheadStyleHeight = kialiStyle({ height: 'unset' });
     }
     return (
       <div

--- a/frontend/src/components/Overview/TLSInfo.tsx
+++ b/frontend/src/components/Overview/TLSInfo.tsx
@@ -1,7 +1,7 @@
 import { Label, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from 'config/KialiIcon';
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { KialiAppState } from '../../store/Store';
 import { istioCertsInfoSelector } from '../../store/Selectors';
 import { CertsInfo } from '../../types/CertsInfo';
@@ -14,7 +14,7 @@ type Props = {
   certsInfo: CertsInfo[];
 };
 
-const lockIconStyle = style({ marginLeft: '5px' });
+const lockIconStyle = kialiStyle({ marginLeft: '5px' });
 
 function showCerts(certs) {
   if (certs) {

--- a/frontend/src/components/Pf/PfBadges.tsx
+++ b/frontend/src/components/Pf/PfBadges.tsx
@@ -1,6 +1,6 @@
 import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import React, { CSSProperties } from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from './PfColors';
 
 export type PFBadgeType = {
@@ -73,7 +73,7 @@ export const PFBadges: { [key: string]: PFBadgeType } = Object.freeze({
 });
 
 // This is styled for consistency with OpenShift Console.  See console: public/components/_resource.scss
-export const kialiBadge = style({
+export const kialiBadge = kialiStyle({
   backgroundColor: PFColors.Badge,
   color: PFColors.White,
   borderRadius: '20px',
@@ -88,7 +88,7 @@ export const kialiBadge = style({
   whiteSpace: 'nowrap'
 });
 
-export const kialiBadgeSmall = style({
+export const kialiBadgeSmall = kialiStyle({
   backgroundColor: PFColors.Badge,
   color: PFColors.White,
   borderRadius: '20px',

--- a/frontend/src/components/Pf/PfTitle.tsx
+++ b/frontend/src/components/Pf/PfTitle.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { MissingSidecar } from '../../components/MissingSidecar/MissingSidecar';
 import { ServiceIcon, BundleIcon, ApplicationsIcon } from '@patternfly/react-icons';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
-const PfTitleStyle = style({
+const PfTitleStyle = kialiStyle({
   fontSize: '19px',
   fontWeight: 400,
   margin: '20px 0',

--- a/frontend/src/components/RightActionBar/RightActionBar.tsx
+++ b/frontend/src/components/RightActionBar/RightActionBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
-export const actionBarStyle = style({
+export const actionBarStyle = kialiStyle({
   position: 'absolute',
   marginTop: -60,
   right: 18,

--- a/frontend/src/components/SummaryPanel/ResponseHostsTable.tsx
+++ b/frontend/src/components/SummaryPanel/ResponseHostsTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import _ from 'lodash';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Responses } from '../../types/Graph';
 import { Tooltip } from '@patternfly/react-core';
 import { summaryTitle } from 'pages/Graph/SummaryPanelCommon';
@@ -17,7 +17,7 @@ interface Row {
   val: string;
 }
 
-const hostStyle = style({
+const hostStyle = kialiStyle({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap'

--- a/frontend/src/components/SummaryPanel/RpsChart.tsx
+++ b/frontend/src/components/SummaryPanel/RpsChart.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { InfoAltIcon, SquareFullIcon } from '@patternfly/react-icons';
 
 import { SparklineChart } from 'components/Charts/SparklineChart';
@@ -35,7 +35,7 @@ type BytesAbbreviation = {
   format: (includeUnit: boolean) => string;
 };
 
-const blockStyle = style({
+const blockStyle = kialiStyle({
   marginTop: '0.5em',
   marginBottom: '0.5em'
 });

--- a/frontend/src/components/Time/DateTimePicker.tsx
+++ b/frontend/src/components/Time/DateTimePicker.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import DatePicker from 'react-datepicker';
 
-const pickerStyle = style({
+const pickerStyle = kialiStyle({
   height: '36px',
   paddingLeft: '.75em',
   width: '10em'

--- a/frontend/src/components/Time/Replay.tsx
+++ b/frontend/src/components/Time/Replay.tsx
@@ -10,7 +10,7 @@ import { ToolbarDropdown } from 'components/ToolbarDropdown/ToolbarDropdown';
 import { UserSettingsActions } from 'actions/UserSettingsActions';
 import { Slider } from 'components/IstioWizards/Slider/Slider';
 import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { toString } from './Utils';
 import { serverConfig } from 'config';
 import { PFColors } from 'components/Pf/PfColors';
@@ -51,7 +51,7 @@ type ReplaySpeed = {
   text: string;
 };
 
-export const replayBorder = style({
+export const replayBorder = kialiStyle({
   borderLeft: `solid 5px ${PFColors.Replay}`
 });
 
@@ -76,56 +76,56 @@ const defaultReplayInterval: IntervalInMilliseconds = 300000; // 5 minutes
 const defaultReplaySpeed: IntervalInMilliseconds = 3000; // medium
 const frameInterval: IntervalInMilliseconds = 10000; // clock advances 10s per frame
 
-const controlStyle = style({
+const controlStyle = kialiStyle({
   display: 'flex',
   margin: '5px 0 0 15px'
 });
 
-const controlButtonStyle = style({
+const controlButtonStyle = kialiStyle({
   margin: '-5px -5px 0 33%',
   height: '37px'
 });
 
-const controlIconStyle = style({
+const controlIconStyle = kialiStyle({
   fontSize: '1.5em'
 });
 
-const frameStyle = style({
+const frameStyle = kialiStyle({
   margin: '2px 20px 0 0'
 });
 
-const isCustomStyle = style({
+const isCustomStyle = kialiStyle({
   height: '36px'
 });
 
-const isCustomActiveStyle = style({
+const isCustomActiveStyle = kialiStyle({
   color: PFColors.Active
 });
 
-const replayStyle = style({
+const replayStyle = kialiStyle({
   display: 'flex',
   width: '100%',
   padding: '5px 5px 0 10px',
   marginTop: '-5px'
 });
 
-const sliderStyle = style({
+const sliderStyle = kialiStyle({
   width: '100%',
   margin: '0 -10px 0 20px'
 });
 
-const speedStyle = style({
+const speedStyle = kialiStyle({
   height: '1.5em',
   margin: '1px 5px 0 5px',
   padding: '0 2px 2px 2px'
 });
 
-const speedActiveStyle = style({
+const speedActiveStyle = kialiStyle({
   color: PFColors.ActiveText,
   fontWeight: 'bolder'
 });
 
-const vrStyle = style({
+const vrStyle = kialiStyle({
   border: '1px inset',
   height: '20px',
   marginTop: '4px',

--- a/frontend/src/components/Time/TimeDurationIndicator.tsx
+++ b/frontend/src/components/Time/TimeDurationIndicator.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { config } from '../../config';
 import { KialiIcon } from '../../config/KialiIcon';
@@ -22,7 +22,7 @@ interface Props {
   timeRange: TimeRange;
 }
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 5px 2px 5px',
   verticalAlign: '-5px !important'
 });

--- a/frontend/src/components/Time/TimeRangeComponent.tsx
+++ b/frontend/src/components/Time/TimeRangeComponent.tsx
@@ -18,7 +18,7 @@ import { KialiDispatch } from 'types/Redux';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type Props = {
   manageURL?: boolean;
@@ -28,7 +28,7 @@ type Props = {
   setTimeRange: (range: TimeRange) => void;
 };
 
-const labelStyle = style({
+const labelStyle = kialiStyle({
   margin: '5px 5px 0px 5px'
 });
 

--- a/frontend/src/components/ToolbarDropdown/ToolbarDropdown.tsx
+++ b/frontend/src/components/ToolbarDropdown/ToolbarDropdown.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Select, SelectOption, Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
-const widthAuto = style({
+const widthAuto = kialiStyle({
   width: 'auto'
 });
 
-const dropdownTitle = style({
+const dropdownTitle = kialiStyle({
   fontSize: 'var(--pf-global--FontSize--md)', // valueOf --pf-c-select__toggle--FontSize
   // @ts-ignore
   fontWeight: 'var(--pf-global--FontSize--normal)', // valueOf --pf-c-select__toggle--FontWeigt

--- a/frontend/src/components/ToolbarDropdown/__tests__/__snapshots__/ToolbarDropdown.test.tsx.snap
+++ b/frontend/src/components/ToolbarDropdown/__tests__/__snapshots__/ToolbarDropdown.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ToolbarDropdown Render correctly all dropdowns 1`] = `
 <Fragment>
   <span
-    className="fzb2262"
+    className="kiali_fzb2262"
   >
     graph_filter_interval_duration
   </span>
@@ -13,7 +13,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 1`] = `
     aria-label="graph_filter_interval_duration"
     aria-labelledby="graph_filter_interval_duration"
     chipGroupComponent={null}
-    className="fhxf3qu"
+    className="kiali_fhxf3qu"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -263,7 +263,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 1`] = `
 exports[`ToolbarDropdown Render correctly all dropdowns 2`] = `
 <Fragment>
   <span
-    className="fzb2262"
+    className="kiali_fzb2262"
   >
     metrics_filter_poll_interval
   </span>
@@ -273,7 +273,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 2`] = `
     aria-label="metrics_filter_poll_interval"
     aria-labelledby="metrics_filter_poll_interval"
     chipGroupComponent={null}
-    className="fhxf3qu"
+    className="kiali_fhxf3qu"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -499,7 +499,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 2`] = `
 exports[`ToolbarDropdown Render correctly all dropdowns 3`] = `
 <Fragment>
   <span
-    className="fzb2262"
+    className="kiali_fzb2262"
   >
     graph_filter_layouts
   </span>
@@ -509,7 +509,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 3`] = `
     aria-label="graph_filter_layouts"
     aria-labelledby="graph_filter_layouts"
     chipGroupComponent={null}
-    className="fhxf3qu"
+    className="kiali_fhxf3qu"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -639,7 +639,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 3`] = `
 exports[`ToolbarDropdown Render dropdowns correctly with controlled values and labels 1`] = `
 <Fragment>
   <span
-    className="fzb2262"
+    className="kiali_fzb2262"
   >
     graph_filter_interval_duration
   </span>
@@ -649,7 +649,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
     aria-label="graph_filter_interval_duration"
     aria-labelledby="graph_filter_interval_duration"
     chipGroupComponent={null}
-    className="fhxf3qu"
+    className="kiali_fhxf3qu"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -899,7 +899,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
 exports[`ToolbarDropdown Render dropdowns correctly with controlled values and labels 2`] = `
 <Fragment>
   <span
-    className="fzb2262"
+    className="kiali_fzb2262"
   >
     metrics_filter_poll_interval
   </span>
@@ -909,7 +909,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
     aria-label="metrics_filter_poll_interval"
     aria-labelledby="metrics_filter_poll_interval"
     chipGroupComponent={null}
-    className="fhxf3qu"
+    className="kiali_fhxf3qu"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -1135,7 +1135,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
 exports[`ToolbarDropdown Render dropdowns correctly with controlled values and labels 3`] = `
 <Fragment>
   <span
-    className="fzb2262"
+    className="kiali_fzb2262"
   >
     graph_filter_layouts
   </span>
@@ -1145,7 +1145,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
     aria-label="graph_filter_layouts"
     aria-labelledby="graph_filter_layouts"
     chipGroupComponent={null}
-    className="fhxf3qu"
+    className="kiali_fhxf3qu"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}

--- a/frontend/src/components/Tour/TourStop.tsx
+++ b/frontend/src/components/Tour/TourStop.tsx
@@ -7,7 +7,7 @@ import { KialiAppState } from 'store/Store';
 import ReactResizeDetector from 'react-resize-detector';
 import { KialiIcon } from 'config/KialiIcon';
 import { TourActions } from 'actions/TourActions';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from 'components/Pf/PfColors';
 
 export interface TourStopInfo {
@@ -24,7 +24,7 @@ export interface TourInfo {
   stops: Array<TourStopInfo>;
 }
 
-const stopNumberStyle = style({
+const stopNumberStyle = kialiStyle({
   borderRadius: '20px',
   backgroundColor: PFColors.Blue300,
   padding: '2px 6px',
@@ -97,7 +97,7 @@ class TourStopComponent extends React.PureComponent<TourStopProps> {
   };
 
   private nextButton = () => {
-    const right = style({
+    const right = kialiStyle({
       float: 'right'
     });
     const stop = this.getStop('forward');

--- a/frontend/src/components/TrafficList/TrafficListComponent.tsx
+++ b/frontend/src/components/TrafficList/TrafficListComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { IRow, sortable, SortByDirection, Table, TableBody, TableHeader, cellWidth } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import { TrafficItem, TrafficNode, TrafficDirection } from './TrafficDetails';
@@ -92,8 +92,8 @@ function LockIcon(props) {
 }
 
 // Style constants
-const containerPadding = style({ padding: '20px' });
-const lockIconStyle = style({ marginLeft: '5px' });
+const containerPadding = kialiStyle({ padding: '20px' });
+const lockIconStyle = kialiStyle({ marginLeft: '5px' });
 
 class TrafficList extends FilterComponent.Component<
   TrafficListComponentProps,

--- a/frontend/src/components/Validations/ServiceValidationSummary.tsx
+++ b/frontend/src/components/Validations/ServiceValidationSummary.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Text, TextVariants } from '@patternfly/react-core';
 import { ValidationSummary } from './ValidationSummary';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
-const tooltipListStyle = style({
+const tooltipListStyle = kialiStyle({
   textAlign: 'left',
   border: 0,
   padding: '0 0 0 0',

--- a/frontend/src/components/Validations/ValidationStack.tsx
+++ b/frontend/src/components/Validations/ValidationStack.tsx
@@ -3,15 +3,15 @@ import { ObjectCheck, ValidationTypes } from '../../types/IstioObjects';
 import { Validation } from './Validation';
 import { highestSeverity } from '../../types/ServiceInfo';
 import { Stack, StackItem, Text, TextVariants } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../Pf/PfColors';
 
 type Props = {
   checks?: ObjectCheck[];
 };
 
-const colorStyle = style({ color: PFColors.White });
-const titleStyle = style({ color: PFColors.White, fontSize: '1.1rem' });
+const colorStyle = kialiStyle({ color: PFColors.White });
+const titleStyle = kialiStyle({ color: PFColors.White, fontSize: '1.1rem' });
 
 export class ValidationStack extends React.Component<Props> {
   validationList() {

--- a/frontend/src/components/Validations/ValidationSummary.tsx
+++ b/frontend/src/components/Validations/ValidationSummary.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CSSProperties } from 'react';
 import { StatusCondition, ValidationTypes } from '../../types/IstioObjects';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Text, TextVariants, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Validation } from './Validation';
 
@@ -14,14 +14,14 @@ interface Props {
   style?: CSSProperties;
 }
 
-const tooltipListStyle = style({
+const tooltipListStyle = kialiStyle({
   textAlign: 'left',
   border: 0,
   padding: '0 0 0 0',
   margin: '0 0 0 0'
 });
 
-const tooltipSentenceStyle = style({
+const tooltipSentenceStyle = kialiStyle({
   textAlign: 'center',
   border: 0,
   padding: '0 0 0 0',

--- a/frontend/src/components/Validations/__tests__/__snapshots__/ServiceValidationSummary.test.tsx.snap
+++ b/frontend/src/components/Validations/__tests__/__snapshots__/ServiceValidationSummary.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ServiceValidationSummary renders error icon when all components are val
         Service validation result
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           1 error found
@@ -51,7 +51,7 @@ exports[`ServiceValidationSummary renders error icon when all components are val
         Service validation result
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           1 error found
@@ -88,7 +88,7 @@ exports[`ServiceValidationSummary renders success icon when all components are v
         Service validation result
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           No issues found
@@ -122,7 +122,7 @@ exports[`ServiceValidationSummary renders warning icon when all components are v
         Service validation result
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           1 warning found
@@ -156,7 +156,7 @@ exports[`ServiceValidationSummary renders warning icon when all components are v
         Service validation result
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           2 warnings found

--- a/frontend/src/components/Validations/__tests__/__snapshots__/ValidationSummary.test.tsx.snap
+++ b/frontend/src/components/Validations/__tests__/__snapshots__/ValidationSummary.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ValidationSummary renders N/A when all components are valid 1`] = `
   aria-label="Validations list"
   content={
     <Text
-      className="f12qq397"
+      className="kiali_f12qq397"
     >
       No Istio config objects found
     </Text>
@@ -44,7 +44,7 @@ exports[`ValidationSummary renders error icon when all components are valid 1`] 
         1
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           1 error found
@@ -79,7 +79,7 @@ exports[`ValidationSummary renders error icon when all components are valid 2`] 
         3
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           1 error found
@@ -117,7 +117,7 @@ exports[`ValidationSummary renders success icon when all components are valid 1`
         1
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           No issues found
@@ -152,7 +152,7 @@ exports[`ValidationSummary renders success icon when all components are valid 2`
         4
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           No issues found
@@ -187,7 +187,7 @@ exports[`ValidationSummary renders warning icon when all components are valid 1`
         1
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           1 warning found
@@ -222,7 +222,7 @@ exports[`ValidationSummary renders warning icon when all components are valid 2`
         3
       </Text>
       <div
-        className="fe0pf1n"
+        className="kiali_fe0pf1n"
       >
         <div>
           1 warning found

--- a/frontend/src/config/KialiIcon.tsx
+++ b/frontend/src/config/KialiIcon.tsx
@@ -19,7 +19,7 @@ import {
   CloseIcon,
   CodeBranchIcon,
   CompressIcon,
-  CopyIcon,  
+  CopyIcon,
   EllipsisHIcon,
   ErrorCircleOIcon,
   ExpandIcon,
@@ -57,13 +57,13 @@ import {
   WarningTriangleIcon,
   ProcessAutomationIcon
 } from '@patternfly/react-icons';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
-export const defaultIconStyle = style({
+export const defaultIconStyle = kialiStyle({
   // nothing special
 });
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   width: '10px'
 });
 
@@ -74,7 +74,7 @@ interface IconProps {
 
 // keep alphabetized
 export const KialiIcon: { [name: string]: React.FunctionComponent<IconProps> } = {
-  AddMore: (props: IconProps) => <PlusCircleIcon className={props.className} />,  
+  AddMore: (props: IconProps) => <PlusCircleIcon className={props.className} />,
   AngleDoubleDown: (props: IconProps) => <AngleDoubleDownIcon className={props.className} />,
   AngleDoubleLeft: (props: IconProps) => <AngleDoubleLeftIcon className={props.className} />,
   AngleDoubleRight: (props: IconProps) => <AngleDoubleRightIcon className={props.className} />,

--- a/frontend/src/pages/AppDetails/AppDescription.tsx
+++ b/frontend/src/pages/AppDetails/AppDescription.tsx
@@ -4,7 +4,7 @@ import { Card, CardBody, CardHeader, Title, TitleSizes, TooltipPosition } from '
 import { DetailDescription } from '../../components/DetailDescription/DetailDescription';
 import { isMultiCluster, serverConfig } from '../../config';
 import { Labels } from '../../components/Label/Labels';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import * as H from '../../types/Health';
 import { HealthIndicator } from '../../components/Health/HealthIndicator';
 import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
@@ -14,14 +14,14 @@ type AppDescriptionProps = {
   health?: H.Health;
 };
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   margin: '0 0 0 0',
   padding: '0 0 0 0',
   display: 'inline-block',
   verticalAlign: '2px !important'
 });
 
-const healthIconStyle = style({
+const healthIconStyle = kialiStyle({
   marginLeft: '10px',
   verticalAlign: '-1px !important'
 });

--- a/frontend/src/pages/AppDetails/AppInfo.tsx
+++ b/frontend/src/pages/AppDetails/AppInfo.tsx
@@ -6,7 +6,7 @@ import { RenderComponentScroll } from '../../components/Nav/Page';
 import { DurationInSeconds } from 'types/Common';
 import { GraphDataSource } from 'services/GraphDataSource';
 import { AppHealth } from 'types/Health';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { GraphEdgeTapEvent } from '../../components/CytoscapeGraph/CytoscapeGraph';
 import { history, URLParam } from '../../app/History';
 import { MiniGraphCard } from '../../components/CytoscapeGraph/MiniGraphCard';
@@ -23,7 +23,7 @@ type AppInfoState = {
   tabHeight?: number;
 };
 
-const fullHeightStyle = style({
+const fullHeightStyle = kialiStyle({
   height: '100%'
 });
 
@@ -73,7 +73,7 @@ export class AppInfo extends React.Component<AppInfoProps, AppInfoState> {
     // This height needs to be propagated to minigraph to proper resize in height
     // Graph resizes correctly on width
     const height = this.state.tabHeight ? this.state.tabHeight - 115 : 300;
-    const graphContainerStyle = style({ width: '100%', height: height });
+    const graphContainerStyle = kialiStyle({ width: '100%', height: height });
     const includeMiniGraphCy = serverConfig.kialiFeatureFlags.uiDefaults.graph.impl !== 'pf';
     const includeMiniGraphPF = serverConfig.kialiFeatureFlags.uiDefaults.graph.impl !== 'cy';
     const miniGraphSpan = includeMiniGraphCy && includeMiniGraphPF ? 4 : 8;

--- a/frontend/src/pages/Graph/GraphHelpFind.tsx
+++ b/frontend/src/pages/Graph/GraphHelpFind.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ReactResizeDetector from 'react-resize-detector';
 import { Tab, Popover, PopoverPosition } from '@patternfly/react-core';
 import { ICell, Table, TableBody, TableHeader, TableVariant, cellWidth } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
 
 export interface GraphHelpFindProps {
@@ -24,7 +24,7 @@ export class GraphHelpFind extends React.Component<GraphHelpFindProps> {
   render() {
     const width = '600px';
     const maxWidth = '604px';
-    const popoverStyle = style({
+    const popoverStyle = kialiStyle({
       width: width,
       maxWidth: maxWidth,
       height: '550px',
@@ -32,7 +32,7 @@ export class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       overflowX: 'auto',
       overflowY: 'auto'
     });
-    const prefaceStyle = style({
+    const prefaceStyle = kialiStyle({
       fontSize: '12px',
       color: '#fff',
       backgroundColor: '#003145',

--- a/frontend/src/pages/Graph/GraphLegend.tsx
+++ b/frontend/src/pages/Graph/GraphLegend.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { legendData, GraphLegendItem, GraphLegendItemRow } from './GraphLegendData';
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import CloseIcon from '@patternfly/react-icons/dist/js/icons/close-icon';
@@ -15,7 +15,7 @@ const width = '190px';
 
 export class GraphLegend extends React.Component<GraphLegendProps> {
   render() {
-    const legendBoxStyle = style({
+    const legendBoxStyle = kialiStyle({
       backgroundColor: PFColors.White,
       border: '1px #ddd solid',
       margin: '0 0 3.25em 0',
@@ -25,16 +25,16 @@ export class GraphLegend extends React.Component<GraphLegendProps> {
       zIndex: 3
     });
 
-    const headerStyle = style({
+    const headerStyle = kialiStyle({
       width: width
     });
 
-    const bodyStyle = style({
+    const bodyStyle = kialiStyle({
       height: 'auto',
       width: width
     });
 
-    const closeBoxStyle = style({
+    const closeBoxStyle = kialiStyle({
       float: 'right',
       margin: '-7px -5px 0 -10px'
     });
@@ -59,11 +59,11 @@ export class GraphLegend extends React.Component<GraphLegendProps> {
   }
 
   renderGraphLegendList(legendData: GraphLegendItem[]) {
-    const legendColumnHeadingStyle = style({
+    const legendColumnHeadingStyle = kialiStyle({
       fontWeight: 'bold',
       paddingTop: '1.25em'
     });
-    const aStyle = style({
+    const aStyle = kialiStyle({
       height: '100%'
     });
 
@@ -88,18 +88,18 @@ export class GraphLegend extends React.Component<GraphLegendProps> {
   static renderLegendIconAndLabel(legendItemRow: GraphLegendItemRow) {
     const keyWidth = '70px';
 
-    const keyStyle = style({
+    const keyStyle = kialiStyle({
       minWidth: keyWidth,
       width: keyWidth
     });
 
-    const legendItemStyle = style({
+    const legendItemStyle = kialiStyle({
       display: 'flex',
       flexDirection: 'row',
       padding: '5px 5px 0 5px'
     });
 
-    const legendItemLabelStyle = style({
+    const legendItemLabelStyle = kialiStyle({
       fontWeight: 'normal'
     });
 

--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import FlexView from 'react-flexview';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { history } from '../../app/History';
 import { DurationInSeconds, IntervalInMilliseconds, TimeInMilliseconds, TimeInSeconds } from '../../types/Common';
 import { MessageType } from '../../types/MessageCenter';
@@ -180,27 +180,27 @@ type GraphPageState = {
 
 const NUMBER_OF_DATAPOINTS = 30;
 
-const containerStyle = style({
+const containerStyle = kialiStyle({
   minHeight: '350px',
   // TODO: try flexbox to remove this calc
   height: 'calc(100vh - 113px)' // View height minus top bar height minus secondary masthead
 });
 
-const kioskContainerStyle = style({
+const kioskContainerStyle = kialiStyle({
   minHeight: '350px',
   height: 'calc(100vh - 10px)' // View height minus top bar height
 });
 
-const cytoscapeGraphContainerStyle = style({ flex: '1', minWidth: '350px', zIndex: 0, paddingRight: '5px' });
-const cytoscapeGraphWrapperDivStyle = style({ position: 'relative', backgroundColor: PFColors.Black200 });
-const cytoscapeToolbarWrapperDivStyle = style({
+const cytoscapeGraphContainerStyle = kialiStyle({ flex: '1', minWidth: '350px', zIndex: 0, paddingRight: '5px' });
+const cytoscapeGraphWrapperDivStyle = kialiStyle({ position: 'relative', backgroundColor: PFColors.Black200 });
+const cytoscapeToolbarWrapperDivStyle = kialiStyle({
   position: 'absolute',
   bottom: '5px',
   zIndex: 2,
   borderStyle: 'hidden'
 });
 
-const graphTimeRange = style({
+const graphTimeRange = kialiStyle({
   position: 'absolute',
   top: '10px',
   left: '10px',
@@ -209,15 +209,15 @@ const graphTimeRange = style({
   backgroundColor: PFColors.White
 });
 
-const whiteBackground = style({
+const whiteBackground = kialiStyle({
   backgroundColor: PFColors.White
 });
 
-const replayBackground = style({
+const replayBackground = kialiStyle({
   backgroundColor: PFColors.Replay
 });
 
-const graphLegendStyle = style({
+const graphLegendStyle = kialiStyle({
   right: '0',
   bottom: '10px',
   position: 'absolute',

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -10,7 +10,7 @@ import * as CytoscapeGraphUtils from '../../../components/CytoscapeGraph/Cytosca
 import { EdgeLabelMode, NodeType, Layout, EdgeMode, EdgeAttr, NodeAttr } from '../../../types/Graph';
 import * as AlertUtils from '../../../utils/AlertUtils';
 import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { TourStop } from 'components/Tour/TourStop';
 import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
 import { TimeInMilliseconds } from 'types/Common';
@@ -67,13 +67,13 @@ const inputWidth = {
 };
 
 // reduce toolbar padding from 20px to 10px to save space
-const thinGroupStyle = style({
+const thinGroupStyle = kialiStyle({
   paddingLeft: '10px',
   paddingRight: '10px'
 });
 
 // styles for clear button
-const buttonClearStyle = style({
+const buttonClearStyle = kialiStyle({
   minWidth: '20px',
   width: '20px',
   paddingLeft: '5px',
@@ -498,7 +498,7 @@ export class GraphFindComponent extends React.Component<GraphFindProps, GraphFin
 
     // unhide hidden elements when we are dealing with the same graph. Either way,release for garbage collection
     if (!!this.hiddenElements && !graphChanged) {
-      this.hiddenElements.style({ visibility: 'visible' });
+      this.hiddenElements.kialiStyle({ visibility: 'visible' });
     }
     this.hiddenElements = undefined;
 
@@ -557,13 +557,13 @@ export class GraphFindComponent extends React.Component<GraphFindProps, GraphFin
       } else {
         // set the remaining hide-hits hidden
         this.hiddenElements = hiddenElements;
-        this.hiddenElements.style({ visibility: 'hidden' });
+        this.hiddenElements.kialiStyle({ visibility: 'hidden' });
         // now subtract any visible boxes that don't have any visible children
         let done = false;
         while (!done) {
           const emptyBoxes = cy.$('$node[isBox]:visible').subtract(cy.$('$node[isBox] > :visible'));
           if (emptyBoxes.length > 0) {
-            emptyBoxes.style({ visibility: 'hidden' });
+            emptyBoxes.kialiStyle({ visibility: 'hidden' });
             this.hiddenElements = this.hiddenElements.add(emptyBoxes);
           } else {
             done = true;

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
@@ -2,7 +2,7 @@ import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
 import * as React from 'react';
 import { KialiIcon } from 'config/KialiIcon';
 import { serverConfig } from 'config';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type FindKind = 'find' | 'hide';
 
@@ -13,7 +13,7 @@ type GraphFindOptionsProps = {
 
 type GraphFindOptionsState = { isOpen: boolean };
 
-const dropdown = style({
+const dropdown = kialiStyle({
   minWidth: '20px',
   width: '20px',
   paddingLeft: '5px',

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
@@ -11,7 +11,7 @@ import * as CytoscapeGraphUtils from '../../../components/CytoscapeGraph/Cytosca
 import { EdgeLabelMode, NodeType, Layout, EdgeMode, NodeAttr, EdgeAttr } from '../../../types/Graph';
 import * as AlertUtils from '../../../utils/AlertUtils';
 import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { TourStop } from 'components/Tour/TourStop';
 import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
 import { TimeInMilliseconds } from 'types/Common';
@@ -78,13 +78,13 @@ const inputWidth = {
 };
 
 // reduce toolbar padding from 20px to 10px to save space
-const thinGroupStyle = style({
+const thinGroupStyle = kialiStyle({
   paddingLeft: '10px',
   paddingRight: '10px'
 });
 
 // styles for clear button
-const buttonClearStyle = style({
+const buttonClearStyle = kialiStyle({
   minWidth: '20px',
   width: '20px',
   paddingLeft: '5px',

--- a/frontend/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SecondaryMasthead } from 'components/Nav/SecondaryMasthead';
 import { NamespaceDropdown } from 'components/NamespaceDropdown';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { TourStop } from 'components/Tour/TourStop';
 import { GraphTourStops } from '../GraphHelpTour';
 import { ToolbarDropdown } from 'components/ToolbarDropdown/ToolbarDropdown';
@@ -19,23 +19,23 @@ type GraphSecondaryMastheadProps = {
   onGraphTypeChange: (graphType: GraphType) => void;
 };
 
-const mastheadStyle = style({
+const mastheadStyle = kialiStyle({
   marginLeft: '-20px',
   marginRight: '-40px'
 });
 
-const leftSpacerStyle = style({
+const leftSpacerStyle = kialiStyle({
   marginLeft: '10px'
 });
 
-const vrStyle = style({
+const vrStyle = kialiStyle({
   border: '1px inset',
   height: '20px',
   margin: '4px 0 0 10px',
   width: '1px'
 });
 
-const rightToolbarStyle = style({
+const rightToolbarStyle = kialiStyle({
   float: 'right'
 });
 

--- a/frontend/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/frontend/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`GraphLegend test should render correctly 1`] = `
 <div
-  className="fsg7me4"
+  className="kiali_fsg7me4"
   data-test="graph-legend"
   style={
     Object {
@@ -11,13 +11,13 @@ exports[`GraphLegend test should render correctly 1`] = `
   }
 >
   <div
-    className="fsgo6a1 f1bv0l2s"
+    className="kiali_fsgo6a1 kiali_f1bv0l2s"
   >
     <span>
       Legend
     </span>
     <span
-      className="f1blspom"
+      className="kiali_f1blspom"
     >
       <Tooltip
         content="Close Legend"
@@ -37,23 +37,23 @@ exports[`GraphLegend test should render correctly 1`] = `
     </span>
   </div>
   <div
-    className="f6nw80o"
+    className="kiali_f6nw80o"
   >
     <div>
       <div
-        className="f10krlro"
+        className="kiali_f10krlro"
       >
         <div
-          className="fng0jlu"
+          className="kiali_fng0jlu"
           key="Node Shapes"
         >
           Node Shapes
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Workload"
@@ -61,17 +61,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Workload
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="app.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="App"
@@ -79,17 +79,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               App
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="aggregate.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Operation"
@@ -97,17 +97,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Operation
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="service.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Service"
@@ -115,17 +115,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Service
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="service-entry.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Service Entry"
@@ -133,23 +133,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Service Entry
             </span>
           </div>
         </div>
         <div
-          className="fng0jlu"
+          className="kiali_fng0jlu"
           key="Node Colors"
         >
           Node Colors
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-color-normal.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Normal"
@@ -157,17 +157,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Normal
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-color-warning.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Warn"
@@ -175,17 +175,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Warn
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-color-danger.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Danger"
@@ -193,17 +193,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Danger
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-color-idle.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Idle"
@@ -211,23 +211,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Idle
             </span>
           </div>
         </div>
         <div
-          className="fng0jlu"
+          className="kiali_fng0jlu"
           key="Node Background"
         >
           Node Background
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="external-namespace.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Unselected Namespace"
@@ -235,17 +235,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Unselected Namespace
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="restricted-namespace.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Restricted / External"
@@ -253,23 +253,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Restricted / External
             </span>
           </div>
         </div>
         <div
-          className="fng0jlu"
+          className="kiali_fng0jlu"
           key="Edges"
         >
           Edges
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="edge-danger.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Failure"
@@ -277,17 +277,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Failure
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="edge-warn.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Degraded"
@@ -295,17 +295,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Degraded
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="edge-success.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Healthy"
@@ -313,17 +313,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Healthy
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="edge-tcp.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="TCP Connection"
@@ -331,17 +331,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               TCP Connection
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="edge-idle.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Idle"
@@ -349,17 +349,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Idle
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="mtls-badge.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="mTLS (badge)"
@@ -367,23 +367,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               mTLS (badge)
             </span>
           </div>
         </div>
         <div
-          className="fng0jlu"
+          className="kiali_fng0jlu"
           key="Traffic Animation"
         >
           Traffic Animation
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="traffic-normal-request.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Normal Request"
@@ -391,17 +391,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Normal Request
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="traffic-failed-request.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Failed Request"
@@ -409,17 +409,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Failed Request
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="traffic-tcp.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="TCP Traffic"
@@ -427,23 +427,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               TCP Traffic
             </span>
           </div>
         </div>
         <div
-          className="fng0jlu"
+          className="kiali_fng0jlu"
           key="Node Badges"
         >
           Node Badges
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-circuit-breaker.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Circuit Breaker"
@@ -451,17 +451,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Circuit Breaker
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-fault-injection.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Fault Injection"
@@ -469,17 +469,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Fault Injection
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-gateways.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Gateway"
@@ -487,17 +487,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Gateway
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-mirroring.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Mirroring"
@@ -505,17 +505,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Mirroring
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-missing-sidecar.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Missing Sidecar"
@@ -523,17 +523,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Missing Sidecar
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-request-timeout.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Request Timeout"
@@ -541,17 +541,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Request Timeout
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-traffic-shifting.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Traffic Shifting / TCP Traffic Shifting"
@@ -559,17 +559,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Traffic Shifting / TCP Traffic Shifting
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-traffic-source.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Traffic Source"
@@ -577,17 +577,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Traffic Source
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-virtual-services.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Virtual Service / Request Routing"
@@ -595,17 +595,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Virtual Service / Request Routing
             </span>
           </div>
           <div
-            className="f13es1gb"
+            className="kiali_f13es1gb"
             key="node-badge-workload-entry.svg"
           >
             <span
-              className="f1irbq61"
+              className="kiali_f1irbq61"
             >
               <img
                 alt="Workload Entry"
@@ -613,7 +613,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="fgzdi7m"
+              className="kiali_fgzdi7m"
             >
               Workload Entry
             </span>

--- a/frontend/src/pages/Graph/SummaryPanel.tsx
+++ b/frontend/src/pages/Graph/SummaryPanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { SummaryPanelEdge } from './SummaryPanelEdge';
 import { SummaryPanelGraph } from './SummaryPanelGraph';
 import { SummaryPanelAppBox } from './SummaryPanelAppBox';
@@ -40,17 +40,17 @@ type MainSummaryPanelPropType = SummaryPanelPropType & {
   ) => void;
 };
 
-const mainStyle = style({
+const mainStyle = kialiStyle({
   fontSize: 'var(--graph-side-panel--font-size)',
   padding: '0',
   position: 'relative'
 });
 
-const expandedStyle = style({ height: '100%' });
+const expandedStyle = kialiStyle({ height: '100%' });
 
-const expandedHalfStyle = style({ height: '50%' });
+const expandedHalfStyle = kialiStyle({ height: '50%' });
 
-const collapsedStyle = style({
+const collapsedStyle = kialiStyle({
   $nest: {
     '& > .panel': {
       display: 'none'
@@ -58,14 +58,14 @@ const collapsedStyle = style({
   }
 });
 
-const summaryPanelBottomSplit = style({
+const summaryPanelBottomSplit = kialiStyle({
   height: '50%',
   width: summaryPanelWidth,
   minWidth: summaryPanelWidth,
   overflowY: 'auto'
 });
 
-const toggleSidePanelStyle = style({
+const toggleSidePanelStyle = kialiStyle({
   backgroundColor: 'white',
   border: '1px #ddd solid',
   borderRadius: '3px',

--- a/frontend/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tab, Tooltip } from '@patternfly/react-core';
 import { Node } from '@patternfly/react-topology';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { summaryFont, summaryHeader, summaryBodyTabs, summaryPanelWidth, getTitle } from './SummaryPanelCommon';
 import { RateTableGrpc, RateTableHttp, RateTableTcp } from 'components/SummaryPanel/RateTable';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
@@ -25,7 +25,7 @@ const defaultState: SummaryPanelClusterBoxState = {
   clusterBox: null
 };
 
-const topologyStyle = style({
+const topologyStyle = kialiStyle({
   margin: '0 1em'
 });
 

--- a/frontend/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelCommon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { NodeType, SummaryPanelPropType, Protocol, DecoratedGraphNodeData, BoxByType } from '../../types/Graph';
 import { IstioMetricsOptions, Reporter, Direction } from '../../types/MetricsOptions';
 import * as API from '../../services/Api';
@@ -17,7 +17,7 @@ export enum NodeMetricType {
   NAMESPACE = 6
 }
 
-export const summaryBodyTabs = style({
+export const summaryBodyTabs = kialiStyle({
   padding: '10px 15px 0 15px'
 });
 
@@ -27,7 +27,7 @@ export const summaryHeader: React.CSSProperties = {
 
 export const summaryPanelWidth = '25em';
 
-export const summaryPanel = style({
+export const summaryPanel = kialiStyle({
   backgroundColor: PFColors.White,
   fontSize: 'var(--graph-side-panel--font-size)',
   height: '100%',
@@ -43,7 +43,7 @@ export const summaryFont: React.CSSProperties = {
   fontSize: 'var(--graph-side-panel--font-size)'
 };
 
-export const summaryTitle = style({
+export const summaryTitle = kialiStyle({
   fontWeight: 'bolder',
   marginBottom: '5px',
   textAlign: 'left'

--- a/frontend/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelEdge.tsx
@@ -37,7 +37,7 @@ import { KialiIcon } from 'config/KialiIcon';
 import { Tab, Tooltip } from '@patternfly/react-core';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
 import { Direction } from 'types/MetricsOptions';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Edge } from '@patternfly/react-topology';
 
 type SummaryPanelEdgeMetricsState = {
@@ -77,7 +77,7 @@ const defaultState: SummaryPanelEdgeState = {
   ...defaultMetricsState
 };
 
-const principalStyle = style({
+const principalStyle = kialiStyle({
   display: 'inline-block',
   overflow: 'hidden',
   textOverflow: 'ellipsis',

--- a/frontend/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelGraph.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tab, Tooltip } from '@patternfly/react-core';
 import { Node, Visualization } from '@patternfly/react-topology';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import _ from 'lodash';
 import { RateTableGrpc, RateTableHttp, RateTableTcp } from '../../components/SummaryPanel/RateTable';
 import { RequestChart, StreamChart } from '../../components/SummaryPanel/RpsChart';
@@ -109,7 +109,7 @@ const defaultState: SummaryPanelGraphState = {
   ...defaultMetricsState
 };
 
-const topologyStyle = style({
+const topologyStyle = kialiStyle({
   margin: '0 1em'
 });
 

--- a/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tab, Tooltip } from '@patternfly/react-core';
 import { Node } from '@patternfly/react-topology';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { RateTableGrpc, RateTableHttp, RateTableTcp } from '../../components/SummaryPanel/RateTable';
 import { RequestChart, StreamChart } from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType, NodeType, TrafficRate, Protocol, UNKNOWN, NodeAttr } from '../../types/Graph';
@@ -104,7 +104,7 @@ const defaultState: SummaryPanelNamespaceBoxState = {
   ...defaultMetricsState
 };
 
-const topologyStyle = style({
+const topologyStyle = kialiStyle({
   margin: '0 1em'
 });
 

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -26,7 +26,8 @@ import { SummaryPanelNodeTraffic } from './SummaryPanelNodeTraffic';
 import { SummaryPanelNodeTraces } from './SummaryPanelNodeTraces';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
 import { JaegerState } from 'reducers/JaegerState';
-import { classes, style } from 'typestyle';
+import { classes } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { ServiceDetailsInfo } from 'types/ServiceInfo';
 import { LoadingWizardActionsDropdownGroup } from 'components/IstioWizards/LoadingWizardActionsDropdownGroup';
@@ -71,7 +72,7 @@ export type SummaryPanelNodeComponentProps = ReduxProps &
     serviceDetails: ServiceDetailsInfo | null | undefined;
   };
 
-const expandableSectionStyle = style({
+const expandableSectionStyle = kialiStyle({
   fontSize: 'var(--graph-side-panel--font-size)',
   paddingLeft: '1em',
   $nest: {
@@ -89,7 +90,7 @@ const expandableSectionStyle = style({
   }
 });
 
-const workloadExpandableSectionStyle = classes(expandableSectionStyle, style({ display: 'inline' }));
+const workloadExpandableSectionStyle = classes(expandableSectionStyle, kialiStyle({ display: 'inline' }));
 
 export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeComponentProps, SummaryPanelNodeState> {
   private readonly mainDivRef: React.RefObject<HTMLDivElement>;

--- a/frontend/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { SimpleList, SimpleListItem, Button, Checkbox, Divider, ButtonVariant } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 import { KialiAppState } from 'store/Store';
 import { JaegerThunkActions } from 'actions/JaegerThunkActions';
@@ -38,12 +38,12 @@ type State = {
 
 const tracesLimit = 15;
 
-const refreshDivStyle = style({
+const refreshDivStyle = kialiStyle({
   display: 'inline-flex',
   width: '100%'
 });
 
-const checkboxStyle = style({
+const checkboxStyle = kialiStyle({
   paddingBottom: 10,
   $nest: {
     '& > label': {
@@ -53,13 +53,13 @@ const checkboxStyle = style({
   }
 });
 
-const refreshButtonStyle = style({
+const refreshButtonStyle = kialiStyle({
   padding: '2px 10px',
   margin: '5px 0 5px auto',
   top: -4
 });
 
-const dividerStyle = style({
+const dividerStyle = kialiStyle({
   paddingBottom: '3px'
 });
 

--- a/frontend/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Tooltip, Button, ButtonVariant, pluralize, SelectOption } from '@patternfly/react-core';
 import {
   InfoAltIcon,
@@ -50,12 +50,12 @@ type State = {
   selectedSpanID: string | undefined;
 };
 
-const closeBoxStyle = style({
+const closeBoxStyle = kialiStyle({
   float: 'right',
   marginTop: '-7px'
 });
 
-const nameStyle = style({
+const nameStyle = kialiStyle({
   display: 'inline-block',
   maxWidth: '95%',
   textOverflow: 'ellipsis',
@@ -63,11 +63,11 @@ const nameStyle = style({
   whiteSpace: 'nowrap'
 });
 
-const pStyle = style({
+const pStyle = kialiStyle({
   paddingTop: 9
 });
 
-const spanSelectStyle = style({
+const spanSelectStyle = kialiStyle({
   $nest: {
     '& > button': {
       fontSize: 'var(--graph-side-panel--font-size)',

--- a/frontend/src/pages/GraphPF/GraphPagePF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPagePF.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import FlexView from 'react-flexview';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { DurationInSeconds, IntervalInMilliseconds, TimeInMilliseconds, TimeInSeconds } from '../../types/Common';
 import { Namespace } from '../../types/Namespace';
 import {
@@ -165,21 +165,21 @@ type GraphPageStatePF = {
 
 const NUMBER_OF_DATAPOINTS = 30;
 
-const containerStyle = style({
+const containerStyle = kialiStyle({
   minHeight: '350px',
   // TODO: try flexbox to remove this calc
   height: 'calc(100vh - 113px)' // View height minus top bar height minus secondary masthead
 });
 
-const kioskContainerStyle = style({
+const kioskContainerStyle = kialiStyle({
   minHeight: '350px',
   height: 'calc(100vh - 10px)' // View height minus top bar height
 });
 
-const graphContainerStyle = style({ flex: '1', minWidth: '350px', zIndex: 0, paddingRight: '5px' });
-const graphWrapperDivStyle = style({ position: 'relative', backgroundColor: PFColors.Black200 });
+const graphContainerStyle = kialiStyle({ flex: '1', minWidth: '350px', zIndex: 0, paddingRight: '5px' });
+const graphWrapperDivStyle = kialiStyle({ position: 'relative', backgroundColor: PFColors.Black200 });
 
-const graphTimeRange = style({
+const graphTimeRange = kialiStyle({
   position: 'absolute',
   top: '10px',
   left: '10px',
@@ -188,15 +188,15 @@ const graphTimeRange = style({
   backgroundColor: PFColors.White
 });
 
-const whiteBackground = style({
+const whiteBackground = kialiStyle({
   backgroundColor: PFColors.White
 });
 
-const replayBackground = style({
+const replayBackground = kialiStyle({
   backgroundColor: PFColors.Replay
 });
 
-const graphLegendStyle = style({
+const graphLegendStyle = kialiStyle({
   right: '0',
   bottom: '10px',
   position: 'absolute',

--- a/frontend/src/pages/GraphPF/components/edge.tsx
+++ b/frontend/src/pages/GraphPF/components/edge.tsx
@@ -24,7 +24,7 @@ import DefaultConnectorTag from '@patternfly/react-topology/dist/esm/components/
 import { getConnectorStartPoint } from '@patternfly/react-topology/dist/esm/components/edges/terminals/terminalUtils';
 import { EdgeData } from '../GraphPFElems';
 import { PFColors } from 'components/Pf/PfColors';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 // This is a copy of PFT DefaultEdge (v4.68.3), then modified.  I don't see a better way to really
 // do this because DefaultEdge doesn't really seem itself extensible and to add certain behavior you have
@@ -133,7 +133,7 @@ const BaseEdgeComponent: React.FunctionComponent<BaseEdgeProps> = ({
 
   const data = element.getData() as EdgeData;
   const pathStyle: React.CSSProperties = data.pathStyle || {};
-  const terminatorFill = style({
+  const terminatorFill = kialiStyle({
     fill: data.pathStyle?.stroke
   });
   const customEndTerminalClass = css(endTerminalClass, terminatorFill);

--- a/frontend/src/pages/GraphPF/components/node.tsx
+++ b/frontend/src/pages/GraphPF/components/node.tsx
@@ -36,7 +36,7 @@ import {
   NODE_SHADOW_FILTER_ID_HOVER
 } from '@patternfly/react-topology/dist/esm/components/nodes/NodeShadows';
 import { PFColors } from 'components/Pf/PfColors';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 // This is a copy of PFT DefaultNode (v4.68.3), then modified.  I don't see a better way to really
 // do this because DefaultNode doesn't really seem itself extensible and to add certain behavior you have
@@ -306,13 +306,13 @@ const BaseNodeComponent: React.FunctionComponent<BaseNodeProps> = ({
   const OverlayWidth = 40;
   const UnhighlightOpacity = 0.1;
 
-  const findOverlayStyle = style({
+  const findOverlayStyle = kialiStyle({
     strokeWidth: OverlayWidth,
     stroke: ColorFind,
     strokeOpacity: OverlayOpacity
   });
 
-  const traceOverlayStyle = style({
+  const traceOverlayStyle = kialiStyle({
     strokeWidth: OverlayWidth,
     stroke: ColorSpan,
     strokeOpacity: OverlayOpacity

--- a/frontend/src/pages/GraphPF/styles/styleEdge.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleEdge.tsx
@@ -2,7 +2,7 @@ import { Edge, observer, ScaleDetailsLevel, WithSelectionProps } from '@patternf
 import { BaseEdge } from '../components/edge';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 // This is the registered Edge component override that utilizes our customized Edge.tsx component.
 
@@ -10,7 +10,7 @@ type StyleEdgeProps = {
   element: Edge;
 } & WithSelectionProps;
 
-const tagClass = style({
+const tagClass = kialiStyle({
   fontFamily: 'Verdana,Arial,Helvetica,sans-serif,pficon'
 });
 

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -30,7 +30,7 @@ import { history } from '../../app/History';
 import { Paths } from '../../config';
 import { MessageType } from '../../types/MessageCenter';
 import { getIstioObject, mergeJsonPatch } from '../../utils/IstioConfigUtils';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { ParameterizedTabs, activeTab } from '../../components/Tab/Tabs';
 import {
   Drawer,
@@ -59,11 +59,11 @@ import { connect } from 'react-redux';
 // Enables the search box for the ACEeditor
 require('ace-builds/src-noconflict/ext-searchbox');
 
-const rightToolbarStyle = style({
+const rightToolbarStyle = kialiStyle({
   zIndex: 500
 });
 
-const editorDrawer = style({
+const editorDrawer = kialiStyle({
   margin: '0'
 });
 

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -16,7 +16,7 @@ import {
   ValidationTypes,
   WorkloadReference
 } from 'types/IstioObjects';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { getIstioObject, getReconciliationCondition } from 'utils/IstioConfigUtils';
 import { IstioConfigHelp } from './IstioConfigHelp';
 import { IstioConfigReferences } from './IstioConfigReferences';
@@ -42,29 +42,29 @@ interface IstioConfigOverviewProps {
   istioAPIEnabled: boolean;
 }
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   margin: '0 0 0 0',
   padding: '0 0 0 0',
   display: 'inline-block',
   verticalAlign: '2px !important'
 });
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 0px 2px 10px',
   verticalAlign: '-5px !important'
 });
 
-const warnStyle = style({
+const warnStyle = kialiStyle({
   margin: '0px 0px 2px 0px',
   verticalAlign: '-3px !important'
 });
 
-const healthIconStyle = style({
+const healthIconStyle = kialiStyle({
   marginLeft: '10px',
   verticalAlign: '-1px !important'
 });
 
-const resourceListStyle = style({
+const resourceListStyle = kialiStyle({
   margin: '0px 0 11px 0',
   $nest: {
     '& > ul > li > span': {

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -3,14 +3,14 @@ import { IstioLevelToSeverity, ObjectCheck, ValidationMessage, ValidationTypes }
 import { Flex, FlexItem, Stack, StackItem, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Validation } from '../../../components/Validations/Validation';
 import { KialiIcon } from '../../../config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 interface Props {
   messages?: ValidationMessage[];
   checks?: ObjectCheck[];
 }
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   verticalAlign: '-0.125em !important'
 });
 

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { isValidIp } from '../../../../utils/IstioConfigUtils';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../../components/Pf/PfColors';
 import { isValid } from 'utils/Common';
 
@@ -38,7 +38,7 @@ const INIT_SOURCE_FIELDS = [
   'notIpBlocks'
 ].sort();
 
-const noSourceStyle = style({
+const noSourceStyle = kialiStyle({
   color: PFColors.Red100
 });
 

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../../components/Pf/PfColors';
 
 type Props = {
@@ -20,7 +20,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-const noSourceStyle = style({
+const noSourceStyle = kialiStyle({
   marginTop: 10,
   color: PFColors.Red100,
   textAlign: 'center',

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
@@ -6,7 +6,7 @@ import { OperationBuilder } from './To/OperationBuilder';
 import { OperationList } from './To/OperationList';
 import { ConditionBuilder, Condition } from './When/ConditionBuilder';
 import { ConditionList } from './When/ConditionList';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { PFColors } from '../../../components/Pf/PfColors';
 
@@ -29,13 +29,13 @@ type State = {
   conditionList: Condition[];
 };
 
-const warningStyle = style({
+const warningStyle = kialiStyle({
   marginLeft: 25,
   color: PFColors.Red100,
   textAlign: 'center'
 });
 
-const addRuleStyle = style({
+const addRuleStyle = kialiStyle({
   marginLeft: 0,
   paddingLeft: 0
 });

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Rule } from './RuleBuilder';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../components/Pf/PfColors';
 
 type Props = {
@@ -32,11 +32,11 @@ const headerCells: ICell[] = [
   }
 ];
 
-const rulesPadding = style({
+const rulesPadding = kialiStyle({
   paddingLeft: 10
 });
 
-const noRulesStyle = style({
+const noRulesStyle = kialiStyle({
   marginTop: 10,
   color: PFColors.Red100,
   textAlign: 'center',

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../../components/Pf/PfColors';
 
 type Props = {
@@ -20,7 +20,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-const noOperationsStyle = style({
+const noOperationsStyle = kialiStyle({
   marginTop: 10,
   color: PFColors.Red100,
   textAlign: 'center',

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
@@ -4,7 +4,7 @@ import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/rea
 import { Button, ButtonVariant, TextInputBase as TextInput } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { isValidRequestHeaderName, isValidRequestAuthClaimName } from '../../../../helpers/ValidationHelpers';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../../components/Pf/PfColors';
 import { isValidIp } from '../../../../utils/IstioConfigUtils';
 import { isValid } from 'utils/Common';
@@ -41,7 +41,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-const noValidKeyStyle = style({
+const noValidKeyStyle = kialiStyle({
   color: PFColors.Red100
 });
 

--- a/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
+++ b/frontend/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Condition } from './ConditionBuilder';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../../components/Pf/PfColors';
 
 type Props = {
@@ -21,7 +21,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-const noConditionsStyle = style({
+const noConditionsStyle = kialiStyle({
   marginTop: 10,
   color: PFColors.Red100,
   textAlign: 'center',

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/AddressList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/AddressList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Address } from '../../../types/IstioObjects';
 import { cellWidth, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { AddressBuilder } from './AddressBuilder';
@@ -12,14 +12,14 @@ type Props = {
   onChange: (address: Address[]) => void;
 };
 
-const noAddressStyle = style({
+const noAddressStyle = kialiStyle({
   marginTop: 10,
   color: PFColors.Red100,
   textAlign: 'center',
   width: '100%'
 });
 
-const addAddressStyle = style({
+const addAddressStyle = kialiStyle({
   marginLeft: 0,
   paddingLeft: 0
 });

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cellWidth, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../components/Pf/PfColors';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
@@ -14,14 +14,14 @@ type Props = {
   listeners: Listener[];
 };
 
-const noListenerStyle = style({
+const noListenerStyle = kialiStyle({
   marginTop: 10,
   color: PFColors.Red100,
   textAlign: 'center',
   width: '100%'
 });
 
-const addListenerStyle = style({
+const addListenerStyle = kialiStyle({
   marginLeft: 0,
   paddingLeft: 0
 });

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ServerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ServerList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Server, ServerForm } from '../../../types/IstioObjects';
 import { cellWidth, Tbody, Td, Th, Thead, Tr, TableComposable } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../components/Pf/PfColors';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
@@ -13,7 +13,7 @@ type Props = {
   onChange: (server: Server[], serverForm: ServerForm[]) => void;
 };
 
-const noServerStyle = style({
+const noServerStyle = kialiStyle({
   marginTop: 10,
   color: PFColors.Red100,
   textAlign: 'center',
@@ -32,7 +32,7 @@ const headerCells = [
   }
 ];
 
-const addServerStyle = style({
+const addServerStyle = kialiStyle({
   marginLeft: 0,
   paddingLeft: 0
 });

--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { Namespace } from '../../types/Namespace';
 import { ActionGroup, Button, ButtonVariant, Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { RenderContent } from '../../components/Nav/Page';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { GatewayForm, GATEWAY, GATEWAYS, GatewayState, initGateway, isGatewayStateValid } from './GatewayForm';
 import {
   K8sGatewayForm,
@@ -89,9 +89,9 @@ type State = {
   sidecar: SidecarState;
 };
 
-const formPadding = style({ padding: '30px 20px 30px 20px' });
+const formPadding = kialiStyle({ padding: '30px 20px 30px 20px' });
 
-const warningStyle = style({
+const warningStyle = kialiStyle({
   marginLeft: 15,
   paddingTop: 5,
   color: PFColors.Red100,

--- a/frontend/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
@@ -3,12 +3,12 @@ import { Button, ButtonVariant, FormGroup, FormSelect, FormSelectOption, Switch 
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { PeerAuthenticationMutualTLSMode } from '../../types/IstioObjects';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../components/Pf/PfColors';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { isValid } from 'utils/Common';
 
-const noPortMtlsStyle = style({
+const noPortMtlsStyle = kialiStyle({
   marginTop: 15,
   color: PFColors.Red100
 });

--- a/frontend/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
@@ -4,7 +4,7 @@ import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/rea
 import { Button, ButtonVariant, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../components/Pf/PfColors';
 import { isValidUrl } from '../../../utils/IstioConfigUtils';
 
@@ -47,11 +47,11 @@ const headerCells: ICell[] = [
   }
 ];
 
-const noValidStyle = style({
+const noValidStyle = kialiStyle({
   color: PFColors.Red100
 });
 
-const warningStyle = style({
+const warningStyle = kialiStyle({
   marginLeft: 25,
   color: PFColors.Red100,
   textAlign: 'center'

--- a/frontend/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleList.tsx
+++ b/frontend/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleList.tsx
@@ -1,6 +1,6 @@
 import { JWTRule } from '../../../types/IstioObjects';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../../components/Pf/PfColors';
 import * as React from 'react';
 import { formatJwtField } from './JwtRuleBuilder';
@@ -22,7 +22,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-const noJWTRulesStyle = style({
+const noJWTRulesStyle = kialiStyle({
   marginTop: 10,
   color: PFColors.Red100,
   textAlign: 'center',

--- a/frontend/src/pages/IstioConfigNew/ServiceEntryForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/ServiceEntryForm.tsx
@@ -5,7 +5,7 @@ import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/compo
 import { isGatewayHostValid } from '../../utils/IstioConfigUtils';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../components/Pf/PfColors';
 import { isValid } from 'utils/Common';
 import { FormEvent } from 'react';
@@ -53,7 +53,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-const noPortsStyle = style({
+const noPortsStyle = kialiStyle({
   marginTop: 15,
   color: PFColors.Red100
 });

--- a/frontend/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../components/Pf/PfColors';
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
 import { Button, ButtonVariant, FormGroup, Switch, TextInputBase as TextInput } from '@patternfly/react-core';
@@ -20,7 +20,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-const noEgressHostsStyle = style({
+const noEgressHostsStyle = kialiStyle({
   marginTop: 15,
   color: PFColors.Red100
 });

--- a/frontend/src/pages/Mesh/MeshPage.tsx
+++ b/frontend/src/pages/Mesh/MeshPage.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { StarIcon } from '@patternfly/react-icons';
 import { cellWidth, sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 import { DefaultSecondaryMasthead } from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import { RenderContent } from '../../components/Nav/Page';
@@ -23,7 +23,7 @@ export const MeshPage: React.FunctionComponent = () => {
   const [meshClustersList, setMeshClustersList] = React.useState(null as MeshClusters | null);
   const [sortBy, setSortBy] = React.useState({ index: 0, direction: SortByDirection.asc });
 
-  const containerPadding = style({ padding: '20px' });
+  const containerPadding = kialiStyle({ padding: '20px' });
   const columns = [
     {
       title: 'Cluster Name',

--- a/frontend/src/pages/Overview/CanaryUpgradeProgress.tsx
+++ b/frontend/src/pages/Overview/CanaryUpgradeProgress.tsx
@@ -3,13 +3,13 @@ import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from 'config/KialiIcon';
 import * as React from 'react';
 import { CanaryUpgradeStatus } from 'types/IstioObjects';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type Props = {
   canaryUpgradeStatus: CanaryUpgradeStatus;
 };
 
-export const infoStyle = style({
+export const infoStyle = kialiStyle({
   margin: '0px 0px -1px 4px'
 });
 

--- a/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
+++ b/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
@@ -11,10 +11,10 @@ import { DurationInSeconds } from 'types/Common';
 import { getName } from 'utils/RateIntervals';
 import { Card, CardBody, Flex, FlexItem, Grid, GridItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from 'config/KialiIcon';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { IstiodResourceThresholds } from 'types/IstioStatus';
 
-export const infoStyle = style({
+export const infoStyle = kialiStyle({
   margin: '0px 0px -1px 4px'
 });
 

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -16,7 +16,7 @@ import {
   Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { AxiosError } from 'axios';
 import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
 import * as FilterHelper from '../../components/FilterList/FilterHelper';
@@ -79,13 +79,13 @@ import { ControlPlaneVersionBadge } from './ControlPlaneVersionBadge';
 import { AmbientBadge } from '../../components/Ambient/AmbientBadge';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
-const gridStyleCompact = style({
+const gridStyleCompact = kialiStyle({
   backgroundColor: '#f5f5f5',
   paddingBottom: '20px',
   marginTop: '0px'
 });
 
-const gridStyleList = style({
+const gridStyleList = kialiStyle({
   backgroundColor: '#f5f5f5',
   // The VirtualTable component has a different style than cards
   // We need to adjust the grid style if we are on compact vs list view
@@ -93,26 +93,26 @@ const gridStyleList = style({
   marginTop: '0px'
 });
 
-const cardGridStyle = style({
+const cardGridStyle = kialiStyle({
   textAlign: 'center',
   marginTop: '0px',
   marginBottom: '10px'
 });
 
-const cardControlPlaneGridStyle = style({
+const cardControlPlaneGridStyle = kialiStyle({
   textAlign: 'center',
   marginTop: '0px',
   marginBottom: '10px'
 });
 
-const emptyStateStyle = style({
+const emptyStateStyle = kialiStyle({
   height: '300px',
   marginRight: 5,
   marginBottom: 10,
   marginTop: 10
 });
 
-const cardNamespaceNameNormalStyle = style({
+const cardNamespaceNameNormalStyle = kialiStyle({
   display: 'table-footer-group',
   verticalAlign: 'middle'
 });
@@ -122,7 +122,7 @@ const cardNamespaceNameNormalStyle = style({
 // maxWidth calc() used doesn't work well for all cases
 const NS_LONG = 20;
 
-const cardNamespaceNameLongStyle = style({
+const cardNamespaceNameLongStyle = kialiStyle({
   overflow: 'hidden',
   display: 'block',
   maxWidth: 'calc(100% - 75px)',

--- a/frontend/src/pages/Overview/OverviewToolbar.tsx
+++ b/frontend/src/pages/Overview/OverviewToolbar.tsx
@@ -15,7 +15,7 @@ import { SortField } from '../../types/SortFilters';
 import { NamespaceInfo } from './NamespaceInfo';
 import * as Sorts from './Sorts';
 import * as Filters from './Filters';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../components/Pf/PfColors';
 import { TimeDurationComponent } from '../../components/Time/TimeDurationComponent';
 import { KialiDispatch } from '../../types/Redux';
@@ -63,35 +63,35 @@ const sortTypes = (function () {
   return o;
 })();
 
-const containerPadding = style({
+const containerPadding = kialiStyle({
   backgroundColor: PFColors.White,
   padding: '0px 20px 0px 20px'
 });
 
-const containerFlex = style({
+const containerFlex = kialiStyle({
   display: 'flex',
   flexWrap: 'wrap'
 });
 
-const filterToolbarStyle = style({
+const filterToolbarStyle = kialiStyle({
   paddingTop: '10px'
 });
 
-const rightToolbarStyle = style({
+const rightToolbarStyle = kialiStyle({
   marginLeft: 'auto',
   height: '118px',
   padding: '10px 0px 0px 0px'
 });
 
-const timeToolbarStyle = style({
+const timeToolbarStyle = kialiStyle({
   textAlign: 'right'
 });
 
-const actionsToolbarStyle = style({
+const actionsToolbarStyle = kialiStyle({
   paddingTop: '17px'
 });
 
-const typeSelectStyle = style({
+const typeSelectStyle = kialiStyle({
   paddingRight: '6px'
 });
 

--- a/frontend/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
+++ b/frontend/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Overview page renders initial layout 1`] = `
     }
   >
     <EmptyState
-      className="fu1tihc"
+      className="kiali_fu1tihc"
       variant="full"
     >
       <Title

--- a/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -4,7 +4,7 @@ import { ServiceDetailsInfo, WorkloadOverview } from '../../types/ServiceInfo';
 import { AppWorkload } from '../../types/App';
 import { isMultiCluster, serverConfig } from '../../config';
 import { Labels } from '../../components/Label/Labels';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { LocalTime } from '../../components/Time/LocalTime';
 import { renderAPILogo } from '../../components/Logo/Logos';
 import { TextOrLink } from '../../components/TextOrLink';
@@ -22,7 +22,7 @@ type State = {
   serviceInfoTabKey: number;
 };
 
-const resourceListStyle = style({
+const resourceListStyle = kialiStyle({
   margin: '0px 0 11px 0',
   $nest: {
     '& > ul > li > span': {
@@ -33,19 +33,19 @@ const resourceListStyle = style({
   }
 });
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   margin: '0 0 0 0',
   padding: '0 0 0 0',
   display: 'inline-block',
   verticalAlign: '2px !important'
 });
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 0px 2px 10px',
   verticalAlign: '-5px !important'
 });
 
-const healthIconStyle = style({
+const healthIconStyle = kialiStyle({
   marginLeft: '10px',
   verticalAlign: '-1px !important'
 });

--- a/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import { ServiceId } from '../../types/ServiceId';
 import { ServiceDescription } from './ServiceDescription';
@@ -66,7 +66,7 @@ type ServiceInfoState = {
   showConfirmDeleteTrafficRouting: boolean;
 };
 
-const fullHeightStyle = style({
+const fullHeightStyle = kialiStyle({
   height: '100%'
 });
 
@@ -222,7 +222,7 @@ class ServiceInfoComponent extends React.Component<Props, ServiceInfoState> {
     // This height needs to be propagated to minigraph to proper resize in height
     // Graph resizes correctly on width
     const height = this.state.tabHeight ? this.state.tabHeight - 115 : 300;
-    const graphContainerStyle = style({ width: '100%', height: height });
+    const graphContainerStyle = kialiStyle({ width: '100%', height: height });
     const includeMiniGraphCy = serverConfig.kialiFeatureFlags.uiDefaults.graph.impl !== 'pf';
     const includeMiniGraphPF = serverConfig.kialiFeatureFlags.uiDefaults.graph.impl !== 'cy';
     const miniGraphSpan = includeMiniGraphCy && includeMiniGraphPF ? 4 : 8;

--- a/frontend/src/pages/ServiceDetails/ServiceNetwork.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceNetwork.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Card, CardBody, CardHeader, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Gateway, ObjectCheck, ObjectValidation, VirtualService } from '../../types/IstioObjects';
 import { ValidationList } from '../../components/Validations/ValidationList';
 import { KialiIcon } from '../../config/KialiIcon';
@@ -18,7 +18,7 @@ type HostnameInfo = {
   fromName: string | undefined;
 };
 
-const resourceListStyle = style({
+const resourceListStyle = kialiStyle({
   margin: '0px 0 11px 0',
   $nest: {
     '& > ul > li > span': {
@@ -29,7 +29,7 @@ const resourceListStyle = style({
   }
 });
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 0px 2px 10px',
   verticalAlign: '-3px !important'
 });

--- a/frontend/src/pages/WorkloadDetails/ProxyStatusList.tsx
+++ b/frontend/src/pages/WorkloadDetails/ProxyStatusList.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { isProxyStatusComponentSynced, isProxyStatusSynced, ProxyStatus } from '../../types/Health';
 import { Stack, StackItem } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from '../../components/Pf/PfColors';
 
 type Props = {
   status?: ProxyStatus;
 };
 
-const smallStyle = style({ fontSize: '70%', color: PFColors.White });
-const colorStyle = style({ fontSize: '1.1rem', color: PFColors.White });
+const smallStyle = kialiStyle({ fontSize: '70%', color: PFColors.White });
+const colorStyle = kialiStyle({ fontSize: '1.1rem', color: PFColors.White });
 
 export class ProxyStatusList extends React.Component<Props> {
   statusList = () => {

--- a/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Workload } from '../../types/Workload';
 import { Card, CardBody, CardHeader, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { Labels } from '../../components/Label/Labels';
 import { LocalTime } from '../../components/Time/LocalTime';
 import { TextOrLink } from '../../components/TextOrLink';
@@ -26,7 +26,7 @@ type WorkloadDescriptionProps = {
   namespace: string;
 };
 
-const resourceListStyle = style({
+const resourceListStyle = kialiStyle({
   margin: '0px 0 11px 0',
   $nest: {
     '& > ul > li > span': {
@@ -37,17 +37,17 @@ const resourceListStyle = style({
   }
 });
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   display: 'inline-block',
   verticalAlign: '2px !important'
 });
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 0px 2px 10px',
   verticalAlign: '-5px !important'
 });
 
-const healthIconStyle = style({
+const healthIconStyle = kialiStyle({
   marginLeft: '10px',
   verticalAlign: '-1px !important'
 });

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { ObjectCheck, Validations, ValidationTypes } from '../../types/IstioObjects';
@@ -35,7 +35,7 @@ type WorkloadInfoState = {
   tabHeight?: number;
 };
 
-const fullHeightStyle = style({
+const fullHeightStyle = kialiStyle({
   height: '100%'
 });
 
@@ -267,7 +267,7 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
     // This height needs to be propagated to minigraph to proper resize in height
     // Graph resizes correctly on width
     const height = this.state.tabHeight ? this.state.tabHeight - 115 : 300;
-    const graphContainerStyle = style({ width: '100%', height: height });
+    const graphContainerStyle = kialiStyle({ width: '100%', height: height });
     const includeMiniGraphCy = serverConfig.kialiFeatureFlags.uiDefaults.graph.impl !== 'pf';
     const includeMiniGraphPF = serverConfig.kialiFeatureFlags.uiDefaults.graph.impl !== 'cy';
     const miniGraphSpan = includeMiniGraphCy && includeMiniGraphPF ? 4 : 8;

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -24,7 +24,7 @@ import {
 } from '@patternfly/react-core';
 import memoize from 'micro-memoize';
 import { AutoSizer, List } from 'react-virtualized';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { addError, addSuccess } from 'utils/AlertUtils';
 import { Pod, LogEntry, AccessLog, PodLogs } from '../../types/IstioObjects';
 import { getPodLogs, getWorkloadSpans, setPodEnvoyProxyLogLevel } from '../../services/Api';
@@ -137,26 +137,26 @@ const MaxLinesOptions = {
   '25000': '25000 lines'
 };
 
-const alInfoIcon = style({
+const alInfoIcon = kialiStyle({
   display: 'inline-block',
   margin: '0px 5px 0px 0px',
   width: '10px'
 });
 
-const infoIcons = style({
+const infoIcons = kialiStyle({
   marginLeft: '0.5em',
   width: '24px'
 });
 
-const toolbarTail = style({
+const toolbarTail = kialiStyle({
   marginTop: '2px'
 });
 
-const logsDiv = style({
+const logsDiv = kialiStyle({
   marginRight: '5px'
 });
 
-const logsDisplay = style({
+const logsDisplay = kialiStyle({
   fontFamily: 'monospace',
   margin: 0,
   overflow: 'auto',
@@ -167,7 +167,7 @@ const logsDisplay = style({
 });
 
 // For some reason checkbox as a ToolbarItem needs to be tweaked
-const toolbarInputStyle = style({
+const toolbarInputStyle = kialiStyle({
   $nest: {
     '& > input': {
       marginTop: '2px'

--- a/frontend/src/pages/WorkloadDetails/WorkloadPods.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPods.tsx
@@ -14,7 +14,7 @@ import {
   TooltipPosition
 } from '@patternfly/react-core';
 import { PodStatus } from './PodStatus';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon } from '../../config/KialiIcon';
 import { LocalTime } from '../../components/Time/LocalTime';
 import { Labels } from '../../components/Label/Labels';
@@ -27,12 +27,12 @@ type WorkloadPodsProps = {
   validations: { [key: string]: ObjectValidation };
 };
 
-const emptyStyle = style({
+const emptyStyle = kialiStyle({
   padding: '0 0 0 0',
   margin: '0 0 0 0'
 });
 
-const resourceListStyle = style({
+const resourceListStyle = kialiStyle({
   margin: '0px 0 11px 0',
   $nest: {
     '& > ul > li > span': {
@@ -43,12 +43,12 @@ const resourceListStyle = style({
   }
 });
 
-const infoStyle = style({
+const infoStyle = kialiStyle({
   margin: '0px 5px 2px 10px',
   verticalAlign: '-4px !important'
 });
 
-const iconStyle = style({
+const iconStyle = kialiStyle({
   display: 'inline-block',
   verticalAlign: '2px !important'
 });

--- a/frontend/src/pages/WorkloadDetails/__tests__/__snapshots__/ProxyStatusList.test.tsx.snap
+++ b/frontend/src/pages/WorkloadDetails/__tests__/__snapshots__/ProxyStatusList.test.tsx.snap
@@ -5,18 +5,18 @@ exports[`ProxyStatusList when status is synced match the snapshot 1`] = `""`;
 exports[`ProxyStatusList when there are components without value match the snapshot 1`] = `
 <Stack>
   <StackItem
-    className="f1rokmn6"
+    className="kiali_f1rokmn6"
   >
     Istio Proxy Status
   </StackItem>
   <StackItem
-    className="f1l42kt0"
+    className="kiali_f1l42kt0"
     key="proxy-status-0"
   >
     CDS: -
   </StackItem>
   <StackItem
-    className="f1l42kt0"
+    className="kiali_f1l42kt0"
     key="proxy-status-3"
   >
     RDS: -
@@ -27,18 +27,18 @@ exports[`ProxyStatusList when there are components without value match the snaps
 exports[`ProxyStatusList when there are unsyced components match the snapshot 1`] = `
 <Stack>
   <StackItem
-    className="f1rokmn6"
+    className="kiali_f1rokmn6"
   >
     Istio Proxy Status
   </StackItem>
   <StackItem
-    className="f1l42kt0"
+    className="kiali_f1l42kt0"
     key="proxy-status-0"
   >
     CDS: NOT_SENT
   </StackItem>
   <StackItem
-    className="f1l42kt0"
+    className="kiali_f1l42kt0"
     key="proxy-status-3"
   >
     RDS: STALE

--- a/frontend/src/styles/DropdownStyles.ts
+++ b/frontend/src/styles/DropdownStyles.ts
@@ -1,24 +1,24 @@
 import { PFColors } from 'components/Pf/PfColors';
-import { style } from 'typestyle';
+import { kialiStyle } from 'styles/StyleUtils';
 import { NestedCSSProperties } from 'typestyle/lib/types';
 
-export const containerStyle = style({
+export const containerStyle = kialiStyle({
   overflow: 'auto'
 });
 
 // this emulates Select component .pf-c-select__menu
-export const menuStyle = style({
+export const menuStyle = kialiStyle({
   fontSize: 'var(--kiali-global--font-size)'
 });
 
 // this emulates Select component .pf-c-select__menu but w/o cursor manipulation
-export const menuEntryStyle = style({
+export const menuEntryStyle = kialiStyle({
   display: 'inline-block',
   width: '100%'
 });
 
 // this emulates Select component .pf-c-select__menu-group-title but with less bottom padding to conserve space
-export const titleStyle = style({
+export const titleStyle = kialiStyle({
   padding: '8px 16px 2px 16px',
   fontWeight: 700,
   color: PFColors.Black600
@@ -40,14 +40,14 @@ const itemStyle: NestedCSSProperties = {
 };
 
 // this emulates Select component .pf-c-select__menu-item but with less vertical padding to conserve space
-export const itemStyleWithoutInfo = style(itemStyle);
+export const itemStyleWithoutInfo = kialiStyle(itemStyle);
 
 // this emulates Select component .pf-c-select__menu-item but with less vertical padding to conserve space
-export const itemStyleWithInfo = style({
+export const itemStyleWithInfo = kialiStyle({
   ...itemStyle,
   padding: '6px 0px 6px 16px'
 });
 
-export const infoStyle = style({
+export const infoStyle = kialiStyle({
   margin: '0px 5px 2px 4px'
 });

--- a/frontend/src/styles/StyleUtils.ts
+++ b/frontend/src/styles/StyleUtils.ts
@@ -1,0 +1,15 @@
+import { style } from 'typestyle';
+import { NestedCSSProperties } from 'typestyle/lib/types';
+
+const cssPrefix = process.env.CSS_PREFIX ?? 'kiali';
+
+/**
+ * Add prefix to CSS classname (mandatory in some plugins like OSSMC)
+ * Default prefix value is kiali if the environment variable CSS_PREFIX is not defined
+ */
+export const kialiStyle = (styleProps: NestedCSSProperties) => {
+  return style({
+    $debugName: cssPrefix,
+    ...styleProps
+  });
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5977,10 +5977,10 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.4.0:
-  version "2.6.17"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.17.tgz#4cf30eb87e1d1a005d8b6510f95292413f6a1c0e"
-  integrity sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==
+csstype@3.0.10:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
 csstype@^3.0.2:
   version "3.0.8"
@@ -8001,10 +8001,10 @@ fraction.js@^4.2.0:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
-free-style@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/free-style/-/free-style-2.6.1.tgz#6af512568291195854842cbbaacd95578a6a9a8b"
-  integrity sha512-uaVA8e57tvhrFKAl6x32SGIrGFBoeTAFtfHDzWxjPhiXQiUxOI6EEdEReRkjNO2H9XcdMJXXEnMHw8Q7iMYLbw==
+free-style@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/free-style/-/free-style-3.1.0.tgz#4e2996029534e6b1731611d843437b9e2f473f08"
+  integrity sha512-vJujYSIyT30iDoaoeigNAxX4yB1RUrh+N2ZMhIElMr3BvCuGXOw7XNJMEEJkDUeamK2Rnb/IKFGKRKlTWIGRWA==
 
 fresh@0.5.2:
   version "0.5.2"
@@ -14317,13 +14317,13 @@ typescript@4.6.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
-typestyle@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/typestyle/-/typestyle-2.0.4.tgz#b8da5feaf8a4f9d1f69066f3cc4659098bd08457"
-  integrity sha512-+57eGqcEjiAc51hB/zXnZFoVuzwuxb9WbPpb1VT2zPJPIo88wGXod7dHa0IJ1Ue+sncHj2WZMZEPJRAqwVraoA==
+typestyle@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/typestyle/-/typestyle-2.4.0.tgz#df5bae6ff15093f5ce51f0caac5ef79428f64e78"
+  integrity sha512-/d1BL6Qi+YlMLEydnUEB8KL/CAjAN8cyt3/UyGnOyBrWf7bLGcR/6yhmsaUstO2IcYwZfagjE7AIzuI2vUW9mg==
   dependencies:
-    csstype "^2.4.0"
-    free-style "2.6.1"
+    csstype "3.0.10"
+    free-style "3.1.0"
 
 umd@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
** Describe the change **

Add prefix to classNames generated by typestyle library.

** Issue reference **

Part of #6266.

Testing PR:
Check that all classNames generated by typestyle library contains 'kiali' prefix (hardcoded value for Kiali standalone, environment variable for OSSMC).

For example:
```
<div class="kiali_f1r2nm0v">
```  