### PR TITLE
Failing gateway pod due to istioctl 1.19 update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -522,7 +522,7 @@ Follow these steps:
 3: Create a remote secret in the Control Plane, using the Data Plane ServiceAccount you just created. This allows the Control Plane to read from and modify the Data Plane
 [source,shell]
 ----
-istioctl x create-remote-secret --service-account kiali-service-account --context=$DataPlane --name kiali | kubectl apply -n istio-system --context=$ControlPlane -f -
+istioctl create-remote-secret --service-account kiali-service-account --context=$DataPlane --name kiali | kubectl apply -n istio-system --context=$ControlPlane -f -
 ----
 
 4: You will now run Kiali in the Control Plane. You need to add the remote secret to the Kiali Deployment by specifying a Volume and VolumeMount. When Kiali sees */kiali-remote-secret/kiali* it will use the remote cluster's API server instead of the local API server

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -100,7 +100,7 @@ if [ "${MANAGE_KIND}" == "true" ]; then
     CLUSTER2_CONTAINER_IP=$(${CLIENT_EXE} get nodes "${CLUSTER2_NAME}"-control-plane --context "${CLUSTER2_CONTEXT}" -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}')
     SERVER_FLAG="--server=https://${CLUSTER2_CONTAINER_IP}:6443"
 fi
-${ISTIOCTL} x create-remote-secret --context=${CLUSTER2_CONTEXT} --name=${CLUSTER2_NAME} ${SERVER_FLAG} | ${CLIENT_EXE} apply -f - --context="${CLUSTER1_CONTEXT}"
+${ISTIOCTL} create-remote-secret --context=${CLUSTER2_CONTEXT} --name=${CLUSTER2_NAME} ${SERVER_FLAG} | ${CLIENT_EXE} apply -f - --context="${CLUSTER1_CONTEXT}"
 
 ${GEN_GATEWAY_SCRIPT} --mesh ${MESH_ID} --cluster ${CLUSTER2_NAME} --network ${NETWORK2_ID} | ${ISTIOCTL} --context=${CLUSTER2_CONTEXT} install -y -f -
 


### PR DESCRIPTION
Partially fixes #6606.

According to the [Istio 1.19 change notes](https://istio.io/latest/news/releases/1.19.x/announcing-1.19/change-notes/#istioctl), `remote_clusters` and `create-remote-secret` subcommands were moved out of the experimental section. 

Situation before: https://github.com/kiali/kiali/actions/runs/6164572810/job/16730830468?pr=6605#step:8:423

Situation now: 
![image](https://github.com/kiali/kiali/assets/45061792/d629793e-abf3-40d3-83cc-0e02b8616140)
 