### PR TITLE
[1.65] Install compatible Istio versions on integration tests

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -49,15 +49,15 @@ TARGET_BRANCH="${TARGET_BRANCH:-master}"
 # https://kiali.io/docs/installation/installation-guide/prerequisites/
 # https://istio.io/latest/docs/releases/supported-releases/
 if [ "${TARGET_BRANCH}" == "v1.48" ]; then
-  ISTIO_VERSION="1.12.0"
+  ISTIO_VERSION="1.12.9"
 elif [ "${TARGET_BRANCH}" == "v1.57" ]; then
-  ISTIO_VERSION="1.14.0"
+  ISTIO_VERSION="1.14.5"
 elif [ "${TARGET_BRANCH}" == "v1.65" ]; then
   ISTIO_VERSION="1.16.7"
 fi
 
 KIND_NODE_IMAGE=""
-if [ "${ISTIO_VERSION}" == "1.12.0" ]; then
+if [ "${ISTIO_VERSION}" == "1.12.9" ]; then
   KIND_NODE_IMAGE="kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
 else
   KIND_NODE_IMAGE="kindest/node:v1.24.15@sha256:24473777a1eef985dc405c23ab9f4daddb1352ca23db60b75de9e7c408096491"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -49,15 +49,15 @@ TARGET_BRANCH="${TARGET_BRANCH:-master}"
 # https://kiali.io/docs/installation/installation-guide/prerequisites/
 # https://istio.io/latest/docs/releases/supported-releases/
 if [ "${TARGET_BRANCH}" == "v1.48" ]; then
-  ISTIO_VERSION="1.13.0"
+  ISTIO_VERSION="1.12.0"
 elif [ "${TARGET_BRANCH}" == "v1.57" ]; then
-  ISTIO_VERSION="1.15.0"
+  ISTIO_VERSION="1.14.0"
 elif [ "${TARGET_BRANCH}" == "v1.65" ]; then
-  ISTIO_VERSION="1.17.0"
+  ISTIO_VERSION="1.16.0"
 fi
 
 KIND_NODE_IMAGE=""
-if [ "${ISTIO_VERSION}" == "1.13.0" ]; then
+if [ "${ISTIO_VERSION}" == "1.12.0" ]; then
   KIND_NODE_IMAGE="kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
 else
   KIND_NODE_IMAGE="kindest/node:v1.24.15@sha256:24473777a1eef985dc405c23ab9f4daddb1352ca23db60b75de9e7c408096491"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -53,7 +53,7 @@ if [ "${TARGET_BRANCH}" == "v1.48" ]; then
 elif [ "${TARGET_BRANCH}" == "v1.57" ]; then
   ISTIO_VERSION="1.14.0"
 elif [ "${TARGET_BRANCH}" == "v1.65" ]; then
-  ISTIO_VERSION="1.16.0"
+  ISTIO_VERSION="1.16.7"
 fi
 
 KIND_NODE_IMAGE=""

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -138,7 +138,7 @@ LBCONFIGMAP
 
 infomsg "Installing istio"
 # Apparently you can't set the requests to zero for the proxy so just setting them to some really low number.
-hack/istio/install-istio-via-istioctl.sh --reduce-resources true --client-exe-path "$(which kubectl)" -cn "cluster-default" -mid "mesh-default" -net "network-default" -gae "true"
+hack/istio/install-istio-via-istioctl.sh --reduce-resources true --client-exe-path "$(which kubectl)" -cn "cluster-default" -mid "mesh-default" -net "network-default" -gae "true" -gav "v0.7.1"
   
 infomsg "Pushing the images into the cluster..."
 make -e DORP="${DORP}" -e CLUSTER_TYPE="kind" -e KIND_NAME="ci" cluster-push-kiali

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -50,6 +50,10 @@ TARGET_BRANCH="${TARGET_BRANCH:-master}"
 # https://istio.io/latest/docs/releases/supported-releases/
 if [ "${TARGET_BRANCH}" == "v1.48" ]; then
   ISTIO_VERSION="1.13.0"
+elif [ "${TARGET_BRANCH}" == "v1.57" ]; then
+  ISTIO_VERSION="1.15.0"
+elif [ "${TARGET_BRANCH}" == "v1.65" ]; then
+  ISTIO_VERSION="1.17.0"
 fi
 
 KIND_NODE_IMAGE=""


### PR DESCRIPTION
**Describe the change**

Install compatible Istio version 1.17 for Kiali 1.65 when performing integration tests.

Compatible Istio versions are obtained from:
https://kiali.io/docs/installation/installation-guide/prerequisites/#version-compatibility

Compatible Kubernetes versions are obtained from:
https://istio.io/latest/docs/releases/supported-releases/

**Issue reference**

#6858 