### PR TITLE
Multi-cluster - negative testing against single cluster setup

### DIFF
--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -1,4 +1,4 @@
-import { And, Then } from '@badeball/cypress-cucumber-preprocessor';
+import { And, Then, But } from '@badeball/cypress-cucumber-preprocessor';
 import { getCellsForCol } from './table';
 import { openTab } from './transition';
 
@@ -63,4 +63,15 @@ And('user can filter spans by app', () => {
   // TODO: Assert that something has opened after clicking. There is currently
   // a bug where the kebab doesn't do anything when clicked.
   getCellsForCol(4).first().click();
+});
+
+But('no cluster badge for the {string} should be visible',(type:string) => {
+  if (type === 'Istio config'){
+    cy.get('#pfbadge-C').should('not.exist');
+  }
+  else{
+    cy.get(`#${type[0].toUpperCase() + type.slice(1)}DescriptionCard`).within(($article)=>{
+      cy.get('#pfbadge-C').should('not.exist');
+    });
+  }
 });

--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -1,6 +1,7 @@
 import { And, Then, But } from '@badeball/cypress-cucumber-preprocessor';
 import { getCellsForCol } from './table';
 import { openTab } from './transition';
+import { clusterParameterExists } from './navigation';
 
 const APP = 'details';
 const NAMESPACE = 'bookinfo';
@@ -10,6 +11,7 @@ Then('user sees details information for the {string} app', (name:string) => {
     cy.get('#pfbadge-A').parent().parent().parent().contains('details'); // App
     cy.get('#pfbadge-W').parent().parent().parent().contains('details-v1'); // Workload
     cy.get('#pfbadge-S').parent().parent().parent().contains('details'); // Service
+    clusterParameterExists(false);
   });
 });
 
@@ -68,6 +70,11 @@ And('user can filter spans by app', () => {
 But('no cluster badge for the {string} should be visible',(type:string) => {
   if (type === 'Istio config'){
     cy.get('#pfbadge-C').should('not.exist');
+  }
+  else if (type === 'graph side panel'){
+    cy.get('#graph-side-panel').within(($div) => {
+      cy.get('#pfbadge-C').should('not.exist');
+    });
   }
   else{
     cy.get(`#${type[0].toUpperCase() + type.slice(1)}DescriptionCard`).within(($article)=>{

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -4,7 +4,7 @@
   pages since these are all similar.
 */
 
-import { And, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { And, Then, When, But } from '@badeball/cypress-cucumber-preprocessor';
 import { 
   checkHealthIndicatorInTable,
   checkHealthStatusInTable,
@@ -155,3 +155,8 @@ Then('user may only see {string}', (sees: string) => {
   });
 });
 
+But('no cluster badge for the {string} should be visible',(type:string) => {
+  cy.get(`#${type[0].toUpperCase() + type.slice(1)}DescriptionCard`).within(($article)=>{
+    cy.get('#pfbadge-C').should('not.exist');
+  })
+});

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -4,7 +4,7 @@
   pages since these are all similar.
 */
 
-import { And, Then, When, But } from '@badeball/cypress-cucumber-preprocessor';
+import { And, Then, When} from '@badeball/cypress-cucumber-preprocessor';
 import { 
   checkHealthIndicatorInTable,
   checkHealthStatusInTable,
@@ -153,10 +153,4 @@ Then('user may only see {string}', (sees: string) => {
       }
     });
   });
-});
-
-But('no cluster badge for the {string} should be visible',(type:string) => {
-  cy.get(`#${type[0].toUpperCase() + type.slice(1)}DescriptionCard`).within(($article)=>{
-    cy.get('#pfbadge-C').should('not.exist');
-  })
 });

--- a/frontend/cypress/integration/common/graph_context_menu.ts
+++ b/frontend/cypress/integration/common/graph_context_menu.ts
@@ -1,4 +1,5 @@
-import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Then, When, And } from '@badeball/cypress-cucumber-preprocessor';
+import { clusterParameterExists } from './navigation';
 
 When('user opens the context menu of the {string} service node', function (svcName: string) {
   cy.waitForReact();
@@ -30,3 +31,13 @@ Then('user should see the confirmation dialog to delete all traffic routing', fu
 Then('user should see the {string} wizard', function (wizardKey: string) {
   cy.get(`[data-test=${wizardKey}_modal]`).should('exist');
 });
+
+And('user should see {string} cluster parameter in links in the context menu',(exists:string)=>{
+  var present:boolean = true;
+  if (exists === 'no'){
+    present = false;
+  }
+  cy.get(`[data-test="graph-node-context-menu"]`).within(() => {
+    clusterParameterExists(present);
+  });
+})

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -335,6 +335,20 @@ And('the {string} option should {string} and {string}', (option:string, optionSt
   cy.get('div#graph-display-menu').find(`input#${option}`).should(optionState.replaceAll(' ','.')).and(`be.${checkState}`);
 });
 
+
+And('only a single cluster box should be visible',() =>{
+  cy.waitForReact();
+  cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
+    .getCurrentState()
+    .then(state => {
+      const clusterBoxes = state.cy.nodes(`[isBox = "cluster"]`).length;
+      assert.equal(clusterBoxes, 0);
+      const namespaceBoxes = state.cy.nodes(`[isBox = "namespace"][namespace = "bookinfo"]`).length;
+      assert.equal(namespaceBoxes, 1);
+    });
+});
+
 function validateInput(option: string, action: string) {
   if (action.startsWith('appear')) {
     cy.get('div#graph-display-menu')

--- a/frontend/cypress/integration/common/kiali_help.ts
+++ b/frontend/cypress/integration/common/kiali_help.ts
@@ -18,3 +18,12 @@ When('user clicks on the {string} button', (title: string) => {
 Then('user sees the {string} modal', (title: string) => {
   cy.get('h1.pf-v5-c-modal-box__title').contains(title).should('be.visible');
 });
+
+And('user sees information about {int} clusters', (numOfClusters:number) => {
+  cy.get('td[data-label="Configuration"]').contains('clusters')
+  .parent()
+  .find('td[data-label="Value"]')
+  .then(($td) =>{
+    expect(Object.keys(JSON.parse($td.get(0).innerText)).length).to.eq(numOfClusters);
+  })
+});

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -55,6 +55,7 @@ And('user is at the details page for the {string} {string} located in the {strin
   ensureKialiFinishedLoading();
 });
 
+// A simple function to check whether the DOM (or a subset of DOM has the cluster parameter in its links). This is related to multi-cluster testing.
 export function clusterParameterExists(present:boolean){
   var exist:string = '';
   if (!present){

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -54,3 +54,15 @@ And('user is at the details page for the {string} {string} located in the {strin
   cy.visit(Cypress.config('baseUrl') + `/console/namespaces/${namespace}/${pageDetail}/${name}?refresh=0${cluster}`);
   ensureKialiFinishedLoading();
 });
+
+export function clusterParameterExists(present:boolean){
+  var exist:string = '';
+  if (!present){
+    exist = 'not.';
+  }
+  cy.get('a').each(($el, index, $list) =>{
+    cy.wrap($el)
+    .should('have.attr', 'href')
+    .and(exist + 'include', 'clusterName=');
+  });
+}

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -232,3 +232,9 @@ And('user sees the {string} label in the {string} namespace card', (label: strin
     .contains(label)
     .should('be.visible');
 });
+
+And ('user does not see any cluster badge in the {string} namespace card',(ns:string) => {
+  cy.get(`[data-test="${ns}-EXPAND"]`).within(($card)=>{
+    cy.get('#pfbadge-C').should('not.exist');
+  })
+});

--- a/frontend/cypress/integration/common/service_details.ts
+++ b/frontend/cypress/integration/common/service_details.ts
@@ -1,4 +1,5 @@
 import { Then, And } from '@badeball/cypress-cucumber-preprocessor';
+import { clusterParameterExists } from './navigation';
 
 function openTab(tab: string) {
   cy.get('.pf-v5-c-tabs__list').should('be.visible').contains(tab).click();
@@ -22,6 +23,7 @@ Then('sd::user sees {string} details information for service {string}', (name: s
       .parent()
       .parent()
       .contains(name + '-' + version); // Workload
+    clusterParameterExists(false);
   });
 });
 

--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -103,6 +103,10 @@ And('user closes the success notification',()=>{
   cy.get('[aria-label^="Close Success alert: alert: Istio Gateway created"]').click();
 });
 
+And('user does not see a dropdown for cluster selection',()=>{
+  cy.get('[data-test="cluster-dropdown"]').should("not.exist");
+});
+
 Then('the {string} {string} should be listed in {string} namespace', function (
   type: string,
   name: string,

--- a/frontend/cypress/integration/common/workloads_details.ts
+++ b/frontend/cypress/integration/common/workloads_details.ts
@@ -1,5 +1,6 @@
 import { When, And, Then } from '@badeball/cypress-cucumber-preprocessor';
 import { getCellsForCol } from './table';
+import { clusterParameterExists } from './navigation';
 
 function openTab(tab: string) {
   cy.get('#basic-tabs').should('be.visible').contains(tab).click();
@@ -14,6 +15,7 @@ Then('user sees details information for workload', () => {
     cy.get('#pfbadge-A').parent().parent().parent().contains('details'); // App
     cy.get('#pfbadge-W').parent().parent().parent().contains('details-v1'); // Workload
     cy.get('#pfbadge-S').parent().parent().parent().contains('details'); // Service
+    clusterParameterExists(false);
   });
 });
 

--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -24,6 +24,7 @@ Feature: Kiali App Details page
   @bookinfo-app
   Scenario: See app Traffic information
     Then user sees inbound and outbound traffic information
+    And the "Cluster" column "disappears"
 
   @bookinfo-app
   Scenario: See Inbound Metrics

--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -16,6 +16,7 @@ Feature: Kiali App Details page
   @bookinfo-app
   Scenario: See details for app.
     Then user sees details information for the "details" app
+    But no cluster badge for the "app" should be visible
 
   @bookinfo-app
   Scenario: See app minigraph for details app.

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -19,6 +19,7 @@ Feature: Kiali Apps List page
     And user sees Namespace information for Apps
     And user sees Labels information for Apps
     And user sees Details information for Apps
+    And the "Cluster" column "disappears"
 
   @bookinfo-app
   Scenario: See all Apps toggles

--- a/frontend/cypress/integration/featureFiles/graph_context_menu.feature
+++ b/frontend/cypress/integration/featureFiles/graph_context_menu.feature
@@ -9,9 +9,11 @@ Feature: Kiali Graph page - Context menu actions
     Given user is at administrator perspective
 
   @bookinfo-app
+  # @multi-cluster
   Scenario: Actions in context menu for service node with existing traffic routing
     When user graphs "bookinfo" namespaces
     And user opens the context menu of the "productpage" service node
+    And user should see "no" cluster parameter in links in the context menu
     And user clicks the "delete-traffic-routing" item of the context menu
     Then user should see the confirmation dialog to delete all traffic routing
 

--- a/frontend/cypress/integration/featureFiles/graph_context_menu.feature
+++ b/frontend/cypress/integration/featureFiles/graph_context_menu.feature
@@ -9,7 +9,6 @@ Feature: Kiali Graph page - Context menu actions
     Given user is at administrator perspective
 
   @bookinfo-app
-  # @multi-cluster
   Scenario: Actions in context menu for service node with existing traffic routing
     When user graphs "bookinfo" namespaces
     And user opens the context menu of the "productpage" service node

--- a/frontend/cypress/integration/featureFiles/graph_display.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display.feature
@@ -213,6 +213,20 @@ Feature: Kiali Graph page - Display menu
     And the "service nodes" option should "not be checked" and "enabled"
     And the "operation nodes" option should "be checked" and "enabled"
 
+  @bookinfo-app
+  Scenario Outline: Multiple cluster boxes should not be visible in the graph
+    When user graphs "bookinfo" namespaces
+    And user resets to factory default
+    And user selects "<type>" graph type
+    Then user sees the "bookinfo" namespace
+    And only a single cluster box should be visible
+    Examples:
+      | type         |
+      | APP          |
+      | SERVICE      |
+      | VERSIONED_APP|
+      | WORKLOAD     |
+
   @skip
   @multi-cluster
   Scenario: Graph bookinfo namespace for the multi-cluster setup

--- a/frontend/cypress/integration/featureFiles/graph_side_panel.feature
+++ b/frontend/cypress/integration/featureFiles/graph_side_panel.feature
@@ -12,7 +12,7 @@ Feature: Kiali Graph page - Side panel menu actions
   Scenario: Actions in kebab menu of the side panel for a service node with existing traffic routing
     When user graphs "bookinfo" namespaces
     And user clicks the "productpage" service node
-    And no cluster badge for the "app" should be visible
+    And no cluster badge for the "graph side panel" should be visible
     And user opens the kebab menu of the graph side panel
     And user clicks the "delete_traffic_routing" item of the kebab menu of the graph side panel
     Then user should see the confirmation dialog to delete all traffic routing
@@ -21,7 +21,7 @@ Feature: Kiali Graph page - Side panel menu actions
   Scenario Outline: Ability to launch <action> wizard from graph side panel
     When user graphs "bookinfo" namespaces
     And user clicks the "reviews" service node
-    And no cluster badge for the "app" should be visible
+    And no cluster badge for the "graph side panel" should be visible
     And user opens the kebab menu of the graph side panel
     And user clicks the "<action>" item of the kebab menu of the graph side panel
     Then user should see the "<action>" wizard

--- a/frontend/cypress/integration/featureFiles/graph_side_panel.feature
+++ b/frontend/cypress/integration/featureFiles/graph_side_panel.feature
@@ -12,6 +12,7 @@ Feature: Kiali Graph page - Side panel menu actions
   Scenario: Actions in kebab menu of the side panel for a service node with existing traffic routing
     When user graphs "bookinfo" namespaces
     And user clicks the "productpage" service node
+    And no cluster badge for the "app" should be visible
     And user opens the kebab menu of the graph side panel
     And user clicks the "delete_traffic_routing" item of the kebab menu of the graph side panel
     Then user should see the confirmation dialog to delete all traffic routing
@@ -20,6 +21,7 @@ Feature: Kiali Graph page - Side panel menu actions
   Scenario Outline: Ability to launch <action> wizard from graph side panel
     When user graphs "bookinfo" namespaces
     And user clicks the "reviews" service node
+    And no cluster badge for the "app" should be visible
     And user opens the kebab menu of the graph side panel
     And user clicks the "<action>" item of the kebab menu of the graph side panel
     Then user should see the "<action>" wizard

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -15,6 +15,7 @@ Feature: Kiali Istio Config page
   @bookinfo-app
   Scenario: See all Istio Config objects in the bookinfo namespace.
     Then user sees all the Istio Config objects in the bookinfo namespace
+    And the "Cluster" column "disappears"
     And user sees Name information for Istio objects
     And user sees Namespace information for Istio objects
     And user sees Type information for Istio objects

--- a/frontend/cypress/integration/featureFiles/istio_config_editor.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_editor.feature
@@ -17,6 +17,7 @@ Feature: Kiali Istio Config editor page
     And user sees "bookinfo"
     And user clicks in "Name" column on the "bookinfo" text
     Then user can see istio config editor
+    But no cluster badge for the "Istio config" should be visible
 
   @multi-cluster
   @skip

--- a/frontend/cypress/integration/featureFiles/kiali_help.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_help.feature
@@ -18,7 +18,17 @@ Feature: Kiali help dropdown verify
   Scenario: User opens the View Debug Info section
     When user clicks on the "View Debug Info" button
     Then user sees the "Debug information" modal
+    And user sees information about 1 clusters
 
   Scenario: User opens the View Certificates Info section
     When user clicks on the "View Certificates Info" button
     Then user sees the "Certificates information" modal
+
+  # Even though this test is already implemented, I skipped it.
+  # It will be better to skip this one until our upstream CI is able to build Kiali from the specific PR it is running on. 
+  @skip  
+  @multi-cluster
+  Scenario: User opens the View Debug Info section for multi-cluster mode
+    When user clicks on the "View Debug Info" button
+    Then user sees the "Debug information" modal
+    And user sees information about 2 clusters

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -34,6 +34,7 @@ Feature: Kiali Overview page
   Scenario: Select the LIST view
     When user clicks in the "LIST" view
     Then user sees a "LIST" "beta" namespace
+    And the "Cluster" column "disappears"
 
   Scenario: Filter by namespace
     When user filters "alpha" namespace

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -18,7 +18,9 @@ Feature: Kiali Overview page
 
   Scenario: See "alpha" and "beta" namespaces
     Then user sees the "alpha" namespace card
+    And user does not see any cluster badge in the "alpha" namespace card
     And user sees the "beta" namespace card
+    And user does not see any cluster badge in the "beta" namespace card
 
   Scenario: Doesn't see a "bad" namespace
     Then user doesn't see the "bad" namespace card
@@ -113,6 +115,7 @@ Feature: Kiali Overview page
   @error-rates-app
   Scenario: The Istio panel should be visible in the control panel
     Then user sees the "istio-system" namespace card
+    And user does not see any cluster badge in the "istio-system" namespace card
     And user sees the "Control plane" label in the "istio-system" namespace card
     And user sees the "Outbound policy" label in the "istio-system" namespace card
     Then the toggle on the right side of the "istio-system" namespace card exists

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -31,6 +31,7 @@ Feature: Kiali Service Details page
   @bookinfo-app
   Scenario: See service Traffic information
     Then sd::user sees inbound and outbound traffic information
+    And the "Cluster" column "disappears"
 
   @bookinfo-app
   Scenario: See Inbound Metrics for productspage service details

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -23,6 +23,7 @@ Feature: Kiali Service Details page
     Then sd::user sees "productpage" details information for service "v1"
     Then sd::user sees Network card
     Then sd::user sees Istio Config
+    But no cluster badge for the "service" should be visible
 
   @bookinfo-app
   Scenario: See service minigraph for details app.

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -23,6 +23,7 @@ Feature: Kiali Services page
     And the "Configuration" column on the "productpage" row has a link ending in "/namespaces/bookinfo/services/productpage"
     And the "Details" column on the "productpage" row has a link ending in "/namespaces/bookinfo/istio/virtualservices/bookinfo"
     And the "Details" column on the "productpage" row has a link ending in "/namespaces/bookinfo/istio/gateways/bookinfo-gateway"
+    And the "Cluster" column "disappears"
 
   Scenario: See all Services toggles
     Then user sees all the Services toggles

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -12,6 +12,12 @@ Feature: Kiali Istio Config page
     And user is at the "istio" page
     And user selects the "bookinfo" namespace
 
+  @bookinfo-app
+  Scenario: Dropdown for cluster selection should not be visible in single cluster setup
+    When user clicks in the "Gateway" Istio config actions
+    Then user sees the "Create Gateway" config wizard
+    And user does not see a dropdown for cluster selection
+
   @gateway-api
   @bookinfo-app
   Scenario: Create a K8s Gateway scenario

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -22,6 +22,7 @@ Feature: Kiali Workloads page
     And the "Labels" column on the "details-v1" row has the text "version=v1"
     And the "Type" column on the "details-v1" row has the text "Deployment"
     And the "Details" column on the "details-v1" row is empty
+    And the "Cluster" column "disappears"
 
   @bookinfo-app
   Scenario: See all Workloads toggles

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -22,6 +22,7 @@ Feature: Kiali Workload Details page
   @bookinfo-app
   Scenario: See workload traffic information
     Then user sees workload inbound and outbound traffic information
+    And the "Cluster" column "disappears"
 
   @bookinfo-app
   Scenario: See workload Inbound Metrics

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -14,6 +14,7 @@ Feature: Kiali Workload Details page
   @bookinfo-app
   Scenario: See details for workload
     Then user sees details information for workload
+    But no cluster badge for the "workload" should be visible
 
   @bookinfo-app
   Scenario: See minigraph for workload.


### PR DESCRIPTION
Related to #6549. 

This PR is adding additional tests and checks to ensure Multi-cluster related features are not causing problems for the single cluster setup. This includes checking that no clusterName parameter is used in links, no cluster badges and columns are visible and also no cluster dropdown should be available in the Istio config wizard. 