### PR TITLE
Remove extra parenthesis in PF Graph

### DIFF
--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -729,7 +729,6 @@ export const TopologyContent: React.FC<{
         />
       }
     >
-      )
       <VisualizationSurface data-test="visualization-surface" state={{}} />
     </TopologyView>
   );


### PR DESCRIPTION
There was an extra parenthesis in the PF Graph, which was visible in the left middle of the graph: 

![image](https://github.com/kiali/kiali/assets/49480155/8e3a33fa-0398-4897-a30e-8e54190bc3f6)

To reproduce, we should set impl: "pf"