### PR TITLE
Fix breadcrumb link issue for istio config type

### DIFF
--- a/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -13,13 +13,13 @@ interface BreadCumbViewProps {
   };
 }
 
-interface BreadCumbViewState {
-  namespace: string;
+interface BreadcrumbViewState {
   cluster?: string;
-  itemName: string;
-  item: string;
-  pathItem: string;
   istioType?: string;
+  item: string;
+  itemName: string;
+  namespace: string;
+  pathItem: string;
 }
 
 const ItemNames = {
@@ -32,7 +32,7 @@ const ItemNames = {
 const IstioName = 'Istio Config';
 const namespaceRegex = /namespaces\/([a-z0-9-]+)\/([\w-.]+)\/([\w-.*]+)(\/([\w-.]+))?(\/([\w-.]+))?/;
 
-export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCumbViewState> {
+export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadcrumbViewState> {
   static capitalize = (str: string) => {
     return str.charAt(0).toUpperCase() + str.slice(1);
   };
@@ -47,29 +47,26 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
     this.state = this.updateItem();
   }
 
-  updateItem = () => {
-    let regex = namespaceRegex;
-    let extension = false;
-    const match = this.props.location.pathname.match(regex) || [];
+  updateItem = (): BreadcrumbViewState => {
+    const match = this.props.location.pathname.match(namespaceRegex) || [];
     const ns = match[1];
     const page = Paths[match[2].toUpperCase()];
     const istioType = match[3];
     const urlParams = new URLSearchParams(this.props.location.search);
     let itemName = page !== 'istio' ? match[3] : match[5];
     return {
-      namespace: ns,
       cluster: HistoryManager.getClusterName(urlParams),
-      pathItem: page,
+      istioType: istioType,
       item: itemName,
       itemName: ItemNames[page],
-      istioType: istioType,
-      extension: extension
+      namespace: ns,
+      pathItem: page
     };
   };
 
   componentDidUpdate(
     prevProps: Readonly<BreadCumbViewProps>,
-    _prevState: Readonly<BreadCumbViewState>,
+    _prevState: Readonly<BreadcrumbViewState>,
     _snapshot?: any
   ): void {
     if (prevProps.location !== this.props.location) {
@@ -120,7 +117,7 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
         {isIstio && (
           <BreadcrumbItem>
             <Link
-              to={`/${pathItem}?namespaces=${namespace}&istiotype=${dicIstioType[this.state.istioType || '']}`}
+              to={`/${pathItem}?namespaces=${namespace}&type=${dicIstioType[this.state.istioType || '']}`}
               onClick={this.cleanFilters}
             >
               {istioType ? BreadcrumbView.istioType(istioType) : istioType}

--- a/frontend/src/components/VirtualList/VirtualList.tsx
+++ b/frontend/src/components/VirtualList/VirtualList.tsx
@@ -84,7 +84,7 @@ class VirtualListComponent<R extends RenderResource> extends React.Component<Vir
     if (direction) {
       HistoryManager.setParam(URLParam.DIRECTION, direction);
     }
-    HistoryManager.setParam(URLParam.SORT, String(this.state.conf.columns[index].param));
+    HistoryManager.setParam(URLParam.SORT, String(this.state.columns[index].param));
     this.props.sort && this.props.sort(FilterHelper.currentSortField(Sorts.sortFields), direction === 'asc');
   };
 
@@ -103,7 +103,7 @@ class VirtualListComponent<R extends RenderResource> extends React.Component<Vir
         info => !this.props.hiddenColumns || !this.props.hiddenColumns.includes(info.column.toLowerCase())
       );
       columns = filteredColumns.map(info => {
-        let config = { title: info.column, renderer: info.renderer };
+        let config = { param: info.param, title: info.column, renderer: info.renderer };
         if (info.transforms) {
           config['transforms'] = info.transforms;
         }

--- a/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -14,8 +14,8 @@ export const sortFields: SortField<IstioConfigItem>[] = [
     }
   },
   {
-    id: 'istiotype',
-    title: 'Istio Type',
+    id: 'type',
+    title: 'Type',
     isNumeric: false,
     param: 'it',
     compare: (a: IstioConfigItem, b: IstioConfigItem) => {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6632

- Fix breadcrumb link issue for istio config type
  - some cleanup: Fix type in type name, add some type safety, add some alphabetization, remove unnecessary vars
- Fix a sorting issue in VirtualList, when there are hidden columns
