### PR TITLE
Added support of multiple Gateway API classes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -226,7 +226,7 @@ type IstioConfig struct {
 	ComponentStatuses                 ComponentStatuses   `yaml:"component_status,omitempty"`
 	ConfigMapName                     string              `yaml:"config_map_name,omitempty"`
 	EnvoyAdminLocalPort               int                 `yaml:"envoy_admin_local_port,omitempty"`
-	GatewayAPIClassName               string              `yaml:"gateway_api_class_name,omitempty"`
+	GatewayAPIClasses                 []GatewayAPIClass   `yaml:"gateway_api_classes,omitempty"`
 	IstioAPIEnabled                   bool                `yaml:"istio_api_enabled"`
 	IstioCanaryRevision               IstioCanaryRevision `yaml:"istio_canary_revision,omitempty"`
 	IstioIdentityDomain               string              `yaml:"istio_identity_domain,omitempty"`
@@ -255,6 +255,11 @@ type ComponentStatus struct {
 	IsCore    bool   `yaml:"is_core,omitempty"`
 	IsProxy   bool   `yaml:"is_proxy,omitempty"`
 	Namespace string `yaml:"namespace,omitempty"`
+}
+
+type GatewayAPIClass struct {
+	Name      string `yaml:"name,omitempty"`
+	ClassName string `yaml:"class_name,omitempty"`
 }
 
 // ExternalServices holds configurations for other systems that Kiali depends on
@@ -625,7 +630,11 @@ func NewConfig() (c *Config) {
 				IstiodPodMonitoringPort:           15014,
 				RootNamespace:                     "istio-system",
 				UrlServiceVersion:                 "http://istiod.istio-system:15014/version",
-				GatewayAPIClassName:               "istio",
+				GatewayAPIClasses: []GatewayAPIClass{
+					{
+						Name: "Istio", ClassName: "istio",
+					},
+				},
 			},
 			Prometheus: PrometheusConfig{
 				Auth: Auth{

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -161,13 +161,16 @@ func FilterSupportedGateways(gateways []*networking_v1beta1.Gateway) []*networki
 }
 
 func FilterSupportedK8sGateways(gateways []*k8s_networking_v1beta1.Gateway) []*k8s_networking_v1beta1.Gateway {
-	var gatewayAPIClassName = config.Get().ExternalServices.Istio.GatewayAPIClassName
-	if gatewayAPIClassName == "" {
-		gatewayAPIClassName = "istio"
+	var gatewayAPIClassNames = map[string]string{}
+	for _, gwClass := range config.Get().ExternalServices.Istio.GatewayAPIClasses {
+		gatewayAPIClassNames[gwClass.ClassName] = gwClass.Name
+	}
+	if len(gatewayAPIClassNames) == 0 {
+		gatewayAPIClassNames["istio"] = "Istio"
 	}
 	filtered := []*k8s_networking_v1beta1.Gateway{}
 	for _, gw := range gateways {
-		if string(gw.Spec.GatewayClassName) == gatewayAPIClassName {
+		if _, exist := gatewayAPIClassNames[string(gw.Spec.GatewayClassName)]; exist {
 			filtered = append(filtered, gw)
 		}
 	}


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/6429

For testing this:
Apply Contour implementation of Gateway API: https://projectcontour.io/docs/1.26/guides/gateway-api/
In Kiali CR make sure to configure classes:
```
external_services:
  istio:
    gateway_api_classes:
      - name: Contour
        class_name: contour
      - name: Istio
        class_name: istio
```
New Gateway config will appear in list:
![Screenshot from 2023-09-05 18-23-01](https://github.com/kiali/kiali/assets/604313/2ebe77b1-d825-49c3-b877-80dd65fb5fe5)

TODO in next PR: Apply multiple classes in config wizards.