### PR TITLE
Prevent "istio type" filter carryover

### DIFF
--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -217,12 +217,9 @@ Given(
   }
 );
 
-Given(
-  'there is not a {string} VirtualService in the {string} namespace',
-  function (vsName: string, namespace: string) {
-    cy.exec(`kubectl delete VirtualService ${vsName} -n ${namespace}`, { failOnNonZeroExit: false });
-  }
-);
+Given('there is not a {string} VirtualService in the {string} namespace', function (vsName: string, namespace: string) {
+  cy.exec(`kubectl delete VirtualService ${vsName} -n ${namespace}`, { failOnNonZeroExit: false });
+});
 
 Given('the DestinationRule enables mTLS', function () {
   cy.exec(
@@ -361,9 +358,13 @@ And('the user filters by {string} for {string}', (filter: string, filterValue: s
   if (filter === 'Istio Name') {
     cy.get('select[aria-label="filter_select_type"]').select(filter);
     cy.get('input[aria-label="filter_input_value"]').type(`${filterValue}{enter}`);
-  } else if (filter === 'Istio Type') {
-    cy.get('select[aria-label="filter_select_type"]').select('Istio Type');
-    cy.get('input[placeholder="Filter by Istio Type"]').type(`${filterValue}{enter}`);
+  } else if (filter === 'Type') {
+    cy.get('select[aria-label="filter_select_type"]').select('Type');
+    cy.get('input[placeholder="Filter by Type"]').type(`${filterValue}{enter}`);
+    cy.get(`button[label="${filterValue}"]`).should('be.visible').click();
+  } else if (filter === 'Istio Config Type') {
+    cy.get('select[aria-label="filter_select_type"]').select('Istio Config Type');
+    cy.get('input[placeholder="Filter by Istio Config Type"]').type(`${filterValue}{enter}`);
     cy.get(`button[label="${filterValue}"]`).should('be.visible').click();
   } else if (filter === 'Config') {
     cy.get('select[aria-label="filter_select_type"]').select(filter);

--- a/frontend/cypress/integration/common/istio_config_type_filters.ts
+++ b/frontend/cypress/integration/common/istio_config_type_filters.ts
@@ -6,7 +6,7 @@ function optionCheck(name: string) {
 }
 
 When('user types {string} into the input', (input: string) => {
-  cy.get('input[placeholder="Filter by Istio Type"]').type(input);
+  cy.get('input[placeholder="Filter by Type"]').type(input);
 });
 
 Then('the {string} phrase is displayed', (phrase: string) => {
@@ -72,9 +72,9 @@ When('multiple filters are chosen', () => {
       objects: 'authorizationpolicies,destinationrules'
     }
   }).as('multipleFilters');
-  cy.get('input[placeholder="Filter by Istio Type"]').type('AuthorizationPolicy{enter}');
+  cy.get('input[placeholder="Filter by Type"]').type('AuthorizationPolicy{enter}');
   cy.get(`button[label="AuthorizationPolicy"]`).should('be.visible').click();
-  cy.get('input[placeholder="Filter by Istio Type"]').type('DestinationRule{enter}');
+  cy.get('input[placeholder="Filter by Type"]').type('DestinationRule{enter}');
   cy.get(`button[label="DestinationRule"]`).should('be.visible').click();
 });
 
@@ -83,7 +83,7 @@ Then('multiple filters are active', () => {
 });
 
 When('a type filter {string} is applied', (category: string) => {
-  cy.get('input[placeholder="Filter by Istio Type"]').type(`${category}{enter}`);
+  cy.get('input[placeholder="Filter by Type"]').type(`${category}{enter}`);
   cy.get(`button[label="${category}"]`).should('be.visible').click();
 });
 
@@ -106,16 +106,19 @@ Then('the filter {string} should be visible only once', (category: string) => {
 });
 
 When('user chooses {int} type filters', (count: number) => {
-  cy.get('select[aria-label="filter_select_type"]').select('Istio Type');
+  cy.get('select[aria-label="filter_select_type"]').select('Type');
   for (let i = 1; i <= count; i++) {
-    cy.get('input[placeholder="Filter by Istio Type"]').click();
+    cy.get('input[placeholder="Filter by Type"]').click();
     cy.get(`[data-test=istio-type-dropdown] > :nth-child(${i})`).should('be.visible').click();
     cy.get('#loading_kiali_spinner').should('not.exist');
   }
 });
 
 And('user clicks the cross on one of them', () => {
-  cy.get('#filter-selection > :nth-child(2)').find('[data-ouia-component-type="PF5/Button" data-ouia-component-id="close"]').first().click();
+  cy.get('#filter-selection > :nth-child(2)')
+    .find('[data-ouia-component-type="PF5/Button" data-ouia-component-id="close"]')
+    .first()
+    .click();
 });
 
 Then('{int} filters should be visible', (count: number) => {

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -66,12 +66,8 @@ And('user filters for name {string}', (name: string) => {
   cy.get('input[aria-label="filter_input_value"]').type(`${name}{enter}`);
 });
 
-When('user filters by {string} istio type', (istioType: string) => {
-  cy.get('select[aria-label="filter_select_type"]').select('istiotype');
-});
-
-And('user filters for istio type {string}', (istioType: string) => {
-  cy.get('input[placeholder="Filter by Istio Type"]').type(`${istioType}{enter}`);
+And('user filters for istio config type {string}', (istioType: string) => {
+  cy.get('input[placeholder="Filter by Istio Config Type"]').type(`${istioType}{enter}`);
   cy.get(`button[label="${istioType}"]`).should('be.visible').click();
 });
 
@@ -89,12 +85,12 @@ export function colExists(colName: string, exists: boolean) {
 // This func makes a couple assumptions:
 //
 // 1. The classes expected
-export const hasAtLeastOneClass = (expectedClasses) => {
-  return ($el) => {
-    const classList = Array.from($el[0].classList); 
+export const hasAtLeastOneClass = expectedClasses => {
+  return $el => {
+    const classList = Array.from($el[0].classList);
     return expectedClasses.some(expectedClass => classList.includes(expectedClass));
-  }
-}
+  };
+};
 
 // getColWithRowText will find the column matching the unique row text and column header name.
 // This func makes a couple assumptions:
@@ -206,7 +202,9 @@ export function checkHealthStatusInTable(
   const selector = targetType
     ? `${targetNamespace}_${targetType}_${targetRowItemName}`
     : `${targetNamespace}_${targetRowItemName}`;
-  cy.get(`[data-test=VirtualItem_Ns${selector}] td:first-child span[class=pf-v5-c-icon__content]`).trigger('mouseenter');
+  cy.get(`[data-test=VirtualItem_Ns${selector}] td:first-child span[class=pf-v5-c-icon__content]`).trigger(
+    'mouseenter'
+  );
   cy.get(`[aria-label='Health indicator'] strong`).should('contain.text', healthStatus);
 }
 

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -51,8 +51,8 @@ Feature: Kiali Apps List page
     Then user may only see "kiali-traffic-generator"
 
   @bookinfo-app
-  Scenario: Filter Apps by Istio Type
-    When the user filters by "Istio Type" for "VirtualService"
+  Scenario: Filter Apps by Istio Config Type
+    When the user filters by "Istio Config Type" for "VirtualService"
     Then user only sees "productpage"
 
   @bookinfo-app

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -37,7 +37,7 @@ Feature: Kiali Istio Config page
     Then user only sees "bookinfo-gateway"
 
   @bookinfo-app
-  Scenario: Filter Istio Config objects by Istio Type
+  Scenario: Filter Istio Config objects by Type
     When the user filters by "Type" for "Gateway"
     Then only "Gateways" are visible in the "bookinfo" namespace
 

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -38,7 +38,7 @@ Feature: Kiali Istio Config page
 
   @bookinfo-app
   Scenario: Filter Istio Config objects by Istio Type
-    When the user filters by "Istio Type" for "Gateway"
+    When the user filters by "Type" for "Gateway"
     Then only "Gateways" are visible in the "bookinfo" namespace
 
   @bookinfo-app

--- a/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
@@ -19,11 +19,11 @@ Feature: Kiali Istio Config page
     And no filters are active
 
   Scenario: Filters should be available in the dropdown
-    When user expands the "Filter by Istio Type" dropdown
+    When user expands the "Filter by Type" dropdown
     Then user can see the filter options
 
   Scenario: Single filter should be usable
-    When chosen from the "Filter by Istio Type" dropdown
+    When chosen from the "Filter by Type" dropdown
     Then the filter is applied
 
   Scenario: Multiple filters should be usable

--- a/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_type_filters.feature
@@ -10,7 +10,7 @@ Feature: Kiali Istio Config page
     Given user is at administrator perspective
     And user is at the "istio" page
     And user selects the "istio-system" namespace
-    And user filters by "Istio Type"
+    And user filters by "Type"
     And no filters are active
 
   Scenario: Fill the input form with nonsense

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -56,10 +56,10 @@ Feature: Kiali Services page
     Then user sees "something" in the table
 
   @bookinfo-app
-  Scenario: Filter services table by Istio Type
+  Scenario: Filter services table by Istio Config Type
     When user selects the "bookinfo" namespace
-    And user selects filter "Istio Type"
-    And user filters for istio type "VirtualService"
+    And user selects filter "Istio Config Type"
+    And user filters for istio config type "VirtualService"
     Then user sees "productpage" in the table
     And table length should be 1
 

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -57,10 +57,10 @@ Feature: Kiali Workloads page
     Then user sees "workloads" in workloads table
 
   @bookinfo-app
-  Scenario: Filter workloads table by Istio Type
+  Scenario: Filter workloads table by Istio Config Type
     When user selects the "bookinfo" namespace
-    And user selects filter "Istio Type"
-    And user filters for istio type "VirtualService"
+    And user selects filter "Istio Config Type"
+    And user filters for istio config type "VirtualService"
     Then user sees "no workloads" in workloads table
 
   @bookinfo-app

--- a/frontend/src/pages/AppList/FiltersAndSorts.ts
+++ b/frontend/src/pages/AppList/FiltersAndSorts.ts
@@ -14,7 +14,7 @@ import {
 import { hasMissingSidecar } from '../../components/VirtualList/Config';
 import { TextInputTypes } from '@patternfly/react-core';
 import { filterByLabel } from '../../helpers/LabelFilterHelper';
-import { istioTypeFilter } from '../IstioConfigList/FiltersAndSorts';
+import { istioConfigTypeFilter } from '../IstioConfigList/FiltersAndSorts';
 import { ObjectReference } from '../../types/IstioObjects';
 import { serverConfig } from 'config';
 
@@ -118,8 +118,8 @@ const appNameFilter: FilterType = {
 
 export const availableFilters: FilterType[] = [
   appNameFilter,
+  istioConfigTypeFilter,
   istioSidecarFilter,
-  istioTypeFilter,
   healthFilter,
   labelFilter
 ];
@@ -177,7 +177,7 @@ export const filterBy = (
     return filterByHealth(ret, healthSelected);
   }
 
-  const istioTypeSelected = getFilterSelectedValues(istioTypeFilter, filters);
+  const istioTypeSelected = getFilterSelectedValues(istioConfigTypeFilter, filters);
   if (istioTypeSelected.length > 0) {
     return filterByIstioType(ret, istioTypeSelected);
   }

--- a/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -89,9 +89,10 @@ export const istioNameFilter: FilterType = {
   filterValues: []
 };
 
+// Used when Istio Config is implied
 export const istioTypeFilter: FilterType = {
-  category: 'Istio Type',
-  placeholder: 'Filter by Istio Type',
+  category: 'Type',
+  placeholder: 'Filter by Type',
   filterType: AllFilterTypes.typeAhead,
   action: FILTER_ACTION_APPEND,
   filterValues: [
@@ -156,6 +157,13 @@ export const istioTypeFilter: FilterType = {
       title: 'WorkloadGroup'
     }
   ]
+};
+
+// Used when Istio Config should be explicit
+export const istioConfigTypeFilter = {
+  ...istioTypeFilter,
+  category: 'Istio Config Type',
+  placeholder: 'Filter by Istio Config Type'
 };
 
 export const configValidationFilter: FilterType = {

--- a/frontend/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/frontend/src/pages/ServiceList/FiltersAndSorts.ts
@@ -14,7 +14,7 @@ import { hasMissingSidecar } from '../../components/VirtualList/Config';
 import { TextInputTypes } from '@patternfly/react-core';
 import { filterByLabel } from '../../helpers/LabelFilterHelper';
 import { calculateErrorRate } from '../../types/ErrorRate';
-import { istioTypeFilter } from '../IstioConfigList/FiltersAndSorts';
+import { istioConfigTypeFilter } from '../IstioConfigList/FiltersAndSorts';
 import { compareObjectReferences } from '../AppList/FiltersAndSorts';
 import { serverConfig } from 'config';
 
@@ -182,8 +182,8 @@ const serviceTypeFilter: FilterType = {
 export const availableFilters: FilterType[] = [
   serviceNameFilter,
   serviceTypeFilter,
+  istioConfigTypeFilter,
   istioSidecarFilter,
-  istioTypeFilter,
   healthFilter,
   labelFilter
 ];
@@ -256,7 +256,7 @@ export const filterBy = (items: ServiceListItem[], filters: ActiveFiltersInfo): 
     return filterByHealth(ret, healthSelected);
   }
 
-  const istioTypeSelected = getFilterSelectedValues(istioTypeFilter, filters);
+  const istioTypeSelected = getFilterSelectedValues(istioConfigTypeFilter, filters);
   if (istioTypeSelected.length > 0) {
     return filterByIstioType(ret, istioTypeSelected);
   }

--- a/frontend/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/frontend/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -22,7 +22,7 @@ import { hasMissingSidecar } from '../../components/VirtualList/Config';
 import { TextInputTypes } from '@patternfly/react-core';
 import { filterByLabel } from '../../helpers/LabelFilterHelper';
 import { calculateErrorRate } from '../../types/ErrorRate';
-import { istioTypeFilter } from '../IstioConfigList/FiltersAndSorts';
+import { istioConfigTypeFilter } from '../IstioConfigList/FiltersAndSorts';
 import { compareObjectReferences } from '../AppList/FiltersAndSorts';
 import { serverConfig } from 'config';
 
@@ -276,8 +276,8 @@ const workloadTypeFilter: FilterType = {
 export const availableFilters: FilterType[] = [
   workloadNameFilter,
   workloadTypeFilter,
+  istioConfigTypeFilter,
   istioSidecarFilter,
-  istioTypeFilter,
   healthFilter,
   appLabelFilter,
   versionLabelFilter,
@@ -352,7 +352,7 @@ export const filterBy = (items: WorkloadListItem[], filters: ActiveFiltersInfo):
     return filterByHealth(ret, healthSelected);
   }
 
-  const istioTypeSelected = getFilterSelectedValues(istioTypeFilter, filters);
+  const istioTypeSelected = getFilterSelectedValues(istioConfigTypeFilter, filters);
   if (istioTypeSelected.length > 0) {
     return filterByIstioType(ret, istioTypeSelected);
   }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6512

Prevent "istio type" filter carryover between config list page and other list pages.

- Change "Istio Type" filter to be "Type" for Istio Config list page, the context is implied.
- Change "Istio Type" filter to be "Istio Config Type" for other list pages. the filter should be more explicit.
- The change in filter naming prevents the previous "Istio Type" filter carryover
