### PR TITLE
[1.57] Install compatible Istio versions on integration tests

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -50,6 +50,8 @@ TARGET_BRANCH="${TARGET_BRANCH:-master}"
 # https://istio.io/latest/docs/releases/supported-releases/
 if [ "${TARGET_BRANCH}" == "v1.48" ]; then
   ISTIO_VERSION="1.13.0"
+elif [ "${TARGET_BRANCH}" == "v1.57" ]; then
+  ISTIO_VERSION="1.15.0"
 fi
 
 KIND_NODE_IMAGE=""


### PR DESCRIPTION
**Describe the change**

Install compatible Istio version 1.15 for Kiali 1.57 when performing integration tests.

Compatible Istio versions are obtained from:
https://kiali.io/docs/installation/installation-guide/prerequisites/#version-compatibility

Compatible Kubernetes versions are obtained from:
https://istio.io/latest/docs/releases/supported-releases/

**Issue reference**

#6858 