### PR TITLE
Istio Status test for Multicluster

### DIFF
--- a/frontend/cypress/integration/featureFiles/kiali_alert.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_alert.feature
@@ -11,3 +11,7 @@ Feature: Kiali help about verify
 
   Scenario: Open Kiali notifications
     Then user should see no Istio Components Status
+
+  @multi-cluster
+  Scenario: Open Kiali notifications
+    Then user should see no Istio Components Status


### PR DESCRIPTION
Currently, there are 2 different CI jobs for front-end testing and there is also an enhancement in the backlog (#6609), which might extend the Status for external services related to multicluster. Because of this, I think it is suitable to duplicate this test. 