### PR TITLE
Increase z-index of datepicker to overlap Metric charts

### DIFF
--- a/frontend/src/components/Time/DateTimePicker.tsx
+++ b/frontend/src/components/Time/DateTimePicker.tsx
@@ -32,12 +32,10 @@ const calendarStyle = kialiStyle({
   }
 });
 
-// Make sure datepicker popper rises above other inflated z-index elements
-// - secondaryMasthead currently at 10
 const popperStyle = kialiStyle({
   $nest: {
     '&.react-datepicker-popper': {
-      zIndex: 11
+      zIndex: 100
     }
   }
 });


### PR DESCRIPTION
**Describe the change**

z-index of datepicker has been increased to overlap Metric charts.

![image](https://github.com/kiali/kiali/assets/122779323/d1dd4784-bb3c-4af1-b94d-107ba79d5d8d)


**Issue reference**

Fixes #6781