### PR TITLE
Istio Status test ensuring there is no warning or danger status upon a fresh install 

### DIFF
--- a/frontend/cypress/integration/common/kiali_alert.ts
+++ b/frontend/cypress/integration/common/kiali_alert.ts
@@ -1,0 +1,16 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+
+Then(`user should see no Istio Components Status`, () => {
+  cy.intercept({
+    pathname: '**/api/istio/status*',
+    query: {
+      objects: ''
+    }
+  }).as('istioStatus');
+
+  cy.request('GET', '/api/istio/status')
+  cy.wait('@istioStatus');
+  cy.waitForReact();
+  cy.get('[data-test="istio-status-danger"]',{ timeout: 1000 }).should('not.exist');
+  cy.get('[data-test="istio-status-warning"]',{ timeout: 1000 }).should('not.exist');
+});

--- a/frontend/cypress/integration/featureFiles/kiali_alert.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_alert.feature
@@ -1,0 +1,11 @@
+Feature: Kiali help about verify
+
+  User does not want to see any alerts when opening a fresh installation of Kiali
+
+  Background:
+    Given user is at administrator perspective
+    And user is at the "overview" page
+
+  @smoke
+  Scenario: Open Kiali notifications
+    Then user should see no Istio Components Status

--- a/frontend/src/components/IstioStatus/IstioStatus.tsx
+++ b/frontend/src/components/IstioStatus/IstioStatus.tsx
@@ -122,20 +122,25 @@ export class IstioStatusComponent extends React.Component<Props> {
       const icons = this.props.icons ? { ...defaultIcons, ...this.props.icons } : defaultIcons;
       const iconColor = this.tooltipColor();
       let Icon: React.ComponentClass<SVGIconProps> = ResourcesFullIcon;
+      let dataTestID: string = 'istio-status';
 
       if (iconColor === PFColors.Danger) {
         Icon = icons.ErrorIcon;
+        dataTestID = dataTestID + '-danger';
       } else if (iconColor === PFColors.Warning) {
         Icon = icons.WarningIcon;
+        dataTestID = dataTestID + '-warning';
       } else if (iconColor === PFColors.Info) {
         Icon = icons.InfoIcon;
+        dataTestID = dataTestID + '-info';
       } else if (iconColor === PFColors.Success) {
         Icon = icons.HealthyIcon;
+        dataTestID = dataTestID + '-success';
       }
 
       return (
         <Tooltip position={TooltipPosition.left} enableFlip={true} content={this.tooltipContent()} maxWidth={'25rem'}>
-          <Icon color={iconColor} style={{ verticalAlign: '-0.2em', marginRight: -8 }} />
+          <Icon color={iconColor} style={{ verticalAlign: '-0.2em', marginRight: -8 }} data-test={dataTestID} />
         </Tooltip>
       );
     }

--- a/frontend/src/components/IstioStatus/__tests__/__snapshots__/IstioStatus.test.tsx.snap
+++ b/frontend/src/components/IstioStatus/__tests__/__snapshots__/IstioStatus.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`When addon component has a problem the Icon shows is displayed in orang
 >
   <ResourcesFullIcon
     color="var(--pf-global--warning-color--100)"
+    data-test="istio-status-warning"
     noVerticalAlign={false}
     size="sm"
     style={
@@ -64,6 +65,7 @@ exports[`When both core and addon component have problems any component is in no
 >
   <ResourcesFullIcon
     color="var(--pf-global--danger-color--100)"
+    data-test="istio-status-danger"
     noVerticalAlign={false}
     size="sm"
     style={
@@ -102,6 +104,7 @@ exports[`When core component has a problem the Icon shows is displayed in Red 1`
 >
   <ResourcesFullIcon
     color="var(--pf-global--danger-color--100)"
+    data-test="istio-status-danger"
     noVerticalAlign={false}
     size="sm"
     style={
@@ -140,6 +143,7 @@ exports[`When there are not-ready components mixed with other not healthy compon
 >
   <ResourcesFullIcon
     color="var(--pf-global--warning-color--100)"
+    data-test="istio-status-warning"
     noVerticalAlign={false}
     size="sm"
     style={
@@ -188,6 +192,7 @@ exports[`When there are not-ready components mixed with other not healthy compon
 >
   <ResourcesFullIcon
     color="var(--pf-global--danger-color--100)"
+    data-test="istio-status-danger"
     noVerticalAlign={false}
     size="sm"
     style={
@@ -226,6 +231,7 @@ exports[`When there are not-ready components mixed with other not healthy compon
 >
   <ResourcesFullIcon
     color="var(--pf-global--danger-color--100)"
+    data-test="istio-status-danger"
     noVerticalAlign={false}
     size="sm"
     style={
@@ -259,6 +265,7 @@ exports[`When there are not-ready components not mixed with other unhealthy comp
 >
   <ResourcesFullIcon
     color="var(--pf-global--info-color--100)"
+    data-test="istio-status-info"
     noVerticalAlign={false}
     size="sm"
     style={
@@ -292,6 +299,7 @@ exports[`When there are not-ready components not mixed with other unhealthy comp
 >
   <ResourcesFullIcon
     color="var(--pf-global--info-color--100)"
+    data-test="istio-status-info"
     noVerticalAlign={false}
     size="sm"
     style={


### PR DESCRIPTION
There is an Istio status in the header of the Kiali page. This status has various states (success, info, warning and danger). This scenario tests that there should be no warning or error status upon new Kiali installation. The reason for adding this test is that there was a faulty Prometheus deployment, but all of the Cypress test passed and the failure was only visible either through Kiali status, or the Prometheus UI. We also think Kiali should not have any warnings or errors upon new installation.

I've also added some data tests in the React code.

Reopened after some issues with #6428 

To test this:
- deploy Kiali
- run the test and it should pass by default
- scale down replicas of something like Prometheus to 0 to invoke the Istio Status icon ` kubectl scale deployment details-v1 --replicas=0`
- run the test again, this time it should fail