### PR TITLE
Apply filter by service selector after loading from kube cache

### DIFF
--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -87,6 +87,11 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 				Name:      "kiali-service",
 				Namespace: "foo",
 			},
+			Spec: core_v1.ServiceSpec{
+				Selector: map[string]string{
+					"app.kubernetes.io/part-of": "kiali",
+				},
+			},
 		},
 	}
 
@@ -158,6 +163,11 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 			},
 			Name:      "kiali-service",
 			Namespace: conf.IstioNamespace,
+		},
+		Spec: core_v1.ServiceSpec{
+			Selector: map[string]string{
+				"app.kubernetes.io/part-of": "kiali",
+			},
 		},
 	}
 
@@ -264,6 +274,11 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 			},
 			Name:      "kiali-service",
 			Namespace: "foo",
+		},
+		Spec: core_v1.ServiceSpec{
+			Selector: map[string]string{
+				"app.kubernetes.io/part-of": "kiali",
+			},
 		},
 	}
 

--- a/frontend/cypress/integration/featureFiles/app_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/app_details_multicluster.feature
@@ -14,6 +14,8 @@ Feature: Kiali App Details page for multicluster
 
   Scenario: See details for app.
     Then user sees details information for the remote "reviews" app
+    And the description card should contain a reference to workload
+    And the description card should contain a reference to service
     And links in the description card should contain a reference to a "west" cluster
     And cluster badge for "west" cluster should be visible
 

--- a/frontend/cypress/integration/featureFiles/service_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/service_details_multicluster.feature
@@ -12,6 +12,8 @@ Feature: Kiali Service Details page for remote cluster
 
   Scenario: See details for remote service
     Then sd::user sees "ratings" details information for service "v1"
+    And the description card should contain a reference to application
+    And the description card should contain a reference to workload
     And links in the description card should contain a reference to a "west" cluster
     And cluster badge for "west" cluster should be visible
 

--- a/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
@@ -16,6 +16,8 @@ Feature: Kiali Workload Details page
 
   Scenario: See details for workload
     Then user sees details information for workload
+    And the description card should contain a reference to application
+    And the description card should contain a reference to service
     And links in the description card should contain a reference to a "west" cluster
     And cluster badge for "west" cluster should be visible
 


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6682

For services loading from kube cache, does not mater local or remote, the label selector was filtering out the services which did not have `version` label selector.
In an contrary, the registry loading was loading all services then filtering by selector.
This was causing an issue for remote cluster services loaded for workload. The selector which contains `version` for workload was filtering out all services from cache. The local cluster's workload's services were loading from registry and were fine. Which was correct but still an Inconsistency with remote ones. 

Now when selector is provided for loading services from kube cache, it lists all services then filters out the selector matched ones, similar to loading from registry.
When no selector is provided, it loads all services as it was before.

![Screenshot from 2023-10-10 14-21-32](https://github.com/kiali/kiali/assets/604313/b917c238-b6f7-40f1-85b7-e2fd786f6c39)
![Screenshot from 2023-10-10 14-21-21](https://github.com/kiali/kiali/assets/604313/0cbd1b8f-c09d-45b6-b229-695dd26692bb)
![Screenshot from 2023-10-10 14-21-06](https://github.com/kiali/kiali/assets/604313/84f70b53-c793-40d4-8e5d-a8ba20d57f8b)
