### PR TITLE
Make cache mandatory and remove some cache config opts

### DIFF
--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -930,7 +930,6 @@ func defaultAddOnCalls(grafana, prom *int) map[string]addOnsSetup {
 }
 
 func addonAddMockUrls(baseUrl string, conf *config.Config, overrideUrl bool) *config.Config {
-	conf.KubernetesConfig.CacheEnabled = false
 	conf.ExternalServices.Grafana.Enabled = true
 	conf.ExternalServices.Grafana.InClusterURL = baseUrl + "/grafana/mock"
 	conf.ExternalServices.Grafana.IsCore = false

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -135,6 +135,7 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 	check := assert.New(t)
 
 	conf := config.NewConfig()
+	conf.InCluster = false
 	config.Set(conf)
 
 	remoteNs := &core_v1.Namespace{

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -28,8 +28,6 @@ import (
 
 func setupWorkloadService(k8s kubernetes.ClientInterface, conf *config.Config) WorkloadService {
 	// config needs to be set by other services since those rely on the global.
-	conf.KubernetesConfig.CacheEnabled = false
-	config.Set(conf)
 	prom := new(prometheustest.PromClientMock)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s

--- a/config/config.go
+++ b/config/config.go
@@ -290,14 +290,6 @@ type KubernetesConfig struct {
 	// Cache duration expressed in seconds
 	// Cache uses watchers to sync with the backend, after a CacheDuration watchers are closed and re-opened
 	CacheDuration int `yaml:"cache_duration,omitempty"`
-	// Enable cache for kubernetes and istio resources
-	// TODO: Remove once all services are migrated to use the cache.
-	CacheEnabled bool `yaml:"-,omitempty"`
-	// Kiali can cache VirtualService,DestinationRule,Gateway and ServiceEntry Istio resources if they are present
-	// on this list of Istio types. Other Istio types are not yet supported.
-	CacheIstioTypes []string `yaml:"cache_istio_types,omitempty"`
-	// List of namespaces or regex defining namespaces to include in a cache
-	CacheNamespaces []string `yaml:"cache_namespaces,omitempty"`
 	// Cache duration expressed in seconds
 	// Kiali cache list of namespaces per user, this is typically short lived cache compared with the duration of the
 	// namespace cache defined by previous CacheDuration parameter
@@ -730,9 +722,6 @@ func NewConfig() (c *Config) {
 		KubernetesConfig: KubernetesConfig{
 			Burst:                       200,
 			CacheDuration:               5 * 60,
-			CacheEnabled:                true,
-			CacheIstioTypes:             []string{"AuthorizationPolicy", "DestinationRule", "EnvoyFilter", "Gateway", "PeerAuthentication", "RequestAuthentication", "ServiceEntry", "Sidecar", "VirtualService", "WorkloadEntry", "WorkloadGroup", "WasmPlugin", "Telemetry", "K8sGateway", "K8sHTTPRoute"},
-			CacheNamespaces:             []string{".*"},
 			CacheTokenNamespaceDuration: 10,
 			ClusterName:                 "", // leave this unset as a flag that we need to fetch the information
 			ExcludeWorkloads:            []string{"CronJob", "DeploymentConfig", "Job", "ReplicationController"},

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/otel/exporters/jaeger v1.2.0
 	go.opentelemetry.io/otel/sdk v1.2.0
 	go.opentelemetry.io/otel/trace v1.2.0
+	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/net v0.8.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292 h1:f+lwQ+GtmgoY+A2YaQxlSOnDjXcQ7ZRLWOHbC6HtRqE=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/graph/telemetry/istio/appender/health_test.go
+++ b/graph/telemetry/istio/appender/health_test.go
@@ -48,9 +48,6 @@ func TestServicesHealthConfigPasses(t *testing.T) {
 }
 
 func TestServicesHealthNoConfigPasses(t *testing.T) {
-	cfg := config.NewConfig()
-	cfg.KubernetesConfig.CacheEnabled = false
-	config.Set(cfg)
 	trafficMap := buildServiceTrafficMap()
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(""), buildFakeWorkloadDeploymentsHealth(""), buildFakePodsHealth(""))
 
@@ -69,9 +66,6 @@ func TestServicesHealthNoConfigPasses(t *testing.T) {
 }
 
 func TestWorkloadHealthConfigPasses(t *testing.T) {
-	cfg := config.NewConfig()
-	cfg.KubernetesConfig.CacheEnabled = false
-	config.Set(cfg)
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
@@ -90,9 +84,6 @@ func TestWorkloadHealthConfigPasses(t *testing.T) {
 }
 
 func TestWorkloadHealthNoConfigPasses(t *testing.T) {
-	cfg := config.NewConfig()
-	cfg.KubernetesConfig.CacheEnabled = false
-	config.Set(cfg)
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(""), buildFakeWorkloadDeploymentsHealth(""), buildFakePodsHealth(""))
 
@@ -113,9 +104,6 @@ func TestWorkloadHealthNoConfigPasses(t *testing.T) {
 func TestHealthDataPresent(t *testing.T) {
 	assert := assert.New(t)
 
-	cfg := config.NewConfig()
-	cfg.KubernetesConfig.CacheEnabled = false
-	config.Set(cfg)
 	svcNodes := buildServiceTrafficMap()
 	appNodes := buildAppTrafficMap()
 	wkNodes := buildWorkloadTrafficMap()

--- a/handlers/proxy_logging_test.go
+++ b/handlers/proxy_logging_test.go
@@ -14,15 +14,10 @@ import (
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/business/authentication"
-	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
 func setupTestLoggingServer(t *testing.T, namespace, pod string) *httptest.Server {
-	conf := config.NewConfig()
-	conf.KubernetesConfig.CacheEnabled = false
-	config.Set(conf)
-
 	mr := mux.NewRouter()
 	path := "/api/namespaces/{namespace}/pods/{pod}/logging"
 	mr.HandleFunc(path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -45,9 +45,6 @@ func setupWorkloadList(t *testing.T, k8s *kubetest.FakeK8sClient) (*httptest.Ser
 }
 
 func TestWorkloadsEndpoint(t *testing.T) {
-	conf := config.NewConfig()
-	conf.KubernetesConfig.CacheEnabled = false
-	config.Set(conf)
 	mockClock()
 
 	kubeObjects := []runtime.Object{&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}}}

--- a/kubernetes/cache/registry_test_helper.go
+++ b/kubernetes/cache/registry_test_helper.go
@@ -19,7 +19,6 @@ var emptyHandler = NewRegistryHandler(func() {})
 func FakeGatewaysKialiCache(gws []*networking_v1beta1.Gateway) KialiCache {
 	cfg := config.Get()
 	cfg.Deployment.AccessibleNamespaces = []string{"bookinfo"}
-	cfg.KubernetesConfig.CacheNamespaces = []string{"test"}
 	cache, err := NewKubeCache(kubetest.NewFakeK8sClient(), *cfg, emptyHandler)
 	if err != nil {
 		panic(fmt.Sprintf("Error creating KialiCache in testing. Err: %v", err))
@@ -57,7 +56,6 @@ func FakeServicesKialiCache(rss []*kubernetes.RegistryService,
 	// Tests that use this rely on namespaced scoped caches.
 	cfg := config.Get()
 	cfg.Deployment.AccessibleNamespaces = []string{"bookinfo"}
-	cfg.KubernetesConfig.CacheNamespaces = []string{"test"}
 	cfg.KubernetesConfig.CacheDuration = 3600 // 1 hr for tests
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(kubetest.NewFakeK8sClient())

--- a/server/server.go
+++ b/server/server.go
@@ -89,7 +89,10 @@ func (s *Server) Start() {
 	// Start the business to initialize cache dependencies.
 	// The business cache should start before the server endpoint to ensure
 	// that the cache is ready before it's used by one of the server handlers.
-	business.Start()
+	if err := business.Start(); err != nil {
+		log.Errorf("Error starting business layer: %s", err)
+		panic(err)
+	}
 
 	conf := config.Get()
 	log.Infof("Server endpoint will start at [%v%v]", s.httpServer.Addr, conf.Server.WebRoot)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -57,6 +57,9 @@ func TestRootContextPath(t *testing.T) {
 	conf.Server.StaticContentRootDirectory = tmpDir
 	conf.Auth.Strategy = "anonymous"
 
+	// Set the global client factory.
+	kubernetes.NewTestingClientFactory(t)
+
 	serverURL := fmt.Sprintf("http://%v", testServerHostPort)
 
 	config.Set(conf)
@@ -298,6 +301,9 @@ func TestTracingConfigured(t *testing.T) {
 	conf.Server.StaticContentRootDirectory = tmpDir
 	conf.Server.Observability.Tracing.Enabled = true
 	conf.Auth.Strategy = "anonymous"
+
+	// Set the global client factory.
+	kubernetes.NewTestingClientFactory(t)
 
 	serverURL := fmt.Sprintf("http://%v", testServerHostPort)
 


### PR DESCRIPTION
Cleanup `cache != nil` checks since cache has been mandatory for awhile. Also removes some caching options from the kiali config.

Fixes #5599 