### PR TITLE
[CI] run molecule tests nightly

### DIFF
--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -2,13 +2,33 @@ name: Kiali Molecule Tests
 
 on:
   schedule:
-    - cron: '0 6 * * *' # This is UTC time
+  - cron: '0 6 * * *' # This is UTC time
+  workflow_dispatch:
+    inputs:
+      all_tests:
+        description: "Molecule Test Names (space-separated)"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   molecules:
     name: Molecule tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - name: Run molecule tests
-        run: wget -qO - "https://raw.githubusercontent.com/kiali/kiali/master/hack/ci-kind-molecule-tests.sh" | bash -s -- -gcp https -ir "" -ce $(which kubectl)
-
+    - name: Checkout the hack script that runs the tests
+      uses: actions/checkout@v3
+      with:
+        sparse-checkout: |
+          hack/ci-kind-molecule-tests.sh
+    - name: Print the names of the tests that are to be run
+      run: |
+        if [ -z "${{ inputs.all_tests }}" ]; then
+          echo "all tests"
+        else
+          echo "tests=${{ inputs.all_tests }}"
+        fi
+    - name: Run molecule tests using helm
+      run: ./hack/ci-kind-molecule-tests.sh --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster true -ci true --operator-installer helm --olm-enabled false
+    - name: Run molecule tests using OLM
+      run: ./hack/ci-kind-molecule-tests.sh --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster true -ci true --operator-installer skip --olm-enabled true


### PR DESCRIPTION
This runs the molecule tests nightly. It will run the tests twice - once with the operator installed via helm and once with the operator installed via OLM.

(merge this only after https://github.com/kiali/kiali/pull/6484 is merged)