### PR TITLE
Revert common cfgmap func and protect against failure

### DIFF
--- a/business/istio_certs.go
+++ b/business/istio_certs.go
@@ -103,7 +103,7 @@ func (ics *IstioCertsService) getCertificateFromSecret(secretName, certName stri
 func (ics *IstioCertsService) getCertsConfigFromIstioConfigMap() ([]certConfig, error) {
 	cfg := config.Get()
 
-	istioConfigMap, err := ics.k8s.GetConfigMap(cfg.IstioNamespace, IstioConfigMapName(*cfg, ""))
+	istioConfigMap, err := ics.k8s.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (ics *IstioCertsService) getChironCertificates(certsConfig []certConfig) ([
 func (ics *IstioCertsService) GetTlsMinVersion() (string, error) {
 	cfg := config.Get()
 
-	istioConfigMap, err := ics.k8s.GetConfigMap(cfg.IstioNamespace, IstioConfigMapName(*cfg, ""))
+	istioConfigMap, err := ics.k8s.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	if err != nil {
 		return "N/A", err
 	}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -563,9 +563,9 @@ func (in *IstioValidationsService) fetchNonLocalmTLSConfigs(mtlsDetails *kuberne
 	var istioConfig *core_v1.ConfigMap
 	var err error
 	if IsNamespaceCached(cfg.IstioNamespace) {
-		istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, IstioConfigMapName(*cfg, ""))
+		istioConfig, err = kialiCache.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	} else {
-		istioConfig, err = userClient.GetConfigMap(cfg.IstioNamespace, IstioConfigMapName(*cfg, ""))
+		istioConfig, err = userClient.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	}
 	if err != nil {
 		errChan <- err

--- a/business/mesh_internal_test.go
+++ b/business/mesh_internal_test.go
@@ -1,0 +1,34 @@
+package business
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIstioConfigMapName(t *testing.T) {
+	testCases := map[string]struct {
+		revision string
+		expected string
+	}{
+		"revision is default": {
+			revision: "default",
+			expected: "istio",
+		},
+		"revision is v1": {
+			revision: "v1",
+			expected: "istio-v1",
+		},
+		"revision is empty": {
+			revision: "",
+			expected: "istio",
+		},
+	}
+
+	for desc, tc := range testCases {
+		t.Run(desc, func(t *testing.T) {
+			result := guessIstioConfigMapName(tc.revision)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -628,6 +628,34 @@ trustDomain: cluster.local
 	require.Len(mesh.ControlPlanes[0].ManagedClusters, 1)
 }
 
+// Ensure that fetching the configmap configuration won't produce failures due to regression: https://github.com/kiali/kiali/issues/6669
+func TestGetMeshSucceedsEvenWhenFetchingIstioConfigFails(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	kubernetes.SetConfig(t, *conf)
+
+	istiodDeployment := &apps_v1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istiod",
+			Namespace: "istio-system",
+			Labels:    map[string]string{"app": "istiod"},
+		},
+	}
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		istiodDeployment,
+	)
+
+	business.SetupBusinessLayer(t, k8s, *conf)
+
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	svc := business.NewWithBackends(clients, clients, nil, nil).Mesh
+	mesh, err := svc.GetMesh(context.TODO())
+	require.NoError(err)
+	require.Len(mesh.ControlPlanes, 1)
+	require.Len(mesh.ControlPlanes[0].ManagedClusters, 1)
+}
+
 func TestGetMeshMultipleRevisions(t *testing.T) {
 	istiod_1_18_Deployment := &apps_v1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
@@ -703,18 +731,6 @@ trustDomain: cluster.local
 	})
 	require.True(*controlPlane_1_19.Config.EnableAutoMtls)
 	require.Len(controlPlane_1_19.ManagedClusters, 1)
-
-	// Test for setting the configmap name explicitly due to regression: https://github.com/kiali/kiali/issues/6669
-	conf.ExternalServices.Istio.ConfigMapName = istio_1_19_ConfigMap.Name
-	config.Set(conf)
-	svc = business.NewWithBackends(clients, clients, nil, nil).Mesh
-	mesh, err = svc.GetMesh(context.TODO())
-	require.NoError(err)
-
-	require.Len(mesh.ControlPlanes, 2)
-	// Both controlplanes should set this to true since both will use the 1.19 configmap.
-	require.True(*mesh.ControlPlanes[0].Config.EnableAutoMtls)
-	require.True(*mesh.ControlPlanes[1].Config.EnableAutoMtls)
 }
 
 func TestGetMeshRemoteClusters(t *testing.T) {
@@ -1043,75 +1059,4 @@ func fakeIstiodDeployment(cluster string, manageExternal bool) *apps_v1.Deployme
 		})
 	}
 	return deployment
-}
-
-func TestIstioConfigMapName(t *testing.T) {
-	testCases := map[string]struct {
-		conf     config.Config
-		revision string
-		expected string
-	}{
-		"ConfigMapName is empty and revision is default": {
-			conf: config.Config{
-				ExternalServices: config.ExternalServices{
-					Istio: config.IstioConfig{
-						ConfigMapName: "",
-					},
-				},
-			},
-			revision: "default",
-			expected: "istio",
-		},
-		"ConfigMapName is empty and revision is v1": {
-			conf: config.Config{
-				ExternalServices: config.ExternalServices{
-					Istio: config.IstioConfig{
-						ConfigMapName: "",
-					},
-				},
-			},
-			revision: "v1",
-			expected: "istio-v1",
-		},
-		"ConfigMapName is set and revision is default": {
-			conf: config.Config{
-				ExternalServices: config.ExternalServices{
-					Istio: config.IstioConfig{
-						ConfigMapName: "my-istio-config",
-					},
-				},
-			},
-			revision: "default",
-			expected: "my-istio-config",
-		},
-		"ConfigMapName is set and revision is v2": {
-			conf: config.Config{
-				ExternalServices: config.ExternalServices{
-					Istio: config.IstioConfig{
-						ConfigMapName: "my-istio-config",
-					},
-				},
-			},
-			revision: "v2",
-			expected: "my-istio-config",
-		},
-		"ConfigMapName is set and revision is empty": {
-			conf: config.Config{
-				ExternalServices: config.ExternalServices{
-					Istio: config.IstioConfig{
-						ConfigMapName: "my-istio-config",
-					},
-				},
-			},
-			revision: "",
-			expected: "my-istio-config",
-		},
-	}
-
-	for desc, tc := range testCases {
-		t.Run(desc, func(t *testing.T) {
-			result := business.IstioConfigMapName(tc.conf, tc.revision)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
 }

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -95,7 +95,7 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 
 	// determine what the discoverySelectors are by examining the Istio ConfigMap
 	var discoverySelectors []*meta_v1.LabelSelector
-	if icm, err := in.kialiCache.GetConfigMap(in.conf.IstioNamespace, IstioConfigMapName(in.conf, "")); err == nil {
+	if icm, err := in.kialiCache.GetConfigMap(in.conf.IstioNamespace, in.conf.ExternalServices.Istio.ConfigMapName); err == nil {
 		if ic, err2 := kubernetes.GetIstioConfigMap(icm); err2 == nil {
 			discoverySelectors = ic.DiscoverySelectors
 		} else {

--- a/business/tls.go
+++ b/business/tls.go
@@ -142,7 +142,7 @@ func (in *TLSService) hasAutoMTLSEnabled(cluster string) bool {
 	}
 
 	cfg := config.Get()
-	istioConfig, err := kubeCache.GetConfigMap(cfg.IstioNamespace, IstioConfigMapName(*cfg, ""))
+	istioConfig, err := kubeCache.GetConfigMap(cfg.IstioNamespace, cfg.ExternalServices.Istio.ConfigMapName)
 	if err != nil {
 		return true
 	}


### PR DESCRIPTION
This reverts the callers of `IstioConfigMapName` back to using `cfg.external_services.istio.config_map_name` directly. It now logs failures in `GetMesh` to auto-detect the configmap instead of returning an error. Nothing is currently using that configuration so an error shouldn't be returned there. Related to: https://github.com/kiali/kiali/issues/6669.