### PR TITLE
Make the scrollbar in RenderComponentScroll optional

### DIFF
--- a/frontend/src/components/IstioConfigPreview/EditorPreview.tsx
+++ b/frontend/src/components/IstioConfigPreview/EditorPreview.tsx
@@ -72,7 +72,7 @@ export class EditorPreviewComponent extends React.Component<Props, State> {
         mode="yaml"
         theme={this.props.theme === Theme.DARK ? 'twilight' : 'eclipse'}
         onChange={value => this.onChange(value)}
-        height={'275px  '}
+        height={'275px'}
         width={'100%'}
         className={istioAceEditorStyle}
         wrapEnabled={true}

--- a/frontend/src/components/Kiosk/KioskActions.ts
+++ b/frontend/src/components/Kiosk/KioskActions.ts
@@ -90,7 +90,7 @@ export const isParentKiosk = (kiosk: string): boolean => {
 // Message has no format, parent should parse it for its needs
 const sendParentMessage = (msg: string): void => {
   // Kiosk parameter will capture the parent target when kiosk !== "true"
-  // this will enable iframe -> parent communication
+  // this will enable parent communication
   const targetOrigin = store.getState().globalState.kiosk;
   window.top?.postMessage(msg, targetOrigin);
 };

--- a/frontend/src/components/Nav/Page/RenderComponentScroll.tsx
+++ b/frontend/src/components/Nav/Page/RenderComponentScroll.tsx
@@ -15,9 +15,9 @@ const EMBEDDED_PADDING = 42;
  * By default, Kiali hides the global scrollbar and fixes the height for some pages to force the scrollbar to appear
  * Hiding global scrollbar is not possible when Kiali is embedded in other application (like Openshift Console)
  * In these cases height is not fixed to avoid multiple scrollbars (https://github.com/kiali/kiali/issues/6601)
- * This environment variable is not defined in standalone Kiali application (default value is true)
+ * GLOBAL_SCROLLBAR environment variable is not defined in standalone Kiali application (value is always false)
  */
-const renderScrollbar = process.env.RENDER_SCROLLBAR ?? 'true';
+const globalScrollbar = process.env.GLOBAL_SCROLLBAR ?? 'false';
 
 const componentStyle = kialiStyle({
   padding: '20px'
@@ -65,7 +65,8 @@ export class RenderComponentScroll extends React.Component<Props, State> {
   render() {
     let scrollStyle = {};
 
-    if (renderScrollbar === 'true') {
+    // If there is no global scrollbar, height is fixed to force the scrollbar to appear in the component
+    if (globalScrollbar === 'false') {
       scrollStyle = { height: this.state.height, overflowY: 'auto' };
     }
 

--- a/frontend/src/components/Nav/Page/RenderComponentScroll.tsx
+++ b/frontend/src/components/Nav/Page/RenderComponentScroll.tsx
@@ -1,13 +1,27 @@
 import React from 'react';
+import { kialiStyle } from 'styles/StyleUtils';
+import { classes } from 'typestyle';
 import { store } from '../../../store/ConfigStore';
 import { isKiosk } from '../../Kiosk/KioskActions';
 
 // TOP_PADDING constant is used to adjust the height of the main div to allow scrolling in the inner container layer.
-export const TOP_PADDING = 76 + 118;
+const TOP_PADDING = 76 + 118;
 
 // EMBEDDED_PADDING constant is a magic number used to adjust the height of the main div to allow scrolling in the inner container layer.
-// 42px is the height of the first tab menu used in iframe scenarios, this will likelely be adjusted in the future
-export const EMBEDDED_PADDING = 42;
+// 42px is the height of the first tab menu
+const EMBEDDED_PADDING = 42;
+
+/**
+ * By default, Kiali hides the global scrollbar and fixes the height for some pages to force the scrollbar to appear
+ * Hiding global scrollbar is not possible when Kiali is embedded in other application (like Openshift Console)
+ * In these cases height is not fixed to avoid multiple scrollbars (https://github.com/kiali/kiali/issues/6601)
+ * This environment variable is not defined in standalone Kiali application (default value is true)
+ */
+const renderScrollbar = process.env.RENDER_SCROLLBAR ?? 'true';
+
+const componentStyle = kialiStyle({
+  padding: '20px'
+});
 
 interface Props {
   className?: any;
@@ -49,8 +63,14 @@ export class RenderComponentScroll extends React.Component<Props, State> {
   };
 
   render() {
+    let scrollStyle = {};
+
+    if (renderScrollbar === 'true') {
+      scrollStyle = { height: this.state.height, overflowY: 'auto' };
+    }
+
     return (
-      <div style={{ height: this.state.height, overflowY: 'auto', padding: '20px' }} className={this.props.className}>
+      <div style={scrollStyle} className={classes(componentStyle, this.props.className)}>
         {this.props.children}
       </div>
     );

--- a/frontend/src/components/Nav/RenderPage.tsx
+++ b/frontend/src/components/Nav/RenderPage.tsx
@@ -17,7 +17,7 @@ import { KialiIcon } from 'config/KialiIcon';
 
 const containerStyle = kialiStyle({ marginLeft: 0, marginRight: 0 });
 const containerPadding = kialiStyle({ padding: '0 20px 0 20px' });
-const containerGray = kialiStyle({ background: PFColors.BackgroundColor200 });
+const containerGray = kialiStyle({ background: PFColors.BackgroundColor200, height: '100%' });
 const containerError = kialiStyle({ height: 'calc(100vh - 76px)' });
 
 export class RenderPage extends React.Component<{ isGraph: boolean }> {

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -511,7 +511,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
           mode="yaml"
           theme={this.props.theme === Theme.DARK ? 'twilight' : 'eclipse'}
           onChange={this.onEditorChange}
-          height={`calc(var(--kiali-yaml-editor-height) + ${isParentKiosk(this.props.kiosk) ? '100px' : '0px'})`}
+          height={`calc(var(--kiali-yaml-editor-height)`}
           width={'100%'}
           className={istioAceEditorStyle}
           wrapEnabled={true}

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -50,7 +50,6 @@ import moment from 'moment';
 import { formatDuration } from 'utils/tracing/TracingHelper';
 import { infoStyle } from 'styles/DropdownStyles';
 import { isValid } from 'utils/Common';
-import { isKiosk } from '../../components/Kiosk/KioskActions';
 import { KioskElement } from '../../components/Kiosk/KioskElement';
 import { TimeDurationModal } from '../../components/Time/TimeDurationModal';
 import { TimeDurationIndicator } from '../../components/Time/TimeDurationIndicator';
@@ -61,7 +60,6 @@ const proxyContainerColor = PFColors.Gold400;
 const spanColor = PFColors.Cyan300;
 
 type ReduxProps = {
-  kiosk: string;
   timeRange: TimeRange;
 };
 
@@ -179,15 +177,13 @@ const toolbarInputStyle = kialiStyle({
 });
 
 const logsBackground = (enabled: boolean) => ({ backgroundColor: enabled ? PFColors.Black1000 : PFColors.Black500 });
-const logsHeight = (showToolbar: boolean, fullscreen: boolean, kiosk: string, showMaxLinesWarning: boolean) => {
+const logsHeight = (showToolbar: boolean, fullscreen: boolean, showMaxLinesWarning: boolean) => {
   const toolbarHeight = showToolbar ? '0px' : '49px';
   const maxLinesWarningHeight = showMaxLinesWarning ? '27px' : '0px';
   return {
     height: fullscreen
       ? `calc(100vh - 130px + ${toolbarHeight} - ${maxLinesWarningHeight})`
-      : `calc(var(--kiali-details-pages-tab-content-height) - ${
-          !isKiosk(kiosk) ? '155px' : '0px'
-        } + ${toolbarHeight} - ${maxLinesWarningHeight})`
+      : `calc(var(--kiali-details-pages-tab-content-height) - 155px + ${toolbarHeight} - ${maxLinesWarningHeight})`
   };
 };
 
@@ -298,7 +294,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
           {this.state.containerOptions && (
             <Grid key="logs" id="logs" style={{ height: '100%' }}>
               <GridItem span={12}>
-                <Card style={{ height: '100%' }}>
+                <Card>
                   <CardBody>
                     {this.state.showToolbar && (
                       <Toolbar style={{ padding: 0, width: '100%' }}>
@@ -697,7 +693,6 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
             ...logsHeight(
               this.state.showToolbar,
               this.state.fullscreen,
-              this.props.kiosk,
               this.state.linesTruncatedContainers.length > 0
             ),
             ...logsBackground(this.hasEntries(this.state.entries))
@@ -1087,7 +1082,6 @@ const formatDate = (timestamp: string): string => {
 
 const mapStateToProps = (state: KialiAppState) => {
   return {
-    kiosk: state.globalState.kiosk,
     timeRange: timeRangeSelector(state)
   };
 };

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -55,9 +55,7 @@ export interface Response<T> {
  * API Proxy defined by the platform is added before url request
  * This environment variable is not defined in standalone Kiali application
  */
-const getAPIProxy = (): string | null => {
-  return process.env.API_PROXY ?? null;
-};
+const apiProxy = process.env.API_PROXY ?? null;
 
 /** API URLs */
 
@@ -69,8 +67,8 @@ const loginHeaders = config.login.headers;
 
 /**  Helpers to Requests */
 
-const getHeaders = (proxyUrl: string | null) => {
-  if (proxyUrl) {
+const getHeaders = () => {
+  if (apiProxy) {
     return { 'Content-Type': 'application/x-www-form-urlencoded' };
   } else {
     return { ...loginHeaders };
@@ -78,8 +76,8 @@ const getHeaders = (proxyUrl: string | null) => {
 };
 
 /** Create content type correctly for a given request type */
-const getHeadersWithMethod = (method: HTTP_VERBS, proxyUrl: string | null) => {
-  let allHeaders = getHeaders(proxyUrl);
+const getHeadersWithMethod = (method: HTTP_VERBS) => {
+  let allHeaders = getHeaders();
   if (method === HTTP_VERBS.PATCH) {
     allHeaders['Content-Type'] = 'application/json';
   }
@@ -92,13 +90,11 @@ const basicAuth = (username: UserName, password: Password) => {
 };
 
 const newRequest = <P>(method: HTTP_VERBS, url: string, queryParams: any, data: any) => {
-  const proxyUrl = getAPIProxy();
-
   return axios.request<P>({
     method: method,
-    url: proxyUrl ? `${proxyUrl}/${url}` : url,
+    url: apiProxy ? `${apiProxy}/${url}` : url,
     data: data,
-    headers: getHeadersWithMethod(method, proxyUrl),
+    headers: getHeadersWithMethod(method),
     params: queryParams
   });
 };
@@ -120,12 +116,10 @@ export const login = async (
   const params = new URLSearchParams();
   params.append('token', request.token);
 
-  const proxyUrl = getAPIProxy();
-
   const axiosRequest = {
     method: HTTP_VERBS.POST,
-    url: proxyUrl ? `${proxyUrl}/${urls.authenticate}` : urls.authenticate,
-    headers: getHeaders(proxyUrl),
+    url: apiProxy ? `${apiProxy}/${urls.authenticate}` : urls.authenticate,
+    headers: getHeaders(),
     data: params
   };
 


### PR DESCRIPTION
**Describe the change**

By default, Kiali hides the global scrollbar (`overflow: hidden` in global style) and fixes the height for pages that use RenderComponentScroll to force the scrollbar to appear. The issues is that hiding the global scrollbar is not possible when Kiali is embedded in other application (like Openshift Console). For this reason an environment variable `RENDER_SCROLLBAR` has been added to make the scrollbar in RenderComponentScroll optional. When `RENDER_SCROLLBAR` is false, the height is not fixed and the component does not force a new scrollbar to appear (the user will use the global scrollbar in this case).

This environment variable is not defined in standalone Kiali application (the value is always true).

Besides, heights of some components have been adjusted in Kiosk mode to fit better in OSSMC withouth breaking the user experience in Kiosk mode:
- IstioConfigDetailsPage:
![image](https://github.com/kiali/kiali/assets/122779323/8b9d848c-74d8-4886-baf6-ebcbe7861597)

- WorkloadPodLogs: 
![image](https://github.com/kiali/kiali/assets/122779323/6eb603eb-e9b9-464f-9ad4-da4bf5077100)

**PR Testing**
This PR only affects to Kiali standalone in kiosk mode and OSSMC. Check that scrollbar works as expected in standalone application and the pages with heights adjusted look fine in kiosk mode.

**Issue reference**

Closes #6601 
