### PR TITLE
Fix issues with gateway-badging in graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ operator
 # Do not commit helm-charts code to this repo
 helm-charts
 
+# Ignore ansible if a dev has installed it under kiali for convenience
+ansible
 
 ############################################
 #                FRONTEND                  #

--- a/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -267,6 +267,7 @@ export class GraphStyles {
       if (node.hasWorkloadEntry) {
         badges = `<span class="${NodeIconWorkloadEntry} ${badgeMargin(badges)}"></span> ${badges}`;
       }
+
       if (node.isRoot) {
         if (
           node.isGateway?.ingressInfo?.hostnames?.length !== undefined ||

--- a/frontend/src/config/Icons.ts
+++ b/frontend/src/config/Icons.ts
@@ -43,15 +43,6 @@ const mutIcons = {
       text: 'Circuit Breaker',
       type: 'fa'
     } as IconType,
-    missingLabel: {
-      ascii: '\uE932',
-      className: 'fa fa-wrench',
-      color: 'red',
-      icon: WrenchIcon,
-      name: 'wrench',
-      text: 'Missing Label',
-      type: 'fa'
-    } as IconType,
     faultInjection: {
       ascii: '\uf05e ',
       className: 'fa fa-ban',
@@ -68,7 +59,7 @@ const mutIcons = {
       type: 'pf'
     } as IconType,
     mirroring: {
-      className: 'pf-icon pf-icon-migration',
+      className: 'pf-v5-pficon pf-v5-pficon-migration',
       icon: MigrationIcon,
       name: 'migration',
       text: 'Mirroring',
@@ -76,16 +67,25 @@ const mutIcons = {
     } as IconType,
     missingAuthPolicy: {
       ascii: '\ue946 ',
-      className: 'pf-icon pf-icon-security',
+      className: 'pf-v5-pficon pf-v5-pficon-security',
       color: 'red',
       icon: SecurityIcon,
       name: 'security',
       text: 'Missing Auth Policy',
       type: 'pf'
     } as IconType,
+    missingLabel: {
+      ascii: '\uE932',
+      className: 'fa fa-wrench',
+      color: 'red',
+      icon: WrenchIcon,
+      name: 'wrench',
+      text: 'Missing Label',
+      type: 'fa'
+    } as IconType,
     missingSidecar: {
       ascii: '\ue915 ',
-      className: 'pf-icon pf-icon-blueprint',
+      className: 'pf-v5-pficon pf-v5-pficon-blueprint',
       color: 'red',
       icon: BlueprintIcon,
       name: 'blueprint',
@@ -94,7 +94,7 @@ const mutIcons = {
     } as IconType,
     mtls: {
       ascii: '\ue923 ',
-      className: 'pf-icon pf-icon-locked',
+      className: 'pf-v5-pficon pf-v5-pficon-locked',
       icon: LockedIcon,
       name: 'locked',
       text: 'mTLS',
@@ -142,7 +142,7 @@ const mutIcons = {
     } as IconType,
     workloadEntry: {
       ascii: '\uf126 ',
-      className: 'pf-icon pf-icon-virtual-machine',
+      className: 'pf-v5-pficon pf-v5-pficon-virtual-machine',
       icon: VirtualMachineIcon,
       name: 'virtual-machine',
       text: 'Workload Entry',

--- a/frontend/src/config/Icons.ts
+++ b/frontend/src/config/Icons.ts
@@ -61,7 +61,7 @@ const mutIcons = {
       type: 'fa'
     } as IconType,
     gateway: {
-      className: 'pf-icon pf-icon-globe-route',
+      className: 'pf-v5-pficon pf-v5-pficon-globe-route',
       icon: GlobeRouteIcon,
       name: 'globe-route',
       text: 'Gateway',

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -334,7 +334,8 @@ func (a IstioAppender) decorateGateways(trafficMap graph.TrafficMap, globalInfo 
 	if len(ingressNodeMapping) != 0 || len(egressNodeMapping) != 0 {
 		gatewaysCrds := a.getIstioGatewayResources(globalInfo)
 
-		for cluster, gwCrds := range gatewaysCrds {
+		for accessibleNamespaceKey, gwCrds := range gatewaysCrds {
+			cluster := strings.Split(accessibleNamespaceKey, ":")[0]
 			for _, gwCrd := range gwCrds {
 				decorateMatchingGateways(cluster, gwCrd, ingressNodeMapping, graph.IsIngressGateway)
 				decorateMatchingGateways(cluster, gwCrd, egressNodeMapping, graph.IsEgressGateway)
@@ -346,7 +347,8 @@ func (a IstioAppender) decorateGateways(trafficMap graph.TrafficMap, globalInfo 
 	if len(gatewayAPINodeMapping) != 0 {
 		gatewaysCrds := a.getGatewayAPIResources(globalInfo)
 
-		for cluster, gwCrds := range gatewaysCrds {
+		for accessibleNamespaceKey, gwCrds := range gatewaysCrds {
+			cluster := strings.Split(accessibleNamespaceKey, ":")[0]
 			for _, gwCrd := range gwCrds {
 				decorateMatchingAPIGateways(cluster, gwCrd, gatewayAPINodeMapping, graph.IsGatewayAPI)
 			}


### PR DESCRIPTION
Fixes #6740 

As far as I can tell this has been broken since Kiali v1.69, due to the multi-cluster work in https://github.com/kiali/kiali/pull/6209.  That is a server-side problem.  But then there was a second problem introduced with the PF5 update, which changed the name of the icon we are using for our gateway badge.

We should backport this to 1.73 (careful of the icon name changes, those may not be necessary).
