### PR TITLE
Adapt run-kiali script to use other tracing backend than Jaeger

### DIFF
--- a/hack/run-kiali.sh
+++ b/hack/run-kiali.sh
@@ -704,7 +704,7 @@ start_port_forward_component() {
     else
       startmsg "The port-forward to ${COMPONENT_NAME} is being started on [${EXPECTED_URL}]"
       set -m
-      if [ ${COMPONENT_NAME} == "Tracing" ]; then
+      if [ "${COMPONENT_NAME}" == "Tracing" ]; then
         NS=${TRACING_NAMESPACE}
       else
         NS=${ISTIO_NAMESPACE}


### PR DESCRIPTION
Ref. #5848 

To use it with the environment set in https://github.com/kiali/kiali.io/pull/686:

`./run-kiali.sh -pg 13000:3000 -pp 19090:9090 -app 8080 -es false -iu http://127.0.0.1:15014 -tr tempo-smm-query-frontend -ts tempo-smm-query-frontend -tn tempo`