### PR TITLE
Change login func to not send Auth header when token is present

### DIFF
--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -122,13 +122,18 @@ export const login = async (
 
   const proxyUrl = getAPIProxy();
 
-  return axios({
+  const axiosRequest = {
     method: HTTP_VERBS.POST,
     url: proxyUrl ? `${proxyUrl}/${urls.authenticate}` : urls.authenticate,
     headers: getHeaders(proxyUrl),
-    auth: basicAuth(request.username, request.password),
     data: params
-  });
+  };
+
+  if (request.username !== '' || request.password !== '') {
+    axiosRequest['auth'] = basicAuth(request.username, request.password);
+  }
+
+  return axios(axiosRequest);
 };
 
 export const logout = () => {


### PR DESCRIPTION
** Describe the change **

When a token is present, we send it through params and when a username and password is present, we send it through Auth header. 

There is no need to send Auth header when the token is not empty.

** Issue reference **

https://github.com/kiali/kiali/issues/6533