### PR TITLE
Add GetMesh method to gather info about controlplanes

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -594,15 +594,16 @@ func (in *IstioValidationsService) fetchRegistryServices(rValue *[]*kubernetes.R
 }
 
 func (in *IstioValidationsService) isGatewayToNamespace() bool {
-	clusters, err := in.businessLayer.Mesh.GetClusters(nil)
+	mesh, err := in.businessLayer.Mesh.GetMesh(context.TODO())
 	if err != nil {
-		log.Errorf("Error fetching clusters: %s", err)
+		log.Errorf("Error getting mesh config: %s", err)
 		return false
 	}
 
-	for _, cluster := range clusters {
-		if cluster.IsKialiHome {
-			return cluster.IsGatewayToNamespace
+	// TODO: Multi-primary support
+	for _, controlPlane := range mesh.ControlPlanes {
+		if controlPlane.Cluster.IsKialiHome {
+			return controlPlane.Config.IsGatewayToNamespace
 		}
 	}
 

--- a/business/layer.go
+++ b/business/layer.go
@@ -21,7 +21,6 @@ type Layer struct {
 	IstioStatus      IstioStatusService
 	IstioCerts       IstioCertsService
 	Jaeger           JaegerService
-	k8sClients       map[string]kubernetes.ClientInterface // Key is the cluster name
 	Mesh             MeshService
 	Namespace        NamespaceService
 	OpenshiftOAuth   OpenshiftOAuthService
@@ -148,7 +147,6 @@ func NewWithBackends(userClients map[string]kubernetes.ClientInterface, kialiSAC
 	temporaryLayer.IstioStatus = IstioStatusService{userClients: userClients, businessLayer: temporaryLayer}
 	temporaryLayer.IstioCerts = IstioCertsService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
 	temporaryLayer.Jaeger = JaegerService{loader: jaegerClient, businessLayer: temporaryLayer}
-	temporaryLayer.k8sClients = userClients
 	temporaryLayer.Namespace = NewNamespaceService(userClients, kialiSAClients, kialiCache, *conf)
 	temporaryLayer.Mesh = NewMeshService(kialiSAClients, kialiCache, temporaryLayer.Namespace, *conf)
 	temporaryLayer.OpenshiftOAuth = OpenshiftOAuthService{k8s: userClients[homeClusterName], kialiSAClient: kialiSAClients[homeClusterName]}

--- a/business/layer.go
+++ b/business/layer.go
@@ -149,8 +149,8 @@ func NewWithBackends(userClients map[string]kubernetes.ClientInterface, kialiSAC
 	temporaryLayer.IstioCerts = IstioCertsService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
 	temporaryLayer.Jaeger = JaegerService{loader: jaegerClient, businessLayer: temporaryLayer}
 	temporaryLayer.k8sClients = userClients
-	temporaryLayer.Mesh = NewMeshService(kialiSAClients, kialiCache, temporaryLayer, *conf)
 	temporaryLayer.Namespace = NewNamespaceService(userClients, kialiSAClients, kialiCache, *conf)
+	temporaryLayer.Mesh = NewMeshService(kialiSAClients, kialiCache, temporaryLayer.Namespace, *conf)
 	temporaryLayer.OpenshiftOAuth = OpenshiftOAuthService{k8s: userClients[homeClusterName], kialiSAClient: kialiSAClients[homeClusterName]}
 	temporaryLayer.ProxyStatus = ProxyStatusService{kialiSAClients: kialiSAClients, kialiCache: kialiCache, businessLayer: temporaryLayer}
 	// Out of order because it relies on ProxyStatus

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -5,20 +5,233 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/observability"
 	"github.com/kiali/kiali/util/httputil"
 )
+
+const (
+	IstiodExternalEnvKey           = "EXTERNAL_ISTIOD"
+	IstiodScopeGatewayEnvKey       = "PILOT_SCOPE_GATEWAY_TO_NAMESPACE"
+	IstioInjectionLabel            = "istio-injection"
+	IstioRevisionLabel             = "istio.io/rev"
+	IstioControlPlaneClustersLabel = "topology.istio.io/controlPlaneClusters"
+)
+
+// Mesh is one or more controlplanes (primaries) managing a dataplane across one or more clusters.
+// There can be multiple primaries on a single cluster when istio revisions are used. A single
+// primary can also manage multiple clusters (primary-remote deployment).
+type Mesh struct {
+	// ControlPlanes that share the same mesh ID.
+	ControlPlanes []ControlPlane
+
+	// ID is the ID of the mesh.
+	ID *string
+}
+
+// ControlPlane manages the dataplane for one or more kube clusters.
+// It's expected to manage the cluster that it is deployed in.
+// It has configuration for all the clusters/namespaces associated with it.
+type ControlPlane struct {
+	// Cluster the kube cluster that the controlplane is running on.
+	Cluster *kubernetes.Cluster
+
+	// ManagedClusters are the clusters that this controlplane manages.
+	// This could include the cluster that the controlplane is running on.
+	ManagedClusters []*kubernetes.Cluster
+
+	// Revision is the revision of the controlplane.
+	// Can be empty when it's the default revision.
+	Revision string
+
+	// External indicates if the controlplane is external.
+	External bool
+
+	// Config
+	Config ControlPlaneConfiguration
+}
+
+// ControlPlaneConfiguration is the configuration for the controlplane and any associated dataplanes.
+type ControlPlaneConfiguration struct {
+	// IsGatewayToNamespace specifies the PILOT_SCOPE_GATEWAY_TO_NAMESPACE environment variable in Control Plane
+	// This is not currently used by the frontend so excluding it from the API response.
+	IsGatewayToNamespace bool `json:"-"`
+
+	// OutboundTrafficPolicy is the outbound traffic policy for the controlplane.
+	OutboundTrafficPolicy models.OutboundPolicy
+
+	// Network is the name of the network that the controlplane is using.
+	Network string
+
+	// IstioMeshConfig comes from the istio configmap.
+	kubernetes.IstioMeshConfig
+}
+
+// gets the mesh configuration for a controlplane from a variety of sources.
+func getControlPlaneConfiguration(kubeCache cache.KubeCache, namespace string, name string) (*ControlPlaneConfiguration, error) {
+	cfg, err := kubeCache.GetConfigMap(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	istioConfigMapInfo, err := kubernetes.GetIstioConfigMap(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ControlPlaneConfiguration{
+		IstioMeshConfig: *istioConfigMapInfo,
+	}, nil
+}
+
+// isRemoteCluster determines if the cluster has a controlplane or if it's a remote cluster without one.
+func (in *MeshService) isRemoteCluster(cluster string) (bool, error) {
+	istioNamespace, err := in.namespaceService.GetClusterNamespace(context.TODO(), in.conf.IstioNamespace, cluster)
+	if err != nil {
+		return false, err
+	}
+
+	// TODO: Is checking for this annotation the only way to tell if something is a remote cluster?
+	// Are there other things we should check like the webhooks?
+	if _, hasAnnotation := istioNamespace.Annotations[IstioControlPlaneClustersLabel]; hasAnnotation {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// GetMesh gathers information about the mesh and controlplanes running in the mesh
+// from various sources e.g. istio configmap, istiod deployment envvars, etc.
+func (in *MeshService) GetMesh(ctx context.Context) (*Mesh, error) {
+	var end observability.EndFunc
+	ctx, end = observability.StartSpan(ctx, "GetMesh",
+		observability.Attribute("package", "business"),
+	)
+	defer end()
+
+	// Ensure user has access to the istio system namespace on the home cluster at least.
+	if _, err := in.namespaceService.GetClusterNamespace(ctx, in.conf.IstioNamespace, in.conf.KubernetesConfig.ClusterName); err != nil {
+		return nil, err
+	}
+
+	clusters, err := in.GetClusters(nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get mesh clusters: %w", err)
+	}
+
+	mesh := &Mesh{}
+	var remoteClusters []*kubernetes.Cluster
+	for _, cluster := range clusters {
+		cluster := cluster
+		kubeCache, err := in.kialiCache.GetKubeCache(cluster.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		if isRemoteCluster, err := in.isRemoteCluster(cluster.Name); err != nil {
+			return nil, err
+		} else if isRemoteCluster {
+			log.Debugf("Cluster [%s] is a remote cluster. Skipping adding a controlplane.", cluster.Name)
+			remoteClusters = append(remoteClusters, &cluster)
+		} else {
+			// Not a remote cluster so add controlplane(s)
+			// It must be a primary.
+			istiods, err := kubeCache.GetDeploymentsWithSelector(in.conf.IstioNamespace, "app=istiod")
+			if err != nil {
+				return nil, err
+			}
+
+			for _, istiod := range istiods {
+				log.Debugf("Found controlplane [%s/%s] on cluster [%s].", istiod.Name, istiod.Namespace, cluster.Name)
+				controlPlane := ControlPlane{
+					Cluster:  &cluster,
+					Revision: istiod.Labels[IstioRevisionLabel],
+				}
+
+				configMapName := in.conf.ExternalServices.Istio.ConfigMapName
+				if revLabel := istiod.Labels[IstioRevisionLabel]; revLabel != "default" && revLabel != "" {
+					configMapName = configMapName + "-" + revLabel
+				}
+
+				controlPlaneConfig, err := getControlPlaneConfiguration(kubeCache, istiod.Namespace, configMapName)
+				if err != nil {
+					return nil, err
+				}
+				controlPlane.Config = *controlPlaneConfig
+
+				// Kiali only supports a single mesh. All controlplanes should share the same mesh id.
+				// Otherwise this is an error.
+				if mesh.ID == nil {
+					mesh.ID = &controlPlane.Config.DefaultConfig.MeshId
+				} else if *mesh.ID != controlPlane.Config.DefaultConfig.MeshId {
+					return nil, fmt.Errorf("multiple mesh ids found: [%s] and [%s]", *mesh.ID, controlPlane.Config.DefaultConfig.MeshId)
+				}
+
+				if containers := istiod.Spec.Template.Spec.Containers; len(containers) > 0 {
+					for _, env := range istiod.Spec.Template.Spec.Containers[0].Env {
+						switch {
+						case envVarIsSet(IstiodExternalEnvKey, env):
+							controlPlane.External = true
+						case envVarIsSet(IstiodScopeGatewayEnvKey, env):
+							controlPlane.Config.IsGatewayToNamespace = true
+						}
+					}
+				}
+
+				// Assume this controlplane also manages the cluster it is deployed on.
+				controlPlane.ManagedClusters = append(controlPlane.ManagedClusters, &cluster)
+				mesh.ControlPlanes = append(mesh.ControlPlanes, controlPlane)
+			}
+		}
+	}
+
+	// We don't have access to the istio secrets so can't use that to determine what
+	// clusters the primaries are connected to. We may be able to use the '/debug/clusterz' endpoint.
+	for _, cluster := range remoteClusters {
+		namespace, err := in.namespaceService.GetClusterNamespace(ctx, in.conf.IstioNamespace, cluster.Name)
+		if err != nil {
+			log.Errorf("unable to process remote clusters for cluster [%s]. Err: %s", cluster.Name, err)
+			continue
+		}
+
+		if controlClusters := namespace.Annotations[IstioControlPlaneClustersLabel]; controlClusters != "" {
+			// First check for '*' which means all controlplane clusters that are part of the mesh
+			// and can managed external controlplanes will be able to manage this remote cluster.
+			if controlClusters == "*" {
+				for _, cp := range mesh.ControlPlanes {
+					if cp.External {
+						cp.ManagedClusters = append(cp.ManagedClusters, cluster)
+					}
+				}
+			} else {
+				for _, controlPlaneCluster := range strings.Split(controlClusters, ",") {
+					for idx := range mesh.ControlPlanes {
+						if mesh.ControlPlanes[idx].Cluster.Name == controlPlaneCluster {
+							mesh.ControlPlanes[idx].ManagedClusters = append(mesh.ControlPlanes[idx].ManagedClusters, cluster)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return mesh, nil
+}
+
+func envVarIsSet(key string, env core_v1.EnvVar) bool {
+	return env.Name == key && env.Value == "true"
+}
 
 const (
 	AllowAny = "ALLOW_ANY"
@@ -32,7 +245,7 @@ type MeshService struct {
 	homeClusterSAClient kubernetes.ClientInterface
 	kialiCache          cache.KialiCache
 	kialiSAClients      map[string]kubernetes.ClientInterface
-	layer               *Layer
+	namespaceService    NamespaceService
 }
 
 type meshTrafficPolicyConfig struct {
@@ -42,13 +255,13 @@ type meshTrafficPolicyConfig struct {
 }
 
 // NewMeshService initializes a new MeshService structure with the given k8s clients.
-func NewMeshService(kialiSAClients map[string]kubernetes.ClientInterface, cache cache.KialiCache, layer *Layer, conf config.Config) MeshService {
+func NewMeshService(kialiSAClients map[string]kubernetes.ClientInterface, cache cache.KialiCache, namespaceService NamespaceService, conf config.Config) MeshService {
 	return MeshService{
 		conf:                conf,
 		homeClusterSAClient: kialiSAClients[conf.KubernetesConfig.ClusterName],
 		kialiCache:          cache,
 		kialiSAClients:      kialiSAClients,
-		layer:               layer,
+		namespaceService:    namespaceService,
 	}
 }
 
@@ -77,15 +290,6 @@ func (in *MeshService) GetClusters(r *http.Request) ([]kubernetes.Cluster, error
 
 		if cluster == in.conf.KubernetesConfig.ClusterName {
 			meshCluster.IsKialiHome = true
-			// The "cluster_id" is set in an environment variable of
-			// the "istiod" deployment. Let's try to fetch it.
-			// TODO: Support multi-primary instead of using home cluster.
-			_, gatewayToNamespace, err := kubernetes.ClusterInfoFromIstiod(in.conf, in.homeClusterSAClient)
-			if err != nil {
-				// We didn't find it. This may mean that Istio is not setup with multi-cluster enabled.
-				return nil, err
-			}
-			meshCluster.IsGatewayToNamespace = gatewayToNamespace
 		}
 		clusters = append(clusters, meshCluster)
 	}
@@ -107,30 +311,26 @@ func convertKialiServiceToInstance(svc *core_v1.Service) kubernetes.KialiInstanc
 	}
 }
 
-// findKialiInNamespace tries to find a Kiali installation certain namespace of a cluster.
-// The clientSet argument should be an already initialized REST client to the API server of the
-// cluster. The namespace argument specifies the namespace where a Kiali instance will be looked for.
-// The clusterName argument is for logging purposes only.
+// discoverKiali tries to find a Kiali installation on the cluster.
 func (in *MeshService) discoverKiali(ctx context.Context, clusterName string, r *http.Request) []kubernetes.KialiInstance {
-	// Not using the cache since it doesn't support cross cluster querying. Perhaps it should.
-	client, ok := in.kialiSAClients[clusterName]
-	if !ok {
-		log.Warningf("Discovery for Kiali instances in cluster [%s] failed. Unable to find SA client for cluster [%s]", clusterName, clusterName)
-
+	kubeCache, err := in.kialiCache.GetKubeCache(clusterName)
+	if err != nil {
+		log.Warningf("Discovery for Kiali instances in cluster [%s] failed. Unable to find kube cache for cluster [%s]", clusterName, clusterName)
 		return nil
 	}
 
 	// The operator and the helm charts set this fixed label. It's also
 	// present in the Istio addon manifest of Kiali.
-	kialiAppLabel := "app.kubernetes.io/part-of=kiali"
-	services, err := client.Kube().CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: kialiAppLabel})
+	kialiAppLabel := map[string]string{"app.kubernetes.io/part-of": "kiali"}
+	// TODO: This will fail if cluster wide mode is not enabled.
+	services, err := kubeCache.GetServices("", kialiAppLabel)
 	if err != nil {
 		log.Warningf("Discovery for Kiali instances in cluster [%s] failed: %s", clusterName, err.Error())
 		return nil
 	}
 
 	var instances []kubernetes.KialiInstance
-	for _, d := range services.Items {
+	for _, d := range services {
 		kiali := convertKialiServiceToInstance(&d)
 		// If URL is already populated (because of an annotation), trust that because it's user configuration.
 		// Only guess ourselves on our own cluster.
@@ -143,10 +343,10 @@ func (in *MeshService) discoverKiali(ctx context.Context, clusterName string, r 
 	return instances
 }
 
-// resolveNetwork tries to resolve the NETWORK_ID (as know by the Control Plane) of the
+// resolveNetwork tries to resolve the NETWORK_ID (as known by the Control Plane) of the
 // cluster that can be accessed using the provided kubeconfig data.
 // Also, it's assumed that the control plane on the remote cluster is hosted in the same
-// namespace as in Kiali's Home cluster. clusterName argument is only for logging purposes.
+// namespace as in Kiali's Home cluster.
 //
 // No errors are returned because we don't want to block processing of other clusters if
 // one fails. So, errors are only logged to let processing continue.
@@ -206,17 +406,10 @@ func (in *MeshService) resolveNetwork(clusterName string) string {
 
 		network = typedNetworkConfig
 	} else {
-		// Remote cluster
-		remoteClientSet, ok := in.kialiSAClients[clusterName]
-		if !ok {
-			log.Warningf("Cannot find a remote client on cluster [%s]: no client set", clusterName)
-			return ""
-		}
-
 		// Let's assume that the istio namespace has the same name on all clusters in the mesh.
-		istioNamespace, getNsErr := remoteClientSet.GetNamespace(in.conf.IstioNamespace)
-		if getNsErr != nil {
-			log.Warningf("Cannot describe the [%s] namespace on cluster [%s]: %v", in.conf.IstioNamespace, clusterName, getNsErr)
+		istioNamespace, err := in.namespaceService.GetClusterNamespace(context.TODO(), in.conf.IstioNamespace, clusterName)
+		if err != nil {
+			log.Warningf("Cannot describe the [%s] namespace on cluster [%s]: %v", in.conf.IstioNamespace, clusterName, err)
 			return ""
 		}
 
@@ -337,6 +530,6 @@ func (in *MeshService) CanaryUpgradeStatus() (*models.CanaryUpgradeStatus, error
 
 // Checks if a cluster exist
 func (in *MeshService) IsValidCluster(cluster string) bool {
-	_, exists := in.layer.k8sClients[cluster]
+	_, exists := in.kialiSAClients[cluster]
 	return exists
 }

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -121,11 +121,6 @@ func (in *MeshService) GetMesh(ctx context.Context) (*Mesh, error) {
 	)
 	defer end()
 
-	// Ensure user has access to the istio system namespace on the home cluster at least.
-	if _, err := in.namespaceService.GetClusterNamespace(ctx, in.conf.IstioNamespace, in.conf.KubernetesConfig.ClusterName); err != nil {
-		return nil, err
-	}
-
 	clusters, err := in.GetClusters(nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get mesh clusters: %w", err)

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -717,7 +718,6 @@ trustDomain: cluster.local
 	remoteClient := kubetest.NewFakeK8sClient(
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "istio-system",
-			Labels:      map[string]string{"istio-injection": "enabled"},
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
 		}},
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
@@ -740,6 +740,247 @@ trustDomain: cluster.local
 	business.FindOrFail(t, controlPlane.ManagedClusters, func(c *kubernetes.Cluster) bool {
 		return c.Name == "remote"
 	})
+}
+
+func TestGetMeshRemoteWithWildcardAnnotation(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	// Set to east because the default is "" which causes the check for
+	// cluster name env var to fail even though it is set.
+	conf.KubernetesConfig.ClusterName = "east"
+	kubernetes.SetConfig(t, *conf)
+
+	istiodDeployment := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, true)
+	const configMapData = `accessLogFile: /dev/stdout
+enableAutoMtls: true
+rootNamespace: istio-system
+trustDomain: cluster.local
+`
+	istioConfigMap := &core_v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istio",
+			Namespace: "istio-system",
+		},
+		Data: map[string]string{"mesh": configMapData},
+	}
+	eastClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		istiodDeployment,
+		istioConfigMap,
+	)
+	remoteClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
+			Name:        "istio-system",
+			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: "*"},
+		}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+	)
+
+	clients := map[string]kubernetes.ClientInterface{"east": eastClient, "remote": remoteClient}
+	factory := kubetest.NewK8SClientFactoryMock(nil)
+	factory.SetClients(clients)
+	business.WithKialiCache(business.NewTestingCacheWithFactory(t, factory, *conf))
+
+	svc := business.NewWithBackends(clients, clients, nil, nil).Mesh
+	mesh, err := svc.GetMesh(context.TODO())
+	require.NoError(err)
+	require.Len(mesh.ControlPlanes, 1)
+	require.Len(mesh.ControlPlanes[0].ManagedClusters, 2)
+
+	controlPlane := mesh.ControlPlanes[0]
+
+	require.Equal(conf.KubernetesConfig.ClusterName, controlPlane.Cluster.Name)
+	business.FindOrFail(t, controlPlane.ManagedClusters, func(c *kubernetes.Cluster) bool {
+		return c.Name == "remote"
+	})
+}
+
+func TestGetMeshPrimaryWithoutExternalEnvVar(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	// Set to east because the default is "" which causes the check for
+	// cluster name env var to fail even though it is set.
+	conf.KubernetesConfig.ClusterName = "east"
+	kubernetes.SetConfig(t, *conf)
+
+	istiodDeployment := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false)
+	const configMapData = `accessLogFile: /dev/stdout
+enableAutoMtls: true
+rootNamespace: istio-system
+trustDomain: cluster.local
+`
+	istioConfigMap := &core_v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istio",
+			Namespace: "istio-system",
+		},
+		Data: map[string]string{"mesh": configMapData},
+	}
+	eastClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		istiodDeployment,
+		istioConfigMap,
+	)
+	remoteClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
+			Name:        "istio-system",
+			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
+		}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+	)
+
+	clients := map[string]kubernetes.ClientInterface{"east": eastClient, "remote": remoteClient}
+	factory := kubetest.NewK8SClientFactoryMock(nil)
+	factory.SetClients(clients)
+	business.WithKialiCache(business.NewTestingCacheWithFactory(t, factory, *conf))
+
+	svc := business.NewWithBackends(clients, clients, nil, nil).Mesh
+	mesh, err := svc.GetMesh(context.TODO())
+	require.NoError(err)
+	require.Len(mesh.ControlPlanes, 1)
+	require.Len(mesh.ControlPlanes[0].ManagedClusters, 1)
+}
+
+func TestGetMeshMultiplePrimaries(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	// Set to east because the default is "" which causes the check for
+	// cluster name env var to fail even though it is set.
+	conf.KubernetesConfig.ClusterName = "east"
+	kubernetes.SetConfig(t, *conf)
+
+	istiodDeployment := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false)
+	const configMapData = `accessLogFile: /dev/stdout
+enableAutoMtls: true
+rootNamespace: istio-system
+trustDomain: cluster.local
+`
+	istioConfigMap := &core_v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istio",
+			Namespace: "istio-system",
+		},
+		Data: map[string]string{"mesh": configMapData},
+	}
+	eastClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		istiodDeployment,
+		istioConfigMap,
+	)
+	westClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		istiodDeployment,
+		istioConfigMap,
+	)
+
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: eastClient, "west": westClient}
+	factory := kubetest.NewK8SClientFactoryMock(nil)
+	factory.SetClients(clients)
+	business.WithKialiCache(business.NewTestingCacheWithFactory(t, factory, *conf))
+
+	svc := business.NewWithBackends(clients, clients, nil, nil).Mesh
+	mesh, err := svc.GetMesh(context.TODO())
+	require.NoError(err)
+	require.Len(mesh.ControlPlanes, 2)
+	require.Len(mesh.ControlPlanes[0].ManagedClusters, 1)
+	require.Len(mesh.ControlPlanes[1].ManagedClusters, 1)
+
+	eastControlPlane := business.FindOrFail(t, mesh.ControlPlanes, func(c business.ControlPlane) bool {
+		return c.Cluster.Name == "east"
+	})
+	westControlPlane := business.FindOrFail(t, mesh.ControlPlanes, func(c business.ControlPlane) bool {
+		return c.Cluster.Name == "west"
+	})
+
+	require.Equal("east", eastControlPlane.ManagedClusters[0].Name)
+	require.Equal("west", westControlPlane.ManagedClusters[0].Name)
+}
+
+func TestGetMeshMultiplePrimariesWithRemotes(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	// Set to east because the default is "" which causes the check for
+	// cluster name env var to fail even though it is set.
+	conf.KubernetesConfig.ClusterName = "east"
+	kubernetes.SetConfig(t, *conf)
+
+	istiodDeployment := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, true)
+	const configMapData = `accessLogFile: /dev/stdout
+enableAutoMtls: true
+rootNamespace: istio-system
+trustDomain: cluster.local
+`
+	istioConfigMap := &core_v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istio",
+			Namespace: "istio-system",
+		},
+		Data: map[string]string{"mesh": configMapData},
+	}
+	eastClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		istiodDeployment,
+		istioConfigMap,
+	)
+	eastRemoteClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
+			Name:        "istio-system",
+			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: "east"},
+		}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+	)
+	westClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		istiodDeployment,
+		istioConfigMap,
+	)
+	westRemoteClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
+			Name:        "istio-system",
+			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: "west"},
+		}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+	)
+
+	clients := map[string]kubernetes.ClientInterface{
+		"east":        eastClient,
+		"east-remote": eastRemoteClient,
+		"west":        westClient,
+		"west-remote": westRemoteClient,
+	}
+	factory := kubetest.NewK8SClientFactoryMock(nil)
+	factory.SetClients(clients)
+	business.WithKialiCache(business.NewTestingCacheWithFactory(t, factory, *conf))
+
+	svc := business.NewWithBackends(clients, clients, nil, nil).Mesh
+	mesh, err := svc.GetMesh(context.TODO())
+	require.NoError(err)
+	require.Len(mesh.ControlPlanes, 2)
+	require.Len(mesh.ControlPlanes[0].ManagedClusters, 2)
+	require.Len(mesh.ControlPlanes[1].ManagedClusters, 2)
+
+	eastControlPlane := business.FindOrFail(t, mesh.ControlPlanes, func(c business.ControlPlane) bool {
+		return c.Cluster.Name == "east"
+	})
+	westControlPlane := business.FindOrFail(t, mesh.ControlPlanes, func(c business.ControlPlane) bool {
+		return c.Cluster.Name == "west"
+	})
+
+	// Sort to get consistent ordering before doing assertions.
+	sortClustersByName := func(a *kubernetes.Cluster, b *kubernetes.Cluster) bool {
+		return a.Name < b.Name
+	}
+	slices.SortFunc(eastControlPlane.ManagedClusters, sortClustersByName)
+	slices.SortFunc(westControlPlane.ManagedClusters, sortClustersByName)
+
+	require.Equal(eastControlPlane.ManagedClusters[0].Name, "east")
+	require.Equal(eastControlPlane.ManagedClusters[1].Name, "east-remote")
+	require.Equal(westControlPlane.ManagedClusters[0].Name, "west")
+	require.Equal(westControlPlane.ManagedClusters[1].Name, "west-remote")
 }
 
 func fakeIstiodDeployment(cluster string, manageExternal bool) *apps_v1.Deployment {

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -618,8 +618,8 @@ func TestGetMeshMultipleRevisions(t *testing.T) {
 			Name:      "istiod-1-18",
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				"app":                     "istiod",
-				models.IstioRevisionLabel: "1-18-0",
+				"app":                       "istiod",
+				business.IstioRevisionLabel: "1-18-0",
 			},
 		},
 	}
@@ -628,8 +628,8 @@ func TestGetMeshMultipleRevisions(t *testing.T) {
 			Name:      "istiod-1-19",
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				"app":                     "istiod",
-				models.IstioRevisionLabel: "1-19-0",
+				"app":                       "istiod",
+				business.IstioRevisionLabel: "1-19-0",
 			},
 		},
 	}
@@ -718,7 +718,7 @@ trustDomain: cluster.local
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "istio-system",
 			Labels:      map[string]string{"istio-injection": "enabled"},
-			Annotations: map[string]string{models.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
+			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
 		}},
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
 	)

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -1,6 +1,7 @@
-package business
+package business_test
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
@@ -106,9 +108,9 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 	}
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	SetupBusinessLayer(t, k8s, *conf)
+	business.SetupBusinessLayer(t, k8s, *conf)
 
-	layer := NewWithBackends(mockClientFactory.Clients, mockClientFactory.Clients, nil, nil)
+	layer := business.NewWithBackends(mockClientFactory.Clients, mockClientFactory.Clients, nil, nil)
 	meshSvc := layer.Mesh
 
 	r := httptest.NewRequest("GET", "http://kiali.url.local/", nil)
@@ -119,7 +121,6 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 	require.Len(a, 1, "GetClusters didn't resolve the Kiali cluster")
 	assert.Equal("KialiCluster", a[0].Name, "Unexpected cluster name")
 	assert.True(a[0].IsKialiHome, "Kiali cluster not properly marked as such")
-	assert.True(a[0].IsGatewayToNamespace, "Kiali GatewayToNamespace not properly marked as such")
 	assert.Equal("http://127.0.0.2:9443", a[0].ApiEndpoint)
 	assert.Equal("kialiNetwork", a[0].Network)
 
@@ -132,7 +133,7 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 }
 
 func TestGetClustersResolvesRemoteClusters(t *testing.T) {
-	check := assert.New(t)
+	check := require.New(t)
 
 	conf := config.NewConfig()
 	conf.InCluster = false
@@ -159,8 +160,6 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 		},
 	}
 
-	SetupBusinessLayer(t, kubetest.NewFakeK8sClient(), *conf)
-
 	remoteClient := kubetest.NewFakeK8sClient(remoteNs, kialiSvc)
 	remoteClient.KubeClusterInfo = kubernetes.ClusterInfo{
 		Name: "KialiCluster",
@@ -172,27 +171,33 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 		},
 	}
 	clients := map[string]kubernetes.ClientInterface{
-		"KialiCluster": remoteClient,
+		"KialiCluster":                    remoteClient,
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(),
 	}
-	layer := NewWithBackends(clients, clients, nil, nil)
+	factory := kubetest.NewK8SClientFactoryMock(nil)
+	factory.SetClients(clients)
+	business.WithKialiCache(business.NewTestingCacheWithFactory(t, factory, *conf))
+	layer := business.NewWithBackends(clients, clients, nil, nil)
 	meshSvc := layer.Mesh
 
 	a, err := meshSvc.GetClusters(nil)
 	check.Nil(err, "GetClusters returned error: %v", err)
 
-	check.NotNil(a, "GetClusters returned nil")
-	check.Len(a, 1, "GetClusters didn't resolve the remote clusters")
-	check.Equal("KialiCluster", a[0].Name, "Unexpected cluster name")
-	check.False(a[0].IsKialiHome, "Remote cluster mistakenly marked as the Kiali home")
-	check.Equal("https://192.168.144.17:123", a[0].ApiEndpoint)
-	check.Equal("TheRemoteNetwork", a[0].Network)
+	remoteCluster := business.FindOrFail(t, a, func(c kubernetes.Cluster) bool { return c.Name == "KialiCluster" })
 
-	check.Len(a[0].KialiInstances, 1, "GetClusters didn't resolve the remote Kiali instance")
-	check.Equal(conf.IstioNamespace, a[0].KialiInstances[0].Namespace, "GetClusters didn't set the right namespace of the Kiali instance")
-	check.Equal("kiali-operator/myKialiCR", a[0].KialiInstances[0].OperatorResource, "GetClusters didn't set the right operator resource of the Kiali instance")
-	check.Equal("", a[0].KialiInstances[0].Url, "GetClusters didn't set the right URL of the Kiali instance")
-	check.Equal("v1.25", a[0].KialiInstances[0].Version, "GetClusters didn't set the right version of the Kiali instance")
-	check.Equal("kiali-service", a[0].KialiInstances[0].ServiceName, "GetClusters didn't set the right service name of the Kiali instance")
+	check.NotNil(a, "GetClusters returned nil")
+	check.Len(a, 2, "GetClusters didn't resolve the remote clusters")
+	check.Equal("KialiCluster", remoteCluster.Name, "Unexpected cluster name")
+	check.False(remoteCluster.IsKialiHome, "Remote cluster mistakenly marked as the Kiali home")
+	check.Equal("https://192.168.144.17:123", remoteCluster.ApiEndpoint)
+	check.Equal("TheRemoteNetwork", remoteCluster.Network)
+
+	check.Len(remoteCluster.KialiInstances, 1, "GetClusters didn't resolve the remote Kiali instance")
+	check.Equal(conf.IstioNamespace, remoteCluster.KialiInstances[0].Namespace, "GetClusters didn't set the right namespace of the Kiali instance")
+	check.Equal("kiali-operator/myKialiCR", remoteCluster.KialiInstances[0].OperatorResource, "GetClusters didn't set the right operator resource of the Kiali instance")
+	check.Equal("", remoteCluster.KialiInstances[0].Url, "GetClusters didn't set the right URL of the Kiali instance")
+	check.Equal("v1.25", remoteCluster.KialiInstances[0].Version, "GetClusters didn't set the right version of the Kiali instance")
+	check.Equal("kiali-service", remoteCluster.KialiInstances[0].ServiceName, "GetClusters didn't set the right service name of the Kiali instance")
 }
 
 type fakeClusterCache struct {
@@ -267,20 +272,19 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 		istioDeploymentMock,
 		kialiSvc,
 	)
-	cache := SetupBusinessLayer(t, k8s, *conf)
+	cache := business.SetupBusinessLayer(t, k8s, *conf)
 	getClustersCache := &fakeClusterCache{KialiCache: cache}
-	WithKialiCache(getClustersCache)
+	business.WithKialiCache(getClustersCache)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: k8s,
 	}
-	layer := NewWithBackends(clients, clients, nil, nil)
+	layer := business.NewWithBackends(clients, clients, nil, nil)
 	meshSvc := layer.Mesh
 	result, err := meshSvc.GetClusters(nil)
 	require.NoError(err)
 	require.NotNil(result)
 	require.Len(result, 1)
 	check.Equal("KialiCluster", result[0].Name) // Sanity check. Rest of values are tested in TestGetClustersResolvesTheKialiCluster
-	check.False(result[0].IsGatewayToNamespace, "Kiali GatewayToNamespace not properly marked as such")
 	// Check that the cache now has clusters populated.
 	check.Len(getClustersCache.clusters, 1)
 
@@ -311,7 +315,7 @@ func TestCanaryUpgradeNotConfigured(t *testing.T) {
 	// Create a MeshService and invoke IsMeshConfigured
 	k8sclients := make(map[string]kubernetes.ClientInterface)
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-	layer := NewWithBackends(k8sclients, k8sclients, nil, nil)
+	layer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	meshSvc := layer.Mesh
 
 	canaryUpgradeStatus, err := meshSvc.CanaryUpgradeStatus()
@@ -351,7 +355,7 @@ func TestCanaryUpgradeConfigured(t *testing.T) {
 	// Create a MeshService and invoke IsMeshConfigured
 	k8sclients := make(map[string]kubernetes.ClientInterface)
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-	layer := NewWithBackends(k8sclients, k8sclients, nil, nil)
+	layer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
 	meshSvc := layer.Mesh
 
 	canaryUpgradeStatus, err := meshSvc.CanaryUpgradeStatus()
@@ -549,10 +553,10 @@ func TestIstiodResourceThresholds(t *testing.T) {
 				istiodDeployment,
 			)
 
-			SetupBusinessLayer(t, k8s, *config.NewConfig())
+			business.SetupBusinessLayer(t, k8s, *config.NewConfig())
 
 			clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
-			ms := NewWithBackends(clients, clients, nil, nil).Mesh
+			ms := business.NewWithBackends(clients, clients, nil, nil).Mesh
 
 			actual, err := ms.IstiodResourceThresholds()
 
@@ -566,4 +570,208 @@ func TestIstiodResourceThresholds(t *testing.T) {
 			require.Equal(testCase.expected, actual)
 		})
 	}
+}
+
+func TestGetMesh(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+
+	istiodDeployment := &apps_v1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istiod",
+			Namespace: "istio-system",
+			Labels:    map[string]string{"app": "istiod"},
+		},
+	}
+	const configMapData = `accessLogFile: /dev/stdout
+enableAutoMtls: true
+rootNamespace: istio-system
+trustDomain: cluster.local
+`
+	istioConfigMap := &core_v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istio",
+			Namespace: "istio-system",
+		},
+		Data: map[string]string{"mesh": configMapData},
+	}
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		istiodDeployment,
+		istioConfigMap,
+	)
+
+	business.SetupBusinessLayer(t, k8s, *config.NewConfig())
+
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	svc := business.NewWithBackends(clients, clients, nil, nil).Mesh
+	mesh, err := svc.GetMesh(context.TODO())
+	require.NoError(err)
+	require.Len(mesh.ControlPlanes, 1)
+	require.True(*mesh.ControlPlanes[0].Config.EnableAutoMtls)
+	require.Len(mesh.ControlPlanes[0].ManagedClusters, 1)
+}
+
+func TestGetMeshMultipleRevisions(t *testing.T) {
+	istiod_1_18_Deployment := &apps_v1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istiod-1-18",
+			Namespace: "istio-system",
+			Labels: map[string]string{
+				"app":                     "istiod",
+				models.IstioRevisionLabel: "1-18-0",
+			},
+		},
+	}
+	istiod_1_19_Deployment := &apps_v1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istiod-1-19",
+			Namespace: "istio-system",
+			Labels: map[string]string{
+				"app":                     "istiod",
+				models.IstioRevisionLabel: "1-19-0",
+			},
+		},
+	}
+	const configMap_1_18_Data = `accessLogFile: /dev/stdout
+enableAutoMtls: false
+rootNamespace: istio-system
+trustDomain: cluster.local
+`
+	istio_1_18_ConfigMap := &core_v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istio-1-18-0",
+			Namespace: "istio-system",
+		},
+		Data: map[string]string{"mesh": configMap_1_18_Data},
+	}
+	const configMap_1_19_Data = `accessLogFile: /dev/stdout
+enableAutoMtls: true
+rootNamespace: istio-system
+trustDomain: cluster.local
+`
+	istio_1_19_ConfigMap := &core_v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istio-1-19-0",
+			Namespace: "istio-system",
+		},
+		Data: map[string]string{"mesh": configMap_1_19_Data},
+	}
+	require := require.New(t)
+	conf := config.NewConfig()
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		istiod_1_18_Deployment,
+		istio_1_18_ConfigMap,
+		istiod_1_19_Deployment,
+		istio_1_19_ConfigMap,
+	)
+
+	business.SetupBusinessLayer(t, k8s, *config.NewConfig())
+
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	svc := business.NewWithBackends(clients, clients, nil, nil).Mesh
+	mesh, err := svc.GetMesh(context.TODO())
+	require.NoError(err)
+	require.Len(mesh.ControlPlanes, 2)
+
+	controlPlane_1_18 := business.FindOrFail(t, mesh.ControlPlanes, func(c business.ControlPlane) bool {
+		return c.Revision == "1-18-0"
+	})
+	require.False(*controlPlane_1_18.Config.EnableAutoMtls)
+	require.Len(controlPlane_1_18.ManagedClusters, 1)
+
+	controlPlane_1_19 := business.FindOrFail(t, mesh.ControlPlanes, func(c business.ControlPlane) bool {
+		return c.Revision == "1-19-0"
+	})
+	require.True(*controlPlane_1_19.Config.EnableAutoMtls)
+	require.Len(controlPlane_1_19.ManagedClusters, 1)
+}
+
+func TestGetMeshRemoteClusters(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	// Set to east because the default is "" which causes the check for
+	// cluster name env var to fail even though it is set.
+	conf.KubernetesConfig.ClusterName = "east"
+	kubernetes.SetConfig(t, *conf)
+
+	istiodDeployment := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, true)
+	const configMapData = `accessLogFile: /dev/stdout
+enableAutoMtls: true
+rootNamespace: istio-system
+trustDomain: cluster.local
+`
+	istioConfigMap := &core_v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istio",
+			Namespace: "istio-system",
+		},
+		Data: map[string]string{"mesh": configMapData},
+	}
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		istiodDeployment,
+		istioConfigMap,
+	)
+	remoteClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
+			Name:        "istio-system",
+			Labels:      map[string]string{"istio-injection": "enabled"},
+			Annotations: map[string]string{models.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
+		}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+	)
+
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s, "remote": remoteClient}
+	factory := kubetest.NewK8SClientFactoryMock(nil)
+	factory.SetClients(clients)
+	business.WithKialiCache(business.NewTestingCacheWithFactory(t, factory, *conf))
+
+	svc := business.NewWithBackends(clients, clients, nil, nil).Mesh
+	mesh, err := svc.GetMesh(context.TODO())
+	require.NoError(err)
+	require.Len(mesh.ControlPlanes, 1)
+	require.Len(mesh.ControlPlanes[0].ManagedClusters, 2)
+
+	controlPlane := mesh.ControlPlanes[0]
+
+	require.Equal(conf.KubernetesConfig.ClusterName, controlPlane.Cluster.Name)
+	business.FindOrFail(t, controlPlane.ManagedClusters, func(c *kubernetes.Cluster) bool {
+		return c.Name == "remote"
+	})
+}
+
+func fakeIstiodDeployment(cluster string, manageExternal bool) *apps_v1.Deployment {
+	deployment := &apps_v1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istiod",
+			Namespace: "istio-system",
+			Labels:    map[string]string{"app": "istiod"},
+		},
+		Spec: apps_v1.DeploymentSpec{
+			Template: core_v1.PodTemplateSpec{
+				Spec: core_v1.PodSpec{
+					Containers: []core_v1.Container{
+						{
+							Name: "discovery",
+							Env: []core_v1.EnvVar{
+								{
+									Name:  "CLUSTER_ID",
+									Value: cluster,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if manageExternal {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, core_v1.EnvVar{
+			Name:  "EXTERNAL_ISTIOD",
+			Value: "true",
+		})
+	}
+	return deployment
 }

--- a/business/testing.go
+++ b/business/testing.go
@@ -8,6 +8,8 @@ package business
 import (
 	"testing"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
@@ -75,4 +77,14 @@ func NewTestingCache(t *testing.T, k8s kubernetes.ClientInterface, conf config.C
 func NewTestingCacheWithFactory(t *testing.T, cf kubernetes.ClientFactory, conf config.Config) cache.KialiCache {
 	t.Helper()
 	return newTestingCache(t, cf, conf)
+}
+
+// FindOrFail will find an element in a slice or fail the test.
+func FindOrFail[T any](t *testing.T, s []T, f func(T) bool) T {
+	t.Helper()
+	idx := slices.IndexFunc(s, f)
+	if idx == -1 {
+		t.Fatal("Element not in slice")
+	}
+	return s[idx]
 }

--- a/handlers/mesh.go
+++ b/handlers/mesh.go
@@ -54,3 +54,18 @@ func IstiodCanariesStatus(w http.ResponseWriter, r *http.Request) {
 	irt, _ := business.Mesh.CanaryUpgradeStatus()
 	RespondWithJSON(w, http.StatusOK, irt)
 }
+
+func GetMesh(w http.ResponseWriter, r *http.Request) {
+	business, err := getBusiness(r)
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	mesh, err := business.Mesh.GetMesh(r.Context())
+	if err != nil {
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	RespondWithJSON(w, http.StatusOK, mesh)
+}

--- a/handlers/mesh_test.go
+++ b/handlers/mesh_test.go
@@ -1,0 +1,78 @@
+package handlers_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/handlers"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+)
+
+// Fails if resp status is non-200
+func checkStatus(t *testing.T, expectedCode int, resp *http.Response) {
+	if resp.StatusCode != expectedCode {
+		// Attempt to read body to get more info.
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Logf("Unable to read response body: %s", err)
+		}
+		t.Fatalf("Expected status code 200, got %d. Body: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestGetMesh(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	kubernetes.SetConfig(t, *conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: conf.IstioNamespace}},
+	)
+	business.SetupBusinessLayer(t, k8s, *conf)
+
+	authInfo := &api.AuthInfo{Token: "test"}
+	server := httptest.NewServer(handlers.WithAuthInfo(authInfo, handlers.GetMesh))
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/mesh")
+	require.NoError(err)
+	checkStatus(t, http.StatusOK, resp)
+}
+
+type forbiddenFake struct{ kubernetes.ClientInterface }
+
+func (f *forbiddenFake) GetNamespace(namespace string) (*corev1.Namespace, error) {
+	return nil, fmt.Errorf("forbidden")
+}
+
+func TestGetMeshWithoutAccess(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	kubernetes.SetConfig(t, *conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: conf.IstioNamespace}},
+	)
+	business.SetupBusinessLayer(t, &forbiddenFake{k8s}, *conf)
+
+	authInfo := &api.AuthInfo{Token: "test"}
+	server := httptest.NewServer(handlers.WithAuthInfo(authInfo, handlers.GetMesh))
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/mesh")
+	require.NoError(err)
+	checkStatus(t, http.StatusForbidden, resp)
+}

--- a/handlers/testing.go
+++ b/handlers/testing.go
@@ -6,11 +6,14 @@ package handlers
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	osproject_v1 "github.com/openshift/api/project/v1"
 	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/kiali/kiali/business/authentication"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/util"
 )
@@ -38,4 +41,13 @@ func (n *noPrivClient) GetNamespace(namespace string) (*core_v1.Namespace, error
 
 func (n *noPrivClient) GetNamespaces(labelSelector string) ([]core_v1.Namespace, error) {
 	return nil, fmt.Errorf("Rejecting")
+}
+
+// WithAuthInfo injects the given auth info into the request context of the given handler.
+// Useful for testing only.
+func WithAuthInfo(authInfo *api.AuthInfo, hf http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		context := authentication.SetAuthInfoContext(r.Context(), authInfo)
+		hf(w, r.WithContext(context))
+	}
 }

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -26,11 +26,14 @@ import (
 type KialiCache interface {
 	GetKubeCaches() map[string]KubeCache
 	GetKubeCache(cluster string) (KubeCache, error)
+
 	// GetClusters returns the list of clusters that the cache knows about.
 	// This gets set by the mesh service.
 	GetClusters() []kubernetes.Cluster
+
 	// SetClusters sets the list of clusters that the cache knows about.
 	SetClusters([]kubernetes.Cluster)
+
 	// Embedded for backward compatibility for business methods that just use one cluster.
 	// All business methods should eventually use the multi-cluster cache.
 	// Instead of using the interface directly for kube objects, use the GetKubeCache() method.
@@ -209,3 +212,6 @@ func (c *kialiCacheImpl) SetClusters(clusters []kubernetes.Cluster) {
 	c.clusterLock.Lock()
 	c.clusters = clusters
 }
+
+// Interface guard for kiali cache impl
+var _ KialiCache = (*kialiCacheImpl)(nil)

--- a/kubernetes/cluster_secret.go
+++ b/kubernetes/cluster_secret.go
@@ -186,9 +186,6 @@ type Cluster struct {
 	// IsKialiHome specifies if this cluster is hosting this Kiali instance (and the observed Mesh Control Plane)
 	IsKialiHome bool `json:"isKialiHome"`
 
-	// IsGatewayToNamespace specifies the PILOT_SCOPE_GATEWAY_TO_NAMESPACE environment variable in Control PLane
-	IsGatewayToNamespace bool `json:"isGatewayToNamespace"`
-
 	// KialiInstances is the list of Kialis discovered in the cluster.
 	KialiInstances []KialiInstance `json:"kialiInstances"`
 

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -177,6 +177,12 @@ type IstioMeshConfig struct {
 	DisableMixerHttpReports bool                    `yaml:"disableMixerHttpReports,omitempty"`
 	DiscoverySelectors      []*metav1.LabelSelector `yaml:"discoverySelectors,omitempty"`
 	EnableAutoMtls          *bool                   `yaml:"enableAutoMtls,omitempty"`
+	MeshMTLS                struct {
+		MinProtocolVersion string `yaml:"minProtocolVersion"`
+	} `yaml:"meshMtls"`
+	DefaultConfig struct {
+		MeshId string `yaml:"meshId"`
+	} `yaml:"defaultConfig" json:"defaultConfig"`
 }
 
 // MTLSDetails is a wrapper to group all Istio objects related to non-local mTLS configurations

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -5,12 +5,12 @@ import (
 
 	osproject_v1 "github.com/openshift/api/project/v1"
 	core_v1 "k8s.io/api/core/v1"
-
-	"github.com/kiali/kiali/config/dashboards"
 )
 
-const AmbientLabel = "istio.io/dataplane-mode"
-const AmbientValue = "ambient"
+const (
+	AmbientLabel = "istio.io/dataplane-mode"
+	AmbientValue = "ambient"
+)
 
 // A Namespace provide a scope for names
 // This type is used to describe a set of objects.
@@ -68,11 +68,8 @@ func CastNamespace(ns core_v1.Namespace, cluster string) Namespace {
 	namespace.Cluster = cluster
 	namespace.CreationTimestamp = ns.CreationTimestamp.Time
 	namespace.Labels = ns.Labels
-	namespace.Annotations = make(map[string]string)
-	// Parse only annotations used by Kiali
-	if da, ok := ns.Annotations[dashboards.DashboardTemplateAnnotation]; ok {
-		namespace.Annotations[dashboards.DashboardTemplateAnnotation] = da
-	}
+	namespace.Annotations = ns.Annotations
+
 	if ns.Labels[AmbientLabel] == AmbientValue {
 		namespace.IsAmbient = true
 	}
@@ -94,11 +91,8 @@ func CastProject(p osproject_v1.Project, cluster string) Namespace {
 	namespace.Cluster = cluster
 	namespace.CreationTimestamp = p.CreationTimestamp.Time
 	namespace.Labels = p.Labels
-	namespace.Annotations = make(map[string]string)
-	// Parse only annotations used by Kiali
-	if da, ok := p.Annotations[dashboards.DashboardTemplateAnnotation]; ok {
-		namespace.Annotations[dashboards.DashboardTemplateAnnotation] = da
-	}
+	namespace.Annotations = p.Annotations
+
 	return namespace
 }
 

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -980,6 +980,27 @@ func NewRoutes() (r *Routes) {
 			handlers.ConfigValidationSummary,
 			true,
 		},
+		// swagger:route GET /mesh mesh configuration
+		// ---
+		// Get Mesh status and configuration
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      200: meshResponse
+		//      400: badRequestError
+		//      500: internalError
+		//
+		{
+			"Mesh",
+			"GET",
+			"/api/mesh",
+			handlers.GetMesh,
+			true,
+		},
 		// swagger:route GET /mesh/tls tls meshTls
 		// ---
 		// Get TLS status for the whole mesh
@@ -1099,7 +1120,6 @@ func NewRoutes() (r *Routes) {
 		//      200: graphResponse
 		//
 		{
-
 			"GraphAggregate",
 			"GET",
 			"/api/namespaces/{namespace}/aggregates/{aggregate}/{aggregateValue}/graph",
@@ -1121,7 +1141,6 @@ func NewRoutes() (r *Routes) {
 		//      200: graphResponse
 		//
 		{
-
 			"GraphAggregateByService",
 			"GET",
 			"/api/namespaces/{namespace}/aggregates/{aggregate}/{aggregateValue}/{service}/graph",
@@ -1143,7 +1162,6 @@ func NewRoutes() (r *Routes) {
 		//      200: graphResponse
 		//
 		{
-
 			"GraphAppVersion",
 			"GET",
 			"/api/namespaces/{namespace}/applications/{app}/versions/{version}/graph",


### PR DESCRIPTION
Creates a couple new models to store controlplane configuration per controlplane since with multi-primary there can be multiple controlplanes. Even with single cluster there can be multiple controlplanes when revisions are used. This will allow Kiali to better support control plane revisions in the future even for single cluster.

This adds the models but stops short of updating various methods that gather controlplane info to use them yet.

Fixes #6430 