### PR TITLE
Use cluster tag for Tempo

### DIFF
--- a/tracing/client.go
+++ b/tracing/client.go
@@ -141,6 +141,7 @@ func NewClient(token string) (*Client, error) {
 				httpTracingClient, err = tempo.NewOtelClient(client, u)
 				if err != nil {
 					log.Errorf("Error creating HTTP client %s", err.Error())
+					return nil, err
 				}
 			}
 			return &Client{httpTracingClient: httpTracingClient, httpClient: client, baseURL: u, ctx: ctx}, nil

--- a/tracing/otel/model/types.go
+++ b/tracing/otel/model/types.go
@@ -18,6 +18,10 @@ type TracingResponse struct {
 	Traces []TraceMetadata `json:"traces"`
 }
 
+type TagsResponse struct {
+	TagNames []string `json:"tagNames"`
+}
+
 type Span struct {
 	SpanID            string           `json:"spanID"`
 	StartTimeUnixNano string           `json:"startTimeUnixNano"`

--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -17,16 +17,41 @@ import (
 	otel "github.com/kiali/kiali/tracing/otel/model"
 	"github.com/kiali/kiali/tracing/otel/model/converter"
 	otelModels "github.com/kiali/kiali/tracing/otel/model/json"
+	"github.com/kiali/kiali/util"
 )
 
 type OtelHTTPClient struct {
+	ClusterTag bool
+}
+
+// New client
+func NewOtelClient(client http.Client, baseURL *url.URL) (otelClient *OtelHTTPClient, err error) {
+	url := *baseURL
+	url.Path = path.Join(url.Path, "/api/search/tags")
+	r, status, _ := makeRequest(client, url.String(), nil)
+	if status != 200 {
+		return nil, fmt.Errorf("Error %d getting tags", status)
+	}
+	var response otel.TagsResponse
+	if errMarshal := json.Unmarshal(r, &response); errMarshal != nil {
+		log.Errorf("Error unmarshalling Tempo API response: %s [URL: %v]", errMarshal, url)
+		return nil, errMarshal
+	}
+	tags := false
+	if util.InSlice(response.TagNames, "cluster") {
+		tags = true
+	}
+
+	return &OtelHTTPClient{ClusterTag: tags}, nil
 }
 
 // GetAppTracesHTTP search traces
 func (oc OtelHTTPClient) GetAppTracesHTTP(client http.Client, baseURL *url.URL, serviceName string, q models.TracingQuery) (response *model.TracingResponse, err error) {
 	url := *baseURL
 	url.Path = path.Join(url.Path, "/api/search")
-	prepareTraceQL(&url, serviceName, q)
+	tracingServiceName := buildTracingServiceName(namespace, app)
+	oc.prepareTraceQL(&url, tracingServiceName, q)
+
 	r, err := oc.queryTracesHTTP(client, &url, q.Tags["error"])
 
 	if r != nil {
@@ -179,7 +204,7 @@ func convertSingleTrace(traces *otelModels.Data, id string) (*model.TracingRespo
 }
 
 // prepareTraceQL returns a query in TraceQL format
-func prepareTraceQL(u *url.URL, tracingServiceName string, query models.TracingQuery) {
+func (oc OtelHTTPClient) prepareTraceQL(u *url.URL, tracingServiceName string, query models.TracingQuery) {
 	q := url.Values{}
 	q.Set("start", fmt.Sprintf("%d", query.Start.Unix()))
 	q.Set("end", fmt.Sprintf("%d", query.End.Unix()))
@@ -195,8 +220,10 @@ func prepareTraceQL(u *url.URL, tracingServiceName string, query models.TracingQ
 
 	if len(query.Tags) > 0 {
 		for k, v := range query.Tags {
-			tag := TraceQL{operator1: "." + k, operand: REGEX, operator2: v}
-			queryPart = TraceQL{operator1: queryPart, operand: AND, operator2: tag}
+			if k != "cluster" && oc.ClusterTag {
+				tag := TraceQL{operator1: "." + k, operand: EQUAL, operator2: v}
+				queryPart = TraceQL{operator1: queryPart, operand: AND, operator2: tag}
+			}
 		}
 	}
 

--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -49,8 +49,7 @@ func NewOtelClient(client http.Client, baseURL *url.URL) (otelClient *OtelHTTPCl
 func (oc OtelHTTPClient) GetAppTracesHTTP(client http.Client, baseURL *url.URL, serviceName string, q models.TracingQuery) (response *model.TracingResponse, err error) {
 	url := *baseURL
 	url.Path = path.Join(url.Path, "/api/search")
-	tracingServiceName := buildTracingServiceName(namespace, app)
-	oc.prepareTraceQL(&url, tracingServiceName, q)
+	oc.prepareTraceQL(&url, serviceName, q)
 
 	r, err := oc.queryTracesHTTP(client, &url, q.Tags["error"])
 

--- a/util/slice.go
+++ b/util/slice.go
@@ -1,0 +1,10 @@
+package util
+
+func InSlice(array []string, value string) bool {
+	for _, v := range array {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #6710 (Tempo)

For some reason, telemetry is not adding the cluster tag. But without this fix, Tempo search is not working, as the cluster tag is included and the search is not returning any result. 