### PR TITLE
Look for current context in remote secret

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -362,6 +362,10 @@ type DeploymentConfig struct {
 	InstanceName         string   `yaml:"instance_name"`
 	Namespace            string   `yaml:"namespace,omitempty"` // Kiali deployment namespace
 	ViewOnlyMode         bool     `yaml:"view_only_mode,omitempty"`
+	// RemoteSecretPath is used to identify the remote cluster Kiali will connect to as its "local cluster".
+	// This is to support installing Kiali in the control plane, but observing only the data plane in the remote cluster.
+	// Experimental feature. See: https://github.com/kiali/kiali/issues/3002
+	RemoteSecretPath string `yaml:"remote_secret_path,omitempty"`
 }
 
 // GraphFindOption defines a single Graph Find/Hide Option
@@ -549,6 +553,7 @@ func NewConfig() (c *Config) {
 			ClusterWideAccess:    true,
 			InstanceName:         "kiali",
 			Namespace:            "istio-system",
+			RemoteSecretPath:     "/kiali-remote-secret/kiali",
 			ViewOnlyMode:         false,
 		},
 		ExternalServices: ExternalServices{

--- a/hack/run-kiali-config-template.yaml
+++ b/hack/run-kiali-config-template.yaml
@@ -19,7 +19,8 @@ auth:
   strategy: "anonymous"
 
 deployment:
-  accessible_namespaces: ['**']
+  accessible_namespaces: ["**"]
+  remote_secret_path: "${REMOTE_SECRET_PATH}"
 
 external_services:
   custom_dashboards:
@@ -41,11 +42,8 @@ external_services:
     in_cluster_url: "${TRACING_URL}"
     url: "${TRACING_URL}"
 
-kubernetes_config:
-  cache_enabled: true
-
 login_token:
-   signing_key: "notsecure"
+  signing_key: "notsecure"
 
 server:
   static_content_root_directory: "${UI_CONSOLE_DIR}"

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -78,11 +78,14 @@ func GetClientFactory() (ClientFactory, error) {
 		}
 
 		// Create a new config based on what was gathered above but don't specify the bearer token to use
-		config.BearerToken = ""
-		config.QPS = kialiConfig.Get().KubernetesConfig.QPS
-		config.Burst = kialiConfig.Get().KubernetesConfig.Burst
+		baseConfig := rest.Config{
+			Host:            config.Host, // TODO: do we need this? remote cluster clients should ignore this
+			TLSClientConfig: config.TLSClientConfig,
+			QPS:             kialiConfig.Get().KubernetesConfig.QPS,
+			Burst:           kialiConfig.Get().KubernetesConfig.Burst,
+		}
 
-		factory, err = newClientFactory(config)
+		factory, err = newClientFactory(&baseConfig)
 	})
 	return factory, err
 }

--- a/kubernetes/client_factory_test.go
+++ b/kubernetes/client_factory_test.go
@@ -343,6 +343,7 @@ func TestClientCreatedWithProxyInfo(t *testing.T) {
 	require := require.New(t)
 
 	cfg := config.NewConfig()
+	cfg.Deployment.RemoteSecretPath = t.TempDir() // Random dir so that the remote secret isn't read if it exists.
 	cfg.Auth.Strategy = config.AuthStrategyOpenId
 	cfg.Auth.OpenId.ApiProxyCAData = base64.StdEncoding.EncodeToString(proxyCAData)
 	cfg.Auth.OpenId.ApiProxy = "https://api-proxy:8443"

--- a/kubernetes/testdata/remote-cluster-multiple-users.yaml
+++ b/kubernetes/testdata/remote-cluster-multiple-users.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+  - cluster:
+      server: https://192.168.1.2:1234
+    name: TestRemoteCluster
+contexts:
+  - context:
+      cluster: TestRemoteCluster
+      user: remoteuser2
+    name: TestRemoteClusterUser2
+current-context: "TestRemoteClusterUser2"
+kind: Config
+preferences: {}
+users:
+  - name: remoteuser1
+    user:
+      token: token1
+  - name: remoteuser2
+    user:
+      token: token2

--- a/kubernetes/testing.go
+++ b/kubernetes/testing.go
@@ -35,6 +35,9 @@ func SetConfig(t *testing.T, newConfig config.Config) {
 // the default path at /var/run/secrets/... which probably doesn't exist and
 // we probably don't want to use it even if it does.
 // This sets globals so it is NOT safe to use in parallel tests.
+// It really should just be used for internal client factory tests
+// since it has side effects with globals and local files/env vars.
+// If you need a test client factory outside this package, use the mock implementation.
 func NewTestingClientFactory(t *testing.T) *clientFactory {
 	t.Helper()
 

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -1,8 +1,11 @@
 package kubernetes
 
 import (
+	"fmt"
 	"os"
 	"time"
+
+	"github.com/kiali/kiali/config"
 )
 
 // Be careful with how you use this token. This is the Kiali Service Account token, not the user token.
@@ -19,11 +22,12 @@ var (
 func GetKialiTokenForHomeCluster() (string, error) {
 	// TODO: refresh the token when it changes rather than after it expires
 	if KialiTokenForHomeCluster == "" || shouldRefreshToken() {
-		if remoteSecret, err := GetRemoteSecret(RemoteSecretData); err == nil { // for experimental feature - for when data plane is in a remote cluster
-			for _, authInfo := range remoteSecret.AuthInfos {
-				// Remote secrets with only a single auth info are supported.
+		if remoteSecret, err := GetRemoteSecret(config.Get().Deployment.RemoteSecretPath); err == nil { // for experimental feature - for when data plane is in a remote cluster
+			currentContextAuthInfo := remoteSecret.Contexts[remoteSecret.CurrentContext].AuthInfo
+			if authInfo, ok := remoteSecret.AuthInfos[currentContextAuthInfo]; ok {
 				KialiTokenForHomeCluster = authInfo.Token
-				break
+			} else {
+				return "", fmt.Errorf("auth info not found for current context: [%s]. Current context must be set for kiali remote secret", remoteSecret.CurrentContext)
 			}
 		} else {
 			token, err := os.ReadFile(DefaultServiceAccountPath)


### PR DESCRIPTION
Instead of taking the first item in the auth info map for the remote secret, Kiali will now look at the current context and get the auth info for the current context. An error is returned if the current context is not set in the kubeconfig.

Also exposes the remote secret path as a config value so that you don't have to use the hardcoded `/kiali-remote-secret/kiali`. Useful when running locally with `run-kiali.sh` so you don't have to create that root dir.

Fixes #6402