### PR TITLE
Realign healthy icon in summary panel graph

### DIFF
--- a/frontend/src/components/Health/HealthIndicator.tsx
+++ b/frontend/src/components/Health/HealthIndicator.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 import { PopoverPosition, Tooltip } from '@patternfly/react-core';
 import { HealthDetails } from './HealthDetails';
 import * as H from '../../types/Health';
-import { createIcon } from './Helper';
+import { Size, createIcon } from './Helper';
 import { createTooltipIcon } from '../../config/KialiIcon';
 import { healthIndicatorStyle } from '../../styles/HealthStyle';
 
 interface HealthIndicatorProps {
   health?: H.Health;
   id: string;
+  size?: Size;
   tooltipPlacement?: PopoverPosition;
 }
 
@@ -16,8 +17,7 @@ export const HealthIndicator: React.FC<HealthIndicatorProps> = (props: HealthInd
   const globalStatus = props.health ? props.health.getGlobalStatus() : H.NA;
 
   if (props.health) {
-    // HealthIndicator will render always in SMALL mode
-    const icon = createIcon(globalStatus, 'md');
+    const icon = createIcon(globalStatus, props.size ?? 'md');
 
     return (
       <Tooltip

--- a/frontend/src/components/Health/Helper.ts
+++ b/frontend/src/components/Health/Helper.ts
@@ -3,7 +3,7 @@ import { Status } from 'types/Health';
 import { Icon } from '@patternfly/react-core';
 import { kialiStyle } from 'styles/StyleUtils';
 
-type Size = 'sm' | 'md' | 'lg' | 'xl';
+export type Size = 'sm' | 'md' | 'lg' | 'xl';
 
 export const createIcon = (status: Status, size?: Size) => {
   const classForColor = kialiStyle({

--- a/frontend/src/components/Pf/PfBadges.tsx
+++ b/frontend/src/components/Pf/PfBadges.tsx
@@ -110,7 +110,7 @@ type PFBadgeProps = {
   position?: TooltipPosition; // default=auto
   size?: 'global' | 'sm';
   style?: CSSProperties;
-  tooltip?: React.ReactFragment;
+  tooltip?: React.ReactNode;
 };
 
 export const PFBadge: React.FC<PFBadgeProps> = (props: PFBadgeProps) => {

--- a/frontend/src/components/Pf/PfBadges.tsx
+++ b/frontend/src/components/Pf/PfBadges.tsx
@@ -76,14 +76,14 @@ export const PFBadges: { [key: string]: PFBadgeType } = Object.freeze({
 export const kialiBadge = kialiStyle({
   backgroundColor: PFColors.Badge,
   color: PFColors.White,
-  borderRadius: '1.25rem',
+  borderRadius: '20px',
   flexShrink: 0,
   fontFamily: 'var(--pf-v5-global--FontFamily--text)',
   fontSize: 'var(--kiali-global--font-size)',
-  lineHeight: '1rem',
-  marginRight: '0.25rem',
+  lineHeight: '16px',
+  marginRight: '4px',
   minWidth: '1.5em',
-  padding: '0.075rem 0.25rem',
+  padding: '1px 4px',
   textAlign: 'center',
   whiteSpace: 'nowrap'
 });
@@ -91,14 +91,14 @@ export const kialiBadge = kialiStyle({
 export const kialiBadgeSmall = kialiStyle({
   backgroundColor: PFColors.Badge,
   color: PFColors.White,
-  borderRadius: '1.25rem',
+  borderRadius: '20px',
   flexShrink: 0,
   fontFamily: 'var(--pf-v5-global--FontFamily--text)',
-  fontSize: '0.75rem',
-  lineHeight: '0.75rem',
-  marginRight: '0.25rem',
+  fontSize: '12px',
+  lineHeight: '13px',
+  marginRight: '5px',
   minWidth: '1.3em',
-  padding: '0.075rem 0.25rem',
+  padding: '1px 3px',
   textAlign: 'center',
   whiteSpace: 'nowrap'
 });

--- a/frontend/src/pages/Graph/SummaryLink.tsx
+++ b/frontend/src/pages/Graph/SummaryLink.tsx
@@ -8,36 +8,47 @@ import {
   DecoratedGraphNodeData
 } from '../../types/Graph';
 import { KialiIcon } from 'config/KialiIcon';
-import { Badge, PopoverPosition } from '@patternfly/react-core';
+import { PopoverPosition } from '@patternfly/react-core';
 import { Health } from 'types/Health';
 import { HealthIndicator } from 'components/Health/HealthIndicator';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { homeCluster } from 'config';
 import { KialiPageLink } from 'components/Link/KialiPageLink';
+import { kialiStyle } from 'styles/StyleUtils';
 
 interface LinkInfo {
-  link: string;
   displayName: string;
   key: string;
+  link: string;
 }
 
-const getTooltip = (tooltip: React.ReactFragment, nodeData: GraphNodeData): React.ReactFragment => {
+const badgeStyle = kialiStyle({
+  display: 'inline-block',
+  marginRight: '0.5rem',
+  marginBottom: '0.25rem'
+});
+
+const getTooltip = (tooltip: React.ReactNode, nodeData: GraphNodeData): React.ReactNode => {
   const addNamespace = nodeData.isBox !== BoxByType.NAMESPACE;
+
   const addCluster =
     nodeData.isBox !== BoxByType.CLUSTER &&
     nodeData.cluster !== CLUSTER_DEFAULT &&
     homeCluster?.name !== nodeData.cluster;
+
   return (
     <div style={{ textAlign: 'left' }}>
       <span>{tooltip}</span>
+
       {addNamespace && <div>{`Namespace: ${nodeData.namespace}`}</div>}
+
       {addCluster && <div>{`Cluster: ${nodeData.cluster}`}</div>}
     </div>
   );
 };
 
-export const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
-  switch (nodeType || nodeData.nodeType) {
+export const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType): React.ReactNode => {
+  switch (nodeType ?? nodeData.nodeType) {
     case NodeType.AGGREGATE:
       return (
         <PFBadge
@@ -85,11 +96,17 @@ export const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   }
 };
 
-export const getLink = (nodeData: GraphNodeData, nodeType?: NodeType, linkGenerator?: () => LinkInfo) => {
+export const getLink = (
+  nodeData: GraphNodeData,
+  nodeType?: NodeType,
+  linkGenerator?: () => LinkInfo
+): React.ReactNode => {
   const { app, cluster, namespace, service, workload } = nodeData;
+
   if (!nodeType || nodeData.nodeType === NodeType.UNKNOWN) {
     nodeType = nodeData.nodeType;
   }
+
   let displayName: string = 'unknown';
   let link: string | undefined;
   let key: string | undefined;
@@ -154,7 +171,7 @@ export const getLink = (nodeData: GraphNodeData, nodeType?: NodeType, linkGenera
   return <span key={key}>{displayName}</span>;
 };
 
-export const renderBadgedHost = (host: string) => {
+export const renderBadgedHost = (host: string): React.ReactNode => {
   return (
     <div>
       <PFBadge key={`badgedHost-${host}`} badge={PFBadges.Host} size="sm" />
@@ -163,15 +180,16 @@ export const renderBadgedHost = (host: string) => {
   );
 };
 
-export const renderBadgedName = (nodeData: GraphNodeData, label?: string) => {
+export const renderBadgedName = (nodeData: GraphNodeData, label?: string): React.ReactNode => {
   return (
     <div key={`badgedName-${nodeData.id}`}>
-      <span style={{ marginRight: '1em', marginBottom: '3px', display: 'inline-block' }}>
+      <span className={badgeStyle}>
         {label && (
           <span style={{ whiteSpace: 'pre' }}>
             <b>{label}</b>
           </span>
         )}
+
         {getBadge(nodeData)}
         {getLink({ ...nodeData, isInaccessible: true })}
       </span>
@@ -184,17 +202,18 @@ export const renderBadgedLink = (
   nodeType?: NodeType,
   label?: string,
   linkGenerator?: () => LinkInfo
-): React.ReactFragment => {
+): React.ReactNode => {
   const link = getLink(nodeData, nodeType, linkGenerator);
 
   return (
     <div key={`node-${nodeData.id}`}>
-      <span style={{ marginRight: '1em', marginBottom: '3px', display: 'inline-block' }}>
+      <span className={badgeStyle}>
         {label && (
           <span style={{ whiteSpace: 'pre' }}>
             <b>{label}</b>
           </span>
         )}
+
         {getBadge(nodeData, nodeType)}
         {link}
       </span>
@@ -203,27 +222,27 @@ export const renderBadgedLink = (
   );
 };
 
-export const renderHealth = (health?: Health) => {
+export const renderHealth = (health?: Health): React.ReactNode => {
   return (
-    <>
-      <Badge style={{ fontWeight: 'normal', marginTop: '4px', marginBottom: '4px' }} isRead={true}>
-        <span style={{ margin: '3px 3px 1px 0' }}>
-          {health ? (
-            <HealthIndicator id="graph-health-indicator" health={health} tooltipPlacement={PopoverPosition.left} />
-          ) : (
-            'n/a'
-          )}
-        </span>
-        health
-      </Badge>
-    </>
+    <span>
+      {health ? (
+        <HealthIndicator
+          id="graph-health-indicator"
+          health={health}
+          tooltipPlacement={PopoverPosition.left}
+          size="sm"
+        />
+      ) : (
+        'n/a'
+      )}
+    </span>
   );
 };
 
-export const renderDestServicesLinks = (nodeData: DecoratedGraphNodeData) => {
+export const renderDestServicesLinks = (nodeData: DecoratedGraphNodeData): React.ReactNode[] => {
   const destServices: DestService[] | undefined = nodeData.destServices;
 
-  const links: any[] = [];
+  const links: React.ReactNode[] = [];
   if (!destServices) {
     return links;
   }
@@ -243,6 +262,7 @@ export const renderDestServicesLinks = (nodeData: DecoratedGraphNodeData) => {
       version: '',
       workload: ''
     };
+
     links.push(renderBadgedLink(serviceNodeData));
   });
 

--- a/frontend/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -38,6 +38,7 @@ import {
   MenuToggleElement
 } from '@patternfly/react-core';
 import { kebabToggleStyle } from 'styles/DropdownStyles';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type SummaryPanelAppBoxMetricsState = {
   grpcRequestIn: Datapoint[];
@@ -91,6 +92,11 @@ const defaultState: SummaryPanelAppBoxState = {
   metricsLoadError: null,
   ...defaultMetricsState
 };
+
+const nodeInfoStyle = kialiStyle({
+  display: 'flex',
+  marginTop: '0.25rem'
+});
 
 export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, SummaryPanelAppBoxState> {
   private metricsPromise?: CancelablePromise<Response<IstioMetricsMap>[]>;
@@ -153,7 +159,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
 
     const options = getOptions(nodeData);
     const items = [
-      <DropdownGroup key="show" label="Show" className="kiali-appbox-menu">
+      <DropdownGroup key="show" label="Show">
         {options.map((o, i) => {
           return (
             <DropdownItem key={`option-${i}`} onClick={() => clickHandler(o, this.props.kiosk)}>
@@ -188,8 +194,10 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
       <div ref={this.mainDivRef} className={classes(panelStyle, summaryPanel)}>
         <div className={panelHeadingStyle}>
           {getTitle('Application')}
+
           <span>
             {firstBadge}
+
             {options.length > 0 && (
               <Dropdown
                 id="summary-appbox-actions"
@@ -214,16 +222,22 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
                 <DropdownList>{items}</DropdownList>
               </Dropdown>
             )}
+
             {secondBadge}
-            {renderBadgedLink(nodeData)}
-            {renderHealth(nodeData.health)}
+
+            <div className={nodeInfoStyle}>
+              {renderBadgedLink(nodeData)}
+              {renderHealth(nodeData.health)}
+            </div>
           </span>
+
           <div>
             {this.renderBadgeSummary(appBox, isPF)}
             {serviceList.length > 0 && <div>{serviceList}</div>}
             {workloadList.length > 0 && <div> {workloadList}</div>}
           </div>
         </div>
+
         <div className={panelBodyStyle}>
           {hasGrpc && isGrpcRequests && (
             <>
@@ -231,16 +245,19 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
               {hr()}
             </>
           )}
+
           {hasHttp && (
             <>
               {this.renderHttpRequests(appBox, isPF)}
               {hr()}
             </>
           )}
+
           <div>
             {this.renderSparklines(appBox, isPF)}
             {hr()}
           </div>
+
           {hasGrpc && !hasGrpcIn && renderNoTraffic('gRPC inbound')}
           {hasGrpc && !hasGrpcOut && renderNoTraffic('gRPC outbound')}
           {!hasGrpc && renderNoTraffic('gRPC')}
@@ -255,11 +272,11 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     );
   }
 
-  private onToggleActions = isExpanded => {
+  private onToggleActions = (isExpanded: boolean): void => {
     this.setState({ isOpen: isExpanded });
   };
 
-  private updateCharts = (props: SummaryPanelPropType) => {
+  private updateCharts = (props: SummaryPanelPropType): void => {
     const isPF = !!this.props.data.isPF;
     const appBox = props.data.summaryTarget;
     const nodeData = isPF ? appBox.getData() : decoratedNodeData(appBox);
@@ -438,7 +455,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return false;
   };
 
-  private renderBadgeSummary = (appBox, isPF: boolean) => {
+  private renderBadgeSummary = (appBox, isPF: boolean): React.ReactNode => {
     if (isPF) {
       return this.renderBadgeSummaryPF(appBox);
     }
@@ -462,6 +479,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
             <span style={{ paddingLeft: '0.25rem' }}>Has Circuit Breaker</span>
           </div>
         )}
+
         {hasVS && (
           <div>
             <KialiIcon.VirtualService />
@@ -472,12 +490,13 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     );
   };
 
-  private renderBadgeSummaryPF = (appBox: Node) => {
+  private renderBadgeSummaryPF = (appBox: Node): React.ReactNode => {
     const appBoxData = appBox.getData();
     let hasCB: boolean = appBoxData[NodeAttr.hasCB] === true;
     let hasVS: boolean = appBoxData[NodeAttr.hasVS] === true;
 
     const appBoxChildren = appBox.getAllNodeChildren();
+
     selectOr(appBoxChildren, [
       [{ prop: NodeAttr.hasCB, op: 'truthy' }],
       [{ prop: NodeAttr.hasVS, op: 'truthy' }]
@@ -494,6 +513,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
             <span style={{ paddingLeft: '0.25rem' }}>Has Circuit Breaker</span>
           </div>
         )}
+
         {hasVS && (
           <div>
             <KialiIcon.VirtualService />
@@ -504,7 +524,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     );
   };
 
-  private renderGrpcRequests = (appBox, isPF: boolean) => {
+  private renderGrpcRequests = (appBox, isPF: boolean): React.ReactNode => {
     if (isPF) {
       return this.renderGrpcRequestsPF(appBox);
     }
@@ -531,13 +551,14 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     );
   };
 
-  private renderGrpcRequestsPF = (appBox: Node) => {
+  private renderGrpcRequestsPF = (appBox: Node): React.ReactNode => {
     // only consider the physical children to avoid inflated rates
     const appBoxChildren = appBox.getAllNodeChildren();
     const validChildren = selectAnd(appBoxChildren, [
       { prop: NodeAttr.nodeType, op: '!=', val: NodeType.SERVICE },
       { prop: NodeAttr.nodeType, op: '!=', val: NodeType.AGGREGATE }
     ]);
+
     const inbound = getAccumulatedTrafficRateGrpc(edgesIn(validChildren as Node[]), true);
     const outbound = getAccumulatedTrafficRateGrpc(edgesOut(validChildren as Node[]), true);
 
@@ -556,7 +577,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     );
   };
 
-  private renderHttpRequests = (appBox, isPF: boolean) => {
+  private renderHttpRequests = (appBox, isPF: boolean): React.ReactNode => {
     if (isPF) {
       return this.renderHttpRequestsPF(appBox);
     }
@@ -588,7 +609,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     );
   };
 
-  private renderHttpRequestsPF = (appBox: Node) => {
+  private renderHttpRequestsPF = (appBox: Node): React.ReactNode => {
     // only consider the physical children to avoid inflated rates
     const appBoxChildren = appBox.getAllNodeChildren();
     const validChildren = selectAnd(appBoxChildren, [
@@ -618,7 +639,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     );
   };
 
-  private renderSparklines = (appBox, isPF: boolean) => {
+  private renderSparklines = (appBox, isPF: boolean): React.ReactNode => {
     if (this.state.loading) {
       return <strong>Loading charts...</strong>;
     } else if (this.state.metricsLoadError) {
@@ -640,7 +661,8 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     const hasTcp = this.hasTcpTraffic(appBox, isPF);
     const hasTcpIn = hasTcp && this.hasTcpIn(appBox, isPF);
     const hasTcpOut = hasTcp && this.hasTcpOut(appBox, isPF);
-    let grpcCharts, httpCharts, tcpCharts;
+
+    let grpcCharts: React.ReactNode, httpCharts: React.ReactNode, tcpCharts: React.ReactNode;
 
     if (hasGrpc) {
       grpcCharts = isGrpcRequests ? (
@@ -653,6 +675,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
               dataErrors={this.state.grpcRequestErrIn}
             />
           )}
+
           {hasGrpcOut && (
             <RequestChart
               key="grpc-outbound-request"
@@ -672,6 +695,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
               unit="messages"
             />
           )}
+
           {hasGrpcOut && (
             <StreamChart
               label="gRPC - Outbound Traffic"
@@ -695,6 +719,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
               dataErrors={this.state.httpRequestErrIn}
             />
           )}
+
           {hasHttpOut && (
             <RequestChart
               key="http-outbound-request"
@@ -719,6 +744,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
               unit="bytes"
             />
           )}
+
           {hasTcpOut && (
             <StreamChart
               key="tcp-outbound-request"
@@ -741,26 +767,30 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     );
   };
 
-  private renderServiceList = (appBox, isPF: boolean): React.ReactFragment[] => {
+  private renderServiceList = (appBox, isPF: boolean): React.ReactNode[] => {
     if (isPF) {
       return this.renderServiceListPF(appBox);
     }
 
     // likely 0 or 1 but support N in case of unanticipated labeling
-    const serviceList: any[] = [];
+    const serviceList: React.ReactNode[] = [];
 
     appBox.children(`node[nodeType = "${NodeType.SERVICE}"]`).forEach((serviceNode, i) => {
       const serviceNodeData = isPF ? serviceNode.getData() : decoratedNodeData(serviceNode);
       serviceList.push(renderBadgedLink(serviceNodeData, NodeType.SERVICE));
+
       const aggregates = appBox.children(
         `node[nodeType = "${NodeType.AGGREGATE}"][service = "${serviceNodeData.service}"]`
       );
+
       if (!!aggregates && aggregates.length > 0) {
-        const aggregateList: any[] = [];
-        aggregates.forEach(aggregateNode => {
+        const aggregateList: React.ReactNode[] = [];
+
+        aggregates.forEach((aggregateNode: any) => {
           const aggregateNodeData = isPF ? aggregateNode.getData() : decoratedNodeData(aggregateNode);
           aggregateList.push(renderBadgedLink(aggregateNodeData, NodeType.AGGREGATE));
         });
+
         serviceList.push(<div key={`service-${i}`}>{aggregateList}</div>);
       }
     });
@@ -768,25 +798,29 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return serviceList;
   };
 
-  private renderServiceListPF = (appBox: Node): React.ReactFragment[] => {
+  private renderServiceListPF = (appBox: Node): React.ReactNode[] => {
     // likely 0 or 1 but support N in case of unanticipated labeling
-    const serviceList: any[] = [];
+    const serviceList: React.ReactNode[] = [];
 
     const appBoxChildren = appBox.getAllNodeChildren();
 
     select(appBoxChildren, { prop: NodeAttr.nodeType, val: NodeType.SERVICE }).forEach((serviceNode, i) => {
       const serviceNodeData = serviceNode.getData();
       serviceList.push(renderBadgedLink(serviceNodeData, NodeType.SERVICE));
+
       const aggregates = selectAnd(appBoxChildren, [
         { prop: NodeAttr.nodeType, val: NodeType.AGGREGATE },
         { prop: NodeAttr.service, val: serviceNodeData.service }
       ]);
+
       if (!!aggregates && aggregates.length > 0) {
-        const aggregateList: any[] = [];
+        const aggregateList: React.ReactNode[] = [];
+
         aggregates.forEach(aggregateNode => {
           const aggregateNodeData = aggregateNode.getData();
           aggregateList.push(renderBadgedLink(aggregateNodeData, NodeType.AGGREGATE));
         });
+
         serviceList.push(<div key={`service-${i}`}>{aggregateList}</div>);
       }
     });
@@ -794,12 +828,12 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return serviceList;
   };
 
-  private renderWorkloadList = (appBox, isPF: boolean): React.ReactFragment[] => {
+  private renderWorkloadList = (appBox, isPF: boolean): React.ReactNode[] => {
     if (isPF) {
       return this.renderWorkloadListPF(appBox);
     }
 
-    const workloadList: any[] = [];
+    const workloadList: React.ReactNode[] = [];
 
     appBox.children('node[workload]').forEach(node => {
       const nodeData = isPF ? node.getData() : decoratedNodeData(node);
@@ -809,8 +843,8 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return workloadList;
   };
 
-  private renderWorkloadListPF = (appBox: Node): React.ReactFragment[] => {
-    const workloadList: any[] = [];
+  private renderWorkloadListPF = (appBox: Node): React.ReactNode[] => {
+    const workloadList: React.ReactNode[] = [];
 
     const appBoxChildren = appBox.getAllNodeChildren();
 
@@ -826,7 +860,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return this.props.trafficRates.includes(TrafficRate.GRPC_REQUEST);
   };
 
-  private hasGrpcTraffic = (appBox, isPF: boolean): boolean => {
+  private hasGrpcTraffic = (appBox: any, isPF: boolean): boolean => {
     if (isPF) {
       const appBoxChildren = (appBox as Node).getAllNodeChildren();
       const notServices = select(appBoxChildren, { prop: NodeAttr.nodeType, op: '!=', val: NodeType.SERVICE });
@@ -842,7 +876,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return appBox.children().filter('[nodeType != "service"]').filter('[grpcIn > 0],[grpcOut > 0]').size() > 0;
   };
 
-  private hasGrpcIn = (appBox, isPF: boolean): boolean => {
+  private hasGrpcIn = (appBox: any, isPF: boolean): boolean => {
     if (isPF) {
       const appBoxChildren = (appBox as Node).getAllNodeChildren();
 
@@ -857,7 +891,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return appBox.children().filter('[nodeType != "service"]').filter('[grpcIn > 0]').size() > 0;
   };
 
-  private hasGrpcOut = (appBox, isPF: boolean): boolean => {
+  private hasGrpcOut = (appBox: any, isPF: boolean): boolean => {
     if (isPF) {
       const appBoxChildren = (appBox as Node).getAllNodeChildren();
 
@@ -868,10 +902,11 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
         ]).length > 0
       );
     }
+
     return appBox.children().filter('[nodeType != "service"]').filter('[grpcOut > 0]').size() > 0;
   };
 
-  private hasHttpTraffic = (appBox, isPF: boolean): boolean => {
+  private hasHttpTraffic = (appBox: any, isPF: boolean): boolean => {
     if (isPF) {
       const appBoxChildren = (appBox as Node).getAllNodeChildren();
       const notServices = select(appBoxChildren, { prop: NodeAttr.nodeType, op: '!=', val: NodeType.SERVICE });
@@ -886,7 +921,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return appBox.children().filter('[nodeType != "service"]').filter('[httpIn > 0],[httpOut > 0]').size() > 0;
   };
 
-  private hasHttpIn = (appBox, isPF: boolean): boolean => {
+  private hasHttpIn = (appBox: any, isPF: boolean): boolean => {
     if (isPF) {
       const appBoxChildren = (appBox as Node).getAllNodeChildren();
 
@@ -900,7 +935,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return appBox.children().filter('[nodeType != "service"]').filter('[httpIn > 0]').size() > 0;
   };
 
-  private hasHttpOut = (appBox, isPF: boolean): boolean => {
+  private hasHttpOut = (appBox: any, isPF: boolean): boolean => {
     if (isPF) {
       const appBoxChildren = (appBox as Node).getAllNodeChildren();
 
@@ -914,7 +949,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return appBox.children().filter('[nodeType != "service"]').filter('[httpOut > 0]').size() > 0;
   };
 
-  private hasTcpTraffic = (appBox, isPF: boolean): boolean => {
+  private hasTcpTraffic = (appBox: any, isPF: boolean): boolean => {
     if (isPF) {
       const appBoxChildren = (appBox as Node).getAllNodeChildren();
       const notServices = select(appBoxChildren, { prop: NodeAttr.nodeType, op: '!=', val: NodeType.SERVICE });
@@ -929,7 +964,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return appBox.children().filter('[nodeType != "service"]').filter('[tcpIn > 0],[tcpOut > 0]').size() > 0;
   };
 
-  private hasTcpIn = (appBox, isPF: boolean): boolean => {
+  private hasTcpIn = (appBox: any, isPF: boolean): boolean => {
     if (isPF) {
       const appBoxChildren = (appBox as Node).getAllNodeChildren();
 
@@ -943,7 +978,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
     return appBox.children().filter('[nodeType != "service"]').filter('[tcpIn > 0]').size() > 0;
   };
 
-  private hasTcpOut = (appBox, isPF: boolean): boolean => {
+  private hasTcpOut = (appBox: any, isPF: boolean): boolean => {
     if (isPF) {
       const appBoxChildren = (appBox as Node).getAllNodeChildren();
 

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -94,6 +94,11 @@ const expandableSectionStyle = kialiStyle({
   }
 });
 
+const nodeInfoStyle = kialiStyle({
+  display: 'flex',
+  marginTop: '0.25rem'
+});
+
 const workloadExpandableSectionStyle = classes(expandableSectionStyle, kialiStyle({ display: 'inline' }));
 
 export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeComponentProps, SummaryPanelNodeState> {
@@ -152,9 +157,9 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
       } else if (this.props.serviceDetails !== null) {
         items.push(
           <ServiceWizardActionsDropdownGroup
-            virtualServices={this.props.serviceDetails.virtualServices || []}
-            destinationRules={this.props.serviceDetails.destinationRules || []}
-            k8sHTTPRoutes={this.props.serviceDetails.k8sHTTPRoutes || []}
+            virtualServices={this.props.serviceDetails.virtualServices ?? []}
+            destinationRules={this.props.serviceDetails.destinationRules ?? []}
+            k8sHTTPRoutes={this.props.serviceDetails.k8sHTTPRoutes ?? []}
             istioPermissions={this.props.serviceDetails.istioPermissions}
             onAction={this.handleLaunchWizard}
             onDelete={this.handleDeleteTrafficRouting}
@@ -174,6 +179,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
         {nodeData.namespace}
       </>
     );
+
     const secondBadge = isMultiCluster ? (
       <div>
         <PFBadge badge={PFBadges.Namespace} size="sm" style={{ marginBottom: '0.125rem' }} />
@@ -187,9 +193,11 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
       <div ref={this.mainDivRef} className={classes(panelStyle, summaryPanel)}>
         <div className={panelHeadingStyle}>
           {getTitle(nodeType)}
+
           <div>
             <span>
               {firstBadge}
+
               {options.length > 0 && (
                 <Dropdown
                   id="summary-node-actions"
@@ -214,11 +222,16 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
                   <DropdownList>{items}</DropdownList>
                 </Dropdown>
               )}
+
               {secondBadge}
-              {renderBadgedLink(nodeData)}
-              {renderHealth(nodeData.health)}
+
+              <div className={nodeInfoStyle}>
+                {renderBadgedLink(nodeData)}
+                {renderHealth(nodeData.health)}
+              </div>
             </span>
           </div>
+
           <div>
             {this.renderBadgeSummary(nodeData)}
             {shouldRenderDestsList && <div>{destsList}</div>}
@@ -228,12 +241,13 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             {shouldRenderWorkload && this.renderWorkloadSection(nodeData)}
           </div>
         </div>
+
         {shouldRenderTraces ? this.renderWithTabs(nodeData) : this.renderTrafficOnly()}
       </div>
     );
   }
 
-  private renderWorkloadSection = (nodeData: DecoratedGraphNodeData) => {
+  private renderWorkloadSection = (nodeData: DecoratedGraphNodeData): React.ReactNode => {
     if (!nodeData.hasWorkloadEntry) {
       return <div>{renderBadgedLink(nodeData, NodeType.WORKLOAD)}</div>;
     }
@@ -253,6 +267,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     return (
       <>
         {getBadge(nodeData, NodeType.WORKLOAD)}
+
         <ExpandableSection
           toggleText={
             nodeData.hasWorkloadEntry.length === 1
@@ -267,7 +282,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     );
   };
 
-  private renderGatewayHostnames = (nodeData: DecoratedGraphNodeData) => {
+  private renderGatewayHostnames = (nodeData: DecoratedGraphNodeData): React.ReactNode => {
     if (nodeData.isGateway?.ingressInfo?.hostnames && nodeData.isGateway?.ingressInfo?.hostnames.length > 0) {
       return this.renderHostnamesSection(nodeData.isGateway?.ingressInfo?.hostnames);
     }
@@ -283,11 +298,11 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     return null;
   };
 
-  private renderVsHostnames = (nodeData: DecoratedGraphNodeData) => {
+  private renderVsHostnames = (nodeData: DecoratedGraphNodeData): React.ReactNode => {
     return this.renderHostnamesSection(nodeData.hasVS?.hostnames!);
   };
 
-  private renderHostnamesSection = (hostnames: string[]) => {
+  private renderHostnamesSection = (hostnames: string[]): React.ReactNode => {
     const numberOfHostnames = hostnames.length;
     let toggleText = `${numberOfHostnames} hosts`;
 
@@ -306,7 +321,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     );
   };
 
-  private renderTrafficOnly() {
+  private renderTrafficOnly(): React.ReactNode {
     return (
       <div className={panelBodyStyle}>
         <SummaryPanelNodeTraffic {...this.props} />
@@ -314,7 +329,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     );
   }
 
-  private renderWithTabs(nodeData: DecoratedGraphNodeData) {
+  private renderWithTabs(nodeData: DecoratedGraphNodeData): React.ReactNode {
     return (
       <div className={summaryBodyTabs}>
         <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '0.5rem' }}>
@@ -323,6 +338,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
               <SummaryPanelNodeTraffic {...this.props} />
             </div>
           </Tab>
+
           <Tab style={summaryFont} title="Traces" eventKey={1}>
             <SummaryPanelNodeTraces nodeData={nodeData} queryTime={this.props.queryTime - this.props.duration} />
           </Tab>
@@ -331,7 +347,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     );
   }
 
-  private onToggleActions = (isOpen: boolean) => {
+  private onToggleActions = (isOpen: boolean): void => {
     this.setState({ isActionOpen: isOpen });
 
     if (this.props.onKebabToggled) {
@@ -339,12 +355,12 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     }
   };
 
-  private renderK8sGatewayAPI(isK8sGatewayAPI?: boolean) {
+  private renderK8sGatewayAPI(isK8sGatewayAPI?: boolean): React.ReactNode {
     return isK8sGatewayAPI ? ' (K8s GW API)' : '';
   }
 
   // TODO:(see https://github.com/kiali/kiali-design/issues/63) If we want to show an icon for SE uncomment below
-  private renderBadgeSummary = (nodeData: DecoratedGraphNodeData) => {
+  private renderBadgeSummary = (nodeData: DecoratedGraphNodeData): React.ReactNode => {
     const {
       hasCB,
       hasFaultInjection,
@@ -359,6 +375,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
       isK8sGatewayAPI,
       isOutOfMesh
     } = nodeData;
+
     const hasTrafficScenario =
       hasRequestRouting ||
       hasFaultInjection ||
@@ -366,6 +383,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
       hasTrafficShifting ||
       hasTCPTrafficShifting ||
       hasRequestTimeout;
+
     const shouldRenderGatewayHostnames =
       (nodeData.isGateway?.ingressInfo?.hostnames !== undefined &&
         nodeData.isGateway.ingressInfo.hostnames.length !== 0) ||
@@ -373,8 +391,11 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
         nodeData.isGateway.egressInfo.hostnames.length !== 0) ||
       (nodeData.isGateway?.gatewayAPIInfo?.hostnames !== undefined &&
         nodeData.isGateway.gatewayAPIInfo.hostnames.length !== 0);
+
     const shouldRenderVsHostnames = nodeData.hasVS?.hostnames !== undefined && nodeData.hasVS?.hostnames.length !== 0;
+
     const shouldRenderRank = this.props.showRank;
+
     return (
       <div style={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}>
         {hasCB && (
@@ -385,6 +406,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             </span>
           </div>
         )}
+
         {hasVS && !hasTrafficScenario && (
           <>
             <div>
@@ -396,24 +418,28 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             {shouldRenderVsHostnames && this.renderVsHostnames(nodeData)}
           </>
         )}
+
         {hasMirroring && (
           <div>
             <KialiIcon.Mirroring />
             <span style={{ paddingLeft: '0.25rem' }}>Has Mirroring{this.renderK8sGatewayAPI(isK8sGatewayAPI)}</span>
           </div>
         )}
+
         {isOutOfMesh && !serverConfig.ambientEnabled && (
           <div>
             <KialiIcon.OutOfMesh />
             <span style={{ paddingLeft: '0.25rem' }}>Has Missing Sidecar</span>
           </div>
         )}
+
         {isOutOfMesh && serverConfig.ambientEnabled && (
           <div>
             <KialiIcon.OutOfMesh />
             <span style={{ paddingLeft: '0.25rem' }}>Out of Mesh</span>
           </div>
         )}
+
         {isDead && (
           <div>
             <span style={{ marginRight: '0.25rem' }}>
@@ -422,6 +448,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             <span style={{ paddingLeft: '0.25rem' }}>Has No Running Pods</span>
           </div>
         )}
+
         {hasRequestRouting && (
           <>
             <div>
@@ -433,6 +460,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             {shouldRenderVsHostnames && this.renderVsHostnames(nodeData)}
           </>
         )}
+
         {hasFaultInjection && (
           <div>
             <KialiIcon.FaultInjection />
@@ -441,6 +469,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             </span>
           </div>
         )}
+
         {hasTrafficShifting && (
           <div>
             <KialiIcon.TrafficShifting />
@@ -449,6 +478,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             </span>
           </div>
         )}
+
         {hasTCPTrafficShifting && (
           <div>
             <KialiIcon.TrafficShifting />
@@ -457,6 +487,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             </span>
           </div>
         )}
+
         {hasRequestTimeout && (
           <div>
             <KialiIcon.RequestTimeout />
@@ -465,6 +496,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             </span>
           </div>
         )}
+
         {isGateway && (
           <>
             <div>
@@ -474,6 +506,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             {shouldRenderGatewayHostnames && this.renderGatewayHostnames(nodeData)}
           </>
         )}
+
         {shouldRenderRank && (
           <div>
             <KialiIcon.Rank />
@@ -486,10 +519,11 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     );
   };
 
-  private renderDestServices = (data: DecoratedGraphNodeData) => {
+  private renderDestServices = (data: DecoratedGraphNodeData): React.ReactNode => {
     const destServices: DestService[] | undefined = data.destServices;
 
-    const entries: any[] = [];
+    const entries: React.ReactNode[] = [];
+
     if (!destServices) {
       return entries;
     }
@@ -501,11 +535,13 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     return entries;
   };
 
-  private handleLaunchWizard = (key: WizardAction, mode: WizardMode) => {
+  private handleLaunchWizard = (key: WizardAction, mode: WizardMode): void => {
     this.onToggleActions(false);
+
     if (this.props.onLaunchWizard) {
       const node = this.props.data.summaryTarget;
       const nodeData = this.props.data.isPF ? node.getData() : decoratedNodeData(node);
+
       this.props.onLaunchWizard(
         key,
         mode,
@@ -517,15 +553,16 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     }
   };
 
-  private handleDeleteTrafficRouting = (key: string) => {
+  private handleDeleteTrafficRouting = (key: string): void => {
     this.onToggleActions(false);
+
     if (this.props.onDeleteTrafficRouting) {
       this.props.onDeleteTrafficRouting(key, this.props.serviceDetails!);
     }
   };
 }
 
-export function SummaryPanelNode(props: SummaryPanelNodeProps) {
+export const SummaryPanelNode: React.FC<SummaryPanelNodeProps> = (props: SummaryPanelNodeProps) => {
   const tracingState = useKialiSelector(state => state.tracingState);
   const kiosk = useKialiSelector(state => state.globalState.kiosk);
   const rankResult = useKialiSelector(state => state.graph.rankResult);
@@ -536,6 +573,7 @@ export function SummaryPanelNode(props: SummaryPanelNodeProps) {
 
   const node = props.data.summaryTarget;
   const nodeData = props.data.isPF ? node.getData() : decoratedNodeData(node);
+
   const [serviceDetails, gateways, peerAuthentications, isServiceDetailsLoading] = useServiceDetailForGraphNode(
     nodeData,
     isKebabOpen,
@@ -543,9 +581,9 @@ export function SummaryPanelNode(props: SummaryPanelNodeProps) {
     updateTime
   );
 
-  function handleKebabToggled(isOpen: boolean) {
+  const handleKebabToggled = (isOpen: boolean) => {
     setIsKebabOpen(isOpen);
-  }
+  };
 
   return (
     <SummaryPanelNodeComponent
@@ -560,4 +598,4 @@ export function SummaryPanelNode(props: SummaryPanelNodeProps) {
       {...props}
     />
   );
-}
+};

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -48,6 +48,13 @@ export const globalStyle = kialiStyle({
     },
 
     /**
+     * Reduce padding of menu group title
+     */
+    '& .pf-v5-c-menu__group-title': {
+      paddingTop: '0.5rem'
+    },
+
+    /**
      * Padding for table rows
      */
     '& .pf-v5-c-table': {


### PR DESCRIPTION
**Describe the change**

Realign healthy icon in summary panel graph next to application/service badge link instead of previous label.

Previous:

![image](https://github.com/kiali/kiali/assets/122779323/4e9dc6be-7d4c-48d4-ad59-719b23c169ee)

Now:

![image](https://github.com/kiali/kiali/assets/122779323/08a8531d-288a-4d6f-9503-be6a6a7cb28f)

I have removed `health` label in order to be consistent with other parts of Kiali where health indicator is placed next to application/service name (e.g. detail info):

![image](https://github.com/kiali/kiali/assets/122779323/8942f73e-8e16-4b15-8bf2-56b94d273b20)

Besides, I have reduced a bit the top padding of kebab toggle menu in graph and overview:

![image](https://github.com/kiali/kiali/assets/122779323/520920a7-dbb5-467e-b922-6daea02d9bdd)


**Issue reference**

Fixes #6884 