### PR TITLE
PFT graph enhancements

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "cytoscape": "3.15.5",
     "cytoscape-canvas": "3.0.1",
     "cytoscape-popper": "1.0.7",
+    "d3": "^5.16.0",
     "dagre": "0.8.5",
     "deep-freeze": "0.0.1",
     "eventemitter3": "4.0.7",

--- a/frontend/src/pages/GraphPF/layouts/layoutFactory.ts
+++ b/frontend/src/pages/GraphPF/layouts/layoutFactory.ts
@@ -9,6 +9,21 @@ import {
 } from '@patternfly/react-topology';
 import { LayoutName } from '../GraphPF';
 
+/*
+This is just for reference, a copy of PFT defaults, so we can compare any tweaks we've made below...
+
+export const LAYOUT_DEFAULTS: LayoutOptions = {
+  linkDistance: 60,
+  nodeDistance: 35,
+  groupDistance: 35,
+  collideDistance: 0,
+  simulationSpeed: 10,
+  chargeStrength: 0,
+  allowDrag: true,
+  layoutOnDrag: true
+};
+*/
+
 export const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined => {
   switch (type) {
     case LayoutName.BreadthFirst:
@@ -16,15 +31,15 @@ export const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout
     case LayoutName.Concentric:
       return new ConcentricLayout(graph);
     case LayoutName.Grid:
-      return new GridLayout(graph);
+      return new GridLayout(graph, {
+        nodeDistance: 50
+      });
     default:
       return new DagreLayout(graph, {
-        //allowDrag: true,
-        //layoutOnDrag: true,
+        linkDistance: 30,
+        nodeDistance: 20,
         marginx: undefined,
         marginy: undefined,
-        //nodesep: undefined,
-        //edgesep: undefined,
         ranker: 'network-simplex',
         rankdir: 'LR'
       });

--- a/frontend/src/pages/GraphPF/layouts/layoutFactory.ts
+++ b/frontend/src/pages/GraphPF/layouts/layoutFactory.ts
@@ -36,8 +36,8 @@ export const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout
       });
     default:
       return new DagreLayout(graph, {
-        linkDistance: 30,
-        nodeDistance: 20,
+        linkDistance: 40,
+        nodeDistance: 25,
         marginx: undefined,
         marginy: undefined,
         ranker: 'network-simplex',


### PR DESCRIPTION
Epic https://github.com/kiali/openshift-servicemesh-plugin/issues/99

This PR makes two enhancements:
- small changes to the layout to reduce distances between nodes and lengths of edges.  This makes the graph slightly more compact to better fit larger graphs.
- add support for bringing labels to the top on hover, to be able to see labels that may be partially overlapped.
  - note that this adds a D3 dependency into package.json.  This is the same version already required by PFT, so I don't think it adds any size or risk, but I did want to call it out.

Before:
- Note the nodes are more zoomed out because the graph takes more space
![image](https://github.com/kiali/kiali/assets/2104052/8eaef5be-e52d-4429-9ae5-d4326f3b90a0)

After:
- The graph is easier to read because it takes less space and requires less zoom
- Note that the "bookinfo" label has ben brought forward by a hover
![image](https://github.com/kiali/kiali/assets/2104052/8ff00ff9-f1fa-4fed-a1e0-67432b9f8551)


