### PR TITLE
[backport 1.73] Update go version 1.20.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VERSION_LABEL ?= ${VERSION}
 # The go commands and the minimum Go version that must be used to build the app.
 GO ?= go
 GOFMT ?= $(shell ${GO} env GOROOT)/bin/gofmt
-GO_VERSION_KIALI = 1.20.5
+GO_VERSION_KIALI = 1.20.10
 GO_TEST_FLAGS ?=
 
 # Identifies the Kiali container image that will be built.


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/6716

```
go mod tidy -v
go: downloading google.golang.org/appengine v1.6.7
go: downloading go.uber.org/goleak v1.2.1
go: downloading github.com/onsi/gomega v1.27.4
go: downloading github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
go: downloading gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
go: downloading github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
go: downloading github.com/onsi/ginkgo/v2 v2.9.1
go: downloading github.com/golang/glog v1.1.0
go: downloading github.com/jpillora/backoff v1.0.0
go: downloading github.com/kr/pretty v0.3.0
go: downloading github.com/rogpeppe/go-internal v1.10.0
go: downloading github.com/kr/text v0.2.0
go: downloading golang.org/x/tools v0.7.0
go: downloading github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0
go: downloading github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1
```