### PR TITLE
Istio Status test ensuring there is no warning or danger status upon a fresh install

### DIFF
--- a/frontend/cypress/integration/common/kiali_alert.ts
+++ b/frontend/cypress/integration/common/kiali_alert.ts
@@ -1,0 +1,7 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { ensureKialiFinishedLoading } from './transition';
+
+Then(`user should see no Istio Components Status`, () => {
+  ensureKialiFinishedLoading(); 
+  cy.get('#istio-status-danger').should('not.be.visible');
+});

--- a/frontend/cypress/integration/featureFiles/kiali_alert.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_alert.feature
@@ -1,0 +1,11 @@
+Feature: Kiali help about verify
+
+  User does not want to see any alerts when opening a fresh installation of Kiali
+
+  Background:
+    Given user is at administrator perspective
+    And user is at the "overview" page
+
+  @smoke
+  Scenario: Open Kiali notifications
+    Then user should see no Istio Components Status

--- a/frontend/src/components/IstioStatus/IstioStatus.tsx
+++ b/frontend/src/components/IstioStatus/IstioStatus.tsx
@@ -122,20 +122,25 @@ export class IstioStatusComponent extends React.Component<Props> {
       const icons = this.props.icons ? { ...defaultIcons, ...this.props.icons } : defaultIcons;
       const iconColor = this.tooltipColor();
       let Icon: React.ComponentClass<SVGIconProps> = ResourcesFullIcon;
+      let dataTestID: string = 'istio-status';
 
       if (iconColor === PFColors.Danger) {
         Icon = icons.ErrorIcon;
+        dataTestID = dataTestID + '-danger';
       } else if (iconColor === PFColors.Warning) {
         Icon = icons.WarningIcon;
+        dataTestID = dataTestID + '-warning';
       } else if (iconColor === PFColors.Info) {
         Icon = icons.InfoIcon;
+        dataTestID = dataTestID + '-info';
       } else if (iconColor === PFColors.Success) {
         Icon = icons.HealthyIcon;
+        dataTestID = dataTestID + '-success';
       }
 
       return (
         <Tooltip position={TooltipPosition.left} enableFlip={true} content={this.tooltipContent()} maxWidth={'25rem'}>
-          <Icon color={iconColor} style={{ verticalAlign: '-0.2em', marginRight: -8 }} />
+          <Icon color={iconColor} style={{ verticalAlign: '-0.2em', marginRight: -8 }} data-test={dataTestID} />
         </Tooltip>
       );
     }


### PR DESCRIPTION
There is an Istio status in the header of the Kiali page. This status has various states (success, info, warning and danger). This scenario tests that there should be no warning or error status upon new Kiali installation. The reason for adding this test is that there was a faulty Prometheus deployment, but all of the Cypress test passed and the failure was only visible either through Kiali status, or the Prometheus UI. We also think Kiali should not have any warnings or errors upon new installation. 

I've also added some data tests in the React code. 

