### PR TITLE
Added missing cluster in K8s Gateway validations.

### DIFF
--- a/business/checkers/k8sgateway_checker.go
+++ b/business/checkers/k8sgateway_checker.go
@@ -21,6 +21,7 @@ func (g K8sGatewayChecker) Check() models.IstioValidations {
 	// Multinamespace checkers
 	validations := k8sgateways.MultiMatchChecker{
 		K8sGateways: g.K8sGateways,
+		Cluster:     g.Cluster,
 	}.Check()
 
 	for _, gw := range g.K8sGateways {

--- a/business/checkers/k8sgateways/multi_match_checker_test.go
+++ b/business/checkers/k8sgateways/multi_match_checker_test.go
@@ -23,10 +23,11 @@ func TestCorrectK8sGateways(t *testing.T) {
 
 	vals := MultiMatchChecker{
 		K8sGateways: k8sgws,
+		Cluster:     config.DefaultClusterID,
 	}.Check()
 
 	assert.Empty(vals)
-	_, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway"}]
+	_, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway", Cluster: config.DefaultClusterID}]
 	assert.False(ok)
 }
 
@@ -46,17 +47,18 @@ func TestDuplicateListenersCheckError(t *testing.T) {
 
 	vals := MultiMatchChecker{
 		K8sGateways: k8sgws,
+		Cluster:     config.DefaultClusterID,
 	}.Check()
 
 	assert.NotEmpty(vals)
 	assert.Equal(2, len(vals))
-	validation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway2"}]
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway2", Cluster: config.DefaultClusterID}]
 	assert.True(ok)
 	assert.NotNil(validation)
 	assert.True(validation.Valid)
 	assert.Greater(len(validation.Checks), 0)
 
-	secValidation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway"}]
+	secValidation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway", Cluster: config.DefaultClusterID}]
 	assert.True(ok)
 	assert.NotNil(secValidation)
 	assert.True(secValidation.Valid)
@@ -83,6 +85,7 @@ func TestDuplicateListenersCheckOk(t *testing.T) {
 
 	vals := MultiMatchChecker{
 		K8sGateways: k8sgws,
+		Cluster:     config.DefaultClusterID,
 	}.Check()
 
 	assert.Empty(vals)
@@ -106,17 +109,18 @@ func TestDuplicateAddresssCheckError(t *testing.T) {
 
 	vals := MultiMatchChecker{
 		K8sGateways: k8sgws,
+		Cluster:     config.DefaultClusterID,
 	}.Check()
 
 	assert.NotEmpty(vals)
 	assert.Equal(2, len(vals))
-	validation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway2"}]
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway2", Cluster: config.DefaultClusterID}]
 	assert.True(ok)
 	assert.NotNil(validation)
 	assert.True(validation.Valid)
 	assert.Greater(len(validation.Checks), 0)
 
-	secValidation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway"}]
+	secValidation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "validk8sgateway", Cluster: config.DefaultClusterID}]
 	assert.True(ok)
 	assert.NotNil(secValidation)
 	assert.True(secValidation.Valid)
@@ -145,6 +149,7 @@ func TestDuplicateAddresssCheckOk(t *testing.T) {
 
 	vals := MultiMatchChecker{
 		K8sGateways: k8sgws,
+		Cluster:     config.DefaultClusterID,
 	}.Check()
 
 	assert.Empty(vals)
@@ -167,6 +172,7 @@ func TestUniqueListenerOk(t *testing.T) {
 
 	vals := MultiMatchChecker{
 		K8sGateways: k8sgws,
+		Cluster:     config.DefaultClusterID,
 	}.Check()
 
 	assert.Empty(vals)
@@ -189,11 +195,12 @@ func TestUniqueListenerDuplicate(t *testing.T) {
 
 	vals := MultiMatchChecker{
 		K8sGateways: k8sgws,
+		Cluster:     config.DefaultClusterID,
 	}.Check()
 
 	assert.NotEmpty(vals)
 	assert.Equal(1, len(vals))
-	validation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "k8sgateway"}]
+	validation, ok := vals[models.IstioValidationKey{ObjectType: "k8sgateway", Namespace: "test", Name: "k8sgateway", Cluster: config.DefaultClusterID}]
 	assert.True(ok)
 	assert.Greater(len(validation.Checks), 0)
 


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6633

Now the validation results will be consistent in lists and details of K8s Gateway objects.

Create 2 K8s Gateways with the same host and port combination. Warning will be shown for both of them.

