### PR TITLE
fix incorrect K8s SA being used with OIDC when RBAC is disabled

### DIFF
--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -207,7 +207,8 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 			var remoteConfig *rest.Config
 			var err2 error
 			// In auth strategy should we use SA token
-			if cfg.Auth.Strategy == kialiConfig.AuthStrategyAnonymous {
+			if cfg.Auth.Strategy == kialiConfig.AuthStrategyAnonymous ||
+				(cfg.Auth.Strategy == kialiConfig.AuthStrategyOpenId && cfg.Auth.OpenId.DisableRBAC) {
 				remoteConfig, err2 = GetConfigForRemoteClusterInfo(clusterInfo[cluster])
 			} else {
 				remoteConfig, err2 = GetConfigWithTokenForRemoteCluster(clusterInfo[cluster].Cluster,


### PR DESCRIPTION
** Describe the change **

When OpenID authentication is used and the `disable_rbac` flag is set to `true`, kiali should use its own K8s ServiceAccount to access remote clusters

** Issue reference **

closes #6308