### PR TITLE
Hide Traces for remote cluster's Workload/Service/App object details

### DIFF
--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -24,6 +24,7 @@ import { ErrorSection } from '../../components/ErrorSection/ErrorSection';
 import { connectRefresh } from '../../components/Refresh/connectRefresh';
 import { history, HistoryManager } from 'app/History';
 import { basicTabStyle } from 'styles/TabStyles';
+import { isHomeCluster } from '../../config/ServerConfig';
 
 type AppDetailsState = {
   app?: App;
@@ -197,7 +198,11 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     const tabsArray: JSX.Element[] = [overTab, trafficTab, inTab, outTab];
 
     // Conditional Traces tab
-    if (this.props.tracingInfo && this.props.tracingInfo.enabled) {
+    if (
+      this.props.tracingInfo &&
+      this.props.tracingInfo.enabled &&
+      isHomeCluster(this.state.cluster ? this.state.cluster : '')
+    ) {
       if (this.props.tracingInfo.integration) {
         tabsArray.push(
           <Tab eventKey={4} style={{ textAlign: 'center' }} title={'Traces'} key={tracesTabName}>

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -34,6 +34,7 @@ import { connectRefresh } from '../../components/Refresh/connectRefresh';
 import { history, HistoryManager } from 'app/History';
 import { durationSelector } from 'store/Selectors';
 import { basicTabStyle } from 'styles/TabStyles';
+import { isHomeCluster } from '../../config/ServerConfig';
 
 type ServiceDetailsState = {
   cluster?: string;
@@ -204,7 +205,12 @@ class ServiceDetailsPageComponent extends React.Component<ServiceDetailsProps, S
 
     const tabsArray: JSX.Element[] = [overTab, trafficTab, inTab];
 
-    if (this.props.tracingInfo && this.props.tracingInfo.enabled && this.props.tracingInfo.integration) {
+    if (
+      this.props.tracingInfo &&
+      this.props.tracingInfo.enabled &&
+      this.props.tracingInfo.integration &&
+      isHomeCluster(this.state.cluster ? this.state.cluster : '')
+    ) {
       tabsArray.push(
         <Tab eventKey={3} title="Traces" key="Traces">
           <TracesComponent

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -8,7 +8,7 @@ import * as AlertUtils from '../../utils/AlertUtils';
 import { IstioMetrics } from '../../components/Metrics/IstioMetrics';
 import { MetricsObjectTypes } from '../../types/Metrics';
 import { CustomMetrics } from '../../components/Metrics/CustomMetrics';
-import { serverConfig } from '../../config/ServerConfig';
+import { isHomeCluster, serverConfig } from '../../config/ServerConfig';
 import { WorkloadPodLogs } from './WorkloadPodLogs';
 import { DurationInSeconds, TimeInMilliseconds } from '../../types/Common';
 import { KialiAppState } from '../../store/Store';
@@ -221,7 +221,12 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
     );
     tabsArray.push(outTab);
 
-    if (this.props.tracingInfo && this.props.tracingInfo.enabled && this.props.tracingInfo.integration) {
+    if (
+      this.props.tracingInfo &&
+      this.props.tracingInfo.enabled &&
+      this.props.tracingInfo.integration &&
+      isHomeCluster(this.state.cluster ? this.state.cluster : '')
+    ) {
       tabsArray.push(
         <Tab eventKey={5} title="Traces" key="Traces">
           <TracesComponent


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6710

As the 'Traces' for multicluster is not implemented yet, and it is not possible to filter in tracing service by cluster, hiding the 'Traces' tab for Service/Workload/Application details pages for remote clusters, as they were duplicating the info from home cluster.