### PR TITLE
Cypress: doubled timeouts for flaky test on interop OSSM-4624

### DIFF
--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -49,6 +49,9 @@ Feature: Kiali Workload Details page
     When the user filters by "Port" with value "9080" on the "Clusters" tab
     Then the user sees clusters expected information
 
+
+  @requestTimeout(30000)
+  @responseTimeout(30000)
   @bookinfo-app
   Scenario: See Envoy listeners configuration for a workload
     When the user filters by "Destination" with value "Route: 9090" on the "Listeners" tab

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -49,7 +49,6 @@ Feature: Kiali Workload Details page
     When the user filters by "Port" with value "9080" on the "Clusters" tab
     Then the user sees clusters expected information
 
-
   @requestTimeout(30000)
   @responseTimeout(30000)
   @bookinfo-app


### PR DESCRIPTION
In feature file there are two tags added. This test fail only on OCP and in interop. Hope this will fix that @FilipB 