### PR TITLE
[make] pass in correct watches file when using make target run-operator

### DIFF
--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -373,6 +373,11 @@ endif
 
 ## run-operator: Runs the Kiali Operator via the ansible-operator locally.
 run-operator: get-ansible-operator crd-create .wait-for-kiali-crd .wait-for-ossmconsole-crd
+ifeq ($(CLUSTER_TYPE),openshift)
+	@$(eval WATCHES_FILE ?= watches-os.yaml)
+else
+	@$(eval WATCHES_FILE ?= watches-k8s.yaml)
+endif
 	@# Make sure we have the collections we need
 	ansible-galaxy collection install -r ${OPERATOR_DIR}/requirements.yml --force-with-deps
 	@# Run the operator directly
@@ -391,4 +396,4 @@ run-operator: get-ansible-operator crd-create .wait-for-kiali-crd .wait-for-ossm
 	POD_NAMESPACE="does-not-exist" \
 	WATCH_NAMESPACE="" \
 	PATH="${PATH}:${OUTDIR}/ansible-operator-install" \
-	ansible-operator run --zap-log-level=debug --leader-election-id=kiali-operator
+	ansible-operator run --zap-log-level=debug --leader-election-id=kiali-operator --watches-file=${WATCHES_FILE}


### PR DESCRIPTION
I missed this spot when I did https://github.com/kiali/kiali/issues/6790

This make target runs the operator locally - useful for dev debugging. It now needs to pass in the correct watches file.

This doesn't affect anything other than a make target that is used during development.
