### PR TITLE
Do not panic if tracer cannot be initialized

### DIFF
--- a/observability/tracing.go
+++ b/observability/tracing.go
@@ -59,7 +59,8 @@ func InitTracer(collectorURL string) *sdktrace.TracerProvider {
 	exporter, err := getExporter(collectorURL)
 
 	if err != nil {
-		panic(err)
+		log.Errorf("Failed to initialize tracer. Kiali will not log its own tracing data: %v", err)
+		return nil
 	}
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(config.Get().Server.Observability.Tracing.SamplingRate))),


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/6913

To test, I just put a bogus server.observability section in the config and ran the server.

Configure it with something like this:

```diff
$ git diff
diff --git a/hack/run-kiali-config-template.yaml b/hack/run-kiali-config-template.yaml
index 83c3b5615..db4330c81 100644
--- a/hack/run-kiali-config-template.yaml
+++ b/hack/run-kiali-config-template.yaml
@@ -49,6 +49,15 @@ login_token:
 
 server:
   static_content_root_directory: "${UI_CONSOLE_DIR}"
+  observability:
+    tracing:
+      collector_type: otel
+      collector_url: http://foo:123
+      enabled: true
+      otel:
+        protocol: grpc
+        skip_verify: true
+        tls_enabled: false
 
 # in_cluster must be false - do not change
 in_cluster: false
```


Run the server via run-kiali.sh:
```
hack/run-kiali.sh -kc current
```

Server now starts up without panic. It does log an ERR message now saying, `Failed to initialize tracer. Kiali will not log its own tracing data`:

```
{"level":"info","time":"2023-12-05T10:14:05-05:00","message":"Adding a RegistryRefreshHandler"}
2023-12-05T10:14:05-05:00 INF Kiali: Version: v1.78.0-SNAPSHOT, Commit: 94b5b58c5a809865ee58b8a6fe0ad8064e2890b2, Go: 1.20.10
2023-12-05T10:14:05-05:00 INF Using authentication strategy [anonymous]
2023-12-05T10:14:05-05:00 WRN Kiali auth strategy is configured for anonymous access - users will not be authenticated.
2023-12-05T10:14:05-05:00 INF Tracing Enabled. Initializing tracer with collector url: http://foo:123
2023-12-05T10:14:15-05:00 ERR Failed to initialize tracer. Kiali will not log its own tracing data: context deadline exceeded
2023-12-05T10:14:15-05:00 INF Initializing Kiali Cache
2023-12-05T10:14:15-05:00 INF Adding a RegistryRefreshHandler
2023-12-05T10:14:15-05:00 INF [Kiali Cache] Waiting for cluster-scoped cache to sync
2023-12-05T10:14:16-05:00 INF [Kiali Cache] Started
2023-12-05T10:14:16-05:00 INF [Kiali Cache] Kube cache is active for cluster: [Kubernetes]
2023-12-05T10:14:16-05:00 INF Server endpoint will start at [:20001/]
2023-12-05T10:14:16-05:00 INF Server endpoint will serve static content from [/home/jmazzite/source/kiali/kiali/frontend/build]
2023-12-05T10:14:16-05:00 INF Starting Metrics Server on [:9090]
```