### PR TITLE
Fix auto-detect of istio cluster name for "remote kiali" setup

### DIFF
--- a/kiali.go
+++ b/kiali.go
@@ -260,6 +260,7 @@ func updateConfigWithIstioInfo() {
 		homeCluster = config.DefaultClusterID
 	}
 
+	log.Debugf("Auto-detected the istio cluster name to be [%s]. Updating the kiali config", homeCluster)
 	conf.KubernetesConfig.ClusterName = homeCluster
 	config.Set(&conf)
 }

--- a/kiali.go
+++ b/kiali.go
@@ -28,6 +28,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -35,8 +36,6 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
-
-	"k8s.io/client-go/rest"
 
 	"github.com/kiali/kiali/business/authentication"
 	"github.com/kiali/kiali/config"
@@ -219,13 +218,10 @@ func determineContainerVersion(defaultVersion string) string {
 	return v
 }
 
+// This is used to update the config with information about istio that
+// comes from the environment such as the cluster name.
 func updateConfigWithIstioInfo() {
 	conf := *config.Get()
-
-	if !conf.InCluster {
-		// If it's not an in-cluster kiali, we don't need to do anything
-		return
-	}
 
 	homeCluster := conf.KubernetesConfig.ClusterName
 	if homeCluster != "" {
@@ -234,18 +230,25 @@ func updateConfigWithIstioInfo() {
 	}
 
 	err := func() error {
-		restConf, err := rest.InClusterConfig()
-		if err != nil {
-			return err
-		}
+		log.Debug("Cluster name is not set. Attempting to auto-detect the cluster name from the home cluster environment.")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-		k8s, err := kubernetes.NewClientFromConfig(restConf)
+		// Need to create a temporary client factory here so that we can create a client
+		// to auto-detect the istio cluster name from the environment. There's a bit of a
+		// chicken and egg problem with the client factory because the client factory
+		// uses the cluster id to keep track of all the clients. But in order to create
+		// a client to get the cluster id from the environment, you need to create a client factory.
+		// To get around that we create a temporary client factory here and then set the kiali
+		// config cluster name. We then create the global client factory later in the business
+		// package and that global client factory has the cluster id set properly.
+		cf, err := kubernetes.NewClientFactory(ctx, conf)
 		if err != nil {
 			return err
 		}
 
 		// Try to auto-detect the cluster name
-		homeCluster, _, err = kubernetes.ClusterInfoFromIstiod(conf, k8s)
+		homeCluster, _, err = kubernetes.ClusterInfoFromIstiod(conf, cf.GetSAHomeClusterClient())
 		if err != nil {
 			return err
 		}

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -142,7 +142,7 @@ func getConfigForLocalCluster() (*rest.Config, error) {
 	}
 }
 
-// NewClientFromConfig creates a new client to the Kubernetes and Istio APIs.
+// newClientFromConfig creates a new client to the Kubernetes and Istio APIs.
 // It takes the assumption that Istio is deployed into the cluster.
 // It hides the access to Kubernetes/Openshift credentials.
 // It hides the low level use of the API of Kubernetes and Istio, it should be considered as an implementation detail.

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -92,8 +92,8 @@ func (client *K8SClient) ClusterInfo() ClusterInfo {
 	return client.clusterInfo
 }
 
-func NewClientWithRemoteClusterInfo(config *rest.Config, remoteClusterInfo *RemoteClusterInfo) (*K8SClient, error) {
-	client, err := NewClientFromConfig(config)
+func newClientWithRemoteClusterInfo(config *rest.Config, remoteClusterInfo *RemoteClusterInfo) (*K8SClient, error) {
+	client, err := newClientFromConfig(config)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func getConfigForLocalCluster() (*rest.Config, error) {
 // It hides the access to Kubernetes/Openshift credentials.
 // It hides the low level use of the API of Kubernetes and Istio, it should be considered as an implementation detail.
 // It returns an error on any problem.
-func NewClientFromConfig(config *rest.Config) (*K8SClient, error) {
+func newClientFromConfig(config *rest.Config) (*K8SClient, error) {
 	client := K8SClient{
 		token: config.BearerToken,
 	}

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/base64"
 	"errors"
@@ -70,24 +71,49 @@ func GetClientFactory() (ClientFactory, error) {
 			return
 		}
 
-		// Get the normal configuration
-		var config *rest.Config
-		config, err = getConfigForLocalCluster()
-		if err != nil {
-			return
-		}
-
-		// Create a new config based on what was gathered above but don't specify the bearer token to use
-		baseConfig := rest.Config{
-			Host:            config.Host, // TODO: do we need this? remote cluster clients should ignore this
-			TLSClientConfig: config.TLSClientConfig,
-			QPS:             kialiConfig.Get().KubernetesConfig.QPS,
-			Burst:           kialiConfig.Get().KubernetesConfig.Burst,
-		}
-
-		factory, err = newClientFactory(&baseConfig)
+		factory, err = getClientFactory(*kialiConfig.Get())
 	})
 	return factory, err
+}
+
+func getClientFactory(conf kialiConfig.Config) (*clientFactory, error) {
+	// Get the normal configuration
+	var config *rest.Config
+	config, err := getConfigForLocalCluster()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new config based on what was gathered above but don't specify the bearer token to use
+	baseConfig := rest.Config{
+		Host:            config.Host, // TODO: do we need this? remote cluster clients should ignore this
+		TLSClientConfig: config.TLSClientConfig,
+		QPS:             conf.KubernetesConfig.QPS,
+		Burst:           conf.KubernetesConfig.Burst,
+	}
+
+	return newClientFactory(&baseConfig)
+}
+
+// NewClientFactory creates a new client factory that can be transitory.
+// Callers should close the ctx when done with the client factory.
+// Does not set the global ClientFactory. You should probably use
+// GetClientFactory instead of this method unless you temporaily need
+// to create a client like when Kiali sets the cluster id.
+func NewClientFactory(ctx context.Context, conf kialiConfig.Config) (ClientFactory, error) {
+	cf, err := getClientFactory(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Need to cleanup the recycle chan since this client factory could be transitory.
+	go func() {
+		<-ctx.Done()
+		log.Debug("Stopping client factory recycle chan")
+		close(cf.recycleChan)
+	}()
+
+	return cf, nil
 }
 
 // newClientFactory allows for specifying the config and expiry duration
@@ -193,7 +219,7 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 
 	var newClient ClientInterface
 	if cluster == cf.homeCluster {
-		client, err := NewClientWithRemoteClusterInfo(&config, nil)
+		client, err := newClientWithRemoteClusterInfo(&config, nil)
 		if err != nil {
 			log.Errorf("Error creating client for cluster %s: %s", cluster, err.Error())
 			return nil, err
@@ -226,7 +252,7 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 			remoteConfig.BearerToken = authInfo.Token
 		}
 
-		newClient, err = NewClientWithRemoteClusterInfo(remoteConfig, &clusterInfo)
+		newClient, err = newClientWithRemoteClusterInfo(remoteConfig, &clusterInfo)
 		if err != nil {
 			log.Errorf("Error getting remote client for cluster [%s]. Err: %s", cluster, err.Error())
 			return nil, err
@@ -251,7 +277,7 @@ func (cf *clientFactory) newSAClient(remoteClusterInfo *RemoteClusterInfo) (*K8S
 		return nil, err
 	}
 
-	client, err := NewClientWithRemoteClusterInfo(config, remoteClusterInfo)
+	client, err := newClientWithRemoteClusterInfo(config, remoteClusterInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +365,7 @@ func (cf *clientFactory) watchClients() {
 		// listen signal from recycleChan
 		tokenHash, ok := <-cf.recycleChan
 		if !ok {
-			log.Error("recycleChan closed when watching clients")
+			log.Debug("recycleChan closed when watching clients")
 			return
 		}
 		// clean expired client with its token hash

--- a/kubernetes/client_factory_test.go
+++ b/kubernetes/client_factory_test.go
@@ -477,7 +477,6 @@ func TestNewClientFactoryClosesRecycleWhenCTXCancelled(t *testing.T) {
 	// Create the remote secret so that the "in cluster" config is not used.
 	// Otherwise the "in cluster" config looks for some env vars that are not present.
 	const testClusterName = "TestRemoteCluster"
-	const testUserToken = "TestUserToken"
 	filename := createTestRemoteClusterSecret(t, testClusterName, remoteClusterYAML)
 
 	cfg := config.NewConfig()
@@ -513,7 +512,6 @@ func TestNewClientFactoryDoesNotSetGlobalClientFactory(t *testing.T) {
 	// Create the remote secret so that the "in cluster" config is not used.
 	// Otherwise the "in cluster" config looks for some env vars that are not present.
 	const testClusterName = "TestRemoteCluster"
-	const testUserToken = "TestUserToken"
 	filename := createTestRemoteClusterSecret(t, testClusterName, remoteClusterYAML)
 
 	cfg := config.NewConfig()
@@ -537,7 +535,6 @@ func TestClientFactoryReturnsSAClientWhenConfigClusterNameIsEmpty(t *testing.T) 
 	// Create the remote secret so that the "in cluster" config is not used.
 	// Otherwise the "in cluster" config looks for some env vars that are not present.
 	const testClusterName = "TestRemoteCluster"
-	const testUserToken = "TestUserToken"
 	filename := createTestRemoteClusterSecret(t, testClusterName, remoteClusterYAML)
 
 	cfg := config.NewConfig()

--- a/kubernetes/client_factory_test.go
+++ b/kubernetes/client_factory_test.go
@@ -531,7 +531,7 @@ func TestNewClientFactoryDoesNotSetGlobalClientFactory(t *testing.T) {
 	require.Nil(factory)
 }
 
-func TestClientFactoryReturnsSAClientWithEmptyClusterName(t *testing.T) {
+func TestClientFactoryReturnsSAClientWhenConfigClusterNameIsEmpty(t *testing.T) {
 	require := require.New(t)
 
 	// Create the remote secret so that the "in cluster" config is not used.

--- a/kubernetes/client_factory_test.go
+++ b/kubernetes/client_factory_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	_ "embed"
 	"encoding/base64"
 	"fmt"
@@ -468,4 +469,89 @@ func TestClientCreatedWithProxyInfo(t *testing.T) {
 	client = clientFactory.GetSAClient(cfg.KubernetesConfig.ClusterName)
 	require.NotEqual(cfg.Auth.OpenId.ApiProxy, client.ClusterInfo().ClientConfig.Host)
 	require.NotEqual(proxyCAData, client.ClusterInfo().ClientConfig.CAData)
+}
+
+func TestNewClientFactoryClosesRecycleWhenCTXCancelled(t *testing.T) {
+	require := require.New(t)
+
+	// Create the remote secret so that the "in cluster" config is not used.
+	// Otherwise the "in cluster" config looks for some env vars that are not present.
+	const testClusterName = "TestRemoteCluster"
+	const testUserToken = "TestUserToken"
+	filename := createTestRemoteClusterSecret(t, testClusterName, remoteClusterYAML)
+
+	cfg := config.NewConfig()
+	cfg.Deployment.RemoteSecretPath = filename
+	SetConfig(t, *cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	f, err := NewClientFactory(ctx, *cfg)
+	t.Cleanup(func() {
+		KialiTokenForHomeCluster = "" // Need to reset this global because other tests depend on it being empty.
+	})
+	require.NoError(err)
+	factory := f.(*clientFactory)
+
+	cancel()
+
+	select {
+	case <-time.After(200 * time.Millisecond):
+		require.Fail("recycleChan should have been closed")
+	case <-factory.recycleChan:
+	}
+}
+
+func TestNewClientFactoryDoesNotSetGlobalClientFactory(t *testing.T) {
+	require := require.New(t)
+
+	// Make sure global is nil before test begins
+	if factory != nil {
+		factory = nil
+	}
+
+	// Create the remote secret so that the "in cluster" config is not used.
+	// Otherwise the "in cluster" config looks for some env vars that are not present.
+	const testClusterName = "TestRemoteCluster"
+	const testUserToken = "TestUserToken"
+	filename := createTestRemoteClusterSecret(t, testClusterName, remoteClusterYAML)
+
+	cfg := config.NewConfig()
+	cfg.Deployment.RemoteSecretPath = filename
+	SetConfig(t, *cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	_, err := NewClientFactory(ctx, *cfg)
+	t.Cleanup(func() {
+		KialiTokenForHomeCluster = "" // Need to reset this global because other tests depend on it being empty.
+	})
+	require.NoError(err)
+
+	require.Nil(factory)
+}
+
+func TestClientFactoryReturnsSAClientWithEmptyClusterName(t *testing.T) {
+	require := require.New(t)
+
+	// Create the remote secret so that the "in cluster" config is not used.
+	// Otherwise the "in cluster" config looks for some env vars that are not present.
+	const testClusterName = "TestRemoteCluster"
+	const testUserToken = "TestUserToken"
+	filename := createTestRemoteClusterSecret(t, testClusterName, remoteClusterYAML)
+
+	cfg := config.NewConfig()
+	cfg.Deployment.RemoteSecretPath = filename
+	cfg.KubernetesConfig.ClusterName = ""
+	SetConfig(t, *cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	clientFactory, err := NewClientFactory(ctx, *cfg)
+	t.Cleanup(func() {
+		KialiTokenForHomeCluster = "" // Need to reset this global because other tests depend on it being empty.
+	})
+	require.NoError(err)
+
+	require.NotNil(clientFactory.GetSAHomeClusterClient())
 }


### PR DESCRIPTION
Previously the auto-detect of the cluster name was skipped entirely when `config.InCluster = false`. Kiali can still auto-detect the cluster name in this case so there's no reason to skip it.

Related to #6742 