### PR TITLE
[v1.65] Backport of https://github.com/kiali/kiali/pull/6389

### DIFF
--- a/tests/integration/tests/applications_test.go
+++ b/tests/integration/tests/applications_test.go
@@ -4,64 +4,64 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
 func TestApplicationsList(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	appList, err := utils.ApplicationsList(utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.NotEmpty(appList)
+	require.Nil(err)
+	require.NotEmpty(appList)
 	for _, app := range appList.Apps {
-		assert.NotEmpty(app.Name)
-		assert.NotNil(app.Health)
-		assert.NotNil(app.Labels)
+		require.NotEmpty(app.Name)
+		require.NotNil(app.Health)
+		require.NotNil(app.Labels)
 		if !strings.Contains(app.Name, "traffic-generator") {
-			assert.True(app.IstioSidecar)
-			assert.NotNil(app.IstioReferences)
+			require.True(app.IstioSidecar)
+			require.NotNil(app.IstioReferences)
 		}
 	}
-	assert.Equal(utils.BOOKINFO, appList.Namespace.Name)
+	require.Equal(utils.BOOKINFO, appList.Namespace.Name)
 }
 
 func TestApplicationDetails(t *testing.T) {
 	name := "productpage"
-	assert := assert.New(t)
+	require := require.New(t)
 	app, _, err := utils.ApplicationDetails(name, utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.NotNil(app)
-	assert.Equal(utils.BOOKINFO, app.Namespace.Name)
-	assert.Equal(name, app.Name)
-	assert.NotEmpty(app.Workloads)
+	require.Nil(err)
+	require.NotNil(app)
+	require.Equal(utils.BOOKINFO, app.Namespace.Name)
+	require.Equal(name, app.Name)
+	require.NotEmpty(app.Workloads)
 	for _, workload := range app.Workloads {
-		assert.NotEmpty(workload.WorkloadName)
+		require.NotEmpty(workload.WorkloadName)
 		if !strings.Contains(workload.WorkloadName, "traffic-generator") {
-			assert.True(workload.IstioSidecar)
+			require.True(workload.IstioSidecar)
 		}
 	}
-	assert.NotEmpty(app.ServiceNames)
+	require.NotEmpty(app.ServiceNames)
 	for _, serviceName := range app.ServiceNames {
-		assert.Equal(name, serviceName)
+		require.Equal(name, serviceName)
 	}
-	assert.NotNil(app.Runtimes)
-	assert.NotNil(app.Health)
-	assert.NotNil(app.Health.Requests)
-	assert.NotNil(app.Health.Requests.Inbound)
-	assert.NotNil(app.Health.Requests.Outbound)
-	assert.NotEmpty(app.Health.WorkloadStatuses)
+	require.NotNil(app.Runtimes)
+	require.NotNil(app.Health)
+	require.NotNil(app.Health.Requests)
+	require.NotNil(app.Health.Requests.Inbound)
+	require.NotNil(app.Health.Requests.Outbound)
+	require.NotEmpty(app.Health.WorkloadStatuses)
 	for _, wlStatus := range app.Health.WorkloadStatuses {
-		assert.Contains(wlStatus.Name, name)
+		require.Contains(wlStatus.Name, name)
 	}
 }
 
 func TestAppDetailsInvalidName(t *testing.T) {
 	name := "invalid"
-	assert := assert.New(t)
+	require := require.New(t)
 	app, code, _ := utils.ApplicationDetails(name, utils.BOOKINFO)
-	assert.NotEqual(200, code)
-	assert.Empty(app)
+	require.NotEqual(200, code)
+	require.Empty(app)
 }

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -7,7 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -17,163 +17,163 @@ import (
 
 func TestAuthPolicyPrincipalsError(t *testing.T) {
 	name := "ratings-policy"
-	assert := assert.New(t)
+	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-auth-policy-principals.yaml")
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
-	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.AuthorizationPolicies, false, assert)
+	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.AuthorizationPolicies, false, require)
 
-	assert.Nil(err)
-	assert.NotNil(config)
-	assert.Equal(kubernetes.AuthorizationPolicies, config.ObjectType)
-	assert.Equal(utils.BOOKINFO, config.Namespace.Name)
-	assert.NotNil(config.AuthorizationPolicy)
-	assert.Equal(name, config.AuthorizationPolicy.Name)
-	assert.Equal(utils.BOOKINFO, config.AuthorizationPolicy.Namespace)
-	assert.NotNil(config.IstioReferences)
-	assert.NotNil(config.IstioValidation)
-	assert.Equal(name, config.IstioValidation.Name)
-	assert.Equal("authorizationpolicy", config.IstioValidation.ObjectType)
-	assert.False(config.IstioValidation.Valid)
-	assert.Empty(config.IstioValidation.References)
-	assert.NotEmpty(config.IstioValidation.Checks)
-	assert.Len(config.IstioValidation.Checks, 1)
-	assert.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
-	assert.Equal("Service Account not found for this principal", config.IstioValidation.Checks[0].Message)
+	require.Nil(err)
+	require.NotNil(config)
+	require.Equal(kubernetes.AuthorizationPolicies, config.ObjectType)
+	require.Equal(utils.BOOKINFO, config.Namespace.Name)
+	require.NotNil(config.AuthorizationPolicy)
+	require.Equal(name, config.AuthorizationPolicy.Name)
+	require.Equal(utils.BOOKINFO, config.AuthorizationPolicy.Namespace)
+	require.NotNil(config.IstioReferences)
+	require.NotNil(config.IstioValidation)
+	require.Equal(name, config.IstioValidation.Name)
+	require.Equal("authorizationpolicy", config.IstioValidation.ObjectType)
+	require.False(config.IstioValidation.Valid)
+	require.Empty(config.IstioValidation.References)
+	require.NotEmpty(config.IstioValidation.Checks)
+	require.Len(config.IstioValidation.Checks, 1)
+	require.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
+	require.Equal("Service Account not found for this principal", config.IstioValidation.Checks[0].Message)
 }
 
 func TestServiceEntryLabels(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-service-entry-labels.yaml")
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
 	// the DR with matching labels with SE
 	name := "dest-rule-labels"
-	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.DestinationRules, false, assert)
-	assert.Nil(err)
-	assert.NotNil(config)
-	assert.True(config.IstioValidation.Valid)
-	assert.Empty(config.IstioValidation.Checks)
+	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.DestinationRules, false, require)
+	require.Nil(err)
+	require.NotNil(config)
+	require.True(config.IstioValidation.Valid)
+	require.Empty(config.IstioValidation.Checks)
 }
 
 func TestServiceEntryLabelsNotMatch(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-service-entry-wrong-labels.yaml")
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
 	// the DR with error, labels not match with SE
 	name := "dest-rule-labels-wrong"
-	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.DestinationRules, false, assert)
-	assert.Nil(err)
-	assert.NotNil(config)
-	assert.False(config.IstioValidation.Valid)
-	assert.NotEmpty(config.IstioValidation.Checks)
-	assert.Len(config.IstioValidation.Checks, 1)
-	assert.Equal("This subset's labels are not found in any matching host", config.IstioValidation.Checks[0].Message)
+	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.DestinationRules, false, require)
+	require.Nil(err)
+	require.NotNil(config)
+	require.False(config.IstioValidation.Valid)
+	require.NotEmpty(config.IstioValidation.Checks)
+	require.Len(config.IstioValidation.Checks, 1)
+	require.Equal("This subset's labels are not found in any matching host", config.IstioValidation.Checks[0].Message)
 }
 
 func TestK8sGatewaysAddressesError(t *testing.T) {
 	name := "gatewayapi"
-	assert := assert.New(t)
+	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-k8sgateways-addresses.yaml")
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
-	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.K8sGateways, true, assert)
+	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.K8sGateways, true, require)
 
-	assert.Nil(err)
-	assert.NotNil(config)
-	assert.Equal(kubernetes.K8sGateways, config.ObjectType)
-	assert.Equal(utils.BOOKINFO, config.Namespace.Name)
-	assert.NotNil(config.K8sGateway)
-	assert.Equal(name, config.K8sGateway.Name)
-	assert.Equal(utils.BOOKINFO, config.K8sGateway.Namespace)
-	assert.NotNil(config.IstioValidation)
-	assert.Equal(name, config.IstioValidation.Name)
-	assert.Equal("k8sgateway", config.IstioValidation.ObjectType)
-	assert.NotEmpty(config.IstioValidation.Checks)
-	assert.Equal(models.WarningSeverity, config.IstioValidation.Checks[0].Severity)
-	assert.Equal("More than one K8s Gateway for the same address and type combination", config.IstioValidation.Checks[0].Message)
+	require.Nil(err)
+	require.NotNil(config)
+	require.Equal(kubernetes.K8sGateways, config.ObjectType)
+	require.Equal(utils.BOOKINFO, config.Namespace.Name)
+	require.NotNil(config.K8sGateway)
+	require.Equal(name, config.K8sGateway.Name)
+	require.Equal(utils.BOOKINFO, config.K8sGateway.Namespace)
+	require.NotNil(config.IstioValidation)
+	require.Equal(name, config.IstioValidation.Name)
+	require.Equal("k8sgateway", config.IstioValidation.ObjectType)
+	require.NotEmpty(config.IstioValidation.Checks)
+	require.Equal(models.WarningSeverity, config.IstioValidation.Checks[0].Severity)
+	require.Equal("More than one K8s Gateway for the same address and type combination", config.IstioValidation.Checks[0].Message)
 }
 
 func TestK8sGatewaysListenersError(t *testing.T) {
 	name := "gatewayapi"
-	assert := assert.New(t)
+	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-k8sgateways-listeners.yaml")
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
-	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.K8sGateways, true, assert)
+	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.K8sGateways, true, require)
 
-	assert.Nil(err)
-	assert.NotNil(config)
-	assert.Equal(kubernetes.K8sGateways, config.ObjectType)
-	assert.Equal(utils.BOOKINFO, config.Namespace.Name)
-	assert.NotNil(config.K8sGateway)
-	assert.Equal(name, config.K8sGateway.Name)
-	assert.Equal(utils.BOOKINFO, config.K8sGateway.Namespace)
-	assert.NotNil(config.IstioValidation)
-	assert.Equal(name, config.IstioValidation.Name)
-	assert.Equal("k8sgateway", config.IstioValidation.ObjectType)
-	assert.NotEmpty(config.IstioValidation.Checks)
-	assert.Equal(models.WarningSeverity, config.IstioValidation.Checks[0].Severity)
-	assert.Equal("More than one K8s Gateway for the same host port combination", config.IstioValidation.Checks[0].Message)
+	require.Nil(err)
+	require.NotNil(config)
+	require.Equal(kubernetes.K8sGateways, config.ObjectType)
+	require.Equal(utils.BOOKINFO, config.Namespace.Name)
+	require.NotNil(config.K8sGateway)
+	require.Equal(name, config.K8sGateway.Name)
+	require.Equal(utils.BOOKINFO, config.K8sGateway.Namespace)
+	require.NotNil(config.IstioValidation)
+	require.Equal(name, config.IstioValidation.Name)
+	require.Equal("k8sgateway", config.IstioValidation.ObjectType)
+	require.NotEmpty(config.IstioValidation.Checks)
+	require.Equal(models.WarningSeverity, config.IstioValidation.Checks[0].Severity)
+	require.Equal("More than one K8s Gateway for the same host port combination", config.IstioValidation.Checks[0].Message)
 }
 
 func TestK8sHTTPRoutesGatewaysError(t *testing.T) {
 	name := "httproute"
-	assert := assert.New(t)
+	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-k8shttproutes-gateways.yaml")
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
-	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.K8sHTTPRoutes, true, assert)
+	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.K8sHTTPRoutes, true, require)
 
-	assert.Nil(err)
-	assert.NotNil(config)
-	assert.Equal(kubernetes.K8sHTTPRoutes, config.ObjectType)
-	assert.Equal(utils.BOOKINFO, config.Namespace.Name)
-	assert.NotNil(config.K8sHTTPRoute)
-	assert.Equal(name, config.K8sHTTPRoute.Name)
-	assert.Equal(utils.BOOKINFO, config.K8sHTTPRoute.Namespace)
-	assert.NotNil(config.IstioValidation)
-	assert.False(config.IstioValidation.Valid)
-	assert.Equal(name, config.IstioValidation.Name)
-	assert.Equal("k8shttproute", config.IstioValidation.ObjectType)
-	assert.NotEmpty(config.IstioValidation.Checks)
-	assert.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
-	assert.Equal("HTTPRoute is pointing to a non-existent K8s gateway", config.IstioValidation.Checks[0].Message)
+	require.Nil(err)
+	require.NotNil(config)
+	require.Equal(kubernetes.K8sHTTPRoutes, config.ObjectType)
+	require.Equal(utils.BOOKINFO, config.Namespace.Name)
+	require.NotNil(config.K8sHTTPRoute)
+	require.Equal(name, config.K8sHTTPRoute.Name)
+	require.Equal(utils.BOOKINFO, config.K8sHTTPRoute.Namespace)
+	require.NotNil(config.IstioValidation)
+	require.False(config.IstioValidation.Valid)
+	require.Equal(name, config.IstioValidation.Name)
+	require.Equal("k8shttproute", config.IstioValidation.ObjectType)
+	require.NotEmpty(config.IstioValidation.Checks)
+	require.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
+	require.Equal("HTTPRoute is pointing to a non-existent K8s gateway", config.IstioValidation.Checks[0].Message)
 }
 
 func TestK8sHTTPRoutesServicesError(t *testing.T) {
 	name := "httprouteservices"
-	assert := assert.New(t)
+	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-k8shttproutes-services.yaml")
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
-	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.K8sHTTPRoutes, true, assert)
+	config, err := getConfigDetails(utils.BOOKINFO, name, kubernetes.K8sHTTPRoutes, true, require)
 
-	assert.Nil(err)
-	assert.NotNil(config)
-	assert.Equal(kubernetes.K8sHTTPRoutes, config.ObjectType)
-	assert.Equal(utils.BOOKINFO, config.Namespace.Name)
-	assert.NotNil(config.K8sHTTPRoute)
-	assert.Equal(name, config.K8sHTTPRoute.Name)
-	assert.Equal(utils.BOOKINFO, config.K8sHTTPRoute.Namespace)
-	assert.NotNil(config.IstioValidation)
-	assert.False(config.IstioValidation.Valid)
-	assert.Equal(name, config.IstioValidation.Name)
-	assert.Equal("k8shttproute", config.IstioValidation.ObjectType)
-	assert.NotEmpty(config.IstioValidation.Checks)
-	assert.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
-	assert.Equal("BackendRef on rule doesn't have a valid service (host not found)", config.IstioValidation.Checks[0].Message)
+	require.Nil(err)
+	require.NotNil(config)
+	require.Equal(kubernetes.K8sHTTPRoutes, config.ObjectType)
+	require.Equal(utils.BOOKINFO, config.Namespace.Name)
+	require.NotNil(config.K8sHTTPRoute)
+	require.Equal(name, config.K8sHTTPRoute.Name)
+	require.Equal(utils.BOOKINFO, config.K8sHTTPRoute.Namespace)
+	require.NotNil(config.IstioValidation)
+	require.False(config.IstioValidation.Valid)
+	require.Equal(name, config.IstioValidation.Name)
+	require.Equal("k8shttproute", config.IstioValidation.ObjectType)
+	require.NotEmpty(config.IstioValidation.Checks)
+	require.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
+	require.Equal("BackendRef on rule doesn't have a valid service (host not found)", config.IstioValidation.Checks[0].Message)
 }
 
-func getConfigDetails(namespace, name, configType string, skipReferences bool, assert *assert.Assertions) (*models.IstioConfigDetails, error) {
+func getConfigDetails(namespace, name, configType string, skipReferences bool, require *require.Assertions) (*models.IstioConfigDetails, error) {
 	config, _, err := utils.IstioConfigDetails(namespace, name, configType)
 	if err == nil && config != nil && config.IstioValidation != nil && config.IstioReferences != nil {
 		return config, nil
@@ -189,6 +189,6 @@ func getConfigDetails(namespace, name, configType string, skipReferences bool, a
 		}
 		return false, nil
 	})
-	assert.Nil(pollErr)
+	require.Nil(pollErr)
 	return config, nil
 }

--- a/tests/integration/tests/dashboards_test.go
+++ b/tests/integration/tests/dashboards_test.go
@@ -3,34 +3,34 @@ package tests
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
 func TestAppDashboard(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
-	assertDashboards("apps", utils.BOOKINFO, name, assert)
+	requireDashboards("apps", utils.BOOKINFO, name, require)
 }
 
 func TestServiceDashboard(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
-	assertDashboards("services", utils.BOOKINFO, name, assert)
+	requireDashboards("services", utils.BOOKINFO, name, require)
 }
 
 func TestWorkloadDashboard(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details-v1"
-	assertDashboards("workloads", utils.BOOKINFO, name, assert)
+	requireDashboards("workloads", utils.BOOKINFO, name, require)
 }
 
-func assertDashboards(objectType, namespace, name string, assert *assert.Assertions) {
+func requireDashboards(objectType, namespace, name string, require *require.Assertions) {
 	dashboard, err := utils.ObjectDashboard(namespace, name, objectType)
 
-	assert.Nil(err)
-	assert.NotNil(dashboard)
-	assert.NotEmpty(dashboard.Charts)
-	assert.NotEmpty(dashboard.Aggregations)
+	require.Nil(err)
+	require.NotNil(dashboard)
+	require.NotEmpty(dashboard.Charts)
+	require.NotEmpty(dashboard.Aggregations)
 }

--- a/tests/integration/tests/external_host_node_test.go
+++ b/tests/integration/tests/external_host_node_test.go
@@ -7,7 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/tests/integration/utils"
 	"github.com/kiali/kiali/tools/cmd"
@@ -17,20 +17,20 @@ func TestExternalHostNode(t *testing.T) {
 	params := map[string]string{"graphType": "versionedApp", "duration": "60s", "injectServiceNodes": "true"}
 	name := "foo.bookinfo.ext"
 
-	assert := assert.New(t)
-	assertExternalNode(params, "bookinfo-ext-service-entry.yaml", name, assert)
+	require := require.New(t)
+	requireExternalNode(params, "bookinfo-ext-service-entry.yaml", name, require)
 }
 
-func assertExternalNode(params map[string]string, yaml, name string, assert *assert.Assertions) {
+func requireExternalNode(params map[string]string, yaml, name string, require *require.Assertions) {
 	params["namespaces"] = utils.BOOKINFO
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/"+yaml)
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		return NodeMatch(params, name)
 	})
-	assert.Nil(pollErr, "Name %s should exist in node services names", name)
+	require.Nil(pollErr, "Name %s should exist in node services names", name)
 }
 
 func NodeMatch(params map[string]string, nodeName string) (bool, error) {

--- a/tests/integration/tests/graph_badges_test.go
+++ b/tests/integration/tests/graph_badges_test.go
@@ -7,153 +7,157 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/tests/integration/utils"
 	"github.com/kiali/kiali/tools/cmd"
 )
 
-const DURATION = "60s"
-const CB_BADGE = "hasCB"
-const VS_BADGE = "hasVS"
-const TF_BADGE = "hasTrafficShifting"
-const TCP_TF_BADGE = "hasTCPTrafficShifting"
-const RT_BADGE = "hasRequestTimeout"
-const FI_BADGE = "hasFaultInjection"
-const CIRCUIT_BREAKER_FILE = "bookinfo-reviews-all-cb.yaml"
-const VIRTUAL_SERVICE_FILE = "bookinfo-ratings-delay.yaml"
-const TRAFFIC_SHIFTING_FILE = "bookinfo-traffic-shifting-reviews.yaml"
-const TCP_TRAFFIC_SHIFTING_FILE = "bookinfo-tcp-traffic-shifting-reviews.yaml"
-const REQUEST_ROUTING_FILE = "bookinfo-request-timeouts-reviews.yaml"
-const FAULT_INJECTION_FILE = "bookinfo-fault-injection-reviews.yaml"
+const (
+	DURATION                  = "60s"
+	CB_BADGE                  = "hasCB"
+	VS_BADGE                  = "hasVS"
+	TF_BADGE                  = "hasTrafficShifting"
+	TCP_TF_BADGE              = "hasTCPTrafficShifting"
+	RT_BADGE                  = "hasRequestTimeout"
+	FI_BADGE                  = "hasFaultInjection"
+	CIRCUIT_BREAKER_FILE      = "bookinfo-reviews-all-cb.yaml"
+	VIRTUAL_SERVICE_FILE      = "bookinfo-ratings-delay.yaml"
+	TRAFFIC_SHIFTING_FILE     = "bookinfo-traffic-shifting-reviews.yaml"
+	TCP_TRAFFIC_SHIFTING_FILE = "bookinfo-tcp-traffic-shifting-reviews.yaml"
+	REQUEST_ROUTING_FILE      = "bookinfo-request-timeouts-reviews.yaml"
+	FAULT_INJECTION_FILE      = "bookinfo-fault-injection-reviews.yaml"
+)
 
-var VERSIONED_APP_PARAMS = map[string]string{"graphType": "versionedApp", "duration": DURATION, "injectServiceNodes": "true"}
-var WORKLOAD_PARAMS = map[string]string{"graphType": "workload", "duration": DURATION, "injectServiceNodes": "true"}
-var APP_PARAMS = map[string]string{"graphType": "app", "duration": DURATION, "injectServiceNodes": "true"}
-var SERVICE_PARAMS = map[string]string{"graphType": "service", "duration": DURATION, "injectServiceNodes": "true"}
+var (
+	VERSIONED_APP_PARAMS = map[string]string{"graphType": "versionedApp", "duration": DURATION, "injectServiceNodes": "true"}
+	WORKLOAD_PARAMS      = map[string]string{"graphType": "workload", "duration": DURATION, "injectServiceNodes": "true"}
+	APP_PARAMS           = map[string]string{"graphType": "app", "duration": DURATION, "injectServiceNodes": "true"}
+	SERVICE_PARAMS       = map[string]string{"graphType": "service", "duration": DURATION, "injectServiceNodes": "true"}
+)
 
 func TestCBVersionedApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(VERSIONED_APP_PARAMS, CIRCUIT_BREAKER_FILE, CB_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(VERSIONED_APP_PARAMS, CIRCUIT_BREAKER_FILE, CB_BADGE, require)
 }
 
 func TestCBWorkload(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(WORKLOAD_PARAMS, CIRCUIT_BREAKER_FILE, CB_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(WORKLOAD_PARAMS, CIRCUIT_BREAKER_FILE, CB_BADGE, require)
 }
 
 func TestCBService(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(SERVICE_PARAMS, CIRCUIT_BREAKER_FILE, CB_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(SERVICE_PARAMS, CIRCUIT_BREAKER_FILE, CB_BADGE, require)
 }
 
 func TestVSVersionedApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(VERSIONED_APP_PARAMS, VIRTUAL_SERVICE_FILE, VS_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(VERSIONED_APP_PARAMS, VIRTUAL_SERVICE_FILE, VS_BADGE, require)
 }
 
 func TestVSWorkload(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(WORKLOAD_PARAMS, VIRTUAL_SERVICE_FILE, VS_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(WORKLOAD_PARAMS, VIRTUAL_SERVICE_FILE, VS_BADGE, require)
 }
 
 func TestVSApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(APP_PARAMS, VIRTUAL_SERVICE_FILE, VS_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(APP_PARAMS, VIRTUAL_SERVICE_FILE, VS_BADGE, require)
 }
 
 func TestVSService(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(SERVICE_PARAMS, VIRTUAL_SERVICE_FILE, VS_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(SERVICE_PARAMS, VIRTUAL_SERVICE_FILE, VS_BADGE, require)
 }
 
 func TestTraficShiftingVersionedApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(VERSIONED_APP_PARAMS, TRAFFIC_SHIFTING_FILE, TF_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(VERSIONED_APP_PARAMS, TRAFFIC_SHIFTING_FILE, TF_BADGE, require)
 }
 
 func TestTcpTraficShiftingVersionedApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(VERSIONED_APP_PARAMS, TCP_TRAFFIC_SHIFTING_FILE, TCP_TF_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(VERSIONED_APP_PARAMS, TCP_TRAFFIC_SHIFTING_FILE, TCP_TF_BADGE, require)
 }
 
 func TestRequestTimeoutsVersionedApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(VERSIONED_APP_PARAMS, REQUEST_ROUTING_FILE, RT_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(VERSIONED_APP_PARAMS, REQUEST_ROUTING_FILE, RT_BADGE, require)
 }
 
 func TestFaultInjectionVersionedApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(VERSIONED_APP_PARAMS, FAULT_INJECTION_FILE, FI_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(VERSIONED_APP_PARAMS, FAULT_INJECTION_FILE, FI_BADGE, require)
 }
 
 func TestTrafficShiftingWorkload(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(WORKLOAD_PARAMS, TRAFFIC_SHIFTING_FILE, TF_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(WORKLOAD_PARAMS, TRAFFIC_SHIFTING_FILE, TF_BADGE, require)
 }
 
 func TestTcpTrafficShiftingWorkload(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(WORKLOAD_PARAMS, TCP_TRAFFIC_SHIFTING_FILE, TCP_TF_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(WORKLOAD_PARAMS, TCP_TRAFFIC_SHIFTING_FILE, TCP_TF_BADGE, require)
 }
 
 func TestRequestTimeoutWorkload(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(WORKLOAD_PARAMS, REQUEST_ROUTING_FILE, RT_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(WORKLOAD_PARAMS, REQUEST_ROUTING_FILE, RT_BADGE, require)
 }
 
 func TestFaultInjectionWorkload(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(WORKLOAD_PARAMS, FAULT_INJECTION_FILE, FI_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(WORKLOAD_PARAMS, FAULT_INJECTION_FILE, FI_BADGE, require)
 }
 
 func TestTrafficShiftingApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(APP_PARAMS, TRAFFIC_SHIFTING_FILE, TF_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(APP_PARAMS, TRAFFIC_SHIFTING_FILE, TF_BADGE, require)
 }
 
 func TestTcpTrafficShiftingApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(APP_PARAMS, TCP_TRAFFIC_SHIFTING_FILE, TCP_TF_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(APP_PARAMS, TCP_TRAFFIC_SHIFTING_FILE, TCP_TF_BADGE, require)
 }
 
 func TestRequestTimeoutsApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(APP_PARAMS, REQUEST_ROUTING_FILE, RT_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(APP_PARAMS, REQUEST_ROUTING_FILE, RT_BADGE, require)
 }
 
 func TestFaultInjectionApp(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(APP_PARAMS, FAULT_INJECTION_FILE, FI_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(APP_PARAMS, FAULT_INJECTION_FILE, FI_BADGE, require)
 }
 
 func TestTrafficShiftingService(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(SERVICE_PARAMS, TRAFFIC_SHIFTING_FILE, TF_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(SERVICE_PARAMS, TRAFFIC_SHIFTING_FILE, TF_BADGE, require)
 }
 
 func TestTcpTrafficShiftingService(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(SERVICE_PARAMS, TCP_TRAFFIC_SHIFTING_FILE, TCP_TF_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(SERVICE_PARAMS, TCP_TRAFFIC_SHIFTING_FILE, TCP_TF_BADGE, require)
 }
 
 func TestRequestTimeoutsService(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(SERVICE_PARAMS, REQUEST_ROUTING_FILE, RT_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(SERVICE_PARAMS, REQUEST_ROUTING_FILE, RT_BADGE, require)
 }
 
 func TestFultInjectionService(t *testing.T) {
-	assert := assert.New(t)
-	assertGraphBadges(SERVICE_PARAMS, FAULT_INJECTION_FILE, FI_BADGE, assert)
+	require := require.New(t)
+	requireGraphBadges(SERVICE_PARAMS, FAULT_INJECTION_FILE, FI_BADGE, require)
 }
 
-func assertGraphBadges(params map[string]string, yaml, badge string, assert *assert.Assertions) {
+func requireGraphBadges(params map[string]string, yaml, badge string, require *require.Assertions) {
 	params["namespaces"] = utils.BOOKINFO
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/"+yaml)
 	preBadgeCount := BadgeCount(params, badge)
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		badgeCount := BadgeCount(params, badge)
@@ -162,7 +166,7 @@ func assertGraphBadges(params map[string]string, yaml, badge string, assert *ass
 		}
 		return false, nil
 	})
-	assert.Nil(pollErr, "Badge %s should exist", badge)
+	require.Nil(pollErr, "Badge %s should exist", badge)
 }
 
 func BadgeCount(params map[string]string, badge string) int {

--- a/tests/integration/tests/graph_nodes_test.go
+++ b/tests/integration/tests/graph_nodes_test.go
@@ -4,29 +4,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
 func TestAppGraph(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
 	graphType := "app"
-	assertGraphConfig("applications", graphType, utils.BOOKINFO, name, assert)
+	requireGraphConfig("applications", graphType, utils.BOOKINFO, name, require)
 }
 
 func TestAppVersionGraph(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
 	graphType := "app"
-	assertGraphConfig("applications", graphType, utils.BOOKINFO, name, assert)
+	requireGraphConfig("applications", graphType, utils.BOOKINFO, name, require)
 }
 
 func TestVersionedAppGraph(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "ratings"
 	graphType := "versionedApp"
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
@@ -34,67 +33,67 @@ func TestVersionedAppGraph(t *testing.T) {
 		if statusCode != 200 {
 			return false, err
 		}
-		assert.Equal(config.GraphType, graphType)
-		assert.NotNil(config.Elements)
+		require.Equal(config.GraphType, graphType)
+		require.NotNil(config.Elements)
 		return len(config.Elements.Nodes) > 0 && len(config.Elements.Edges) > 0, nil
 	})
-	assert.Nil(pollErr, "Graph elements should contains Nodes and Edges")
+	require.Nil(pollErr, "Graph elements should contains Nodes and Edges")
 }
 
 func TestAppGraphEmpty(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "detailswrong"
 	graphType := "app"
-	assertEmptyGraphConfig("applications", graphType, utils.BOOKINFO, name, assert)
+	requireEmptyGraphConfig("applications", graphType, utils.BOOKINFO, name, require)
 }
 
 func TestServiceGraph(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
 	graphType := "versionedApp"
-	assertGraphConfig("services", graphType, utils.BOOKINFO, name, assert)
+	requireGraphConfig("services", graphType, utils.BOOKINFO, name, require)
 }
 
 func TestServiceGraphEmpty(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "detailswrong"
 	graphType := "workload"
-	assertEmptyGraphConfig("services", graphType, utils.BOOKINFO, name, assert)
+	requireEmptyGraphConfig("services", graphType, utils.BOOKINFO, name, require)
 }
 
 func TestWorkloadGraph(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details-v1"
 	graphType := "workload"
-	assertGraphConfig("workloads", graphType, utils.BOOKINFO, name, assert)
+	requireGraphConfig("workloads", graphType, utils.BOOKINFO, name, require)
 }
 
 func TestWorkloadGraphEmpty(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "reviews-wrong"
 	graphType := "workload"
-	assertEmptyGraphConfig("workloads", graphType, utils.BOOKINFO, name, assert)
+	requireEmptyGraphConfig("workloads", graphType, utils.BOOKINFO, name, require)
 }
 
-func assertGraphConfig(objectType, graphType, namespace, name string, assert *assert.Assertions) {
+func requireGraphConfig(objectType, graphType, namespace, name string, require *require.Assertions) {
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		config, statusCode, err := utils.ObjectGraph(objectType, graphType, name, namespace)
 		if statusCode != 200 {
 			return false, err
 		}
-		assert.Equal(config.GraphType, graphType)
-		assert.NotNil(config.Elements)
+		require.Equal(config.GraphType, graphType)
+		require.NotNil(config.Elements)
 		return len(config.Elements.Nodes) > 0 && len(config.Elements.Edges) > 0, nil
 	})
-	assert.Nil(pollErr, "Graph elements should contains Nodes and Edges")
+	require.Nil(pollErr, "Graph elements should contains Nodes and Edges")
 }
 
-func assertEmptyGraphConfig(objectType, graphType, namespace, name string, assert *assert.Assertions) {
+func requireEmptyGraphConfig(objectType, graphType, namespace, name string, require *require.Assertions) {
 	config, statusCode, err := utils.ObjectGraph(objectType, graphType, name, namespace)
-	assert.Equal(200, statusCode)
-	assert.Nil(err)
-	assert.Equal(config.GraphType, graphType)
-	assert.NotNil(config.Elements)
-	assert.Empty(config.Elements.Nodes)
-	assert.Empty(config.Elements.Edges)
+	require.Equal(200, statusCode)
+	require.Nil(err)
+	require.Equal(config.GraphType, graphType)
+	require.NotNil(config.Elements)
+	require.Empty(config.Elements.Nodes)
+	require.Empty(config.Elements.Edges)
 }

--- a/tests/integration/tests/graph_test.go
+++ b/tests/integration/tests/graph_test.go
@@ -5,237 +5,237 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
 func TestAppBase(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "duration": "60s"}
-	assertBoxBy(params, assert)
+	requireBoxBy(params, require)
 }
 
 func TestAppNoLabels(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "edges": "noEdgeLabels", "duration": "60s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestAppRequestsPerSecond(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "edges": "requestsPerSecond", "duration": "60s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestAppRequestsPercentage(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "edges": "requestsPercentage", "duration": "60s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestAppRequestsResponseTime(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "edges": "responseTime", "duration": "60s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestAppInjectServiceNodesTrue(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "edges": "responseTime", "duration": "60s", "injectServiceNodes": "true"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestAppInjectServiceNodesFalse(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "edges": "responseTime", "duration": "60s", "injectServiceNodes": "false"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestAppAppendersBlank(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "duration": "60s", "appenders": ""}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestAppAppendersInvalid(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "duration": "60s", "appenders": "invalid"}
-	assertGraphInvalid(params, assert)
+	requireGraphInvalid(params, require)
 }
 
 func TestServiceBase(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "service", "duration": "300s"}
-	assertBoxBy(params, assert)
+	requireBoxBy(params, require)
 }
 
 func TestServiceNoLabels(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "service", "edges": "noEdgeLabels", "duration": "300s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestServiceRequestsPerSecond(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "service", "edges": "requestsPerSecond", "duration": "300s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestServiceRequestsPercentage(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "service", "edges": "requestsPercentage", "duration": "300s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestServiceResponseTime(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "service", "edges": "responseTime", "duration": "300s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestServiceInjectServiceNodesTrue(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "service", "edges": "responseTime", "duration": "60s", "injectServiceNodes": "true"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestServiceInjectServiceNodesFalse(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "service", "edges": "responseTime", "duration": "60s", "injectServiceNodes": "false"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestServiceAppendersBlank(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "service", "duration": "60s", "appenders": ""}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestVersionedAppBase(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "duration": "600s"}
-	assertBoxBy(params, assert)
+	requireBoxBy(params, require)
 }
 
 func TestVersionedAppNoLabels(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "edges": "noEdgeLabels", "duration": "600s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestVersionedAppRequestsPerSecond(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "edges": "requestsPerSecond", "duration": "600s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestVersionedAppRequestsPercentage(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "edges": "requestsPercentage", "duration": "600s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestVersionedAppRequestsResponseTime(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "edges": "responseTime", "duration": "600s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestVersionedAppRInjectServiceNodesTrue(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "edges": "responseTime", "duration": "60s", "injectServiceNodes": "true"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestVersionedAppRInjectServiceNodesFalse(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "edges": "responseTime", "duration": "60s", "injectServiceNodes": "false"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestVersionedAppAppendersBlank(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "duration": "60s", "appenders": ""}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestWorkloadNoLabels(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "workload", "edges": "noEdgeLabels", "duration": "21600s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestWorkloadRequestsPerSecond(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "workload", "edges": "requestsPerSecond", "duration": "21600s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestWorkloadRequestPercentage(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "workload", "edges": "requestsPercentage", "duration": "21600s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestWorkloadRequestsResponseTime(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "workload", "edges": "responseTime", "duration": "21600s"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestWorkloadAppendersBlank(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "workload", "duration": "60s", "appenders": ""}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestBoxNegative(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "duration": "60s"}
 	params["boxBy"] = "junk"
-	assertGraphInvalid(params, assert)
+	requireGraphInvalid(params, require)
 }
 
 func TestGraphTypeNegative(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "app", "duration": "60s"}
 	params["graphType"] = "junk"
-	assertGraphInvalid(params, assert)
+	requireGraphInvalid(params, require)
 }
 
 func TestDisplayIdleEdges(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "duration": "300s", "idleEdges": "true"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestDisplayIdleNodes(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "duration": "300s", "idleNodes": "true"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestDisplayOperationNodes(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "duration": "300s", "operationNodes": "true"}
-	assertGraph(params, assert)
+	requireGraph(params, require)
 }
 
 func TestDisplayServiceNodes(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"graphType": "versionedApp", "duration": "300s", "injectServiceNodes": "true"}
-	assertGraph(params, assert)
-}
-func assertGraphInvalid(params map[string]string, assert *assert.Assertions) {
-	params["namespaces"] = utils.BOOKINFO
-	_, statusCode, _ := utils.Graph(params)
-	assert.Equal(statusCode, 400)
+	requireGraph(params, require)
 }
 
-func assertGraph(params map[string]string, assert *assert.Assertions) {
+func requireGraphInvalid(params map[string]string, require *require.Assertions) {
+	params["namespaces"] = utils.BOOKINFO
+	_, statusCode, _ := utils.Graph(params)
+	require.Equal(statusCode, 400)
+}
+
+func requireGraph(params map[string]string, require *require.Assertions) {
 	params["namespaces"] = utils.BOOKINFO
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		graph, statusCode, err := utils.Graph(params)
@@ -246,19 +246,19 @@ func assertGraph(params map[string]string, assert *assert.Assertions) {
 		for key, value := range params {
 			switch key {
 			case "duration":
-				assert.Contains(value, fmt.Sprintf("%d", graph.Duration))
+				require.Contains(value, fmt.Sprintf("%d", graph.Duration))
 			case "graphType":
-				assert.Equal(value, graph.GraphType)
+				require.Equal(value, graph.GraphType)
 			}
 		}
 		return len(graph.Elements.Nodes) > 0 && len(graph.Elements.Edges) > 0, nil
 	})
-	assert.Nil(pollErr, "Graph elements should contains Nodes and Edges")
+	require.Nil(pollErr, "Graph elements should contains Nodes and Edges")
 }
 
-func assertBoxBy(params map[string]string, assert *assert.Assertions) {
+func requireBoxBy(params map[string]string, require *require.Assertions) {
 	for _, v := range []string{"cluster", "namespace", "app"} {
 		params["boxBy"] = v
-		assertGraph(params, assert)
+		requireGraph(params, require)
 	}
 }

--- a/tests/integration/tests/istio_config_test.go
+++ b/tests/integration/tests/istio_config_test.go
@@ -4,7 +4,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/tests/integration/utils"
@@ -12,136 +12,136 @@ import (
 )
 
 func TestIstioConfigList(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-k8sgateways.yaml")
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 
 	configList, err := utils.IstioConfigsList(utils.BOOKINFO)
 
-	assert.Nil(err)
-	assertConfigs(*configList, assert)
+	require.Nil(err)
+	requireConfigs(*configList, require)
 }
 
 func TestIstioConfigs(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-k8sgateways.yaml")
 	defer utils.DeleteFile(filePath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(filePath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(filePath, utils.BOOKINFO))
 	configMap, err := utils.IstioConfigs()
 
-	assert.Nil(err)
-	assert.NotEmpty(configMap)
-	assertConfigs(*configMap["bookinfo"], assert)
+	require.Nil(err)
+	require.NotEmpty(configMap)
+	requireConfigs(*configMap["bookinfo"], require)
 }
 
-func assertConfigs(configList utils.IstioConfigListJson, assert *assert.Assertions) {
-	assert.NotEmpty(configList)
-	assert.NotNil(configList.IstioValidations)
-	assert.Equal(utils.BOOKINFO, configList.Namespace.Name)
+func requireConfigs(configList utils.IstioConfigListJson, require *require.Assertions) {
+	require.NotEmpty(configList)
+	require.NotNil(configList.IstioValidations)
+	require.Equal(utils.BOOKINFO, configList.Namespace.Name)
 
-	assert.NotNil(configList.DestinationRules)
+	require.NotNil(configList.DestinationRules)
 	for _, dr := range configList.DestinationRules {
-		assert.True(dr.Namespace == configList.Namespace.Name)
-		assert.NotNil(dr.Name)
+		require.True(dr.Namespace == configList.Namespace.Name)
+		require.NotNil(dr.Name)
 	}
-	assert.NotNil(configList.VirtualServices)
+	require.NotNil(configList.VirtualServices)
 	for _, vs := range configList.VirtualServices {
-		assert.True(vs.Namespace == configList.Namespace.Name)
-		assert.NotNil(vs.Name)
+		require.True(vs.Namespace == configList.Namespace.Name)
+		require.NotNil(vs.Name)
 	}
-	assert.NotNil(configList.PeerAuthentications)
+	require.NotNil(configList.PeerAuthentications)
 	for _, pa := range configList.PeerAuthentications {
-		assert.True(pa.Namespace == configList.Namespace.Name)
-		assert.NotNil(pa.Name)
+		require.True(pa.Namespace == configList.Namespace.Name)
+		require.NotNil(pa.Name)
 	}
-	assert.NotNil(configList.ServiceEntries)
+	require.NotNil(configList.ServiceEntries)
 	for _, se := range configList.ServiceEntries {
-		assert.True(se.Namespace == configList.Namespace.Name)
-		assert.NotNil(se.Name)
+		require.True(se.Namespace == configList.Namespace.Name)
+		require.NotNil(se.Name)
 	}
-	assert.NotNil(configList.Sidecars)
+	require.NotNil(configList.Sidecars)
 	for _, sc := range configList.Sidecars {
-		assert.True(sc.Namespace == configList.Namespace.Name)
-		assert.NotNil(sc.Name)
+		require.True(sc.Namespace == configList.Namespace.Name)
+		require.NotNil(sc.Name)
 	}
-	assert.NotNil(configList.AuthorizationPolicies)
+	require.NotNil(configList.AuthorizationPolicies)
 	for _, ap := range configList.AuthorizationPolicies {
-		assert.True(ap.Namespace == configList.Namespace.Name)
-		assert.NotNil(ap.Name)
+		require.True(ap.Namespace == configList.Namespace.Name)
+		require.NotNil(ap.Name)
 	}
-	assert.NotNil(configList.Gateways)
+	require.NotNil(configList.Gateways)
 	for _, gw := range configList.Gateways {
-		assert.True(gw.Namespace == configList.Namespace.Name)
-		assert.NotNil(gw.Name)
+		require.True(gw.Namespace == configList.Namespace.Name)
+		require.NotNil(gw.Name)
 	}
-	assert.NotNil(configList.K8sGateways)
+	require.NotNil(configList.K8sGateways)
 	for _, gw := range configList.K8sGateways {
-		assert.True(gw.Namespace == configList.Namespace.Name)
-		assert.NotNil(gw.Name)
+		require.True(gw.Namespace == configList.Namespace.Name)
+		require.NotNil(gw.Name)
 	}
-	assert.NotNil(configList.K8sHTTPRoutes)
+	require.NotNil(configList.K8sHTTPRoutes)
 	for _, gw := range configList.K8sHTTPRoutes {
-		assert.True(gw.Namespace == configList.Namespace.Name)
-		assert.NotNil(gw.Name)
+		require.True(gw.Namespace == configList.Namespace.Name)
+		require.NotNil(gw.Name)
 	}
-	assert.NotNil(configList.RequestAuthentications)
+	require.NotNil(configList.RequestAuthentications)
 	for _, ra := range configList.RequestAuthentications {
-		assert.True(ra.Namespace == configList.Namespace.Name)
-		assert.NotNil(ra.Name)
+		require.True(ra.Namespace == configList.Namespace.Name)
+		require.NotNil(ra.Name)
 	}
-	assert.NotNil(configList.WorkloadEntries)
+	require.NotNil(configList.WorkloadEntries)
 	for _, we := range configList.WorkloadEntries {
-		assert.True(we.Namespace == configList.Namespace.Name)
-		assert.NotNil(we.Name)
+		require.True(we.Namespace == configList.Namespace.Name)
+		require.NotNil(we.Name)
 	}
-	assert.NotNil(configList.WorkloadGroups)
+	require.NotNil(configList.WorkloadGroups)
 	for _, wg := range configList.WorkloadGroups {
-		assert.True(wg.Namespace == configList.Namespace.Name)
-		assert.NotNil(wg.Name)
+		require.True(wg.Namespace == configList.Namespace.Name)
+		require.NotNil(wg.Name)
 	}
-	assert.NotNil(configList.EnvoyFilters)
+	require.NotNil(configList.EnvoyFilters)
 	for _, ef := range configList.EnvoyFilters {
-		assert.True(ef.Namespace == configList.Namespace.Name)
-		assert.NotNil(ef.Name)
+		require.True(ef.Namespace == configList.Namespace.Name)
+		require.NotNil(ef.Name)
 	}
 }
 
 func TestIstioConfigDetails(t *testing.T) {
 	name := "bookinfo"
-	assert := assert.New(t)
+	require := require.New(t)
 	config, _, err := utils.IstioConfigDetails(utils.BOOKINFO, name, kubernetes.VirtualServices)
 
-	assert.Nil(err)
-	assert.NotNil(config)
-	assert.Equal(kubernetes.VirtualServices, config.ObjectType)
-	assert.Equal(utils.BOOKINFO, config.Namespace.Name)
-	assert.NotNil(config.VirtualService)
-	assert.Equal(name, config.VirtualService.Name)
-	assert.Equal(utils.BOOKINFO, config.VirtualService.Namespace)
-	assert.NotNil(config.IstioReferences)
-	assert.NotNil(config.IstioValidation)
-	assert.Equal(name, config.IstioValidation.Name)
-	assert.Equal("virtualservice", config.IstioValidation.ObjectType)
+	require.Nil(err)
+	require.NotNil(config)
+	require.Equal(kubernetes.VirtualServices, config.ObjectType)
+	require.Equal(utils.BOOKINFO, config.Namespace.Name)
+	require.NotNil(config.VirtualService)
+	require.Equal(name, config.VirtualService.Name)
+	require.Equal(utils.BOOKINFO, config.VirtualService.Namespace)
+	require.NotNil(config.IstioReferences)
+	require.NotNil(config.IstioValidation)
+	require.Equal(name, config.IstioValidation.Name)
+	require.Equal("virtualservice", config.IstioValidation.ObjectType)
 	if !config.IstioValidation.Valid {
-		assert.NotEmpty(config.IstioValidation.References)
+		require.NotEmpty(config.IstioValidation.References)
 	}
 }
 
 func TestIstioConfigInvalidName(t *testing.T) {
 	name := "invalid"
-	assert := assert.New(t)
+	require := require.New(t)
 	config, code, _ := utils.IstioConfigDetails(utils.BOOKINFO, name, kubernetes.VirtualServices)
-	assert.NotEqual(200, code)
-	assert.Empty(config)
+	require.NotEqual(200, code)
+	require.Empty(config)
 }
 
 func TestIstioConfigPermissions(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	perms, err := utils.IstioConfigPermissions(utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.NotEmpty(perms)
-	assert.NotEmpty((*perms)[utils.BOOKINFO])
-	assert.NotEmpty((*(*perms)[utils.BOOKINFO])["authorizationpolicies"])
+	require.Nil(err)
+	require.NotEmpty(perms)
+	require.NotEmpty((*perms)[utils.BOOKINFO])
+	require.NotEmpty((*(*perms)[utils.BOOKINFO])["authorizationpolicies"])
 }

--- a/tests/integration/tests/kiali_metrics_test.go
+++ b/tests/integration/tests/kiali_metrics_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/tests/integration/utils"
 )
@@ -14,46 +13,46 @@ import (
 var METRICS_PARAMS = map[string]string{"direction": "outbound", "reporter": "destination"}
 
 func TestNamespaceMetrics(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		metrics, err := utils.NamespaceMetrics(utils.BOOKINFO, METRICS_PARAMS)
 		return CheckMetrics(metrics.ResponseSize, metrics.RequestSize), err
 	})
-	assert.Nil(pollErr, "Metrics should be returned")
+	require.Nil(pollErr, "Metrics should be returned")
 }
 
 func TestServiceMetrics(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "ratings"
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		metrics, err := utils.ObjectMetrics(utils.BOOKINFO, name, "services", METRICS_PARAMS)
 		return CheckMetrics(metrics.RequestCount, metrics.RequestDurationMillis, metrics.RequestErrorCount), err
 	})
-	assert.Nil(pollErr, "Metrics should be returned")
+	require.Nil(pollErr, "Metrics should be returned")
 }
 
 func TestAppMetrics(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "productpage"
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		metrics, err := utils.ObjectMetrics(utils.BOOKINFO, name, "apps", METRICS_PARAMS)
 		return CheckMetrics(metrics.RequestDurationMillis), err
 	})
-	assert.Nil(pollErr, "Metrics should be returned")
+	require.Nil(pollErr, "Metrics should be returned")
 }
 
 func TestWorkloadMetrics(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "productpage-v1"
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		metrics, err := utils.ObjectMetrics(utils.BOOKINFO, name, "workloads", METRICS_PARAMS)
 		return CheckMetrics(metrics.RequestSize, metrics.ResponseSize), err
 	})
-	assert.Nil(pollErr, "Metrics should be returned")
+	require.Nil(pollErr, "Metrics should be returned")
 }
 
 func CheckMetrics(metrics ...[]utils.MetricJson) bool {

--- a/tests/integration/tests/kiali_urls_test.go
+++ b/tests/integration/tests/kiali_urls_test.go
@@ -4,91 +4,91 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
 func TestKialiStatus(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	response, statusCode, err := utils.KialiStatus()
 
-	assert.Nil(err)
-	assert.True(response)
-	assert.Equal(200, statusCode)
+	require.Nil(err)
+	require.True(response)
+	require.Equal(200, statusCode)
 }
 
 func TestKialiConfig(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	response, statusCode, err := utils.KialiConfig()
 
-	assert.Nil(err)
-	assert.Equal(200, statusCode)
-	assert.NotEmpty(response)
+	require.Nil(err)
+	require.Equal(200, statusCode)
+	require.NotEmpty(response)
 }
 
 func TestIstioPermissions(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	response, statusCode, err := utils.IstioPermissions()
 
-	assert.Nil(err)
-	assert.Equal(200, statusCode)
-	assert.NotNil(response)
+	require.Nil(err)
+	require.Equal(200, statusCode)
+	require.NotNil(response)
 }
 
 func TestJaeger(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	response, statusCode, err := utils.Jaeger()
 
 	if statusCode == 200 {
-		assert.Nil(err)
-		assert.NotNil(response)
-		assert.True(response.Enabled)
-		assert.True(response.Integration)
-		assert.NotEmpty(response.URL)
+		require.Nil(err)
+		require.NotNil(response)
+		require.True(response.Enabled)
+		require.True(response.Integration)
+		require.NotEmpty(response.URL)
 	} else {
-		assert.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err.Error()))
+		require.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err.Error()))
 	}
 }
 
 func TestGrafana(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	response, statusCode, err := utils.Grafana()
 
 	if statusCode == 200 {
-		assert.Nil(err)
-		assert.NotNil(response)
-		assert.NotEmpty(response.ExternalLinks)
+		require.Nil(err)
+		require.NotNil(response)
+		require.NotEmpty(response.ExternalLinks)
 		for _, extLink := range response.ExternalLinks {
-			assert.NotEmpty(extLink.Name)
-			assert.NotEmpty(extLink.URL)
+			require.NotEmpty(extLink.Name)
+			require.NotEmpty(extLink.URL)
 		}
 	} else {
-		assert.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err))
+		require.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err))
 	}
 }
 
 func TestMeshTls(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	response, statusCode, err := utils.MeshTls()
 
-	assert.Nil(err)
-	assert.Equal(200, statusCode)
-	assert.NotNil(response)
-	assert.NotNil(response.Status)
-	assert.True(MTLSCorrect(response.Status))
+	require.Nil(err)
+	require.Equal(200, statusCode)
+	require.NotNil(response)
+	require.NotNil(response.Status)
+	require.True(MTLSCorrect(response.Status))
 }
 
 func TestNamespaceTls(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	response, statusCode, err := utils.NamespaceTls(utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.Equal(200, statusCode)
-	assert.NotNil(response)
-	assert.NotNil(response.Status)
-	assert.True(MTLSCorrect(response.Status))
+	require.Nil(err)
+	require.Equal(200, statusCode)
+	require.NotNil(response)
+	require.NotNil(response.Status)
+	require.True(MTLSCorrect(response.Status))
 }
 
 func MTLSCorrect(status string) bool {

--- a/tests/integration/tests/namespaces_test.go
+++ b/tests/integration/tests/namespaces_test.go
@@ -3,81 +3,81 @@ package tests
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
 func TestNamespaces(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	namespaces, code, err := utils.Namespaces()
 
-	assert.Nil(err)
-	assert.Equal(200, code)
-	assert.NotEmpty(namespaces)
-	assert.Contains(namespaces.GetNames(), utils.BOOKINFO)
+	require.Nil(err)
+	require.Equal(200, code)
+	require.NotEmpty(namespaces)
+	require.Contains(namespaces.GetNames(), utils.BOOKINFO)
 }
 
 func TestNamespaceHealthWorkload(t *testing.T) {
 	name := "ratings-v1"
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"rateInterval": "60s"}
 
 	health, code, err := utils.NamespaceWorkloadHealth(utils.BOOKINFO, params)
 
-	assert.Nil(err)
-	assert.Equal(200, code)
-	assert.NotNil(health)
-	assert.NotNil((*health)[name])
-	assert.NotNil((*health)[name].WorkloadStatus)
-	assert.NotNil((*health)[name].Requests)
+	require.Nil(err)
+	require.Equal(200, code)
+	require.NotNil(health)
+	require.NotNil((*health)[name])
+	require.NotNil((*health)[name].WorkloadStatus)
+	require.NotNil((*health)[name].Requests)
 }
 
 func TestInvalidNamespaceHealth(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"rateInterval": "60s"}
 
 	_, code, err := utils.NamespaceWorkloadHealth("invalid", params)
 
-	assert.NotNil(err)
-	assert.NotEqual(200, code)
+	require.NotNil(err)
+	require.NotEqual(200, code)
 }
 
 func TestNamespaceHealthApp(t *testing.T) {
 	name := "details"
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"rateInterval": "60s"}
 
 	health, code, err := utils.NamespaceAppHealth(utils.BOOKINFO, params)
 
-	assert.Nil(err)
-	assert.Equal(200, code)
-	assert.NotNil(health)
-	assert.NotNil((*health)[name])
-	assert.NotEmpty((*health)[name].WorkloadStatuses)
-	assert.NotNil((*health)[name].Requests)
+	require.Nil(err)
+	require.Equal(200, code)
+	require.NotNil(health)
+	require.NotNil((*health)[name])
+	require.NotEmpty((*health)[name].WorkloadStatuses)
+	require.NotNil((*health)[name].Requests)
 }
 
 func TestNamespaceHealthInvalidRate(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"rateInterval": "invalid"}
 
 	_, code, err := utils.NamespaceAppHealth(utils.BOOKINFO, params)
 
-	assert.NotNil(err)
-	assert.NotEqual(200, code)
+	require.NotNil(err)
+	require.NotEqual(200, code)
 }
 
 func TestNamespaceHealthService(t *testing.T) {
 	name := "details"
-	assert := assert.New(t)
+	require := require.New(t)
 	params := map[string]string{"rateInterval": "60s"}
 
 	health, code, err := utils.NamespaceServiceHealth(utils.BOOKINFO, params)
 
-	assert.Nil(err)
-	assert.Equal(200, code)
-	assert.NotNil(health)
-	assert.NotNil((*health)[name])
-	assert.NotNil((*health)[name].Requests)
+	require.Nil(err)
+	require.Equal(200, code)
+	require.NotNil(health)
+	require.NotNil((*health)[name])
+	require.NotNil((*health)[name].Requests)
 }

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
 
@@ -49,7 +48,6 @@ func update_istio_api_enabled(t *testing.T, value bool, kubeClientSet kubernetes
 
 	// Restart Kiali pod to pick up the new config.
 	require.NoError(restartKialiPod(ctx, kubeClientSet, kialiNamespace, false, podName))
-
 }
 
 func TestNoIstiod(t *testing.T) {
@@ -61,16 +59,16 @@ func TestNoIstiod(t *testing.T) {
 	t.Run("ServicesListNoRegistryServices", servicesListNoRegistryServices)
 	t.Run("NoProxyStatus", noProxyStatus)
 	t.Run("istioStatus", istioStatus)
-	//t.Run("emptyValidations", emptyValidations)
+	// t.Run("emptyValidations", emptyValidations)
 }
 
 func servicesListNoRegistryServices(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	serviceList, err := utils.ServicesList(utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.NotEmpty(serviceList)
-	assert.True(len(serviceList.Services) >= 4)
+	require.Nil(err)
+	require.NotEmpty(serviceList)
+	require.True(len(serviceList.Services) >= 4)
 	sl := len(serviceList.Services)
 
 	// Deploy an external service entry
@@ -82,14 +80,14 @@ func servicesListNoRegistryServices(t *testing.T) {
 
 	// The service result should be the same
 	serviceList2, err3 := utils.ServicesList(utils.BOOKINFO)
-	assert.True(len(serviceList2.Services) == sl)
+	require.True(len(serviceList2.Services) == sl)
 	if err3 != nil {
 		log.Errorf("Failed to execute command: %s", applySe)
 	}
 
 	// Now, create a Service Entry (Part of th
-	assert.NotNil(serviceList.Validations)
-	assert.Equal(utils.BOOKINFO, serviceList.Namespace.Name)
+	require.NotNil(serviceList.Validations)
+	require.Equal(utils.BOOKINFO, serviceList.Namespace.Name)
 
 	// Cleanup
 	rmSe := ocCommand + " delete -f ../assets/bookinfo-service-entry-external.yaml"
@@ -101,44 +99,44 @@ func servicesListNoRegistryServices(t *testing.T) {
 
 func noProxyStatus(t *testing.T) {
 	name := "details-v1"
-	assert := assert.New(t)
+	require := require.New(t)
 	wl, _, err := utils.WorkloadDetails(name, utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.NotNil(wl)
-	assert.Equal(name, wl.Name)
-	assert.Equal("Deployment", wl.Type)
-	assert.NotNil(wl.Pods)
+	require.Nil(err)
+	require.NotNil(wl)
+	require.Equal(name, wl.Name)
+	require.Equal("Deployment", wl.Type)
+	require.NotNil(wl.Pods)
 	for _, pod := range wl.Pods {
-		assert.NotEmpty(pod.Status)
-		assert.NotEmpty(pod.Name)
-		assert.Empty(pod.ProxyStatus)
+		require.NotEmpty(pod.Status)
+		require.NotEmpty(pod.Name)
+		require.Empty(pod.ProxyStatus)
 	}
 }
 
 /*
 func emptyValidations(t *testing.T) {
 	name := "bookinfo-gateway"
-	assert := assert.New(t)
+	require := require.New(t)
 
 	config, err := getConfigForNamespace(utils.BOOKINFO, name, k8s.Gateways)
 
-	assert.Nil(err)
-	assert.NotNil(config)
-	assert.Equal(k8s.Gateways, config.ObjectType)
-	assert.Equal(utils.BOOKINFO, config.Namespace.Name)
-	assert.NotNil(config.Gateway)
-	assert.Equal(name, config.Gateway.Name)
-	assert.Equal(utils.BOOKINFO, config.Gateway.Namespace)
-	assert.Nil(config.IstioValidation)
-	assert.Nil(config.IstioReferences)
+	require.Nil(err)
+	require.NotNil(config)
+	require.Equal(k8s.Gateways, config.ObjectType)
+	require.Equal(utils.BOOKINFO, config.Namespace.Name)
+	require.NotNil(config.Gateway)
+	require.Equal(name, config.Gateway.Name)
+	require.Equal(utils.BOOKINFO, config.Gateway.Namespace)
+	require.Nil(config.IstioValidation)
+	require.Nil(config.IstioReferences)
 }
 */
 
 func istioStatus(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 
 	isEnabled, err := utils.IstioApiEnabled()
-	assert.Nil(err)
-	assert.False(isEnabled)
+	require.Nil(err)
+	require.False(isEnabled)
 }

--- a/tests/integration/tests/pod_logs_test.go
+++ b/tests/integration/tests/pod_logs_test.go
@@ -4,72 +4,72 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
 func TestLogsContainerIstioProxy(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	workloadName := "details-v1"
 	lines := 50
 	podName, err := utils.FirstPodName(workloadName, utils.BOOKINFO)
-	assert.Nil(err)
-	assert.NotEmpty(podName)
+	require.Nil(err)
+	require.NotEmpty(podName)
 	params := map[string]string{"container": "istio-proxy", "maxLines": fmt.Sprintf("%d", lines)}
 	logs, err := utils.PodLogs(podName, utils.BOOKINFO, params)
-	assertLogs(logs, lines, err, assert)
+	requireLogs(logs, lines, err, require)
 }
 
 func TestLogsContainerDetails(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	workloadName := "details-v1"
 	lines := 25
 	podName, err := utils.FirstPodName(workloadName, utils.BOOKINFO)
-	assert.Nil(err)
-	assert.NotEmpty(podName)
+	require.Nil(err)
+	require.NotEmpty(podName)
 	params := map[string]string{"container": "details", "maxLines": fmt.Sprintf("%d", lines)}
 	logs, err := utils.PodLogs(podName, utils.BOOKINFO, params)
-	assertLogs(logs, lines, err, assert)
+	requireLogs(logs, lines, err, require)
 }
 
 func TestLogsInvalidContainer(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	workloadName := "details-v1"
 	lines := 25
 	podName, err := utils.FirstPodName(workloadName, utils.BOOKINFO)
-	assert.Nil(err)
-	assert.NotEmpty(podName)
+	require.Nil(err)
+	require.NotEmpty(podName)
 	params := map[string]string{"container": "invalid", "maxLines": fmt.Sprintf("%d", lines)}
 	logs, err := utils.PodLogs(podName, utils.BOOKINFO, params)
-	assertEmptyLogs(logs, err, assert)
+	requireEmptyLogs(logs, err, require)
 }
 
 func TestLogsInvalidLineCount(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	workloadName := "details-v1"
 	podName, err := utils.FirstPodName(workloadName, utils.BOOKINFO)
-	assert.Nil(err)
-	assert.NotEmpty(podName)
+	require.Nil(err)
+	require.NotEmpty(podName)
 	params := map[string]string{"container": "details", "maxLines": "*50"}
 	logs, err := utils.PodLogs(podName, utils.BOOKINFO, params)
-	assertEmptyLogs(logs, err, assert)
+	requireEmptyLogs(logs, err, require)
 }
 
-func assertEmptyLogs(logs *business.PodLog, err error, assert *assert.Assertions) {
-	assert.Nil(err)
-	assert.NotNil(logs)
-	assert.Empty(logs.Entries)
+func requireEmptyLogs(logs *business.PodLog, err error, require *require.Assertions) {
+	require.Nil(err)
+	require.NotNil(logs)
+	require.Empty(logs.Entries)
 }
 
-func assertLogs(logs *business.PodLog, lines int, err error, assert *assert.Assertions) {
-	assert.Nil(err)
-	assert.NotNil(logs)
-	assert.LessOrEqual(len(logs.Entries), lines)
+func requireLogs(logs *business.PodLog, lines int, err error, require *require.Assertions) {
+	require.Nil(err)
+	require.NotNil(logs)
+	require.LessOrEqual(len(logs.Entries), lines)
 	for _, entry := range logs.Entries {
-		assert.NotNil(entry.Message)
-		assert.NotNil(entry.Severity)
-		assert.NotNil(entry.Timestamp)
+		require.NotNil(entry.Message)
+		require.NotNil(entry.Severity)
+		require.NotNil(entry.Timestamp)
 	}
 }

--- a/tests/integration/tests/services_test.go
+++ b/tests/integration/tests/services_test.go
@@ -6,159 +6,158 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/tests/integration/utils"
 	"github.com/kiali/kiali/tools/cmd"
 )
 
 func TestServicesList(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	serviceList, err := utils.ServicesList(utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.NotEmpty(serviceList)
-	assert.True(len(serviceList.Services) >= 4)
+	require.Nil(err)
+	require.NotEmpty(serviceList)
+	require.True(len(serviceList.Services) >= 4)
 	for _, service := range serviceList.Services {
-		assert.NotEmpty(service.Name)
-		assert.True(service.IstioSidecar)
-		assert.True(service.AppLabel)
-		assert.NotNil(service.Health)
-		assert.NotNil(service.Health.Requests)
-		assert.NotNil(service.Health.Requests.Outbound)
-		assert.NotNil(service.Health.Requests.Inbound)
+		require.NotEmpty(service.Name)
+		require.True(service.IstioSidecar)
+		require.True(service.AppLabel)
+		require.NotNil(service.Health)
+		require.NotNil(service.Health.Requests)
+		require.NotNil(service.Health.Requests.Outbound)
+		require.NotNil(service.Health.Requests.Inbound)
 	}
-	assert.NotNil(serviceList.Validations)
-	assert.Equal(utils.BOOKINFO, serviceList.Namespace.Name)
+	require.NotNil(serviceList.Validations)
+	require.Equal(utils.BOOKINFO, serviceList.Namespace.Name)
 }
 
 func TestServiceDetails(t *testing.T) {
 	name := "productpage"
-	assert := assert.New(t)
+	require := require.New(t)
 	service, _, err := utils.ServiceDetails(name, utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.NotNil(service)
-	assert.NotNil(service.Service)
-	assert.Equal(utils.BOOKINFO, service.Service.Namespace.Name)
-	assert.NotEmpty(service.Workloads)
-	assert.NotEmpty(service.Service.Ports)
-	assert.NotEmpty(service.Service.Ports)
-	assert.NotNil(service.Endpoints)
-	assert.NotNil(service.VirtualServices)
-	assert.NotNil(service.DestinationRules)
-	assert.NotNil(service.Validations)
+	require.Nil(err)
+	require.NotNil(service)
+	require.NotNil(service.Service)
+	require.Equal(utils.BOOKINFO, service.Service.Namespace.Name)
+	require.NotEmpty(service.Workloads)
+	require.NotEmpty(service.Service.Ports)
+	require.NotEmpty(service.Service.Ports)
+	require.NotNil(service.Endpoints)
+	require.NotNil(service.VirtualServices)
+	require.NotNil(service.DestinationRules)
+	require.NotNil(service.Validations)
 
-	assert.NotNil(service.Health)
-	assert.NotNil(service.Health.Requests)
-	assert.NotNil(service.Health.Requests.Outbound)
-	assert.NotNil(service.Health.Requests.Inbound)
+	require.NotNil(service.Health)
+	require.NotNil(service.Health.Requests)
+	require.NotNil(service.Health.Requests.Outbound)
+	require.NotNil(service.Health.Requests.Inbound)
 
-	assert.True(service.IstioSidecar)
+	require.True(service.IstioSidecar)
 }
 
 func TestServiceDetailsInvalidName(t *testing.T) {
 	name := "invalid"
-	assert := assert.New(t)
+	require := require.New(t)
 	app, code, _ := utils.ServiceDetails(name, utils.BOOKINFO)
-	assert.NotEqual(200, code)
-	assert.Empty(app)
+	require.NotEqual(200, code)
+	require.Empty(app)
 }
 
 func TestServiceDiscoverVS(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	serviceName := "reviews"
 	vsName := "reviews"
 	vsPath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-reviews-80-20.yaml")
 	service, _, err := utils.ServiceDetails(serviceName, utils.BOOKINFO)
-	assert.Nil(err)
-	assert.NotNil(service)
+	require.Nil(err)
+	require.NotNil(service)
 	preVsCount := len(service.VirtualServices)
 	defer utils.DeleteFile(vsPath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(vsPath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(vsPath, utils.BOOKINFO))
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		service, _, err = utils.ServiceDetails(serviceName, utils.BOOKINFO)
-		assert.Nil(err)
-		assert.NotNil(service)
+		require.Nil(err)
+		require.NotNil(service)
 		if len(service.VirtualServices) > preVsCount {
 			return true, nil
 		}
 		return false, nil
 	})
-	assert.Nil(pollErr)
-	assert.NotEmpty(service.VirtualServices)
+	require.Nil(pollErr)
+	require.NotEmpty(service.VirtualServices)
 	found := false
 	for _, vs := range service.VirtualServices {
 		if vs.Name == vsName {
 			found = true
 
 			http := vs.Spec.Http
-			assert.NotEmpty(http)
+			require.NotEmpty(http)
 			routes := http[0].Route
-			assert.Len(routes, 2)
+			require.Len(routes, 2)
 
-			assert.Equal(routes[0].Weight, int32(80))
+			require.Equal(routes[0].Weight, int32(80))
 			destination := routes[0].Destination
-			assert.NotNil(destination)
-			assert.Equal(destination.Host, "reviews")
-			assert.Equal(destination.Subset, "v1")
+			require.NotNil(destination)
+			require.Equal(destination.Host, "reviews")
+			require.Equal(destination.Subset, "v1")
 
-			assert.Equal(routes[1].Weight, int32(20))
+			require.Equal(routes[1].Weight, int32(20))
 			destination = routes[1].Destination
-			assert.NotNil(destination)
-			assert.Equal(destination.Host, "reviews")
-			assert.Equal(destination.Subset, "v2")
+			require.NotNil(destination)
+			require.Equal(destination.Host, "reviews")
+			require.Equal(destination.Subset, "v2")
 
 			break
 		}
 	}
-	assert.True(found)
+	require.True(found)
 }
 
 func TestServiceDiscoverDR(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	serviceName := "reviews"
 	drName := "reviews"
 	drPath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-destination-rule-reviews.yaml")
 	service, _, err := utils.ServiceDetails(serviceName, utils.BOOKINFO)
-	assert.Nil(err)
-	assert.NotNil(service)
+	require.Nil(err)
+	require.NotNil(service)
 	preDrCount := len(service.DestinationRules)
 	defer utils.DeleteFile(drPath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(drPath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(drPath, utils.BOOKINFO))
 
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		service, _, err = utils.ServiceDetails(serviceName, utils.BOOKINFO)
-		assert.Nil(err)
-		assert.NotNil(service)
+		require.Nil(err)
+		require.NotNil(service)
 		if len(service.DestinationRules) > preDrCount {
 			return true, nil
 		}
 		return false, nil
 	})
-	assert.Nil(pollErr)
-	assert.NotEmpty(service.DestinationRules)
+	require.Nil(pollErr)
+	require.NotEmpty(service.DestinationRules)
 	found := false
 	for _, dr := range service.DestinationRules {
 		if dr.Name == drName {
 			found = true
 
-			assert.NotNil(dr.Spec.TrafficPolicy)
-			assert.Len(dr.Spec.Subsets, 3)
+			require.NotNil(dr.Spec.TrafficPolicy)
+			require.Len(dr.Spec.Subsets, 3)
 
 			for i, subset := range dr.Spec.Subsets {
-				assert.Equal(subset.Name, fmt.Sprintf("v%d", i+1))
+				require.Equal(subset.Name, fmt.Sprintf("v%d", i+1))
 
 				labels := subset.Labels
-				assert.NotNil(labels)
-				assert.Equal(labels["version"], fmt.Sprintf("v%d", i+1))
+				require.NotNil(labels)
+				require.Equal(labels["version"], fmt.Sprintf("v%d", i+1))
 			}
 
 			break
 		}
 	}
-	assert.True(found)
+	require.True(found)
 }

--- a/tests/integration/tests/traces_spans_test.go
+++ b/tests/integration/tests/traces_spans_test.go
@@ -4,116 +4,116 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/jaeger"
 	"github.com/kiali/kiali/tests/integration/utils"
 )
 
 func TestServiceTraces(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
 	traces, statusCode, err := utils.Traces("services", name, utils.BOOKINFO)
-	assertTraces(traces, statusCode, err, assert)
+	requireTraces(traces, statusCode, err, require)
 }
 
 func TestWorkloadTraces(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details-v1"
 	traces, statusCode, err := utils.Traces("workloads", name, utils.BOOKINFO)
-	assertTraces(traces, statusCode, err, assert)
+	requireTraces(traces, statusCode, err, require)
 }
 
 func TestAppTraces(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
 	traces, statusCode, err := utils.Traces("apps", name, utils.BOOKINFO)
-	assertTraces(traces, statusCode, err, assert)
+	requireTraces(traces, statusCode, err, require)
 }
 
 func TestWrongTracesType(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
 	traces, statusCode, err := utils.Traces("wrong", name, utils.BOOKINFO)
-	assert.NotEqual(200, statusCode)
-	assert.NotNil(err)
-	assert.Empty(traces)
+	require.NotEqual(200, statusCode)
+	require.NotNil(err)
+	require.Empty(traces)
 }
 
 func TestWrongNamespaceTraces(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
 	traces, _, _ := utils.Traces("apps", name, "wrong")
-	assert.Empty(traces.Data)
-	assert.Empty(traces.Errors)
+	require.Empty(traces.Data)
+	require.Empty(traces.Errors)
 }
 
 func TestServiceSpans(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
 	spans, statusCode, err := utils.Spans("services", name, utils.BOOKINFO)
-	assertSpans(spans, statusCode, err, assert)
+	requireSpans(spans, statusCode, err, require)
 }
 
 func TestAppSpans(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details"
 	spans, statusCode, err := utils.Spans("apps", name, utils.BOOKINFO)
-	assertSpans(spans, statusCode, err, assert)
+	requireSpans(spans, statusCode, err, require)
 }
 
 func TestWorkloadSpans(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details-v1"
 	spans, statusCode, err := utils.Spans("workloads", name, utils.BOOKINFO)
-	assertSpans(spans, statusCode, err, assert)
+	requireSpans(spans, statusCode, err, require)
 }
 
 func TestWrongTypeSpans(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details-v1"
 	spans, statusCode, err := utils.Spans("wrong", name, utils.BOOKINFO)
-	assert.NotEqual(200, statusCode)
-	assert.NotNil(err)
-	assert.Empty(spans)
+	require.NotEqual(200, statusCode)
+	require.NotNil(err)
+	require.Empty(spans)
 }
 
 func TestWrongNamespaceSpans(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	name := "details-v1"
 	spans, _, _ := utils.Spans("apps", name, "wrong")
-	assert.Empty(spans)
+	require.Empty(spans)
 }
 
-func assertTraces(traces *jaeger.JaegerResponse, statusCode int, err error, assert *assert.Assertions) {
+func requireTraces(traces *jaeger.JaegerResponse, statusCode int, err error, require *require.Assertions) {
 	if statusCode == 200 {
-		assert.Nil(err)
-		assert.NotNil(traces)
-		assert.NotNil(traces.Data)
+		require.Nil(err)
+		require.NotNil(traces)
+		require.NotNil(traces.Data)
 		if len(traces.Data) > 0 {
-			assert.NotNil(traces.Data[0].TraceID)
-			assert.NotEmpty(traces.Data[0].Spans)
+			require.NotNil(traces.Data[0].TraceID)
+			require.NotEmpty(traces.Data[0].Spans)
 			for _, span := range traces.Data[0].Spans {
-				assert.NotNil(span.TraceID)
-				assert.Equal(span.TraceID, traces.Data[0].TraceID)
+				require.NotNil(span.TraceID)
+				require.Equal(span.TraceID, traces.Data[0].TraceID)
 			}
 		}
 	} else {
-		assert.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err))
+		require.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err))
 	}
 }
 
-func assertSpans(spans []jaeger.JaegerSpan, statusCode int, err error, assert *assert.Assertions) {
+func requireSpans(spans []jaeger.JaegerSpan, statusCode int, err error, require *require.Assertions) {
 	if statusCode == 200 {
-		assert.Nil(err)
-		assert.NotNil(spans)
+		require.Nil(err)
+		require.NotNil(spans)
 		if len(spans) > 0 {
-			assert.NotNil(spans[0].TraceID)
-			assert.NotEmpty(spans[0].References)
-			assert.NotNil(spans[0].References[0].TraceID)
-			assert.Equal(spans[0].TraceID, spans[0].References[0].TraceID)
+			require.NotNil(spans[0].TraceID)
+			require.NotEmpty(spans[0].References)
+			require.NotNil(spans[0].References[0].TraceID)
+			require.Equal(spans[0].TraceID, spans[0].References[0].TraceID)
 		}
 	} else {
-		assert.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err))
+		require.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err))
 	}
 }

--- a/tests/integration/tests/workloads_test.go
+++ b/tests/integration/tests/workloads_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kiali/kiali/tests/integration/utils"
@@ -14,64 +14,64 @@ import (
 )
 
 func TestWorkloadsList(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	wlList, err := utils.WorkloadsList(utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.NotEmpty(wlList)
+	require.Nil(err)
+	require.NotEmpty(wlList)
 	for _, wl := range wlList.Workloads {
-		assert.NotEmpty(wl.Name)
-		assert.NotNil(wl.Health)
-		assert.NotNil(wl.Labels)
+		require.NotEmpty(wl.Name)
+		require.NotNil(wl.Health)
+		require.NotNil(wl.Labels)
 		if !strings.Contains(wl.Name, "traffic-generator") {
-			assert.True(wl.IstioSidecar)
-			assert.NotNil(wl.IstioReferences)
+			require.True(wl.IstioSidecar)
+			require.NotNil(wl.IstioReferences)
 		}
 	}
-	assert.NotNil(wlList.Validations)
-	assert.Equal(utils.BOOKINFO, wlList.Namespace.Name)
+	require.NotNil(wlList.Validations)
+	require.Equal(utils.BOOKINFO, wlList.Namespace.Name)
 }
 
 func TestWorkloadDetails(t *testing.T) {
 	name := "details-v1"
-	assert := assert.New(t)
+	require := require.New(t)
 	wl, _, err := utils.WorkloadDetails(name, utils.BOOKINFO)
 
-	assert.Nil(err)
-	assert.NotNil(wl)
-	assert.Equal(name, wl.Name)
-	assert.Equal("Deployment", wl.Type)
-	assert.NotNil(wl.Pods)
+	require.Nil(err)
+	require.NotNil(wl)
+	require.Equal(name, wl.Name)
+	require.Equal("Deployment", wl.Type)
+	require.NotNil(wl.Pods)
 	for _, pod := range wl.Pods {
-		assert.NotEmpty(pod.Status)
-		assert.NotEmpty(pod.Name)
+		require.NotEmpty(pod.Status)
+		require.NotEmpty(pod.Name)
 
 	}
-	assert.NotEmpty(wl.Services)
+	require.NotEmpty(wl.Services)
 	for _, wl := range wl.Services {
-		assert.Equal(utils.BOOKINFO, wl.Namespace)
+		require.Equal(utils.BOOKINFO, wl.Namespace)
 	}
-	assert.NotEmpty(wl.Runtimes)
-	assert.NotEmpty(wl.Validations)
-	assert.NotEmpty(wl.Workload.Health)
-	assert.NotNil(wl.Workload.Health)
-	assert.NotNil(wl.Workload.Health.WorkloadStatus)
-	assert.Contains(wl.Workload.Health.WorkloadStatus.Name, name)
-	assert.NotNil(wl.Workload.Health.Requests)
-	assert.NotNil(wl.Workload.Health.Requests.Outbound)
-	assert.NotNil(wl.Workload.Health.Requests.Inbound)
+	require.NotEmpty(wl.Runtimes)
+	require.NotEmpty(wl.Validations)
+	require.NotEmpty(wl.Workload.Health)
+	require.NotNil(wl.Workload.Health)
+	require.NotNil(wl.Workload.Health.WorkloadStatus)
+	require.Contains(wl.Workload.Health.WorkloadStatus.Name, name)
+	require.NotNil(wl.Workload.Health.Requests)
+	require.NotNil(wl.Workload.Health.Requests.Outbound)
+	require.NotNil(wl.Workload.Health.Requests.Inbound)
 }
 
 func TestWorkloadDetailsInvalidName(t *testing.T) {
 	name := "invalid"
-	assert := assert.New(t)
+	require := require.New(t)
 	app, code, _ := utils.WorkloadDetails(name, utils.BOOKINFO)
-	assert.NotEqual(200, code)
-	assert.Empty(app)
+	require.NotEqual(200, code)
+	require.Empty(app)
 }
 
 func TestDiscoverWorkload(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	workloadsPath := path.Join(cmd.KialiProjectRoot, utils.ASSETS+"/bookinfo-workloads.yaml")
 	extraWorkloads := map[string]string{
 		"details-v2": "Pod",
@@ -79,11 +79,11 @@ func TestDiscoverWorkload(t *testing.T) {
 	}
 
 	defer utils.DeleteFile(workloadsPath, utils.BOOKINFO)
-	assert.True(utils.ApplyFile(workloadsPath, utils.BOOKINFO))
+	require.True(utils.ApplyFile(workloadsPath, utils.BOOKINFO))
 	pollErr := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		wlList, err := utils.WorkloadsList(utils.BOOKINFO)
-		assert.Nil(err)
-		assert.NotNil(wlList)
+		require.Nil(err)
+		require.NotNil(wlList)
 		foundWorkloads := 0
 		for _, wl := range wlList.Workloads {
 			for k, v := range extraWorkloads {
@@ -97,5 +97,5 @@ func TestDiscoverWorkload(t *testing.T) {
 		}
 		return false, nil
 	})
-	assert.Nil(pollErr)
+	require.Nil(pollErr)
 }


### PR DESCRIPTION
Backport of #6389 to v1.65. Just a find/replace of `assert` --> `require` in e2e tests so that tests will fail without panicing.