### PR TITLE
Recreate map with annotations after deleting a numeric key

### DIFF
--- a/frontend/src/components/IstioWizards/WizardAnnotations.tsx
+++ b/frontend/src/components/IstioWizards/WizardAnnotations.tsx
@@ -57,8 +57,12 @@ export class WizardAnnotations extends React.Component<Props, State> {
   };
 
   removeAnnotation = (k: number) => {
-    const annotations = this.state.annotations;
-    annotations.delete(k);
+    const annotations = new Map<number, [string, string]>();
+    const condition = (key: number) => key !== k;
+    let index = 0;
+    Array.from(this.state.annotations.entries())
+      .filter(([key, _]) => condition(key))
+      .map(([_, [key, value]]: [number, [string, string]]) => annotations.set(index++, [key, value]));
     this.setState({ annotations });
   };
 


### PR DESCRIPTION
https://github.com/kiali/kiali/issues/6676

Deleting a numeric key in map does not reorder the keys, so recreating a map.

