### PR TITLE
Support K8s Native Sidecars. Added a script to prepare env.

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -20,6 +20,7 @@ CLIENT_EXE=""
 CLUSTER_NAME=""
 CONFIG_PROFILE="" # see "istioctl profile list" for valid values. See: https://istio.io/docs/setup/additional-setup/config-profiles/
 DELETE_ISTIO="false"
+ENABLE_NATIVE_SIDECARS="false"
 PURGE_UNINSTALL="true"
 ISTIOCTL=
 ISTIO_DIR=
@@ -150,6 +151,15 @@ while [[ $# -gt 0 ]]; do
       NETWORK="$2"
       shift;shift
       ;;
+    -nsc|--native-sidecars)
+      if [ "${2}" == "true" ] || [ "${2}" == "false" ]; then
+        ENABLE_NATIVE_SIDECARS="$2"
+      else
+        echo "ERROR: The --nsc flag must be 'true' or 'false'"
+        exit 1
+      fi
+      shift;shift
+      ;;
     -rr|--reduce-resources)
       if [ "${2}" == "true" ] || [ "${2}" == "false" ]; then
         REDUCE_RESOURCES="$2"
@@ -233,6 +243,9 @@ Valid command line arguments:
   -net|--network <network>:
        Installs istio as part of network with the given name.
        Default: unset
+  -nsc|--native-sidecars (true|false):
+       Indicate if you want native sidecars enabled.
+       Default: false
   -rr|--reduce-resources (true|false):
        When true some Istio components (such as the sidecar proxies) will be given
        a smaller amount of resources (CPU and memory) which will allow you
@@ -335,6 +348,8 @@ fi
 
 MTLS_OPTIONS="--set values.meshConfig.enableAutoMtls=${MTLS}"
 
+NATIVE_SIDECARS_OPTIONS="--set values.pilot.env.ENABLE_NATIVE_SIDECARS=${ENABLE_NATIVE_SIDECARS}"
+
 # When installing Istio (i.e. not deleting it) perform some preparation steps
 if [ "${DELETE_ISTIO}" != "true" ]; then
   # Create the istio-system namespace
@@ -414,6 +429,7 @@ for s in \
    "${IMAGE_HUB_OPTION}" \
    "${IMAGE_TAG_OPTION}" \
    "${MTLS_OPTIONS}" \
+   "${NATIVE_SIDECARS_OPTIONS}" \
    "${CUSTOM_NAMESPACE_OPTIONS}" \
    "--set values.gateways.istio-egressgateway.enabled=${ISTIO_EGRESSGATEWAY_ENABLED}" \
    "--set values.gateways.istio-ingressgateway.enabled=${ISTIO_INGRESSGATEWAY_ENABLED}" \

--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -155,7 +155,7 @@ while [[ $# -gt 0 ]]; do
       if [ "${2}" == "true" ] || [ "${2}" == "false" ]; then
         ENABLE_NATIVE_SIDECARS="$2"
       else
-        echo "ERROR: The --nsc flag must be 'true' or 'false'"
+        echo "ERROR: The --native-sidecars flag must be 'true' or 'false'"
         exit 1
       fi
       shift;shift

--- a/hack/istio/nativesiecars/install-native-sidecars-env.sh
+++ b/hack/istio/nativesiecars/install-native-sidecars-env.sh
@@ -93,7 +93,7 @@ EOF
   fi
 
   if [ "${INSTALL_BOOKINFO}" == "true" ]; then
-    echo -e "Installing bookinfo \n"
+    echo "Installing bookinfo"
     ${SCRIPT_DIR}/../install-bookinfo-demo.sh -c ${CLIENT_EXE} -tg
   fi
 

--- a/hack/istio/nativesiecars/install-native-sidecars-env.sh
+++ b/hack/istio/nativesiecars/install-native-sidecars-env.sh
@@ -97,7 +97,7 @@ EOF
     ${SCRIPT_DIR}/../install-bookinfo-demo.sh -c ${CLIENT_EXE} -tg
   fi
 
-  echo -e "Installation finished. You can port forward the services with: \n"
+  echo "Installation finished. You can port forward the services with:"
   echo "./run-kiali.sh -pg 13000:3000 -pp 19090:9090 -app 8080 -es false -iu http://127.0.0.1:15014"
 
 fi

--- a/hack/istio/nativesiecars/install-native-sidecars-env.sh
+++ b/hack/istio/nativesiecars/install-native-sidecars-env.sh
@@ -81,7 +81,7 @@ EOF
   echo "Script Directory: ${SCRIPT_DIR}"
 
   if [ "${INSTALL_ISTIO}" == "true" ]; then
-    echo -e "Installing istio with values.pilot.env.ENABLE_NATIVE_SIDECARS=true option \n"
+    echo "Installing istio with values.pilot.env.ENABLE_NATIVE_SIDECARS=true option"
     ${SCRIPT_DIR}/../install-istio-via-istioctl.sh -c ${CLIENT_EXE} -a "prometheus grafana jaeger" -nsc true
   fi
 

--- a/hack/istio/nativesiecars/install-native-sidecars-env.sh
+++ b/hack/istio/nativesiecars/install-native-sidecars-env.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+##############################################################################
+# install-nativesidecars-env
+#
+# Installs the environment in kind with native sidecars enabled.
+#
+# See --help for more details on options to this script.
+#
+##############################################################################
+
+CLIENT_EXE="kubectl"
+DELETE_ALL="false"
+INSTALL_BOOKINFO="true"
+INSTALL_ISTIO="true"
+INSTALL_KIALI="true"
+
+# process command line args
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -c|--client)
+      CLIENT_EXE="$2"
+      shift;shift
+      ;;
+    -da|--delete-all)
+      DELETE_ALL="$2"
+      shift;shift
+      ;;
+    -ib|--install-bookinfo)
+      INSTALL_BOOKINFO="$2"
+      shift;shift
+      ;;
+    -ii|--install-istio)
+      INSTALL_ISTIO="$2"
+      shift;shift
+      ;;
+    -ik|--install-kiali)
+      INSTALL_KIALI="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -c|--client:
+       client exe. Just kubectl is supported at the moment.
+  -da|--delete-all:
+       Delete the cluster created in kind.
+  -ib|--install-bookinfo:
+       If bookinfo should be installed. true by default.
+  -ii|--install-istio:
+       If istio should be installed. true by default.
+  -ik|--install-kiali:
+       If Kiali should be installed. true by default.
+  -h|--help:
+       this message
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "ERROR: Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+if [ "${DELETE_ALL}" == "true" ]; then
+  echo -e "Deleting cluster \n"
+  kind delete cluster --name sidecars
+else
+  echo -e "Creating a cluster in kind with native sidecars \n"
+  cat <<EOF | kind create cluster --name sidecars --image gcr.io/istio-testing/kind-node:v1.28.0 --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  SidecarContainers: true
+EOF
+
+  echo "Script Directory: ${SCRIPT_DIR}"
+
+  if [ "${INSTALL_ISTIO}" == "true" ]; then
+    echo -e "Installing istio with values.pilot.env.ENABLE_NATIVE_SIDECARS=true option \n"
+    ${SCRIPT_DIR}/../install-istio-via-istioctl.sh -c ${CLIENT_EXE} -a "prometheus grafana jaeger" -nsc true
+  fi
+
+  if [ "${INSTALL_KIALI}" == "true" ]; then
+    OUTPUT_DIR="${OUTPUT_DIR:-${SCRIPT_DIR}/../../../_output}"
+    ISTIO_DIR=$(ls -dt1 ${OUTPUT_DIR}/istio-* | head -n1)
+    echo "Istio directory where the Kiali addon yaml should be found: ${ISTIO_DIR}"
+    ${CLIENT_EXE} apply -f ${ISTIO_DIR}/samples/addons/kiali.yaml
+  fi
+
+  if [ "${INSTALL_BOOKINFO}" == "true" ]; then
+    echo -e "Installing bookinfo \n"
+    ${SCRIPT_DIR}/../install-bookinfo-demo.sh -c ${CLIENT_EXE} -tg
+  fi
+
+  echo -e "Installation finished. You can port forward the services with: \n"
+  echo "./run-kiali.sh -pg 13000:3000 -pp 19090:9090 -app 8080 -es false -iu http://127.0.0.1:15014"
+
+fi

--- a/hack/istio/nativesiecars/install-native-sidecars-env.sh
+++ b/hack/istio/nativesiecars/install-native-sidecars-env.sh
@@ -70,7 +70,7 @@ if [ "${DELETE_ALL}" == "true" ]; then
   echo "Deleting cluster"
   kind delete cluster --name sidecars
 else
-  echo -e "Creating a cluster in kind with native sidecars \n"
+  echo "Creating a cluster in kind with native sidecars"
   cat <<EOF | kind create cluster --name sidecars --image gcr.io/istio-testing/kind-node:v1.28.0 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4

--- a/hack/istio/nativesiecars/install-native-sidecars-env.sh
+++ b/hack/istio/nativesiecars/install-native-sidecars-env.sh
@@ -67,7 +67,7 @@ done
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 if [ "${DELETE_ALL}" == "true" ]; then
-  echo -e "Deleting cluster \n"
+  echo "Deleting cluster"
   kind delete cluster --name sidecars
 else
   echo -e "Creating a cluster in kind with native sidecars \n"


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6130

Istio is supporting Native Sidecars since version 1.19.0.

When kubernetes env is created in SidecarContainers mode, and Istio is installed by 'ENABLE_NATIVE_SIDECARS=true', then Kiali is recognizing "istio-proxy" in a `initContainers` instead of `containers` of pods and not showing any warning that "Missing Sidecar".

Added a script to prepare `kind` environment and test on 'bookinfo'.
Run `./hack/istio/nativesiecars/install-native-sidecars-env.sh` and the env will be created and installed.
Run the proxy and connect to your local running Kiali from this PR sources.
No warning message about missing sidecars in Workloads/Apps/Services, Kiali behaves as usual when sidecars are installed.

More info in https://istio.io/latest/blog/2023/native-sidecars/