### PR TITLE
Cypress automation for a Graph page test scenario

### DIFF
--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -1,4 +1,4 @@
-import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Before, Then, When, And } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
 
 const url = '/console';
@@ -62,6 +62,9 @@ When('user {string} {string} option', (action, option: string) => {
       break;
     case 'namespace boxes':
       option = 'boxByNamespace';
+      break;
+    case 'operation nodes':
+      option = 'filterOperationNodes';
       break;
     case 'rank':
       option = 'rank';
@@ -316,6 +319,20 @@ Then('{string} option {string} in the graph', (option: string, action: string) =
   }
 
   validateInput(option, action);
+});
+
+And('the {string} option should {string} and {string}', (option:string, optionState:string, checkState:string) => {
+  switch (option) {
+    case 'operation nodes':
+      option = 'filterOperationNodes';
+      break;
+    case 'service nodes':
+      option = 'filterServiceNodes';
+      break;
+    default:
+      option = 'xxx';
+  }
+  cy.get('div#graph-display-menu').find(`input#${option}`).should(optionState.replaceAll(' ','.')).and(`be.${checkState}`);
 });
 
 function validateInput(option: string, action: string) {

--- a/frontend/cypress/integration/featureFiles/graph_display.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display.feature
@@ -226,3 +226,19 @@ Feature: Kiali Graph page - Display menu
     And user opens display menu
     Then the display menu opens
     And the display menu has default settings
+
+  @error-rates-app
+  @graph-page-display
+  Scenario: User observes some options not being clickable when switching to Service graph 
+    When user "disables" "service nodes" option
+    And user "enables" "operation nodes" option
+    And user selects "SERVICE" graph type
+    And user opens display menu
+    Then the display menu opens
+    And the "service nodes" option should "not be checked" and "disabled"
+    And the "operation nodes" option should "be checked" and "disabled"
+    When user selects "APP" graph type
+    And user opens display menu
+    Then the display menu opens
+    And the "service nodes" option should "not be checked" and "enabled"
+    And the "operation nodes" option should "be checked" and "enabled"


### PR DESCRIPTION
This is a Cypress automation of a test scenario (#6307) and it relates to certain Graph page controls being disabled when using the Service graph (#6188). 