### PR TITLE
[hack] support ambient by telling bookinfo install script if you want injection and if so what kind

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -26,6 +26,7 @@ MANUAL_INJECTION="false"
 DELETE_BOOKINFO="false"
 MINIKUBE_PROFILE="minikube"
 ARCH="amd64"
+WAIT_TIMEOUT="0" # can be things like "60s" or "30m"
 
 AMBIENT_ENABLED="false" # the script will set this to true only if Ambient is enabled and no sidecars are injected
 
@@ -89,6 +90,10 @@ while [[ $# -gt 0 ]]; do
       TRAFFIC_GENERATOR_ENABLED="true"
       shift;
       ;;
+    -wt|--wait-timeout)
+      WAIT_TIMEOUT="$2"
+      shift;shift
+      ;;
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
@@ -105,6 +110,7 @@ Valid command line arguments:
   -g|--gateway.yaml <file>: A custom yaml file to deploy the bookinfo-gateway resources
   --mongo: Install a Mongo DB that a ratings service will access
   --mysql: Install a MySQL DB that a ratings service will access
+  -wt|--wait-timeout <timeout>: If not "0", then this script will wait for all pods in the new bookinfo namespace to be Ready before exiting. This value can be things like "60s" or "30m". (default: 0)
   -tg|--traffic-generator: Install Kiali Traffic Generator on Bookinfo
   -h|--help : this message
 HELPMSG
@@ -424,4 +430,9 @@ spec:
 AUTHPOLICY
     fi
   fi
+fi
+
+if [ "${WAIT_TIMEOUT}" != "0" ]; then
+  echo "Waiting for all pods to be ready in namespace [${NAMESPACE}]"
+  $CLIENT_EXE wait pods --all -n ${NAMESPACE} --for=condition=Ready --timeout=${WAIT_TIMEOUT}
 fi

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -380,6 +380,9 @@ if [ "${TRAFFIC_GENERATOR_ENABLED}" == "true" ]; then
       echo "Failed to get minikube ip. If you are using minikube, make sure it is up and your profile is defined properly (--minikube-profile option)"
       echo "Will try to get the ingressgateway IP in case you are running 'kind' and we can access it directly."
       INGRESS_HOST=$($CLIENT_EXE get service -n ${ISTIO_NAMESPACE} istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+      if [ "${INGRESS_HOST}" == ""]; then
+        INGRESS_HOST="istio-ingressgateway.${ISTIO_NAMESPACE}"
+      fi
       INGRESS_PORT="80"
       INGRESS_ROUTE=$INGRESS_HOST:$INGRESS_PORT
     fi


### PR DESCRIPTION
This supports ambient mode. The default behavior stays the same (which is auto-injecting the sidecar), however, if you turn off auto-injection (`-ai false`) then no sidecars are injected. If you do this, a message will spit out telling you what you have to do to enable ambient mode (you are told what command to use to label the namespace).

Note that this still retains the ability to manually inject the sidecars via istioctl (you do this using the `-mi` option )