### PR TITLE
workaround opm render bug by providing custom docker_config location

### DIFF
--- a/make/Makefile.olm.mk
+++ b/make/Makefile.olm.mk
@@ -113,7 +113,9 @@ build-olm-index: .ensure-opm-exists cluster-push-olm-bundle
 	@rm -rf ${OUTDIR}/index
 	@mkdir -p ${OUTDIR}/index/kiali-index
 	${OPM} init ${OLM_BUNDLE_PACKAGE} --default-channel=stable --output yaml > ${OUTDIR}/index/kiali-index/index.yaml
-	${OPM} render $$(if [[ "${OC}" = *"oc" ]]; then echo '--skip-tls-verify'; else echo '--use-http'; fi) ${CLUSTER_OLM_BUNDLE_NAME}:${BUNDLE_VERSION} --output yaml >> ${OUTDIR}/index/kiali-index/index.yaml
+	@if [ "${DORP}" == "podman" -a -n "$${XDG_RUNTIME_DIR}" ]; then cp "$${XDG_RUNTIME_DIR}/containers/auth.json" "${OUTDIR}/index/kiali-index/config.json"; fi
+	@if [ -f "${OUTDIR}/index/kiali-index/config.json" ]; then export DOCKER_CONFIG="${OUTDIR}/index/kiali-index"; fi ; ${OPM} render $$(if [[ "${OC}" = *"oc" ]]; then echo '--skip-tls-verify'; else echo '--use-http'; fi) ${CLUSTER_OLM_BUNDLE_NAME}:${BUNDLE_VERSION} --output yaml >> ${OUTDIR}/index/kiali-index/index.yaml
+	@rm -f ${OUTDIR}/index/kiali-index/config.json
 	@# We need OLM to pull the index from the internal registry - change the index to only use the internal registry name
 	sed -i 's|${CLUSTER_REPO}|${CLUSTER_REPO_INTERNAL}|g' ${OUTDIR}/index/kiali-index/index.yaml
 	@echo "---"                                               >> ${OUTDIR}/index/kiali-index/index.yaml


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/6545

We will want to do a similar fix for the OSSMC make target that is similar: https://github.com/kiali/openshift-servicemesh-plugin/blob/main/make/Makefile.olm.mk#L69 (_update_: this was done in this PR: https://github.com/kiali/openshift-servicemesh-plugin/pull/201)