### PR TITLE
Use Kiali instance url info to create 'Edit in Kiali' link (kiosk mode)

### DIFF
--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -108,9 +108,14 @@ export class IstioConfigOverview extends React.Component<IstioConfigOverviewProp
 
     let urlInKiali = '';
     if (istioObject !== undefined && istioObject.metadata.namespace !== undefined && istioObject.kind !== undefined) {
-      // here a "/console" is required as external link is used
+      const clusterInfo = serverConfig.clusters[this.props.cluster ?? homeCluster?.name ?? CLUSTER_DEFAULT];
+      const kialiInstance = clusterInfo?.kialiInstances?.find(instance => instance.url.length !== 0);
+
+      // Set the kiali url from kialiInstance info (here a "/console" is required as external link is used)
+      const kialiUrl = `${kialiInstance?.url ?? ''}/console`;
+
       urlInKiali =
-        '/console' +
+        kialiUrl +
         GetIstioObjectUrl(
           istioObject.metadata.name,
           istioObject.metadata.namespace,

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -25,7 +25,8 @@ import { IstioStatusMessageList } from './IstioStatusMessageList';
 import { KioskElement } from '../../../components/Kiosk/KioskElement';
 import { PFColors } from '../../../components/Pf/PfColors';
 import { GetIstioObjectUrl } from '../../../components/Link/IstioObjectLink';
-import { homeCluster, isMultiCluster } from '../../../config';
+import { homeCluster, isMultiCluster, serverConfig } from '../../../config';
+import { CLUSTER_DEFAULT } from 'types/Graph';
 
 interface IstioConfigOverviewProps {
   istioObjectDetails: IstioConfigDetails;


### PR DESCRIPTION
**Describe the change**

Absolute url is defined in 'Edit in Kiali' link to support those use cases where Kiali instance is not hosted at the same path that kiosk mode Kiali frontend (e.g. OSSMC).

**Issue reference**

Fixes #6593.

**PR Testing**

1. Go to any Istio Config page and select any object to see YAML editor.
2. Add `?kiosk=true` to URL to activate kiosk mode
3. Click on 'Edit in Kiali' link to check that it redirects to the Kiali instance.

![image](https://github.com/kiali/kiali/assets/122779323/496a6a48-cd4d-4e97-8ff1-13b725475f4c)
