### PR TITLE
Add refresh delay to avoid multiple refresh in a very short period of time

### DIFF
--- a/frontend/src/components/Refresh/RefreshButton.tsx
+++ b/frontend/src/components/Refresh/RefreshButton.tsx
@@ -2,39 +2,37 @@ import * as React from 'react';
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
 
-type ComponentProps = {
-  id?: string;
+type RefreshButtonProps = {
   disabled?: boolean;
   handleRefresh: () => void;
+  id?: string;
 };
 
-export class RefreshButton extends React.Component<ComponentProps> {
-  getElementId() {
-    return this.props.id || 'refresh_button';
-  }
+export const RefreshButton: React.FC<RefreshButtonProps> = (props: RefreshButtonProps) => {
+  const [enableRefresh, setEnableRefresh] = React.useState<boolean>(true);
 
-  getDisabled() {
-    return this.props.disabled || false;
-  }
+  const handleRefresh = (): void => {
+    if (enableRefresh) {
+      props.handleRefresh();
 
-  render() {
-    return (
-      <Tooltip position="bottom" content={<>Refresh</>}>
-        <Button
-          id={this.getElementId()}
-          data-test="refresh-button"
-          onClick={this.handleRefresh}
-          isDisabled={this.getDisabled()}
-          aria-label="Action"
-          variant={ButtonVariant.primary}
-        >
-          <SyncAltIcon />
-        </Button>
-      </Tooltip>
-    );
-  }
-
-  private handleRefresh = () => {
-    this.props.handleRefresh();
+      // Disable refresh during 500 ms to avoid multiple refresh in very short period of time
+      setEnableRefresh(false);
+      setTimeout(() => setEnableRefresh(true), 500);
+    }
   };
-}
+
+  return (
+    <Tooltip position="bottom" content={<>Refresh</>}>
+      <Button
+        id={props.id ?? 'refresh_button'}
+        data-test="refresh-button"
+        onClick={handleRefresh}
+        isDisabled={props.disabled ?? false}
+        aria-label="Action"
+        variant={ButtonVariant.primary}
+      >
+        <SyncAltIcon />
+      </Button>
+    </Tooltip>
+  );
+};

--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -146,39 +146,51 @@ class GraphToolbarComponent extends React.PureComponent<GraphToolbarProps> {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: GraphToolbarProps) {
     // ensure redux state and URL are aligned
-    if (this.props.edgeLabels?.length === 0) {
-      HistoryManager.deleteParam(URLParam.GRAPH_EDGE_LABEL, true);
-    } else {
-      HistoryManager.setParam(URLParam.GRAPH_EDGE_LABEL, String(this.props.edgeLabels));
+    if (String(prevProps.edgeLabels) !== String(this.props.edgeLabels)) {
+      if (this.props.edgeLabels?.length === 0) {
+        HistoryManager.deleteParam(URLParam.GRAPH_EDGE_LABEL, true);
+      } else {
+        HistoryManager.setParam(URLParam.GRAPH_EDGE_LABEL, String(this.props.edgeLabels));
+      }
     }
 
-    if (this.props.rankBy?.length === 0) {
-      HistoryManager.deleteParam(URLParam.GRAPH_RANK_BY, true);
-    } else {
-      HistoryManager.setParam(URLParam.GRAPH_RANK_BY, String(this.props.rankBy));
+    if (String(prevProps.rankBy) !== String(this.props.rankBy)) {
+      if (this.props.rankBy?.length === 0) {
+        HistoryManager.deleteParam(URLParam.GRAPH_RANK_BY, true);
+      } else {
+        HistoryManager.setParam(URLParam.GRAPH_RANK_BY, String(this.props.rankBy));
+      }
     }
 
-    if (this.props.activeNamespaces?.length === 0) {
-      HistoryManager.deleteParam(URLParam.NAMESPACES, true);
-    } else {
-      HistoryManager.setParam(URLParam.NAMESPACES, namespacesToString(this.props.activeNamespaces));
+    if (namespacesToString(prevProps.activeNamespaces) !== namespacesToString(this.props.activeNamespaces)) {
+      if (this.props.activeNamespaces?.length === 0) {
+        HistoryManager.deleteParam(URLParam.NAMESPACES, true);
+      } else {
+        HistoryManager.setParam(URLParam.NAMESPACES, namespacesToString(this.props.activeNamespaces));
+      }
     }
 
-    if (this.props.replayActive === INITIAL_USER_SETTINGS_STATE.replayActive) {
-      HistoryManager.deleteParam(URLParam.GRAPH_REPLAY_ACTIVE, true);
-    } else {
-      HistoryManager.setParam(URLParam.GRAPH_REPLAY_ACTIVE, String(this.props.replayActive));
+    if (String(prevProps.replayActive) !== String(this.props.replayActive)) {
+      if (this.props.replayActive === INITIAL_USER_SETTINGS_STATE.replayActive) {
+        HistoryManager.deleteParam(URLParam.GRAPH_REPLAY_ACTIVE, true);
+      } else {
+        HistoryManager.setParam(URLParam.GRAPH_REPLAY_ACTIVE, String(this.props.replayActive));
+      }
     }
 
-    if (this.props.trafficRates?.length === 0) {
-      HistoryManager.deleteParam(URLParam.GRAPH_TRAFFIC, true);
-    } else {
-      HistoryManager.setParam(URLParam.GRAPH_TRAFFIC, String(this.props.trafficRates));
+    if (String(prevProps.trafficRates) !== String(this.props.trafficRates)) {
+      if (this.props.trafficRates?.length === 0) {
+        HistoryManager.deleteParam(URLParam.GRAPH_TRAFFIC, true);
+      } else {
+        HistoryManager.setParam(URLParam.GRAPH_TRAFFIC, String(this.props.trafficRates));
+      }
     }
 
-    HistoryManager.setParam(URLParam.GRAPH_TYPE, String(this.props.graphType));
+    if (prevProps.graphType !== this.props.graphType) {
+      HistoryManager.setParam(URLParam.GRAPH_TYPE, String(this.props.graphType));
+    }
   }
 
   componentWillUnmount() {
@@ -250,7 +262,7 @@ class GraphToolbarComponent extends React.PureComponent<GraphToolbarProps> {
     );
   }
 
-  private handleNamespaceReturn = () => {
+  private handleNamespaceReturn = (): void => {
     const route = this.props.isPF ? 'graphpf' : 'graph';
     if (
       !this.props.summaryData ||


### PR DESCRIPTION
**Describe the change**

Add refresh delay when clicking Refresh Button to avoid multiple refresh in a very short period of time.

Besides, I have converted the Refresh button component in a React Hook.

**Issue reference**

Fixes #6714. 