### PR TITLE
Fix typo in var name

### DIFF
--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -129,7 +129,7 @@ ensureKialiTracesReady() {
   local trace_url="${KIALI_URL}/api/namespaces/bookinfo/workloads/productpage-v1/traces?startMicros=${traces_date}&tags=&limit=100"
   infomsg "Traces url: ${trace_url}"
   while true; do
-    result=$(curl "$trace_url" \
+    result=$(curl -k -s --fail "$trace_url" \
         -H 'Accept: application/json, text/plain, */*' \
         -H 'Content-Type: application/json' | jq -r '.data')
 

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -127,8 +127,9 @@ ensureKialiTracesReady() {
   # Get traces from the last 5m
   local traces_date=$((($(date +%s) - 300) * 1000))
   local trace_url="${KIALI_URL}/api/namespaces/bookinfo/workloads/productpage-v1/traces?startMicros=${traces_date}&tags=&limit=100"
+  infomsg "Traces url: ${trace_url}"
   while true; do
-    result=$(curl "$url" \
+    result=$(curl "$trace_url" \
         -H 'Accept: application/json, text/plain, */*' \
         -H 'Content-Type: application/json' | jq -r '.data')
 


### PR DESCRIPTION
Fix the issue in run-integration-tests:

```
2023-10-05T11:28:45.4174734Z [INFO] Waiting for Kiali to have traces
2023-10-05T11:28:45.4323074Z curl: (3) URL using bad/illegal format or missing URL
```