### PR TITLE
[make] fix molecule test make target

### DIFF
--- a/make/Makefile.molecule.mk
+++ b/make/Makefile.molecule.mk
@@ -146,9 +146,13 @@ endif
 
 ifndef MOLECULE_ADD_HOST_ARGS
 .prepare-add-host-args: .prepare-cluster
+ifeq ($(CLUSTER_TYPE),openshift)
 	@echo "Will auto-detect hosts to add based on the CLUSTER_REPO: ${CLUSTER_REPO}"
 	@$(eval MOLECULE_ADD_HOST_ARGS ?= $(shell basehost="$(shell echo ${CLUSTER_REPO} | sed 's/^.*\.apps\.\(.*\)/\1/')"; kialihost="kiali-istio-system.apps.$${basehost}"; kialiip="$$(getent hosts $${kialihost} | head -n 1 | awk '{ print $$1 }')"; prometheushost="prometheus-istio-system.apps.$${basehost}"; prometheusip="$$(getent hosts $${prometheushost} | head -n 1 | awk '{ print $$1 }')" apihost="api.$${basehost}"; apiip="$$(getent hosts $${apihost} | head -n 1 | awk '{ print $$1 }')"; oauthoshost="oauth-openshift.apps.$${basehost}"; oauthosip="$$(getent hosts $${oauthoshost} | head -n 1 | awk '{ print $$1 }')"; echo "--add-host=$$kialihost:$$kialiip --add-host=$$prometheushost:$$prometheusip --add-host=$$apihost:$$apiip --add-host=$$oauthoshost:$$oauthosip"))
 	@echo "Auto-detected add host args: ${MOLECULE_ADD_HOST_ARGS}"
+else
+	@echo "Will not auto-detect any hosts for non-OpenShift clusters."
+endif
 else
 .prepare-add-host-args:
 	@echo "Will use the given add host args: ${MOLECULE_ADD_HOST_ARGS}"


### PR DESCRIPTION
This auto-detection of hosts should never occur unless the cluster is openshift. Without this fix, the getent commands hang until they timeout causing the test times to go from 2 minutes to 16 minutes. lol