### PR TITLE
Issue6572

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -99,7 +99,8 @@ type Metrics struct {
 
 // OpenTelemetry collector configuration for tracing
 type OtelCollector struct {
-	Protocol string `yaml:"protocol,omitempty"` // http or https or grp
+	Protocol   string `yaml:"protocol,omitempty"` // http or https or grp
+	TlsEnabled bool   `yaml:"tls_enabled,omitempty"`
 }
 
 // Tracing provides tracing configuration for the Kiali server.
@@ -792,7 +793,8 @@ func NewConfig() (c *Config) {
 					CollectorURL:  "http://jaeger-collector.istio-system:14268/api/traces",
 					Enabled:       false,
 					Otel: OtelCollector{
-						Protocol: "http",
+						Protocol:   "http",
+						TlsEnabled: false,
 					},
 					// Sample half of traces.
 					SamplingRate: 0.5,

--- a/config/config.go
+++ b/config/config.go
@@ -99,7 +99,9 @@ type Metrics struct {
 
 // OpenTelemetry collector configuration for tracing
 type OtelCollector struct {
+	CaName     string `yaml:"ca_name,omitempty"`
 	Protocol   string `yaml:"protocol,omitempty"` // http or https or grp
+	SkipVerify bool   `yaml:"skip_verify,omitempty"`
 	TlsEnabled bool   `yaml:"tls_enabled,omitempty"`
 }
 
@@ -793,7 +795,9 @@ func NewConfig() (c *Config) {
 					CollectorURL:  "http://jaeger-collector.istio-system:14268/api/traces",
 					Enabled:       false,
 					Otel: OtelCollector{
+						CaName:     "",
 						Protocol:   "http",
+						SkipVerify: true,
 						TlsEnabled: false,
 					},
 					// Sample half of traces.


### PR DESCRIPTION
Fixes #6572 

Config example: 

```
server:
  address: localhost
  port: 8000
  static_content_root_directory: /home/jcordoba/Tests/kiali-static-files
  observability: 
   tracing: 
    collector_type: "otel"
    collector_url: "localhost:4317"
    enabled: true
    otel: 
     protocol: "grpc"
     tls_enabled: true
     skip_verify: true
     ca_name: "/tmp/tls.crt"
```

Tempo CR: 

```
kubectl apply -n tempo -f - <<EOF
apiVersion: tempo.grafana.com/v1alpha1
kind: TempoStack
metadata:
  name: cr
spec:
  storageSize: 1Gi
  storage:
    secret:
      type: s3
      name: tempostack-dev-minio
  resources:
    total:
      limits:
        memory: 2Gi
        cpu: 2000m
  template:
    queryFrontend:
      jaegerQuery:
        enabled: false
    distributor: 
      tls:
        enabled: true
        certName: custom-cert
EOF
```

