### PR TITLE
Fix tracing config in run-kiali template

### DIFF
--- a/hack/run-kiali-config-template.yaml
+++ b/hack/run-kiali-config-template.yaml
@@ -39,8 +39,10 @@ external_services:
 
   tracing:
     enabled: true
+    provider: "${TRACING_APP}"
     in_cluster_url: "${TRACING_URL}"
     url: "${TRACING_URL}"
+    use_grpc: false
 
 login_token:
   signing_key: "notsecure"

--- a/hack/run-kiali.sh
+++ b/hack/run-kiali.sh
@@ -444,7 +444,8 @@ if [ -z "${TRACING_URL:-}" ]; then
           trac_local_port="$(echo ${LOCAL_REMOTE_PORTS_TRACING} | cut -d ':' -f 1)"
           LOCAL_REMOTE_PORTS_TRACING="${trac_local_port}:${trac_remote_port}"
         fi
-        TRACING_URL="http://127.0.0.1:$(echo ${LOCAL_REMOTE_PORTS_TRACING} | cut -d ':' -f 1)"
+        [ ${TRACING_APP} == 'jaeger' ] && TRACING_PREFIX="/jaeger" || TRACING_PREFIX=""
+        TRACING_URL="http://127.0.0.1:$(echo ${LOCAL_REMOTE_PORTS_TRACING} | cut -d ':' -f 1)${TRACING_PREFIX}"
       fi
     else
       infomsg "Auto-discovered OpenShift route that exposes Tracing"
@@ -468,7 +469,8 @@ if [ -z "${TRACING_URL:-}" ]; then
         trac_local_port="$(echo ${LOCAL_REMOTE_PORTS_TRACING} | cut -d ':' -f 1)"
         LOCAL_REMOTE_PORTS_TRACING="${trac_local_port}:${trac_remote_port}"
       fi
-      TRACING_URL="http://127.0.0.1:$(echo ${LOCAL_REMOTE_PORTS_TRACING} | cut -d ':' -f 1)"
+      [ ${TRACING_APP} == 'jaeger' ] && TRACING_PREFIX="/jaeger" || TRACING_PREFIX=""
+      TRACING_URL="http://127.0.0.1:$(echo ${LOCAL_REMOTE_PORTS_TRACING} | cut -d ':' -f 1)${TRACING_PREFIX}"
     fi
   fi
 fi
@@ -586,6 +588,7 @@ cat ${KIALI_CONFIG_TEMPLATE_FILE} | \
   ISTIOD_URL=${ISTIOD_URL} \
   PROMETHEUS_URL=${PROMETHEUS_URL} \
   GRAFANA_URL=${GRAFANA_URL} \
+  TRACING_APP=${TRACING_APP} \
   TRACING_URL=${TRACING_URL} \
   UI_CONSOLE_DIR=${UI_CONSOLE_DIR}   \
   REMOTE_SECRET_PATH=${REMOTE_SECRET_PATH} \


### PR DESCRIPTION
**Describe the change**

Adapt standard kiali configuration template to latest changes in tracing:

- Add tracing provider: `${TRACING_APP}`
- Add tracing prefix for jaeger client: `/jaeger`
- Disable `use_grpc` by default in tracing

**Issue reference**

Fixes #6808 