### PR TITLE
Component status check in multicluster mode

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -16,6 +16,8 @@ import (
 	"github.com/kiali/kiali/util/httputil"
 )
 
+const istioEastWestGateway = "istio-eastwestgateway"
+
 // SvcService deals with fetching istio/kubernetes services related content and convert to kiali model
 type IstioStatusService struct {
 	userClients   map[string]kubernetes.ClientInterface
@@ -142,6 +144,11 @@ func (iss *IstioStatusService) getStatusOf(workloads []*models.Workload) (kubern
 	statusComponents := istioCoreComponents()
 	isc := kubernetes.IstioComponentStatus{}
 	cf := map[string]bool{}
+
+	// eastwest gateway is checked in multicluster
+	if _, ok := statusComponents[istioEastWestGateway]; !ok && len(iss.userClients) > 1 {
+		statusComponents[istioEastWestGateway] = true
+	}
 
 	// Map workloads there by app name
 	for _, workload := range workloads {

--- a/config/config.go
+++ b/config/config.go
@@ -259,10 +259,11 @@ type ComponentStatuses struct {
 }
 
 type ComponentStatus struct {
-	AppLabel  string `yaml:"app_label,omitempty"`
-	IsCore    bool   `yaml:"is_core,omitempty"`
-	IsProxy   bool   `yaml:"is_proxy,omitempty"`
-	Namespace string `yaml:"namespace,omitempty"`
+	AppLabel       string `yaml:"app_label,omitempty"`
+	IsCore         bool   `yaml:"is_core,omitempty"`
+	IsProxy        bool   `yaml:"is_proxy,omitempty"`
+	IsMultiCluster bool   `yaml:"is_multicluster,omitempty"`
+	Namespace      string `yaml:"namespace,omitempty"`
 }
 
 type GatewayAPIClass struct {


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6609

Now it is possible to check Istio component status on multiple clusters,
just add to any component's config the new `is_multicluster: true` (by default 'false') and the component status check will check the existence of the particular component in all clusters.
```
external_services:
  istio:
    component_status:
      components:
      - app_label: istio-eastwestgateway
        is_core: true
        is_proxy: true
        is_multicluster: true
        namespace: ''
```

![Screenshot from 2023-09-26 14-17-00](https://github.com/kiali/kiali/assets/604313/6f43f18c-55f6-4fb4-a67b-6d0f0b2c54c4)
