### PR TITLE
Skip loading requests health for apps and workloads without sidecar

### DIFF
--- a/business/health.go
+++ b/business/health.go
@@ -70,7 +70,7 @@ func (in *HealthService) getAppHealth(namespace, cluster, app, rateInterval stri
 	// Perf: do not bother fetching request rate if there are no workloads or no workload has sidecar
 	hasSidecar := false
 	for _, w := range ws {
-		if w.IstioSidecar {
+		if w.IstioSidecar || w.IsGateway() {
 			hasSidecar = true
 			break
 		}
@@ -103,7 +103,7 @@ func (in *HealthService) GetWorkloadHealth(ctx context.Context, namespace, clust
 	defer end()
 
 	// Perf: do not bother fetching request rate if workload has no sidecar
-	if !w.IstioSidecar {
+	if !w.IstioSidecar && !w.IsGateway() {
 		return models.WorkloadHealth{
 			WorkloadStatus: w.CastWorkloadStatus(),
 			Requests:       models.NewEmptyRequestHealth(),
@@ -163,7 +163,7 @@ func (in *HealthService) getNamespaceAppHealth(appEntities namespaceApps, criter
 			if entities != nil {
 				h.WorkloadStatuses = entities.Workloads.CastWorkloadStatuses()
 				for _, w := range entities.Workloads {
-					if w.IstioSidecar {
+					if w.IstioSidecar || w.IsGateway() {
 						sidecarPresent = true
 						appSidecars[app] = true
 						break
@@ -307,7 +307,7 @@ func (in *HealthService) getNamespaceWorkloadHealth(ws models.Workloads, criteri
 		allHealth[w.Name] = models.EmptyWorkloadHealth()
 		allHealth[w.Name].Requests.HealthAnnotations = models.GetHealthAnnotation(w.HealthAnnotations, HealthAnnotation)
 		allHealth[w.Name].WorkloadStatus = w.CastWorkloadStatus()
-		if w.IstioSidecar {
+		if w.IstioSidecar || w.IsGateway() {
 			hasSidecar = true
 			wlSidecars[w.Name] = true
 		}

--- a/models/workload.go
+++ b/models/workload.go
@@ -437,6 +437,16 @@ func (workload *Workload) HasIstioSidecar() bool {
 	return workload.Pods.HasIstioSidecar()
 }
 
+// IsGateway return true if the workload is Ingress or Egress Gateway
+func (workload *Workload) IsGateway() bool {
+	if workload.Type == "Deployment" {
+		if labelValue, ok := workload.Labels["operator.istio.io/component"]; ok && (labelValue == "IngressGateways" || labelValue == "EgressGateways") {
+			return true
+		}
+	}
+	return false
+}
+
 // HasIstioAmbient returns true if the workload has any pod with Ambient mesh annotations
 func (workload *Workload) HasIstioAmbient() bool {
 	// if no pods we can't prove that ambient is enabled, so return false (Default)


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6372

The issue can be reproduced on multicluster env, for 'east' cluster's 'istio-system' namespace (easiest way).
It shows 1 Error on the 'istio-system' namespace card for 'east' cluster in Overview page for Apps and Workloads, for the workload 'istio-ingressgateway', but in fact when checking Apps list or details, all are healthy.
The failure is because there is some 'outbound' request with '403' for that workload 'istio-ingressgateway'.
The issue is in inconsistency when calculating health for App/Workloads and for Namespace in Overview page.
For individual or list of Apps/Workloads, those workloads which does not have sidecars, the health does not include Requests.
But in Overview page there was a bug, if at least one workload has a sidecar, then load Requests for all Apps/Workloads in that namespace.
And in 'istio-system' namespace there is one workload 'istio-eastwestgateway' which has a sidecar. This causes loading Requests for 'istio-ingressgateway' workload as well, and in fact I am not sure why there is that Request for this workload, but as it does not have a sidecar, the Requests should be ignored.
The fix is to introduce a map of App/Workload names and sidecars, so for each App or Workload while calculating Namespace health in Overview page, keep loading Requests only for those which has sidecars.

