### PR TITLE
Filter traces by cluster, show warning otherwise

### DIFF
--- a/frontend/cypress/integration/featureFiles/app_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/app_details_multicluster.feature
@@ -35,6 +35,7 @@ Feature: Kiali App Details page for multicluster
 
   Scenario: See tracing info after selecting a trace
     And user sees trace information
+    And user sees tracing warning
     When user selects a trace
     Then user sees trace details
 

--- a/frontend/cypress/integration/featureFiles/service_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/service_details_multicluster.feature
@@ -48,6 +48,7 @@ Feature: Kiali Service Details page for remote cluster
 
   Scenario: See graph traces for ratings service details
     And user sees trace information
+    And user sees tracing warning
     When user selects a trace
     Then user sees trace details
 

--- a/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
@@ -37,6 +37,7 @@ Feature: Kiali Workload Details page
 
   Scenario: See workload span info after selecting a span
     And user sees trace information
+    And user sees tracing warning
     When user selects a trace
     And user sees span details
     And user can filter spans by workload

--- a/frontend/src/components/TracingIntegration/TracesFetcher.ts
+++ b/frontend/src/components/TracingIntegration/TracesFetcher.ts
@@ -5,6 +5,7 @@ import { TracingQuery } from 'types/Tracing';
 import { TargetKind } from 'types/Common';
 import { getTimeRangeMicros } from 'utils/tracing/TracingHelper';
 import { transformTraceData } from 'utils/tracing/TraceTransform';
+import { isMultiCluster } from '../../config';
 
 export type FetchOptions = {
   namespace: string;
@@ -65,6 +66,11 @@ export class TracesFetcher {
         this.onChange(traces, response.data.tracingServiceName);
         if (response.data.errors && response.data.errors.length > 0) {
           this.onErrors(response.data.errors);
+        }
+        if (response.data.fromAllClusters && isMultiCluster) {
+          AlertUtils.addWarning(
+            'Loading traces for all clusters. Tracing is not configured to store traces per cluster.'
+          );
         }
       })
       .catch(error => {

--- a/frontend/src/types/TracingInfo.ts
+++ b/frontend/src/types/TracingInfo.ts
@@ -123,6 +123,7 @@ export type TracingError = {
 export type TracingResponse = {
   data: JaegerTrace[] | null;
   errors: TracingError[];
+  fromAllClusters: boolean;
   tracingServiceName: string;
 };
 

--- a/handlers/tracing.go
+++ b/handlers/tracing.go
@@ -233,7 +233,7 @@ func readQuery(values url.Values) (models.TracingQuery, error) {
 		End:     time.Now(),
 		Limit:   100,
 		Tags:    make(map[string]string),
-		Cluster: clusterNameFromQuery(values),
+		Cluster: values.Get("clusterName"), // should not get default cluster
 	}
 
 	if v := values.Get("startMicros"); v != "" {

--- a/handlers/tracing.go
+++ b/handlers/tracing.go
@@ -233,7 +233,7 @@ func readQuery(values url.Values) (models.TracingQuery, error) {
 		End:     time.Now(),
 		Limit:   100,
 		Tags:    make(map[string]string),
-		Cluster: values.Get("clusterName"), // should not get default cluster
+		Cluster: clusterNameFromQuery(values),
 	}
 
 	if v := values.Get("startMicros"); v != "" {
@@ -275,6 +275,12 @@ func readQuery(values url.Values) (models.TracingQuery, error) {
 
 	for key, value := range config.Get().ExternalServices.Tracing.QueryScope {
 		q.Tags[key] = value
+	}
+
+	// 'cluster' in tags is used to query in tracing by cluster in multi-cluster mode
+	// while 'Cluster' in models.TracingQuery can have default cluster
+	if values.Get("clusterName") != "" {
+		q.Tags["cluster"] = values.Get("clusterName")
 	}
 
 	return q, nil

--- a/tracing/client.go
+++ b/tracing/client.go
@@ -174,15 +174,15 @@ func (in *Client) GetAppTraces(namespace, app string, q models.TracingQuery) (*m
 				SearchDepth:  int32(q.Limit),
 			},
 		}
-		tracesMap, err = in.queryTraces(*findTracesRQMC)
+		tracesMap, err = in.queryTraces(findTracesRQMC)
 		if err != nil || len(tracesMap) == 0 {
 			// show warning to user that cannot query by cluster
 			// query second time without cluster filter
-			tracesMap, err = in.queryTraces(*findTracesRQ)
+			tracesMap, err = in.queryTraces(findTracesRQ)
 			r.FromAllClusters = true
 		}
 	} else {
-		tracesMap, err = in.queryTraces(*findTracesRQ)
+		tracesMap, err = in.queryTraces(findTracesRQ)
 	}
 
 	if err != nil {
@@ -197,11 +197,11 @@ func (in *Client) GetAppTraces(namespace, app string, q models.TracingQuery) (*m
 	return &r, nil
 }
 
-func (in *Client) queryTraces(findTracesRQ model.FindTracesRequest) (map[model.TraceID]*model.Trace, error) {
+func (in *Client) queryTraces(findTracesRQ *model.FindTracesRequest) (map[model.TraceID]*model.Trace, error) {
 	ctx, cancel := context.WithTimeout(in.ctx, time.Duration(config.Get().ExternalServices.Tracing.QueryTimeout)*time.Second)
 	defer cancel()
 
-	stream, err := in.grpcClient.FindTraces(ctx, &findTracesRQ)
+	stream, err := in.grpcClient.FindTraces(ctx, findTracesRQ)
 	if err != nil {
 		err = fmt.Errorf("GetAppTraces, Tracing GRPC client error: %v", err)
 		log.Error(err.Error())

--- a/tracing/client.go
+++ b/tracing/client.go
@@ -149,7 +149,7 @@ func (in *Client) GetAppTraces(namespace, app string, q models.TracingQuery) (*m
 		Data:               []jsonModel.Trace{},
 		TracingServiceName: jaegerServiceName,
 	}
-	findTracesRQ := model.FindTracesRequest{
+	findTracesRQ := &model.FindTracesRequest{
 		Query: &model.TraceQueryParameters{
 			ServiceName:  jaegerServiceName,
 			StartTimeMin: timestamppb.New(q.Start),
@@ -164,25 +164,25 @@ func (in *Client) GetAppTraces(namespace, app string, q models.TracingQuery) (*m
 	if q.Cluster != "" {
 		var tagsCL = util.CopyStringMap(q.Tags)
 		tagsCL["cluster"] = q.Cluster
-		findTracesRQMC := model.FindTracesRequest{
+		findTracesRQMC := &model.FindTracesRequest{
 			Query: &model.TraceQueryParameters{
 				ServiceName:  jaegerServiceName,
 				StartTimeMin: timestamppb.New(q.Start),
 				StartTimeMax: timestamppb.New(q.End),
-				Tags:         q.Tags,
+				Tags:         tagsCL,
 				DurationMin:  durationpb.New(q.MinDuration),
 				SearchDepth:  int32(q.Limit),
 			},
 		}
-		tracesMap, err = in.queryTraces(findTracesRQMC)
+		tracesMap, err = in.queryTraces(*findTracesRQMC)
 		if err != nil || len(tracesMap) == 0 {
 			// show warning to user that cannot query by cluster
 			// query second time without cluster filter
-			tracesMap, err = in.queryTraces(findTracesRQ)
+			tracesMap, err = in.queryTraces(*findTracesRQ)
 			r.FromAllClusters = true
 		}
 	} else {
-		tracesMap, err = in.queryTraces(findTracesRQ)
+		tracesMap, err = in.queryTraces(*findTracesRQ)
 	}
 
 	if err != nil {

--- a/tracing/jaeger/http_client.go
+++ b/tracing/jaeger/http_client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tracing/jaeger/model"
+	"github.com/kiali/kiali/util"
 )
 
 type JaegerHTTPClient struct {
@@ -31,6 +32,7 @@ func (jc JaegerHTTPClient) GetAppTracesHTTP(client http.Client, baseURL *url.URL
 		// query without cluster tag, warn user that tracing is not configured to use cluster tags
 		prepareQuery(&url, jaegerServiceName, q, false)
 		r, err = queryTracesHTTP(client, &url)
+		r.FromAllClusters = true
 	}
 
 	if r != nil {
@@ -103,7 +105,7 @@ func prepareQuery(u *url.URL, jaegerServiceName string, query models.TracingQuer
 	q.Set("service", jaegerServiceName)
 	q.Set("start", fmt.Sprintf("%d", query.Start.Unix()*time.Second.Microseconds()))
 	q.Set("end", fmt.Sprintf("%d", query.End.Unix()*time.Second.Microseconds()))
-	var tags = query.Tags
+	var tags = util.CopyStringMap(query.Tags)
 
 	if useCluster && query.Cluster != "" {
 		tags["cluster"] = query.Cluster

--- a/tracing/jaeger/model/types.go
+++ b/tracing/jaeger/model/types.go
@@ -17,6 +17,7 @@ type TracingServices struct {
 type TracingResponse struct {
 	Data               []jaegerModels.Trace `json:"data"`
 	Errors             []structuredError    `json:"errors"`
+	FromAllClusters    bool                 `json:"fromAllClusters"`
 	TracingServiceName string               `json:"tracingServiceName"`
 }
 

--- a/util/maps.go
+++ b/util/maps.go
@@ -16,7 +16,7 @@ func RemoveNilValues(root interface{}) {
 func CopyStringMap(originalMap map[string]string) map[string]string {
 	copyMap := make(map[string]string)
 
-	if originalMap == nil || len(originalMap) == 0 {
+	if len(originalMap) == 0 {
 		return copyMap
 	}
 

--- a/util/maps.go
+++ b/util/maps.go
@@ -12,3 +12,17 @@ func RemoveNilValues(root interface{}) {
 		}
 	}
 }
+
+func CopyStringMap(originalMap map[string]string) map[string]string {
+	copyMap := make(map[string]string)
+
+	if originalMap == nil || len(originalMap) == 0 {
+		return copyMap
+	}
+
+	for key, value := range originalMap {
+		copyMap[key] = value
+	}
+
+	return copyMap
+}

--- a/util/maps_test.go
+++ b/util/maps_test.go
@@ -39,3 +39,17 @@ func TestRemoveNilValues(t *testing.T) {
 	assert.True(t, k3k1)
 	assert.True(t, k3k3k1)
 }
+
+func TestCopyMap(t *testing.T) {
+	initialMap := map[string]string{
+		"cluster":   "east",
+		"namespace": "bookinfo",
+	}
+	copyMap := CopyStringMap(initialMap)
+
+	initialMap["cluster"] = "west"
+
+	assert.Equal(t, initialMap["cluster"], "west")
+	assert.Equal(t, copyMap["cluster"], "east")
+	assert.Equal(t, copyMap["namespace"], initialMap["namespace"])
+}


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6710

Follow up after discussion on https://github.com/kiali/kiali/pull/6749

In a multi-cluster primary-remote mode, when Jaeger is configured to have Cluster ID [(Multi-cluster Setup)](https://kiali.io/docs/configuration/multi-cluster/#setup) and the Istio installation includes the [workaround for Telemetry setup](https://github.com/istio/istio/issues/35750#issuecomment-1165988761).
The Jaeger traces are including a `cluster` tag.
As in the multi-cluster env, the Tracing service supposed to be setup at once and during the installation, then it will be configured to support traces per cluster. This is the expected behavior, otherwise all Traces will be duplicated per service name which exists in all clusters.

What is done: 
In Multi-cluster mode, the Traces are first filtered by the `cluster` tag. This is the expected behavior.
However if no traces are found for particular cluster, then all traces are loaded and a warning message is shown to user saying that 'Loading traces for all clusters. Tracing is not configured to store traces per cluster.'. This is a sign to user to setup Jaeger to support traces per cluster.

![Screenshot from 2023-10-31 18-30-00](https://github.com/kiali/kiali/assets/604313/61350edd-b919-4fe2-beee-1497e503e713)

Currently done for the Jaeger only.

