### PR TITLE
[ci test] wait for the operator deployment to be created

### DIFF
--- a/hack/ci-kind-molecule-tests.sh
+++ b/hack/ci-kind-molecule-tests.sh
@@ -479,6 +479,10 @@ if [ "${OLM_ENABLED}" == "true" ]; then
   infomsg "Waiting for Kiali CRD to be established."
   ${CLIENT_EXE} wait --for condition=established --timeout=300s crd kialis.kiali.io
 
+  infomsg -n "Waiting for operator to be created."
+  timeout 1h bash -c 'until [ -n "$(${CLIENT_EXE} get --namespace operators -o name deployments)" ]; do echo -n "." ; sleep 2; done'
+  infomsg
+
   infomsg "Waiting for deployments to start up in the operators namespace."
   ${CLIENT_EXE} wait --for condition=available --timeout=300s --all --namespace operators deployments
 


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/6567

This is what the output should look like now:
```
...
[INFO] OLM v0.25.0 is installed.
[INFO] Installing Kiali Operator via OLM
subscription.operators.coreos.com/my-kiali created
[INFO] Waiting for Kiali CRD to be created...............
[INFO] Waiting for Kiali CRD to be established.
customresourcedefinition.apiextensions.k8s.io/kialis.kiali.io condition met
[INFO] Waiting for operator to be created.
[INFO] Waiting for deployments to start up in the operators namespace.
deployment.apps/kiali-operator condition met
[INFO] Configuring the Kiali operator to allow ad hoc images, ad hoc namespaces, and changes to security context.
[INFO] Kiali operator namespace: [operators]
...
```