### PR TITLE
Fixed hardcoded params separator for metrics tab links.

### DIFF
--- a/frontend/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
+++ b/frontend/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
@@ -34,7 +34,7 @@ import { MetricsStatsThunkActions } from 'actions/MetricsStatsThunkActions';
 import { EnvoySpanInfo, OpenTracingHTTPInfo, OpenTracingTCPInfo, RichSpanData } from 'types/JaegerInfo';
 import { sameSpans } from 'utils/tracing/TracingHelper';
 import { buildQueriesFromSpans } from 'utils/tracing/TraceStats';
-import { getSpanId } from '../../../utils/SearchParamUtils';
+import { getParamsSeparator, getSpanId } from '../../../utils/SearchParamUtils';
 import { kialiStyle } from 'styles/StyleUtils';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { formatDuration, isErrorTag } from 'utils/tracing/TracingHelper';
@@ -235,7 +235,7 @@ class SpanTableComponent extends React.Component<Props, State> {
       {
         title: 'Inbound Metrics',
         onClick: (_event, _rowId, rowData, _extra) => {
-          const href = rowData.item.linkToApp + '?tab=in_metrics';
+          const href = rowData.item.linkToApp + getParamsSeparator(rowData.item.linkToApp) + 'tab=in_metrics';
           if (parentKiosk) {
             kioskContextMenuAction(href);
           } else {
@@ -246,7 +246,7 @@ class SpanTableComponent extends React.Component<Props, State> {
       {
         title: 'Outbound Metrics',
         onClick: (_event, _rowId, rowData, _extra) => {
-          const href = rowData.item.linkToApp + '?tab=out_metrics';
+          const href = rowData.item.linkToApp + getParamsSeparator(rowData.item.linkToApp) + 'tab=out_metrics';
           if (parentKiosk) {
             kioskContextMenuAction(href);
           } else {
@@ -282,7 +282,8 @@ class SpanTableComponent extends React.Component<Props, State> {
         {
           title: 'Inbound Metrics',
           onClick: (_event, _rowId, rowData, _extra) => {
-            const href = rowData.item.linkToWorkload + '?tab=in_metrics';
+            const href =
+              rowData.item.linkToWorkload + getParamsSeparator(rowData.item.linkToWorkload) + 'tab=in_metrics';
             if (parentKiosk) {
               kioskContextMenuAction(href);
             } else {
@@ -293,7 +294,8 @@ class SpanTableComponent extends React.Component<Props, State> {
         {
           title: 'Outbound Metrics',
           onClick: (_event, _rowId, rowData, _extra) => {
-            const href = rowData.item.linkToWorkload + '?tab=out_metrics';
+            const href =
+              rowData.item.linkToWorkload + getParamsSeparator(rowData.item.linkToWorkload) + 'tab=out_metrics';
             if (parentKiosk) {
               kioskContextMenuAction(href);
             } else {

--- a/frontend/src/components/TrafficList/TrafficListComponent.tsx
+++ b/frontend/src/components/TrafficList/TrafficListComponent.tsx
@@ -19,6 +19,7 @@ import { connect } from 'react-redux';
 import { isParentKiosk, kioskContextMenuAction } from '../Kiosk/KioskActions';
 import { isMultiCluster } from 'config';
 import { virtualItemLinkStyle } from 'components/VirtualList/VirtualListStyle';
+import { getParamsSeparator } from '../../utils/SearchParamUtils';
 
 export interface TrafficListItem {
   direction: TrafficDirection;
@@ -351,7 +352,7 @@ class TrafficList extends FilterComponent.Component<
     }?clusterName=${item.node.cluster}`;
 
     const metricsDirection = item.direction === 'inbound' ? 'in_metrics' : 'out_metrics';
-    let metrics = `${history.location.pathname}?tab=${metricsDirection}`;
+    let metrics = `${history.location.pathname}${getParamsSeparator(history.location.pathname)}tab=${metricsDirection}`;
 
     switch (item.node.type) {
       case NodeType.APP:
@@ -375,7 +376,7 @@ class TrafficList extends FilterComponent.Component<
             metrics += `&${URLParam.BY_LABELS}=${encodeURIComponent('destination_service_name=' + item.node.name)}`;
           } else {
             // Services have only one metrics tab.
-            metrics = `${detail}?tab=metrics`;
+            metrics = `${detail}${getParamsSeparator(detail)}tab=metrics`;
           }
         }
         break;
@@ -386,7 +387,7 @@ class TrafficList extends FilterComponent.Component<
         // user is redirected to the "opposite" metrics. When looking at certain item, if traffic is *inbound*
         // from a certain workload, that traffic is reflected in the *outbound* metrics of the workload (and vice-versa).
         const inverseMetricsDirection = item.direction === 'inbound' ? 'out_metrics' : 'in_metrics';
-        metrics = `${detail}?tab=${inverseMetricsDirection}`;
+        metrics = `${detail}${getParamsSeparator(detail)}tab=${inverseMetricsDirection}`;
         break;
       default:
         metrics = '';

--- a/frontend/src/utils/SearchParamUtils.ts
+++ b/frontend/src/utils/SearchParamUtils.ts
@@ -48,3 +48,7 @@ export const setTraceId = (traceId?: string) => {
     HistoryManager.deleteParam(URLParam.JAEGER_TRACE_ID);
   }
 };
+
+export const getParamsSeparator = (url: string): string => {
+  return url.includes('?') ? '&' : '?';
+};


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6462

In "View metrics" url's parameter 'tab' had hardcoded separator '?', but with with '?clusterName=...' param it was having a conflict, so added a check to put '&' separator.

In "Traffic" tab's "View Metrics" links and in 'Span Details' subtab's kebab menu 'Inbound/Outbound Metrics' links.
![Screenshot from 2023-08-09 18-49-34](https://github.com/kiali/kiali/assets/604313/377849be-c70c-4dda-82d7-4f4d1d500965)
![Screenshot from 2023-08-09 18-51-11](https://github.com/kiali/kiali/assets/604313/7251301e-ede6-4253-b41a-68b4da9d1cf7)

