### PR TITLE
[Test Flake] See tracing info after selecting a trace

### DIFF
--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -25,12 +25,17 @@ MINIKUBE_PROFILE="minikube"
 : ${ENABLE_INJECTION:=true}
 : ${GATEWAY_HOST:="")}
 ISTIO_NAMESPACE="istio-system"
+BOOKINFO_TIMEOUT="0"
 
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
     -a|--arch)
       ARCH="$2"
+      shift;shift
+      ;;
+    -bt|--bookinfo-timeout)
+      BOOKINFO_TIMEOUT="$2"
       shift;shift
       ;;
     -c|--client)
@@ -57,6 +62,7 @@ while [ $# -gt 0 ]; do
       cat <<HELPMSG
 Valid command line arguments:
   -a|--arch <amd64|ppc64le|s390x>: Images for given arch will be used (default: amd64).
+  -bt|--bookinfo-timeout: wait timeout for Bookinfo application. Can be in the format "60s" or "30m". 0 by default.
   -c|--client: either 'oc' or 'kubectl'
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
   -g|--gateway-host: host to use for the ingress gateway
@@ -163,7 +169,7 @@ spec:
 EOF
     fi
     echo "Deploying bookinfo demo..."
-    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -mp ${MINIKUBE_PROFILE} -tg -in ${ISTIO_NAMESPACE} -a ${ARCH} ${gateway_yaml:+-g ${gateway_yaml}} -wt 5m
+    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -mp ${MINIKUBE_PROFILE} -tg -in ${ISTIO_NAMESPACE} -a ${ARCH} ${gateway_yaml:+-g ${gateway_yaml}} -wt ${BOOKINFO_TIMEOUT}
 
     echo "Deploying error rates demo..."
     "${SCRIPT_DIR}/install-error-rates-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE} -a ${ARCH}

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -25,17 +25,12 @@ MINIKUBE_PROFILE="minikube"
 : ${ENABLE_INJECTION:=true}
 : ${GATEWAY_HOST:="")}
 ISTIO_NAMESPACE="istio-system"
-BOOKINFO_TIMEOUT="0"
 
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
     -a|--arch)
       ARCH="$2"
-      shift;shift
-      ;;
-    -bt|--bookinfo-timeout)
-      BOOKINFO_TIMEOUT="$2"
       shift;shift
       ;;
     -c|--client)
@@ -62,7 +57,6 @@ while [ $# -gt 0 ]; do
       cat <<HELPMSG
 Valid command line arguments:
   -a|--arch <amd64|ppc64le|s390x>: Images for given arch will be used (default: amd64).
-  -bt|--bookinfo-timeout: wait timeout for Bookinfo application. Can be in the format "60s" or "30m". 0 by default.
   -c|--client: either 'oc' or 'kubectl'
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
   -g|--gateway-host: host to use for the ingress gateway
@@ -169,7 +163,7 @@ spec:
 EOF
     fi
     echo "Deploying bookinfo demo..."
-    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -mp ${MINIKUBE_PROFILE} -tg -in ${ISTIO_NAMESPACE} -a ${ARCH} ${gateway_yaml:+-g ${gateway_yaml}} -wt ${BOOKINFO_TIMEOUT}
+    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -mp ${MINIKUBE_PROFILE} -tg -in ${ISTIO_NAMESPACE} -a ${ARCH} ${gateway_yaml:+-g ${gateway_yaml}}
 
     echo "Deploying error rates demo..."
     "${SCRIPT_DIR}/install-error-rates-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE} -a ${ARCH}

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -163,7 +163,7 @@ spec:
 EOF
     fi
     echo "Deploying bookinfo demo..."
-    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -mp ${MINIKUBE_PROFILE} -tg -in ${ISTIO_NAMESPACE} -a ${ARCH} ${gateway_yaml:+-g ${gateway_yaml}}
+    "${SCRIPT_DIR}/install-bookinfo-demo.sh" -c kubectl -mp ${MINIKUBE_PROFILE} -tg -in ${ISTIO_NAMESPACE} -a ${ARCH} ${gateway_yaml:+-g ${gateway_yaml}} -wt 5m
 
     echo "Deploying error rates demo..."
     "${SCRIPT_DIR}/install-error-rates-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE} -a ${ARCH}

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -145,7 +145,7 @@ elif [ "${TEST_SUITE}" == "frontend" ]; then
 
   ISTIO_INGRESS_IP="$(kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')"
   # Install demo apps
-  "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" -g "${ISTIO_INGRESS_IP}"
+  "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" -g "${ISTIO_INGRESS_IP}" -bt "5m"
 
   # Get Kiali URL
   KIALI_URL="http://${ISTIO_INGRESS_IP}/kiali"

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -184,7 +184,7 @@ elif [ "${TEST_SUITE}" == "frontend" ]; then
   export CYPRESS_VIDEO=false
 
   ensureKialiServerReady "${KIALI_URL}"
-  ensureTracesReady "${KIALI_URL}"
+  ensureKialiTracesReady "${KIALI_URL}"
 
   if [ "${SETUP_ONLY}" == "true" ]; then
     exit 0

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -117,6 +117,35 @@ ensureKialiServerReady() {
   done
 }
 
+ensureKialiTracesReady() {
+  local KIALI_URL="$1"
+
+  infomsg "Waiting for Kiali to have traces"
+  local start_time=$(date +%s)
+  local end_time=$((start_time + 60))
+
+  # Get traces from the last 5m
+  local traces_date=$((($(date +%s) - 300) * 1000))
+  local trace_url="${KIALI_URL}/api/namespaces/bookinfo/workloads/productpage-v1/traces?startMicros=${traces_date}&tags=&limit=100"
+  while true; do
+    result=$(curl "$url" \
+        -H 'Accept: application/json, text/plain, */*' \
+        -H 'Content-Type: application/json' | jq -r '.data')
+
+    if [ "$result" == "[]" ]; then
+      local now=$(date +%s)
+      if [ "${now}" -gt "${end_time}" ]; then
+        echo "Timed out waiting for Kiali to get any trace"
+        break
+      fi
+      sleep 1
+    else
+      break
+    fi
+
+  done
+}
+
 infomsg "Running ${TEST_SUITE} integration tests"
 if [ "${TEST_SUITE}" == "backend" ]; then
   "${SCRIPT_DIR}"/setup-kind-in-ci.sh ${ISTIO_VERSION_ARG}
@@ -145,7 +174,7 @@ elif [ "${TEST_SUITE}" == "frontend" ]; then
 
   ISTIO_INGRESS_IP="$(kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')"
   # Install demo apps
-  "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" -g "${ISTIO_INGRESS_IP}" -bt "5m"
+  "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" -g "${ISTIO_INGRESS_IP}"
 
   # Get Kiali URL
   KIALI_URL="http://${ISTIO_INGRESS_IP}/kiali"
@@ -155,6 +184,7 @@ elif [ "${TEST_SUITE}" == "frontend" ]; then
   export CYPRESS_VIDEO=false
 
   ensureKialiServerReady "${KIALI_URL}"
+  ensureTracesReady "${KIALI_URL}"
 
   if [ "${SETUP_ONLY}" == "true" ]; then
     exit 0


### PR DESCRIPTION
Reviewing the failures of these flakes, the test seems to happen when there are no traces yet, for some reason. 
There are no errors in the logs or the screenshot (related to error getting traces). 
There are another traces test, that runs latter, `See graph traces for productspage service details` and never seen it flake (At least when this test failed). 
It makes me think it could be related to something not ready yet in the environment. 

Fixes #6671 