### PR TITLE
Remove cluster info from config response

### DIFF
--- a/frontend/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/frontend/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -40,7 +40,7 @@ import { EmptyGraphLayout } from './EmptyGraphLayout';
 import { FocusAnimation } from './FocusAnimation';
 import { GraphHighlighter } from './graphs/GraphHighlighter';
 import { TrafficRenderer } from './TrafficAnimation/TrafficRenderer';
-import { serverConfig } from 'config';
+import { homeCluster, serverConfig } from 'config';
 import { decoratedNodeData } from './CytoscapeGraphUtils';
 import { scoreNodes, ScoringCriteria } from './GraphScore';
 import { assignEdgeHealth } from 'types/ErrorRate/GraphEdgeStatus';
@@ -813,7 +813,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       edgeLabels: this.props.edgeLabels,
       forceLabels: false,
       graphType: this.props.graphData.fetchParams.graphType,
-      homeCluster: serverConfig?.clusterInfo?.name || CLUSTER_DEFAULT,
+      homeCluster: homeCluster?.name || CLUSTER_DEFAULT,
       showMissingSidecars: this.props.showMissingSidecars,
       showSecurity: this.props.showSecurity,
       showVirtualServices: this.props.showVirtualServices,

--- a/frontend/src/components/Link/KialiPageLink.tsx
+++ b/frontend/src/components/Link/KialiPageLink.tsx
@@ -20,7 +20,7 @@ class KialiPageLinkComponent extends React.Component<KialiPageLinkProps> {
   render() {
     // Without a cluster, simply render a local link
     // If cluster is specified, and it's the home cluster, render a local link.
-    if (!this.props.cluster || !homeCluster?.name || this.props.cluster === homeCluster.name) {
+    if (!this.props.cluster || homeCluster?.name !== '' || this.props.cluster === homeCluster?.name) {
       if (isParentKiosk(this.props.kiosk)) {
         return (
           <Link

--- a/frontend/src/components/Link/KialiPageLink.tsx
+++ b/frontend/src/components/Link/KialiPageLink.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { serverConfig } from '../../config';
+import { homeCluster, serverConfig } from '../../config';
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
 import { isParentKiosk, kioskContextMenuAction } from '../Kiosk/KioskActions';
@@ -20,11 +20,7 @@ class KialiPageLinkComponent extends React.Component<KialiPageLinkProps> {
   render() {
     // Without a cluster, simply render a local link
     // If cluster is specified, and it's the home cluster, render a local link.
-    if (
-      !this.props.cluster ||
-      !serverConfig.clusterInfo?.name ||
-      this.props.cluster === serverConfig.clusterInfo.name
-    ) {
+    if (!this.props.cluster || homeCluster?.name || this.props.cluster === homeCluster?.name) {
       if (isParentKiosk(this.props.kiosk)) {
         return (
           <Link

--- a/frontend/src/components/Link/KialiPageLink.tsx
+++ b/frontend/src/components/Link/KialiPageLink.tsx
@@ -20,7 +20,7 @@ class KialiPageLinkComponent extends React.Component<KialiPageLinkProps> {
   render() {
     // Without a cluster, simply render a local link
     // If cluster is specified, and it's the home cluster, render a local link.
-    if (!this.props.cluster || homeCluster?.name || this.props.cluster === homeCluster?.name) {
+    if (!this.props.cluster || !homeCluster?.name || this.props.cluster === homeCluster.name) {
       if (isParentKiosk(this.props.kiosk)) {
         return (
           <Link

--- a/frontend/src/components/Nav/Masthead/Masthead.tsx
+++ b/frontend/src/components/Nav/Masthead/Masthead.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Label, Flex, FlexItem, Tooltip, Toolbar, ToolbarItem } from '@patternfly/react-core';
 import { ClusterIcon } from '@patternfly/react-icons';
 
-import { serverConfig } from '../../../config';
+import { homeCluster } from '../../../config';
 import { MeshMTLSStatus } from '../../../components/MTls/MeshMTLSStatus';
 import { IstioStatus } from '../../IstioStatus/IstioStatus';
 import { PfSpinner } from '../../PfSpinner';
@@ -19,20 +19,20 @@ export class MastheadItems extends React.Component {
           <ToolbarItem>
             <Flex>
               <FlexItem align={{ default: 'alignRight' }}>
-                {!!serverConfig.clusterInfo?.name && (
+                {homeCluster?.name && (
                   <Tooltip
                     entryDelay={0}
                     position="bottom"
-                    content={<div>Kiali home cluster: {serverConfig.clusterInfo.name}</div>}
+                    content={<div>Kiali home cluster: {homeCluster?.name}</div>}
                   >
                     <Label color="blue" icon={<ClusterIcon />}>
-                      {serverConfig.clusterInfo.name}
+                      {homeCluster?.name}
                     </Label>
                   </Tooltip>
                 )}
               </FlexItem>
               <FlexItem>
-                <IstioStatus cluster={serverConfig.clusterInfo?.name} />
+                <IstioStatus cluster={homeCluster?.name} />
               </FlexItem>
               <FlexItem>
                 <MeshMTLSStatus />

--- a/frontend/src/components/Nav/Menu.tsx
+++ b/frontend/src/components/Nav/Menu.tsx
@@ -6,7 +6,7 @@ import { Nav, NavList, NavItem } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { history } from '../../app/History';
 import { navMenuItems } from '../../routes';
-import { serverConfig } from '../../config';
+import { homeCluster, serverConfig } from '../../config';
 import { kialiStyle } from 'styles/StyleUtils';
 
 const externalLinkStyle = kialiStyle({
@@ -77,7 +77,7 @@ export class Menu extends React.Component<MenuProps, MenuState> {
     return allNavMenuItems
       .filter(item => {
         if (item.title === 'Mesh') {
-          return serverConfig.clusterInfo?.name !== undefined;
+          return homeCluster?.name !== undefined;
         }
         if (item.title === 'Graph [Cy]') {
           return graphEnableCytoscape;

--- a/frontend/src/components/Nav/Navigation.tsx
+++ b/frontend/src/components/Nav/Navigation.tsx
@@ -19,7 +19,7 @@ import {
 import { BarsIcon } from '@patternfly/react-icons';
 import { kialiStyle } from 'styles/StyleUtils';
 import { MessageCenter } from '../../components/MessageCenter/MessageCenter';
-import { kialiLogo, serverConfig } from '../../config';
+import { homeCluster, kialiLogo, serverConfig } from '../../config';
 import { KialiAppState } from '../../store/Store';
 import { UserSettingsThunkActions } from '../../actions/UserSettingsThunkActions';
 import { Menu } from './Menu';
@@ -68,8 +68,8 @@ export class NavigationComponent extends React.Component<PropsType, NavigationSt
 
   componentDidMount() {
     let pageTitle = serverConfig.installationTag ? serverConfig.installationTag : 'Kiali';
-    if (!!serverConfig.clusterInfo?.name) {
-      pageTitle += ` [${serverConfig.clusterInfo.name}]`;
+    if (homeCluster?.name) {
+      pageTitle += ` [${homeCluster?.name}]`;
     }
 
     document.title = pageTitle;

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -1,12 +1,17 @@
 import _ from 'lodash';
 import { ServerConfig } from '../types/ServerConfig';
 import { parseHealthConfig } from './HealthConfig';
+import { MeshCluster } from '../types/Mesh';
 
 export type Durations = { [key: number]: string };
 
 export type ComputedServerConfig = ServerConfig & {
   durations: Durations;
 };
+
+function getHomeCluster(cfg: ServerConfig): MeshCluster | undefined {
+  return Object.values(cfg.clusters).find(cluster => cluster.isKialiHome);
+}
 
 export const humanDurations = (cfg: ComputedServerConfig, prefix?: string, suffix?: string) =>
   _.mapValues(cfg.durations, v => _.reject([prefix, v, suffix], _.isEmpty).join(' '));
@@ -122,6 +127,9 @@ let serverConfig = defaultServerConfig;
 computeValidDurations(serverConfig);
 export { serverConfig };
 
+let homeCluster = getHomeCluster(serverConfig);
+export { homeCluster };
+
 export const toValidDuration = (duration: number): number => {
   // Check if valid
   if (serverConfig.durations[duration]) {
@@ -145,6 +153,8 @@ export const setServerConfig = (cfg: ServerConfig) => {
 
   serverConfig.healthConfig = cfg.healthConfig ? parseHealthConfig(cfg.healthConfig) : serverConfig.healthConfig;
   computeValidDurations(serverConfig);
+
+  homeCluster = getHomeCluster(serverConfig);
 };
 
 export const isIstioNamespace = (namespace: string): boolean => {

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -18,6 +18,16 @@ import { Paths } from './Paths';
 import { jaegerQuery } from './JaegerQuery';
 
 // ServerConfig
-import { isMultiCluster, serverConfig } from './ServerConfig';
+import { homeCluster, isMultiCluster, serverConfig } from './ServerConfig';
 
-export { authenticationConfig, config, Paths, icons, isMultiCluster, kialiLogo, serverConfig, jaegerQuery };
+export {
+  authenticationConfig,
+  config,
+  Paths,
+  icons,
+  homeCluster,
+  isMultiCluster,
+  kialiLogo,
+  serverConfig,
+  jaegerQuery
+};

--- a/frontend/src/pages/Graph/SummaryLink.tsx
+++ b/frontend/src/pages/Graph/SummaryLink.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react';
-import { NodeType, GraphNodeData, DestService, BoxByType, CLUSTER_DEFAULT, DecoratedGraphNodeData } from '../../types/Graph';
+import {
+  NodeType,
+  GraphNodeData,
+  DestService,
+  BoxByType,
+  CLUSTER_DEFAULT,
+  DecoratedGraphNodeData
+} from '../../types/Graph';
 import { KialiIcon } from 'config/KialiIcon';
 import { Badge, PopoverPosition } from '@patternfly/react-core';
 import { Health } from 'types/Health';
 import { HealthIndicator } from 'components/Health/HealthIndicator';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
-import { serverConfig } from 'config';
+import { homeCluster } from 'config';
 import { KialiPageLink } from 'components/Link/KialiPageLink';
 
 interface LinkInfo {
@@ -19,7 +26,7 @@ const getTooltip = (tooltip: React.ReactFragment, nodeData: GraphNodeData): Reac
   const addCluster =
     nodeData.isBox !== BoxByType.CLUSTER &&
     nodeData.cluster !== CLUSTER_DEFAULT &&
-    serverConfig?.clusterInfo?.name !== nodeData.cluster;
+    homeCluster?.name !== nodeData.cluster;
   return (
     <div style={{ textAlign: 'left' }}>
       <span>{tooltip}</span>

--- a/frontend/src/pages/Graph/__tests__/SummaryLink.test.tsx
+++ b/frontend/src/pages/Graph/__tests__/SummaryLink.test.tsx
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { store } from '../../../store/ConfigStore';
 import { Provider } from 'react-redux';
+import { serverConfig, setServerConfig } from '../../../config/ServerConfig';
 
 let defaultGraphData: GraphNodeData;
 
@@ -20,6 +21,17 @@ describe('renderBadgedLink', () => {
   });
 
   it('should generate a link to workload page and badge', () => {
+    serverConfig.clusters = {
+      'cluster-default': {
+        apiEndpoint: '',
+        isKialiHome: true,
+        kialiInstances: [],
+        name: 'cluster-default',
+        network: 'test-net',
+        secretName: 'test-secret'
+      }
+    };
+    setServerConfig(serverConfig);
     const node = { ...defaultGraphData, workload: 'details-v1' };
     const expectedLink = `/namespaces/${encodeURIComponent(node.namespace)}/workloads/${encodeURIComponent(
       node.workload!
@@ -29,6 +41,9 @@ describe('renderBadgedLink', () => {
         <MemoryRouter>{renderBadgedLink(node)}</MemoryRouter>
       </Provider>
     );
+    debugger;
+    console.log('change');
+    console.log(wrapper.find('a').debug());
     expect(wrapper.find('a').filter(`[href="${expectedLink}"]`).exists()).toBeTruthy();
     expect(
       wrapper

--- a/frontend/src/pages/Graph/__tests__/SummaryLink.test.tsx
+++ b/frontend/src/pages/Graph/__tests__/SummaryLink.test.tsx
@@ -18,9 +18,7 @@ describe('renderBadgedLink', () => {
       cluster: 'default-cluster',
       namespace: 'bookinfo'
     };
-  });
 
-  it('should generate a link to workload page and badge', () => {
     serverConfig.clusters = {
       'cluster-default': {
         apiEndpoint: '',
@@ -32,6 +30,9 @@ describe('renderBadgedLink', () => {
       }
     };
     setServerConfig(serverConfig);
+  });
+
+  it('should generate a link to workload page and badge', () => {
     const node = { ...defaultGraphData, workload: 'details-v1' };
     const expectedLink = `/namespaces/${encodeURIComponent(node.namespace)}/workloads/${encodeURIComponent(
       node.workload!
@@ -41,9 +42,6 @@ describe('renderBadgedLink', () => {
         <MemoryRouter>{renderBadgedLink(node)}</MemoryRouter>
       </Provider>
     );
-    debugger;
-    console.log('change');
-    console.log(wrapper.find('a').debug());
     expect(wrapper.find('a').filter(`[href="${expectedLink}"]`).exists()).toBeTruthy();
     expect(
       wrapper

--- a/frontend/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
+++ b/frontend/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { ExpandableSection } from '@patternfly/react-core';
 import { store } from '../../../store/ConfigStore';
 import { Provider } from 'react-redux';
+import { serverConfig, setServerConfig } from '../../../config/ServerConfig';
 
 let defaultProps: SummaryPanelNodeComponentProps;
 let nodeData: GraphNodeData;
@@ -44,6 +45,18 @@ describe('SummaryPanelNodeComponent', () => {
       peerAuthentications: null,
       serviceDetails: null
     };
+
+    serverConfig.clusters = {
+      'cluster-default': {
+        apiEndpoint: '',
+        isKialiHome: true,
+        kialiInstances: [],
+        name: 'cluster-default',
+        network: 'test-net',
+        secretName: 'test-secret'
+      }
+    };
+    setServerConfig(serverConfig);
   });
 
   it('renders', () => {

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -19,7 +19,7 @@ import {
   TopologyQuadrant
 } from '@patternfly/react-topology';
 import { PFBadges, PFBadgeType } from 'components/Pf/PfBadges';
-import { icons, serverConfig } from 'config';
+import { homeCluster as kialiHomeCluster, icons } from 'config';
 import {
   BoxByType,
   CLUSTER_DEFAULT,
@@ -279,7 +279,7 @@ export const setNodeLabel = (node: NodeModel, nodeMap: NodeMap, settings: GraphP
   }
 
   // append cluster if necessary
-  const homeCluster = serverConfig?.clusterInfo?.name || CLUSTER_DEFAULT;
+  const homeCluster = kialiHomeCluster?.name || CLUSTER_DEFAULT;
   if (!!cluster && cluster !== UNKNOWN && cluster !== homeCluster && !isBoxed && isBox !== BoxByType.CLUSTER) {
     content.push(`(${cluster})`);
   }

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -25,7 +25,7 @@ import { IstioStatusMessageList } from './IstioStatusMessageList';
 import { KioskElement } from '../../../components/Kiosk/KioskElement';
 import { PFColors } from '../../../components/Pf/PfColors';
 import { GetIstioObjectUrl } from '../../../components/Link/IstioObjectLink';
-import { isMultiCluster, serverConfig } from '../../../config';
+import { homeCluster, isMultiCluster } from '../../../config';
 
 interface IstioConfigOverviewProps {
   istioObjectDetails: IstioConfigDetails;
@@ -203,7 +203,7 @@ export class IstioConfigOverview extends React.Component<IstioConfigOverviewProp
             ></IstioConfigHelp>
           </StackItem>
         )}
-        {!this.props.istioAPIEnabled && this.props.cluster === serverConfig.clusterInfo?.name && (
+        {!this.props.istioAPIEnabled && this.props.cluster === homeCluster?.name && (
           <StackItem>
             <KialiIcon.Warning className={warnStyle} /> <b>Istio API is disabled.</b> Be careful when editing the
             configuration as the Istio config validations are disabled when the Istio API is disabled.

--- a/frontend/src/store/ConfigStore.ts
+++ b/frontend/src/store/ConfigStore.ts
@@ -68,7 +68,7 @@ const persistConfig = {
 const composeEnhancers =
   (process.env.NODE_ENV === 'development' && window && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
 
-export const configureStore = (initialState: KialiAppState): Store<KialiAppState, KialiAppAction> => {
+const configureStore = (initialState: KialiAppState): Store<KialiAppState, KialiAppAction> => {
   // configure middlewares
   const middlewares = [thunk];
   // compose enhancers
@@ -82,7 +82,7 @@ export const configureStore = (initialState: KialiAppState): Store<KialiAppState
 // Setup the initial state of the Redux store with defaults
 // (instead of having things be undefined until they are populated by query)
 // Redux 4.0 actually required this
-export const initialStore: KialiAppState = {
+const initialStore: KialiAppState = {
   globalState: INITIAL_GLOBAL_STATE,
   statusState: INITIAL_STATUS_STATE,
   namespaces: INITIAL_NAMESPACE_STATE,

--- a/frontend/src/store/ConfigStore.ts
+++ b/frontend/src/store/ConfigStore.ts
@@ -68,7 +68,7 @@ const persistConfig = {
 const composeEnhancers =
   (process.env.NODE_ENV === 'development' && window && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
 
-const configureStore = (initialState: KialiAppState): Store<KialiAppState, KialiAppAction> => {
+export const configureStore = (initialState: KialiAppState): Store<KialiAppState, KialiAppAction> => {
   // configure middlewares
   const middlewares = [thunk];
   // compose enhancers
@@ -82,7 +82,7 @@ const configureStore = (initialState: KialiAppState): Store<KialiAppState, Kiali
 // Setup the initial state of the Redux store with defaults
 // (instead of having things be undefined until they are populated by query)
 // Redux 4.0 actually required this
-const initialStore: KialiAppState = {
+export const initialStore: KialiAppState = {
   globalState: INITIAL_GLOBAL_STATE,
   statusState: INITIAL_STATUS_STATE,
   namespaces: INITIAL_NAMESPACE_STATE,

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -3,11 +3,6 @@ import { MeshCluster } from './Mesh';
 
 export type IstioLabelKey = 'appLabelName' | 'versionLabelName' | 'injectionLabelName' | 'injectionLabelRev';
 
-interface ClusterInfo {
-  name: string;
-  network: string;
-}
-
 interface DeploymentConfig {
   viewOnlyMode: boolean;
 }
@@ -123,7 +118,6 @@ export interface ServerConfig {
   accessibleNamespaces: Array<string>;
   ambientEnabled: boolean;
   authStrategy: string;
-  clusterInfo?: ClusterInfo;
   clusters: { [key: string]: MeshCluster };
   deployment: DeploymentConfig;
   gatewayAPIEnabled: boolean;

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -19,11 +19,6 @@ const (
 	defaultPrometheusGlobalStorageTSDBRetention = 21600 // seconds
 )
 
-type ClusterInfo struct {
-	Name    string `json:"name,omitempty"`
-	Network string `json:"network,omitempty"`
-}
-
 type IstioAnnotations struct {
 	IstioInjectionAnnotation string `json:"istioInjectionAnnotation,omitempty"`
 }
@@ -50,7 +45,6 @@ type PublicConfig struct {
 	AccessibleNamespaces []string                      `json:"accessibleNamespaces,omitempty"`
 	AuthStrategy         string                        `json:"authStrategy,omitempty"`
 	AmbientEnabled       bool                          `json:"ambientEnabled,omitempty"`
-	ClusterInfo          ClusterInfo                   `json:"clusterInfo,omitempty"`
 	Clusters             map[string]kubernetes.Cluster `json:"clusters,omitempty"`
 	Deployment           DeploymentConfig              `json:"deployment,omitempty"`
 	GatewayAPIEnabled    bool                          `json:"gatewayAPIEnabled,omitempty"`
@@ -127,15 +121,6 @@ func Config(w http.ResponseWriter, r *http.Request) {
 
 		for _, cluster := range clusters {
 			publicConfig.Clusters[cluster.Name] = cluster
-			// Setting this will cause the "mesh" page to appear in the UI.
-			// Keeping the old behavior where this only appears when more than
-			// one cluster is present.
-			if len(clusters) > 1 && cluster.IsKialiHome {
-				publicConfig.ClusterInfo = ClusterInfo{
-					Name:    cluster.Name,
-					Network: cluster.Network,
-				}
-			}
 		}
 
 		return nil


### PR DESCRIPTION
Get cluster info from the clusters object and remove the duplicated `ClusterInfo` field from the `/config` response.

Fixes #6373 