### PR TITLE
Install compatible Istio versions on integration tests

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -61,11 +61,17 @@ TARGET_BRANCH="${TARGET_BRANCH:-master}"
 if [ -z "${ISTIO_VERSION}" ]; then
   if [ "${TARGET_BRANCH}" == "v1.48" ]; then
     ISTIO_VERSION="1.13.0"
+  elif [ "${TARGET_BRANCH}" == "v1.57" ]; then
+    ISTIO_VERSION="1.15.0"
+  elif [ "${TARGET_BRANCH}" == "v1.65" ]; then
+    ISTIO_VERSION="1.17.0"
+  elif [ "${TARGET_BRANCH}" == "v1.73" ]; then
+    ISTIO_VERSION="1.18.0"
   fi
 fi
 
 KIND_NODE_IMAGE=""
-if [ "${ISTIO_VERSION}" == "1.13.0" ]; then
+if [ "${ISTIO_VERSION}" == "1.13.0" || "${ISTIO_VERSION}" == "1.15.0" || "${ISTIO_VERSION}" == "1.17.0" ]; then
   KIND_NODE_IMAGE="kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
 else
   KIND_NODE_IMAGE="kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -71,7 +71,7 @@ if [ -z "${ISTIO_VERSION}" ]; then
 fi
 
 KIND_NODE_IMAGE=""
-if [ "${ISTIO_VERSION}" == "1.13.0" || "${ISTIO_VERSION}" == "1.15.0" || "${ISTIO_VERSION}" == "1.17.0" ]; then
+if [[ "${ISTIO_VERSION}" == "1.13.0" || "${ISTIO_VERSION}" == "1.15.0" || "${ISTIO_VERSION}" == "1.17.0" ]]; then
   KIND_NODE_IMAGE="kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
 else
   KIND_NODE_IMAGE="kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"


### PR DESCRIPTION
**Describe the change**

Install compatible Istio versions depending on target branch when performing integration tests.

Compatible Istio versions are obtained from:
https://kiali.io/docs/installation/installation-guide/prerequisites/#version-compatibility

Compatible Kubernetes versions are obtained from:
https://istio.io/latest/docs/releases/supported-releases/

**Issue reference**

#6858 