### PR TITLE
Added missing cluster param in App and Service traffic.

### DIFF
--- a/frontend/src/components/TrafficList/TrafficDetails.tsx
+++ b/frontend/src/components/TrafficList/TrafficDetails.tsx
@@ -163,7 +163,8 @@ class TrafficDetailsComponent extends React.Component<TrafficDetailsProps, Traff
         const params = this.graphDataSource.fetchForServiceParams(
           this.props.duration,
           this.props.namespace,
-          this.props.itemName
+          this.props.itemName,
+          this.props.cluster
         );
         params.includeHealth = false;
         params.showSecurity = true;
@@ -187,7 +188,8 @@ class TrafficDetailsComponent extends React.Component<TrafficDetailsProps, Traff
         const params = this.graphDataSource.fetchForAppParams(
           this.props.duration,
           this.props.namespace,
-          this.props.itemName
+          this.props.itemName,
+          this.props.cluster
         );
         params.includeHealth = false;
         params.injectServiceNodes = false;

--- a/frontend/src/services/GraphDataSource.ts
+++ b/frontend/src/services/GraphDataSource.ts
@@ -310,17 +310,25 @@ export class GraphDataSource {
 
   // Some helpers
 
-  public fetchForApp = (duration: DurationInSeconds, namespace: string, app: string) => {
-    const params = this.fetchForAppParams(duration, namespace, app);
+  public fetchForApp = (duration: DurationInSeconds, namespace: string, app: string, cluster?: string) => {
+    const params = this.fetchForAppParams(duration, namespace, app, cluster);
     params.showSecurity = true;
     this.fetchGraphData(params);
   };
 
-  public fetchForAppParams = (duration: DurationInSeconds, namespace: string, app: string): FetchParams => {
+  public fetchForAppParams = (
+    duration: DurationInSeconds,
+    namespace: string,
+    app: string,
+    cluster?: string
+  ): FetchParams => {
     const params = GraphDataSource.defaultFetchParams(duration, namespace);
     params.graphType = GraphType.APP;
     params.node!.nodeType = NodeType.APP;
     params.node!.app = app;
+    if (cluster) {
+      params.node!.cluster = cluster;
+    }
     return params;
   };
 


### PR DESCRIPTION
https://github.com/kiali/kiali/issues/6712

Remote cluster's App Details and Service Details pages Traffic tab pages sent 'clusterName' params.

![Screenshot from 2023-10-16 10-44-30](https://github.com/kiali/kiali/assets/604313/72b6a23a-dfbe-41f4-be06-14ccf12b2308)
![Screenshot from 2023-10-16 10-44-06](https://github.com/kiali/kiali/assets/604313/fcf461aa-0426-48e7-8850-e0ab9e912f51)

