### PR TITLE
[hack] fix install-bookinfo-demo and other hack scripts for SCC priority

### DIFF
--- a/hack/istio/create-mesh-namespace.sh
+++ b/hack/istio/create-mesh-namespace.sh
@@ -154,6 +154,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:${USERS}
 SCC
 fi

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -268,11 +268,12 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAMESPACE}:bookinfo-details"
 - "system:serviceaccount:${NAMESPACE}:bookinfo-productpage"
 - "system:serviceaccount:${NAMESPACE}:bookinfo-ratings"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-ratings=v2"
+- "system:serviceaccount:${NAMESPACE}:bookinfo-ratings-v2"
 - "system:serviceaccount:${NAMESPACE}:bookinfo-reviews"
 - "system:serviceaccount:${NAMESPACE}:default"
 SCC

--- a/hack/istio/install-electronic-shop-demo.sh
+++ b/hack/istio/install-electronic-shop-demo.sh
@@ -36,6 +36,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAME}:default"
 - "system:serviceaccount:${NAME}:${NAME}"

--- a/hack/istio/install-error-rates-demo.sh
+++ b/hack/istio/install-error-rates-demo.sh
@@ -214,6 +214,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAMESPACE_ALPHA}:default"
 - "system:serviceaccount:${NAMESPACE_BETA}:default"

--- a/hack/istio/install-federated-travels-demo.sh
+++ b/hack/istio/install-federated-travels-demo.sh
@@ -32,6 +32,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAME}:default"
 - "system:serviceaccount:${NAME}:${NAME}"

--- a/hack/istio/install-fraud-detection-demo.sh
+++ b/hack/istio/install-fraud-detection-demo.sh
@@ -114,6 +114,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAMESPACE}:default"
 SCC

--- a/hack/istio/install-music-store-demo.sh
+++ b/hack/istio/install-music-store-demo.sh
@@ -36,6 +36,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAME}:default"
 - "system:serviceaccount:${NAME}:${NAME}"

--- a/hack/istio/install-runtimes-demo.sh
+++ b/hack/istio/install-runtimes-demo.sh
@@ -34,6 +34,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAME}:default"
 - "system:serviceaccount:${NAME}:${NAME}"

--- a/hack/istio/install-scale-mesh-demo.sh
+++ b/hack/istio/install-scale-mesh-demo.sh
@@ -36,6 +36,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAME}:default"
 - "system:serviceaccount:${NAME}:${NAME}"

--- a/hack/istio/install-service-spawner-demo.sh
+++ b/hack/istio/install-service-spawner-demo.sh
@@ -35,6 +35,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAME}:default"
 - "system:serviceaccount:${NAME}:${NAME}"

--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -120,6 +120,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:sleep:default"
 - "system:serviceaccount:sleep:sleep"

--- a/hack/istio/install-topology-generator-demo.sh
+++ b/hack/istio/install-topology-generator-demo.sh
@@ -38,6 +38,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAME}:default"
 - "system:serviceaccount:${NAME}:${NAME}"

--- a/hack/istio/install-travel-agency-demo.sh
+++ b/hack/istio/install-travel-agency-demo.sh
@@ -189,6 +189,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:${NAMESPACE_AGENCY}:default"
 - "system:serviceaccount:${NAMESPACE_PORTAL}:default"

--- a/hack/perf-ibmcloud-openshift.sh
+++ b/hack/perf-ibmcloud-openshift.sh
@@ -185,6 +185,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 - "system:serviceaccount:prometheus:prometheus-alertmanager"
 - "system:serviceaccount:prometheus:prometheus-kube-state-metrics"
@@ -352,6 +353,7 @@ seLinuxContext:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
+priority: 9
 users:
 ${SCC_SERVICE_ACCOUNTS}
 SCC


### PR DESCRIPTION
https://docs.openshift.com/container-platform/4.13/authentication/managing-security-context-constraints.html#scc-prioritization_configuring-internal-oauth

The SCC created by the script didn't have a priority, so it defaults to 0, which is the same as all the other restrictive sccs that come out of box. So...

```
If the priorities are equal, the SCCs are sorted from most restrictive to least restrictive.
```