### PR TITLE
Kind support for MC hack scripts

### DIFF
--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -80,22 +80,22 @@ deploy_kiali() {
 
   if [ "${KIALI_CREATE_REMOTE_CLUSTER_SECRETS}" == "true" ]; then
     if [ "${SINGLE_KIALI}" == "true" ]; then
-      local server_flag
+      local remote_url_flag
       if [ "${MANAGE_KIND}" == "true" ]; then
-        server_flag="--server https://$(${CLIENT_EXE} get nodes ${CLUSTER2_NAME}-control-plane --context ${CLUSTER2_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
+        remote_url_flag="--remote-cluster-url https://$(${CLIENT_EXE} get nodes ${CLUSTER2_NAME}-control-plane --context ${CLUSTER2_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
       fi
       echo "Preparing remote cluster secret for single Kiali install in multicluster mode."
-      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${server_flag} -vo false
+      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${remote_url_flag} -vo false
     else
       echo "Preparing remote cluster secrets for both Kiali installs."
-      local server1_flag
-      local server2_flag
+      local remote_url_flag1
+      local remote_url_flag2
       if [ "${MANAGE_KIND}" == "true" ]; then
-        server1_flag="--server https://$(${CLIENT_EXE} get nodes ${CLUSTER2_NAME}-control-plane --context ${CLUSTER2_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
-        server2_flag="--server https://$(${CLIENT_EXE} get nodes ${CLUSTER1_NAME}-control-plane --context ${CLUSTER1_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
+        remote_url_flag1="--remote-cluster-url https://$(${CLIENT_EXE} get nodes ${CLUSTER2_NAME}-control-plane --context ${CLUSTER2_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
+        remote_url_flag2="--remote-cluster-url https://$(${CLIENT_EXE} get nodes ${CLUSTER1_NAME}-control-plane --context ${CLUSTER1_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
       fi
-      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${server1_flag} -vo false
-      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER1_NAME} -kcc ${CLUSTER2_CONTEXT} -rcc ${CLUSTER1_CONTEXT} ${server2_flag} -vo false
+      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${remote_url_flag1} -vo false
+      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER1_NAME} -kcc ${CLUSTER2_CONTEXT} -rcc ${CLUSTER1_CONTEXT} ${remote_url_flag2} -vo false
     fi
   fi
 

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -101,8 +101,8 @@ deploy_kiali() {
 
   local ingress_enabled_flag
   if [ "${MANAGE_KIND}" == "true" ]; then
-  # Re-use bookinfo gateway to access Kiali externally.
-  ${CLIENT_EXE} apply -f - <<EOF
+    # Re-use bookinfo gateway to access Kiali externally.
+    ${CLIENT_EXE} apply -f - <<EOF
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -123,7 +123,7 @@ spec:
         port:
           number: 20001
 EOF
-  ingress_enabled_flag=false
+    ingress_enabled_flag=false
   else
     ingress_enabled_flag=true
   fi

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -43,11 +43,29 @@ deploy_kiali() {
   [ ! -z "${web_fqdn}" ] && helm_args="--set server.web_fqdn=${web_fqdn} ${helm_args}"
   [ ! -z "${web_schema}" ] && helm_args="--set server.web_schema=${web_schema} ${helm_args}"
 
-  local minikube_ip=$(minikube ip -p "${cluster_name}")
+  local auth_flags
+  if [ "${KIALI_AUTH_STRATEGY}" == "anonymous" ]; then
+    auth_flags="--set auth.strategy=anonymous"
+  elif [ "${KIALI_AUTH_STRATEGY}" == "openid" ]; then
+    # These need to exist prior to installing Kiali.
+    # Create secret with the oidc secret
+    ${CLIENT_EXE} create configmap kiali-cabundle --from-file="openid-server-ca.crt=${KEYCLOAK_CERTS_DIR}/root-ca.pem" -n "${ISTIO_NAMESPACE}"
+    ${CLIENT_EXE} create secret generic kiali --from-literal="oidc-secret=kube-client-secret" -n istio-system
+    ${CLIENT_EXE} create clusterrolebinding kiali-user-viewer --clusterrole=kiali-viewer --user=oidc:kiali
 
-  # determine where we can find keycloak
-  local keycloak_minikube_ip_dashed=$(minikube ip -p "${keycloak_cluster_name}" | sed 's/\./-/g')
-  local keycloak_hostname="keycloak-${keycloak_minikube_ip_dashed}.nip.io"
+    local minikube_ip
+    minikube_ip=$(minikube ip -p "${cluster_name}")
+
+    # determine where we can find keycloak
+
+    local keycloak_minikube_ip_dashed
+    keycloak_minikube_ip_dashed=$(minikube ip -p "${keycloak_cluster_name}" | sed 's/\./-/g')
+    local keycloak_hostname="keycloak-${keycloak_minikube_ip_dashed}.nip.io"
+    auth_flags="--set auth.strategy=openid --set auth.openid.client_id=kube --set auth.openid.issuer_uri=\"https://${keycloak_hostname}/realms/kube\" --set auth.openid.insecure_skip_verify_tls=\"false\""
+  else
+    echo "Kiali auth strategy [${KIALI_AUTH_STRATEGY}] is not supported for multi-cluster - will not install Kiali"
+    return 1
+  fi
 
   if [ "${KIALI_USE_DEV_IMAGE}" == "true" ]; then
     local image_to_tag="quay.io/kiali/kiali:dev"
@@ -59,36 +77,67 @@ deploy_kiali() {
     helm_args="--set deployment.image_name=localhost:5000/kiali/kiali --set deployment.image_version=dev ${helm_args}"
   fi
 
-  # These need to exist prior to installing Kiali.
-  # Create secret with the oidc secret
-  ${CLIENT_EXE} create configmap kiali-cabundle --from-file="openid-server-ca.crt=${KEYCLOAK_CERTS_DIR}/root-ca.pem" -n "${ISTIO_NAMESPACE}"
-  ${CLIENT_EXE} create secret generic kiali --from-literal="oidc-secret=kube-client-secret" -n istio-system
-  ${CLIENT_EXE} create clusterrolebinding kiali-user-viewer --clusterrole=kiali-viewer --user=oidc:kiali
 
   if [ "${KIALI_CREATE_REMOTE_CLUSTER_SECRETS}" == "true" ]; then
     if [ "${SINGLE_KIALI}" == "true" ]; then
+      local server_flag
+      if [ "${MANAGE_KIND}" == "true" ]; then
+        server_flag="--server https://$(${CLIENT_EXE} get nodes ${CLUSTER2_NAME}-control-plane --context ${CLUSTER2_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
+      fi
       echo "Preparing remote cluster secret for single Kiali install in multicluster mode."
-      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} -vo false
+      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${server_flag} -vo false
     else
       echo "Preparing remote cluster secrets for both Kiali installs."
-      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} -vo false
-      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} -kcc ${CLUSTER2_CONTEXT} -rcc ${CLUSTER1_CONTEXT} -vo false
+      local server1_flag
+      local server2_flag
+      if [ "${MANAGE_KIND}" == "true" ]; then
+        server1_flag="--server https://$(${CLIENT_EXE} get nodes ${CLUSTER2_NAME}-control-plane --context ${CLUSTER2_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
+        server2_flag="--server https://$(${CLIENT_EXE} get nodes ${CLUSTER1_NAME}-control-plane --context ${CLUSTER1_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
+      fi
+      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${server1_flag} -vo false
+      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER1_NAME} -kcc ${CLUSTER2_CONTEXT} -rcc ${CLUSTER1_CONTEXT} ${server2_flag} -vo false
     fi
   fi
 
+  local ingress_enabled_flag
+  if [ "${MANAGE_KIND}" == "true" ]; then
+  # Re-use bookinfo gateway to access Kiali externally.
+  ${CLIENT_EXE} apply -f - <<EOF
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  gateways:
+  - bookinfo/bookinfo-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /kiali
+    route:
+    - destination:
+        host: kiali
+        port:
+          number: 20001
+EOF
+  ingress_enabled_flag=false
+  else
+    ingress_enabled_flag=true
+  fi
+
+
   # use the latest published server helm chart (if using dev images, it is up to the user to make sure this chart works with the dev image)
-  helm upgrade --install                          \
-    ${helm_args}                                  \
-    --namespace ${ISTIO_NAMESPACE}                \
-    --set kubernetes_config.cache_enabled="false" \
-    --set auth.strategy="openid"                  \
-    --set auth.openid.client_id="kube"            \
-    --set auth.openid.issuer_uri="https://${keycloak_hostname}/realms/kube" \
-    --set auth.openid.insecure_skip_verify_tls="false" \
-    --set deployment.logger.log_level="debug"     \
-    --set deployment.ingress.enabled="true"       \
-    --repo https://kiali.org/helm-charts          \
-    kiali-server                                  \
+  helm upgrade --install                                       \
+    ${helm_args}                                               \
+    --namespace ${ISTIO_NAMESPACE}                             \
+    ${auth_flags}                                              \
+    --set deployment.logger.log_level="debug"                  \
+    --set deployment.ingress.enabled="${ingress_enabled_flag}" \
+    --repo https://kiali.org/helm-charts                       \
+    kiali-server                                               \
     ${KIALI_SERVER_HELM_CHARTS}
 }
 

--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -104,6 +104,9 @@ KIALI_ENABLED="true"
 # When installing Kiali, this will determine if a released image is used or if a local dev image is to be pushed and used.
 KIALI_USE_DEV_IMAGE="false"
 
+# Sets the auth strategy for kiali. If "openid" is used then keycloak is provisioned for the auth provider.
+KIALI_AUTH_STRATEGY="openid"
+
 # Should Bookinfo demo be installed? If so, where?
 BOOKINFO_ENABLED="true"
 BOOKINFO_NAMESPACE="bookinfo"
@@ -200,6 +203,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     -it|--istio-tag)
       ISTIO_TAG="$2"
+      shift;shift
+      ;;
+    -kas|--kiali-auth-strategy)
+      [ "${2:-}" != "anonymous" -a "${2:-}" != "openid" ] && echo "--kiali-auth-strategy must be 'anonymous' or 'openid'" && exit 1
+      KIALI_AUTH_STRATEGY="$2"
       shift;shift
       ;;
     -kcrcs|--kiali-create-remote-cluster-secrets)
@@ -306,6 +314,7 @@ Valid command line arguments:
   -id|--istio-dir <dir>: Where Istio has already been downloaded. If not found, this script aborts.
   -in|--istio-namespace <name>: Where the Istio control plane is installed (default: istio-system).
   -it|--istio-tag <tag>: If you want to override the image tag used by istioctl, set this to the tag name.
+  -kas|--kiali-auth-strategy <openid|anonymous>: The authentication strategy to use for Kiali (Default: openid)
   -kcrcs|--kiali-create-remote-cluster-secrets <bool>: Create remote cluster secrets for kiali remote cluster access.
   -ke|--kiali-enabled <bool>: If "true" the latest release of Kiali will be installed in both clusters. If you want
                               a different version of Kiali installed, you must set this to "false" and install it yourself.
@@ -482,6 +491,7 @@ export BOOKINFO_ENABLED \
        ISTIO_DIR \
        ISTIO_NAMESPACE \
        ISTIO_TAG \
+       KIALI_AUTH_STRATEGY \
        KIALI_CREATE_REMOTE_CLUSTER_SECRETS \
        KIALI_ENABLED \
        KIALI_USE_DEV_IMAGE \
@@ -516,6 +526,7 @@ IS_OPENSHIFT=$IS_OPENSHIFT
 ISTIO_DIR=$ISTIO_DIR
 ISTIO_NAMESPACE=$ISTIO_NAMESPACE
 ISTIO_TAG=$ISTIO_TAG
+KIALI_AUTH_STRATEGY=$KIALI_AUTH_STRATEGY
 KIALI_CREATE_REMOTE_CLUSTER_SECRETS=$KIALI_CREATE_REMOTE_CLUSTER_SECRETS
 KIALI_ENABLED=$KIALI_ENABLED
 KIALI_USE_DEV_IMAGE=$KIALI_USE_DEV_IMAGE

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -35,6 +35,7 @@ DEFAULT_PROCESS_REMOTE_RESOURCES="true"
 DEFAULT_REMOTE_CLUSTER_CONTEXT="west"
 DEFAULT_REMOTE_CLUSTER_NAME=""
 DEFAULT_REMOTE_CLUSTER_NAMESPACE="kiali-access-ns"
+DEFAULT_SERVER=""
 DEFAULT_VIEW_ONLY="true"
 DEFAULT_EXEC_AUTH_JSON=""
 
@@ -51,6 +52,7 @@ DEFAULT_EXEC_AUTH_JSON=""
 : ${REMOTE_CLUSTER_CONTEXT:=${DEFAULT_REMOTE_CLUSTER_CONTEXT}}
 : ${REMOTE_CLUSTER_NAMESPACE:=${DEFAULT_REMOTE_CLUSTER_NAMESPACE}}
 : ${REMOTE_CLUSTER_NAME:=${DEFAULT_REMOTE_CLUSTER_NAME}}
+: ${SERVER:=${DEFAULT_SERVER}}
 : ${VIEW_ONLY:=${DEFAULT_VIEW_ONLY}}
 : ${EXEC_AUTH_JSON:=${DEFAULT_EXEC_AUTH_JSON}}
 
@@ -199,7 +201,12 @@ create_kiali_remote_cluster_secret() {
   info "Create the remote cluster secret in the Kiali cluster"
 
   # Examine the local kubeconfig and extract the rest of the necessary data we need in order to create the Kiali remote cluster secret.
-  local remote_cluster_server_url="$(${CLIENT_EXE} config view -o jsonpath='{.clusters[?(@.name == "'${REMOTE_CLUSTER_NAME_FROM_CONTEXT}'")].cluster.server}' 2>/dev/null)"
+  local remote_cluster_server_url
+  if [ "${SERVER}" == "" ]; then
+    remote_cluster_server_url="$(${CLIENT_EXE} config view -o jsonpath='{.clusters[?(@.name == "'${REMOTE_CLUSTER_NAME_FROM_CONTEXT}'")].cluster.server}' 2>/dev/null)"
+  else
+    remote_cluster_server_url="${SERVER}"
+  fi
   if [ "${remote_cluster_server_url}" == "" ]; then
     error "Unable to determine the remote cluster server URL from the kubeconfig remote cluster named [${REMOTE_CLUSTER_NAME_FROM_CONTEXT}]. Check that the kubeconfig is correct."
   else
@@ -369,6 +376,10 @@ while [ $# -gt 0 ]; do
       REMOTE_CLUSTER_NAMESPACE="$2"
       shift;shift
       ;;
+    -s|--server)
+      SERVER="$2"
+      shift;shift
+      ;;
     -vo|--view-only)
       [ "${2:-}" != "true" -a "${2:-}" != "false" ] && error "--view-only must be 'true' or 'false'"
       VIEW_ONLY="$2"
@@ -469,6 +480,8 @@ Valid command line arguments:
   -rcns|--remote-cluster-namespace: the namespace where the resources will be
                                     created on the remote cluster.
                                     Default: "${DEFAULT_REMOTE_CLUSTER_NAMESPACE}"
+  -s|--server: the URL to the Kubernetes API server for the remote cluster.
+               Default: "${DEFAULT_SERVER}"
   -vo|--view-only: if 'true' then the created service account/remote secret
                    will only provide a read-only view of the remote cluster.
                    Default: "${DEFAULT_VIEW_ONLY}"
@@ -506,6 +519,7 @@ info KIALI_VERSION=${KIALI_VERSION}
 info REMOTE_CLUSTER_CONTEXT=${REMOTE_CLUSTER_CONTEXT}
 info REMOTE_CLUSTER_NAME=${REMOTE_CLUSTER_NAME}
 info REMOTE_CLUSTER_NAMESPACE=${REMOTE_CLUSTER_NAMESPACE}
+info SERVER=${SERVER}
 info VIEW_ONLY=${VIEW_ONLY}
 info EXEC_AUTH_JSON="${EXEC_AUTH_JSON}"
 

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -35,7 +35,7 @@ DEFAULT_PROCESS_REMOTE_RESOURCES="true"
 DEFAULT_REMOTE_CLUSTER_CONTEXT="west"
 DEFAULT_REMOTE_CLUSTER_NAME=""
 DEFAULT_REMOTE_CLUSTER_NAMESPACE="kiali-access-ns"
-DEFAULT_SERVER=""
+DEFAULT_REMOTE_CLUSTER_URL=""
 DEFAULT_VIEW_ONLY="true"
 DEFAULT_EXEC_AUTH_JSON=""
 
@@ -52,7 +52,7 @@ DEFAULT_EXEC_AUTH_JSON=""
 : ${REMOTE_CLUSTER_CONTEXT:=${DEFAULT_REMOTE_CLUSTER_CONTEXT}}
 : ${REMOTE_CLUSTER_NAMESPACE:=${DEFAULT_REMOTE_CLUSTER_NAMESPACE}}
 : ${REMOTE_CLUSTER_NAME:=${DEFAULT_REMOTE_CLUSTER_NAME}}
-: ${SERVER:=${DEFAULT_SERVER}}
+: ${REMOTE_CLUSTER_URL:=${DEFAULT_REMOTE_CLUSTER_URL}}
 : ${VIEW_ONLY:=${DEFAULT_VIEW_ONLY}}
 : ${EXEC_AUTH_JSON:=${DEFAULT_EXEC_AUTH_JSON}}
 
@@ -200,12 +200,12 @@ get_remote_cluster_token() {
 create_kiali_remote_cluster_secret() {
   info "Create the remote cluster secret in the Kiali cluster"
 
-  # Examine the local kubeconfig and extract the rest of the necessary data we need in order to create the Kiali remote cluster secret.
+  # If the remote cluster URL was not provided by the user, then examine the local kubeconfig and extract the rest of the necessary data we need in order to create the Kiali remote cluster secret.
   local remote_cluster_server_url
-  if [ "${SERVER}" == "" ]; then
+  if [ "${REMOTE_CLUSTER_URL}" == "" ]; then
     remote_cluster_server_url="$(${CLIENT_EXE} config view -o jsonpath='{.clusters[?(@.name == "'${REMOTE_CLUSTER_NAME_FROM_CONTEXT}'")].cluster.server}' 2>/dev/null)"
   else
-    remote_cluster_server_url="${SERVER}"
+    remote_cluster_server_url="${REMOTE_CLUSTER_URL}"
   fi
   if [ "${remote_cluster_server_url}" == "" ]; then
     error "Unable to determine the remote cluster server URL from the kubeconfig remote cluster named [${REMOTE_CLUSTER_NAME_FROM_CONTEXT}]. Check that the kubeconfig is correct."
@@ -376,8 +376,8 @@ while [ $# -gt 0 ]; do
       REMOTE_CLUSTER_NAMESPACE="$2"
       shift;shift
       ;;
-    -s|--server)
-      SERVER="$2"
+    -rcu|--remote-cluster-url)
+      REMOTE_CLUSTER_URL="$2"
       shift;shift
       ;;
     -vo|--view-only)
@@ -480,8 +480,10 @@ Valid command line arguments:
   -rcns|--remote-cluster-namespace: the namespace where the resources will be
                                     created on the remote cluster.
                                     Default: "${DEFAULT_REMOTE_CLUSTER_NAMESPACE}"
-  -s|--server: the URL to the Kubernetes API server for the remote cluster.
-               Default: "${DEFAULT_SERVER}"
+  -rcu|--remote_cluster_url: the URL to the Kubernetes API server for the remote cluster.
+                             If empty, the local kubeconfig will be examined and the server
+                             associated with the remote cluster context will be used.
+                             Default: "${DEFAULT_REMOTE_CLUSTER_URL}"
   -vo|--view-only: if 'true' then the created service account/remote secret
                    will only provide a read-only view of the remote cluster.
                    Default: "${DEFAULT_VIEW_ONLY}"
@@ -519,7 +521,7 @@ info KIALI_VERSION=${KIALI_VERSION}
 info REMOTE_CLUSTER_CONTEXT=${REMOTE_CLUSTER_CONTEXT}
 info REMOTE_CLUSTER_NAME=${REMOTE_CLUSTER_NAME}
 info REMOTE_CLUSTER_NAMESPACE=${REMOTE_CLUSTER_NAMESPACE}
-info SERVER=${SERVER}
+info REMOTE_CLUSTER_URL=${REMOTE_CLUSTER_URL}
 info VIEW_ONLY=${VIEW_ONLY}
 info EXEC_AUTH_JSON="${EXEC_AUTH_JSON}"
 


### PR DESCRIPTION
Adds kind support for MC hack scripts. Only `anonymous` mode is supported for now since some of the setup for keycloak is minikube specific. 

Testing instructions:
1. Deploy istio primary-remote
```
hack/istio/multicluster/install-primary-remote.sh --manage-kind true -dorp docker
```
2. Deploy Kiali
```
hack/istio/multicluster/deploy-kiali.sh --manage-kind true -dorp docker -kas anonymous
```
3. Visit Kiali URL and verify everything is working correctly
```
curl http://$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip})/kiali
``` 

Fixes #6358 