### PR TITLE
Improve appearance of workload log checkboxes

### DIFF
--- a/frontend/.eslintrc_precommit
+++ b/frontend/.eslintrc_precommit
@@ -12,8 +12,13 @@
     "no-var": "error",
     "prefer-template": "error",
     "prefer-arrow-callback": "error",
+    "@typescript-eslint/member-ordering": ["error", {
+      "default": {},
+      "interfaces": {"order": "alphabetically"},
+      "typeLiterals": {"order": "alphabetically"}
+    }],
     "@typescript-eslint/no-inferrable-types": "error",
-    "@typescript-eslint/explicit-function-return-type": "error",
+    "@typescript-eslint/explicit-function-return-type": ["error", { "allowExpressions": true }],
     "@typescript-eslint/explicit-module-boundary-types": ["error", { "allowArgumentsExplicitlyTypedAsAny": true }]
   }
 }

--- a/frontend/src/components/Pf/PfColors.tsx
+++ b/frontend/src/components/Pf/PfColors.tsx
@@ -37,9 +37,11 @@ export enum PFColors {
   LightGreen400 = 'var(--pf-v5-global--palette--light-green-400)',
   LightGreen500 = 'var(--pf-v5-global--palette--light-green-500)',
   Orange50 = 'var(--pf-v5-global--palette--orange-50)',
+  Orange300 = 'var(--pf-v5-global--palette--orange-300)',
   Orange400 = 'var(--pf-v5-global--palette--orange-400)',
   Purple100 = 'var(--pf-v5-global--palette--purple-100)',
   Purple200 = 'var(--pf-v5-global--palette--purple-200)',
+  Purple300 = 'var(--pf-v5-global--palette--purple-300)',
   Purple500 = 'var(--pf-v5-global--palette--purple-500)',
   Red50 = 'var(--pf-v5-global--palette--red-50)',
   Red100 = 'var(--pf-v5-global--palette--red-100)',
@@ -93,6 +95,7 @@ export enum PFColors {
 export type PFColorVal = string;
 
 // Color values used by Kiali outside of CSS (i.e. when we must have the actual hex value)
+/* eslint-disable @typescript-eslint/member-ordering*/
 export type PFColorValues = {
   Black100: PFColorVal;
   Black150: PFColorVal;
@@ -143,11 +146,11 @@ export let PFColorVals: PFColorValues;
 
   - In case there is not var then return the same input
 */
-const getColor = (val: string) => {
+const getColor = (val: string): string => {
   return val.indexOf('var(') === 0 ? val.split('(').pop()!.split(')')[0] : val;
 };
 
-export const setPFColorVals = (element: Element) => {
+export const setPFColorVals = (element: Element): void => {
   PFColorVals = {
     // color values used by kiali
     Black100: getComputedStyle(element).getPropertyValue(getColor(PFColors.Black100)),

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -55,7 +55,7 @@ import { TimeDurationModal } from '../../components/Time/TimeDurationModal';
 import { TimeDurationIndicator } from '../../components/Time/TimeDurationIndicator';
 import { serverConfig } from '../../config';
 
-const appContainerColors = [PFColors.White, PFColors.LightGreen400, PFColors.Purple100, PFColors.LightBlue400];
+const appContainerColors = [PFColors.Blue300, PFColors.Green300, PFColors.Purple300, PFColors.Orange300];
 const proxyContainerColor = PFColors.Gold400;
 const spanColor = PFColors.Cyan300;
 
@@ -122,7 +122,6 @@ enum LogLevel {
   Critical = 'critical'
 }
 
-const RETURN_KEY_CODE = 13;
 const NoLogsFoundMessage = 'No container logs found for the time period.';
 
 const MaxLinesDefault = 3000;
@@ -138,8 +137,7 @@ const MaxLinesOptions = {
 };
 
 const alInfoIcon = kialiStyle({
-  display: 'inline-block',
-  margin: '0 0.25rem 0 0',
+  display: 'flex',
   width: '0.75rem'
 });
 
@@ -180,8 +178,53 @@ const expandActionStyle = kialiStyle({
   marginTop: '0.375rem'
 });
 
-const logsBackground = (enabled: boolean) => ({ backgroundColor: enabled ? PFColors.Black1000 : PFColors.Black500 });
-const logsHeight = (showToolbar: boolean, fullscreen: boolean, showMaxLinesWarning: boolean) => {
+const checkboxStyle = kialiStyle({
+  marginLeft: '0.5rem',
+  marginRight: '1rem'
+});
+
+const logListStyle = kialiStyle({
+  overflowX: 'auto',
+  overflowY: 'auto',
+  paddingTop: '0.375rem',
+  paddingBottom: '0.75rem'
+});
+
+const noLogsStyle = kialiStyle({
+  paddingTop: '0.75rem',
+  paddingLeft: '0.75rem'
+});
+
+const logLineStyle = kialiStyle({
+  display: 'flex',
+  height: '1.5rem',
+  lineHeight: '1.5rem',
+  paddingLeft: '0.75rem'
+});
+
+const logInfoStyle = kialiStyle({
+  paddingLeft: 0,
+  width: '0.75rem',
+  height: '0.75rem',
+  fontFamily: 'monospace',
+  fontSize: '0.75rem'
+});
+
+const logMessaageStyle = kialiStyle({
+  fontSize: '0.75rem',
+  paddingRight: '1rem'
+});
+
+const colorCheck = (color: string): string =>
+  kialiStyle({
+    accentColor: color
+  });
+
+const logsBackground = (enabled: boolean): React.CSSProperties => ({
+  backgroundColor: enabled ? PFColors.Black1000 : PFColors.Black500
+});
+
+const logsHeight = (showToolbar: boolean, fullscreen: boolean, showMaxLinesWarning: boolean): React.CSSProperties => {
   const toolbarHeight = showToolbar ? '0px' : '49px';
   const maxLinesWarningHeight = showMaxLinesWarning ? '27px' : '0px';
 
@@ -249,7 +292,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     };
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     const screenFullAlias = screenfull as Screenfull;
     screenFullAlias.onchange(() => this.setState({ fullscreen: !this.state.fullscreen }));
 
@@ -267,7 +310,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     }
   }
 
-  componentDidUpdate(prevProps: WorkloadPodLogsProps, prevState: WorkloadPodLogsState) {
+  componentDidUpdate(prevProps: WorkloadPodLogsProps, prevState: WorkloadPodLogsState): void {
     const prevContainerOptions = prevState.containerOptions ? prevState.containerOptions : undefined;
     const newContainerOptions = this.state.containerOptions ? this.state.containerOptions : undefined;
     const updateContainerOptions = newContainerOptions && newContainerOptions !== prevContainerOptions;
@@ -290,11 +333,11 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     }
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     this.promises.cancelAll();
   }
 
-  render() {
+  render(): React.ReactNode {
     return (
       <>
         <RenderComponentScroll>
@@ -312,7 +355,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
 
                           <ToolbarItem>
                             <ToolbarDropdown
-                              id={'wpl_pods'}
+                              id="wpl_pods"
                               tooltip="Display logs for the selected pod"
                               handleSelect={key => this.setPod(key)}
                               value={this.state.podValue}
@@ -329,7 +372,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
                               validated={isValid(this.state.showLogValue ? !this.state.showError : undefined)}
                               autoComplete="on"
                               type="text"
-                              onKeyPress={this.checkSubmitShow}
+                              onKeyDown={this.checkSubmitShow}
                               onChange={(_event, val) => this.updateShow(val)}
                               defaultValue={this.state.showLogValue}
                               aria-label="show log text"
@@ -351,7 +394,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
                               validated={isValid(this.state.hideLogValue ? !this.state.hideError : undefined)}
                               autoComplete="on"
                               type="text"
-                              onKeyPress={this.checkSubmitHide}
+                              onKeyDown={this.checkSubmitHide}
                               onChange={(_event, val) => this.updateHide(val)}
                               defaultValue={this.state.hideLogValue}
                               aria-label="hide log text"
@@ -383,12 +426,14 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
                           <ToolbarItem style={{ alignSelf: 'center' }}>
                             <Checkbox
                               id="log-spans"
+                              className={checkboxStyle}
+                              inputClassName={colorCheck(spanColor)}
                               isChecked={this.state.showSpans}
                               label={
                                 <span
                                   style={{
-                                    backgroundColor: PFColors.Black1000,
-                                    color: spanColor
+                                    color: spanColor,
+                                    fontWeight: 'bold'
                                   }}
                                 >
                                   spans
@@ -400,12 +445,12 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
 
                           <ToolbarItem style={{ marginLeft: 'auto' }}>
                             <ToolbarDropdown
-                              id={'wpl_maxLines'}
+                              id="wpl_maxLines"
                               handleSelect={key => this.setMaxLines(Number(key))}
                               value={this.state.maxLines}
                               label={MaxLinesOptions[this.state.maxLines]}
                               options={MaxLinesOptions}
-                              tooltip={'Truncate after N log lines'}
+                              tooltip="Truncate after N log lines"
                               className={toolbarTail}
                             />
                           </ToolbarItem>
@@ -438,17 +483,17 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     );
   }
 
-  private toggleSpans = (checked: boolean) => {
+  private toggleSpans = (checked: boolean): void => {
     const urlParams = new URLSearchParams(history.location.search);
     urlParams.set(URLParam.SHOW_SPANS, String(checked));
-    history.replace(history.location.pathname + '?' + urlParams.toString());
+    history.replace(`${history.location.pathname}?${urlParams.toString()}`);
 
     this.setState({ showSpans: !this.state.showSpans });
   };
 
-  private getContainerLegend = () => {
+  private getContainerLegend = (): React.ReactNode => {
     return (
-      <Form data-test={'workload-logs-pod-containers'} style={{ marginTop: '0.375rem' }}>
+      <Form data-test="workload-logs-pod-containers" style={{ marginTop: '0.375rem' }}>
         <FormGroup fieldId="container-log-selection" isInline>
           <PFBadge
             badge={{ badge: PFBadges.Container.badge, tt: 'Containers' }}
@@ -461,12 +506,14 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
               <Checkbox
                 id={`container-${c.displayName}`}
                 key={`c-d-${i}`}
+                className={checkboxStyle}
+                inputClassName={colorCheck(c.color)}
                 isChecked={c.isSelected}
                 label={
                   <span
                     style={{
-                      backgroundColor: PFColors.Black1000,
-                      color: c.color
+                      color: c.color,
+                      fontWeight: 'bold'
                     }}
                   >
                     {c.displayName}
@@ -481,16 +528,16 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     );
   };
 
-  private toggleSelected = (c: ContainerOption) => {
+  private toggleSelected = (c: ContainerOption): void => {
     c.isSelected = !c.isSelected;
     this.setState({ containerOptions: [...this.state.containerOptions!] });
   };
 
-  private toggleTimeOptionsVisibility = () => {
+  private toggleTimeOptionsVisibility = (): void => {
     this.setState(prevState => ({ isTimeOptionsOpen: !prevState.isTimeOptionsOpen }));
   };
 
-  private renderLogLine = ({ index, style }: { index: number; style: Object }) => {
+  private renderLogLine = ({ index, style }: { index: number; style: React.CSSProperties }): React.ReactNode => {
     let e = this.filteredEntries(
       this.state.entries,
       this.state.showLogValue,
@@ -500,9 +547,9 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
 
     if (e.span) {
       return (
-        <div key={`s-${index}`} style={{ height: '1.5rem', lineHeight: '1.5rem', paddingLeft: '0.75rem', ...style }}>
+        <div key={`s-${index}`} className={logLineStyle} style={{ ...style }}>
           {this.state.showTimestamps && (
-            <span key={`al-s-${index}`} style={{ color: spanColor, fontSize: '0.75rem', marginRight: '0.5rem' }}>
+            <span key={`al-s-${index}`} className={logMessaageStyle} style={{ color: spanColor }}>
               {e.timestamp}
             </span>
           )}
@@ -515,13 +562,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
             <Button
               key={`s-b-${index}`}
               variant={ButtonVariant.plain}
-              style={{
-                paddingLeft: '0.5rem',
-                width: '0.75rem',
-                height: '0.75rem',
-                fontFamily: 'monospace',
-                fontSize: '0.75rem'
-              }}
+              className={logInfoStyle}
               onClick={() => {
                 this.gotoSpan(e.span!);
               }}
@@ -529,15 +570,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
               <KialiIcon.Info key={`al-i-${index}`} className={alInfoIcon} color={spanColor} />
             </Button>
           </Tooltip>
-          <p
-            key={`al-p-${index}`}
-            style={{
-              color: spanColor,
-              fontSize: '0.75rem',
-              verticalAlign: 'center',
-              display: 'inline-block'
-            }}
-          >
+          <p key={`al-p-${index}`} className={logMessaageStyle} style={{ color: spanColor }}>
             {this.entryToString(e)}
           </p>
         </div>
@@ -548,15 +581,15 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     const messageColor = le.color! ?? PFColors.Color200;
 
     return !le.accessLog ? (
-      <div key={`le-d-${index}`} style={{ height: '1.5rem', lineHeight: '1.5rem', paddingLeft: '0.75rem', ...style }}>
-        <p key={`le-${index}`} style={{ color: messageColor, fontSize: '0.75rem' }}>
+      <div key={`le-d-${index}`} className={logLineStyle} style={{ ...style }}>
+        <p key={`le-${index}`} className={logMessaageStyle} style={{ color: messageColor }}>
           {this.entryToString(e)}
         </p>
       </div>
     ) : (
-      <div key={`al-${index}`} style={{ height: '1.5rem', lineHeight: '1.5rem', paddingLeft: '0.75rem', ...style }}>
+      <div key={`al-${index}`} className={logLineStyle} style={{ ...style }}>
         {this.state.showTimestamps && (
-          <span key={`al-s-${index}`} style={{ color: messageColor, fontSize: '0.75rem', marginRight: '0.5rem' }}>
+          <span key={`al-s-${index}`} className={logMessaageStyle} style={{ color: messageColor }}>
             {formatDate(le.timestamp)}
           </span>
         )}
@@ -570,13 +603,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
           <Button
             key={`al-b-${index}`}
             variant={ButtonVariant.plain}
-            style={{
-              paddingLeft: '0.5rem',
-              width: '0.75rem',
-              height: '0.75rem',
-              fontFamily: 'monospace',
-              fontSize: '0.75rem'
-            }}
+            className={logInfoStyle}
             onClick={() => {
               this.addAccessLogModal(le.message, le.accessLog!);
             }}
@@ -585,17 +612,14 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
           </Button>
         </Tooltip>
 
-        <p
-          key={`al-p-${index}`}
-          style={{ color: messageColor, fontSize: '0.75rem', verticalAlign: 'center', display: 'inline-block' }}
-        >
+        <p key={`al-p-${index}`} className={logMessaageStyle} style={{ color: messageColor }}>
           {le.message}
         </p>
       </div>
     );
   };
 
-  private getLogsDiv = () => {
+  private getLogsDiv = (): React.ReactNode => {
     const hasProxyContainer = this.state.containerOptions?.some(opt => opt.isProxy);
 
     const logDropDowns = Object.keys(LogLevel).map(level => {
@@ -648,6 +672,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
       </DropdownItem>,
 
       <Divider key="logLevelSeparator" />,
+
       <MenuGroup key="setLogLevels" label={dropdownGroupLabel}>
         {hasProxyContainer && logDropDowns}
       </MenuGroup>
@@ -753,11 +778,9 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
                 height={height}
                 width={width}
                 scrollToIndex={logEntries.length - 1}
-                noRowsRenderer={() => (
-                  <div style={{ paddingTop: '0.75rem', paddingLeft: '0.75rem' }}>{NoLogsFoundMessage}</div>
-                )}
-                containerStyle={{ overflow: 'initial !important' }}
-                style={{ overflowX: 'auto', overflowY: 'auto' }}
+                noRowsRenderer={() => <div className={noLogsStyle}>{NoLogsFoundMessage}</div>}
+                containerStyle={{ overflow: 'initial' }}
+                className={logListStyle}
               />
             )}
           </AutoSizer>
@@ -766,8 +789,8 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     );
   };
 
-  private getAccessLogModals = (): React.ReactFragment[] => {
-    const modals: React.ReactFragment[] = [];
+  private getAccessLogModals = (): React.ReactNode[] => {
+    const modals: React.ReactNode[] = [];
     let i = 0;
 
     this.state.accessLogModals.forEach((v, k) => {
@@ -784,52 +807,52 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     return modals;
   };
 
-  private setPod = (podValue: string) => {
+  private setPod = (podValue: string): void => {
     const pod = this.props.pods[Number(podValue)];
     const containerNames = this.getContainerOptions(pod);
     this.setState({ containerOptions: containerNames, podValue: Number(podValue) });
   };
 
-  private setMaxLines = (maxLines: number) => {
+  private setMaxLines = (maxLines: number): void => {
     this.setState({ maxLines: maxLines });
   };
 
-  private setKebabOpen = (kebabOpen: boolean) => {
+  private setKebabOpen = (kebabOpen: boolean): void => {
     this.setState({ kebabOpen: kebabOpen });
   };
 
-  private gotoSpan = (span: Span) => {
+  private gotoSpan = (span: Span): void => {
     const link =
       `/namespaces/${this.props.namespace}/workloads/${this.props.workload}` +
       `?tab=traces&${URLParam.TRACING_TRACE_ID}=${span.traceID}&${URLParam.TRACING_SPAN_ID}=${span.spanID}`;
     history.push(link);
   };
 
-  private addAccessLogModal = (k: string, v: AccessLog) => {
+  private addAccessLogModal = (k: string, v: AccessLog): void => {
     const accessLogModals = new Map<string, AccessLog>(this.state.accessLogModals);
     accessLogModals.set(k, v);
     this.setState({ accessLogModals: accessLogModals });
   };
 
-  private removeAccessLogModal = (k: string) => {
+  private removeAccessLogModal = (k: string): void => {
     this.state.accessLogModals.delete(k);
     const accessLogModals = new Map<string, AccessLog>(this.state.accessLogModals);
     this.setState({ accessLogModals: accessLogModals });
   };
 
-  private toggleShowTimestamps = () => {
+  private toggleShowTimestamps = (): void => {
     this.setState({ showTimestamps: !this.state.showTimestamps, kebabOpen: false });
   };
 
-  private toggleToolbar = () => {
+  private toggleToolbar = (): void => {
     this.setState({ showToolbar: !this.state.showToolbar, kebabOpen: false });
   };
 
-  private toggleUseRegex = () => {
+  private toggleUseRegex = (): void => {
     this.setState({ useRegex: !this.state.useRegex, kebabOpen: false });
   };
 
-  private setLogLevel = (level: LogLevel) => {
+  private setLogLevel = (level: LogLevel): void => {
     this.setState({ kebabOpen: false });
     const pod = this.props.pods[this.state.podValue!];
 
@@ -842,18 +865,18 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
       });
   };
 
-  private checkSubmitShow = event => {
-    const keyCode = event.keyCode ? event.keyCode : event.which;
-    if (keyCode === RETURN_KEY_CODE) {
+  private checkSubmitShow = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Enter') {
       event.preventDefault();
+
       this.setState({
-        showClearShowLogButton: !!event.target.value,
-        showLogValue: event.target.value
+        showClearShowLogButton: !!(event.target as HTMLInputElement).value,
+        showLogValue: (event.target as HTMLInputElement).value
       });
     }
   };
 
-  private updateShow = val => {
+  private updateShow = (val: string): void => {
     if ('' === val) {
       this.clearShow();
     }
@@ -873,6 +896,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
         try {
           const regexp = RegExp(showValue);
           filteredEntries = filteredEntries.filter(e => !e.logEntry || regexp.test(e.logEntry.message));
+
           if (!!this.state.showError) {
             this.setState({ showError: undefined });
           }
@@ -891,6 +915,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
         try {
           const regexp = RegExp(hideValue);
           filteredEntries = filteredEntries.filter(e => !e.logEntry || !regexp.test(e.logEntry.message));
+
           if (!!this.state.hideError) {
             this.setState({ hideError: undefined });
           }
@@ -907,7 +932,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     return filteredEntries;
   });
 
-  private clearShow = () => {
+  private clearShow = (): void => {
     // TODO: when TextInput refs are fixed in PF4 then use the ref and remove the direct HTMLElement usage
     // this.showInputRef.value = '';
     const htmlInputElement: HTMLInputElement = document.getElementById('log_show') as HTMLInputElement;
@@ -922,25 +947,24 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     });
   };
 
-  private checkSubmitHide = event => {
-    const keyCode = event.keyCode ? event.keyCode : event.which;
-
-    if (keyCode === RETURN_KEY_CODE) {
+  private checkSubmitHide = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Enter') {
       event.preventDefault();
+
       this.setState({
-        showClearHideLogButton: !!event.target.value,
-        hideLogValue: event.target.value
+        showClearHideLogButton: !!(event.target as HTMLInputElement).value,
+        hideLogValue: (event.target as HTMLInputElement).value
       });
     }
   };
 
-  private updateHide = val => {
+  private updateHide = (val: string): void => {
     if ('' === val) {
       this.clearHide();
     }
   };
 
-  private clearHide = () => {
+  private clearHide = (): void => {
     // TODO: when TextInput refs are fixed in PF4 then use the ref and remove the direct HTMLElement usage
     // this.hideInputRef.value = '';
     const htmlInputElement: HTMLInputElement = document.getElementById('log_hide') as HTMLInputElement;
@@ -956,7 +980,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     });
   };
 
-  private toggleFullscreen = () => {
+  private toggleFullscreen = (): void => {
     const screenFullAlias = screenfull as Screenfull; // this casting was necessary
 
     if (screenFullAlias.isFullscreen) {
@@ -974,8 +998,8 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
 
   private getContainerOptions = (pod: Pod): ContainerOption[] => {
     // sort containers by name, consistently positioning proxy container first.
-    let containers = [...(pod.istioContainers || [])];
-    containers.push(...(pod.containers || []));
+    let containers = [...(pod.istioContainers ?? [])];
+    containers.push(...(pod.containers ?? []));
 
     containers = containers.sort((c1, c2) => {
       if (c1.isProxy !== c2.isProxy) {
@@ -1007,11 +1031,12 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     maxLines: number,
     timeRange: TimeRange,
     cluster?: string
-  ) => {
+  ): void => {
     const now: TimeInMilliseconds = Date.now();
     const timeRangeDates = evalTimeRange(timeRange);
     const sinceTime: TimeInSeconds = Math.floor(timeRangeDates[0].getTime() / 1000);
     const endTime: TimeInMilliseconds = timeRangeDates[1].getTime();
+
     // to save work on the server-side, only supply duration when time range is in the past
     let duration = 0;
 
@@ -1040,8 +1065,10 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
         let entries = [] as Entry[];
         if (showSpans) {
           const spans = showSpans ? (responses[0].data as Span[]) : ([] as Span[]);
+
           entries = spans.map(span => {
             let startTimeU = Math.floor(span.startTime / 1000);
+
             return {
               timestamp: moment(startTimeU).utc().format('YYYY-MM-DD HH:mm:ss.SSS'),
               timestampUnix: startTimeU,
@@ -1091,7 +1118,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
           return;
         }
 
-        const errorMsg = error.response?.data?.error || error.message;
+        const errorMsg = error.response?.data?.error ?? error.message;
         const now = Date.now();
 
         this.setState({
@@ -1140,7 +1167,7 @@ const formatDate = (timestamp: string): string => {
   return entryTimestamp;
 };
 
-const mapStateToProps = (state: KialiAppState) => {
+const mapStateToProps = (state: KialiAppState): ReduxProps => {
   return {
     timeRange: timeRangeSelector(state)
   };


### PR DESCRIPTION
**Describe the change**

I have removed black background of workload log checkboxes that makes the look and feel a bit weird. In order to maintain the legend of integrated logs, I have change the color of the checkbox itself with `accent-color` CSS class. Also I have adapted log colors to work fine both in light and dark themes and adjust some margins and paddings of log lines.

![image](https://github.com/kiali/kiali/assets/122779323/2442a5f9-ef9f-4984-a5ff-b6a7217eb2c2)

For first application container I have selected blue color. These are the other colors selected for multiple application containers:
![image](https://github.com/kiali/kiali/assets/122779323/ee4bd17e-0038-4151-9bb2-7d0a125140ce)

![image](https://github.com/kiali/kiali/assets/122779323/735832b3-eeec-434f-a72b-a5023eff141a)

![image](https://github.com/kiali/kiali/assets/122779323/cb0f3b3b-02c3-418f-bc32-80dff86a724f)


Besides, I have added new eslint rule `@typescript-eslint/member-ordering` to force type and interface properties to be sorted alphabetically and modify `@typescript-eslint/explicit-function-return-type` to allow expressions (probably more rules will have to be adjusted in the next PRs until we find an optimal set of rules to apply in edited files).

**Issue reference**

Closes #6811 