### PR TITLE
[hack] When installing via istioctl, emit all traces

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -436,6 +436,7 @@ for s in \
    "--set values.global.meshID=${MESH_ID}" \
    "--set values.global.multiCluster.clusterName=${CLUSTER_NAME}" \
    "--set values.global.network=${NETWORK}" \
+   "--set values.meshConfig.defaultConfig.tracing.sampling=100.00" \
    "--set values.meshConfig.accessLogFile=/dev/stdout" \
    "${CNI_OPTIONS}" \
    "${REDUCE_RESOURCES_OPTIONS}" \


### PR DESCRIPTION
Increases the sampling rate for tracing to 100. This will hopefully fix #6671 where traces are not being seen because the env is very slow. The kiali traffic generator that creates traffic for the e2e tests probably doesn't produce enough requests to overwhelm the jaeger deployment in the testing environment but the sampling rate can be lowered in the future if that happens.