### PR TITLE
v1.65 - remote istiod obtain Istio deployment name 

### DIFF
--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -94,6 +94,7 @@ func TestRemoteIstiod(t *testing.T) {
 	kialiNamespace := "istio-system"
 	kialiDeploymentNamespace := kialiNamespace
 	ipods, err := kubeClient.AppsV1().Deployments(kialiNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app=istiod"})
+	require.NoError(err)
 	istioDeploymentName := ipods.Items[0].Name
 
 	if kialiCRDExists {


### PR DESCRIPTION
Reported failure for interop tests: 

`deployments.apps "istiod-install-istio-system" not found`

The Istio deployment name was hard coded in the tests. 