### PR TITLE
Increase specificity of kiali style

### DIFF
--- a/frontend/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/frontend/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HealthIndicator proxy status section renders the degraded workloads 1`] = `
 <Tooltip
   aria-label="Health indicator"
-  className="kiali_f1gl57f9"
+  className="kiali_f1icezv7"
   content={
     <div>
       <strong>
@@ -98,7 +98,7 @@ exports[`HealthIndicator proxy status section renders the degraded workloads 1`]
 >
   <span>
     <Icon
-      className="icon-degraded kiali_fpjhxhv"
+      className="icon-degraded kiali_frkkrth"
       size="md"
     >
       <ExclamationTriangleIcon />
@@ -110,7 +110,7 @@ exports[`HealthIndicator proxy status section renders the degraded workloads 1`]
 exports[`HealthIndicator renders healthy 1`] = `
 <Tooltip
   aria-label="Health indicator"
-  className="kiali_f1gl57f9"
+  className="kiali_f1icezv7"
   content={
     <div>
       <strong>
@@ -215,7 +215,7 @@ exports[`HealthIndicator renders healthy 1`] = `
 >
   <span>
     <Icon
-      className="icon-healthy kiali_f1iy6moq"
+      className="icon-healthy kiali_f1r5cf3w"
       size="md"
     >
       <CheckCircleIcon />

--- a/frontend/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/frontend/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`#Badge render correctly with data should render badge 1`] = `
 <Label
-  className="kiali_fahj8d2"
+  className="kiali_f1il4iwg"
   isCompact={true}
 >
   app=bookinfo

--- a/frontend/src/components/Label/__tests__/__snapshots__/Labels.test.tsx.snap
+++ b/frontend/src/components/Label/__tests__/__snapshots__/Labels.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`#Labels render correctly with data should render badges with More labels link 1`] = `
 <div
-  className="kiali_faowcuh"
+  className="kiali_fj1yjm7"
 >
   <div
     data-test="app-label-container"
@@ -25,7 +25,7 @@ exports[`#Labels render correctly with data should render badges with More label
     />
   </div>
   <Button
-    className="kiali_f1tvybfg"
+    className="kiali_f1m3uny2"
     data-test="label_more"
     key="label_more"
     onClick={[Function]}
@@ -38,7 +38,7 @@ exports[`#Labels render correctly with data should render badges with More label
 
 exports[`#Labels render correctly with data should render badges without More labels link 1`] = `
 <div
-  className="kiali_faowcuh"
+  className="kiali_fj1yjm7"
 >
   <div
     data-test="app-label-container"

--- a/frontend/src/components/ToolbarDropdown/__tests__/__snapshots__/ToolbarDropdown.test.tsx.snap
+++ b/frontend/src/components/ToolbarDropdown/__tests__/__snapshots__/ToolbarDropdown.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ToolbarDropdown Render correctly all dropdowns 1`] = `
 <Fragment>
   <span
-    className="kiali_f1m56v19"
+    className="kiali_fbcnhsr"
   >
     graph_filter_interval_duration
   </span>
@@ -13,7 +13,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 1`] = `
     aria-label="graph_filter_interval_duration"
     aria-labelledby="graph_filter_interval_duration"
     chipGroupComponent={null}
-    className="kiali_fhxf3qu"
+    className="kiali_f13qzac0"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -262,7 +262,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 1`] = `
 exports[`ToolbarDropdown Render correctly all dropdowns 2`] = `
 <Fragment>
   <span
-    className="kiali_f1m56v19"
+    className="kiali_fbcnhsr"
   >
     metrics_filter_poll_interval
   </span>
@@ -272,7 +272,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 2`] = `
     aria-label="metrics_filter_poll_interval"
     aria-labelledby="metrics_filter_poll_interval"
     chipGroupComponent={null}
-    className="kiali_fhxf3qu"
+    className="kiali_f13qzac0"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -497,7 +497,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 2`] = `
 exports[`ToolbarDropdown Render correctly all dropdowns 3`] = `
 <Fragment>
   <span
-    className="kiali_f1m56v19"
+    className="kiali_fbcnhsr"
   >
     graph_filter_layouts
   </span>
@@ -507,7 +507,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 3`] = `
     aria-label="graph_filter_layouts"
     aria-labelledby="graph_filter_layouts"
     chipGroupComponent={null}
-    className="kiali_fhxf3qu"
+    className="kiali_f13qzac0"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -636,7 +636,7 @@ exports[`ToolbarDropdown Render correctly all dropdowns 3`] = `
 exports[`ToolbarDropdown Render dropdowns correctly with controlled values and labels 1`] = `
 <Fragment>
   <span
-    className="kiali_f1m56v19"
+    className="kiali_fbcnhsr"
   >
     graph_filter_interval_duration
   </span>
@@ -646,7 +646,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
     aria-label="graph_filter_interval_duration"
     aria-labelledby="graph_filter_interval_duration"
     chipGroupComponent={null}
-    className="kiali_fhxf3qu"
+    className="kiali_f13qzac0"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -895,7 +895,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
 exports[`ToolbarDropdown Render dropdowns correctly with controlled values and labels 2`] = `
 <Fragment>
   <span
-    className="kiali_f1m56v19"
+    className="kiali_fbcnhsr"
   >
     metrics_filter_poll_interval
   </span>
@@ -905,7 +905,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
     aria-label="metrics_filter_poll_interval"
     aria-labelledby="metrics_filter_poll_interval"
     chipGroupComponent={null}
-    className="kiali_fhxf3qu"
+    className="kiali_f13qzac0"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -1130,7 +1130,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
 exports[`ToolbarDropdown Render dropdowns correctly with controlled values and labels 3`] = `
 <Fragment>
   <span
-    className="kiali_f1m56v19"
+    className="kiali_fbcnhsr"
   >
     graph_filter_layouts
   </span>
@@ -1140,7 +1140,7 @@ exports[`ToolbarDropdown Render dropdowns correctly with controlled values and l
     aria-label="graph_filter_layouts"
     aria-labelledby="graph_filter_layouts"
     chipGroupComponent={null}
-    className="kiali_fhxf3qu"
+    className="kiali_f13qzac0"
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}

--- a/frontend/src/components/Validations/__tests__/__snapshots__/ServiceValidationSummary.test.tsx.snap
+++ b/frontend/src/components/Validations/__tests__/__snapshots__/ServiceValidationSummary.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ServiceValidationSummary renders error icon when all components are val
         Service validation result
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           1 error found
@@ -51,7 +51,7 @@ exports[`ServiceValidationSummary renders error icon when all components are val
         Service validation result
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           1 error found
@@ -88,7 +88,7 @@ exports[`ServiceValidationSummary renders success icon when all components are v
         Service validation result
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           No issues found
@@ -122,7 +122,7 @@ exports[`ServiceValidationSummary renders warning icon when all components are v
         Service validation result
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           1 warning found
@@ -156,7 +156,7 @@ exports[`ServiceValidationSummary renders warning icon when all components are v
         Service validation result
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           2 warnings found

--- a/frontend/src/components/Validations/__tests__/__snapshots__/ValidationSummary.test.tsx.snap
+++ b/frontend/src/components/Validations/__tests__/__snapshots__/ValidationSummary.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ValidationSummary renders N/A when all components are valid 1`] = `
   aria-label="Validations list"
   content={
     <Text
-      className="kiali_f12qq397"
+      className="kiali_f7610ot"
     >
       No Istio config objects found
     </Text>
@@ -44,7 +44,7 @@ exports[`ValidationSummary renders error icon when all components are valid 1`] 
         1
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           1 error found
@@ -79,7 +79,7 @@ exports[`ValidationSummary renders error icon when all components are valid 2`] 
         3
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           1 error found
@@ -117,7 +117,7 @@ exports[`ValidationSummary renders success icon when all components are valid 1`
         1
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           No issues found
@@ -152,7 +152,7 @@ exports[`ValidationSummary renders success icon when all components are valid 2`
         4
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           No issues found
@@ -187,7 +187,7 @@ exports[`ValidationSummary renders warning icon when all components are valid 1`
         1
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           1 warning found
@@ -222,7 +222,7 @@ exports[`ValidationSummary renders warning icon when all components are valid 2`
         3
       </Text>
       <div
-        className="kiali_fe0pf1n"
+        className="kiali_fljtil"
       >
         <div>
           1 warning found

--- a/frontend/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/frontend/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`GraphLegend test should render correctly 1`] = `
 <div
-  className="kiali_fwdhk2f"
+  className="kiali_fwvte8h"
   data-test="graph-legend"
   style={
     Object {
@@ -11,13 +11,13 @@ exports[`GraphLegend test should render correctly 1`] = `
   }
 >
   <div
-    className="kiali_fsgo6a1 kiali_f1bv0l2s"
+    className="kiali_fxa4sy7 kiali_f1mm2w2a"
   >
     <span>
       Legend
     </span>
     <span
-      className="kiali_f1blspom"
+      className="kiali_fj2dqxs"
     >
       <Tooltip
         content="Close Legend"
@@ -33,23 +33,23 @@ exports[`GraphLegend test should render correctly 1`] = `
     </span>
   </div>
   <div
-    className="kiali_f6nw80o"
+    className="kiali_fu2odq6"
   >
     <div>
       <div
-        className="kiali_f10krlro"
+        className="kiali_fzj1afm"
       >
         <div
-          className="kiali_fng0jlu"
+          className="kiali_f14iq4pw"
           key="Node Shapes"
         >
           Node Shapes
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Workload"
@@ -57,17 +57,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Workload
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="app.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="App"
@@ -75,17 +75,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               App
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="aggregate.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Operation"
@@ -93,17 +93,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Operation
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="service.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Service"
@@ -111,17 +111,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Service
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="service-entry.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Service Entry"
@@ -129,23 +129,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Service Entry
             </span>
           </div>
         </div>
         <div
-          className="kiali_fng0jlu"
+          className="kiali_f14iq4pw"
           key="Node Colors"
         >
           Node Colors
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-color-normal.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Normal"
@@ -153,17 +153,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Normal
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-color-warning.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Warn"
@@ -171,17 +171,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Warn
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-color-danger.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Unhealthy"
@@ -189,17 +189,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Unhealthy
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-color-idle.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Idle"
@@ -207,23 +207,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Idle
             </span>
           </div>
         </div>
         <div
-          className="kiali_fng0jlu"
+          className="kiali_f14iq4pw"
           key="Node Background"
         >
           Node Background
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="external-namespace.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Unselected Namespace"
@@ -231,17 +231,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Unselected Namespace
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="restricted-namespace.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Restricted / External"
@@ -249,23 +249,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Restricted / External
             </span>
           </div>
         </div>
         <div
-          className="kiali_fng0jlu"
+          className="kiali_f14iq4pw"
           key="Edges"
         >
           Edges
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="edge-danger.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Failure"
@@ -273,17 +273,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Failure
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="edge-warn.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Degraded"
@@ -291,17 +291,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Degraded
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="edge-success.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Healthy"
@@ -309,17 +309,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Healthy
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="edge-tcp.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="TCP Connection"
@@ -327,17 +327,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               TCP Connection
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="edge-idle.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Idle"
@@ -345,17 +345,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Idle
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="mtls-badge.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="mTLS (badge)"
@@ -363,23 +363,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               mTLS (badge)
             </span>
           </div>
         </div>
         <div
-          className="kiali_fng0jlu"
+          className="kiali_f14iq4pw"
           key="Traffic Animation"
         >
           Traffic Animation
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="traffic-normal-request.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Normal Request"
@@ -387,17 +387,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Normal Request
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="traffic-failed-request.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Failed Request"
@@ -405,17 +405,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Failed Request
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="traffic-tcp.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="TCP Traffic"
@@ -423,23 +423,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               TCP Traffic
             </span>
           </div>
         </div>
         <div
-          className="kiali_fng0jlu"
+          className="kiali_f14iq4pw"
           key="Node Badges"
         >
           Node Badges
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-circuit-breaker.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Circuit Breaker"
@@ -447,17 +447,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Circuit Breaker
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-fault-injection.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Fault Injection"
@@ -465,17 +465,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Fault Injection
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-gateways.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Gateway"
@@ -483,17 +483,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Gateway
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-mirroring.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Mirroring"
@@ -501,17 +501,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Mirroring
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-missing-sidecar.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Missing Sidecar"
@@ -519,17 +519,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Missing Sidecar
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-request-timeout.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Request Timeout"
@@ -537,17 +537,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Request Timeout
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-traffic-shifting.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Traffic Shifting / TCP Traffic Shifting"
@@ -555,17 +555,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Traffic Shifting / TCP Traffic Shifting
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-traffic-source.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Traffic Source"
@@ -573,17 +573,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Traffic Source
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-virtual-services.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Virtual Service / Request Routing"
@@ -591,17 +591,17 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Virtual Service / Request Routing
             </span>
           </div>
           <div
-            className="kiali_f13es1gb"
+            className="kiali_fasfm8t"
             key="node-badge-workload-entry.svg"
           >
             <span
-              className="kiali_f1irbq61"
+              className="kiali_fzoxfwf"
             >
               <img
                 alt="Workload Entry"
@@ -609,7 +609,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="kiali_fgzdi7m"
+              className="kiali_f7pgfh0"
             >
               Workload Entry
             </span>

--- a/frontend/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/frontend/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`#LoginPage render correctly should render LoginPage 1`] = `
 <LoginPage
   brandImgAlt="Kiali logo"
   brandImgSrc="logo-alt.svg"
-  className="kiali_f25vqgy"
+  className="kiali_f11fk3j8"
   footerListItems={
     <React.Fragment>
       <ListItem>

--- a/frontend/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
+++ b/frontend/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Overview page renders initial layout 1`] = `
     }
   />
   <EmptyState
-    className="kiali_fu1tihc"
+    className="kiali_f17rctdi"
     variant="full"
   >
     <EmptyStateHeader

--- a/frontend/src/pages/WorkloadDetails/__tests__/__snapshots__/ProxyStatusList.test.tsx.snap
+++ b/frontend/src/pages/WorkloadDetails/__tests__/__snapshots__/ProxyStatusList.test.tsx.snap
@@ -5,18 +5,18 @@ exports[`ProxyStatusList when status is synced match the snapshot 1`] = `""`;
 exports[`ProxyStatusList when there are components without value match the snapshot 1`] = `
 <Stack>
   <StackItem
-    className="kiali_flhasb0"
+    className="kiali_f1hhefje"
   >
     Istio Proxy Status
   </StackItem>
   <StackItem
-    className="kiali_f1vko8vu"
+    className="kiali_fbpk5b0"
     key="proxy-status-0"
   >
     CDS: -
   </StackItem>
   <StackItem
-    className="kiali_f1vko8vu"
+    className="kiali_fbpk5b0"
     key="proxy-status-3"
   >
     RDS: -
@@ -27,18 +27,18 @@ exports[`ProxyStatusList when there are components without value match the snaps
 exports[`ProxyStatusList when there are unsyced components match the snapshot 1`] = `
 <Stack>
   <StackItem
-    className="kiali_flhasb0"
+    className="kiali_f1hhefje"
   >
     Istio Proxy Status
   </StackItem>
   <StackItem
-    className="kiali_f1vko8vu"
+    className="kiali_fbpk5b0"
     key="proxy-status-0"
   >
     CDS: NOT_SENT
   </StackItem>
   <StackItem
-    className="kiali_f1vko8vu"
+    className="kiali_fbpk5b0"
     key="proxy-status-3"
   >
     RDS: STALE

--- a/frontend/src/styles/StyleUtils.ts
+++ b/frontend/src/styles/StyleUtils.ts
@@ -10,6 +10,12 @@ const cssPrefix = process.env.CSS_PREFIX ?? 'kiali';
 export const kialiStyle = (styleProps: NestedCSSProperties) => {
   return style({
     $debugName: cssPrefix,
-    ...styleProps
+    $nest: {
+      // Increase specificity to make kiali style more relevant within CSS cascade
+      // https://typestyle.github.io/#/advanced/concept-ordering-pseudo-classes
+      '&&&': {
+        ...styleProps
+      }
+    }
   });
 };


### PR DESCRIPTION
** Describe the change **

A typestyle custom style is added when you want to apply a direct style to a component. For this reason it should have a high specificity value to be at the top of CSS cascade (more details about CSS specificity here: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance). Currently kiali style has a specificity of (0,1,0) which is quite low to be placed at the the top of CSS cascade. Actually there are some Openshift CSS classes that have more specificity and overwrite the typestyle style defined for the component in OSSMC plugin.

For this reason specificity of kiali styles have been increased to (0,3,0). This value is quite high and it is weird that an external CSS class has more specificity than that (usual values are 0,1,0 and 0,2,0).

Example:
Before:
![image](https://github.com/kiali/kiali/assets/122779323/065ab3c2-223b-467e-8c39-97042621af7d)

After:
![image](https://github.com/kiali/kiali/assets/122779323/74e4bf5e-9420-42a5-baee-3fb25317dd95)


** Issue reference **

Fixes #6561. 

** PR Testing **
This fix does not affect Kiali app standalone (no Openshift CSS classes loaded here), only to OSSMC.