### PR TITLE
Do external health check before running tests

### DIFF
--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -116,7 +116,7 @@ if [ "${TEST_SUITE}" == "backend" ]; then
 
   # Run backend integration tests
   cd "${SCRIPT_DIR}"/../tests/integration/tests
-  go test -v
+  go test -v -failfast
 elif [ "${TEST_SUITE}" == "frontend" ]; then
   ensureCypressInstalled
   "${SCRIPT_DIR}"/setup-kind-in-ci.sh --auth-strategy token

--- a/tests/integration/utils/kiali/retry.go
+++ b/tests/integration/utils/kiali/retry.go
@@ -1,0 +1,34 @@
+package kiali
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/util/httputil"
+)
+
+// withRetry does a function call with retries and returns the last error
+// if it fails.
+func withRetry(f func() error, retries int) error {
+	var err error
+	for i := 0; i < retries; i++ {
+		err = f()
+		if err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+// httpGETWithRetry wraps the httpGET function with retries.
+func httpGETWithRetry(url string, auth *config.Auth, timeout time.Duration, customHeaders map[string]string, cookies []*http.Cookie) ([]byte, int, []*http.Cookie, error) {
+	var body []byte
+	var code int
+	var err error
+	err = withRetry(func() error {
+		body, code, cookies, err = httputil.HttpGet(url, auth, timeout, customHeaders, cookies)
+		return err
+	}, 3)
+	return body, code, cookies, err
+}


### PR DESCRIPTION
Add an external health check before running tests. My guess is that it takes a minute for the pods to be added to the service's load balancer pool even after the pods are ready so we need to do an external health check before running the tests.

Fixes (hopefully) https://github.com/kiali/kiali/issues/6418