### PR TITLE
Read Namespaces per cluster

### DIFF
--- a/business/proxy_status.go
+++ b/business/proxy_status.go
@@ -68,7 +68,7 @@ func (in *ProxyStatusService) GetConfigDumpResourceEntries(cluster, namespace, p
 		return nil, err
 	}
 
-	namespaces, err := in.businessLayer.Namespace.GetNamespaces(context.TODO())
+	namespaces, err := in.businessLayer.Namespace.GetClusterNamespaces(context.TODO(), cluster)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Found missing a `cluster` in reading namespaces while checking https://github.com/kiali/kiali/issues/6711

However the original issue could not be reproduced. 