### PR TITLE
Fix unwanted graph "fit" on refresh 

### DIFF
--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -507,7 +507,7 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
                 </div>
               )}
             </ErrorBoundary>
-            {this.props.summaryData && !this.state.graphData.isLoading && (
+            {isReady && this.props.summaryData && (
               <SummaryPanel
                 data={this.props.summaryData}
                 duration={this.state.graphData.fetchParams.duration}

--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -244,7 +244,6 @@ class GraphToolbarComponent extends React.PureComponent<GraphToolbarProps> {
   }
 
   private handleNamespaceReturn = () => {
-    console.log(`isPf=${this.props.isPF}`);
     const route = this.props.isPF ? 'graphpf' : 'graph';
     if (
       !this.props.summaryData ||


### PR DESCRIPTION
Fixes #6248 

Fix regression introduced in https://github.com/kiali/kiali/pull/6087 (v1.69). That PR successfully fixed an metrics query issue caused by premature rendering of the SummaryPanel.  But the overly-delayed rendering caused a resize of the available graph space, which forced a unwanted "fit".  The fit operation loses the user's custom zoom/pan. This PR changes the approach, delaying an appropriate amount.

To test, open the browser debug Network tab.  Filter on 'metrics'.   Go to the main graph and set a 10s refresh.  Ensure that the main graph renders fine.  Zoom in and ensure the zoom stays constant on auto-refresh.  Select nodes and ensure the side-panel updates as expected and refreshes as expected.

Double-click a node to enter the node-detail graph.  Ensure it looks fine and refreshes appropriately.  Exit node detail and return to main graph.

Enter Graph Replay and while replaying ensure zoom levels are maintained as the frame advances.

Finally, check the Network tab and ensure all requests returned 200.  There should be no 503s.  This last check ensures the new approach fixes the issue for the problem PR, #6087.