### PR TITLE
Use KubernetesConfig.ClusterName for Metrics query Target.Cluster by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1011,3 +1011,11 @@ func IsFeatureDisabled(featureName FeatureName) bool {
 	}
 	return false
 }
+
+// GetSafeClusterName checks the input value provides a default cluster name if it's empty
+func GetSafeClusterName(cluster string) string {
+	if cluster == "" {
+		return Get().KubernetesConfig.ClusterName
+	}
+	return cluster
+}

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -47,6 +47,15 @@ And('user sees span details', () => {
     .find('td')
     .eq(4) // take 5th cell (kebab)
     .should('be.visible');
+  cy.get('table')
+    .should('be.visible')
+    .find('tbody tr') // ignore thead rows
+    .should('have.length.above', 1) // retries above cy.find() until we have a non head-row
+    .eq(1) // take 1st  row
+    .find('td')
+    .eq(3) // take 4th cell (Statistics)
+    .children('button')
+    .should('not.exist'); // Load Statistics button should not exist when metrics are loaded
 });
 
 When('I fetch the list of applications', function () {

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -376,7 +376,7 @@ func prepareStatsQueries(w http.ResponseWriter, r *http.Request, rawQ []models.M
 			}
 		}
 		if !found {
-			newNs := models.Namespace{Name: q.Target.Namespace, Cluster: models.ClusterNameFromTarget(q.Target)}
+			newNs := models.Namespace{Name: q.Target.Namespace, Cluster: config.GetSafeClusterName(q.Target.Cluster)}
 			namespaces = append(namespaces, newNs)
 		}
 	}

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -376,7 +376,7 @@ func prepareStatsQueries(w http.ResponseWriter, r *http.Request, rawQ []models.M
 			}
 		}
 		if !found {
-			newNs := models.Namespace{Name: q.Target.Namespace, Cluster: q.Target.Cluster}
+			newNs := models.Namespace{Name: q.Target.Namespace, Cluster: models.ClusterNameFromTarget(q.Target)}
 			namespaces = append(namespaces, newNs)
 		}
 	}

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -8,7 +8,6 @@ import (
 
 	pmod "github.com/prometheus/common/model"
 
-	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/util"
 )
@@ -251,14 +250,4 @@ func convertSamplePair(from *pmod.SamplePair, scale float64) Datapoint {
 		Timestamp: int64(from.Timestamp),
 		Value:     scale * float64(from.Value),
 	}
-}
-
-// ClusterNameFromTarget extracts the cluster name from the Target query
-// and provides a default value if it's not present.
-func ClusterNameFromTarget(target Target) string {
-	cluster := target.Cluster
-	if cluster == "" {
-		cluster = config.Get().KubernetesConfig.ClusterName
-	}
-	return cluster
 }

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -8,6 +8,7 @@ import (
 
 	pmod "github.com/prometheus/common/model"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/util"
 )
@@ -250,4 +251,14 @@ func convertSamplePair(from *pmod.SamplePair, scale float64) Datapoint {
 		Timestamp: int64(from.Timestamp),
 		Value:     scale * float64(from.Value),
 	}
+}
+
+// ClusterNameFromTarget extracts the cluster name from the Target query
+// and provides a default value if it's not present.
+func ClusterNameFromTarget(target Target) string {
+	cluster := target.Cluster
+	if cluster == "" {
+		cluster = config.Get().KubernetesConfig.ClusterName
+	}
+	return cluster
 }


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6405

For single OCP cluster environment, the Target.Cluster param is empty in Metrics json query. Thus the backend fails to retrieve userClient for a cluster. https://github.com/kiali/kiali/blob/master/business/namespaces.go#L570
Using similar logic as in `clusterNameFromQuery` for Target.Cluster.

Is there a better way to set default cluster?
