### PR TITLE
Add sysctl info to README and hack script

### DIFF
--- a/hack/README.adoc
+++ b/hack/README.adoc
@@ -53,11 +53,21 @@ Use this to access the Kiali UI that is installed locally in `minikube` or `kind
 
 * `link:purge-kiali-from-cluster.sh[]`
 
-Sets up the environment for the integration tests and runs them. This is the same setup that is used by the CI system.
+Removes all remnants of Kiali and Kiali Operator from a cluster.
 
 * `link:run-integration-tests.sh[]`
 
-Removes all remnants of Kiali and Kiali Operator from a cluster.
+Sets up the environment for the integration tests and runs them. This is the same setup that is used by the CI system.
+
+NOTE: When running the multi-cluster tests locally, it might be necessary to
+edit some kernel settings to allow for the kind clusters to be created.
+
+The following settings added to your `/etc/sysctl.d/local.conf` file
+should work but YMMV depending on your system:
+```bash
+fs.inotify.max_user_watches=524288
+fs.inotify.max_user_instances=512
+```
 
 * `link:run-kiali.sh[]`
 

--- a/hack/README.adoc
+++ b/hack/README.adoc
@@ -62,8 +62,12 @@ Sets up the environment for the integration tests and runs them. This is the sam
 NOTE: When running the multi-cluster tests locally, it might be necessary to
 edit some kernel settings to allow for the kind clusters to be created.
 
-The following settings added to your `/etc/sysctl.d/local.conf` file
-should work but YMMV depending on your system:
+These commands will set the kernel settings temporarily. After a reboot, your system will revert back to its original settings:
+```bash
+sudo sysctl fs.inotify.max_user_watches=524288
+sudo sysctl fs.inotify.max_user_instances=512
+```
+If you wish to make these settings permanent, the following lines added to your sysctl configuration file should work (depending on your operating system, this configuration file can be something like `/etc/sysctl.d/local.conf`, `/etc/sysctl.conf`, or something else. Refer to the `man sysctl` docs for details):
 ```bash
 fs.inotify.max_user_watches=524288
 fs.inotify.max_user_instances=512

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -42,8 +42,7 @@ Valid command line arguments:
 NOTE: When running the multi-cluster tests locally, it might be necessary to
 edit some kernel settings to allow for the kind clusters to be created.
 
-The following settings added to your /etc/sysctl.d/local.conf file
-should work but YMMV depending on your system:
+The following settings added to your sysctl config file should work (the filename will be something like '/etc/sysctl.d/local.conf' - refer to your operating system 'man sysctl' docs to determine which file should be changed):
 fs.inotify.max_user_watches=524288
 fs.inotify.max_user_instances=512
 HELPMSG

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -38,6 +38,14 @@ Valid command line arguments:
     Default: false 
   -h|--help:
        this message
+
+NOTE: When running the multi-cluster tests locally, it might be necessary to
+edit some kernel settings to allow for the kind clusters to be created.
+
+The following settings added to your /etc/sysctl.d/local.conf file
+should work but YMMV depending on your system:
+fs.inotify.max_user_watches=524288
+fs.inotify.max_user_instances=512
 HELPMSG
       exit 1
       ;;


### PR DESCRIPTION
Adds a section to the README and help message about increasing some kernel settings when setting up a multi-cluster environment locally with kind.