### PR TITLE
An approach to handling the "mutiple badge" issue for Nodes

### DIFF
--- a/frontend/src/config/Icons.ts
+++ b/frontend/src/config/Icons.ts
@@ -1,56 +1,153 @@
 import deepFreeze from 'deep-freeze';
-
 import solidPinIcon from '../assets/img/solid-pin.png';
 import hollowPinIcon from '../assets/img/hollow-pin.png';
-import { BlueprintIcon, WrenchIcon, SecurityIcon } from '@patternfly/react-icons';
+import {
+  ArrowAltCircleRightIcon,
+  BanIcon,
+  BlueprintIcon,
+  BoltIcon,
+  ClockIcon,
+  CodeBranchIcon,
+  GlobeRouteIcon,
+  LockedIcon,
+  MigrationIcon,
+  SecurityIcon,
+  ShareAltIcon,
+  VirtualMachineIcon,
+  WrenchIcon
+} from '@patternfly/react-icons';
+import React from 'react';
 
 export { solidPinIcon, hollowPinIcon };
+
+export type IconType = {
+  ascii?: string;
+  className: string;
+  color?: string;
+  icon: React.ComponentClass<any, any>;
+  name: string;
+  text: string;
+  type: string;
+};
 
 // The unicode values in the ascii fields come from:
 // https://www.patternfly.org/v3/styles/icons/index.html
 // or from the font awesome site: https://fontawesome.com/icons
 const mutIcons = {
   istio: {
-    circuitBreaker: { className: 'fa fa-bolt', type: 'fa', name: 'bolt', ascii: '\uf0e7 ' },
+    circuitBreaker: {
+      ascii: '\uf0e7 ',
+      className: 'fa fa-bolt',
+      icon: BoltIcon,
+      name: 'bolt',
+      text: 'Circuit Breaker',
+      type: 'fa'
+    } as IconType,
     missingLabel: {
-      icon: WrenchIcon,
-      className: 'fa fa-wrench',
-      type: 'fa',
-      name: 'wrench',
       ascii: '\uE932',
-      color: 'red'
-    },
-    faultInjection: { className: 'fa fa-ban', type: 'fa', name: 'ban', ascii: '\uf05e ' },
-    gateway: { className: 'pf-icon pf-icon-globe-route', type: 'pf', name: 'globe-route' },
-    mirroring: { className: 'pf-icon pf-icon-migration', type: 'pf', name: 'migration' },
+      className: 'fa fa-wrench',
+      color: 'red',
+      icon: WrenchIcon,
+      name: 'wrench',
+      text: 'Missing Label',
+      type: 'fa'
+    } as IconType,
+    faultInjection: {
+      ascii: '\uf05e ',
+      className: 'fa fa-ban',
+      icon: BanIcon,
+      name: 'ban',
+      text: 'Fault Injection',
+      type: 'fa'
+    } as IconType,
+    gateway: {
+      className: 'pf-icon pf-icon-globe-route',
+      icon: GlobeRouteIcon,
+      name: 'globe-route',
+      text: 'Gateway',
+      type: 'pf'
+    } as IconType,
+    mirroring: {
+      className: 'pf-icon pf-icon-migration',
+      icon: MigrationIcon,
+      name: 'migration',
+      text: 'Mirroring',
+      type: 'pf'
+    } as IconType,
     missingAuthPolicy: {
-      icon: SecurityIcon,
-      className: 'pf-icon pf-icon-security',
-      type: 'pf',
-      name: 'security',
       ascii: '\ue946 ',
-      color: 'red'
-    },
+      className: 'pf-icon pf-icon-security',
+      color: 'red',
+      icon: SecurityIcon,
+      name: 'security',
+      text: 'Missing Auth Policy',
+      type: 'pf'
+    } as IconType,
     missingSidecar: {
-      icon: BlueprintIcon,
-      className: 'pf-icon pf-icon-blueprint',
-      type: 'pf',
-      name: 'blueprint',
       ascii: '\ue915 ',
-      color: 'red'
+      className: 'pf-icon pf-icon-blueprint',
+      color: 'red',
+      icon: BlueprintIcon,
+      name: 'blueprint',
+      text: 'Missing Sidecar',
+      type: 'pf'
+    } as IconType,
+    mtls: {
+      ascii: '\ue923 ',
+      className: 'pf-icon pf-icon-locked',
+      icon: LockedIcon,
+      name: 'locked',
+      text: 'mTLS',
+      type: 'pf'
+    } as IconType,
+    requestRouting: {
+      ascii: '\uf126 ',
+      className: 'fa fa-code-branch',
+      icon: CodeBranchIcon,
+      name: 'code-fork',
+      text: 'Request Routing',
+      type: 'fa'
+    } as IconType,
+    requestTimeout: {
+      ascii: '\uf017 ',
+      className: 'fa fa-clock',
+      icon: ClockIcon,
+      name: 'clock',
+      text: 'request Timeout',
+      type: 'fa'
     },
-    mtls: { className: 'pf-icon pf-icon-locked', type: 'pf', name: 'locked', ascii: '\ue923 ' },
-    requestRouting: { className: 'fa fa-code-branch', type: 'fa', name: 'code-fork', ascii: '\uf126 ' },
-    requestTimeout: { className: 'fa fa-clock', type: 'fa', name: 'clock', ascii: '\uf017 ' },
-    root: { className: 'fa fa-arrow-alt-circle-right', type: 'fa', name: 'arrow-alt-circle-right', ascii: '\uf35a ' },
-    trafficShifting: { className: 'fa fa-share-alt', type: 'fa', name: 'share-alt', ascii: '\uf1e0 ' },
-    virtualService: { className: 'fa fa-code-branch', type: 'fa', name: 'code-fork', ascii: '\uf126 ' },
+    root: {
+      ascii: '\uf35a ',
+      className: 'fa fa-arrow-alt-circle-right',
+      icon: ArrowAltCircleRightIcon,
+      name: 'arrow-alt-circle-right',
+      text: 'Traffic Source',
+      type: 'fa'
+    } as IconType,
+    trafficShifting: {
+      ascii: '\uf1e0 ',
+      className: 'fa fa-share-alt',
+      icon: ShareAltIcon,
+      name: 'share-alt',
+      text: 'Traffic Shifting',
+      type: 'fa'
+    } as IconType,
+    virtualService: {
+      ascii: '\uf126 ',
+      className: 'fa fa-code-branch',
+      icon: CodeBranchIcon,
+      name: 'code-fork',
+      text: 'Virtual Service',
+      type: 'fa'
+    } as IconType,
     workloadEntry: {
+      ascii: '\uf126 ',
       className: 'pf-icon pf-icon-virtual-machine',
-      type: 'pf',
+      icon: VirtualMachineIcon,
       name: 'virtual-machine',
-      ascii: '\uf126 '
-    }
+      text: 'Workload Entry',
+      type: 'pf'
+    } as IconType
   }
 };
 

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -51,6 +51,7 @@ import {
   selectAnd,
   SelectAnd,
   setEdgeOptions,
+  setNodeAttachments,
   setNodeLabel
 } from './GraphPFElems';
 import { layoutFactory } from './layouts/layoutFactory';
@@ -67,7 +68,7 @@ import { tcpTimerConfig, timerConfig } from 'components/CytoscapeGraph/TrafficAn
 let initialLayout = false;
 let requestFit = false;
 
-const DEFAULT_NODE_SIZE = 75;
+const DEFAULT_NODE_SIZE = 50;
 const ZOOM_IN = 4 / 3;
 const ZOOM_OUT = 3 / 4;
 
@@ -423,6 +424,11 @@ export const TopologyContent: React.FC<{
       controller.fromModel(model);
       controller.getGraph().setData({ graphData: graphData });
 
+      const { nodes } = elems(controller);
+
+      // set decorators
+      nodes.forEach(n => setNodeAttachments(n, graphSettings));
+
       // pre-select node if provided
       const graphNode = graphData.fetchParams.node;
       if (graphNode) {
@@ -449,7 +455,6 @@ export const TopologyContent: React.FC<{
             selector.push({ prop: NodeAttr.workload, val: graphNode.workload });
         }
 
-        const { nodes } = elems(controller);
         const selectedNodes = selectAnd(nodes, selector);
         if (selectedNodes.length > 0) {
           let target = selectedNodes[0];

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -1,9 +1,12 @@
 import {
   BadgeLocation,
   Controller,
+  Decorator,
+  DEFAULT_DECORATOR_RADIUS,
   Edge,
   EdgeModel,
   EdgeTerminalType,
+  getDefaultShapeDecoratorCenter,
   GraphElement,
   isEdge,
   isNode,
@@ -11,7 +14,8 @@ import {
   Node,
   NodeModel,
   NodeShape,
-  NodeStatus
+  NodeStatus,
+  TopologyQuadrant
 } from '@patternfly/react-topology';
 import { PFBadges, PFBadgeType } from 'components/Pf/PfBadges';
 import { icons, serverConfig } from 'config';
@@ -35,6 +39,9 @@ import _ from 'lodash';
 import { PFColors } from 'components/Pf/PfColors';
 import { getEdgeHealth } from 'types/ErrorRate/GraphEdgeStatus';
 import { Span } from 'types/JaegerInfo';
+import { Tooltip } from '@patternfly/react-core';
+import { IconType } from 'config/Icons';
+import React from 'react';
 
 // Utilities for working with PF Topology
 // - most of these add cytoscape-like functions
@@ -44,6 +51,7 @@ export type NodeMap = Map<string, NodeModel>;
 export type NodeData = DecoratedGraphNodeData & {
   // These are node.data fields that have an impact on the PFT rendering of the node.
   // TODO: Is there an actual type defined for these in PFT?
+  attachments?: React.ReactNode; // ie. decorators
   badge?: string;
   badgeBorderColor?: string;
   badgeClassName?: string;
@@ -59,6 +67,7 @@ export type NodeData = DecoratedGraphNodeData & {
   isUnhighlighted?: boolean;
   labelIcon?: React.ReactNode;
   labelIconClass?: string;
+  labelIconPadding?: number;
   labelPosition?: LabelPosition;
   marginX?: number;
   onHover?: (element: GraphElement, isMouseIn: boolean) => void;
@@ -96,18 +105,18 @@ export type GraphPFSettings = {
   trafficRates: TrafficRate[];
 };
 
-const badgeMap = new Map<string, string>()
-  .set('CB', icons.istio.circuitBreaker.className) // bolt
-  .set('FI', icons.istio.faultInjection.className) // ban
-  .set('GW', icons.istio.gateway.className) // globe
-  .set('MI', icons.istio.mirroring.className) // migration
-  .set('MS', icons.istio.missingSidecar.className) // blueprint
-  .set('RO', icons.istio.root.className) // alt-arrow-circle-right
-  .set('RR', icons.istio.requestRouting.className) // code-branch
-  .set('RT', icons.istio.requestTimeout.className) // clock
-  .set('TS', icons.istio.trafficShifting.className) // share-alt
-  .set('VS', icons.istio.virtualService.className) // code-branch
-  .set('WE', icons.istio.workloadEntry.className); // pf-icon-virtual-machine
+const badgeMap = new Map<string, IconType>()
+  .set('CB', icons.istio.circuitBreaker) // bolt
+  .set('FI', icons.istio.faultInjection) // ban
+  .set('GW', icons.istio.gateway) // globe
+  .set('MI', icons.istio.mirroring) // migration
+  .set('MS', icons.istio.missingSidecar) // blueprint
+  .set('RO', icons.istio.root) // alt-arrow-circle-right
+  .set('RR', icons.istio.requestRouting) // code-branch
+  .set('RT', icons.istio.requestTimeout) // clock
+  .set('TS', icons.istio.trafficShifting) // share-alt
+  .set('VS', icons.istio.virtualService) // code-branch
+  .set('WE', icons.istio.workloadEntry); // pf-icon-virtual-machine
 
 const EdgeColor = PFColors.Success;
 const EdgeColorDead = PFColors.Black500;
@@ -145,6 +154,62 @@ export const getNodeShape = (data: NodeData): NodeShape => {
   }
 };
 
+const getDecorator = (element: Node, quadrant: TopologyQuadrant, icon: IconType, tooltip?: string): React.ReactNode => {
+  const { x, y } = getDefaultShapeDecoratorCenter(quadrant, element);
+
+  return (
+    <Tooltip content={!!tooltip ? tooltip : icon.text}>
+      <Decorator x={x} y={y} radius={DEFAULT_DECORATOR_RADIUS} showBackground icon={React.createElement(icon.icon)} />
+    </Tooltip>
+  );
+};
+
+export const setNodeAttachments = (node: Node<NodeModel>, settings: GraphPFSettings): void => {
+  // PFT provides the ability to add a single Icon (badge) on the label. And so we will use
+  // attachments (up to 4) to display what we would have done with label badges in Cytoscape.
+  const data = node.getData() as NodeData;
+  const attachments = [] as React.ReactNode[];
+
+  if (settings.showMissingSidecars && data.hasMissingSC) {
+    attachments.push(getDecorator(node, TopologyQuadrant.lowerRight, badgeMap.get('MS')!));
+  }
+  if (data.hasWorkloadEntry) {
+    attachments.push(getDecorator(node, TopologyQuadrant.upperRight, badgeMap.get('WE')!));
+  }
+  if (settings.showVirtualServices) {
+    if (data.hasCB) {
+      attachments.push(getDecorator(node, TopologyQuadrant.upperLeft, badgeMap.get('CB')!));
+    }
+    // Because we have limited attachments, just show a single VS attachement and let the
+    // Tooltip list the active VS features
+    if (data.hasVS) {
+      const vsFeatures: string[] = [];
+      if (data.hasFaultInjection) {
+        vsFeatures.push(badgeMap.get('FI')!.text);
+      }
+      if (data.hasMirroring) {
+        vsFeatures.push(badgeMap.get('MI')!.text);
+      }
+      if (data.hasRequestRouting) {
+        vsFeatures.push(badgeMap.get('RR')!.text);
+      }
+      if (data.hasRequestTimeout) {
+        vsFeatures.push(badgeMap.get('RT')!.text);
+      }
+      if (data.hasTrafficShifting || data.hasTCPTrafficShifting) {
+        vsFeatures.push(badgeMap.get('TS')!.text);
+      }
+      const tooltip = vsFeatures.length === 0 ? undefined : `${badgeMap.get('VS')!.text}:\n ${vsFeatures.join(' ,')}`;
+
+      attachments.push(getDecorator(node, TopologyQuadrant.lowerLeft, badgeMap.get('VS')!, tooltip));
+    }
+  }
+
+  if (attachments.length > 0) {
+    data.attachments = attachments;
+  }
+};
+
 export const setNodeLabel = (node: NodeModel, nodeMap: NodeMap, settings: GraphPFSettings): void => {
   const data = node.data as NodeData;
   const app = data.app || '';
@@ -172,67 +237,31 @@ export const setNodeLabel = (node: NodeModel, nodeMap: NodeMap, settings: GraphP
 
   // Badges portion of label...
 
-  let badges = [] as string[];
-  if (settings.showMissingSidecars && data.hasMissingSC) {
-    badges.push(badgeMap.get('MS')!);
-  }
-  if (settings.showVirtualServices) {
-    if (data.hasCB) {
-      badges.push(badgeMap.get('CB')!);
-    }
-    // If there's an additional traffic scenario present then it's assumed
-    // that there is a VS present so the VS badge is omitted.
-    if (data.hasVS) {
-      const hasKialiScenario =
-        data.hasFaultInjection ||
-        data.hasMirroring ||
-        data.hasRequestRouting ||
-        data.hasRequestTimeout ||
-        data.hasTCPTrafficShifting ||
-        data.hasTrafficShifting;
-      if (!hasKialiScenario) {
-        badges.push(badgeMap.get('VS')!);
-      } else {
-        if (data.hasFaultInjection) {
-          badges.push(badgeMap.get('FI')!);
-        }
-        if (data.hasMirroring) {
-          badges.push(badgeMap.get('MI')!);
-        }
-        if (data.hasTrafficShifting || data.hasTCPTrafficShifting) {
-          badges.push(badgeMap.get('TS')!);
-        }
-        if (data.hasRequestTimeout) {
-          badges.push(badgeMap.get('RT')!);
-        }
-        if (data.hasRequestRouting) {
-          badges.push(badgeMap.get('RR')!);
-        }
-      }
-    }
+  // PFT provides the ability to add a single Icon (badge) on the label. Given that we can't
+  // duplicate what we do with Cytoscape, which is to add multiple badges on the label,
+  // we'll reserve the single icon to be used only to identify traffic sources (i.e. roots).
+  // Note that a gateway is a special traffic source.
+  // Other badges will be added as attachments (decorators) on the node, but that requires
+  // the Node, not the NodeModel, and it;s no longer part of the label, so it's not done here.
 
-    if (data.hasWorkloadEntry) {
-      badges.push(badgeMap.get('WE')!);
-    }
-    if (data.isRoot) {
-      if (
-        data.isGateway?.ingressInfo?.hostnames?.length !== undefined ||
-        data.isGateway?.gatewayAPIInfo?.hostnames?.length !== undefined
-      ) {
-        badges.push(badgeMap.get('GW')!);
-      }
-      badges.push(badgeMap.get('RO')!);
+  if (data.isRoot) {
+    if (
+      data.isGateway?.ingressInfo?.hostnames?.length !== undefined ||
+      data.isGateway?.gatewayAPIInfo?.hostnames?.length !== undefined
+    ) {
+      data.labelIcon = (
+        <span className={`${badgeMap.get('GW')?.className}`} style={{ fontSize: '14px', marginBottom: '1px' }}></span>
+      );
     } else {
-      if (data.isGateway?.egressInfo?.hostnames?.length !== undefined) {
-        badges.push(badgeMap.get('GW')!);
-      }
+      data.labelIcon = (
+        <span className={`${badgeMap.get('RO')?.className}`} style={{ marginBottom: '1px', marginLeft: '2px' }}></span>
+      );
+    }
+  } else {
+    if (data.isGateway?.egressInfo?.hostnames?.length !== undefined) {
+      data.labelIcon = <span className={`${badgeMap.get('GW')?.className}`}></span>;
     }
   }
-  // TODO: PFT can only handle one badge/icon at the moment, need an RFE
-  if (badges.length > 0) {
-    data.labelIcon = <span className={`${badges[0]}`}></span>;
-  }
-  data.component = <span className={`${badges[0]}`}></span>;
 
   // Content portion of label (i.e. the text)...
   const content: string[] = [];

--- a/frontend/src/pages/GraphPF/styles/styleNode.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleNode.tsx
@@ -65,6 +65,7 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
         element={element}
         {...rest}
         {...passedData}
+        attachments={hover || detailsLevel === ScaleDetailsLevel.high ? data.attachments : undefined}
         scaleLabel={hover && detailsLevel !== ScaleDetailsLevel.high}
         // scaleNode={hover && detailsLevel === ScaleDetailsLevel.low}
         showLabel={hover || detailsLevel === ScaleDetailsLevel.high}


### PR DESCRIPTION
Closes #6370 

Because PFT allows for only a single labelIcon (i.e badge), we will reserve that specifically to indicate Traffic Sources (or Gateways) because it helps users identify where traffic is entering the mesh.  The other badges we see in Cytoscape will be presented as node attachments.  BUT, since there are only a limited number of attachments (4), and we want to present badges in a consistent location, all VS features will be indicated by the VS icon, and the tooltip will indicate the specific VS features in play.

![Screenshot from 2023-07-20 16-52-53](https://github.com/kiali/kiali/assets/2104052/4f6bc1b0-af14-4bf8-ae58-371009fb0d3e)
