### PR TITLE
[backport 1.65] Update go version 1.20.10

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.10
-          #go-version-file: go.mod
+          go-version-file: go.mod
           # The builtin cache feature ensures that installing golangci-lint
           # is consistently fast.
           cache: true

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -22,7 +22,7 @@ jobs:
           go-version-file: go.mod
           # The builtin cache feature ensures that installing golangci-lint
           # is consistently fast.
-          cache: true
+          cache: false
           cache-dependency-path: go.sum
       - name: Lint Install
         run: make lint-install

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -24,6 +24,7 @@ jobs:
           # is consistently fast.
           cache: true
           cache-dependency-path: go.sum
+          check-latest: true
       - name: Lint Install
         run: make lint-install
 

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -19,10 +19,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: go.mod
+          go-version: 1.20.10
+          #go-version-file: go.mod
           # The builtin cache feature ensures that installing golangci-lint
           # is consistently fast.
-          cache: false
+          cache: true
           cache-dependency-path: go.sum
       - name: Lint Install
         run: make lint-install

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.20.5
+GO_VERSION_KIALI = 1.20.10
 GO_TEST_FLAGS ?=
 
 # Identifies the Kiali container image that will be built.


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6716

```
go mod tidy -v
go: downloading google.golang.org/appengine v1.6.7
go: downloading gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
go: downloading github.com/google/uuid v1.1.2
go: downloading github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
go: downloading github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
go: downloading github.com/onsi/ginkgo v1.14.0
go: downloading github.com/onsi/gomega v1.10.1
go: downloading github.com/jpillora/backoff v1.0.0
go: downloading github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e
go: downloading github.com/kr/text v0.2.0
go: downloading github.com/nxadm/tail v1.4.4
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading github.com/fsnotify/fsnotify v1.4.9
```