### PR TITLE
Remove wildcard VS bookinfo before checking KIA0104

### DIFF
--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -217,6 +217,13 @@ Given(
   }
 );
 
+Given(
+  'there is not a {string} VirtualService in the {string} namespace',
+  function (vsName: string, namespace: string) {
+    cy.exec(`kubectl delete VirtualService ${vsName} -n ${namespace}`, { failOnNonZeroExit: false });
+  }
+);
+
 Given('the DestinationRule enables mTLS', function () {
   cy.exec(
     `kubectl patch DestinationRule ${this.targetDestinationRule} -n ${this.targetNamespace} --type=merge -p '{"spec":{"trafficPolicy":{"tls": {"mode": "ISTIO_MUTUAL"}} }}'`

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -95,6 +95,7 @@ Feature: Kiali Istio Config page
   @crd-validation
   @bookinfo-app
   Scenario: KIA0104 validation
+    Given there is not a "bookinfo" VirtualService in the "bookinfo" namespace
     Given a "foo" AuthorizationPolicy in the "bookinfo" namespace
     And the AuthorizationPolicy has a to-operation rule with "missing.hostname" host
     When the user refreshes the list page


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6460

'bookinfo' VS is a wildcard, which covers KIA0104 validation, so make sure it is removed before.