### PR TITLE
Avoid cluster in API query params, only clusterName

### DIFF
--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Tab } from '@patternfly/react-core';
 import * as API from '../../services/Api';
-import { App, AppId } from '../../types/App';
+import { App, AppId, AppQuery } from '../../types/App';
 import { AppInfo } from './AppInfo';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { IstioMetrics } from '../../components/Metrics/IstioMetrics';
@@ -93,7 +93,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     if (!cluster) {
       cluster = this.state.cluster;
     }
-    const params: { [key: string]: string } = { rateInterval: String(this.props.duration) + 's', health: 'true' };
+    const params: AppQuery = { rateInterval: `${String(this.props.duration)}s`, health: 'true' };
     API.getApp(this.props.appId.namespace, this.props.appId.app, params, cluster)
       .then(details => {
         this.setState({

--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -28,17 +28,17 @@ import { basicTabStyle } from 'styles/TabStyles';
 type AppDetailsState = {
   app?: App;
   cluster?: string;
-  health?: AppHealth;
   // currentTab is needed to (un)mount tab components
   // when the tab is not rendered.
   currentTab: string;
   error?: ErrorMsg;
+  health?: AppHealth;
 };
 
 type ReduxProps = {
   duration: DurationInSeconds;
-  tracingInfo?: TracingInfo;
   timeRange: TimeRange;
+  tracingInfo?: TracingInfo;
 };
 
 type AppDetailsProps = ReduxProps & {
@@ -73,6 +73,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     // when linking from one cluster's app to another cluster's app, cluster in state should be changed
     const cluster = HistoryManager.getClusterName() || this.state.cluster;
     const currentTab = activeTab(tabName, defaultTab);
+
     if (
       this.props.appId.namespace !== prevProps.appId.namespace ||
       this.props.appId.app !== prevProps.appId.app ||
@@ -89,10 +90,11 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     }
   }
 
-  private fetchApp = (cluster?: string) => {
+  private fetchApp = (cluster?: string): void => {
     if (!cluster) {
       cluster = this.state.cluster;
     }
+
     const params: AppQuery = { rateInterval: `${String(this.props.duration)}s`, health: 'true' };
     API.getApp(this.props.appId.namespace, this.props.appId.app, params, cluster)
       .then(details => {
@@ -109,13 +111,13 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
         AlertUtils.addError('Could not fetch App Details.', error);
         const msg: ErrorMsg = {
           title: 'No App is selected',
-          description: this.props.appId.app + ' is not found in the mesh'
+          description: `${this.props.appId.app} is not found in the mesh`
         };
         this.setState({ error: msg });
       });
   };
 
-  private runtimeTabs() {
+  private runtimeTabs(): JSX.Element[] {
     let tabOffset = 0;
 
     const tabs: JSX.Element[] = [];
@@ -124,10 +126,10 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
         runtime.dashboardRefs.forEach(dashboard => {
           if (dashboard.template !== 'envoy') {
             const tabKey = tabOffset + nextTabIndex;
-            paramToTab['cd-' + dashboard.template] = tabKey;
+            paramToTab[`cd-${dashboard.template}`] = tabKey;
 
             const tab = (
-              <Tab title={dashboard.title} key={'cd-' + dashboard.template} eventKey={tabKey}>
+              <Tab title={dashboard.title} key={`cd-${dashboard.template}`} eventKey={tabKey}>
                 <CustomMetrics
                   lastRefreshAt={this.props.lastRefreshAt}
                   namespace={this.props.appId.namespace}
@@ -146,7 +148,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     return tabs;
   }
 
-  private staticTabs() {
+  private staticTabs(): JSX.Element[] {
     const overTab = (
       <Tab title="Overview" eventKey={0} key={'Overview'}>
         <AppInfo app={this.state.app} duration={this.props.duration} health={this.state.health} />
@@ -212,12 +214,12 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
         );
       } else {
         const service = this.props.tracingInfo.namespaceSelector
-          ? this.props.appId.app + '.' + this.props.appId.namespace
+          ? `${this.props.appId.app}.${this.props.appId.namespace}`
           : this.props.appId.app;
         tabsArray.push(
           <Tab
             eventKey={4}
-            href={this.props.tracingInfo.url + `/search?service=${service}`}
+            href={`${this.props.tracingInfo.url}/search?service=${service}`}
             target="_blank"
             title={
               <>
@@ -232,8 +234,8 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     return tabsArray;
   }
 
-  private renderTabs() {
-    // PF4 Tabs doesn't support static tabs followed of an array of tabs created dynamically.
+  private renderTabs(): JSX.Element[] {
+    // PF Tabs doesn't support static tabs followed of an array of tabs created dynamically.
     return this.staticTabs().concat(this.runtimeTabs());
   }
 
@@ -254,7 +256,9 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     return (
       <>
         <RenderHeader location={history.location} rightToolbar={<TimeControl customDuration={useCustomTime} />} />
+
         {this.state.error && <ErrorSection error={this.state.error} />}
+
         {this.state.app && (
           <ParameterizedTabs
             id="basic-tabs"

--- a/frontend/src/pages/AppList/AppListPage.tsx
+++ b/frontend/src/pages/AppList/AppListPage.tsx
@@ -4,7 +4,7 @@ import { RenderContent } from '../../components/Nav/Page';
 import * as AppListFilters from './FiltersAndSorts';
 import { DefaultSecondaryMasthead } from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import * as FilterComponent from '../../components/FilterList/FilterComponent';
-import { AppListItem } from '../../types/AppList';
+import { AppListItem, AppListQuery } from '../../types/AppList';
 import { DurationInSeconds } from '../../types/Common';
 import { Namespace } from '../../types/Namespace';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
@@ -96,8 +96,8 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
       return API.getApps(namespace, {
         health: health,
         istioResources: istioResources,
-        rateInterval: String(rateInterval) + 's'
-      });
+        rateInterval: `${String(rateInterval)}s`
+      } as AppListQuery);
     });
     this.promises
       .registerAll('apps', appsPromises)

--- a/frontend/src/pages/AppList/AppListPage.tsx
+++ b/frontend/src/pages/AppList/AppListPage.tsx
@@ -4,7 +4,7 @@ import { RenderContent } from '../../components/Nav/Page';
 import * as AppListFilters from './FiltersAndSorts';
 import { DefaultSecondaryMasthead } from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import * as FilterComponent from '../../components/FilterList/FilterComponent';
-import { AppListItem, AppListQuery } from '../../types/AppList';
+import { AppListItem } from '../../types/AppList';
 import { DurationInSeconds } from '../../types/Common';
 import { Namespace } from '../../types/Namespace';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
@@ -25,8 +25,8 @@ import { isMultiCluster } from '../../config';
 type AppListPageState = FilterComponent.State<AppListItem>;
 
 type ReduxProps = {
-  duration: DurationInSeconds;
   activeNamespaces: Namespace[];
+  duration: DurationInSeconds;
 };
 
 type AppListPageProps = ReduxProps & FilterComponent.Props<AppListItem>;
@@ -39,6 +39,7 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
     super(props);
     const prevCurrentSortField = FilterHelper.currentSortField(AppListFilters.sortFields);
     const prevIsSortAscending = FilterHelper.isCurrentSortAscending();
+
     this.state = {
       listItems: [],
       currentSortField: prevCurrentSortField,
@@ -53,6 +54,7 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
   componentDidUpdate(prevProps: AppListPageProps) {
     const prevCurrentSortField = FilterHelper.currentSortField(AppListFilters.sortFields);
     const prevIsSortAscending = FilterHelper.isCurrentSortAscending();
+
     if (
       !namespaceEquals(this.props.activeNamespaces, prevProps.activeNamespaces) ||
       this.props.duration !== prevProps.duration ||
@@ -63,6 +65,7 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
         currentSortField: prevCurrentSortField,
         isSortAscending: prevIsSortAscending
       });
+
       this.updateListItems();
     }
   }
@@ -77,11 +80,12 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
     return AppListFilters.sortAppsItems(items, sortField, isAscending);
   }
 
-  updateListItems() {
+  updateListItems(): void {
     this.promises.cancelAll();
     const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
     const activeToggles: ActiveTogglesInfo = Toggles.getToggles();
     const namespacesSelected = this.props.activeNamespaces.map(item => item.name);
+
     if (namespacesSelected.length !== 0) {
       this.fetchApps(namespacesSelected, activeFilters, activeToggles, this.props.duration);
     } else {
@@ -89,7 +93,7 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
     }
   }
 
-  fetchApps(namespaces: string[], filters: ActiveFiltersInfo, toggles: ActiveTogglesInfo, rateInterval: number) {
+  fetchApps(namespaces: string[], filters: ActiveFiltersInfo, toggles: ActiveTogglesInfo, rateInterval: number): void {
     const appsPromises = namespaces.map(namespace => {
       const health = toggles.get('health') ? 'true' : 'false';
       const istioResources = toggles.get('istioResources') ? 'true' : 'false';
@@ -97,8 +101,9 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
         health: health,
         istioResources: istioResources,
         rateInterval: `${String(rateInterval)}s`
-      } as AppListQuery);
+      });
     });
+
     this.promises
       .registerAll('apps', appsPromises)
       .then(responses => {
@@ -122,6 +127,7 @@ class AppListPageComponent extends FilterComponent.Component<AppListPageProps, A
 
   render() {
     const hiddenColumns = isMultiCluster ? ([] as string[]) : ['cluster'];
+
     Toggles.getToggles().forEach((v, k) => {
       if (!v) {
         hiddenColumns.push(k);

--- a/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -192,26 +192,30 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
           <br />
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}
         </div>
+
         <div className={summaryBodyTabs}>
-          <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
+          <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '0.5rem' }}>
             <Tooltip
               id="tooltip-inbound"
               content="Traffic entering from another namespace."
               entryDelay={1250}
               triggerRef={tooltipInboundRef}
             />
+
             <Tooltip
               id="tooltip-outbound"
               content="Traffic exiting to another namespace."
               entryDelay={1250}
               triggerRef={tooltipOutboundRef}
             />
+
             <Tooltip
               id="tooltip-total"
               content="All inbound, outbound and internal namespace traffic."
               entryDelay={1250}
               triggerRef={tooltipTotalRef}
             />
+
             <Tab style={summaryFont} title="Inbound" eventKey={0} ref={tooltipInboundRef}>
               <div style={summaryFont}>
                 {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
@@ -219,6 +223,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                     <KialiIcon.Info /> No inbound traffic.
                   </>
                 )}
+
                 {grpcIn.rate > 0 && (
                   <RateTableGrpc
                     isRequests={isGrpcRequests}
@@ -227,6 +232,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                     rateNR={grpcIn.rateNoResponse}
                   />
                 )}
+
                 {httpIn.rate > 0 && (
                   <RateTableHttp
                     title="HTTP (requests per second):"
@@ -237,6 +243,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                     rateNR={httpIn.rateNoResponse}
                   />
                 )}
+
                 {tcpIn.rate > 0 && <RateTableTcp rate={tcpIn.rate} />}
                 {
                   // We don't show a sparkline here because we need to aggregate the traffic of an
@@ -244,6 +251,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                 }
               </div>
             </Tab>
+
             <Tab style={summaryFont} title="Outbound" eventKey={1} ref={tooltipOutboundRef}>
               <div style={summaryFont}>
                 {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
@@ -251,6 +259,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                     <KialiIcon.Info /> No outbound traffic.
                   </>
                 )}
+
                 {grpcOut.rate > 0 && (
                   <RateTableGrpc
                     isRequests={isGrpcRequests}
@@ -259,6 +268,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                     rateNR={grpcOut.rateNoResponse}
                   />
                 )}
+
                 {httpOut.rate > 0 && (
                   <RateTableHttp
                     title="HTTP (requests per second):"
@@ -269,6 +279,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                     rateNR={httpOut.rateNoResponse}
                   />
                 )}
+
                 {tcpOut.rate > 0 && <RateTableTcp rate={tcpOut.rate} />}
                 {
                   // We don't show a sparkline here because we need to aggregate the traffic of an
@@ -276,6 +287,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                 }
               </div>
             </Tab>
+
             <Tab style={summaryFont} title="Total" eventKey={2} ref={tooltipTotalRef}>
               <div style={summaryFont}>
                 {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
@@ -283,6 +295,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                     <KialiIcon.Info /> No traffic.
                   </>
                 )}
+
                 {grpcTotal.rate > 0 && (
                   <RateTableGrpc
                     isRequests={isGrpcRequests}
@@ -291,6 +304,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                     rateNR={grpcTotal.rateNoResponse}
                   />
                 )}
+
                 {httpTotal.rate > 0 && (
                   <RateTableHttp
                     title="HTTP (requests per second):"
@@ -302,6 +316,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
                   />
                 )}
                 {tcpTotal.rate > 0 && <RateTableTcp rate={tcpTotal.rate} />}
+
                 <div>
                   {hr()}
                   {this.renderCharts(isPF)}
@@ -325,17 +340,22 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
     let inboundEdges;
     let outboundEdges;
     let totalEdges;
+
     if (isPF) {
       const controller = (namespaceBox as Node).getController();
       const { nodes } = elems(controller);
+
       const outsideNodes = selectOr(nodes, [
         [{ prop: NodeAttr.namespace, op: '!=', val: namespace }],
         [{ prop: NodeAttr.cluster, op: '!=', val: cluster }]
       ]) as Node[];
+
       // inbound edges are from a different namespace or a different cluster
       inboundEdges = edgesOut(outsideNodes, boxed);
+
       // outbound edges are to a different namespace or a different cluster
       outboundEdges = edgesIn(outsideNodes, boxed);
+
       // total edges are inbound + edges from boxed workload|app|root nodes (i.e. not injected service nodes or box nodes)
       totalEdges = [...inboundEdges];
       totalEdges.push(...edgesOut(select(boxed, { prop: NodeAttr.workload, op: 'truthy' }) as Node[]));
@@ -345,8 +365,10 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
         .cy()
         .nodes(`[${NodeAttr.namespace} != "${namespace}"],[${NodeAttr.cluster} != "${cluster}"]`)
         .edgesTo(boxed);
+
       // outbound edges are to a different namespace or a different cluster
       outboundEdges = boxed.edgesTo(`[${NodeAttr.namespace} != "${namespace}"],[${NodeAttr.cluster} != "${cluster}"]`);
+
       // total edges are inbound + edges from boxed workload|app|root nodes (i.e. not injected service nodes or box nodes)
       totalEdges = inboundEdges.add(boxed.filter(`[?${NodeAttr.workload}]`).edgesTo('*'));
     }
@@ -374,9 +396,11 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
 
     boxed.filter(`node[nodeType = "${NodeType.APP}"]`).forEach(node => {
       const app = node.data(NodeAttr.app);
+
       if (appVersions[app] === undefined) {
         appVersions[app] = new Set();
       }
+
       appVersions[app].add(node.data(NodeAttr.version));
     });
 
@@ -394,9 +418,11 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
     select(boxed, { prop: NodeAttr.nodeType, val: NodeType.APP }).forEach(node => {
       const data = node.getData();
       const app = data[NodeAttr.app];
+
       if (appVersions[app] === undefined) {
         appVersions[app] = new Set();
       }
+
       appVersions[app].add(data[NodeAttr.version]);
     });
 
@@ -408,12 +434,13 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
     };
   };
 
-  private renderNamespace = (ns: string) => {
+  private renderNamespace = (ns: string): React.ReactNode => {
     const validation = this.state.validation;
+
     return (
       <React.Fragment key={ns}>
         <span>
-          <PFBadge badge={PFBadges.Namespace} size="sm" style={{ marginBottom: '2px' }} />
+          <PFBadge badge={PFBadges.Namespace} size="sm" style={{ marginBottom: '0.125rem' }} />
           {ns}{' '}
           {!!validation && (
             <ValidationSummaryLink
@@ -423,11 +450,11 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
               warnings={validation.warnings}
             >
               <ValidationSummary
-                id={'ns-val-' + ns}
+                id={`ns-val-${ns}`}
                 errors={validation.errors}
                 warnings={validation.warnings}
                 objectCount={validation.objectCount}
-                style={{ marginLeft: '5px' }}
+                style={{ marginLeft: '0.25rem' }}
               />
             </ValidationSummaryLink>
           )}
@@ -443,7 +470,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
     numApps: number,
     numVersions: number,
     numEdges: number
-  ) => (
+  ): React.ReactNode => (
     <>
       {numApps > 0 && (
         <>
@@ -476,8 +503,9 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
     </>
   );
 
-  private renderCharts = (isPF: boolean) => {
+  private renderCharts = (isPF: boolean): React.ReactNode => {
     const props: SummaryPanelPropType = this.props;
+
     const namespace = isPF
       ? props.data.summaryTarget.getData()[NodeAttr.namespace]
       : props.data.summaryTarget.data(NodeAttr.namespace);
@@ -517,6 +545,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
             />
           </>
         )}
+
         {grpcTotal.rate > 0 && !isGrpcRequests && (
           <>
             <StreamChart
@@ -533,6 +562,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
             />
           </>
         )}
+
         {httpTotal.rate > 0 && (
           <>
             <RequestChart
@@ -547,6 +577,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
             />
           </>
         )}
+
         {tcpTotal.rate > 0 && (
           <>
             <StreamChart
@@ -567,8 +598,9 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
     );
   };
 
-  private updateCharts = (isPF: boolean) => {
+  private updateCharts = (isPF: boolean): void => {
     const props: SummaryPanelPropType = this.props;
+
     const cluster = isPF
       ? props.data.summaryTarget.getData()[NodeAttr.cluster]
       : props.data.summaryTarget.data(NodeAttr.cluster);
@@ -598,6 +630,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
     let promiseOut: Promise<Response<IstioMetricsMap>> = Promise.resolve({ data: {} });
 
     let filters: string[] = [];
+
     if (grpcTotal.rate > 0 && !isGrpcRequests) {
       filters.push('grpc_sent', 'grpc_received');
     }
@@ -646,6 +679,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
         const comparator = (labels: Labels, protocol?: Protocol) => {
           return protocol ? labels.request_protocol === protocol : true;
         };
+
         const metricsIn = responses[0].data;
         const metricsOut = responses[1].data;
 
@@ -674,7 +708,9 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
           console.debug('SummaryPanelNamespaceBox: Ignore fetch error (canceled).');
           return;
         }
+
         const errorMsg = error.response && error.response.data.error ? error.response.data.error : error.message;
+
         this.setState({
           loading: false,
           metricsLoadError: errorMsg,
@@ -691,6 +727,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
       : this.props.data.summaryTarget.data(NodeAttr.namespace);
 
     this.validationPromise = makeCancelablePromise(API.getNamespaceValidations(namespace));
+
     this.validationPromise.promise
       .then(rs => {
         this.setState({ validation: rs.data });

--- a/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -610,28 +610,34 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
     }
 
     if (filters.length > 0) {
-      promiseIn = API.getNamespaceMetrics(namespace, {
-        byLabels: ['request_protocol'], // ignored by prom if it doesn't exist
-        cluster: cluster,
-        direction: 'inbound',
-        duration: props.duration,
-        filters: filters,
-        queryTime: props.queryTime,
-        rateInterval: props.rateInterval,
-        reporter: 'destination',
-        step: props.step
-      } as IstioMetricsOptions);
-      promiseOut = API.getNamespaceMetrics(namespace, {
-        byLabels: ['request_protocol'], // ignored by prom if it doesn't exist
-        cluster: cluster,
-        direction: 'outbound',
-        duration: props.duration,
-        filters: filters,
-        queryTime: props.queryTime,
-        rateInterval: props.rateInterval,
-        reporter: 'source',
-        step: props.step
-      } as IstioMetricsOptions);
+      promiseIn = API.getNamespaceMetrics(
+        namespace,
+        {
+          byLabels: ['request_protocol'], // ignored by prom if it doesn't exist
+          direction: 'inbound',
+          duration: props.duration,
+          filters: filters,
+          queryTime: props.queryTime,
+          rateInterval: props.rateInterval,
+          reporter: 'destination',
+          step: props.step
+        } as IstioMetricsOptions,
+        cluster
+      );
+      promiseOut = API.getNamespaceMetrics(
+        namespace,
+        {
+          byLabels: ['request_protocol'], // ignored by prom if it doesn't exist
+          direction: 'outbound',
+          duration: props.duration,
+          filters: filters,
+          queryTime: props.queryTime,
+          rateInterval: props.rateInterval,
+          reporter: 'source',
+          step: props.step
+        } as IstioMetricsOptions,
+        cluster
+      );
     }
 
     this.metricsPromise = makeCancelablePromise(Promise.all([promiseIn, promiseOut]));

--- a/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -26,7 +26,6 @@ import {
 } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { IstioMetricsMap, Datapoint, Labels } from '../../types/Metrics';
-import { IstioMetricsOptions } from '../../types/MetricsOptions';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { KialiIcon } from 'config/KialiIcon';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
@@ -621,7 +620,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
           rateInterval: props.rateInterval,
           reporter: 'destination',
           step: props.step
-        } as IstioMetricsOptions,
+        },
         cluster
       );
       promiseOut = API.getNamespaceMetrics(
@@ -635,7 +634,7 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
           rateInterval: props.rateInterval,
           reporter: 'source',
           step: props.step
-        } as IstioMetricsOptions,
+        },
         cluster
       );
     }

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -348,7 +348,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
       });
   }
 
-  fetchHealthChunk(chunk: NamespaceInfo[], duration: DurationInSeconds, type: OverviewType) {
+  async fetchHealthChunk(chunk: NamespaceInfo[], duration: DurationInSeconds, type: OverviewType) {
     const apiFunc = switchType(
       type,
       API.getNamespaceAppHealth,
@@ -356,7 +356,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
       API.getNamespaceWorkloadHealth
     );
     return Promise.all(
-      chunk.map(nsInfo => {
+      chunk.map(async nsInfo => {
         const healthPromise: Promise<NamespaceAppHealth | NamespaceWorkloadHealth | NamespaceServiceHealth> = apiFunc(
           nsInfo.name,
           duration,
@@ -422,11 +422,14 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
     };
 
     return Promise.all(
-      chunk.map(nsInfo => {
+      chunk.map(async nsInfo => {
+        let clusterParam: string | undefined;
+
         if (nsInfo.cluster && isMultiCluster) {
-          options.clusterName = nsInfo.cluster;
+          clusterParam = nsInfo.cluster;
         }
-        return API.getNamespaceMetrics(nsInfo.name, options).then(rs => {
+
+        return API.getNamespaceMetrics(nsInfo.name, options, clusterParam).then(rs => {
           nsInfo.metrics = rs.data.request_count;
           nsInfo.errorMetrics = rs.data.request_error_count;
           if (nsInfo.name === serverConfig.istioNamespace) {

--- a/frontend/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
+++ b/frontend/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Overview page renders initial layout 1`] = `
     }
   />
   <EmptyState
-    className="kiali_f17rctdi"
+    className="kiali_f1grtvu0"
     variant="full"
   >
     <EmptyStateHeader

--- a/frontend/src/pages/ServiceList/ServiceListPage.tsx
+++ b/frontend/src/pages/ServiceList/ServiceListPage.tsx
@@ -3,7 +3,7 @@ import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import { RenderContent } from '../../components/Nav/Page';
 import * as ServiceListFilters from './FiltersAndSorts';
 import * as FilterComponent from '../../components/FilterList/FilterComponent';
-import { ServiceList, ServiceListItem } from '../../types/ServiceList';
+import { ServiceList, ServiceListItem, ServiceListQuery } from '../../types/ServiceList';
 import { DurationInSeconds } from '../../types/Common';
 import { Namespace } from '../../types/Namespace';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
@@ -131,9 +131,9 @@ class ServiceListPageComponent extends FilterComponent.Component<
       API.getServices(ns, {
         health: health,
         istioResources: istioResources,
-        rateInterval: String(rateInterval) + 's',
+        rateInterval: `${String(rateInterval)}s`,
         onlyDefinitions: onlyDefinitions
-      })
+      } as ServiceListQuery)
     );
 
     this.promises

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { EmptyState, EmptyStateBody, EmptyStateVariant, Tab, EmptyStateHeader } from '@patternfly/react-core';
 import * as API from '../../services/Api';
-import { Workload, WorkloadId } from '../../types/Workload';
+import { Workload, WorkloadId, WorkloadQuery } from '../../types/Workload';
 import { WorkloadInfo } from './WorkloadInfo';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { IstioMetrics } from '../../components/Metrics/IstioMetrics';
@@ -105,9 +105,9 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
     if (!cluster) {
       cluster = this.state.cluster;
     }
-    const params: { [key: string]: string } = {
+    const params: WorkloadQuery = {
       validate: 'true',
-      rateInterval: String(this.props.duration) + 's',
+      rateInterval: `${String(this.props.duration)}s`,
       health: 'true'
     };
     await API.getWorkload(this.props.workloadId.namespace, this.props.workloadId.workload, params, cluster)

--- a/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -3,7 +3,7 @@ import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import { RenderContent } from '../../components/Nav/Page';
 import * as WorkloadListFilters from './FiltersAndSorts';
 import * as FilterComponent from '../../components/FilterList/FilterComponent';
-import { WorkloadListItem, WorkloadNamespaceResponse } from '../../types/Workload';
+import { WorkloadListItem, WorkloadListQuery, WorkloadNamespaceResponse } from '../../types/Workload';
 import { DurationInSeconds } from '../../types/Common';
 import { Namespace } from '../../types/Namespace';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
@@ -131,8 +131,8 @@ class WorkloadListPageComponent extends FilterComponent.Component<
       return API.getWorkloads(namespace, {
         health: health,
         istioResources: istioResources,
-        rateInterval: String(rateInterval) + 's'
-      });
+        rateInterval: `${String(rateInterval)}s`
+      } as WorkloadListQuery);
     });
     this.promises
       .registerAll('workloads', workloadsConfigPromises)

--- a/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -3,7 +3,7 @@ import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import { RenderContent } from '../../components/Nav/Page';
 import * as WorkloadListFilters from './FiltersAndSorts';
 import * as FilterComponent from '../../components/FilterList/FilterComponent';
-import { WorkloadListItem, WorkloadListQuery, WorkloadNamespaceResponse } from '../../types/Workload';
+import { WorkloadListItem, WorkloadNamespaceResponse } from '../../types/Workload';
 import { DurationInSeconds } from '../../types/Common';
 import { Namespace } from '../../types/Namespace';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
@@ -28,8 +28,8 @@ import { validationKey } from '../../types/IstioConfigList';
 type WorkloadListPageState = FilterComponent.State<WorkloadListItem>;
 
 type ReduxProps = {
-  duration: DurationInSeconds;
   activeNamespaces: Namespace[];
+  duration: DurationInSeconds;
 };
 
 type WorkloadListPageProps = ReduxProps & FilterComponent.Props<WorkloadListItem>;
@@ -57,7 +57,7 @@ class WorkloadListPageComponent extends FilterComponent.Component<
     this.updateListItems();
   }
 
-  componentDidUpdate(prevProps: WorkloadListPageProps, _prevState: WorkloadListPageState, _snapshot: any) {
+  componentDidUpdate(prevProps: WorkloadListPageProps) {
     const prevCurrentSortField = FilterHelper.currentSortField(WorkloadListFilters.sortFields);
     const prevIsSortAscending = FilterHelper.isCurrentSortAscending();
     if (
@@ -78,17 +78,22 @@ class WorkloadListPageComponent extends FilterComponent.Component<
     this.promises.cancelAll();
   }
 
-  sortItemList(workloads: WorkloadListItem[], sortField: SortField<WorkloadListItem>, isAscending: boolean) {
+  sortItemList(
+    workloads: WorkloadListItem[],
+    sortField: SortField<WorkloadListItem>,
+    isAscending: boolean
+  ): WorkloadListItem[] {
     // Chain promises, as there may be an ongoing fetch/refresh and sort can be called after UI interaction
     // This ensures that the list will display the new data with the right sorting
     return WorkloadListFilters.sortWorkloadsItems(workloads, sortField, isAscending);
   }
 
-  updateListItems() {
+  updateListItems(): void {
     this.promises.cancelAll();
     const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
     const activeToggles: ActiveTogglesInfo = Toggles.getToggles();
     const namespacesSelected = this.props.activeNamespaces.map(item => item.name);
+
     if (namespacesSelected.length !== 0) {
       this.fetchWorkloads(namespacesSelected, activeFilters, activeToggles, this.props.duration);
     } else {
@@ -121,30 +126,41 @@ class WorkloadListPageComponent extends FilterComponent.Component<
         )
       }));
     }
+
     return [];
   };
 
-  fetchWorkloads(namespaces: string[], filters: ActiveFiltersInfo, toggles: ActiveTogglesInfo, rateInterval: number) {
+  fetchWorkloads(
+    namespaces: string[],
+    filters: ActiveFiltersInfo,
+    toggles: ActiveTogglesInfo,
+    rateInterval: number
+  ): void {
     const workloadsConfigPromises = namespaces.map(namespace => {
       const health = toggles.get('health') ? 'true' : 'false';
       const istioResources = toggles.get('istioResources') ? 'true' : 'false';
+
       return API.getWorkloads(namespace, {
         health: health,
         istioResources: istioResources,
         rateInterval: `${String(rateInterval)}s`
-      } as WorkloadListQuery);
+      });
     });
+
     this.promises
       .registerAll('workloads', workloadsConfigPromises)
       .then(responses => {
         let workloadsItems: WorkloadListItem[] = [];
+
         responses.forEach(response => {
           workloadsItems = workloadsItems.concat(this.getDeploymentItems(response.data));
         });
+
         return WorkloadListFilters.filterBy(workloadsItems, filters);
       })
       .then(workloadsItems => {
         this.promises.cancel('sort');
+
         this.setState({
           listItems: this.sortItemList(workloadsItems, this.state.currentSortField, this.state.isSortAscending)
         });
@@ -158,7 +174,8 @@ class WorkloadListPageComponent extends FilterComponent.Component<
   }
 
   render() {
-    const hiddenColumns = isMultiCluster ? ([] as string[]) : ['cluster'];
+    const hiddenColumns = isMultiCluster ? [] : ['cluster'];
+
     Toggles.getToggles().forEach((v, k) => {
       if (!v) {
         hiddenColumns.push(k);
@@ -168,11 +185,13 @@ class WorkloadListPageComponent extends FilterComponent.Component<
     return (
       <>
         <RefreshNotifier onTick={this.updateListItems} />
+
         <DefaultSecondaryMasthead
           rightToolbar={
-            <TimeDurationComponent key={'DurationDropdown'} id="workload-list-duration-dropdown" disabled={false} />
+            <TimeDurationComponent key="DurationDropdown" id="workload-list-duration-dropdown" disabled={false} />
           }
         />
+
         <RenderContent>
           <VirtualList rows={this.state.listItems} hiddenColumns={hiddenColumns} type="workloads">
             <StatefulFilters
@@ -188,7 +207,7 @@ class WorkloadListPageComponent extends FilterComponent.Component<
   }
 }
 
-const mapStateToProps = (state: KialiAppState) => ({
+const mapStateToProps = (state: KialiAppState): ReduxProps => ({
   activeNamespaces: activeNamespacesSelector(state),
   duration: durationSelector(state)
 });

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -458,13 +458,8 @@ export const getWorkloadDashboard = (
   return newRequest<DashboardModel>(HTTP_VERBS.GET, urls.workloadDashboard(namespace, workload), queryParams, {});
 };
 
-export const getCustomDashboard = (
-  ns: string,
-  tpl: string,
-  params: DashboardQuery,
-  cluster?: string
-) => {
-  const queryParams: any = { ...params };
+export const getCustomDashboard = (ns: string, tpl: string, params: DashboardQuery, cluster?: string) => {
+  const queryParams: QueryParams<DashboardQuery> = { ...params };
   if (cluster) {
     queryParams.clusterName = cluster;
   }

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -510,7 +510,7 @@ export const getNamespaceServiceHealth = async (
   };
 
   if (duration) {
-    params.rateInterval = `${String(duration)}s}`;
+    params.rateInterval = `${String(duration)}s`;
   }
   if (queryTime) {
     params.queryTime = String(queryTime);
@@ -545,7 +545,7 @@ export const getNamespaceWorkloadHealth = async (
   };
 
   if (duration) {
-    params.rateInterval = `${String(duration)}s}`;
+    params.rateInterval = `${String(duration)}s`;
   }
   if (queryTime) {
     params.queryTime = String(queryTime);

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -466,7 +466,7 @@ export const getCustomDashboard = (ns: string, tpl: string, params: DashboardQue
   return newRequest<DashboardModel>(HTTP_VERBS.GET, urls.customDashboard(ns, tpl), queryParams, {});
 };
 
-export const getNamespaceAppHealth = async (
+export const getNamespaceAppHealth = (
   namespace: string,
   duration: DurationInSeconds,
   cluster?: string,
@@ -609,16 +609,13 @@ export const getTrace = (idTrace: string) => {
   return newRequest<TracingSingleResponse>(HTTP_VERBS.GET, urls.tracingTrace(idTrace), {}, {});
 };
 
-export const getGraphElements = (params: GraphElementsQuery, cluster?: string) => {
-  const queryParams: QueryParams<GraphElementsQuery> = { ...params };
-  if (cluster) {
-    queryParams.clusterName = cluster;
-  }
-  return newRequest<GraphDefinition>(HTTP_VERBS.GET, urls.namespacesGraphElements, queryParams, {});
+export const getGraphElements = (params: GraphElementsQuery) => {
+  return newRequest<GraphDefinition>(HTTP_VERBS.GET, urls.namespacesGraphElements, params, {});
 };
 
 export const getNodeGraphElements = (node: NodeParamsType, params: GraphElementsQuery, cluster?: string) => {
   const queryParams: QueryParams<GraphElementsQuery> = { ...params };
+
   if (cluster) {
     queryParams.clusterName = cluster;
   }

--- a/frontend/src/services/GraphDataSource.ts
+++ b/frontend/src/services/GraphDataSource.ts
@@ -306,7 +306,7 @@ export class GraphDataSource {
     if (fetchParams.node) {
       this.fetchDataForNode(restParams, cluster);
     } else {
-      this.fetchDataForNamespaces(restParams, cluster);
+      this.fetchDataForNamespaces(restParams);
     }
   };
 
@@ -492,10 +492,10 @@ export class GraphDataSource {
     this.eventEmitter.emit(eventName, ...args);
   };
 
-  private fetchDataForNamespaces = (restParams: GraphElementsQuery, cluster?: string) => {
+  private fetchDataForNamespaces = (restParams: GraphElementsQuery) => {
     restParams.namespaces = this.fetchParameters.namespaces.map(namespace => namespace.name).join(',');
 
-    this.promiseRegistry.register(PROMISE_KEY, API.getGraphElements(restParams, cluster)).then(
+    this.promiseRegistry.register(PROMISE_KEY, API.getGraphElements(restParams)).then(
       response => {
         const responseData: any = response.data;
         this.graphElements = responseData && responseData.elements ? responseData.elements : EMPTY_GRAPH_DATA;

--- a/frontend/src/services/GraphDataSource.ts
+++ b/frontend/src/services/GraphDataSource.ts
@@ -136,7 +136,7 @@ export class GraphDataSource {
     this._isError = this._isLoading = false;
   }
 
-  public fetchGraphData = (fetchParams: FetchParams) => {
+  public fetchGraphData = (fetchParams: FetchParams): void => {
     const previousFetchParams = this.fetchParameters;
 
     // Copy fetch parameters to a local attribute
@@ -310,17 +310,17 @@ export class GraphDataSource {
     }
   };
 
-  public on: OnEvents = (eventName: any, callback: any) => {
+  public on: OnEvents = (eventName: any, callback: any): void => {
     this.eventEmitter.on(eventName, callback);
   };
 
-  public removeListener: OnEvents = (eventName: any, callback: any) => {
+  public removeListener: OnEvents = (eventName: any, callback: any): void => {
     this.eventEmitter.removeListener(eventName, callback);
   };
 
   // Some helpers
 
-  public fetchForApp = (duration: DurationInSeconds, namespace: string, app: string, cluster?: string) => {
+  public fetchForApp = (duration: DurationInSeconds, namespace: string, app: string, cluster?: string): void => {
     const params = this.fetchForAppParams(duration, namespace, app, cluster);
     params.showSecurity = true;
     this.fetchGraphData(params);
@@ -344,7 +344,12 @@ export class GraphDataSource {
     return params;
   };
 
-  public fetchForVersionedApp = (duration: DurationInSeconds, namespace: string, app: string, cluster?: string) => {
+  public fetchForVersionedApp = (
+    duration: DurationInSeconds,
+    namespace: string,
+    app: string,
+    cluster?: string
+  ): void => {
     const params = this.fetchForVersionedAppParams(duration, namespace, app, cluster);
     params.showSecurity = true;
     this.fetchGraphData(params);
@@ -378,7 +383,12 @@ export class GraphDataSource {
     return params;
   };
 
-  public fetchForWorkload = (duration: DurationInSeconds, namespace: string, workload: string, cluster?: string) => {
+  public fetchForWorkload = (
+    duration: DurationInSeconds,
+    namespace: string,
+    workload: string,
+    cluster?: string
+  ): void => {
     const params = this.fetchForWorkloadParams(duration, namespace, workload, cluster);
     params.showSecurity = true;
     this.fetchGraphData(params);
@@ -412,7 +422,12 @@ export class GraphDataSource {
     return params;
   };
 
-  public fetchForService = (duration: DurationInSeconds, namespace: string, service: string, cluster?: string) => {
+  public fetchForService = (
+    duration: DurationInSeconds,
+    namespace: string,
+    service: string,
+    cluster?: string
+  ): void => {
     const params = this.fetchForServiceParams(duration, namespace, service, cluster);
     params.showSecurity = true;
     this.fetchGraphData(params);
@@ -446,7 +461,7 @@ export class GraphDataSource {
     return params;
   };
 
-  public fetchForNamespace = (duration: DurationInSeconds, namespace: string) => {
+  public fetchForNamespace = (duration: DurationInSeconds, namespace: string): void => {
     const params = this.fetchForNamespaceParams(duration, namespace);
     this.fetchGraphData(params);
   };
@@ -488,11 +503,11 @@ export class GraphDataSource {
     };
   }
 
-  private emit: EmitEvents = (eventName: any, ...args) => {
+  private emit: EmitEvents = (eventName: string, ...args: unknown[]) => {
     this.eventEmitter.emit(eventName, ...args);
   };
 
-  private fetchDataForNamespaces = (restParams: GraphElementsQuery) => {
+  private fetchDataForNamespaces = (restParams: GraphElementsQuery): void => {
     restParams.namespaces = this.fetchParameters.namespaces.map(namespace => namespace.name).join(',');
 
     this.promiseRegistry.register(PROMISE_KEY, API.getGraphElements(restParams)).then(
@@ -527,7 +542,7 @@ export class GraphDataSource {
     );
   };
 
-  private fetchDataForNode = (restParams: GraphElementsQuery, cluster?: string) => {
+  private fetchDataForNode = (restParams: GraphElementsQuery, cluster?: string): void => {
     this.promiseRegistry
       .register(PROMISE_KEY, API.getNodeGraphElements(this.fetchParameters.node!, restParams, cluster))
       .then(

--- a/frontend/src/services/__mocks__/Api.ts
+++ b/frontend/src/services/__mocks__/Api.ts
@@ -1,10 +1,11 @@
 import * as GraphData from '../__mockData__/getGraphElements';
 import * as ServiceData from '../__mockData__/getServiceDetail';
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
+import { GraphElementsQuery } from 'types/Graph';
 
-export const getGraphElements = (params: any) => {
-  if (GraphData.hasOwnProperty(params.namespaces)) {
-    return Promise.resolve({ data: GraphData[params.namespaces] });
+export const getGraphElements = (params: GraphElementsQuery) => {
+  if (GraphData.hasOwnProperty(params.namespaces!)) {
+    return Promise.resolve({ data: GraphData[params.namespaces!] });
   } else {
     return Promise.resolve({ data: {} });
   }

--- a/frontend/src/types/App.ts
+++ b/frontend/src/types/App.ts
@@ -3,25 +3,30 @@ import { Runtime } from './Workload';
 import { AppHealthResponse } from '../types/Health';
 
 export interface AppId {
+  app: string;
   cluster?: string;
   namespace: string;
-  app: string;
 }
 
 export interface AppWorkload {
-  workloadName: string;
   istioSidecar: boolean;
   istioAmbient: boolean;
-  serviceAccountNames: string[];
   labels: { [key: string]: string };
+  serviceAccountNames: string[];
+  workloadName: string;
 }
 
 export interface App {
   cluster?: string;
-  namespace: Namespace;
-  name: string;
-  workloads: AppWorkload[];
-  serviceNames: string[];
-  runtimes: Runtime[];
   health: AppHealthResponse;
+  name: string;
+  namespace: Namespace;
+  runtimes: Runtime[];
+  serviceNames: string[];
+  workloads: AppWorkload[];
+}
+
+export interface AppQuery {
+  health: 'true' | 'false';
+  rateInterval: string;
 }

--- a/frontend/src/types/AppList.ts
+++ b/frontend/src/types/AppList.ts
@@ -3,20 +3,26 @@ import { AppHealth } from './Health';
 import { ObjectReference } from './IstioObjects';
 
 export interface AppList {
-  namespace: Namespace;
   applications: AppOverview[];
+  namespace: Namespace;
 }
 
 export interface AppOverview {
-  name: string;
   cluster?: string;
-  istioSidecar: boolean;
-  istioAmbient: boolean;
-  labels: { [key: string]: string };
-  istioReferences: ObjectReference[];
   health: AppHealth;
+  istioAmbient: boolean;
+  istioReferences: ObjectReference[];
+  istioSidecar: boolean;
+  labels: { [key: string]: string };
+  name: string;
 }
 
 export interface AppListItem extends AppOverview {
   namespace: string;
+}
+
+export interface AppListQuery {
+  health: 'true' | 'false';
+  istioResources: 'true' | 'false';
+  rateInterval: string;
 }

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -1,5 +1,5 @@
 import { Namespace } from './Namespace';
-import { DurationInSeconds, TimeInSeconds } from './Common';
+import { AppenderString, DurationInSeconds, TimeInSeconds } from './Common';
 import { Health } from './Health';
 import { HealthAnnotationType } from './HealthAnnotation';
 
@@ -8,7 +8,9 @@ export interface Layout {
 }
 
 export const SUMMARY_PANEL_CHART_WIDTH = 250;
+
 export type SummaryType = 'graph' | 'node' | 'edge' | 'box';
+
 export interface SummaryData {
   isPF?: boolean;
   summaryType: SummaryType;
@@ -41,8 +43,8 @@ export enum EdgeMode {
 }
 
 export enum EdgeLabelMode {
-  RESPONSE_TIME_GROUP = 'responseTime',
   RESPONSE_TIME_AVERAGE = 'avg',
+  RESPONSE_TIME_GROUP = 'responseTime',
   RESPONSE_TIME_P50 = 'rt50',
   RESPONSE_TIME_P95 = 'rt95',
   RESPONSE_TIME_P99 = 'rt99',
@@ -199,12 +201,12 @@ export interface NodeParamsType {
   aggregate?: string;
   aggregateValue?: string;
   app: string;
+  cluster?: string;
   namespace: Namespace;
   nodeType: NodeType;
   service: string;
   version?: string;
   workload: string;
-  cluster?: string;
 }
 
 // This data is stored in the _global scratch area in the cy graph
@@ -224,8 +226,8 @@ export type CytoscapeGlobalScratchData = {
 };
 
 export interface CytoscapeBaseEvent {
-  summaryType: SummaryType; // what the summary panel should show
   summaryTarget: any; // the cytoscape element that was the target of the event
+  summaryType: SummaryType; // what the summary panel should show
 }
 
 export interface GraphEvent extends CytoscapeBaseEvent {
@@ -233,7 +235,6 @@ export interface GraphEvent extends CytoscapeBaseEvent {
 }
 
 // Graph Structures
-
 type PercentageOfTrafficByFlag = {
   [flag: string]: string;
 };
@@ -306,14 +307,14 @@ export const prettyProtocol = (protocol: ValidProtocols): string => {
 
 export interface DestService {
   cluster: string;
-  namespace: string;
   name: string;
+  namespace: string;
 }
 
 export interface DestService {
   cluster: string;
-  namespace: string;
   name: string;
+  namespace: string;
 }
 
 export interface SEInfo {
@@ -327,27 +328,27 @@ export interface WEInfo {
 }
 
 export interface GraphRequestsHealth {
+  healthAnnotations: { [idx: string]: string };
   inbound: { [idx: string]: { [idx: string]: number } };
   outbound: { [idx: string]: { [idx: string]: number } };
-  healthAnnotations: { [idx: string]: string };
 }
 
 export interface GraphWorkloadStatus {
-  name: string;
-  desiredReplicas: number;
-  currentReplicas: number;
   availableReplicas: number;
+  currentReplicas: number;
+  desiredReplicas: number;
+  name: string;
   syncedProxies: number;
 }
 
 export interface GraphNodeAppHealth {
-  workloadStatuses: GraphWorkloadStatus[];
   requests: GraphRequestsHealth;
+  workloadStatuses: GraphWorkloadStatus[];
 }
 
 export interface GraphNodeWorkloadHealth {
-  workloadStatus: GraphWorkloadStatus;
   requests: GraphRequestsHealth;
+  workloadStatus: GraphWorkloadStatus;
 }
 
 export interface GraphNodeServiceHealth {
@@ -413,14 +414,14 @@ export interface GraphNodeData {
 
 // Edge data expected from server
 export interface GraphEdgeData {
-  id: string;
-  source: string;
-  target: string;
   destPrincipal?: string;
-  responseTime?: number;
-  sourcePrincipal?: string;
-  traffic?: ProtocolTraffic;
+  id: string;
   isMTLS?: number;
+  responseTime?: number;
+  source: string;
+  sourcePrincipal?: string;
+  target: string;
+  traffic?: ProtocolTraffic;
 }
 
 export interface GraphNodeWrapper {
@@ -432,8 +433,24 @@ export interface GraphEdgeWrapper {
 }
 
 export interface GraphElements {
-  nodes?: GraphNodeWrapper[];
   edges?: GraphEdgeWrapper[];
+  nodes?: GraphNodeWrapper[];
+}
+
+export interface GraphElementsQuery {
+  appenders?: AppenderString;
+  boxBy?: string;
+  duration?: string;
+  graphType?: GraphType;
+  includeIdleEdges?: boolean;
+  injectServiceNodes?: boolean;
+  namespaces?: string;
+  queryTime?: string;
+  rateGrpc?: string;
+  rateHttp?: string;
+  rateTcp?: string;
+  responseTime?: string;
+  throughputType?: string;
 }
 
 export interface GraphDefinition {
@@ -459,7 +476,6 @@ export interface DecoratedGraphNodeData extends GraphNodeData {
   httpOut: number;
   tcpIn: number;
   tcpOut: number;
-
   traffic: never;
 
   // computed values...
@@ -513,8 +529,8 @@ export interface DecoratedGraphEdgeWrapper {
 }
 
 export interface DecoratedGraphElements {
-  nodes?: DecoratedGraphNodeWrapper[];
   edges?: DecoratedGraphEdgeWrapper[];
+  nodes?: DecoratedGraphNodeWrapper[];
 }
 
 export const EdgeAttr = {

--- a/frontend/src/types/Health.ts
+++ b/frontend/src/types/Health.ts
@@ -59,7 +59,7 @@ export interface WorkloadHealthResponse {
 
 export const TRAFFICSTATUS = 'Traffic Status';
 
-const createTrafficTitle = (time: string) => {
+const createTrafficTitle = (time: string): string => {
   return `${TRAFFICSTATUS} (Last ${time})`;
 };
 
@@ -337,7 +337,7 @@ interface HealthContext {
 }
 
 export class ServiceHealth extends Health {
-  public static fromJson = (ns: string, srv: string, json: any, ctx: HealthContext) =>
+  public static fromJson = (ns: string, srv: string, json: any, ctx: HealthContext): ServiceHealth =>
     new ServiceHealth(ns, srv, json.requests, ctx);
 
   private static computeItems(ns: string, srv: string, requests: RequestHealth, ctx: HealthContext): HealthConfig {
@@ -388,7 +388,7 @@ export class ServiceHealth extends Health {
 }
 
 export class AppHealth extends Health {
-  public static fromJson = (ns: string, app: string, json: any, ctx: HealthContext) =>
+  public static fromJson = (ns: string, app: string, json: any, ctx: HealthContext): AppHealth =>
     new AppHealth(ns, app, json.workloadStatuses, json.requests, ctx);
 
   private static computeItems(
@@ -405,9 +405,11 @@ export class AppHealth extends Health {
       const children: HealthSubItem[] = workloadStatuses.map(d => {
         const status = ratioCheck(d.availableReplicas, d.currentReplicas, d.desiredReplicas, d.syncedProxies);
         let proxyMessage = '';
+
         if (d.syncedProxies >= 0) {
           proxyMessage = proxyStatusMessage(d.syncedProxies, d.desiredReplicas);
         }
+
         return {
           text: `${d.name}: ${d.availableReplicas} / ${d.desiredReplicas}${proxyMessage}`,
           status: status
@@ -415,6 +417,7 @@ export class AppHealth extends Health {
       });
 
       const podsStatus = children.map(i => i.status).reduce((prev, cur) => mergeStatus(prev, cur), NA);
+
       const item: HealthItem = {
         title: POD_STATUS,
         status: podsStatus,
@@ -462,7 +465,7 @@ export class AppHealth extends Health {
 }
 
 export class WorkloadHealth extends Health {
-  public static fromJson = (ns: string, workload: string, json: any, ctx: HealthContext) =>
+  public static fromJson = (ns: string, workload: string, json: any, ctx: HealthContext): WorkloadHealth =>
     new WorkloadHealth(ns, workload, json.workloadStatus, json.requests, ctx);
 
   private static computeItems(
@@ -483,6 +486,7 @@ export class WorkloadHealth extends Health {
         workloadStatus.desiredReplicas,
         workloadStatus.syncedProxies
       );
+
       const item: HealthItem = {
         title: POD_STATUS,
         status: podsStatus,
@@ -493,6 +497,7 @@ export class WorkloadHealth extends Health {
           }
         ]
       };
+
       if (podsStatus !== NA && podsStatus !== HEALTHY) {
         item.children = [
           {

--- a/frontend/src/types/Health.ts
+++ b/frontend/src/types/Health.ts
@@ -19,18 +19,18 @@ interface HealthConfig {
 }
 
 export interface HealthItem {
-  status: Status;
-  title: string;
-  text?: string;
   children?: HealthSubItem[];
+  status: Status;
+  text?: string;
+  title: string;
 }
 
 export interface HealthItemConfig {
   status: Status;
-  title: string;
   text?: string;
-  value: number;
   threshold?: ToleranceConfig;
+  title: string;
+  value: number;
 }
 
 export interface HealthSubItem {
@@ -40,27 +40,27 @@ export interface HealthSubItem {
 }
 
 export interface WorkloadStatus {
-  name: string;
-  desiredReplicas: number;
-  currentReplicas: number;
   availableReplicas: number;
+  currentReplicas: number;
+  desiredReplicas: number;
+  name: string;
   syncedProxies: number;
 }
 
 export interface AppHealthResponse {
-  workloadStatuses: WorkloadStatus[];
   requests: RequestHealth;
+  workloadStatuses: WorkloadStatus[];
 }
 
 export interface WorkloadHealthResponse {
-  workloadStatus: WorkloadStatus;
   requests: RequestHealth;
+  workloadStatus: WorkloadStatus;
 }
 
 export const TRAFFICSTATUS = 'Traffic Status';
 
 const createTrafficTitle = (time: string) => {
-  return TRAFFICSTATUS + ' (Last ' + time + ')';
+  return `${TRAFFICSTATUS} (Last ${time})`;
 };
 
 /*
@@ -72,18 +72,19 @@ Example: { "http": {"200": 2, "404": 1 ...} ... }
 export interface RequestType {
   [key: string]: { [key: string]: number };
 }
+
 export interface RequestHealth {
+  healthAnnotations: HealthAnnotationType;
   inbound: RequestType;
   outbound: RequestType;
-  healthAnnotations: HealthAnnotationType;
 }
 
 export interface Status {
-  name: string;
-  color: string;
-  priority: number;
-  icon: React.ComponentClass<SVGIconProps>;
   class: string;
+  color: string;
+  icon: React.ComponentClass<SVGIconProps>;
+  name: string;
+  priority: number;
 }
 
 export interface ProxyStatus {
@@ -94,39 +95,43 @@ export interface ProxyStatus {
 }
 
 export const FAILURE: Status = {
-  name: 'Failure',
+  class: 'icon-failure',
   color: PFColors.Danger,
-  priority: 4,
   icon: ExclamationCircleIcon,
-  class: 'icon-failure'
+  name: 'Failure',
+  priority: 4
 };
+
 export const DEGRADED: Status = {
-  name: 'Degraded',
+  class: 'icon-degraded',
   color: PFColors.Warning,
-  priority: 3,
+  name: 'Degraded',
   icon: ExclamationTriangleIcon,
-  class: 'icon-degraded'
+  priority: 3
 };
+
 export const NOT_READY: Status = {
-  name: 'Not Ready',
+  class: 'icon-idle',
   color: PFColors.InfoBackground,
-  priority: 2,
   icon: MinusCircleIcon,
-  class: 'icon-idle'
+  name: 'Not Ready',
+  priority: 2
 };
+
 export const HEALTHY: Status = {
-  name: 'Healthy',
+  class: 'icon-healthy',
   color: PFColors.Success,
-  priority: 1,
   icon: CheckCircleIcon,
-  class: 'icon-healthy'
+  name: 'Healthy',
+  priority: 1
 };
+
 export const NA: Status = {
-  name: 'No health information',
+  class: 'icon-na',
   color: PFColors.Color200,
-  priority: 0,
+  name: 'No health information',
   icon: UnknownIcon,
-  class: 'icon-na'
+  priority: 0
 };
 
 interface Thresholds {
@@ -136,8 +141,8 @@ interface Thresholds {
 }
 
 export interface ThresholdStatus {
-  value: number;
   status: Status;
+  value: number;
   violation?: string;
 }
 
@@ -210,9 +215,7 @@ export const proxyStatusMessage = (syncedProxies: number, desiredReplicas: numbe
   let msg: string = '';
   if (syncedProxies < desiredReplicas) {
     const unsynced = desiredReplicas - syncedProxies;
-    msg = ' (' + unsynced;
-    msg += unsynced !== 1 ? ' proxies' : ' proxy';
-    msg += ' unsynced)';
+    msg = ` (${unsynced} ${unsynced !== 1 ? 'proxies' : 'proxy'} unsynced)`;
   }
   return msg;
 };
@@ -240,13 +243,13 @@ export const ascendingThresholdCheck = (value: number, thresholds: Thresholds): 
       return {
         value: value,
         status: FAILURE,
-        violation: value.toFixed(2) + thresholds.unit + '>=' + thresholds.failure + thresholds.unit
+        violation: `${value.toFixed(2)}${thresholds.unit}>=${thresholds.failure}${thresholds.unit}`
       };
     } else if (value >= thresholds.degraded) {
       return {
         value: value,
         status: DEGRADED,
-        violation: value.toFixed(2) + thresholds.unit + '>=' + thresholds.degraded + thresholds.unit
+        violation: `${value.toFixed(2)}${thresholds.unit}>=${thresholds.degraded}${thresholds.unit}`
       };
     }
   }
@@ -261,6 +264,7 @@ export const getRequestErrorsStatus = (ratio: number, tolerance?: ToleranceConfi
       failure: tolerance.failure,
       unit: '%'
     };
+
     return ascendingThresholdCheck(100 * ratio, thresholds);
   }
 
@@ -273,7 +277,7 @@ export const getRequestErrorsStatus = (ratio: number, tolerance?: ToleranceConfi
 export const getRequestErrorsSubItem = (thresholdStatus: ThresholdStatus, prefix: string): HealthSubItem => {
   return {
     status: thresholdStatus.status,
-    text: prefix + ': ' + (thresholdStatus.status === NA ? 'No requests' : thresholdStatus.value.toFixed(2) + '%'),
+    text: `${prefix}: ${thresholdStatus.status === NA ? 'No requests' : `${thresholdStatus.value.toFixed(2)}%`}`,
     value: thresholdStatus.status === NA ? 0 : thresholdStatus.value
   };
 };
@@ -288,6 +292,7 @@ export abstract class Health {
   getStatusConfig(): ToleranceConfig | undefined {
     // Check if the config applied is the kiali defaults one
     const tolConfDefault = serverConfig.healthConfig.rate[serverConfig.healthConfig.rate.length - 1].tolerance;
+
     for (let tol of tolConfDefault) {
       // Check if the tolerance applied is one of kiali defaults
       if (this.health.statusConfig && tol === this.health.statusConfig.threshold) {
@@ -295,6 +300,7 @@ export abstract class Health {
         return undefined;
       }
     }
+
     // Otherwise return the threshold configuration that kiali used to calculate the status
     return this.health.statusConfig?.threshold;
   }
@@ -302,28 +308,32 @@ export abstract class Health {
   getTrafficStatus(): HealthItem | undefined {
     for (let i = 0; i < this.health.items.length; i++) {
       const item = this.health.items[i];
+
       if (item.title.startsWith(TRAFFICSTATUS)) {
         return item;
       }
     }
+
     return undefined;
   }
 
   getWorkloadStatus(): HealthItem | undefined {
     for (let i = 0; i < this.health.items.length; i++) {
       const item = this.health.items[i];
+
       if (item.title.startsWith(POD_STATUS)) {
         return item;
       }
     }
+
     return undefined;
   }
 }
 
 interface HealthContext {
-  rateInterval: number;
-  hasSidecar: boolean;
   hasAmbient: boolean;
+  hasSidecar: boolean;
+  rateInterval: number;
 }
 
 export class ServiceHealth extends Health {
@@ -333,25 +343,29 @@ export class ServiceHealth extends Health {
   private static computeItems(ns: string, srv: string, requests: RequestHealth, ctx: HealthContext): HealthConfig {
     const items: HealthItem[] = [];
     let statusConfig: HealthItemConfig | undefined = undefined;
+
     if (ctx.hasSidecar) {
       // Request errors
       const reqError = calculateErrorRate(ns, srv, 'service', requests);
       const reqErrorsText =
         reqError.errorRatio.global.status.status === NA
           ? 'No requests'
-          : reqError.errorRatio.global.status.value.toFixed(2) + '%';
+          : `${reqError.errorRatio.global.status.value.toFixed(2)}%`;
+
       const item: HealthItem = {
         title: createTrafficTitle(getName(ctx.rateInterval).toLowerCase()),
         status: reqError.errorRatio.global.status.status,
         children: [
           {
-            text: 'Inbound: ' + reqErrorsText,
+            text: `Inbound: ${reqErrorsText}`,
             status: reqError.errorRatio.global.status.status,
             value: reqError.errorRatio.global.status.value
           }
         ]
       };
+
       items.push(item);
+
       statusConfig = {
         title: createTrafficTitle(getName(ctx.rateInterval).toLowerCase()),
         status: reqError.errorRatio.global.status.status,
@@ -395,16 +409,18 @@ export class AppHealth extends Health {
           proxyMessage = proxyStatusMessage(d.syncedProxies, d.desiredReplicas);
         }
         return {
-          text: d.name + ': ' + d.availableReplicas + ' / ' + d.desiredReplicas + proxyMessage,
+          text: `${d.name}: ${d.availableReplicas} / ${d.desiredReplicas}${proxyMessage}`,
           status: status
         };
       });
+
       const podsStatus = children.map(i => i.status).reduce((prev, cur) => mergeStatus(prev, cur), NA);
       const item: HealthItem = {
         title: POD_STATUS,
         status: podsStatus,
         children: children
       };
+
       items.push(item);
     }
 
@@ -414,19 +430,23 @@ export class AppHealth extends Health {
       const reqIn = reqError.errorRatio.inbound.status;
       const reqOut = reqError.errorRatio.outbound.status;
       const both = mergeStatus(reqIn.status, reqOut.status);
+
       const item: HealthItem = {
         title: createTrafficTitle(getName(ctx.rateInterval).toLowerCase()),
         status: both,
         children: [getRequestErrorsSubItem(reqIn, 'Inbound'), getRequestErrorsSubItem(reqOut, 'Outbound')]
       };
+
       statusConfig = {
         title: createTrafficTitle(getName(ctx.rateInterval).toLowerCase()),
         status: reqError.errorRatio.global.status.status,
         threshold: reqError.errorRatio.global.toleranceConfig,
         value: reqError.errorRatio.global.status.value
       };
+
       items.push(item);
     }
+
     return { items, statusConfig };
   }
 
@@ -454,6 +474,7 @@ export class WorkloadHealth extends Health {
   ): HealthConfig {
     const items: HealthItem[] = [];
     let statusConfig: HealthItemConfig | undefined = undefined;
+
     if (workloadStatus) {
       // Pods
       const podsStatus = ratioCheck(
@@ -467,8 +488,7 @@ export class WorkloadHealth extends Health {
         status: podsStatus,
         children: [
           {
-            text:
-              workloadStatus.name + ': ' + workloadStatus.availableReplicas + ' / ' + workloadStatus.desiredReplicas,
+            text: `${workloadStatus.name}: ${workloadStatus.availableReplicas} / ${workloadStatus.desiredReplicas}`,
             status: podsStatus
           }
         ]
@@ -478,19 +498,19 @@ export class WorkloadHealth extends Health {
           {
             status: podsStatus,
             text: String(
-              workloadStatus.desiredReplicas + ' desired pod' + (workloadStatus.desiredReplicas !== 1 ? 's' : '')
+              `${workloadStatus.desiredReplicas} desired pod${workloadStatus.desiredReplicas !== 1 ? 's' : ''}`
             )
           },
           {
             status: podsStatus,
             text: String(
-              workloadStatus.currentReplicas + ' current pod' + (workloadStatus.currentReplicas !== 1 ? 's' : '')
+              `${workloadStatus.currentReplicas} current pod${workloadStatus.currentReplicas !== 1 ? 's' : ''}`
             )
           },
           {
             status: podsStatus,
             text: String(
-              workloadStatus.availableReplicas + ' available pod' + (workloadStatus.availableReplicas !== 1 ? 's' : '')
+              `${workloadStatus.availableReplicas} available pod${workloadStatus.availableReplicas !== 1 ? 's' : ''}`
             )
           }
         ];
@@ -499,24 +519,28 @@ export class WorkloadHealth extends Health {
           item.children.push({
             status: podsStatus,
             text: String(
-              workloadStatus.syncedProxies + ' synced prox' + (workloadStatus.availableReplicas !== 1 ? 'ies' : 'y')
+              `${workloadStatus.syncedProxies} synced prox${workloadStatus.availableReplicas !== 1 ? 'ies' : 'y'}`
             )
           });
         }
       }
+
       items.push(item);
     }
+
     // Request errors
     if (ctx.hasSidecar) {
       const reqError = calculateErrorRate(ns, workload, 'workload', requests);
       const reqIn = reqError.errorRatio.inbound.status;
       const reqOut = reqError.errorRatio.outbound.status;
       const both = mergeStatus(reqIn.status, reqOut.status);
+
       const item: HealthItem = {
         title: createTrafficTitle(getName(ctx.rateInterval).toLowerCase()),
         status: both,
         children: [getRequestErrorsSubItem(reqIn, 'Inbound'), getRequestErrorsSubItem(reqOut, 'Outbound')]
       };
+
       items.push(item);
 
       statusConfig = {
@@ -526,6 +550,7 @@ export class WorkloadHealth extends Health {
         value: reqError.errorRatio.global.status.value
       };
     }
+
     return { items, statusConfig };
   }
 
@@ -560,3 +585,9 @@ export type WithWorkloadHealth<T> = T & { health: WorkloadHealth };
 
 export type WithHealth<T> = WithAppHealth<T> | WithServiceHealth<T> | WithWorkloadHealth<T>;
 export const hasHealth = <T>(val: T): val is WithHealth<T> => !!val['health'];
+
+export interface NamespaceHealthQuery {
+  queryTime?: string;
+  rateInterval?: string;
+  type: string;
+}

--- a/frontend/src/types/IstioConfigDetails.ts
+++ b/frontend/src/types/IstioConfigDetails.ts
@@ -25,37 +25,42 @@ import { AceOptions } from 'react-ace/types';
 
 export interface IstioConfigId {
   namespace: string;
-  objectType: string;
   object: string;
+  objectType: string;
 }
 
 export interface IstioConfigDetails {
-  namespace: Namespace;
+  authorizationPolicy: AuthorizationPolicy;
   cluster?: string;
+  destinationRule: DestinationRule;
+  envoyFilter: EnvoyFilter;
   gateway: Gateway;
+  help?: HelpMessage[];
   k8sGateway: K8sGateway;
   k8sHTTPRoute: K8sHTTPRoute;
-  virtualService: VirtualService;
-  destinationRule: DestinationRule;
+  namespace: Namespace;
+  peerAuthentication: PeerAuthentication;
+  permissions: ResourcePermissions;
+  references?: References;
+  requestAuthentication: RequestAuthentication;
   serviceEntry: ServiceEntry;
   sidecar: Sidecar;
+  telemetry: Telemetry;
+  validation: ObjectValidation;
+  virtualService: VirtualService;
+  wasmPlugin: WasmPlugin;
   workloadEntry: WorkloadEntry;
   workloadGroup: WorkloadGroup;
-  envoyFilter: EnvoyFilter;
-  wasmPlugin: WasmPlugin;
-  telemetry: Telemetry;
-  authorizationPolicy: AuthorizationPolicy;
-  peerAuthentication: PeerAuthentication;
-  requestAuthentication: RequestAuthentication;
-  permissions: ResourcePermissions;
-  validation: ObjectValidation;
-  references?: References;
-  help?: HelpMessage[];
+}
+
+export interface IstioConfigDetailsQuery {
+  help?: boolean;
+  validate?: boolean;
 }
 
 export const aceOptions: AceOptions = {
-  showPrintMargin: false,
-  autoScrollEditorIntoView: true
+  autoScrollEditorIntoView: true,
+  showPrintMargin: false
 };
 
 export const safeDumpOptions = {
@@ -65,8 +70,8 @@ export const safeDumpOptions = {
 };
 
 export interface ParsedSearch {
-  type?: string;
   name?: string;
+  type?: string;
 }
 
 export interface IstioPermissions {
@@ -75,20 +80,26 @@ export interface IstioPermissions {
   };
 }
 
+export interface IstioPermissionsQuery {
+  namespaces: string;
+}
+
 // Helper function to compare two IstioConfigDetails iterating over its IstioObject children.
 // When an IstioObject child has changed (resourceVersion is different) it will return a tuple with
 //  boolean: true if resourceVersion has changed in newer version
 //  string: IstioObject child
 //  string: resourceVersion of newer version
 export const compareResourceVersion = (
-  oldIstioConfigDetails,
+  oldIstioConfigDetails: IstioConfigDetails,
   newIstioConfigDetails: IstioConfigDetails
 ): [boolean, string, string] => {
   const keys = Object.keys(oldIstioConfigDetails);
+
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     const oldIstioObject = oldIstioConfigDetails[key] as IstioObject;
     const newIstioObject = newIstioConfigDetails[key] as IstioObject;
+
     if (
       oldIstioObject &&
       newIstioObject &&
@@ -101,5 +112,6 @@ export const compareResourceVersion = (
       return [true, key, newIstioObject.metadata.resourceVersion];
     }
   }
+
   return [false, '', ''];
 };

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -21,106 +21,117 @@ import {
 import { ResourcePermissions } from './Permissions';
 
 export interface IstioConfigItem {
-  namespace: string;
+  authorizationPolicy?: AuthorizationPolicy;
   cluster?: string;
-  type: string;
-  name: string;
   creationTimestamp?: string;
-  resourceVersion?: string;
+  destinationRule?: DestinationRule;
+  envoyFilter?: EnvoyFilter;
   gateway?: Gateway;
   k8sGateway?: K8sGateway;
   k8sHTTPRoute?: K8sHTTPRoute;
-  virtualService?: VirtualService;
-  destinationRule?: DestinationRule;
-  serviceEntry?: ServiceEntry;
-  authorizationPolicy?: AuthorizationPolicy;
-  sidecar?: Sidecar;
-  wasmPlugin?: WasmPlugin;
-  telemetry?: Telemetry;
+  name: string;
+  namespace: string;
   peerAuthentication?: PeerAuthentication;
   requestAuthentication?: RequestAuthentication;
+  resourceVersion?: string;
+  serviceEntry?: ServiceEntry;
+  sidecar?: Sidecar;
+  telemetry?: Telemetry;
+  type: string;
+  validation?: ObjectValidation;
+  virtualService?: VirtualService;
+  wasmPlugin?: WasmPlugin;
   workloadEntry?: WorkloadEntry;
   workloadGroup?: WorkloadGroup;
-  envoyFilter?: EnvoyFilter;
-  validation?: ObjectValidation;
+}
+
+export interface IstioConfigList {
+  authorizationPolicies: AuthorizationPolicy[];
+  destinationRules: DestinationRule[];
+  envoyFilters: EnvoyFilter[];
+  gateways: Gateway[];
+  k8sGateways: K8sGateway[];
+  k8sHTTPRoutes: K8sHTTPRoute[];
+  namespace: Namespace;
+  peerAuthentications: PeerAuthentication[];
+  permissions: { [key: string]: ResourcePermissions };
+  requestAuthentications: RequestAuthentication[];
+  serviceEntries: ServiceEntry[];
+  sidecars: Sidecar[];
+  telemetries: Telemetry[];
+  validations: Validations;
+  virtualServices: VirtualService[];
+  wasmPlugins: WasmPlugin[];
+  workloadEntries: WorkloadEntry[];
+  workloadGroups: WorkloadGroup[];
+}
+
+export interface IstioConfigListQuery {
+  labelSelector?: string;
+  objects?: string;
+  validate?: boolean;
+  workloadSelector?: string;
 }
 
 export declare type IstioConfigsMap = { [key: string]: IstioConfigList };
 
-export interface IstioConfigList {
-  namespace: Namespace;
-  gateways: Gateway[];
-  k8sGateways: K8sGateway[];
-  k8sHTTPRoutes: K8sHTTPRoute[];
-  virtualServices: VirtualService[];
-  destinationRules: DestinationRule[];
-  serviceEntries: ServiceEntry[];
-  workloadEntries: WorkloadEntry[];
-  workloadGroups: WorkloadGroup[];
-  envoyFilters: EnvoyFilter[];
-  authorizationPolicies: AuthorizationPolicy[];
-  sidecars: Sidecar[];
-  wasmPlugins: WasmPlugin[];
-  telemetries: Telemetry[];
-  peerAuthentications: PeerAuthentication[];
-  requestAuthentications: RequestAuthentication[];
-  permissions: { [key: string]: ResourcePermissions };
-  validations: Validations;
+export interface IstioConfigsMapQuery extends IstioConfigListQuery {
+  namespaces?: string;
 }
 
 export const dicIstioType = {
-  Sidecar: 'sidecars',
+  AuthorizationPolicy: 'authorizationpolicies',
+  DestinationRule: 'destinationrules',
+  EnvoyFilter: 'envoyfilters',
   Gateway: 'gateways',
   K8sGateway: 'k8sgateways',
   K8sHTTPRoute: 'k8shttproutes',
-  VirtualService: 'virtualservices',
-  DestinationRule: 'destinationrules',
-  ServiceEntry: 'serviceentries',
-  AuthorizationPolicy: 'authorizationpolicies',
   PeerAuthentication: 'peerauthentications',
   RequestAuthentication: 'requestauthentications',
+  ServiceEntry: 'serviceentries',
+  Sidecar: 'sidecars',
+  Telemetry: 'telemetries',
+  VirtualService: 'virtualservices',
+  WasmPlugin: 'wasmPlugins',
   WorkloadEntry: 'workloadentries',
   WorkloadGroup: 'workloadgroups',
-  EnvoyFilter: 'envoyfilters',
-  WasmPlugin: 'wasmPlugins',
-  Telemetry: 'telemetries',
 
+  authorizationpolicies: 'AuthorizationPolicy',
+  destinationrules: 'DestinationRule',
+  envoyfilters: 'EnvoyFilter',
   gateways: 'Gateway',
   k8sgateways: 'K8sGateway',
   k8shttproutes: 'K8sHTTPRoute',
-  virtualservices: 'VirtualService',
-  destinationrules: 'DestinationRule',
-  serviceentries: 'ServiceEntry',
-  authorizationpolicies: 'AuthorizationPolicy',
-  sidecars: 'Sidecar',
   peerauthentications: 'PeerAuthentication',
   requestauthentications: 'RequestAuthentication',
+  serviceentries: 'ServiceEntry',
+  sidecars: 'Sidecar',
+  telemetries: 'Telemetry',
+  virtualservices: 'VirtualService',
+  wasmplugins: 'WasmPlugin',
   workloadentries: 'WorkloadEntry',
   workloadgroups: 'WorkloadGroup',
-  envoyfilters: 'EnvoyFilter',
-  telemetries: 'Telemetry',
-  wasmplugins: 'WasmPlugin',
 
+  authorizationpolicy: 'AuthorizationPolicy',
+  destinationrule: 'DestinationRule',
+  envoyfilter: 'EnvoyFilter',
   gateway: 'Gateway',
   k8sgateway: 'K8sGateway',
   k8shttproute: 'K8sHTTPRoute',
-  virtualservice: 'VirtualService',
-  destinationrule: 'DestinationRule',
-  serviceentry: 'ServiceEntry',
-  authorizationpolicy: 'AuthorizationPolicy',
-  sidecar: 'Sidecar',
-  wasmplugin: 'WasmPlugin',
-  telemetry: 'Telemetry',
   peerauthentication: 'PeerAuthentication',
   requestauthentication: 'RequestAuthentication',
+  serviceentry: 'ServiceEntry',
+  sidecar: 'Sidecar',
+  telemetry: 'Telemetry',
+  virtualservice: 'VirtualService',
+  wasmplugin: 'WasmPlugin',
   workloadentry: 'WorkloadEntry',
-  workloadgroup: 'WorkloadGroup',
-  envoyfilter: 'EnvoyFilter'
+  workloadgroup: 'WorkloadGroup'
 };
 
 export function validationKey(name: string, namespace?: string): string {
   if (namespace !== undefined) {
-    return name + '.' + namespace;
+    return `${name}.${namespace}`;
   } else {
     return name;
   }
@@ -139,6 +150,7 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
   if (names && names.length === 0) {
     return unfiltered;
   }
+
   return {
     namespace: unfiltered.namespace,
     gateways: unfiltered.gateways.filter(gw => includeName(gw.metadata.name, names)),
@@ -165,12 +177,14 @@ export const filterByConfigValidation = (unfiltered: IstioConfigItem[], configFi
   if (configFilters && configFilters.length === 0) {
     return unfiltered;
   }
+
   const filtered: IstioConfigItem[] = [];
 
   const filterByValid = configFilters.indexOf('Valid') > -1;
   const filterByNotValid = configFilters.indexOf('Not Valid') > -1;
   const filterByNotValidated = configFilters.indexOf('Not Validated') > -1;
   const filterByWarning = configFilters.indexOf('Warning') > -1;
+
   if (filterByValid && filterByNotValid && filterByNotValidated && filterByWarning) {
     return unfiltered;
   }
@@ -189,6 +203,7 @@ export const filterByConfigValidation = (unfiltered: IstioConfigItem[], configFi
       filtered.push(item);
     }
   });
+
   return filtered;
 };
 
@@ -255,6 +270,7 @@ export const vsToIstioItems = (
 
   vss.forEach(vs => {
     const vKey = validationKey(vs.metadata.name, vs.metadata.namespace);
+
     const item = {
       cluster: cluster,
       namespace: vs.metadata.namespace || '',
@@ -264,9 +280,11 @@ export const vsToIstioItems = (
       resourceVersion: vs.metadata.resourceVersion,
       validation: hasValidations(vKey) ? validations.virtualservice[vKey] : undefined
     };
+
     item[entryName] = vs;
     istioItems.push(item);
   });
+
   return istioItems;
 };
 
@@ -284,6 +302,7 @@ export const drToIstioItems = (
 
   drs.forEach(dr => {
     const vKey = validationKey(dr.metadata.name, dr.metadata.namespace);
+
     const item = {
       cluster: cluster,
       namespace: dr.metadata.namespace || '',
@@ -293,9 +312,11 @@ export const drToIstioItems = (
       resourceVersion: dr.metadata.resourceVersion,
       validation: hasValidations(vKey) ? validations.destinationrule[vKey] : undefined
     };
+
     item[entryName] = dr;
     istioItems.push(item);
   });
+
   return istioItems;
 };
 
@@ -326,6 +347,7 @@ export const gwToIstioItems = (
   gws.forEach(gw => {
     if (vsGateways.has(gw.metadata.namespace + '/' + gw.metadata.name)) {
       const vKey = validationKey(gw.metadata.name, gw.metadata.namespace);
+
       const item = {
         cluster: cluster,
         namespace: gw.metadata.namespace || '',
@@ -335,10 +357,12 @@ export const gwToIstioItems = (
         resourceVersion: gw.metadata.resourceVersion,
         validation: hasValidations(vKey) ? validations.gateway[vKey] : undefined
       };
+
       item[entryName] = gw;
       istioItems.push(item);
     }
   });
+
   return istioItems;
 };
 
@@ -369,6 +393,7 @@ export const k8sGwToIstioItems = (
   gws.forEach(gw => {
     if (k8sGateways.has(gw.metadata.namespace + '/' + gw.metadata.name)) {
       const vKey = validationKey(gw.metadata.name, gw.metadata.namespace);
+
       const item = {
         cluster: cluster,
         namespace: gw.metadata.namespace || '',
@@ -378,10 +403,12 @@ export const k8sGwToIstioItems = (
         resourceVersion: gw.metadata.resourceVersion,
         validation: hasValidations(vKey) ? validations.k8sgateway[vKey] : undefined
       };
+
       item[entryName] = gw;
       istioItems.push(item);
     }
   });
+
   return istioItems;
 };
 
@@ -395,6 +422,7 @@ export const seToIstioItems = (see: ServiceEntry[], validations: Validations, cl
 
   see.forEach(se => {
     const vKey = validationKey(se.metadata.name, se.metadata.namespace);
+
     const item = {
       cluster: cluster,
       namespace: se.metadata.namespace || '',
@@ -404,9 +432,11 @@ export const seToIstioItems = (see: ServiceEntry[], validations: Validations, cl
       resourceVersion: se.metadata.resourceVersion,
       validation: hasValidations(vKey) ? validations.serviceentry[vKey] : undefined
     };
+
     item[entryName] = se;
     istioItems.push(item);
   });
+
   return istioItems;
 };
 
@@ -424,6 +454,7 @@ export const k8sHTTPRouteToIstioItems = (
 
   routes.forEach(route => {
     const vKey = validationKey(route.metadata.name, route.metadata.namespace);
+
     const item = {
       cluster: cluster,
       namespace: route.metadata.namespace || '',
@@ -433,8 +464,10 @@ export const k8sHTTPRouteToIstioItems = (
       resourceVersion: route.metadata.resourceVersion,
       validation: hasValidations(vKey) ? validations.k8shttproute[vKey] : undefined
     };
+
     item[entryName] = route;
     istioItems.push(item);
   });
+
   return istioItems;
 };

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -8,8 +8,8 @@ import { PFColorVal } from 'components/Pf/PfColors';
 // Common types
 
 export interface HelpMessage {
-  objectField: string;
   message: string;
+  objectField: string;
 }
 
 export interface K8sInitializer {
@@ -17,9 +17,9 @@ export interface K8sInitializer {
 }
 
 export interface K8sStatus {
-  status?: string;
   message?: string;
   reason?: string;
+  status?: string;
 }
 
 export interface K8sInitializers {
@@ -28,34 +28,34 @@ export interface K8sInitializers {
 }
 
 export interface K8sMetadata {
-  name: string;
+  annotations?: { [key: string]: string };
+  clusterName?: string;
+  creationTimestamp?: string;
+  deletionGracePeriodSeconds?: number;
+  deletionTimestamp?: string;
+  finalizers?: string[];
   generateName?: string;
+  generation?: number;
+  initializers?: K8sInitializers[];
+  labels?: { [key: string]: string };
+  name: string;
   namespace?: string;
+  ownerReferences?: K8sOwnerReference[];
+  resourceVersion?: string;
   selfLink?: string;
   uid?: string;
-  resourceVersion?: string;
-  generation?: number;
-  creationTimestamp?: string;
-  deletionTimestamp?: string;
-  deletionGracePeriodSeconds?: number;
-  labels?: { [key: string]: string };
-  annotations?: { [key: string]: string };
-  ownerReferences?: K8sOwnerReference[];
-  initializers?: K8sInitializers[];
-  finalizers?: string[];
-  clusterName?: string;
 }
 
 export interface IstioObject {
-  kind?: string;
   apiVersion?: string;
+  kind?: string;
   metadata: K8sMetadata;
   status?: IstioStatus;
 }
 
 export interface IstioStatus {
-  validationMessages?: ValidationMessage[];
   conditions?: StatusCondition[];
+  validationMessages?: ValidationMessage[];
 }
 
 export interface ValidationMessage {
@@ -66,9 +66,9 @@ export interface ValidationMessage {
 }
 
 export interface StatusCondition {
-  type: string;
-  status: boolean;
   message: string;
+  status: boolean;
+  type: string;
 }
 
 export interface ValidationMessageType {
@@ -86,36 +86,36 @@ export enum ValidationTypes {
 }
 
 export const IstioLevelToSeverity = {
-  UNKNOWN: ValidationTypes.Info,
   ERROR: ValidationTypes.Error,
-  WARNING: ValidationTypes.Warning,
-  INFO: ValidationTypes.Info
+  INFO: ValidationTypes.Info,
+  UNKNOWN: ValidationTypes.Info,
+  WARNING: ValidationTypes.Warning
 };
 
 export interface ObjectValidation {
+  checks: ObjectCheck[];
   name: string;
   objectType: string;
-  valid: boolean;
-  checks: ObjectCheck[];
   references?: ObjectReference[];
+  valid: boolean;
 }
 
 export interface ObjectCheck {
   code?: string;
   message: string;
-  severity: ValidationTypes;
   path: string;
+  severity: ValidationTypes;
 }
 
 export interface ObjectReference {
-  objectType: string;
   name: string;
   namespace: string;
+  objectType: string;
 }
 
 export interface PodReference {
-  name: string;
   kind: string;
+  name: string;
 }
 
 export interface References {
@@ -141,36 +141,36 @@ export interface WorkloadReference {
 }
 
 export interface ContainerInfo {
-  name: string;
   image: string;
   isProxy: boolean;
   isReady: boolean;
+  name: string;
 }
 
 // 1.6
 export interface Port {
+  name: string;
   number: number;
   protocol: string;
-  name: string;
   targetPort?: number;
 }
 
 export interface Pod {
-  name: string;
   annotations?: { [key: string]: string };
-  labels?: { [key: string]: string };
+  appLabel: boolean;
+  containers?: ContainerInfo[];
   createdAt: string;
   createdBy: PodReference[];
-  containers?: ContainerInfo[];
   istioContainers?: ContainerInfo[];
   istioInitContainers?: ContainerInfo[];
+  labels?: { [key: string]: string };
+  name: string;
+  proxyStatus?: ProxyStatus;
   serviceAccountName: string;
   status: string;
   statusMessage?: string;
   statusReason?: string;
-  appLabel: boolean;
   versionLabel: boolean;
-  proxyStatus?: ProxyStatus;
 }
 
 // models Engarde Istio proxy AccessLog
@@ -260,9 +260,9 @@ export interface LogLevelQuery {
 }
 
 export interface EnvoyProxyDump {
-  configDump?: EnvoyConfigDump;
   bootstrap?: BootstrapSummary;
   clusters?: ClusterSummary[];
+  configDump?: EnvoyConfigDump;
   listeners?: ListenerSummary[];
   routes?: RouteSummary[];
 }
@@ -274,25 +274,25 @@ export interface EnvoyConfigDump {
 export type EnvoySummary = ClusterSummary | RouteSummary | ListenerSummary;
 
 export interface ClusterSummary {
-  service_fqdn: Host;
-  port: number;
-  subset: string;
-  direction: string;
-  type: number;
   destination_rule: string;
+  direction: string;
+  port: number;
+  service_fqdn: Host;
+  subset: string;
+  type: number;
 }
 
 export interface ListenerSummary {
-  address: string;
-  port: number;
-  match: string;
   destination: string;
+  address: string;
+  match: string;
+  port: number;
 }
 
 export interface RouteSummary {
-  name: string;
   domains: Host;
   match: string;
+  name: string;
   virtual_service: string;
 }
 
@@ -301,46 +301,46 @@ export interface BootstrapSummary {
 }
 
 export interface Service {
-  name: string;
   createdAt: string;
-  resourceVersion: string;
-  namespace: Namespace;
-  labels?: { [key: string]: string };
-  type: string;
   ip: string;
+  labels?: { [key: string]: string };
+  name: string;
+  namespace: Namespace;
   ports?: ServicePort[];
+  resourceVersion: string;
+  type: string;
 }
 
 export interface Host {
-  service: string;
-  namespace: string;
   cluster?: string;
+  namespace: string;
+  service: string;
 }
 
 export interface IstioService {
+  domain?: string;
+  labels?: { [key: string]: string };
   name?: string;
   namespace?: string;
-  domain?: string;
   service?: string;
-  labels?: { [key: string]: string };
 }
 
 // 1.6
 export interface L4MatchAttributes {
   destinationSubnets?: string[];
+  gateways?: string[];
   port?: number;
   sourceLabels?: { [key: string]: string };
-  gateways?: string[];
   sourceName?: string;
 }
 
 // 1.6
 export interface TLSMatchAttributes {
-  sniHosts: string[];
   destinationSubnets?: string[];
-  port?: number;
-  sourceLabels?: { [key: string]: string };
   gateways?: string[];
+  port?: number;
+  sniHosts: string[];
+  sourceLabels?: { [key: string]: string };
   sourceName?: string;
 }
 
@@ -353,9 +353,9 @@ export interface StringMatch {
 
 // 1.6
 export interface HeaderOperations {
-  set?: { [key: string]: string };
   add?: { [key: string]: string };
   remove?: string[];
+  set?: { [key: string]: string };
 }
 
 // 1.6
@@ -367,8 +367,8 @@ export interface Headers {
 // 1.6
 export interface HTTPRouteDestination {
   destination: Destination;
-  weight?: number;
   headers?: Headers;
+  weight?: number;
 }
 
 // 1.6
@@ -379,9 +379,9 @@ export interface RouteDestination {
 
 // 1.6
 export interface HTTPRedirect {
-  uri?: string;
   authority?: string;
   redirectCode?: number;
+  uri?: string;
 }
 
 // 1.6
@@ -392,8 +392,8 @@ export interface Delegate {
 
 // 1.6
 export interface HTTPRewrite {
-  uri?: string;
   authority?: string;
+  uri?: string;
 }
 
 // 1.6
@@ -406,8 +406,8 @@ export interface HTTPRetry {
 
 // 1.6
 export interface HTTPFaultInjection {
-  delay?: Delay;
   abort?: Abort;
+  delay?: Delay;
 }
 
 // 1.6
@@ -429,12 +429,12 @@ export interface Abort {
 
 // 1.6
 export interface CorsPolicy {
-  allowOrigin?: StringMatch[];
-  allowMethods?: string[];
+  allowCredentials?: string;
   allowHeaders?: string[];
+  allowMethods?: string[];
+  allowOrigin?: StringMatch[];
   exposeHeaders?: string[];
   maxAge?: string;
-  allowCredentials?: string;
 }
 
 // Destination Rule
@@ -447,11 +447,11 @@ export interface HTTPCookie {
 
 // 1.6
 export interface ConsistentHashLB {
-  httpHeaderName?: string | null;
   httpCookie?: HTTPCookie | null;
-  useSourceIp?: boolean | null;
+  httpHeaderName?: string | null;
   httpQueryParameterName?: string | null;
   minimumRingSize?: number;
+  useSourceIp?: boolean | null;
 }
 
 // 1.6
@@ -469,83 +469,83 @@ export interface Failover {
 // 1.6
 export interface LocalityLoadBalancerSetting {
   distribute?: Distribute[];
-  failover?: Failover[];
   enabled?: boolean;
+  failover?: Failover[];
 }
 
 // 1.6
 export interface LoadBalancerSettings {
-  simple?: string | null;
   consistentHash?: ConsistentHashLB | null;
   localityLbSetting?: LocalityLoadBalancerSetting | null;
+  simple?: string | null;
 }
 
 // 1.6
 export interface TcpKeepalive {
+  interval?: string;
   probes?: number;
   time?: string;
-  interval?: string;
 }
 
 // 1.6
 export interface ConnectionPoolSettingsTCPSettings {
-  maxConnections?: number;
   connectTimeout?: string;
+  maxConnections?: number;
   tcpKeepalive?: TcpKeepalive;
 }
 
 // 1.6
 export interface ConnectionPoolSettingsHTTPSettings {
+  h2UpgradePolicy?: string;
   http1MaxPendingRequests?: number;
   http2MaxRequests?: number;
+  idleTimeout?: string;
   maxRequestsPerConnection?: number;
   maxRetries?: number;
-  idleTimeout?: string;
-  h2UpgradePolicy?: string;
 }
 
 // 1.6
 export interface ConnectionPoolSettings {
-  tcp?: ConnectionPoolSettingsTCPSettings;
   http?: ConnectionPoolSettingsHTTPSettings;
+  tcp?: ConnectionPoolSettingsTCPSettings;
 }
 
 // 1.6
 export interface OutlierDetection {
-  consecutiveErrors?: number;
-  consecutive5xxErrors?: number;
-  interval?: string;
   baseEjectionTime?: string;
+  consecutive5xxErrors?: number;
+  consecutiveErrors?: number;
+  interval?: string;
   maxEjectionPercent?: number;
   minHealthPercent?: number;
 }
 
 // 1.6
 export interface ClientTLSSettings {
-  mode: string;
-  clientCertificate?: string | null;
-  privateKey?: string | null;
   caCertificates?: string | null;
-  subjectAltNames?: string[] | null;
+  clientCertificate?: string | null;
+  mode: string;
+  privateKey?: string | null;
   sni?: string | null;
+  subjectAltNames?: string[] | null;
 }
 
 // 1.6
 export interface PortTrafficPolicy {
-  port?: PortSelector;
-  loadBalancer?: LoadBalancerSettings;
   connectionPool?: ConnectionPoolSettings;
+  loadBalancer?: LoadBalancerSettings;
   outlierDetection?: OutlierDetection;
+  port?: PortSelector;
   tls?: ClientTLSSettings;
 }
 
 // 1.6
 export interface TrafficPolicy {
-  loadBalancer?: LoadBalancerSettings | null;
   connectionPool?: ConnectionPoolSettings;
+  loadBalancer?: LoadBalancerSettings | null;
   outlierDetection?: OutlierDetection;
-  tls?: ClientTLSSettings | null;
   portLevelSettings?: PortTrafficPolicy[];
+  tls?: ClientTLSSettings | null;
 }
 
 // 1.6
@@ -557,10 +557,10 @@ export interface Subset {
 
 // 1.6
 export interface DestinationRuleSpec {
-  host?: string;
-  trafficPolicy?: TrafficPolicy | null;
-  subsets?: Subset[];
   exportTo?: string[];
+  host?: string;
+  subsets?: Subset[];
+  trafficPolicy?: TrafficPolicy | null;
 }
 
 // 1.6
@@ -576,7 +576,7 @@ export class DestinationRuleC implements DestinationRule {
     Object.assign(this, dr);
   }
 
-  static fromDrArray(drs: DestinationRule[]) {
+  static fromDrArray(drs: DestinationRule[]): DestinationRuleC[] {
     return drs.map(item => new DestinationRuleC(item));
   }
 
@@ -607,42 +607,42 @@ export interface PortSelector {
 // 1.6
 export interface Destination {
   host: string;
-  subset?: string;
   port?: PortSelector;
+  subset?: string;
 }
 
 // 1.6
 export interface HTTPMatchRequest {
-  name?: string;
-  uri?: StringMatch;
-  scheme?: StringMatch;
-  method?: StringMatch;
   authority?: StringMatch;
-  headers?: { [key: string]: StringMatch };
-  port?: PortSelector;
-  sourceLabels?: { [key: string]: string };
   gateways?: string[];
-  queryParams?: { [key: string]: StringMatch };
+  headers?: { [key: string]: StringMatch };
   ignoreUriCase?: boolean;
-  withoutHeaders?: { [key: string]: StringMatch };
+  method?: StringMatch;
+  name?: string;
+  port?: PortSelector;
+  queryParams?: { [key: string]: StringMatch };
+  scheme?: StringMatch;
+  sourceLabels?: { [key: string]: string };
   sourceNamespace?: string;
+  uri?: StringMatch;
+  withoutHeaders?: { [key: string]: StringMatch };
 }
 
 // 1.6
 export interface HTTPRoute {
-  name?: string;
-  match?: HTTPMatchRequest[];
-  route?: HTTPRouteDestination[];
-  redirect?: HTTPRedirect;
+  corsPolicy?: CorsPolicy;
   delegate?: Delegate;
-  rewrite?: HTTPRewrite;
-  timeout?: string;
-  retries?: HTTPRetry;
   fault?: HTTPFaultInjection;
+  headers?: Headers;
+  match?: HTTPMatchRequest[];
   mirror?: Destination;
   mirrorPercentage?: Percent;
-  corsPolicy?: CorsPolicy;
-  headers?: Headers;
+  name?: string;
+  redirect?: HTTPRedirect;
+  retries?: HTTPRetry;
+  rewrite?: HTTPRewrite;
+  route?: HTTPRouteDestination[];
+  timeout?: string;
 }
 
 // 1.6
@@ -659,12 +659,12 @@ export interface TLSRoute {
 
 // 1.6
 export interface VirtualServiceSpec {
-  hosts?: string[];
-  gateways?: string[] | null;
-  http?: HTTPRoute[];
-  tls?: TLSRoute[];
-  tcp?: TCPRoute[];
   exportTo?: string[] | null;
+  gateways?: string[] | null;
+  hosts?: string[];
+  http?: HTTPRoute[];
+  tcp?: TCPRoute[];
+  tls?: TLSRoute[];
 }
 
 // 1.6
@@ -672,23 +672,26 @@ export interface VirtualService extends IstioObject {
   spec: VirtualServiceSpec;
 }
 
-export function getWizardUpdateLabel(
+export const getWizardUpdateLabel = (
   vs: VirtualService | VirtualService[] | null,
   k8sr: K8sHTTPRoute | K8sHTTPRoute[] | null
-) {
+): string => {
   let label = getVirtualServiceUpdateLabel(vs);
+
   if (label === '') {
     label = getK8sHTTPRouteUpdateLabel(k8sr);
   }
-  return label;
-}
 
-export function getVirtualServiceUpdateLabel(vs: VirtualService | VirtualService[] | null) {
+  return label;
+};
+
+export const getVirtualServiceUpdateLabel = (vs: VirtualService | VirtualService[] | null): string => {
   if (!vs) {
     return '';
   }
 
   let virtualService: VirtualService | null = null;
+
   if ('length' in vs) {
     if (vs.length === 1) {
       virtualService = vs[0];
@@ -702,14 +705,15 @@ export function getVirtualServiceUpdateLabel(vs: VirtualService | VirtualService
   } else {
     return '';
   }
-}
+};
 
-export function getK8sHTTPRouteUpdateLabel(k8sr: K8sHTTPRoute | K8sHTTPRoute[] | null) {
+export const getK8sHTTPRouteUpdateLabel = (k8sr: K8sHTTPRoute | K8sHTTPRoute[] | null): string => {
   if (!k8sr) {
     return '';
   }
 
   let k8sHTTPRoute: K8sHTTPRoute | null = null;
+
   if ('length' in k8sr) {
     if (k8sr.length === 1) {
       k8sHTTPRoute = k8sr[0];
@@ -723,21 +727,21 @@ export function getK8sHTTPRouteUpdateLabel(k8sr: K8sHTTPRoute | K8sHTTPRoute[] |
   } else {
     return '';
   }
-}
+};
 
 export interface K8sOwnerReference {
   apiVersion: string;
+  blockOwnerDeletion?: boolean;
+  controller?: boolean;
   kind: string;
   name: string;
   uid: string;
-  controller?: boolean;
-  blockOwnerDeletion?: boolean;
 }
 
 // 1.6
 export interface GatewaySpec {
-  servers?: Server[];
   selector?: { [key: string]: string };
+  servers?: Server[];
 }
 
 // 1.6
@@ -745,35 +749,35 @@ export interface Gateway extends IstioObject {
   spec: GatewaySpec;
 }
 
-export function getGatewaysAsList(gws: Gateway[]): string[] {
-  return gws.map(gateway => gateway.metadata.namespace + '/' + gateway.metadata.name).sort();
-}
+export const getGatewaysAsList = (gws: Gateway[]): string[] => {
+  return gws.map(gateway => `${gateway.metadata.namespace}/${gateway.metadata.name}`).sort();
+};
 
-export function filterAutogeneratedGateways(gws: Gateway[]): Gateway[] {
+export const filterAutogeneratedGateways = (gws: Gateway[]): Gateway[] => {
   return gws.filter(gateway => !gateway.metadata.name.includes('autogenerated-k8s'));
-}
+};
 
-export function getK8sGatewaysAsList(k8sGws: K8sGateway[]): string[] {
+export const getK8sGatewaysAsList = (k8sGws: K8sGateway[]): string[] => {
   if (k8sGws) {
-    return k8sGws.map(gateway => gateway.metadata.namespace + '/' + gateway.metadata.name).sort();
+    return k8sGws.map(gateway => `${gateway.metadata.namespace}/${gateway.metadata.name}`).sort();
   } else {
     return [];
   }
-}
+};
 
 // K8s Gateway API https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/
 
 export interface Listener {
-  name: string;
+  allowedRoutes: AllowedRoutes;
   hostname: string;
+  name: string;
   port: number;
   protocol: string;
-  allowedRoutes: AllowedRoutes;
 }
 
 export interface Address {
-  type: string;
   value: string;
+  type: string;
 }
 
 export interface AllowedRoutes {
@@ -795,9 +799,9 @@ export interface ParentRef {
 }
 
 export interface K8sGatewaySpec {
-  listeners?: Listener[];
   addresses?: Address[];
   gatewayClassName: string;
+  listeners?: Listener[];
 }
 
 export interface K8sGateway extends IstioObject {
@@ -805,29 +809,29 @@ export interface K8sGateway extends IstioObject {
 }
 
 export interface K8sHTTPRouteSpec {
-  parentRefs?: ParentRef[];
   hostnames?: string[];
+  parentRefs?: ParentRef[];
   rules?: K8sRouteRule[];
 }
 
 export interface K8sRouteRule {
-  matches?: K8sHTTPRouteMatch[];
-  filters?: K8sHTTPRouteFilter[];
   backendRefs?: K8sRouteBackendRef[];
+  filters?: K8sHTTPRouteFilter[];
+  matches?: K8sHTTPRouteMatch[];
 }
 
 export interface K8sRouteBackendRef {
-  name: string;
-  weight?: number;
-  port?: number;
-  namespace?: string;
   filters?: K8sHTTPRouteFilter[];
+  name: string;
+  namespace?: string;
+  port?: number;
+  weight?: number;
 }
 
 export interface K8sHTTPRouteFilter {
-  requestRedirect?: K8sHTTPRouteRequestRedirect;
   requestHeaderModifier?: K8sHTTPHeaderFilter;
   requestMirror?: K8sHTTPRequestMirrorFilter;
+  requestRedirect?: K8sHTTPRouteRequestRedirect;
   type?: string;
 }
 
@@ -836,28 +840,28 @@ export interface K8sHTTPRequestMirrorFilter {
 }
 
 export interface K8sHTTPHeaderFilter {
-  set?: HTTPHeader[];
   add?: HTTPHeader[];
   remove?: string[];
+  set?: HTTPHeader[];
 }
 
 export interface K8sHTTPRouteRequestRedirect {
-  scheme?: string;
   hostname?: string;
   port?: number;
   statusCode?: number;
+  scheme?: string;
 }
 
 export interface K8sHTTPRouteMatch {
-  path?: HTTPMatch;
   headers?: HTTPMatch[];
-  queryParams?: HTTPMatch[];
   method?: string;
+  path?: HTTPMatch;
+  queryParams?: HTTPMatch[];
 }
 
 export interface HTTPMatch {
-  type?: string;
   name?: string;
+  type?: string;
   value?: string;
 }
 
@@ -876,20 +880,20 @@ export enum CaptureMode {
 
 // 1.6
 export interface IstioEgressListener {
-  port?: Port;
   bind?: string;
   captureMode?: CaptureMode;
   hosts: string[];
   localhostServerTls?: ServerTLSSettings;
+  port?: Port;
 }
 
 // 1.6
 export interface IstioIngressListener {
-  port: Port;
   bind?: string;
   captureMode?: CaptureMode;
   defaultEndpoint: string;
   localhostClientTls?: ClientTLSSettings;
+  port: Port;
 }
 
 // 1.6
@@ -910,11 +914,11 @@ export interface Localhost {
 
 // 1.6
 export interface SidecarSpec {
-  workloadSelector?: WorkloadSelector;
-  ingress?: IstioIngressListener[];
   egress?: IstioEgressListener[];
-  outboundTrafficPolicy?: OutboundTrafficPolicy;
+  ingress?: IstioIngressListener[];
   localhost?: Localhost;
+  outboundTrafficPolicy?: OutboundTrafficPolicy;
+  workloadSelector?: WorkloadSelector;
 }
 
 // 1.6
@@ -924,54 +928,54 @@ export interface Sidecar extends IstioObject {
 
 // 1.6
 export interface Server {
-  port: ServerPort;
   hosts: string[];
+  port: ServerPort;
   tls?: ServerTLSSettings;
 }
 
 export interface ServerForm {
-  number: string;
-  protocol: string;
   name: string;
+  number: string;
   hosts: string[];
-  tlsMode: string;
-  tlsServerCertificate: string;
-  tlsPrivateKey: string;
+  protocol: string;
   tlsCaCertificate: string;
+  tlsMode: string;
+  tlsPrivateKey: string;
+  tlsServerCertificate: string;
 }
 
 // 1.6
 export interface ServerPort {
+  name: string;
   number: number;
   protocol: string;
-  name: string;
 }
 
 // 1.6
 export interface ServerTLSSettings {
-  httpsRedirect?: boolean;
-  mode?: string;
-  serverCertificate?: string;
-  privateKey?: string;
   caCertificates?: string;
-  credentialName?: string;
-  subjectAltNames?: string[];
-  verifyCertificateSpki?: string[];
-  verifyCertificateHash?: string[];
-  minProtocolVersion?: string;
-  maxProtocolVersion?: string;
   cipherSuites?: string[];
+  credentialName?: string;
+  httpsRedirect?: boolean;
+  maxProtocolVersion?: string;
+  minProtocolVersion?: string;
+  mode?: string;
+  privateKey?: string;
+  serverCertificate?: string;
+  subjectAltNames?: string[];
+  verifyCertificateHash?: string[];
+  verifyCertificateSpki?: string[];
 }
 
 // 1.6
 export interface ServiceEntrySpec {
-  hosts?: string[];
   addresses?: string[];
-  ports?: Port[];
-  location?: string;
-  resolution?: string;
   endpoints?: WorkloadEntrySpec[];
   exportTo?: string[];
+  hosts?: string[];
+  location?: string;
+  ports?: Port[];
+  resolution?: string;
   subjectAltNames?: string[];
   workloadSelector?: WorkloadSelector;
 }
@@ -986,9 +990,9 @@ export interface WasmPlugin extends IstioObject {
 }
 
 export interface WasmPluginSpec extends IstioObject {
-  workloadSelector?: WorkloadSelector;
-  url: string;
   pluginName: string;
+  url: string;
+  workloadSelector?: WorkloadSelector;
 }
 
 export interface Telemetry extends IstioObject {
@@ -1001,8 +1005,8 @@ export interface TelemetrySpec extends IstioObject {
 
 export interface Endpoint {
   address: string;
-  ports: { [key: string]: number };
   labels: { [key: string]: string };
+  ports: { [key: string]: number };
 }
 
 export interface Match {
@@ -1015,8 +1019,8 @@ export interface TargetSelector {
 }
 
 export enum MutualTlsMode {
-  STRICT = 'STRICT',
-  PERMISSIVE = 'PERMISSIVE'
+  PERMISSIVE = 'PERMISSIVE',
+  STRICT = 'STRICT'
 }
 
 export interface MutualTls {
@@ -1029,8 +1033,8 @@ export interface PeerAuthenticationMethod {
 }
 
 export interface Jwt {
-  issuer: string;
   audiences: string[];
+  issuer: string;
   jwksUri?: string;
   jwtHeaders: string[];
   jwtParams: string[];
@@ -1041,8 +1045,8 @@ export interface OriginAuthenticationMethod {
 }
 
 export enum PrincipalBinding {
-  USE_PEER = 'USE_PEER',
-  USE_ORIGIN = 'USE_ORIGIN'
+  USE_ORIGIN = 'USE_ORIGIN',
+  USE_PEER = 'USE_PEER'
 }
 
 export interface AuthorizationPolicy extends IstioObject {
@@ -1054,9 +1058,9 @@ export interface AuthorizationPolicyWorkloadSelector {
 }
 
 export interface AuthorizationPolicySpec {
-  selector?: AuthorizationPolicyWorkloadSelector;
-  rules?: AuthorizationPolicyRule[];
   action?: string;
+  rules?: AuthorizationPolicyRule[];
+  selector?: AuthorizationPolicyWorkloadSelector;
 }
 
 export interface AuthorizationPolicyRule {
@@ -1070,14 +1074,14 @@ export interface RuleFrom {
 }
 
 export interface Source {
-  principals?: string[];
-  notPrincipals?: string[];
-  requestPrincipals?: string[];
-  notRequestPrincipals?: string[];
-  namespaces?: string[];
-  notNamespaces?: string[];
   ipBlocks?: string[];
+  namespaces?: string[];
   notIpBlocks?: string[];
+  notNamespaces?: string[];
+  notPrincipals?: string[];
+  notRequestPrincipals?: string[];
+  principals?: string[];
+  requestPrincipals?: string[];
 }
 
 export interface RuleTo {
@@ -1086,13 +1090,13 @@ export interface RuleTo {
 
 export interface Operation {
   hosts?: string[];
-  notHosts?: string[];
-  ports?: string[];
-  notPorts?: string[];
   methods?: string[];
+  notHosts?: string[];
   notMethods?: string[];
-  paths?: string[];
   notPaths?: string[];
+  notPorts?: string[];
+  paths?: string[];
+  ports?: string[];
 }
 
 export interface Condition {
@@ -1106,9 +1110,9 @@ export interface PeerAuthentication extends IstioObject {
 }
 
 export interface PeerAuthenticationSpec {
-  selector?: PeerAuthenticationWorkloadSelector;
   mtls?: PeerAuthenticationMutualTls;
   portLevelMtls?: { [key: number]: PeerAuthenticationMutualTls };
+  selector?: PeerAuthenticationWorkloadSelector;
 }
 
 export interface PeerAuthenticationWorkloadSelector {
@@ -1120,10 +1124,10 @@ export interface PeerAuthenticationMutualTls {
 }
 
 export enum PeerAuthenticationMutualTLSMode {
-  UNSET = 'UNSET',
   DISABLE = 'DISABLE',
   PERMISSIVE = 'PERMISSIVE',
-  STRICT = 'STRICT'
+  STRICT = 'STRICT',
+  UNSET = 'UNSET'
 }
 
 // 1.6
@@ -1133,12 +1137,12 @@ export interface WorkloadEntry extends IstioObject {
 
 export interface WorkloadEntrySpec {
   address: string;
-  ports?: { [key: string]: number };
   labels?: { [key: string]: string };
-  network?: string;
   locality?: string;
-  weight?: number;
+  network?: string;
+  ports?: { [key: string]: number };
   serviceAccount?: string;
+  weight?: number;
 }
 
 export interface WorkloadGroup extends IstioObject {
@@ -1147,28 +1151,28 @@ export interface WorkloadGroup extends IstioObject {
 
 export interface WorkloadGroupSpec {
   // Note that WorkloadGroup has a metadata section inside Spec
+  probe?: ReadinessProbe;
   metadata?: K8sMetadata;
   template: WorkloadEntrySpec;
-  probe?: ReadinessProbe;
 }
 
 export interface ReadinessProbe {
-  initialDelaySeconds?: number;
-  timeoutSeconds?: number;
-  periodSeconds?: number;
-  successThreshold?: number;
+  exec?: ExecHealthCheckConfig;
   failureThreshold?: number;
   httpGet?: HTTPHealthCheckConfig;
+  initialDelaySeconds?: number;
+  periodSeconds?: number;
+  successThreshold?: number;
+  timeoutSeconds?: number;
   tcpSocket?: TCPHealthCheckConfig;
-  exec?: ExecHealthCheckConfig;
 }
 
 export interface HTTPHealthCheckConfig {
+  host?: string;
+  httpHeaders?: HTTPHeader[];
   path?: string;
   port: number;
-  host?: string;
   scheme?: string;
-  httpHeaders?: HTTPHeader[];
 }
 
 export interface HTTPHeader {
@@ -1195,14 +1199,14 @@ export interface JWTHeader {
 }
 
 export interface JWTRule {
-  issuer?: string;
   audiences?: string[];
-  jwksUri?: string;
-  jwks?: string;
+  forwardOriginalToken?: boolean;
   fromHeaders?: JWTHeader[];
   fromParams?: string[];
+  issuer?: string;
+  jwks?: string;
+  jwksUri?: string;
   outputPayloadToHeader?: string;
-  forwardOriginalToken?: boolean;
 }
 
 // 1.6
@@ -1212,13 +1216,13 @@ export interface RequestAuthentication extends IstioObject {
 
 // 1.6
 export interface RequestAuthenticationSpec {
-  selector?: WorkloadMatchSelector;
   jwtRules: JWTRule[];
+  selector?: WorkloadMatchSelector;
 }
 
 export interface ProxyMatch {
-  proxyVersion?: string;
   metadata?: { [key: string]: string };
+  proxyVersion?: string;
 }
 
 export interface SubFilterMatch {
@@ -1231,21 +1235,21 @@ export interface FilterMatch {
 }
 
 export interface FilterChainMatch {
+  applicationProtocols?: string;
+  filter?: FilterMatch;
   name?: string;
   sni?: string;
   transportProtocol?: string;
-  applicationProtocols?: string;
-  filter?: FilterMatch;
 }
 
 export interface ListenerMatch {
-  portNumber?: number;
   filterChain?: FilterChainMatch;
+  portNumber?: number;
 }
 
 export interface RouteMatch {
-  name?: string;
   action?: string;
+  name?: string;
 }
 
 export interface VirtualHostMatch {
@@ -1254,26 +1258,26 @@ export interface VirtualHostMatch {
 }
 
 export interface RouteConfigurationMatch {
-  portNumber?: number;
-  portName?: string;
   gateway?: string;
-  vhost?: VirtualHostMatch;
   name?: string;
+  portName?: string;
+  portNumber?: number;
+  vhost?: VirtualHostMatch;
 }
 
 export interface ClusterMatch {
+  name?: string;
   portNumber?: number;
   service?: string;
   subset?: string;
-  name?: string;
 }
 
 export interface EnvoyConfigObjectMatch {
-  context?: string;
-  proxy?: ProxyMatch;
-  listener?: ListenerMatch;
-  routeConfiguration?: RouteConfigurationMatch;
   cluster?: ClusterMatch;
+  context?: string;
+  listener?: ListenerMatch;
+  proxy?: ProxyMatch;
+  routeConfiguration?: RouteConfigurationMatch;
 }
 
 export interface Patch {
@@ -1288,8 +1292,8 @@ export interface EnvoyConfigObjectPatch {
 }
 
 export interface EnvoyFilterSpec {
-  workloadSelector?: WorkloadSelector;
   configPatches: EnvoyConfigObjectPatch[];
+  workloadSelector?: WorkloadSelector;
 }
 
 export interface EnvoyFilter extends IstioObject {
@@ -1302,16 +1306,16 @@ export interface AttributeInfo {
 }
 
 export interface APIKey {
-  query?: string;
-  header?: string;
   cookie?: string;
+  header?: string;
+  query?: string;
 }
 
 export interface CanaryUpgradeStatus {
   currentVersion: string;
-  upgradeVersion: string;
   migratedNamespaces: string[];
   pendingNamespaces: string[];
+  upgradeVersion: string;
 }
 
 export const MAX_PORT = 65535;

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -247,6 +247,18 @@ export interface PodLogs {
   linesTruncated?: boolean;
 }
 
+export interface PodLogsQuery {
+  container?: string;
+  duration?: string;
+  isProxy?: boolean;
+  maxLines?: number;
+  sinceTime?: number;
+}
+
+export interface LogLevelQuery {
+  level: string;
+}
+
 export interface EnvoyProxyDump {
   configDump?: EnvoyConfigDump;
   bootstrap?: BootstrapSummary;

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -13,7 +13,6 @@ export interface MetricsQuery {
 
 export interface DashboardQuery extends MetricsQuery {
   additionalLabels?: string;
-  cluster?: string;
   labelsFilters?: string;
   rawDataAggregator?: Aggregator;
   workload?: string;

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -48,7 +48,8 @@ export interface MetricsStatsQuery {
   target: Target;
 }
 
-export const statsQueryToKey = (q: MetricsStatsQuery) => genStatsKey(q.target, q.peerTarget, q.direction, q.interval);
+export const statsQueryToKey = (q: MetricsStatsQuery): string =>
+  genStatsKey(q.target, q.peerTarget, q.direction, q.interval);
 
 // !! genStatsKey HAS to mirror backend's models.MetricsStatsQuery#GenKey in models/metrics.go
 export const genStatsKey = (target: Target, peer: Target | undefined, direction: string, interval: string): string => {

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -1,20 +1,21 @@
 import { TargetKind } from './Common';
 
 export interface MetricsQuery {
-  rateInterval?: string;
-  rateFunc?: string;
-  queryTime?: number;
-  duration?: number;
-  step?: number;
-  quantiles?: string[];
   avg?: boolean;
   byLabels?: string[];
+  duration?: number;
+  quantiles?: string[];
+  queryTime?: number;
+  rateFunc?: string;
+  rateInterval?: string;
+  step?: number;
 }
 
 export interface DashboardQuery extends MetricsQuery {
-  rawDataAggregator?: Aggregator;
-  labelsFilters?: string;
   additionalLabels?: string;
+  cluster?: string;
+  labelsFilters?: string;
+  rawDataAggregator?: Aggregator;
   workload?: string;
   workloadType?: string;
 }
@@ -26,17 +27,16 @@ export interface IstioMetricsOptions extends MetricsQuery {
   filters?: string[];
   requestProtocol?: string;
   reporter: Reporter;
-  clusterName?: string;
 }
 
 export type Reporter = 'source' | 'destination' | 'both';
 export type Direction = 'inbound' | 'outbound';
 
 export interface Target {
-  namespace: string;
-  name: string;
-  kind: TargetKind;
   cluster?: string;
+  kind: TargetKind;
+  name: string;
+  namespace: string;
 }
 
 export interface MetricsStatsQuery {

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -17,11 +17,11 @@ import { KIALI_WIZARD_LABEL } from '../components/IstioWizards/WizardActions';
 import { ServiceOverview } from './ServiceList';
 
 export interface ServicePort {
+  appProtocol?: string;
+  istioProtocol: string;
   name: string;
   port: number;
   protocol: string;
-  appProtocol?: string;
-  istioProtocol: string;
   tlsMode: string;
 }
 
@@ -32,71 +32,82 @@ export interface Endpoints {
 
 interface EndpointAddress {
   ip: string;
+  istioProtocol?: string;
   kind?: string;
   name?: string;
-  istioProtocol?: string;
   tlsMode?: string;
 }
 
 export interface WorkloadOverview {
-  name: string;
-  type: string;
-  istioSidecar: boolean;
-  istioAmbient: boolean;
-  labels?: { [key: string]: string };
-  resourceVersion: string;
   createdAt: string;
+  istioAmbient: boolean;
+  istioSidecar: boolean;
+  labels?: { [key: string]: string };
+  name: string;
+  resourceVersion: string;
   serviceAccountNames: string[];
+  type: string;
 }
 
 export interface Service {
-  type: string;
-  name: string;
-  createdAt: string;
-  resourceVersion: string;
-  ip: string;
-  ports?: ServicePort[];
   annotations: { [key: string]: string };
-  externalName: string;
-  labels?: { [key: string]: string };
-  selectors?: { [key: string]: string };
   cluster?: string;
+  createdAt: string;
+  externalName: string;
+  ip: string;
+  labels?: { [key: string]: string };
+  name: string;
+  ports?: ServicePort[];
+  resourceVersion: string;
+  selectors?: { [key: string]: string };
+  type: string;
 }
 
 export interface ServiceDetailsInfo {
-  service: Service;
-  endpoints?: Endpoints[];
-  istioSidecar: boolean;
-  istioAmbient: boolean;
-  virtualServices: VirtualService[];
-  k8sHTTPRoutes: K8sHTTPRoute[];
-  destinationRules: DestinationRule[];
-  serviceEntries: ServiceEntry[];
-  istioPermissions: ResourcePermissions;
-  health?: ServiceHealth;
-  workloads?: WorkloadOverview[];
-  subServices?: ServiceOverview[];
-  namespaceMTLS?: TLSStatus;
-  validations: Validations;
   additionalDetails: AdditionalItem[];
   cluster?: string;
+  destinationRules: DestinationRule[];
+  endpoints?: Endpoints[];
+  health?: ServiceHealth;
+  istioAmbient: boolean;
+  istioPermissions: ResourcePermissions;
+  istioSidecar: boolean;
+  k8sHTTPRoutes: K8sHTTPRoute[];
+  namespaceMTLS?: TLSStatus;
+  service: Service;
+  serviceEntries: ServiceEntry[];
+  subServices?: ServiceOverview[];
+  validations: Validations;
+  virtualServices: VirtualService[];
+  workloads?: WorkloadOverview[];
+}
+
+export interface ServiceDetailsQuery {
+  rateInterval?: string;
+  validate?: boolean;
+}
+
+export interface ServiceUpdateQuery {
+  patchType?: string;
 }
 
 export function getServiceDetailsUpdateLabel(serviceDetails: ServiceDetailsInfo | null) {
   return getWizardUpdateLabel(serviceDetails?.virtualServices || null, serviceDetails?.k8sHTTPRoutes || null);
 }
 
-export function hasServiceDetailsTrafficRouting(serviceDetails: ServiceDetailsInfo | null);
+export function hasServiceDetailsTrafficRouting(serviceDetails: ServiceDetailsInfo | null): boolean;
+
 export function hasServiceDetailsTrafficRouting(
   vsList: VirtualService[],
   drList: DestinationRule[],
   routeList?: K8sHTTPRoute[]
-);
+): boolean;
+
 export function hasServiceDetailsTrafficRouting(
   serviceDetailsOrVsList: ServiceDetailsInfo | VirtualService[] | null,
   drList?: DestinationRule[],
   routeList?: K8sHTTPRoute[]
-) {
+): boolean {
   let virtualServicesList: VirtualService[];
   let destinationRulesList: DestinationRule[];
   let httpRoutesList: K8sHTTPRoute[];
@@ -128,7 +139,7 @@ const higherThan = [
 ];
 
 export const higherSeverity = (a: ValidationTypes, b: ValidationTypes): boolean => {
-  return higherThan.includes(a + '-' + b);
+  return higherThan.includes(`${a}-${b}`);
 };
 
 export const highestSeverity = (checks: ObjectCheck[]): ValidationTypes => {
@@ -145,6 +156,7 @@ export const highestSeverity = (checks: ObjectCheck[]): ValidationTypes => {
 
 export const validationToHealth = (severity: ValidationTypes): Status => {
   let status: Status = NA;
+
   if (severity === ValidationTypes.Correct) {
     status = HEALTHY;
   } else if (severity === ValidationTypes.Warning) {
@@ -152,6 +164,7 @@ export const validationToHealth = (severity: ValidationTypes): Status => {
   } else if (severity === ValidationTypes.Error) {
     status = FAILURE;
   }
+
   return status;
 };
 

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -91,9 +91,9 @@ export interface ServiceUpdateQuery {
   patchType?: string;
 }
 
-export function getServiceDetailsUpdateLabel(serviceDetails: ServiceDetailsInfo | null) {
-  return getWizardUpdateLabel(serviceDetails?.virtualServices || null, serviceDetails?.k8sHTTPRoutes || null);
-}
+export const getServiceDetailsUpdateLabel = (serviceDetails: ServiceDetailsInfo | null): string => {
+  return getWizardUpdateLabel(serviceDetails?.virtualServices ?? null, serviceDetails?.k8sHTTPRoutes ?? null);
+};
 
 export function hasServiceDetailsTrafficRouting(serviceDetails: ServiceDetailsInfo | null): boolean;
 
@@ -118,8 +118,8 @@ export function hasServiceDetailsTrafficRouting(
 
   if ('length' in serviceDetailsOrVsList) {
     virtualServicesList = serviceDetailsOrVsList;
-    destinationRulesList = drList || [];
-    httpRoutesList = routeList || [];
+    destinationRulesList = drList ?? [];
+    httpRoutesList = routeList ?? [];
   } else {
     virtualServicesList = serviceDetailsOrVsList.virtualServices;
     destinationRulesList = serviceDetailsOrVsList.destinationRules;
@@ -168,7 +168,7 @@ export const validationToHealth = (severity: ValidationTypes): Status => {
   return status;
 };
 
-const numberOfChecks = (type: ValidationTypes, object: ObjectValidation) =>
+const numberOfChecks = (type: ValidationTypes, object: ObjectValidation): number =>
   (object && object.checks ? object.checks : []).filter(i => i.severity === type).length;
 
 export const validationToSeverity = (object: ObjectValidation): ValidationTypes => {
@@ -201,8 +201,10 @@ export function getServiceWizardLabel(serviceDetails: Service): string {
 
 export function getServicePort(ports: { [key: string]: number }): number {
   let port = 80;
+
   if (ports) {
     port = Object.values(ports)[0];
   }
+
   return port;
 }

--- a/frontend/src/types/ServiceList.ts
+++ b/frontend/src/types/ServiceList.ts
@@ -10,20 +10,27 @@ export interface ServiceList {
 }
 
 export interface ServiceOverview {
-  name: string;
-  cluster?: string;
-  istioSidecar: boolean;
-  istioAmbient: boolean;
   additionalDetailSample?: AdditionalItem;
-  labels: { [key: string]: string };
-  ports: { [key: string]: number };
-  istioReferences: ObjectReference[];
-  kialiWizard: string;
-  serviceRegistry: string;
+  cluster?: string;
   health: ServiceHealth;
+  istioAmbient: boolean;
+  istioReferences: ObjectReference[];
+  istioSidecar: boolean;
+  kialiWizard: string;
+  labels: { [key: string]: string };
+  name: string;
+  ports: { [key: string]: number };
+  serviceRegistry: string;
 }
 
 export interface ServiceListItem extends ServiceOverview {
   namespace: string;
   validation?: ObjectValidation;
+}
+
+export interface ServiceListQuery {
+  health: 'true' | 'false';
+  istioResources: 'true' | 'false';
+  onlyDefinitions: 'true' | 'false';
+  rateInterval: string;
 }

--- a/frontend/src/types/Workload.ts
+++ b/frontend/src/types/Workload.ts
@@ -8,46 +8,46 @@ export interface WorkloadId {
 }
 
 export interface Workload {
+  additionalDetails: AdditionalItem[];
+  annotations: { [key: string]: string };
+  appLabel: boolean;
+  availableReplicas: Number;
   name: string;
   cluster?: string;
-  type: string;
   createdAt: string;
-  resourceVersion: string;
+  health?: WorkloadHealthResponse;
+  istioAmbient: boolean;
   istioInjectionAnnotation?: boolean;
   istioSidecar: boolean;
-  istioAmbient: boolean;
   labels: { [key: string]: string };
-  appLabel: boolean;
-  versionLabel: boolean;
-  replicas: Number;
-  availableReplicas: Number;
   pods: Pod[];
-  annotations: { [key: string]: string };
-  health?: WorkloadHealthResponse;
-  services: Service[];
+  replicas: Number;
+  resourceVersion: string;
   runtimes: Runtime[];
-  additionalDetails: AdditionalItem[];
+  services: Service[];
+  type: string;
   validations?: Validations;
+  versionLabel: boolean;
   waypointWorkloads: Workload[];
 }
 
 export const emptyWorkload: Workload = {
-  name: '',
-  type: '',
-  createdAt: '',
-  resourceVersion: '',
-  istioSidecar: true, // true until proven otherwise
-  istioAmbient: false,
-  labels: {},
-  appLabel: false,
-  versionLabel: false,
-  replicas: 0,
-  availableReplicas: 0,
-  pods: [],
-  annotations: {},
-  services: [],
-  runtimes: [],
   additionalDetails: [],
+  annotations: {},
+  appLabel: false,
+  availableReplicas: 0,
+  createdAt: '',
+  istioAmbient: false,
+  istioSidecar: true, // true until proven otherwise
+  labels: {},
+  name: '',
+  pods: [],
+  replicas: 0,
+  resourceVersion: '',
+  runtimes: [],
+  services: [],
+  type: '',
+  versionLabel: false,
   waypointWorkloads: []
 };
 
@@ -64,33 +64,50 @@ export const WorkloadType = {
 };
 
 export interface WorkloadOverview {
-  name: string;
-  cluster?: string;
-  type: string;
-  istioSidecar: boolean;
-  istioAmbient: boolean;
   additionalDetailSample?: AdditionalItem;
   appLabel: boolean;
-  versionLabel: boolean;
-  labels: { [key: string]: string };
-  istioReferences: ObjectReference[];
-  notCoveredAuthPolicy: boolean;
+  cluster?: string;
   health: WorkloadHealth;
+  istioAmbient: boolean;
+  istioReferences: ObjectReference[];
+  istioSidecar: boolean;
+  labels: { [key: string]: string };
+  name: string;
+  notCoveredAuthPolicy: boolean;
+  type: string;
+  versionLabel: boolean;
+}
+
+export interface WorkloadQuery {
+  health: 'true' | 'false';
+  rateInterval: string;
+  validate: 'true' | 'false';
+}
+
+export interface WorkloadUpdateQuery {
+  type: string;
+  patchType?: string;
 }
 
 export interface WorkloadListItem extends WorkloadOverview {
   namespace: string;
 }
 
+export interface WorkloadListQuery {
+  health: 'true' | 'false';
+  istioResources: 'true' | 'false';
+  rateInterval: string;
+}
+
 export interface WorkloadNamespaceResponse {
   namespace: Namespace;
-  workloads: WorkloadOverview[];
   validations: Validations;
+  workloads: WorkloadOverview[];
 }
 
 export interface Runtime {
-  name: string;
   dashboardRefs: DashboardRef[];
+  name: string;
 }
 
 export interface DashboardRef {
@@ -99,7 +116,7 @@ export interface DashboardRef {
 }
 
 export interface AdditionalItem {
+  icon?: string;
   title: string;
   value: string;
-  icon?: string;
 }

--- a/frontend/src/types/Workload.ts
+++ b/frontend/src/types/Workload.ts
@@ -85,8 +85,8 @@ export interface WorkloadQuery {
 }
 
 export interface WorkloadUpdateQuery {
-  type: string;
   patchType?: string;
+  type: string;
 }
 
 export interface WorkloadListItem extends WorkloadOverview {


### PR DESCRIPTION
**Describe the change**

API getNamespaceMetrics is modified to send clusterName query param instead of cluster:

![image](https://github.com/kiali/kiali/assets/122779323/1b2438cf-dbca-4c27-b373-1b96ac63d8e6)

To avoid the use of cluster param in the future, I have added types to query params of all API methods (too many anys in Api.ts). Besides, cluster should be a parameter in the API method, not an attribute in the query params type.

For this reason I have removed cluster attribute from IstioMetricsOptions interface:
```
export interface IstioMetricsOptions extends MetricsQuery {
  direction: Direction;
  filters?: string[];
  requestProtocol?: string;
  reporter: Reporter;
}

export const getNamespaceMetrics = (namespace: string, params: IstioMetricsOptions, cluster?: string) => {
  const queryParams: QueryParams<IstioMetricsOptions> = { ...params };
  if (cluster) {
    queryParams.clusterName = cluster;
  }
  return newRequest<Readonly<IstioMetricsMap>>(HTTP_VERBS.GET, urls.namespaceMetrics(namespace), queryParams, {});
};
```

Bonus:
- Alphabetized props lists to modified files
- Replace strings with correct concatenation to files modified (https://github.com/kiali/kiali/issues/6736)

**Issue reference**

Fixes #6753 