### PR TITLE
[CI] github workflow to test with specific istio version

### DIFF
--- a/.github/workflows/integration-tests-backend.yml
+++ b/.github/workflows/integration-tests-backend.yml
@@ -9,6 +9,10 @@ on:
       build_branch:
         required: true
         type: string
+      istio_version:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -48,7 +52,7 @@ jobs:
           path: frontend/build
 
       - name: Run backend integration tests
-        run: hack/run-integration-tests.sh --test-suite backend
+        run: hack/run-integration-tests.sh --test-suite backend $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
 
       - name: Get debug info when integration tests fail
         if: failure()

--- a/.github/workflows/integration-tests-frontend-multicluster.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster.yml
@@ -9,6 +9,10 @@ on:
       build_branch:
         required: true
         type: string
+      istio_version:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -57,7 +61,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Run frontend multi-cluster integration tests
-        run: hack/run-integration-tests.sh --test-suite frontend-multi-cluster
+        run: hack/run-integration-tests.sh --test-suite frontend-multi-cluster $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
 
       - name: Get debug info when integration tests fail
         if: failure()

--- a/.github/workflows/integration-tests-frontend.yml
+++ b/.github/workflows/integration-tests-frontend.yml
@@ -9,6 +9,10 @@ on:
       build_branch:
         required: true
         type: string
+      istio_version:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -59,7 +63,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Run frontend integration tests
-        run: hack/run-integration-tests.sh --test-suite frontend
+        run: hack/run-integration-tests.sh --test-suite frontend $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
 
       - name: Get debug info when integration tests fail
         if: failure()

--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -1,0 +1,70 @@
+name: Test Istio Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      istio_version:
+        description: "The version of Istio to test with. Format is either #.#.# or #.#-dev"
+        required: true
+        type: string
+      branch_to_test:
+        description: "The branch to build and test."
+        required: true
+        default: "master"
+        type: string
+
+jobs:
+  initialize:
+    name: Initialize
+    runs-on: ubuntu-latest
+    outputs:
+      target-branch: ${{ inputs.branch_to_test }}
+      build-branch: ${{ inputs.branch_to_test }}
+      istio-version: ${{ inputs.istio_version }}
+    steps:
+      # The initialize job gathers variables for later use in jobs.
+      - run: echo "target-branch -> ${{ inputs.branch_to_test }}"
+      - run: echo "build-branch -> ${{ inputs.branch_to_test }}"
+      - run: echo "istio-version -> ${{ inputs.istio_version }}"
+
+  build_backend:
+    name: Build backend
+    uses: ./.github/workflows/build-backend.yml
+    needs: [initialize]
+    with:
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
+
+  build_frontend:
+    name: Build frontend
+    uses: ./.github/workflows/build-frontend.yml
+    needs: [initialize]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
+
+  integration_tests_backend:
+    name: Run backend integration tests
+    uses: ./.github/workflows/integration-tests-backend.yml
+    needs: [initialize, build_backend, build_frontend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
+      istio_version: ${{ needs.initialize.outputs.istio-version }}
+
+  integration_tests_frontend:
+    name: Run frontend integration tests
+    uses: ./.github/workflows/integration-tests-frontend.yml
+    needs: [initialize, build_backend, build_frontend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
+      istio_version: ${{ needs.initialize.outputs.istio-version }}
+
+  integration_tests_frontend_multicluster:
+    name: Run frontend multicluster integration tests
+    uses: ./.github/workflows/integration-tests-frontend-multicluster.yml
+    needs: [initialize, build_backend, build_frontend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
+      istio_version: ${{ needs.initialize.outputs.istio-version }}

--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -324,6 +324,8 @@ Valid command line arguments:
   -gr|--gateway-required <bool>: If a gateway is required to cross between networks, set this to true
   -id|--istio-dir <dir>: Where Istio has already been downloaded. If not found, this script aborts.
   -in|--istio-namespace <name>: Where the Istio control plane is installed (default: istio-system).
+  -ih|--istio-hub <hub>: If you want to override the image hub used by istioctl (where the images are found),
+                         set this to the hub name, or "default" to use the default image locations.
   -it|--istio-tag <tag>: If you want to override the image tag used by istioctl, set this to the tag name.
   -kas|--kiali-auth-strategy <openid|anonymous>: The authentication strategy to use for Kiali (Default: openid)
   -kcrcs|--kiali-create-remote-cluster-secrets <bool>: Create remote cluster secrets for kiali remote cluster access.

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -58,10 +58,10 @@ ${CLIENT_EXE} label namespace ${ISTIO_NAMESPACE} topology.istio.io/network=${NET
 
 ISTIO_INSTALL_SCRIPT="${SCRIPT_DIR}/../install-istio-via-istioctl.sh"
 if [ ! -z "${ISTIO_TAG}" ]; then
-  local image_tag_arg="--image-tag ${ISTIO_TAG}"
+  image_tag_arg="--image-tag ${ISTIO_TAG}"
 fi
 if [ ! -z "${ISTIO_HUB}" ]; then
-  local image_hub_arg="--image-hub ${ISTIO_HUB}"
+  image_hub_arg="--image-hub ${ISTIO_HUB}"
 fi
 ${ISTIO_INSTALL_SCRIPT} ${image_tag_arg:-} ${image_hub_arg:-} --client-exe-path ${CLIENT_EXE} --cluster-name ${CLUSTER1_NAME} --istioctl ${ISTIOCTL} --istio-dir ${ISTIO_DIR} --mesh-id ${MESH_ID} --namespace ${ISTIO_NAMESPACE} --network ${NETWORK1_ID} --set values.pilot.env.EXTERNAL_ISTIOD=true --k8s-gateway-api-enabled true
 

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -200,7 +200,10 @@ setup_kind_multicluster() {
   # use the Istio release that was last downloaded (that's the -t option to ls)
   local istio_dir
   istio_dir=$(ls -dt1 ${output_dir}/istio-* | head -n1)
-  hack/istio/multicluster/install-primary-remote.sh --manage-kind true -dorp docker --istio-dir "${istio_dir}"
+  if [[ "${ISTIO_VERSION}" == *-dev ]]; then
+    local hub_arg="--istio-hub default"
+  fi
+  hack/istio/multicluster/install-primary-remote.sh --manage-kind true -dorp docker --istio-dir "${istio_dir}" ${hub_arg:-}
   hack/istio/multicluster/deploy-kiali.sh --manage-kind true -dorp docker -kas anonymous -kudi true -kshc "${HELM_CHARTS_DIR}"/_output/charts/kiali-server-*.tgz
 }
 


### PR DESCRIPTION
This provides a new workflow that can be triggered manually. It will allow you to run the integration tests with any version of Istio you want (including even dev builds of Istio that have not been released, such as `1.20-dev`).

This will provide us the ability to see if Kiali can support older versions (or newer versions in development) of Istio.

You can test master branch or any other branch you select.
