### PR TITLE
Consider d3 target to have multiple classes in pf graph

### DIFF
--- a/frontend/src/pages/GraphPF/components/groupExpanded.tsx
+++ b/frontend/src/pages/GraphPF/components/groupExpanded.tsx
@@ -217,10 +217,14 @@ const BaseGroupExpandedComponent: React.FunctionComponent<BaseGroupExpandedProps
   // "knows" it needs to go one level higher to reach the proper grouping.
   const raise = e => {
     let target = e.target;
-    while (!d3.select(target).attr('class')?.startsWith('pf-topology__group ')) {
-      target = target.parentNode;
+    try {
+      while (d3.select(target).attr('class') !== 'pf-topology__group') {
+        target = target.parentNode;
+      }
+      d3.select(target.parentNode).raise();
+    } catch (err) {
+      // ignore when this logic doesn't work and travels too far up the chain
     }
-    d3.select(target.parentNode).raise();
   };
 
   const data = element.getData();

--- a/frontend/src/pages/GraphPF/components/groupExpanded.tsx
+++ b/frontend/src/pages/GraphPF/components/groupExpanded.tsx
@@ -217,7 +217,7 @@ const BaseGroupExpandedComponent: React.FunctionComponent<BaseGroupExpandedProps
   // "knows" it needs to go one level higher to reach the proper grouping.
   const raise = e => {
     let target = e.target;
-    while (d3.select(target).attr('class') !== 'pf-topology__group') {
+    while (!d3.select(target).attr('class')?.startsWith('pf-topology__group')) {
       target = target.parentNode;
     }
     d3.select(target.parentNode).raise();

--- a/frontend/src/pages/GraphPF/components/groupExpanded.tsx
+++ b/frontend/src/pages/GraphPF/components/groupExpanded.tsx
@@ -217,7 +217,7 @@ const BaseGroupExpandedComponent: React.FunctionComponent<BaseGroupExpandedProps
   // "knows" it needs to go one level higher to reach the proper grouping.
   const raise = e => {
     let target = e.target;
-    while (!d3.select(target).attr('class')?.startsWith('pf-topology__group')) {
+    while (!d3.select(target).attr('class')?.startsWith('pf-topology__group ')) {
       target = target.parentNode;
     }
     d3.select(target.parentNode).raise();

--- a/frontend/src/pages/GraphPF/components/node.tsx
+++ b/frontend/src/pages/GraphPF/components/node.tsx
@@ -326,10 +326,14 @@ const BaseNodeComponent: React.FunctionComponent<BaseNodeProps> = ({
   // "knows" it needs to go two levels higher to reach the proper grouping.
   const raise = e => {
     let target = e.target;
-    while (!d3.select(target).attr('class')?.startsWith('pf-topology__node ')) {
-      target = target.parentNode;
+    try {
+      while (!d3.select(target).attr('class')?.startsWith('pf-topology__node ')) {
+        target = target.parentNode;
+      }
+      d3.select(target.parentNode.parentNode).raise();
+    } catch (err) {
+      // ignore when this logic doesn't work and travels too far up the chain
     }
-    d3.select(target.parentNode.parentNode).raise();
   };
 
   const data = element.getData();


### PR DESCRIPTION
** Describe the change **

When user hovers an application label in PF graph, application considers that d3 target can have only one class, but this is not correct and the error is produced. Instead of comparing the whole string, just check the first class is `pf-topology__group`

** Issue reference **

Fixes #6458

** PR testing **

After the fix is applied, no error message appears in the console.