### PR TITLE
Include Ambient annotations in the config

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1770,7 +1770,7 @@ func (in *WorkloadService) getWaypointForWorkload(ctx context.Context, namespace
 	var workloadslist []models.Workload
 	// Get service Account name for each pod from the workload
 	for _, wk := range wlist {
-		if wk.Labels[models.WaypointLabel] == "istio.io-mesh-controller" {
+		if wk.Labels[config.WaypointLabel] == "istio.io-mesh-controller" {
 			for _, pod := range wk.Pods {
 				if pod.Labels["istio.io/gateway-name"] == "namespace" {
 					workloadslist = append(workloadslist, *wk)
@@ -1803,7 +1803,7 @@ func (in *WorkloadService) listWaypointWorkloadsForSA(ctx context.Context, names
 	var workloadslist []models.Workload
 	// Get service Account name for each pod from the workload
 	for _, workload := range wlist {
-		if workload.Labels[models.WaypointLabel] != "istio.io-mesh-controller" {
+		if workload.Labels[config.WaypointLabel] != "istio.io-mesh-controller" {
 			for _, pod := range workload.Pods {
 				if pod.ServiceAccountName == sa {
 					workloadslist = append(workloadslist, *workload)
@@ -1826,7 +1826,7 @@ func (in *WorkloadService) listWaypointWorkloadsForNamespace(ctx context.Context
 	var workloadslist []models.Workload
 	// Get service Account name for each pod from the workload
 	for _, workload := range wlist {
-		if workload.Labels[models.WaypointLabel] != "istio.io-mesh-controller" {
+		if workload.Labels[config.WaypointLabel] != "istio.io-mesh-controller" {
 			workloadslist = append(workloadslist, *workload)
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -284,8 +284,8 @@ func (lt *LoginToken) Obfuscate() {
 
 // IstioLabels holds configuration about the labels required by Istio
 type IstioLabels struct {
-	AmbientNamespaceLabel      string `yaml:"ambient_namespace_label,omitempty" json:"appLabelName"`
-	AmbientNamespaceLabelValue string `yaml:"ambient_namespace_label_value,omitempty" json:"appLabelName"`
+	AmbientNamespaceLabel      string `yaml:"ambient_namespace_label,omitempty" json:"ambientNamespaceLabel"`
+	AmbientNamespaceLabelValue string `yaml:"ambient_namespace_label_value,omitempty" json:"ambientNamespaceLabelValue"`
 	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
 	InjectionLabelName         string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,13 @@ const (
 	DefaultClusterID = "Kubernetes"
 )
 
+const (
+	AmbientAnnotation        = "ambient.istio.io/redirection"
+	AmbientAnnotationEnabled = "enabled"
+	WaypointLabel            = "gateway.istio.io/managed"
+	WaypointLabelValue       = "istio.io-mesh-controller"
+)
+
 // FeatureName is the enum type used for named features that can be disabled via KialiFeatureFlags.DisabledFeatures
 type FeatureName string
 
@@ -286,6 +293,8 @@ func (lt *LoginToken) Obfuscate() {
 type IstioLabels struct {
 	AmbientNamespaceLabel      string `yaml:"ambient_namespace_label,omitempty" json:"ambientNamespaceLabel"`
 	AmbientNamespaceLabelValue string `yaml:"ambient_namespace_label_value,omitempty" json:"ambientNamespaceLabelValue"`
+	AmbientWaypointLabel       string `yaml:"ambient_waypoint_label,omitempty" json:"ambientWaypointLabel"`
+	AmbientWaypointLabelValue  string `yaml:"ambient_waypoint_label_value,omitempty" json:"ambientWaypointLabelValue"`
 	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
 	InjectionLabelName         string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
@@ -676,6 +685,8 @@ func NewConfig() (c *Config) {
 		IstioLabels: IstioLabels{
 			AmbientNamespaceLabel:      "istio.io/dataplane-mode",
 			AmbientNamespaceLabelValue: "ambient",
+			AmbientWaypointLabel:       WaypointLabel,
+			AmbientWaypointLabelValue:  WaypointLabelValue,
 			AppLabelName:               "app",
 			InjectionLabelName:         "istio-injection",
 			InjectionLabelRev:          "istio.io/rev",

--- a/config/config.go
+++ b/config/config.go
@@ -291,10 +291,10 @@ func (lt *LoginToken) Obfuscate() {
 
 // IstioLabels holds configuration about the labels required by Istio
 type IstioLabels struct {
-	AmbientNamespaceLabel      string `yaml:"ambient_namespace_label,omitempty" json:"ambientNamespaceLabel"`
-	AmbientNamespaceLabelValue string `yaml:"ambient_namespace_label_value,omitempty" json:"ambientNamespaceLabelValue"`
-	AmbientWaypointLabel       string `yaml:"ambient_waypoint_label,omitempty" json:"ambientWaypointLabel"`
-	AmbientWaypointLabelValue  string `yaml:"ambient_waypoint_label_value,omitempty" json:"ambientWaypointLabelValue"`
+	AmbientNamespaceLabel      string
+	AmbientNamespaceLabelValue string
+	AmbientWaypointLabel       string
+	AmbientWaypointLabelValue  string
 	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
 	InjectionLabelName         string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`

--- a/config/config.go
+++ b/config/config.go
@@ -284,10 +284,12 @@ func (lt *LoginToken) Obfuscate() {
 
 // IstioLabels holds configuration about the labels required by Istio
 type IstioLabels struct {
-	AppLabelName       string `yaml:"app_label_name,omitempty" json:"appLabelName"`
-	InjectionLabelName string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
-	InjectionLabelRev  string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
-	VersionLabelName   string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
+	AmbientNamespaceLabel      string `yaml:"ambient_namespace_label,omitempty" json:"appLabelName"`
+	AmbientNamespaceLabelValue string `yaml:"ambient_namespace_label_value,omitempty" json:"appLabelName"`
+	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
+	InjectionLabelName         string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
+	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
+	VersionLabelName           string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
 // AdditionalDisplayItem holds some display-related configuration, like which annotations are to be displayed
@@ -672,10 +674,12 @@ func NewConfig() (c *Config) {
 			},
 		},
 		IstioLabels: IstioLabels{
-			AppLabelName:       "app",
-			InjectionLabelName: "istio-injection",
-			InjectionLabelRev:  "istio.io/rev",
-			VersionLabelName:   "version",
+			AmbientNamespaceLabel:      "istio.io/dataplane-mode",
+			AmbientNamespaceLabelValue: "ambient",
+			AppLabelName:               "app",
+			InjectionLabelName:         "istio-injection",
+			InjectionLabelRev:          "istio.io/rev",
+			VersionLabelName:           "version",
 		},
 		KialiFeatureFlags: KialiFeatureFlags{
 			CertificatesInformationIndicators: CertificatesInformationIndicators{

--- a/frontend/src/components/Ambient/AmbientBadge.tsx
+++ b/frontend/src/components/Ambient/AmbientBadge.tsx
@@ -23,16 +23,6 @@ export class AmbientBadge extends React.Component<AmbientLabelProps, {}> {
         <Label style={{ marginLeft: 5 }} color="blue" isCompact>
           Ambient
         </Label>
-        {!this.props.tooltip && (
-          <span style={{ marginLeft: '8px' }}>
-            {this.props.tooltip}
-            <Tooltip key={`tooltip_ambient_label`} position={TooltipPosition.top} content={tooltipContent}>
-              <Label style={{ marginLeft: 5 }} color="blue" isCompact>
-                Ambient
-              </Label>
-            </Tooltip>
-          </span>
-        )}
       </span>
     );
     return (

--- a/frontend/src/components/Ambient/AmbientBadge.tsx
+++ b/frontend/src/components/Ambient/AmbientBadge.tsx
@@ -4,11 +4,12 @@ import { Label, Tooltip, TooltipPosition } from '@patternfly/react-core';
 type AmbientLabelProps = {
   tooltip: boolean;
   style?: React.CSSProperties;
+  message?: string;
 };
 
 export class AmbientBadge extends React.Component<AmbientLabelProps, {}> {
   render() {
-    const msg = 'Istio Ambient profile is detected.';
+    const msg = this.props.message ? this.props.message : 'Istio Ambient ztunnel detected in the Control plane';
 
     const tooltipContent = (
       <div style={{ textAlign: 'left' }}>

--- a/frontend/src/components/Ambient/AmbientBadge.tsx
+++ b/frontend/src/components/Ambient/AmbientBadge.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { Label, Tooltip, TooltipPosition } from '@patternfly/react-core';
 
 type AmbientLabelProps = {
-  tooltip: boolean;
-  style?: React.CSSProperties;
   message?: string;
+  style?: React.CSSProperties;
+  tooltip: boolean;
 };
 
 export class AmbientBadge extends React.Component<AmbientLabelProps, {}> {

--- a/frontend/src/components/Ambient/AmbientBadge.tsx
+++ b/frontend/src/components/Ambient/AmbientBadge.tsx
@@ -2,20 +2,17 @@ import * as React from 'react';
 import { Label, Tooltip, TooltipPosition } from '@patternfly/react-core';
 
 type AmbientLabelProps = {
-  message?: string;
   style?: React.CSSProperties;
-  tooltip: boolean;
+  tooltip: string;
 };
 
 export class AmbientBadge extends React.Component<AmbientLabelProps, {}> {
   render() {
-    const msg = this.props.message ? this.props.message : 'Istio Ambient ztunnel detected in the Control plane';
-
     const tooltipContent = (
       <div style={{ textAlign: 'left' }}>
         <>
           <div>
-            {msg}
+            {this.props.tooltip}
             <br />
           </div>
         </>
@@ -28,7 +25,7 @@ export class AmbientBadge extends React.Component<AmbientLabelProps, {}> {
         </Label>
         {!this.props.tooltip && (
           <span style={{ marginLeft: '8px' }}>
-            {msg}
+            {this.props.tooltip}
             <Tooltip key={`tooltip_ambient_label`} position={TooltipPosition.top} content={tooltipContent}>
               <Label style={{ marginLeft: 5 }} color="blue" isCompact>
                 Ambient
@@ -38,12 +35,10 @@ export class AmbientBadge extends React.Component<AmbientLabelProps, {}> {
         )}
       </span>
     );
-    return this.props.tooltip ? (
+    return (
       <Tooltip key={`tooltip_ambient_label`} position={TooltipPosition.right} content={tooltipContent}>
         {iconComponent}
       </Tooltip>
-    ) : (
-      iconComponent
     );
   }
 }

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -71,6 +71,8 @@ const defaultServerConfig: ComputedServerConfig = {
   },
   installationTag: 'Kiali Console',
   istioAnnotations: {
+    ambientAnnotation: 'ambient.istio.io/redirection',
+    ambientAnnotationEnabled: 'enabled',
     istioInjectionAnnotation: 'sidecar.istio.io/inject'
   },
   istioCanaryRevision: {
@@ -80,6 +82,8 @@ const defaultServerConfig: ComputedServerConfig = {
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {
+    ambientWaypointLabel: 'gateway.istio.io/managed',
+    ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',

--- a/frontend/src/pages/Overview/ControlPlaneBadge.tsx
+++ b/frontend/src/pages/Overview/ControlPlaneBadge.tsx
@@ -19,7 +19,9 @@ export class ControlPlaneBadge extends React.Component<Props> {
           Control plane
         </Label>
         {isRemoteCluster(this.props.annotations) && <RemoteClusterBadge />}
-        {serverConfig.ambientEnabled && <AmbientBadge tooltip={true}></AmbientBadge>}{' '}
+        {serverConfig.ambientEnabled && (
+          <AmbientBadge tooltip={'Istio Ambient ztunnel detected in the Control plane'}></AmbientBadge>
+        )}{' '}
         <IstioStatusInline cluster={this.props.cluster} />
       </>
     );

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -1004,10 +1004,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
                                     ns.name !== serverConfig.istioNamespace &&
                                     ns.labels &&
                                     ns.isAmbient && (
-                                      <AmbientBadge
-                                        tooltip={true}
-                                        message={'labeled as part of Ambient Mesh'}
-                                      ></AmbientBadge>
+                                      <AmbientBadge tooltip={'labeled as part of Ambient Mesh'}></AmbientBadge>
                                     )}
                                 </span>
                               </Title>

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -1003,7 +1003,12 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
                                   {serverConfig.ambientEnabled &&
                                     ns.name !== serverConfig.istioNamespace &&
                                     ns.labels &&
-                                    ns.isAmbient && <AmbientBadge tooltip={true}></AmbientBadge>}
+                                    ns.isAmbient && (
+                                      <AmbientBadge
+                                        tooltip={true}
+                                        message={'labeled as part of Ambient Mesh'}
+                                      ></AmbientBadge>
+                                    )}
                                 </span>
                               </Title>
                             </>

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -19,6 +19,7 @@ import { history, URLParam } from '../../app/History';
 import { MiniGraphCard } from '../../components/CytoscapeGraph/MiniGraphCard';
 import { IstioConfigCard } from '../../components/IstioConfigCard/IstioConfigCard';
 import { MiniGraphCardPF } from 'pages/GraphPF/MiniGraphCardPF';
+import { AmbientAnnotation, AmbientAnnotationEnabled, WaypointLabel, WaypointLabelValue } from '../../types/Mesh';
 
 type WorkloadInfoProps = {
   duration: DurationInSeconds;
@@ -141,9 +142,7 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
 
     const validations: Validations = {};
     const isWaypoint =
-      serverConfig.ambientEnabled === true &&
-      workload.labels &&
-      workload.labels['gateway.istio.io/managed'] === 'istio.io-mesh-controller';
+      serverConfig.ambientEnabled === true && workload.labels && workload.labels[WaypointLabel] === WaypointLabelValue;
 
     if (workload.pods.length > 0) {
       validations.pod = {};
@@ -160,7 +159,7 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
               if (
                 !(
                   serverConfig.ambientEnabled === true &&
-                  (pod.annotations ? pod.annotations['ambient.istio.io/redirection'] === 'enabled' : false)
+                  (pod.annotations ? pod.annotations[AmbientAnnotation] === AmbientAnnotationEnabled : false)
                 )
               ) {
                 validations.pod[pod.name].checks.push(noIstiosidecar);

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -19,7 +19,6 @@ import { history, URLParam } from '../../app/History';
 import { MiniGraphCard } from '../../components/CytoscapeGraph/MiniGraphCard';
 import { IstioConfigCard } from '../../components/IstioConfigCard/IstioConfigCard';
 import { MiniGraphCardPF } from 'pages/GraphPF/MiniGraphCardPF';
-import { AmbientAnnotation, AmbientAnnotationEnabled, WaypointLabel, WaypointLabelValue } from '../../types/Mesh';
 
 type WorkloadInfoProps = {
   duration: DurationInSeconds;
@@ -140,9 +139,13 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
       path: ''
     };
 
+    const istioLabels = serverConfig.istioLabels;
+    const istioAnnotations = serverConfig.istioAnnotations;
     const validations: Validations = {};
     const isWaypoint =
-      serverConfig.ambientEnabled === true && workload.labels && workload.labels[WaypointLabel] === WaypointLabelValue;
+      serverConfig.ambientEnabled &&
+      workload.labels &&
+      workload.labels[istioLabels.ambientWaypointLabel] === istioLabels.ambientWaypointLabelValue;
 
     if (workload.pods.length > 0) {
       validations.pod = {};
@@ -158,8 +161,10 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
             if (!pod.istioContainers || pod.istioContainers.length === 0) {
               if (
                 !(
-                  serverConfig.ambientEnabled === true &&
-                  (pod.annotations ? pod.annotations[AmbientAnnotation] === AmbientAnnotationEnabled : false)
+                  serverConfig.ambientEnabled &&
+                  (pod.annotations
+                    ? pod.annotations[istioAnnotations.ambientAnnotation] === istioAnnotations.ambientAnnotationEnabled
+                    : false)
                 )
               ) {
                 validations.pod[pod.name].checks.push(noIstiosidecar);

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -151,6 +151,8 @@ export const serverRateConfig = {
   },
   installationTag: 'Kiali Console',
   istioAnnotations: {
+    ambientAnnotation: 'ambient.istio.io/redirection',
+    ambientAnnotationEnabled: 'enabled',
     istioInjectionAnnotation: ''
   },
   istioCanaryRevision: {
@@ -160,6 +162,8 @@ export const serverRateConfig = {
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {
+    ambientWaypointLabel: 'gateway.istio.io/managed',
+    ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',

--- a/frontend/src/types/Mesh.ts
+++ b/frontend/src/types/Mesh.ts
@@ -16,3 +16,9 @@ export interface KialiInstance {
 }
 
 export type MeshClusters = MeshCluster[];
+
+// Internal Ambient Mesh indicators
+export const AmbientAnnotation = 'ambient.istio.io/redirection';
+export const AmbientAnnotationEnabled = 'enabled';
+export const WaypointLabel = 'gateway.istio.io/managed';
+export const WaypointLabelValue = 'istio.io-mesh-controller';

--- a/frontend/src/types/Mesh.ts
+++ b/frontend/src/types/Mesh.ts
@@ -16,9 +16,3 @@ export interface KialiInstance {
 }
 
 export type MeshClusters = MeshCluster[];
-
-// Internal Ambient Mesh indicators
-export const AmbientAnnotation = 'ambient.istio.io/redirection';
-export const AmbientAnnotationEnabled = 'enabled';
-export const WaypointLabel = 'gateway.istio.io/managed';
-export const WaypointLabelValue = 'istio.io-mesh-controller';

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -1,13 +1,21 @@
 import { DurationInSeconds } from './Common';
 import { MeshCluster } from './Mesh';
 
-export type IstioLabelKey = 'appLabelName' | 'versionLabelName' | 'injectionLabelName' | 'injectionLabelRev';
+export type IstioLabelKey =
+  | 'ambientWaypointLabel'
+  | 'ambientWaypointLabelValue'
+  | 'appLabelName'
+  | 'versionLabelName'
+  | 'injectionLabelName'
+  | 'injectionLabelRev';
 
 interface DeploymentConfig {
   viewOnlyMode: boolean;
 }
 
 interface IstioAnnotations {
+  ambientAnnotation: string;
+  ambientAnnotationEnabled: string;
   // this could also be the name of the pod label, both label and annotation are supported
   istioInjectionAnnotation: string;
 }

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -71,6 +71,8 @@ export const healthConfig = {
   },
   installationTag: 'Kiali Console',
   istioAnnotations: {
+    ambientAnnotation: 'ambient.istio.io/redirection',
+    ambientAnnotationEnabled: 'enabled',
     istioInjectionAnnotation: ''
   },
   istioCanaryRevision: {
@@ -80,6 +82,8 @@ export const healthConfig = {
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {
+    ambientWaypointLabel: 'gateway.istio.io/managed',
+    ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -20,6 +20,8 @@ const (
 )
 
 type IstioAnnotations struct {
+	ambientAnnotation        string `json:"ambientAnnotation,omitempty"`
+	ambientAnnotationEnabled string `json:"ambientAnnotationEnabled,omitempty"`
 	IstioInjectionAnnotation string `json:"istioInjectionAnnotation,omitempty"`
 }
 
@@ -70,29 +72,31 @@ func Config(w http.ResponseWriter, r *http.Request) {
 	// Note that determine the Prometheus config at request time because it is not
 	// guaranteed to remain the same during the Kiali lifespan.
 	promConfig := getPrometheusConfig()
-	config := config.Get()
+	conf := config.Get()
 	publicConfig := PublicConfig{
-		AccessibleNamespaces: config.Deployment.AccessibleNamespaces,
-		AuthStrategy:         config.Auth.Strategy,
+		AccessibleNamespaces: conf.Deployment.AccessibleNamespaces,
+		AuthStrategy:         conf.Auth.Strategy,
 		Clusters:             make(map[string]kubernetes.Cluster),
 		Deployment: DeploymentConfig{
-			ViewOnlyMode: config.Deployment.ViewOnlyMode,
+			ViewOnlyMode: conf.Deployment.ViewOnlyMode,
 		},
-		InstallationTag: config.InstallationTag,
+		InstallationTag: conf.InstallationTag,
 		IstioAnnotations: IstioAnnotations{
-			IstioInjectionAnnotation: config.ExternalServices.Istio.IstioInjectionAnnotation,
+			ambientAnnotation:        config.AmbientAnnotation,
+			ambientAnnotationEnabled: config.AmbientAnnotationEnabled,
+			IstioInjectionAnnotation: conf.ExternalServices.Istio.IstioInjectionAnnotation,
 		},
-		HealthConfig:        config.HealthConfig,
-		IstioStatusEnabled:  config.ExternalServices.Istio.ComponentStatuses.Enabled,
-		IstioIdentityDomain: config.ExternalServices.Istio.IstioIdentityDomain,
-		IstioNamespace:      config.IstioNamespace,
-		IstioLabels:         config.IstioLabels,
-		IstioConfigMap:      config.ExternalServices.Istio.ConfigMapName,
+		HealthConfig:        conf.HealthConfig,
+		IstioStatusEnabled:  conf.ExternalServices.Istio.ComponentStatuses.Enabled,
+		IstioIdentityDomain: conf.ExternalServices.Istio.IstioIdentityDomain,
+		IstioNamespace:      conf.IstioNamespace,
+		IstioLabels:         conf.IstioLabels,
+		IstioConfigMap:      conf.ExternalServices.Istio.ConfigMapName,
 		IstioCanaryRevision: IstioCanaryRevision{
-			Current: config.ExternalServices.Istio.IstioCanaryRevision.Current,
-			Upgrade: config.ExternalServices.Istio.IstioCanaryRevision.Upgrade,
+			Current: conf.ExternalServices.Istio.IstioCanaryRevision.Current,
+			Upgrade: conf.ExternalServices.Istio.IstioCanaryRevision.Upgrade,
 		},
-		KialiFeatureFlags: config.KialiFeatureFlags,
+		KialiFeatureFlags: conf.KialiFeatureFlags,
 		LogLevel:          log.GetLogLevel(),
 		Prometheus: PrometheusConfig{
 			GlobalScrapeInterval: promConfig.GlobalScrapeInterval,
@@ -110,7 +114,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// @TODO hardcoded home cluster
-		publicConfig.GatewayAPIEnabled = layer.IstioConfig.IsGatewayAPI(config.KubernetesConfig.ClusterName)
+		publicConfig.GatewayAPIEnabled = layer.IstioConfig.IsGatewayAPI(conf.KubernetesConfig.ClusterName)
 		publicConfig.AmbientEnabled = layer.IstioConfig.IsAmbientEnabled()
 		publicConfig.GatewayAPIClasses = layer.IstioConfig.GatewayAPIClasses()
 

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -20,8 +20,8 @@ const (
 )
 
 type IstioAnnotations struct {
-	ambientAnnotation        string `json:"ambientAnnotation,omitempty"`
-	ambientAnnotationEnabled string `json:"ambientAnnotationEnabled,omitempty"`
+	AmbientAnnotation        string `json:"ambientAnnotation,omitempty"`
+	AmbientAnnotationEnabled string `json:"ambientAnnotationEnabled,omitempty"`
 	IstioInjectionAnnotation string `json:"istioInjectionAnnotation,omitempty"`
 }
 
@@ -82,8 +82,8 @@ func Config(w http.ResponseWriter, r *http.Request) {
 		},
 		InstallationTag: conf.InstallationTag,
 		IstioAnnotations: IstioAnnotations{
-			ambientAnnotation:        config.AmbientAnnotation,
-			ambientAnnotationEnabled: config.AmbientAnnotationEnabled,
+			AmbientAnnotation:        config.AmbientAnnotation,
+			AmbientAnnotationEnabled: config.AmbientAnnotationEnabled,
 			IstioInjectionAnnotation: conf.ExternalServices.Istio.IstioInjectionAnnotation,
 		},
 		HealthConfig:        conf.HealthConfig,

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -5,11 +5,8 @@ import (
 
 	osproject_v1 "github.com/openshift/api/project/v1"
 	core_v1 "k8s.io/api/core/v1"
-)
 
-const (
-	AmbientLabel = "istio.io/dataplane-mode"
-	AmbientValue = "ambient"
+	"github.com/kiali/kiali/config"
 )
 
 // A Namespace provide a scope for names
@@ -63,6 +60,8 @@ func CastNamespaceCollection(ns []core_v1.Namespace, cluster string) []Namespace
 }
 
 func CastNamespace(ns core_v1.Namespace, cluster string) Namespace {
+	istioLabels := config.Get().IstioLabels
+
 	namespace := Namespace{}
 	namespace.Name = ns.Name
 	namespace.Cluster = cluster
@@ -70,7 +69,7 @@ func CastNamespace(ns core_v1.Namespace, cluster string) Namespace {
 	namespace.Labels = ns.Labels
 	namespace.Annotations = ns.Annotations
 
-	if ns.Labels[AmbientLabel] == AmbientValue {
+	if ns.Labels[istioLabels.AmbientNamespaceLabel] == istioLabels.AmbientNamespaceLabelValue {
 		namespace.IsAmbient = true
 	}
 	return namespace

--- a/models/pod.go
+++ b/models/pod.go
@@ -149,7 +149,7 @@ func isIstioProxy(pod *core_v1.Pod, container *core_v1.Container, conf *config.C
 }
 
 func isIstioAmbient(pod *core_v1.Pod) bool {
-	return pod.ObjectMeta.Annotations[AmbientAnnotation] == AmbientAnnotationEnabled
+	return pod.ObjectMeta.Annotations[config.AmbientAnnotation] == config.AmbientAnnotationEnabled
 }
 
 func lookupImage(containerName string, containers []core_v1.Container) string {
@@ -213,12 +213,12 @@ func (pods Pods) HasAnyAmbient() bool {
 
 // AmbientEnabled returns true if the pod is labeled as ambient-type
 func (pod *Pod) AmbientEnabled() bool {
-	return pod.Annotations[AmbientAnnotation] == AmbientAnnotationEnabled
+	return pod.Annotations[config.AmbientAnnotation] == config.AmbientAnnotationEnabled
 }
 
 // IsWaypoint returns true if the pod is a waypoint proxy
 func (pod *Pod) IsWaypoint() bool {
-	return pod.Labels[WaypointLabel] == WaypointLabelValue
+	return pod.Labels[config.WaypointLabel] == config.WaypointLabelValue
 }
 
 // HasNativeSidecar returns true if the pod has istio-proxy init containers

--- a/models/pod.go
+++ b/models/pod.go
@@ -13,8 +13,10 @@ import (
 type Pods []*Pod
 
 const AmbientAnnotation = "ambient.istio.io/redirection"
+const AmbientAnnotationEnabled = "enabled"
 const WaypointLabel = "gateway.istio.io/managed"
 const IstioProxy = "istio-proxy"
+const WaypointLabelValue = "istio.io-mesh-controller"
 
 // Pod holds a subset of v1.Pod data that is meaningful in Kiali
 type Pod struct {
@@ -147,7 +149,7 @@ func isIstioProxy(pod *core_v1.Pod, container *core_v1.Container, conf *config.C
 }
 
 func isIstioAmbient(pod *core_v1.Pod) bool {
-	return pod.ObjectMeta.Annotations[AmbientAnnotation] == "enabled"
+	return pod.ObjectMeta.Annotations[AmbientAnnotation] == AmbientAnnotationEnabled
 }
 
 func lookupImage(containerName string, containers []core_v1.Container) string {
@@ -211,12 +213,12 @@ func (pods Pods) HasAnyAmbient() bool {
 
 // AmbientEnabled returns true if the pod is labeled as ambient-type
 func (pod *Pod) AmbientEnabled() bool {
-	return pod.Annotations[AmbientAnnotation] == "enabled"
+	return pod.Annotations[AmbientAnnotation] == AmbientAnnotationEnabled
 }
 
 // IsWaypoint returns true if the pod is a waypoint proxy
 func (pod *Pod) IsWaypoint() bool {
-	return pod.Labels[WaypointLabel] == "istio.io-mesh-controller"
+	return pod.Labels[WaypointLabel] == WaypointLabelValue
 }
 
 // HasNativeSidecar returns true if the pod has istio-proxy init containers


### PR DESCRIPTION
Fixes #6522 

- Include some istio Ambient annotations as part of the config. 
- The labels used internally by Istio were just added as a constant. 
- Update the badge messages in the control plane to indicate that the ztunnel was detected in the control plane, independently as how the user installs it (If with the profile, helm chart, ...)