### PR TITLE
Added new config for kiali URL per cluster name mapping

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -330,16 +330,14 @@ func (in *MeshService) discoverKiali(ctx context.Context, clusterName string, r 
 	for _, d := range services {
 		kiali := convertKialiServiceToInstance(&d)
 		// If URL is already populated (because of an annotation), trust that because it's user configuration.
-		// If empty, check Kiali URL configured per cluster name.
-		if kiali.Url == "" {
-			for _, cfgurl := range config.Get().KialiFeatureFlags.Clustering.KialiURLs {
-				if cfgurl.ClusterName == clusterName {
-					kiali.Url = cfgurl.URL
-					break
-				}
+		// But if Kiali URL configured per cluster name, instance name and namespace, then use that URL.
+		for _, cfgurl := range config.Get().KialiFeatureFlags.Clustering.KialiURLs {
+			if cfgurl.ClusterName == clusterName && cfgurl.InstanceName == kiali.ServiceName && cfgurl.Namespace == kiali.Namespace {
+				kiali.Url = cfgurl.URL
+				break
 			}
 		}
-		// If still empty, only guess ourselves on our own cluster.
+		// If URL is still empty, only guess ourselves on our own cluster.
 		if kiali.Url == "" && clusterName == in.conf.KubernetesConfig.ClusterName {
 			kiali.Url = httputil.GuessKialiURL(r)
 		}

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -330,7 +330,15 @@ func (in *MeshService) discoverKiali(ctx context.Context, clusterName string, r 
 	for _, d := range services {
 		kiali := convertKialiServiceToInstance(&d)
 		// If URL is already populated (because of an annotation), trust that because it's user configuration.
-		// Only guess ourselves on our own cluster.
+		// If empty, check Kiali URL configured per cluster name.
+		if kiali.Url == "" {
+			for _, cfgurl := range config.Get().KialiFeatureFlags.Clustering.KialiURLs {
+				if cfgurl.ClusterName == clusterName {
+					kiali.Url = cfgurl.URL
+				}
+			}
+		}
+		// If still empty, only guess ourselves on our own cluster.
 		if kiali.Url == "" && clusterName == in.conf.KubernetesConfig.ClusterName {
 			kiali.Url = httputil.GuessKialiURL(r)
 		}

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -335,6 +335,7 @@ func (in *MeshService) discoverKiali(ctx context.Context, clusterName string, r 
 			for _, cfgurl := range config.Get().KialiFeatureFlags.Clustering.KialiURLs {
 				if cfgurl.ClusterName == clusterName {
 					kiali.Url = cfgurl.URL
+					break
 				}
 			}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -448,7 +448,14 @@ type CertificatesInformationIndicators struct {
 
 // Clustering defines configuration around multi-cluster functionality.
 type Clustering struct {
-	EnableExecProvider bool `yaml:"enable_exec_provider,omitempty" json:"enable_exec_provider"`
+	EnableExecProvider bool       `yaml:"enable_exec_provider,omitempty" json:"enable_exec_provider"`
+	KialiURLs          []KialiURL `yaml:"kiali_urls,omitempty" json:"kialiURLs,omitempty"`
+}
+
+// KialiURL defines a cluster name to URL map.
+type KialiURL struct {
+	ClusterName string `yaml:"cluster_name,omitempty"`
+	URL         string `yaml:"url,omitempty"`
 }
 
 // KialiFeatureFlags available from the CR

--- a/config/config.go
+++ b/config/config.go
@@ -449,13 +449,15 @@ type CertificatesInformationIndicators struct {
 // Clustering defines configuration around multi-cluster functionality.
 type Clustering struct {
 	EnableExecProvider bool       `yaml:"enable_exec_provider,omitempty" json:"enable_exec_provider"`
-	KialiURLs          []KialiURL `yaml:"kiali_urls,omitempty" json:"kialiURLs,omitempty"`
+	KialiURLs          []KialiURL `yaml:"kiali_urls,omitempty" json:"kiali_urls,omitempty"`
 }
 
-// KialiURL defines a cluster name to URL map.
+// KialiURL defines a cluster name, namespace and instance name properties to URL.
 type KialiURL struct {
-	ClusterName string `yaml:"cluster_name,omitempty"`
-	URL         string `yaml:"url,omitempty"`
+	ClusterName  string `yaml:"cluster_name,omitempty"`
+	InstanceName string `yaml:"instance_name,omitempty"`
+	Namespace    string `yaml:"namespace,omitempty"`
+	URL          string `yaml:"url,omitempty"`
 }
 
 // KialiFeatureFlags available from the CR


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6243

Operator PR https://github.com/kiali/kiali-operator/pull/672

A new configuration is added in Kiali configmap, called 'kiali_urls', which is a mapping between cluster name and Kiali URL.
This value will be used if Kiali Service annotation 'kiali.io/external-url' does not have value.