### PR TITLE
Change fixed position for help icon in Envoy tab

### DIFF
--- a/frontend/src/components/Envoy/tables/BaseTable.tsx
+++ b/frontend/src/components/Envoy/tables/BaseTable.tsx
@@ -73,7 +73,7 @@ export function SummaryTableRenderer<T extends SummaryTable>() {
                 label={this.props.pod}
                 options={this.props.pods.sort()}
               />
-              <div className={kialiStyle({ position: 'fixed', right: '60px' })}>{this.props.writer.tooltip()}</div>
+              <div className={kialiStyle({ position: 'absolute', right: '60px' })}>{this.props.writer.tooltip()}</div>
             </>
           </StatefulFilters>
           <Table


### PR DESCRIPTION
Fixes: #6502

This is a very small fix to not fix the position of the help icon (In the right corner of the table) in the Envoy tab. 
Previous to this fix: 

![image](https://github.com/kiali/kiali/assets/49480155/daaeab9f-2c9d-410f-9d6f-7a7a338cb9bb)

The position of the icon was fixed, so it didn't move when we scroll down. 

After the fix: 

![image](https://github.com/kiali/kiali/assets/49480155/22d15274-d2c1-4a15-aae2-40b43fa3088c)
