### PR TITLE
[make] don't allow ossmc cr to be installed before kiali is installed

### DIFF
--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -163,6 +163,7 @@ endif
 ## ossmconsole-create: Create a OSSMConsole CR to the cluster, informing the Kiali operator to install OSSMC.
 ossmconsole-create: .ensure-operator-repo-exists .prepare-cluster .create-plugin-pull-secret
 ifeq ($(CLUSTER_TYPE),openshift)
+	@if ! (${OC} get pods -l app.kubernetes.io/name=kiali --all-namespaces --no-headers 2>/dev/null | grep -q Running); then echo "Kiali needs to be installed and running before you can install OSSMC."; exit 1; fi
 	@echo Deploy OSSM Console using the settings found in ${OSSMCONSOLE_CR_FILE}
 	cat ${OSSMCONSOLE_CR_FILE} | \
 DEPLOYMENT_IMAGE_NAME="${CLUSTER_PLUGIN_INTERNAL_NAME}" \


### PR DESCRIPTION
trivial enhancement to the ossmconsole-create target - don't allow the dev to run this make target if Kiali isn't installed yet.