### PR TITLE
Make Multicluster CI use snapshot version and not release version

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -146,6 +146,7 @@ EOF
   # but they don't need to be accessible outside the cluster.
   # Need a single dashboard set for grafana.
   ${HELM} install \
+    --debug \
     --namespace istio-system \
     --wait \
     --set auth.strategy="${AUTH_STRATEGY}" \
@@ -174,6 +175,10 @@ setup_kind_multicluster() {
   infomsg "Downloading istio"
   hack/istio/download-istio.sh ${DOWNLOAD_ISTIO_VERSION_ARG}
 
+  infomsg "Cloning kiali helm-charts..."
+  git clone --single-branch --branch "${TARGET_BRANCH}" https://github.com/kiali/helm-charts.git "${HELM_CHARTS_DIR}"
+  make -C "${HELM_CHARTS_DIR}" build-helm-charts
+
   infomsg "Kind cluster to be created with name [ci]"
   local script_dir 
   script_dir="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
@@ -183,7 +188,7 @@ setup_kind_multicluster() {
   local istio_dir
   istio_dir=$(ls -dt1 ${output_dir}/istio-* | head -n1)
   hack/istio/multicluster/install-primary-remote.sh --manage-kind true -dorp docker --istio-dir "${istio_dir}"
-  hack/istio/multicluster/deploy-kiali.sh --manage-kind true -dorp docker -kas anonymous
+  hack/istio/multicluster/deploy-kiali.sh --manage-kind true -dorp docker -kas anonymous -kudi true -kshc "${HELM_CHARTS_DIR}"/_output/charts/kiali-server-*.tgz
 }
 
 if [ "${MULTICLUSTER}" == "true" ]; then

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -146,7 +146,6 @@ EOF
   # but they don't need to be accessible outside the cluster.
   # Need a single dashboard set for grafana.
   ${HELM} install \
-    --debug \
     --namespace istio-system \
     --wait \
     --set auth.strategy="${AUTH_STRATEGY}" \


### PR DESCRIPTION
Related to #6547.

To test this:
- build Kiali locally 
- run the `./hack/run-integration-tests.sh --test-suite frontend-multi-cluster -so true` command
- open the Kiali page and check that it uses SNAPSHOT version and not release