### PR TITLE
Multi-cluster test implementation related mainly to Istio Config page

### DIFF
--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -1,4 +1,5 @@
 import { Before } from '@badeball/cypress-cucumber-preprocessor';
+import { ensureKialiFinishedLoading } from './transition';
 
 const CLUSTER1_CONTEXT = Cypress.env('CLUSTER1_CONTEXT');
 const CLUSTER2_CONTEXT = Cypress.env('CLUSTER2_CONTEXT');
@@ -42,6 +43,7 @@ function install_demoapp(demoapp: string) {
                   }).then(() => {
                     cy.log('Waiting for demoapp to be ready.');
                     cy.exec(`../hack/istio/wait-for-namespace.sh -n ${namespaces}`, { timeout: 400000 });
+                    ensureKialiFinishedLoading();
                   });
                 });
               } else {

--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -401,10 +401,6 @@ And('user sees {string} information for Istio objects from both clusters',(colum
   });
 });
 
-And('user sees Namespace information for Istio objects',() => {});
-And('user sees Type information for Istio objects',() => {});
-And('user sees Configuration information for Istio objects',()=> {});
-
 Then('there are Istio config objects created in both clusters',() => {
   cy.exec(`kubectl delete AuthorizationPolicy foo-east -n bookinfo --context ${CLUSTER1_CONTEXT}`, { failOnNonZeroExit: false });
   cy.exec(`kubectl delete AuthorizationPolicy foo-west -n bookinfo --context ${CLUSTER2_CONTEXT}`, { failOnNonZeroExit: false });

--- a/frontend/cypress/integration/common/istio_config_editor.ts
+++ b/frontend/cypress/integration/common/istio_config_editor.ts
@@ -1,5 +1,9 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Then, And } from '@badeball/cypress-cucumber-preprocessor';
 
 Then('user can see istio config editor', () => {
 	cy.get('#ace-editor').should('be.visible');
 })
+
+And('cluster badge for {string} cluster should be visible in the side panel',(cluster:string) => {
+	cy.get('h3').contains('Overview').parent().parent().find('#pfbadge-C').should('be.visible');
+});

--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -108,6 +108,18 @@ And('user does not see a dropdown for cluster selection', () => {
   cy.get('[data-test="cluster-dropdown"]').should('not.exist');
 });
 
+And('user selects {string} from the cluster dropdown',(clusters:string)=>{
+  clusters.split(",").forEach((value:string) =>{
+    cy.getBySel('cluster-dropdown').click();
+    cy.get(`input[type="checkbox"][value="${value}"]`).check();
+    cy.getBySel('cluster-dropdown').click();
+  })
+});
+
+And('no danger alert should be visible', () => {
+  cy.get('h4').contains('Danger alert').should('not.exist');
+});
+
 Then(
   'the {string} {string} should be listed in {string} namespace',
   (type: string, name: string, namespace: string) => {
@@ -153,4 +165,8 @@ Then('{string} details information for service entry {string} can be seen', (hos
   cy.get('#IstioConfigCard').within(() => {
     cy.get('#pfbadge-SE').parent().parent().contains(name);
   });
+});
+
+Then('an info message {string} is displayed',(message:string) =>{
+  cy.contains(message).should('be.visible');
 });

--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -139,6 +139,7 @@ Then('the preview button should be disabled', () => {
 });
 
 Then('an error message {string} is displayed', (message: string) => {
+  ensureKialiFinishedLoading();
   cy.get('h4').contains(message).should('be.visible');
 });
 
@@ -168,5 +169,6 @@ Then('{string} details information for service entry {string} can be seen', (hos
 });
 
 Then('an info message {string} is displayed',(message:string) =>{
+  ensureKialiFinishedLoading();
   cy.contains(message).should('be.visible');
 });

--- a/frontend/cypress/integration/common/wizard_request_routing.ts
+++ b/frontend/cypress/integration/common/wizard_request_routing.ts
@@ -87,6 +87,10 @@ And('the {string} {string} should be listed in {string} {string} namespace', (ty
   cy.get(`[data-test="VirtualItem_Ns${ns}_${type.toLowerCase()}_${svc}"]`).find('[data-label="Cluster"]').contains(cluster);
 })
 
+And('the {string} {string} should not be listed in {string} {string} namespace', (type:string, svc:string, cluster:string, ns:string) => {
+  cy.get(`[data-test="VirtualItem_Ns${ns}_${type.toLowerCase()}_${svc}"]`).find('[data-label="Cluster"]').should('not.include.text',cluster);
+})
+
 And('user sees the {string} wizard', (title: string) => {
   cy.get('div[aria-label="' + title + '"]');
 });

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -78,14 +78,13 @@ Feature: Kiali Istio Config page
     Then the user can create a "Sidecar" Istio object
 
   @multi-cluster
-  @skip
+  @remote-istio-crds
   Scenario: See all Istio Config objects in the bookinfo namespace in the multi-cluster environment.
+    And there are Istio config objects created in both clusters
     Then the "Cluster" column "appears"
-    And user sees all the Istio Config objects from both clusters in the bookinfo namespace
-    And user sees Name information for Istio objects
-    And user sees Namespace information for Istio objects
-    And user sees Type information for Istio objects
-    And user sees Configuration information for Istio objects
+    And user sees the Istio Config objects from both clusters in the bookinfo namespace
+    And user sees "Name" information for Istio objects from both clusters
+    And user sees "Configuration" information for Istio objects from both clusters
 
   @skip
   @multi-cluster

--- a/frontend/cypress/integration/featureFiles/istio_config_editor.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_editor.feature
@@ -20,11 +20,10 @@ Feature: Kiali Istio Config editor page
     But no cluster badge for the "Istio config" should be visible
 
   @multi-cluster
-  @skip
   Scenario: Filter Istio Config editor objects by Valid configuration
     When the user filters by "Config" for "Valid"
     And user sees "bookinfo-gateway"
     And user sees "bookinfo"
     And user clicks in "Name" column on the "bookinfo" text
     Then user can see istio config editor
-    And cluster badge for "east" cluster should be visible
+    And cluster badge for "east" cluster should be visible in the side panel

--- a/frontend/cypress/integration/featureFiles/kiali_help.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_help.feature
@@ -22,9 +22,3 @@ Feature: Kiali help dropdown verify
   Scenario: User opens the View Certificates Info section
     When user clicks on the "View Certificates Info" button
     Then user sees the "Certificates information" modal
-
-  @multi-cluster
-  Scenario: User opens the View Debug Info section for multi-cluster mode
-    When user clicks on the "View Debug Info" button
-    Then user sees the "Debug information" modal
-    And user sees information about 2 clusters

--- a/frontend/cypress/integration/featureFiles/kiali_help.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_help.feature
@@ -23,9 +23,6 @@ Feature: Kiali help dropdown verify
     When user clicks on the "View Certificates Info" button
     Then user sees the "Certificates information" modal
 
-  # Even though this test is already implemented, I skipped it.
-  # It will be better to skip this one until our upstream CI is able to build Kiali from the specific PR it is running on. 
-  @skip  
   @multi-cluster
   Scenario: User opens the View Debug Info section for multi-cluster mode
     When user clicks on the "View Debug Info" button

--- a/frontend/cypress/integration/featureFiles/kiali_help_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_help_multicluster.feature
@@ -1,0 +1,16 @@
+@multi-cluster
+# don't change first line of this file - the tag is used for the test scripts to identify the test suite
+
+Feature: Kiali help dropdown verify
+
+  User wants to verify the Kiali help about information
+
+  Background:
+    Given user is at administrator perspective
+    And user is at the "overview" page
+    When user clicks on Help Button
+
+  Scenario: User opens the View Debug Info section for multi-cluster mode
+    When user clicks on the "View Debug Info" button
+    Then user sees the "Debug information" modal
+    And user sees information about 2 clusters

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config_multicluster.feature
@@ -80,4 +80,5 @@ Feature: Kiali Istio Config page
     And user types "foobar" in the "addPortName_0" input
     And user previews the configuration
     And user creates the istio config
-    Then the "Gateway" "sleep-gateway" should not be listed in "sleep" namespace
+    Then the "Gateway" "sleep-gateway" should not be listed in "west" "sleep" namespace
+    And the "Gateway" "sleep-gateway" should be listed in "east" "sleep" namespace

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config_multicluster.feature
@@ -26,7 +26,6 @@ Feature: Kiali Istio Config page
 
   Scenario: Try to Create a Gateway in both clusters without Istio CRDs present in the remote cluster 
     When user deletes gateway named "bookinfo-gateway-mc" and the resource is no longer available in any cluster
-    And Istio CRDs are "not" present in the "west" cluster
     And user selects the "bookinfo" namespace
     And user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
@@ -34,9 +33,9 @@ Feature: Kiali Istio Config page
     And user types "bookinfo-gateway-mc" in the "name" input
     And user adds a server to a server list
     Then the preview button should be disabled
-    And user types "website.com" in the "hosts0" input
-    And user types "8080" in the "addPortNumber0" input
-    And user types "foobar" in the "addPortName0" input
+    And user types "website.com" in the "hosts_0" input
+    And user types "8080" in the "addPortNumber_0" input
+    And user types "foobar" in the "addPortName_0" input
     And user previews the configuration
     And user creates the istio config
     Then an error message "Could not create Istio Gateway objects" is displayed

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config_multicluster.feature
@@ -11,7 +11,6 @@ Feature: Kiali Istio Config page
     Given user is at administrator perspective
     And user is at the "istio" page
 
-@skip
   Scenario: Try to Create a Gateway without selecting any cluster
     When user deletes gateway named "bookinfo-gateway-mc" and the resource is no longer available in any cluster
     And user selects the "bookinfo" namespace
@@ -20,12 +19,11 @@ Feature: Kiali Istio Config page
     And user types "bookinfo-gateway-mc" in the "name" input
     And user adds a server to a server list
     Then the preview button should be disabled
-    And user types "website.com" in the "hosts0" input
-    And user types "8080" in the "addPortNumber0" input
-    And user types "foobar" in the "addPortName0" input
+    And user types "website.com" in the "hosts_0" input
+    And user types "8080" in the "addPortNumber_0" input
+    And user types "foobar" in the "addPortName_0" input
     Then the preview button should be disabled
 
-  @skip
   Scenario: Try to Create a Gateway in both clusters without Istio CRDs present in the remote cluster 
     When user deletes gateway named "bookinfo-gateway-mc" and the resource is no longer available in any cluster
     And Istio CRDs are "not" present in the "west" cluster
@@ -45,14 +43,12 @@ Feature: Kiali Istio Config page
     And the "Gateway" "bookinfo-gateway-mc" should be listed in "east" "bookinfo" namespace 
     And the "Gateway" "bookinfo-gateway-mc" should not be listed in "west" "bookinfo" namespace 
 
-  @skip
   @remote-istio-crds
   # We can test for both the CRDs being and not being present in the remote cluster, but some order of execution
   # using the Gherkin tags is necessary. We don't want the suite to install/remove the CRDs and restart the 
   # Kiali pod multiple times during a single run.
   Scenario: Try to Create a Gateway in both clusters with Istio CRDs present in the remote cluster 
     When user deletes gateway named "bookinfo-gateway-mc" and the resource is no longer available in any cluster
-    And Istio CRDs are "" present in the "west" cluster
     And user selects the "bookinfo" namespace
     And user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
@@ -60,29 +56,29 @@ Feature: Kiali Istio Config page
     And user types "bookinfo-gateway-mc" in the "name" input
     And user adds a server to a server list
     Then the preview button should be disabled
-    And user types "website.com" in the "hosts0" input
-    And user types "8080" in the "addPortNumber0" input
-    And user types "foobar" in the "addPortName0" input
+    And user types "website.com" in the "hosts_0" input
+    And user types "8080" in the "addPortNumber_0" input
+    And user types "foobar" in the "addPortName_0" input
     And user previews the configuration
     And user creates the istio config
     And the "Gateway" "bookinfo-gateway-mc" should be listed in "east" "bookinfo" namespace 
     And the "Gateway" "bookinfo-gateway-mc" should be listed in "west" "bookinfo" namespace
 
-  @skip
   @sleep-app
   # For this test, I deployed a sleep app in the east cluster. 
   Scenario: Try to create a remotely located Gateway in a namespace, which is only present in the local cluster
-    When user selects the "sleep" namespace
+    When user deletes gateway named "sleep-gateway" and the resource is no longer available in any cluster
+    And user selects the "sleep" namespace
     And user clicks in the "Gateway" Istio config actions
     And user sees the "Create Gateway" config wizard
+    And user selects "east,west" from the cluster dropdown
     Then an info message "Namespace: sleep is not found in cluster west" is displayed
-    And user selects "west" from the cluster dropdown
     And user types "sleep-gateway" in the "name" input
     And user adds a server to a server list
     Then the preview button should be disabled
-    And user types "website.com" in the "hosts0" input
-    And user types "8080" in the "addPortNumber0" input
-    And user types "foobar" in the "addPortName0" input
+    And user types "website.com" in the "hosts_0" input
+    And user types "8080" in the "addPortNumber_0" input
+    And user types "foobar" in the "addPortName_0" input
     And user previews the configuration
     And user creates the istio config
     Then the "Gateway" "sleep-gateway" should not be listed in "sleep" namespace

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "cypress:mc": "cypress open -e TAGS=\"@multi-cluster\"",
     "cypress:run": "cypress run -e TAGS=\"@smoke\" && cypress run -e TAGS=\"not @crd-validation and not @multi-cluster and not @smoke\" && cypress run -e TAGS=\"@crd-validation and not @multi-cluster and not @smoke\"",
     "cypress:run:smoke": "cypress run -e TAGS=\"@smoke\"",
-    "cypress:run:multi-cluster": "cypress run -e TAGS=\"not @crd-validation and @multi-cluster\"",
+    "cypress:run:multi-cluster": "cypress run -e TAGS=\"@crd-validation and @multi-cluster and not @remote-istio-crds\" && cypress run -e TAGS=\"@multi-cluster and @remote-istio-crds\"",
     "cypress:run:junit": "cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"not @crd-validation and not @multi-cluster\" && cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"@crd-validation and not @multi-cluster\"",
     "cypress:delete:reports": "rm cypress/results/* || true",
     "cypress:combine:reports": "jrm cypress/results/combined-report.xml \"cypress/results/*.xml\"",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "cypress:mc": "cypress open -e TAGS=\"@multi-cluster\"",
     "cypress:run": "cypress run -e TAGS=\"@smoke\" && cypress run -e TAGS=\"not @crd-validation and not @multi-cluster and not @smoke\" && cypress run -e TAGS=\"@crd-validation and not @multi-cluster and not @smoke\"",
     "cypress:run:smoke": "cypress run -e TAGS=\"@smoke\"",
-    "cypress:run:multi-cluster": "cypress run -e TAGS=\"@crd-validation and @multi-cluster and not @remote-istio-crds\" && cypress run -e TAGS=\"@multi-cluster and @remote-istio-crds\"",
+    "cypress:run:multi-cluster": "cypress run -e TAGS=\"not @crd-validation and @multi-cluster and not @remote-istio-crds\" && cypress run -e TAGS=\"@multi-cluster and @remote-istio-crds\"",
     "cypress:run:junit": "cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"not @crd-validation and not @multi-cluster\" && cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"@crd-validation and not @multi-cluster\"",
     "cypress:delete:reports": "rm cypress/results/* || true",
     "cypress:combine:reports": "jrm cypress/results/combined-report.xml \"cypress/results/*.xml\"",


### PR DESCRIPTION
I have decided to change the order of test execution a little. We can now test for remote Istio CRDs both being and not being present. I have also installed a sleep app for one of the tests to also cover situation, where namespace is present only on 1 of the clusters. I think the demo app will be useful when testing this issue as well: https://github.com/kiali/kiali/issues/6815.

