### PR TITLE
New hack script for tempo

### DIFF
--- a/hack/istio/tempo/install-tempo-env.sh
+++ b/hack/istio/tempo/install-tempo-env.sh
@@ -145,7 +145,7 @@ EOF
   if [ "${INSTALL_KIALI}" == "true" ]; then
     OUTPUT_DIR="${OUTPUT_DIR:-${SCRIPT_DIR}/../../../_output}"
     ISTIO_DIR=$(ls -dt1 ${OUTPUT_DIR}/istio-* | head -n1)
-    echo ${ISTIO_DIR}
+    echo "Istio directory where the Kiali addon yaml should be found: ${ISTIO_DIR}"
     ${CLIENT_EXE} apply -f ${ISTIO_DIR}/samples/addons/kiali.yaml
   fi
 

--- a/hack/istio/tempo/install-tempo-env.sh
+++ b/hack/istio/tempo/install-tempo-env.sh
@@ -135,7 +135,7 @@ spec:
 EOF
 
 
-  echo "${SCRIPT_DIR}"
+  echo "Script Directory: ${SCRIPT_DIR}"
 
   if [ "${INSTALL_ISTIO}" == "true" ]; then
     echo -e "Installing istio \n"

--- a/hack/istio/tempo/install-tempo-env.sh
+++ b/hack/istio/tempo/install-tempo-env.sh
@@ -142,7 +142,7 @@ EOF
     ${SCRIPT_DIR}/../install-istio-via-istioctl.sh -c ${CLIENT_EXE} -a "prometheus grafana" -s values.meshConfig.defaultConfig.tracing.zipkin.address="tempo-smm-distributor.tempo:9411"
   fi
 
-  if [ "${INSTALL_ISTIO}" == "true" ]; then
+  if [ "${INSTALL_KIALI}" == "true" ]; then
     OUTPUT_DIR="${OUTPUT_DIR:-${SCRIPT_DIR}/../../../_output}"
     ISTIO_DIR=$(ls -dt1 ${OUTPUT_DIR}/istio-* | head -n1)
     echo ${ISTIO_DIR}

--- a/hack/istio/tempo/install-tempo-env.sh
+++ b/hack/istio/tempo/install-tempo-env.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+##############################################################################
+# install-tempo-env
+#
+# Installs the Tempo environment using the Tempo operator.
+#
+# See --help for more details on options to this script.
+#
+##############################################################################
+
+CLIENT_EXE="kubectl"
+DELETE_ALL="false"
+DELETE_TEMPO="false"
+INSTALL_BOOKINFO="true"
+INSTALL_ISTIO="true"
+INSTALL_KIALI="true"
+TEMPO_NS="tempo"
+
+# process command line args
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -c|--client)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -da|--delete-all)
+      DELETE_ALL="$2"
+      shift;shift
+      ;;
+    -dt|--delete-tempo)
+      DELETE_TEMPO="$2"
+      shift;shift
+      ;;
+    -ib|--install-bookinfo)
+      INSTALL_BOOKINFO="$2"
+      shift;shift
+      ;;
+    -ii|--install-istio)
+      INSTALL_ISTIO="$2"
+      shift;shift
+      ;;
+    -t|--tempo-ns)
+      TEMPO_NS="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -c|--client:
+       client exe. Just kubectl is supported at the moment.
+  -da|--delete-all:
+       Delete tempo and all the components installed (Including Istio, Kiali & bookinfo).
+  -dt|--delete-tempo:
+       Delete tempo, tempo operator and cert manager.
+  -ib|--install-bookinfo:
+       If bookinfo should be installed. true by default.
+  -ii|--install-istio:
+       If istio should be installed. true by default.
+  -t|--tempo-ns:
+       Tempo namespace. Tempo by default.
+  -h|--help:
+       this message
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "ERROR: Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+if [ "${DELETE_ALL}" == "true" ]; then
+  DELETE_TEMPO="true"
+fi
+
+if [ "${DELETE_TEMPO}" == "true" ]; then
+  echo -e "Deleting tempo \n"
+  ${CLIENT_EXE} delete -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+  ${CLIENT_EXE} delete -f https://github.com/grafana/tempo-operator/releases/latest/download/tempo-operator.yaml
+  ${CLIENT_EXE} delete secret -n ${TEMPO_NS} tempostack-dev-minio
+  ${CLIENT_EXE} delete TempoStack smm -n ${TEMPO_NS}
+  ${CLIENT_EXE} delete ns ${TEMPO_NS}
+  if [ "${DELETE_ALL}" == "true" ]; then
+    ${SCRIPT_DIR}/../install-istio-via-istioctl.sh -c ${CLIENT_EXE} -di true
+    ${SCRIPT_DIR}/../install-bookinfo-demo.sh -c ${CLIENT_EXE} -db true
+  fi
+else
+  echo -e "Installing cert manager...\n"
+  ${CLIENT_EXE} apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+  echo -e "Waiting for cert-manager pods to be ready... \n"
+  $CLIENT_EXE wait pods --all -n cert-manager --for=condition=Ready --timeout=5m
+
+  echo -e "Installing latest Tempo operator \n"
+  ${CLIENT_EXE} apply -f https://github.com/grafana/tempo-operator/releases/latest/download/tempo-operator.yaml
+  echo -e "Waiting for Tempo operator to be ready... \n"
+  $CLIENT_EXE wait pods --all -n tempo-operator-system --for=condition=Ready --timeout=5m
+
+  ${CLIENT_EXE} create namespace ${TEMPO_NS}
+
+  echo -e "Installing minio and create secret \n"
+  ${CLIENT_EXE} apply --namespace ${TEMPO_NS} -f ${SCRIPT_DIR}/minio.yaml
+
+  ${CLIENT_EXE} create secret generic -n ${TEMPO_NS} tempostack-dev-minio \
+    --from-literal=bucket="tempo-data" \
+    --from-literal=endpoint="http://minio:9000" \
+    --from-literal=access_key_id="minio" \
+    --from-literal=access_key_secret="minio123"
+
+  echo -e "Installing tempo \n"
+  ${CLIENT_EXE} apply -n ${TEMPO_NS} -f - <<EOF
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoStack
+metadata:
+  name: smm
+spec:
+  storageSize: 1Gi
+  storage:
+    secret:
+      type: s3
+      name: tempostack-dev-minio
+  resources:
+    total:
+      limits:
+        memory: 2Gi
+        cpu: 2000m
+  template:
+    queryFrontend:
+      jaegerQuery:
+        enabled: false
+EOF
+
+
+  echo "${SCRIPT_DIR}"
+
+  if [ "${INSTALL_ISTIO}" == "true" ]; then
+    echo -e "Installing istio \n"
+    ${SCRIPT_DIR}/../install-istio-via-istioctl.sh -c ${CLIENT_EXE} -a "prometheus grafana" -s values.meshConfig.defaultConfig.tracing.zipkin.address="tempo-smm-distributor.tempo:9411"
+  fi
+
+  if [ "${INSTALL_ISTIO}" == "true" ]; then
+    OUTPUT_DIR="${OUTPUT_DIR:-${SCRIPT_DIR}/../../../_output}"
+    ISTIO_DIR=$(ls -dt1 ${OUTPUT_DIR}/istio-* | head -n1)
+    echo ${ISTIO_DIR}
+    ${CLIENT_EXE} apply -f ${ISTIO_DIR}/samples/addons/kiali.yaml
+  fi
+
+  if [ "${INSTALL_BOOKINFO}" == "true" ]; then
+    echo -e "Installing bookinfo \n"
+    ${SCRIPT_DIR}/../install-bookinfo-demo.sh -c ${CLIENT_EXE} -tg
+  fi
+
+  echo -e "Installation finished. You can port forward the services with: \n"
+  echo "./run-kiali.sh -pg 13000:3000 -pp 19090:9090 -pt 3200:3200 -app 8080 -es false -iu http://127.0.0.1:15014 -tr tempo-smm-query-frontend -ts tempo-smm-query-frontend -tn tempo"
+
+fi

--- a/hack/istio/tempo/install-tempo-env.sh
+++ b/hack/istio/tempo/install-tempo-env.sh
@@ -41,6 +41,10 @@ while [[ $# -gt 0 ]]; do
       INSTALL_ISTIO="$2"
       shift;shift
       ;;
+    -ik|--install-kiali)
+      INSTALL_KIALI="$2"
+      shift;shift
+      ;;
     -t|--tempo-ns)
       TEMPO_NS="$2"
       shift;shift
@@ -58,6 +62,8 @@ Valid command line arguments:
        If bookinfo should be installed. true by default.
   -ii|--install-istio:
        If istio should be installed. true by default.
+  -ik|--install-kiali:
+       If Kiali should be installed. true by default.
   -t|--tempo-ns:
        Tempo namespace. Tempo by default.
   -h|--help:
@@ -83,7 +89,7 @@ if [ "${DELETE_TEMPO}" == "true" ]; then
   ${CLIENT_EXE} delete -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
   ${CLIENT_EXE} delete -f https://github.com/grafana/tempo-operator/releases/latest/download/tempo-operator.yaml
   ${CLIENT_EXE} delete secret -n ${TEMPO_NS} tempostack-dev-minio
-  ${CLIENT_EXE} delete TempoStack smm -n ${TEMPO_NS}
+  ${CLIENT_EXE} delete TempoStack cr -n ${TEMPO_NS}
   ${CLIENT_EXE} delete ns ${TEMPO_NS}
   if [ "${DELETE_ALL}" == "true" ]; then
     ${SCRIPT_DIR}/../install-istio-via-istioctl.sh -c ${CLIENT_EXE} -di true
@@ -116,7 +122,7 @@ else
 apiVersion: tempo.grafana.com/v1alpha1
 kind: TempoStack
 metadata:
-  name: smm
+  name: cr
 spec:
   storageSize: 1Gi
   storage:
@@ -139,7 +145,7 @@ EOF
 
   if [ "${INSTALL_ISTIO}" == "true" ]; then
     echo -e "Installing istio \n"
-    ${SCRIPT_DIR}/../install-istio-via-istioctl.sh -c ${CLIENT_EXE} -a "prometheus grafana" -s values.meshConfig.defaultConfig.tracing.zipkin.address="tempo-smm-distributor.tempo:9411"
+    ${SCRIPT_DIR}/../install-istio-via-istioctl.sh -c ${CLIENT_EXE} -a "prometheus grafana" -s values.meshConfig.defaultConfig.tracing.zipkin.address="tempo-cr-distributor.tempo:9411"
   fi
 
   if [ "${INSTALL_KIALI}" == "true" ]; then
@@ -155,6 +161,6 @@ EOF
   fi
 
   echo -e "Installation finished. You can port forward the services with: \n"
-  echo "./run-kiali.sh -pg 13000:3000 -pp 19090:9090 -pt 3200:3200 -app 8080 -es false -iu http://127.0.0.1:15014 -tr tempo-smm-query-frontend -ts tempo-smm-query-frontend -tn tempo"
+  echo "./run-kiali.sh -pg 13000:3000 -pp 19090:9090 -pt 3200:3200 -app 8080 -es false -iu http://127.0.0.1:15014 -tr tempo-cr-query-frontend -ts tempo-cr-query-frontend -tn tempo"
 
 fi

--- a/hack/istio/tempo/minio.yaml
+++ b/hack/istio/tempo/minio.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # This name uniquely identifies the PVC. Will be used in deployment below.
+  name: minio-pv-claim
+  labels:
+    app: minio-storage-claim
+spec:
+  # Read more about access modes here: http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    # This is the request for storage. Should be available in the cluster.
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # Label is used as selector in the service.
+        app: minio
+    spec:
+      # Refer to the PVC created earlier
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            # Name of the PVC created earlier
+            claimName: minio-pv-claim
+      initContainers:
+        - name: create-buckets
+          image: busybox:1.28
+          command:
+            - "sh"
+            - "-c"
+            - "mkdir -p /storage/tempo-data"
+          volumeMounts:
+            - name: storage # must match the volume name, above
+              mountPath: "/storage"
+      containers:
+        - name: minio
+          # Pulls the default Minio image from Docker Hub
+          image: minio/minio:latest
+          args:
+            - server
+            - /storage
+            - --console-address
+            - ":9001"
+          env:
+            # Minio access key and secret key
+            - name: MINIO_ACCESS_KEY
+              value: "minio"
+            - name: MINIO_SECRET_KEY
+              value: "minio123"
+          ports:
+            - containerPort: 9000
+            - containerPort: 9001
+          volumeMounts:
+            - name: storage # must match the volume name, above
+              mountPath: "/storage"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      name: api
+    - port: 9001
+      targetPort: 9001
+      protocol: TCP
+      name: console
+  selector:
+    app: minio

--- a/hack/istio/tempo/minio.yaml
+++ b/hack/istio/tempo/minio.yaml
@@ -12,7 +12,7 @@ spec:
   resources:
     # This is the request for storage. Should be available in the cluster.
     requests:
-      storage: 5Gi
+      storage: 1Gi
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/hack/istio/tempo/minio.yaml
+++ b/hack/istio/tempo/minio.yaml
@@ -12,7 +12,7 @@ spec:
   resources:
     # This is the request for storage. Should be available in the cluster.
     requests:
-      storage: 1Gi
+      storage: 256Mi
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Fixes #6592 

Grafana Tempo docs: https://grafana.com/docs/tempo/latest/setup/operator/ 

`kiali/hack$ istio/tempo/install-tempo-env.sh `

The script will install:

- tempo namespace with cert manager (required for tempo operator), the tempo operator, minio, tempoStack resource, istio (Optional), kiali (optional) and bookinfo demo (optional). 

Can be tested validating that all the tempo resources are running: 
`kubectl get all -n tempo`

```
deployment.apps/minio                 
deployment.apps/tempo-smm-compactor  
deployment.apps/tempo-smm-distributor      
deployment.apps/tempo-smm-querier        
deployment.apps/tempo-smm-query-frontend
```

To test with Kiali, there is needed another PR with the tempo integration: https://github.com/kiali/kiali/pull/6518

Kiali config: 

```
  tracing:
    enabled: true
    provider: "otel"
    in_cluster_url: http://localhost:3200
    url: http://localhost:3200
```